### PR TITLE
engine: add core state types + Action/Event enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,6 +482,9 @@ dependencies = [
 [[package]]
 name = "game-core"
 version = "0.1.0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "getrandom"

--- a/crates/game-core/Cargo.toml
+++ b/crates/game-core/Cargo.toml
@@ -11,3 +11,4 @@ description = "Eldritch rules engine: game state, actions, events, effect system
 workspace = true
 
 [dependencies]
+serde = { version = "1", features = ["derive"] }

--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -1,0 +1,92 @@
+//! Actions: the alphabet of the action log.
+//!
+//! Every change to game state happens by applying an [`Action`]. The
+//! action log is a flat sequence of these, replayable into bit-identical
+//! state. There are two kinds of actions, distinguished by who or what
+//! initiated them:
+//!
+//! - [`Action::Player`] wraps a [`PlayerAction`] — input from a human via
+//!   the websocket. Submitting a player action is the only thing a client
+//!   can do; the wire protocol parses incoming messages as `PlayerAction`,
+//!   so a client cannot fabricate engine-only events.
+//! - [`Action::Engine`] wraps an [`EngineRecord`] — recorded output of
+//!   engine-side randomness or system events (chaos token draws, deck
+//!   shuffles). The engine generates these itself so the action log is
+//!   replayable; clients never construct them.
+
+use serde::{Deserialize, Serialize};
+
+use crate::state::{ChaosToken, InvestigatorId, LocationId};
+
+/// A single entry in the action log.
+///
+/// See the module docs for the rationale of the two-bucket split.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Action {
+    /// Action initiated by a human player.
+    Player(PlayerAction),
+    /// Action emitted by the engine itself, recording a system event or
+    /// random draw.
+    Engine(EngineRecord),
+}
+
+/// Input from a human player.
+///
+/// Phase-1 minimal set; later phases add `Investigate`, `Move`, `Fight`,
+/// `Evade`, `PlayCard`, `ActivateAbility`, etc.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum PlayerAction {
+    /// Begin a scenario session. Carries no payload at this stage; later
+    /// phases will attach scenario code, investigator selections, deck
+    /// snapshots, etc.
+    StartScenario,
+    /// Active investigator ends their turn during the Investigation phase.
+    EndTurn,
+    /// Respond to an `AwaitingInput` prompt the engine emitted. The
+    /// shape of `response` is dictated by the active prompt. (The
+    /// `EngineOutcome::AwaitingInput` variant lands in a later PR.)
+    ResolveInput {
+        /// The chosen response payload.
+        response: InputResponse,
+    },
+}
+
+/// Engine-recorded events.
+///
+/// Anything non-deterministic from the engine's perspective (RNG draws,
+/// timer-derived values) goes into the log as one of these variants so
+/// replay produces identical results.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum EngineRecord {
+    /// A chaos token was drawn from the bag.
+    ChaosTokenDrawn {
+        /// The token that was drawn.
+        token: ChaosToken,
+    },
+    /// A deck was shuffled with the given seed. Replays use the same seed
+    /// to reproduce the order.
+    DeckShuffled {
+        /// Seed used for the shuffle.
+        seed: u64,
+    },
+}
+
+/// The shape of a response to an `AwaitingInput` prompt.
+///
+/// Phase-1 minimal set; later phases add target lists, card commits,
+/// multi-target picks, etc. (The `EngineOutcome::AwaitingInput` variant
+/// lands in a later PR.)
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum InputResponse {
+    /// Confirm / yes / proceed with the prompted action.
+    Confirm,
+    /// Decline / skip the prompted optional action.
+    Skip,
+    /// Pick the option at the given zero-based index from the prompt's
+    /// option list.
+    PickIndex(usize),
+    /// Pick a specific investigator.
+    PickInvestigator(InvestigatorId),
+    /// Pick a specific location.
+    PickLocation(LocationId),
+}

--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -5,10 +5,10 @@
 //! state. There are two kinds of actions, distinguished by who or what
 //! initiated them:
 //!
-//! - [`Action::Player`] wraps a [`PlayerAction`] — input from a human via
-//!   the websocket. Submitting a player action is the only thing a client
-//!   can do; the wire protocol parses incoming messages as `PlayerAction`,
-//!   so a client cannot fabricate engine-only events.
+//! - [`Action::Player`] wraps a [`PlayerAction`] — input crossing the
+//!   transport boundary from a client. The wire layer parses incoming
+//!   messages as `PlayerAction`, so a client cannot fabricate
+//!   engine-only events.
 //! - [`Action::Engine`] wraps an [`EngineRecord`] — recorded output of
 //!   engine-side randomness or system events (chaos token draws, deck
 //!   shuffles). The engine generates these itself so the action log is
