### PR TITLE
infra: auto-merge Dependabot patch + minor PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Auto-merge only patch and minor updates. Major bumps stay manual
+      # because of potential breaking changes; we want eyes on them.
+      - name: Enable auto-merge for patch + minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary

Adds a workflow that auto-merges Dependabot patch and minor updates so they don't pile up. Major bumps stay manual.

## What changed

- New \`.github/workflows/dependabot-auto-merge.yml\`.
- Uses \`dependabot/fetch-metadata@v2\` to read the update-type.
- Calls \`gh pr merge --auto --squash\` for any update-type that isn't \`version-update:semver-major\`.

## Test notes

The workflow only triggers on \`pull_request_target\` events from \`dependabot[bot]\`. Auto-merge respects branch protection, so the merge only fires after CI passes — the safety net is unchanged.

We'll see this in action the next time Dependabot opens a patch/minor PR. Major bumps (like the leptos 0.7 → 0.8 we just merged) will continue to wait for manual review.

## Linked issues

Closes #22