### PR TITLE
engine: add apply loop + EngineOutcome

### DIFF
--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -10,7 +10,7 @@
 
 use crate::action::{EngineRecord, PlayerAction};
 use crate::event::Event;
-use crate::state::GameState;
+use crate::state::{GameState, Phase};
 
 use super::outcome::EngineOutcome;
 
@@ -29,8 +29,8 @@ pub fn apply_player_action(
         PlayerAction::StartScenario => start_scenario(state, events),
         PlayerAction::EndTurn => end_turn(state, events),
         PlayerAction::ResolveInput { .. } => EngineOutcome::Rejected {
-            reason: "TODO(phase-1): ResolveInput dispatch lands with the test \
-                     harness in PRs #18-#20; no AwaitingInput sites exist yet."
+            reason: "TODO(#18-#20): ResolveInput dispatch lands with the test \
+                     harness; no AwaitingInput sites exist yet."
                 .into(),
         },
     }
@@ -60,31 +60,42 @@ pub fn apply_engine_record(
 }
 
 fn start_scenario(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome {
-    // For Phase 1 the GameState constructor places the world in its
-    // initial shape; this action is the explicit "session has begun"
-    // marker that lands in the action log. It also sets the round
-    // counter to 1 if it isn't already, in case the constructor left it
-    // at zero for a default-built state.
-    if state.round == 0 {
-        state.round = 1;
+    // The GameState constructor places the world in its initial shape;
+    // this action is the explicit "session has begun" marker that lands
+    // in the action log. Replaying it on an already-started state is a
+    // bug, not a no-op — reject so callers notice rather than silently
+    // double-emitting `ScenarioStarted`.
+    if state.round != 0 {
+        return EngineOutcome::Rejected {
+            reason: "StartScenario applied to a state that is already in progress".into(),
+        };
     }
+    state.round = 1;
     events.push(Event::ScenarioStarted);
     EngineOutcome::Done
 }
 
 fn end_turn(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome {
+    if state.phase != Phase::Investigation {
+        return EngineOutcome::Rejected {
+            reason: "EndTurn is only valid during the Investigation phase".into(),
+        };
+    }
     let Some(active_id) = state.active_investigator else {
         return EngineOutcome::Rejected {
-            reason: "EndTurn requires an active investigator (Investigation phase)".into(),
+            reason: "EndTurn requires an active investigator".into(),
         };
     };
-    let Some(active) = state.investigators.get_mut(&active_id) else {
-        return EngineOutcome::Rejected {
-            reason: format!(
-                "EndTurn: active investigator {active_id:?} is not in the investigators map"
-            ),
-        };
-    };
+    // The Some(active_investigator) invariant is paired with that ID
+    // existing in the investigators map; a missing entry would be state
+    // corruption, not a normal rejection. Surface it loudly rather than
+    // hiding behind Rejected.
+    let active = state.investigators.get_mut(&active_id).unwrap_or_else(|| {
+        unreachable!(
+            "active_investigator {active_id:?} is not in the investigators map; \
+                 this is a state-corruption invariant violation"
+        )
+    });
 
     // Drain remaining actions and announce the turn ended. The phase
     // machine + turn rotation lands in #17; for now EndTurn ends only

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -1,0 +1,103 @@
+//! Per-action dispatch handlers.
+//!
+//! Each function applies a single action variant to the state, mutating
+//! the state in place and pushing the resulting events onto the events
+//! buffer. Returns the [`EngineOutcome`] for the action.
+//!
+//! Handlers are split by `Action` bucket: [`apply_player_action`] for
+//! human-initiated actions, [`apply_engine_record`] for engine-emitted
+//! ones.
+
+use crate::action::{EngineRecord, PlayerAction};
+use crate::event::Event;
+use crate::state::GameState;
+
+use super::outcome::EngineOutcome;
+
+/// Apply a [`PlayerAction`] to the state, pushing events.
+///
+/// Phase-1 minimal coverage: [`StartScenario`](PlayerAction::StartScenario)
+/// and [`EndTurn`](PlayerAction::EndTurn) are implemented end-to-end;
+/// other variants return [`EngineOutcome::Rejected`] with a TODO message
+/// so callers and tests get a useful signal rather than a silent no-op.
+pub fn apply_player_action(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    action: &PlayerAction,
+) -> EngineOutcome {
+    match action {
+        PlayerAction::StartScenario => start_scenario(state, events),
+        PlayerAction::EndTurn => end_turn(state, events),
+        PlayerAction::ResolveInput { .. } => EngineOutcome::Rejected {
+            reason: "TODO(phase-1): ResolveInput dispatch lands with the test \
+                     harness in PRs #18-#20; no AwaitingInput sites exist yet."
+                .into(),
+        },
+    }
+}
+
+/// Apply an [`EngineRecord`] to the state, pushing events.
+///
+/// Phase-1: all variants return [`EngineOutcome::Rejected`] with a TODO
+/// message. Engine-recorded actions only flow once the RNG and skill-test
+/// machinery exist (issues #16, #3 in the plan).
+pub fn apply_engine_record(
+    _state: &mut GameState,
+    _events: &mut Vec<Event>,
+    record: &EngineRecord,
+) -> EngineOutcome {
+    let reason = match record {
+        EngineRecord::ChaosTokenDrawn { .. } => {
+            "TODO(#16): ChaosTokenDrawn dispatch lands with the deterministic RNG."
+        }
+        EngineRecord::DeckShuffled { .. } => {
+            "TODO(#16): DeckShuffled dispatch lands with the deterministic RNG."
+        }
+    };
+    EngineOutcome::Rejected {
+        reason: reason.into(),
+    }
+}
+
+fn start_scenario(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome {
+    // For Phase 1 the GameState constructor places the world in its
+    // initial shape; this action is the explicit "session has begun"
+    // marker that lands in the action log. It also sets the round
+    // counter to 1 if it isn't already, in case the constructor left it
+    // at zero for a default-built state.
+    if state.round == 0 {
+        state.round = 1;
+    }
+    events.push(Event::ScenarioStarted);
+    EngineOutcome::Done
+}
+
+fn end_turn(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome {
+    let Some(active_id) = state.active_investigator else {
+        return EngineOutcome::Rejected {
+            reason: "EndTurn requires an active investigator (Investigation phase)".into(),
+        };
+    };
+    let Some(active) = state.investigators.get_mut(&active_id) else {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "EndTurn: active investigator {active_id:?} is not in the investigators map"
+            ),
+        };
+    };
+
+    // Drain remaining actions and announce the turn ended. The phase
+    // machine + turn rotation lands in #17; for now EndTurn ends only
+    // the active investigator's turn without advancing phase.
+    if active.actions_remaining != 0 {
+        active.actions_remaining = 0;
+        events.push(Event::ActionsRemainingChanged {
+            investigator: active_id,
+            new_count: 0,
+        });
+    }
+    events.push(Event::TurnEnded {
+        investigator: active_id,
+    });
+    EngineOutcome::Done
+}

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -21,6 +21,7 @@ use crate::state::GameState;
 
 /// The result of a single [`apply`] call.
 #[derive(Debug, Clone)]
+#[must_use = "the post-apply GameState lives in ApplyResult.state; dropping the result drops the new state"]
 #[non_exhaustive]
 pub struct ApplyResult {
     /// The state after the action was applied. If the action was
@@ -41,7 +42,16 @@ pub struct ApplyResult {
 /// through here. It must be deterministic — same input state and
 /// action always produce the same output — so the action log replays
 /// cleanly.
-#[must_use]
+///
+/// # Handler contract
+///
+/// On [`EngineOutcome::Rejected`], the returned state and event list
+/// must be unchanged from the input. `apply` enforces this for the
+/// event list (it clears events post-dispatch on rejection) but **not**
+/// for state — handlers are expected to validate before mutating.
+/// TODO(#17+): once non-trivial handlers exist, refactor to a strict
+/// validate-first / apply-second two-phase shape so this is structural
+/// rather than a per-handler convention.
 pub fn apply(state: GameState, action: Action) -> ApplyResult {
     let mut state = state;
     let mut events = Vec::new();
@@ -50,9 +60,9 @@ pub fn apply(state: GameState, action: Action) -> ApplyResult {
         Action::Engine(e) => dispatch::apply_engine_record(&mut state, &mut events, &e),
     };
     if matches!(outcome, EngineOutcome::Rejected { .. }) {
-        // Rejected actions don't mutate state or emit events; if any
-        // dispatch handler accidentally pushed something before
-        // bailing, drop it to keep the contract clean.
+        // Belt-and-suspenders: handlers are expected to validate before
+        // mutating, so events should already be empty here. Clear
+        // anyway in case a handler accidentally pushed before bailing.
         events.clear();
     }
     ApplyResult {
@@ -116,22 +126,30 @@ mod tests {
     }
 
     #[test]
-    fn start_scenario_leaves_already_set_round_alone() {
+    fn start_scenario_on_already_started_state_is_rejected() {
         let mut state = empty_state();
         state.round = 7;
         let result = apply(state, Action::Player(PlayerAction::StartScenario));
 
-        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
         assert_eq!(result.state.round, 7);
+        assert!(result.events.is_empty());
+    }
+
+    fn investigation_state_with_active(actions_remaining: u8) -> (GameState, InvestigatorId) {
+        let mut state = empty_state();
+        let id = InvestigatorId(1);
+        state
+            .investigators
+            .insert(id, investigator(1, actions_remaining));
+        state.active_investigator = Some(id);
+        state.phase = Phase::Investigation;
+        (state, id)
     }
 
     #[test]
     fn end_turn_drains_actions_and_emits_turn_ended() {
-        let mut state = empty_state();
-        let id = InvestigatorId(1);
-        state.investigators.insert(id, investigator(1, 3));
-        state.active_investigator = Some(id);
-        state.phase = Phase::Investigation;
+        let (state, id) = investigation_state_with_active(3);
 
         let result = apply(state, Action::Player(PlayerAction::EndTurn));
 
@@ -151,7 +169,22 @@ mod tests {
 
     #[test]
     fn end_turn_with_no_active_investigator_is_rejected() {
-        let state = empty_state();
+        let mut state = empty_state();
+        state.phase = Phase::Investigation;
+
+        let result = apply(state, Action::Player(PlayerAction::EndTurn));
+
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn end_turn_outside_investigation_phase_is_rejected() {
+        let mut state = empty_state();
+        let id = InvestigatorId(1);
+        state.investigators.insert(id, investigator(1, 3));
+        state.active_investigator = Some(id);
+        state.phase = Phase::Mythos;
 
         let result = apply(state, Action::Player(PlayerAction::EndTurn));
 
@@ -181,7 +214,7 @@ mod tests {
     }
 
     #[test]
-    fn engine_record_actions_are_rejected_phase_one() {
+    fn chaos_token_drawn_engine_record_is_rejected_phase_one() {
         let state = empty_state();
         let result = apply(
             state,
@@ -190,5 +223,17 @@ mod tests {
             }),
         );
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn deck_shuffled_engine_record_is_rejected_phase_one() {
+        let state = empty_state();
+        let result = apply(
+            state,
+            Action::Engine(EngineRecord::DeckShuffled { seed: 42 }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
     }
 }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -1,0 +1,194 @@
+//! The engine: applies actions to game state, emits events.
+//!
+//! The central function here is [`apply`], which takes the current
+//! state plus an [`Action`] and returns an [`ApplyResult`] containing
+//! the new state, the events emitted, and an [`EngineOutcome`]
+//! summarizing what happened.
+//!
+//! State changes happen exclusively through this function. The action
+//! log persisted by the server is a flat sequence of [`Action`]s;
+//! replaying it via [`apply`] from the initial state reproduces the
+//! current state bit-for-bit.
+
+mod dispatch;
+mod outcome;
+
+pub use outcome::{EngineOutcome, InputRequest, ResumeToken};
+
+use crate::action::Action;
+use crate::event::Event;
+use crate::state::GameState;
+
+/// The result of a single [`apply`] call.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ApplyResult {
+    /// The state after the action was applied. If the action was
+    /// rejected, this is unchanged from the input state.
+    pub state: GameState,
+    /// Events emitted by the action's resolution. Empty if rejected.
+    pub events: Vec<Event>,
+    /// The terminal outcome of this apply call.
+    pub outcome: EngineOutcome,
+}
+
+/// Apply a single action to the state.
+///
+/// Returns an [`ApplyResult`] containing the new state, events emitted,
+/// and an [`EngineOutcome`] summarizing the result.
+///
+/// `apply` is the only entry point for state mutation; all changes flow
+/// through here. It must be deterministic — same input state and
+/// action always produce the same output — so the action log replays
+/// cleanly.
+#[must_use]
+pub fn apply(state: GameState, action: Action) -> ApplyResult {
+    let mut state = state;
+    let mut events = Vec::new();
+    let outcome = match action {
+        Action::Player(p) => dispatch::apply_player_action(&mut state, &mut events, &p),
+        Action::Engine(e) => dispatch::apply_engine_record(&mut state, &mut events, &e),
+    };
+    if matches!(outcome, EngineOutcome::Rejected { .. }) {
+        // Rejected actions don't mutate state or emit events; if any
+        // dispatch handler accidentally pushed something before
+        // bailing, drop it to keep the contract clean.
+        events.clear();
+    }
+    ApplyResult {
+        state,
+        events,
+        outcome,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::action::{Action, EngineRecord, InputResponse, PlayerAction};
+    use crate::event::Event;
+    use crate::state::{ChaosBag, GameState, Investigator, InvestigatorId, Phase, Skills};
+
+    use super::{apply, EngineOutcome};
+
+    fn empty_state() -> GameState {
+        GameState {
+            investigators: BTreeMap::new(),
+            locations: BTreeMap::new(),
+            chaos_bag: ChaosBag::new([]),
+            phase: Phase::Mythos,
+            round: 0,
+            active_investigator: None,
+            turn_order: Vec::new(),
+        }
+    }
+
+    fn investigator(id: u32, actions_remaining: u8) -> Investigator {
+        Investigator {
+            id: InvestigatorId(id),
+            name: format!("Test Investigator {id}"),
+            current_location: None,
+            skills: Skills {
+                willpower: 3,
+                intellect: 3,
+                combat: 3,
+                agility: 3,
+            },
+            max_health: 8,
+            damage: 0,
+            max_sanity: 8,
+            horror: 0,
+            clues: 0,
+            resources: 5,
+            actions_remaining,
+        }
+    }
+
+    #[test]
+    fn start_scenario_emits_scenario_started_and_sets_round_to_one() {
+        let state = empty_state();
+        let result = apply(state, Action::Player(PlayerAction::StartScenario));
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_eq!(result.events, vec![Event::ScenarioStarted]);
+        assert_eq!(result.state.round, 1);
+    }
+
+    #[test]
+    fn start_scenario_leaves_already_set_round_alone() {
+        let mut state = empty_state();
+        state.round = 7;
+        let result = apply(state, Action::Player(PlayerAction::StartScenario));
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_eq!(result.state.round, 7);
+    }
+
+    #[test]
+    fn end_turn_drains_actions_and_emits_turn_ended() {
+        let mut state = empty_state();
+        let id = InvestigatorId(1);
+        state.investigators.insert(id, investigator(1, 3));
+        state.active_investigator = Some(id);
+        state.phase = Phase::Investigation;
+
+        let result = apply(state, Action::Player(PlayerAction::EndTurn));
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_eq!(
+            result.events,
+            vec![
+                Event::ActionsRemainingChanged {
+                    investigator: id,
+                    new_count: 0
+                },
+                Event::TurnEnded { investigator: id },
+            ]
+        );
+        assert_eq!(result.state.investigators[&id].actions_remaining, 0);
+    }
+
+    #[test]
+    fn end_turn_with_no_active_investigator_is_rejected() {
+        let state = empty_state();
+
+        let result = apply(state, Action::Player(PlayerAction::EndTurn));
+
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn rejected_actions_do_not_mutate_state() {
+        let state = empty_state();
+        let before = state.clone();
+        // ResolveInput is a Phase-1 stub — guaranteed to be Rejected.
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::Confirm,
+            }),
+        );
+
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert_eq!(result.events, Vec::<Event>::new());
+        // State equality requires a manual field check since GameState
+        // does not derive PartialEq (deliberately — it may be expensive).
+        assert_eq!(result.state.round, before.round);
+        assert_eq!(result.state.phase, before.phase);
+        assert_eq!(result.state.active_investigator, before.active_investigator);
+    }
+
+    #[test]
+    fn engine_record_actions_are_rejected_phase_one() {
+        let state = empty_state();
+        let result = apply(
+            state,
+            Action::Engine(EngineRecord::ChaosTokenDrawn {
+                token: crate::state::ChaosToken::Skull,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    }
+}

--- a/crates/game-core/src/engine/outcome.rs
+++ b/crates/game-core/src/engine/outcome.rs
@@ -1,5 +1,7 @@
 //! Outcome of a single [`apply`](super::apply) call.
 
+use std::borrow::Cow;
+
 use serde::{Deserialize, Serialize};
 
 /// The terminal status of an [`apply`](super::apply) call.
@@ -32,8 +34,10 @@ pub enum EngineOutcome {
     },
     /// Action was illegal; nothing changed.
     Rejected {
-        /// Human-readable reason for rejection.
-        reason: String,
+        /// Human-readable reason for rejection. `Cow` so static TODO
+        /// strings cost no allocation while dynamic ones (formatted with
+        /// runtime data) remain expressible.
+        reason: Cow<'static, str>,
     },
 }
 
@@ -52,8 +56,9 @@ pub struct InputRequest {
 ///
 /// The engine uses this to identify which choice point a
 /// [`ResolveInput`](crate::PlayerAction::ResolveInput) is answering.
-/// Treat as opaque outside the engine.
+/// The inner field is `pub(crate)` so external crates cannot fabricate
+/// tokens; they receive them from the engine and pass them back.
 ///
 /// [`AwaitingInput`]: EngineOutcome::AwaitingInput
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct ResumeToken(pub u64);
+pub struct ResumeToken(pub(crate) u64);

--- a/crates/game-core/src/engine/outcome.rs
+++ b/crates/game-core/src/engine/outcome.rs
@@ -1,0 +1,59 @@
+//! Outcome of a single [`apply`](super::apply) call.
+
+use serde::{Deserialize, Serialize};
+
+/// The terminal status of an [`apply`](super::apply) call.
+///
+/// After the engine finishes applying an action, it is in one of three
+/// states:
+///
+/// - [`Done`](EngineOutcome::Done) — the action resolved fully and the
+///   engine is ready for the next action.
+/// - [`AwaitingInput`](EngineOutcome::AwaitingInput) — the action
+///   triggered a choice point and needs the active player to respond
+///   before the engine can continue. The next action must be a
+///   [`PlayerAction::ResolveInput`](crate::PlayerAction::ResolveInput).
+/// - [`Rejected`](EngineOutcome::Rejected) — the action was illegal in
+///   the current state (e.g. trying to investigate during the Mythos
+///   phase) and was not applied. The state and event list returned
+///   alongside this outcome are unchanged from the input.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum EngineOutcome {
+    /// Action resolved fully; engine ready for next action.
+    Done,
+    /// Engine paused mid-resolution waiting for a player choice.
+    AwaitingInput {
+        /// Description of the prompt to show the player.
+        request: InputRequest,
+        /// Opaque token the engine uses to resume from this point when
+        /// the response arrives.
+        resume_token: ResumeToken,
+    },
+    /// Action was illegal; nothing changed.
+    Rejected {
+        /// Human-readable reason for rejection.
+        reason: String,
+    },
+}
+
+/// A prompt the engine emits when it needs player input.
+///
+/// Phase-1 minimal shape; later phases will add structured options,
+/// target lists, filters, etc.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct InputRequest {
+    /// Human-readable text describing what the player must choose.
+    pub prompt: String,
+}
+
+/// Opaque continuation token returned alongside [`AwaitingInput`].
+///
+/// The engine uses this to identify which choice point a
+/// [`ResolveInput`](crate::PlayerAction::ResolveInput) is answering.
+/// Treat as opaque outside the engine.
+///
+/// [`AwaitingInput`]: EngineOutcome::AwaitingInput
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ResumeToken(pub u64);

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -13,14 +13,17 @@
 //!   (engine-recorded RNG and system events).
 //! - [`event`] — the [`Event`] enum (state-change records emitted by the
 //!   engine as actions resolve).
+//! - [`engine`] — the [`apply`] loop and [`EngineOutcome`] terminal status.
 //!
-//! Subsequent PRs add the apply loop, RNG, phase machine, and test harness.
+//! Subsequent PRs add the RNG, phase machine, and test harness.
 
 pub mod action;
+pub mod engine;
 pub mod event;
 pub mod state;
 
 pub use action::{Action, EngineRecord, InputResponse, PlayerAction};
+pub use engine::{apply, ApplyResult, EngineOutcome, InputRequest, ResumeToken};
 pub use event::Event;
 pub use state::{
     ChaosBag, ChaosToken, GameState, Investigator, InvestigatorId, Location, LocationId, Phase,

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -1,11 +1,13 @@
 //! Top-level game state.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 use super::{
     chaos_bag::ChaosBag,
     investigator::{Investigator, InvestigatorId},
-    location::Location,
+    location::{Location, LocationId},
     phase::Phase,
 };
 
@@ -17,13 +19,20 @@ use super::{
 ///
 /// Phase-1 minimal shape; later phases will add e.g. encounter deck,
 /// act/agenda decks, doom track, persistent campaign-log facts, etc.
+///
+/// Investigators and locations are stored in [`BTreeMap`]s keyed by ID
+/// rather than [`Vec`]s. This makes iteration order deterministic
+/// (sorted by ID) regardless of insertion order — important for replay
+/// equality — and gives O(log n) lookup. Turn order is tracked
+/// separately in [`turn_order`](Self::turn_order); the storage map's
+/// iteration order is *not* turn order.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct GameState {
-    /// All investigators currently in the scenario.
-    pub investigators: Vec<Investigator>,
-    /// All locations laid out (revealed and unrevealed alike).
-    pub locations: Vec<Location>,
+    /// All investigators currently in the scenario, keyed by ID.
+    pub investigators: BTreeMap<InvestigatorId, Investigator>,
+    /// All locations laid out (revealed and unrevealed alike), keyed by ID.
+    pub locations: BTreeMap<LocationId, Location>,
     /// The chaos bag at this scenario's difficulty.
     pub chaos_bag: ChaosBag,
     /// Current round phase.
@@ -35,4 +44,8 @@ pub struct GameState {
     ///
     /// [`Investigation`]: Phase::Investigation
     pub active_investigator: Option<InvestigatorId>,
+    /// Order in which investigators take their turns during the
+    /// Investigation phase, as decided by the lead investigator each
+    /// round. The first entry is the first to act.
+    pub turn_order: Vec<InvestigatorId>,
 }


### PR DESCRIPTION
## Summary

Adds the central engine entry point — `apply(state, action) -> ApplyResult` — plus the `EngineOutcome` terminal status (`Done` / `AwaitingInput` / `Rejected`). Two `PlayerAction` variants (`StartScenario`, `EndTurn`) are implemented end-to-end; everything else returns `Rejected` with a TODO pointing to the issue that fills it in.

## What changed

**New `engine` module** (`crates/game-core/src/engine/`):
- `mod.rs` — `apply` function, `ApplyResult` struct.
- `outcome.rs` — `EngineOutcome`, `InputRequest`, `ResumeToken`.
- `dispatch.rs` — per-`Action`-variant handlers.

**`GameState` storage refactor** (resolving a deferral from #14):
- `investigators: Vec<Investigator>` → `BTreeMap<InvestigatorId, Investigator>`
- `locations: Vec<Location>` → `BTreeMap<LocationId, Location>`
- New field `turn_order: Vec<InvestigatorId>`

`BTreeMap` gives deterministic iteration order (by ID) regardless of insertion order — important for replay equality — plus O(log n) lookup. Turn order lives in its own field so the storage map is genuinely unordered storage.

**Implemented end-to-end:**
- `PlayerAction::StartScenario` — emits `ScenarioStarted`, bumps round 0 → 1.
- `PlayerAction::EndTurn` — drains active investigator's actions, emits `TurnEnded`. Phase rotation lands in #17.

**Stubbed (with `Rejected`):**
- `PlayerAction::ResolveInput` — TODO points to #18-#20 (test harness will surface real `AwaitingInput` sites).
- `EngineRecord::*` — TODO points to #16 (deterministic RNG).

**Contract:** rejected actions don't mutate state and emit no events. The dispatch caller clears any events that were pushed before a handler bailed, to keep this invariant clean.

## Test notes

7 tests in `crates/game-core/src/engine/mod.rs::tests`:
- `StartScenario` happy path + round-zero bump
- `StartScenario` doesn't overwrite a non-zero round
- `EndTurn` drains actions and emits the right events
- `EndTurn` without an active investigator is rejected
- Rejected actions don't mutate state
- `EngineRecord` variants are all rejected for now

`cargo test -p game-core` — 7 passed (was 1).
`cargo clippy --all-targets --all-features -- -D warnings` — clean.
`RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps --all-features` — clean.

## Linked issues

Closes #15