@@ -22,6 +22,7 @@ use crate::state::{ChaosToken, InvestigatorId, LocationId};
 ///
 /// See the module docs for the rationale of the two-bucket split.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum Action {
     /// Action initiated by a human player.
     Player(PlayerAction),
@@ -35,6 +36,7 @@ pub enum Action {
 /// Phase-1 minimal set; later phases add `Investigate`, `Move`, `Fight`,
 /// `Evade`, `PlayCard`, `ActivateAbility`, etc.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum PlayerAction {
     /// Begin a scenario session. Carries no payload at this stage; later
     /// phases will attach scenario code, investigator selections, deck
@@ -57,6 +59,7 @@ pub enum PlayerAction {
 /// timer-derived values) goes into the log as one of these variants so
 /// replay produces identical results.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum EngineRecord {
     /// A chaos token was drawn from the bag.
     ChaosTokenDrawn {
@@ -65,6 +68,11 @@ pub enum EngineRecord {
     },
     /// A deck was shuffled with the given seed. Replays use the same seed
     /// to reproduce the order.
+    //
+    // TODO(#15): once there are multiple decks (encounter deck, each
+    // investigator's deck, act/agenda decks), this needs a `deck:
+    // DeckId` field to disambiguate. Punted to the apply-loop PR where
+    // DeckId will be defined.
     DeckShuffled {
         /// Seed used for the shuffle.
         seed: u64,
@@ -77,14 +85,16 @@ pub enum EngineRecord {
 /// multi-target picks, etc. (The `EngineOutcome::AwaitingInput` variant
 /// lands in a later PR.)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum InputResponse {
     /// Confirm / yes / proceed with the prompted action.
     Confirm,
     /// Decline / skip the prompted optional action.
     Skip,
     /// Pick the option at the given zero-based index from the prompt's
-    /// option list.
-    PickIndex(usize),
+    /// option list. `u32` rather than `usize` for a stable wire format
+    /// independent of host pointer width.
+    PickIndex(u32),
     /// Pick a specific investigator.
     PickInvestigator(InvestigatorId),
     /// Pick a specific location.

--- a/crates/game-core/src/event.rs
+++ b/crates/game-core/src/event.rs
@@ -1,0 +1,93 @@
+//! Events: state-change records emitted as actions resolve.
+//!
+//! When the engine applies an [`Action`], it produces a sequence of
+//! [`Event`] values describing what changed. Events flow back to clients
+//! over the websocket (clients update their local view by replaying
+//! them) and are the substrate that triggered card abilities listen to.
+//!
+//! Events are NOT the source of truth for state — that's the action log.
+//! Events are derived from action application and are useful as a
+//! denormalized "what happened" stream.
+//!
+//! [`Action`]: crate::Action
+
+use serde::{Deserialize, Serialize};
+
+use crate::state::{ChaosToken, InvestigatorId, LocationId, Phase};
+
+/// One state-change record emitted by the engine.
+///
+/// Phase-1 minimal set. Later phases add events for skill-test
+/// commits, card plays, ability triggers, encounter draws, doom changes,
+/// trauma, scenario resolution, etc.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Event {
+    /// A scenario session has begun.
+    ScenarioStarted,
+    /// A new phase began.
+    PhaseStarted {
+        /// The phase that just started.
+        phase: Phase,
+    },
+    /// A phase ended.
+    PhaseEnded {
+        /// The phase that just ended.
+        phase: Phase,
+    },
+    /// An investigator's turn ended (Investigation phase).
+    TurnEnded {
+        /// Whose turn it was.
+        investigator: InvestigatorId,
+    },
+    /// An investigator's action point count changed.
+    ActionsRemainingChanged {
+        /// Whose action count changed.
+        investigator: InvestigatorId,
+        /// New count.
+        new_count: u8,
+    },
+    /// An investigator moved between locations.
+    InvestigatorMoved {
+        /// Who moved.
+        investigator: InvestigatorId,
+        /// Origin location.
+        from: LocationId,
+        /// Destination location.
+        to: LocationId,
+    },
+    /// A chaos token was revealed during a skill test.
+    ChaosTokenRevealed {
+        /// The token revealed.
+        token: ChaosToken,
+        /// Numeric modifier applied to the test's skill total.
+        modifier: i8,
+    },
+    /// One or more clues moved to an investigator.
+    CluePlaced {
+        /// Who received the clues.
+        investigator: InvestigatorId,
+        /// Number of clues placed.
+        count: u8,
+    },
+    /// A location's clue count changed.
+    LocationCluesChanged {
+        /// The location.
+        location: LocationId,
+        /// New clue count.
+        new_count: u8,
+    },
+    /// An investigator suffered physical damage.
+    DamageTaken {
+        /// Who was damaged.
+        investigator: InvestigatorId,
+        /// Amount of damage.
+        amount: u8,
+    },
+    /// An investigator suffered horror.
+    HorrorTaken {
+        /// Who took horror.
+        investigator: InvestigatorId,
+        /// Amount of horror.
+        amount: u8,
+    },
+}

--- a/crates/game-core/src/event.rs
+++ b/crates/game-core/src/event.rs
@@ -21,6 +21,7 @@ use crate::state::{ChaosToken, InvestigatorId, LocationId, Phase};
 /// commits, card plays, ability triggers, encounter draws, doom changes,
 /// trauma, scenario resolution, etc.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum Event {
     /// A scenario session has begun.
     ScenarioStarted,

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -4,3 +4,25 @@
 //! and event types, the apply loop, and the effect system. It has no I/O and
 //! no async; everything here is pure and deterministic, so the same code
 //! compiles to native (server) and `wasm32` (client).
+//!
+//! # Layout
+//!
+//! - [`state`] — pure data: [`GameState`] and the entities it contains.
+//! - [`action`] — the [`Action`] enum (the alphabet of the action log),
+//!   split into [`PlayerAction`] (human input) and [`EngineRecord`]
+//!   (engine-recorded RNG and system events).
+//! - [`event`] — the [`Event`] enum (state-change records emitted by the
+//!   engine as actions resolve).
+//!
+//! Subsequent PRs add the apply loop, RNG, phase machine, and test harness.
+
+pub mod action;
+pub mod event;
+pub mod state;
+
+pub use action::{Action, EngineRecord, InputResponse, PlayerAction};
+pub use event::Event;
+pub use state::{
+    ChaosBag, ChaosToken, GameState, Investigator, InvestigatorId, Location, LocationId, Phase,
+    Skills,
+};

--- a/crates/game-core/src/state/chaos_bag.rs
+++ b/crates/game-core/src/state/chaos_bag.rs
@@ -1,0 +1,64 @@
+//! The chaos bag: pool of tokens drawn during skill tests.
+
+use serde::{Deserialize, Serialize};
+
+/// One token in the chaos bag.
+///
+/// Tokens are drawn during skill tests; each token's modifier (positive or
+/// negative) is added to the test's skill total. Symbol tokens
+/// ([`Skull`], [`Cultist`], [`Tablet`], [`ElderThing`]) have scenario- or
+/// effect-specific modifiers that are resolved by separate logic, not by
+/// this enum directly.
+///
+/// [`Skull`]: ChaosToken::Skull
+/// [`Cultist`]: ChaosToken::Cultist
+/// [`Tablet`]: ChaosToken::Tablet
+/// [`ElderThing`]: ChaosToken::ElderThing
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ChaosToken {
+    /// Numeric modifier token (+1, 0, −1, …, −8). The wrapped value is the
+    /// modifier applied to the test's skill total when drawn.
+    Numeric(i8),
+    /// Skull symbol — modifier set per scenario, often `−1` to `−4`.
+    Skull,
+    /// Cultist symbol — scenario-specific effect.
+    Cultist,
+    /// Tablet symbol — scenario-specific effect.
+    Tablet,
+    /// Elder Thing symbol — scenario-specific effect.
+    ElderThing,
+    /// Auto-fail. Test fails regardless of skill total.
+    AutoFail,
+    /// Elder Sign. Investigator's own elder-sign ability triggers.
+    ElderSign,
+}
+
+/// The pool of chaos tokens for the current scenario.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChaosBag {
+    /// Tokens currently in the bag. Order is not significant; the engine
+    /// draws via the deterministic RNG, not list position.
+    pub tokens: Vec<ChaosToken>,
+}
+
+impl ChaosBag {
+    /// Build a chaos bag from an iterator of tokens.
+    #[must_use]
+    pub fn new(tokens: impl IntoIterator<Item = ChaosToken>) -> Self {
+        Self {
+            tokens: tokens.into_iter().collect(),
+        }
+    }
+
+    /// Number of tokens currently in the bag.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.tokens.len()
+    }
+
+    /// True if the bag has no tokens (e.g. all temporarily set aside).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.tokens.is_empty()
+    }
+}

--- a/crates/game-core/src/state/chaos_bag.rs
+++ b/crates/game-core/src/state/chaos_bag.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 /// [`Tablet`]: ChaosToken::Tablet
 /// [`ElderThing`]: ChaosToken::ElderThing
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum ChaosToken {
     /// Numeric modifier token (+1, 0, −1, …, −8). The wrapped value is the
     /// modifier applied to the test's skill total when drawn.
@@ -35,6 +36,7 @@ pub enum ChaosToken {
 
 /// The pool of chaos tokens for the current scenario.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ChaosBag {
     /// Tokens currently in the bag. Order is not significant; the engine
     /// draws via the deterministic RNG, not list position.
@@ -48,17 +50,5 @@ impl ChaosBag {
         Self {
             tokens: tokens.into_iter().collect(),
         }
-    }
-
-    /// Number of tokens currently in the bag.
-    #[must_use]
-    pub fn len(&self) -> usize {
-        self.tokens.len()
-    }
-
-    /// True if the bag has no tokens (e.g. all temporarily set aside).
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.tokens.is_empty()
     }
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -18,6 +18,7 @@ use super::{
 /// Phase-1 minimal shape; later phases will add e.g. encounter deck,
 /// act/agenda decks, doom track, persistent campaign-log facts, etc.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct GameState {
     /// All investigators currently in the scenario.
     pub investigators: Vec<Investigator>,

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -1,0 +1,37 @@
+//! Top-level game state.
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    chaos_bag::ChaosBag,
+    investigator::{Investigator, InvestigatorId},
+    location::Location,
+    phase::Phase,
+};
+
+/// The full state of a scenario at a single point in time.
+///
+/// `GameState` is the world the engine mutates by applying actions.
+/// In the event-sourced model, the canonical state is *derived* by
+/// replaying the action log; `GameState` is the materialized cache.
+///
+/// Phase-1 minimal shape; later phases will add e.g. encounter deck,
+/// act/agenda decks, doom track, persistent campaign-log facts, etc.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GameState {
+    /// All investigators currently in the scenario.
+    pub investigators: Vec<Investigator>,
+    /// All locations laid out (revealed and unrevealed alike).
+    pub locations: Vec<Location>,
+    /// The chaos bag at this scenario's difficulty.
+    pub chaos_bag: ChaosBag,
+    /// Current round phase.
+    pub phase: Phase,
+    /// 1-based round counter, incremented on each Mythos phase entry.
+    pub round: u32,
+    /// Whose turn it is during the [`Investigation`] phase, if any.
+    /// `None` outside of Investigation.
+    ///
+    /// [`Investigation`]: Phase::Investigation
+    pub active_investigator: Option<InvestigatorId>,
+}

--- a/crates/game-core/src/state/investigator.rs
+++ b/crates/game-core/src/state/investigator.rs
@@ -13,23 +13,32 @@ pub struct InvestigatorId(pub u32);
 /// Phase-1 minimal shape; fields will grow as later phases need them
 /// (mental/physical trauma carried in from the campaign log, traits,
 /// passive ability flags, etc.).
+///
+/// # Invariants
+///
+/// `damage <= max_health` and `horror <= max_sanity` are enforced by the
+/// apply loop, not by the type system. Constructing an `Investigator`
+/// with damage exceeding max-health is a bug, not a defeat.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Investigator {
     /// Stable identifier within this scenario.
     pub id: InvestigatorId,
     /// Display name.
     pub name: String,
-    /// Location the investigator is currently at.
-    pub current_location: LocationId,
+    /// Location the investigator is currently at, or `None` if they are
+    /// "between locations" (resigned, defeated, or in scenario setup
+    /// before initial placement).
+    pub current_location: Option<LocationId>,
     /// Skill values.
     pub skills: Skills,
     /// Maximum health (physical hit points).
     pub max_health: u8,
-    /// Current physical damage suffered.
+    /// Current physical damage suffered. Invariant: `<= max_health`.
     pub damage: u8,
     /// Maximum sanity.
     pub max_sanity: u8,
-    /// Current horror suffered.
+    /// Current horror suffered. Invariant: `<= max_sanity`.
     pub horror: u8,
     /// Clues currently held by the investigator.
     pub clues: u8,

--- a/crates/game-core/src/state/investigator.rs
+++ b/crates/game-core/src/state/investigator.rs
@@ -1,0 +1,54 @@
+//! Investigators: the players' avatars in the game.
+
+use serde::{Deserialize, Serialize};
+
+use super::location::LocationId;
+
+/// Stable identifier for an investigator within a scenario.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct InvestigatorId(pub u32);
+
+/// An investigator's full state during a scenario.
+///
+/// Phase-1 minimal shape; fields will grow as later phases need them
+/// (mental/physical trauma carried in from the campaign log, traits,
+/// passive ability flags, etc.).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Investigator {
+    /// Stable identifier within this scenario.
+    pub id: InvestigatorId,
+    /// Display name.
+    pub name: String,
+    /// Location the investigator is currently at.
+    pub current_location: LocationId,
+    /// Skill values.
+    pub skills: Skills,
+    /// Maximum health (physical hit points).
+    pub max_health: u8,
+    /// Current physical damage suffered.
+    pub damage: u8,
+    /// Maximum sanity.
+    pub max_sanity: u8,
+    /// Current horror suffered.
+    pub horror: u8,
+    /// Clues currently held by the investigator.
+    pub clues: u8,
+    /// Resources currently held.
+    pub resources: u8,
+    /// Action points remaining this turn (refreshed at the start of each
+    /// investigation phase).
+    pub actions_remaining: u8,
+}
+
+/// The four base skill values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Skills {
+    /// Used for tests against effects of the will / fear.
+    pub willpower: i8,
+    /// Used for investigate tests.
+    pub intellect: i8,
+    /// Used for fight tests.
+    pub combat: i8,
+    /// Used for evade tests.
+    pub agility: i8,
+}

--- a/crates/game-core/src/state/investigator.rs
+++ b/crates/game-core/src/state/investigator.rs
@@ -50,6 +50,10 @@ pub struct Investigator {
 }
 
 /// The four base skill values.
+///
+/// Deliberately NOT `#[non_exhaustive]`: the four skills are fixed by
+/// FFG's rules. Card effects modify these values at query time; they
+/// don't add new fields.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Skills {
     /// Used for tests against effects of the will / fear.

--- a/crates/game-core/src/state/location.rs
+++ b/crates/game-core/src/state/location.rs
@@ -1,0 +1,29 @@
+//! Locations: places investigators move between.
+
+use serde::{Deserialize, Serialize};
+
+/// Stable identifier for a location within a scenario.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct LocationId(pub u32);
+
+/// A location in the current scenario.
+///
+/// Phase-1 minimal shape; later phases will add e.g. encounter-set
+/// affiliation, victory points, location-specific effects, and
+/// hidden-information state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Location {
+    /// Stable identifier within this scenario.
+    pub id: LocationId,
+    /// Display name.
+    pub name: String,
+    /// Difficulty modifier added to investigate tests at this location.
+    pub shroud: u8,
+    /// Clues currently on the location.
+    pub clues: u8,
+    /// Whether the location is face-up. Unrevealed locations show only
+    /// their "back" name and aren't yet investigatable.
+    pub revealed: bool,
+    /// Locations physically connected to this one (movement targets).
+    pub connections: Vec<LocationId>,
+}

--- a/crates/game-core/src/state/location.rs
+++ b/crates/game-core/src/state/location.rs
@@ -12,6 +12,7 @@ pub struct LocationId(pub u32);
 /// affiliation, victory points, location-specific effects, and
 /// hidden-information state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Location {
     /// Stable identifier within this scenario.
     pub id: LocationId,

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -1,0 +1,18 @@
+//! Game state types.
+//!
+//! The engine's data model: top-level [`GameState`] plus the entities it
+//! contains ([`Investigator`], [`Location`], [`ChaosBag`], [`Phase`]).
+//! These are pure data with no engine logic — they describe the world,
+//! they don't run the game.
+
+pub mod chaos_bag;
+pub mod game_state;
+pub mod investigator;
+pub mod location;
+pub mod phase;
+
+pub use chaos_bag::{ChaosBag, ChaosToken};
+pub use game_state::GameState;
+pub use investigator::{Investigator, InvestigatorId, Skills};
+pub use location::{Location, LocationId};
+pub use phase::Phase;

--- a/crates/game-core/src/state/phase.rs
+++ b/crates/game-core/src/state/phase.rs
@@ -6,6 +6,11 @@ use serde::{Deserialize, Serialize};
 ///
 /// Phases cycle in order: [`Mythos`] → [`Investigation`] → [`Enemy`] → [`Upkeep`] → [`Mythos`]…
 ///
+/// Deliberately NOT `#[non_exhaustive]`: the four phases are fixed by FFG's
+/// rules, not an open extension point. Scenario-specific timing
+/// (interludes, special encounter windows) is modeled with special rules,
+/// not by adding new phase variants.
+///
 /// [`Mythos`]: Phase::Mythos
 /// [`Investigation`]: Phase::Investigation
 /// [`Enemy`]: Phase::Enemy

--- a/crates/game-core/src/state/phase.rs
+++ b/crates/game-core/src/state/phase.rs
@@ -1,0 +1,55 @@
+//! Game phases.
+
+use serde::{Deserialize, Serialize};
+
+/// One of the four phases in an Arkham Horror round.
+///
+/// Phases cycle in order: [`Mythos`] → [`Investigation`] → [`Enemy`] → [`Upkeep`] → [`Mythos`]…
+///
+/// [`Mythos`]: Phase::Mythos
+/// [`Investigation`]: Phase::Investigation
+/// [`Enemy`]: Phase::Enemy
+/// [`Upkeep`]: Phase::Upkeep
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Phase {
+    /// Encounter cards drawn, doom advances.
+    Mythos,
+    /// Investigators take turns, spending action points.
+    Investigation,
+    /// Engaged enemies attack; investigators may resolve hunter movement.
+    Enemy,
+    /// Cards ready, hand size adjusted, agenda/act effects.
+    Upkeep,
+}
+
+impl Phase {
+    /// The phase that follows this one in normal round order.
+    #[must_use]
+    pub const fn next(self) -> Self {
+        match self {
+            Self::Mythos => Self::Investigation,
+            Self::Investigation => Self::Enemy,
+            Self::Enemy => Self::Upkeep,
+            Self::Upkeep => Self::Mythos,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Phase;
+
+    #[test]
+    fn phases_cycle_in_round_order() {
+        let mut p = Phase::Mythos;
+        for expected in [
+            Phase::Investigation,
+            Phase::Enemy,
+            Phase::Upkeep,
+            Phase::Mythos,
+        ] {
+            p = p.next();
+            assert_eq!(p, expected);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

First foundational engine PR — pure data, no logic yet. Defines the alphabet every later piece of the engine speaks: state structs, the `Action` enum, the `Event` enum, and ID newtypes.

## What changed

**State module** (`crates/game-core/src/state/`):
- `GameState` — top-level world (investigators, locations, chaos bag, phase, round, active investigator).
- `Investigator` + `InvestigatorId` + `Skills`.
- `Location` + `LocationId`.
- `ChaosBag` + `ChaosToken`.
- `Phase` (with `.next()` cycling Mythos → Investigation → Enemy → Upkeep → Mythos).

**`Action` enum** (`crates/game-core/src/action.rs`) — two-bucket nested, per the design we agreed on:
- `Action::Player(PlayerAction)` — human input from a client (`StartScenario`, `EndTurn`, `ResolveInput { response }`).
- `Action::Engine(EngineRecord)` — engine-recorded RNG / system events (`ChaosTokenDrawn { token }`, `DeckShuffled { seed }`).
- The split gives boundary validation for free: the wire layer parses incoming messages as `PlayerAction`, so a client physically cannot fabricate engine events.

**`Event` enum** (`crates/game-core/src/event.rs`) — state-change records emitted as actions resolve. Phase-1 minimal set; later phases extend it.

**ID newtypes** — `InvestigatorId(u32)` and `LocationId(u32)` catch type-mismatches at compile time.

**Serde derives** — every public type derives `Serialize`/`Deserialize` from the start so the action log can persist in Phase 5 without retrofit pain. `serde` added as a dependency to `game-core` (`derive` feature only).

## Test notes

- `cargo test -p game-core` — 1 test (`phases_cycle_in_round_order`).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps --all-features` — clean.

Subsequent PRs add the apply loop (#15), RNG (#16), phase machine + action points (#17), and the test harness (#18, #19, #20).

## Linked issues

Closes #14