### PR TITLE
test: add TestGame builder + event assertion macros

### DIFF
--- a/crates/game-core/Cargo.toml
+++ b/crates/game-core/Cargo.toml
@@ -10,5 +10,11 @@ description = "Eldritch rules engine: game state, actions, events, effect system
 [lints]
 workspace = true
 
+[features]
+# Exposes the `test_support` module (TestGame builder, fixtures, event
+# assertion macros) for downstream crates' own tests. Always available
+# inside game-core's own test runs via `cfg(test)`.
+test-support = []
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -74,61 +74,28 @@ pub fn apply(state: GameState, action: Action) -> ApplyResult {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
     use crate::action::{Action, EngineRecord, InputResponse, PlayerAction};
     use crate::event::Event;
-    use crate::state::{ChaosBag, GameState, Investigator, InvestigatorId, Phase, Skills};
+    use crate::state::{ChaosToken, InvestigatorId, Phase};
+    use crate::test_support::{test_investigator, TestGame};
+    use crate::{assert_event, assert_event_count, assert_no_event};
 
     use super::{apply, EngineOutcome};
 
-    fn empty_state() -> GameState {
-        GameState {
-            investigators: BTreeMap::new(),
-            locations: BTreeMap::new(),
-            chaos_bag: ChaosBag::new([]),
-            phase: Phase::Mythos,
-            round: 0,
-            active_investigator: None,
-            turn_order: Vec::new(),
-        }
-    }
-
-    fn investigator(id: u32, actions_remaining: u8) -> Investigator {
-        Investigator {
-            id: InvestigatorId(id),
-            name: format!("Test Investigator {id}"),
-            current_location: None,
-            skills: Skills {
-                willpower: 3,
-                intellect: 3,
-                combat: 3,
-                agility: 3,
-            },
-            max_health: 8,
-            damage: 0,
-            max_sanity: 8,
-            horror: 0,
-            clues: 0,
-            resources: 5,
-            actions_remaining,
-        }
-    }
-
     #[test]
     fn start_scenario_emits_scenario_started_and_sets_round_to_one() {
-        let state = empty_state();
+        let state = TestGame::new().build();
         let result = apply(state, Action::Player(PlayerAction::StartScenario));
 
         assert_eq!(result.outcome, EngineOutcome::Done);
-        assert_eq!(result.events, vec![Event::ScenarioStarted]);
+        assert_event!(result.events, Event::ScenarioStarted);
+        assert_event_count!(result.events, 1, _);
         assert_eq!(result.state.round, 1);
     }
 
     #[test]
     fn start_scenario_on_already_started_state_is_rejected() {
-        let mut state = empty_state();
-        state.round = 7;
+        let state = TestGame::new().with_round(7).build();
         let result = apply(state, Action::Player(PlayerAction::StartScenario));
 
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
@@ -136,41 +103,34 @@ mod tests {
         assert!(result.events.is_empty());
     }
 
-    fn investigation_state_with_active(actions_remaining: u8) -> (GameState, InvestigatorId) {
-        let mut state = empty_state();
-        let id = InvestigatorId(1);
-        state
-            .investigators
-            .insert(id, investigator(1, actions_remaining));
-        state.active_investigator = Some(id);
-        state.phase = Phase::Investigation;
-        (state, id)
-    }
-
     #[test]
     fn end_turn_drains_actions_and_emits_turn_ended() {
-        let (state, id) = investigation_state_with_active(3);
+        let id = InvestigatorId(1);
+        let mut roland = test_investigator(1);
+        roland.actions_remaining = 3;
+        let state = TestGame::new()
+            .with_phase(Phase::Investigation)
+            .with_investigator(roland)
+            .with_active_investigator(id)
+            .build();
 
         let result = apply(state, Action::Player(PlayerAction::EndTurn));
 
         assert_eq!(result.outcome, EngineOutcome::Done);
-        assert_eq!(
+        assert_event!(
             result.events,
-            vec![
-                Event::ActionsRemainingChanged {
-                    investigator: id,
-                    new_count: 0
-                },
-                Event::TurnEnded { investigator: id },
-            ]
+            Event::ActionsRemainingChanged { investigator, new_count: 0 } if *investigator == id
+        );
+        assert_event!(
+            result.events,
+            Event::TurnEnded { investigator } if *investigator == id
         );
         assert_eq!(result.state.investigators[&id].actions_remaining, 0);
     }
 
     #[test]
     fn end_turn_with_no_active_investigator_is_rejected() {
-        let mut state = empty_state();
-        state.phase = Phase::Investigation;
+        let state = TestGame::new().with_phase(Phase::Investigation).build();
 
         let result = apply(state, Action::Player(PlayerAction::EndTurn));
 
@@ -180,11 +140,12 @@ mod tests {
 
     #[test]
     fn end_turn_outside_investigation_phase_is_rejected() {
-        let mut state = empty_state();
         let id = InvestigatorId(1);
-        state.investigators.insert(id, investigator(1, 3));
-        state.active_investigator = Some(id);
-        state.phase = Phase::Mythos;
+        let state = TestGame::new()
+            .with_phase(Phase::Mythos)
+            .with_investigator(test_investigator(1))
+            .with_active_investigator(id)
+            .build();
 
         let result = apply(state, Action::Player(PlayerAction::EndTurn));
 
@@ -194,8 +155,11 @@ mod tests {
 
     #[test]
     fn rejected_actions_do_not_mutate_state() {
-        let state = empty_state();
-        let before = state.clone();
+        let state = TestGame::new().build();
+        let round_before = state.round;
+        let phase_before = state.phase;
+        let active_before = state.active_investigator;
+
         // ResolveInput is a Phase-1 stub — guaranteed to be Rejected.
         let result = apply(
             state,
@@ -205,21 +169,19 @@ mod tests {
         );
 
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
-        assert_eq!(result.events, Vec::<Event>::new());
-        // State equality requires a manual field check since GameState
-        // does not derive PartialEq (deliberately — it may be expensive).
-        assert_eq!(result.state.round, before.round);
-        assert_eq!(result.state.phase, before.phase);
-        assert_eq!(result.state.active_investigator, before.active_investigator);
+        assert_no_event!(result.events, _);
+        assert_eq!(result.state.round, round_before);
+        assert_eq!(result.state.phase, phase_before);
+        assert_eq!(result.state.active_investigator, active_before);
     }
 
     #[test]
     fn chaos_token_drawn_engine_record_is_rejected_phase_one() {
-        let state = empty_state();
+        let state = TestGame::new().build();
         let result = apply(
             state,
             Action::Engine(EngineRecord::ChaosTokenDrawn {
-                token: crate::state::ChaosToken::Skull,
+                token: ChaosToken::Skull,
             }),
         );
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
@@ -228,7 +190,7 @@ mod tests {
 
     #[test]
     fn deck_shuffled_engine_record_is_rejected_phase_one() {
-        let state = empty_state();
+        let state = TestGame::new().build();
         let result = apply(
             state,
             Action::Engine(EngineRecord::DeckShuffled { seed: 42 }),

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -22,6 +22,9 @@ pub mod engine;
 pub mod event;
 pub mod state;
 
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;
+
 pub use action::{Action, EngineRecord, InputResponse, PlayerAction};
 pub use engine::{apply, ApplyResult, EngineOutcome, InputRequest, ResumeToken};
 pub use event::Event;

--- a/crates/game-core/src/test_support/assertions.rs
+++ b/crates/game-core/src/test_support/assertions.rs
@@ -1,0 +1,97 @@
+//! Order-insensitive event assertion macros.
+//!
+//! Tests assert on what happened, not on the order events fired in.
+//! The macros below take a slice or `Vec<Event>` as the first argument
+//! and a Rust pattern (with optional `if` guard) as the second; on
+//! failure they print the actual event list to make the mismatch
+//! obvious.
+//!
+//! # Examples
+//!
+//! ```
+//! use game_core::{
+//!     apply, Action, Event, InvestigatorId, PlayerAction, Phase,
+//!     assert_event, assert_no_event,
+//!     test_support::{test_investigator, TestGame},
+//! };
+//!
+//! let state = TestGame::new()
+//!     .with_phase(Phase::Investigation)
+//!     .with_investigator(test_investigator(1))
+//!     .with_active_investigator(InvestigatorId(1))
+//!     .build();
+//! let result = apply(state, Action::Player(PlayerAction::EndTurn));
+//!
+//! assert_event!(result.events, Event::TurnEnded { .. });
+//! assert_no_event!(result.events, Event::ScenarioStarted);
+//! ```
+
+/// Assert that at least one [`Event`](crate::Event) in the slice
+/// matches the given pattern (with optional guard).
+///
+/// On failure, panics with the pattern source plus a debug-printed
+/// list of actual events.
+#[macro_export]
+macro_rules! assert_event {
+    ($events:expr, $pat:pat $(if $guard:expr)?) => {{
+        let events = &$events;
+        let matched = events.iter().any(|e| matches!(e, $pat $(if $guard)?));
+        if !matched {
+            panic!(
+                "assert_event!: no event matching `{}` in:\n{:#?}",
+                stringify!($pat $(if $guard)?),
+                events,
+            );
+        }
+    }};
+}
+
+/// Assert that NO [`Event`](crate::Event) in the slice matches the
+/// given pattern (with optional guard).
+///
+/// On failure, panics with the pattern source plus a debug-printed
+/// list of actual events.
+#[macro_export]
+macro_rules! assert_no_event {
+    ($events:expr, $pat:pat $(if $guard:expr)?) => {{
+        let events = &$events;
+        let matched: Vec<&_> = events
+            .iter()
+            .filter(|e| matches!(e, $pat $(if $guard)?))
+            .collect();
+        if !matched.is_empty() {
+            panic!(
+                "assert_no_event!: expected no event matching `{}`, but found:\n{:#?}\nin full list:\n{:#?}",
+                stringify!($pat $(if $guard)?),
+                matched,
+                events,
+            );
+        }
+    }};
+}
+
+/// Assert that exactly `$count` [`Event`](crate::Event)s in the slice
+/// match the given pattern (with optional guard).
+///
+/// On failure, panics with the pattern source, the expected count, the
+/// actual count, and a debug-printed list of all events.
+#[macro_export]
+macro_rules! assert_event_count {
+    ($events:expr, $count:expr, $pat:pat $(if $guard:expr)?) => {{
+        let events = &$events;
+        let expected: usize = $count;
+        let actual = events
+            .iter()
+            .filter(|e| matches!(e, $pat $(if $guard)?))
+            .count();
+        if actual != expected {
+            panic!(
+                "assert_event_count!: expected {} events matching `{}`, found {}, in:\n{:#?}",
+                expected,
+                stringify!($pat $(if $guard)?),
+                actual,
+                events,
+            );
+        }
+    }};
+}

--- a/crates/game-core/src/test_support/assertions.rs
+++ b/crates/game-core/src/test_support/assertions.rs
@@ -6,6 +6,16 @@
 //! failure they print the actual event list to make the mismatch
 //! obvious.
 //!
+//! **When event order matters**, fall back to plain `assert_eq!` on the
+//! slice (e.g. `assert_eq!(result.events, vec![Event::A, Event::B])`).
+//! The macros here intentionally do not enforce ordering, because most
+//! tests are about the set of effects rather than their sequence.
+//!
+//! If `assert_eq!` ever becomes unwieldy (e.g. several tests want to
+//! assert "these N events appeared in this order, ignoring others
+//! interleaved between them"), we can add an `assert_event_sequence!`
+//! macro then. Don't add one preemptively.
+//!
 //! # Examples
 //!
 //! ```
@@ -35,7 +45,7 @@
 macro_rules! assert_event {
     ($events:expr, $pat:pat $(if $guard:expr)?) => {{
         let events = &$events;
-        let matched = events.iter().any(|e| matches!(e, $pat $(if $guard)?));
+        let matched = events.iter().any(|__event| matches!(__event, $pat $(if $guard)?));
         if !matched {
             panic!(
                 "assert_event!: no event matching `{}` in:\n{:#?}",
@@ -57,7 +67,7 @@ macro_rules! assert_no_event {
         let events = &$events;
         let matched: Vec<&_> = events
             .iter()
-            .filter(|e| matches!(e, $pat $(if $guard)?))
+            .filter(|__event| matches!(__event, $pat $(if $guard)?))
             .collect();
         if !matched.is_empty() {
             panic!(
@@ -82,7 +92,7 @@ macro_rules! assert_event_count {
         let expected: usize = $count;
         let actual = events
             .iter()
-            .filter(|e| matches!(e, $pat $(if $guard)?))
+            .filter(|__event| matches!(__event, $pat $(if $guard)?))
             .count();
         if actual != expected {
             panic!(

--- a/crates/game-core/src/test_support/builder.rs
+++ b/crates/game-core/src/test_support/builder.rs
@@ -1,0 +1,131 @@
+//! Fluent [`TestGame`] builder.
+//!
+//! The single most important piece of test infrastructure in the
+//! engine. Every card, scenario, and engine test that follows depends
+//! on this — if the API is awkward, every test pays the cost. Keep it
+//! ergonomic.
+//!
+//! # Example
+//!
+//! ```
+//! use game_core::{
+//!     apply, Action, PlayerAction, Phase, InvestigatorId,
+//!     test_support::{test_investigator, test_location, TestGame},
+//! };
+//!
+//! let state = TestGame::new()
+//!     .with_phase(Phase::Investigation)
+//!     .with_investigator(test_investigator(1))
+//!     .with_location(test_location(10, "Study"))
+//!     .with_active_investigator(InvestigatorId(1))
+//!     .build();
+//!
+//! let result = apply(state, Action::Player(PlayerAction::EndTurn));
+//! ```
+
+use std::collections::BTreeMap;
+
+use crate::state::{ChaosBag, GameState, Investigator, InvestigatorId, Location, Phase};
+
+/// Fluent builder for a [`GameState`].
+///
+/// Construct with [`TestGame::new`], chain `.with_*` setters and
+/// adders, then call [`build`](TestGame::build) to get a `GameState`
+/// ready for [`apply`](crate::apply).
+#[derive(Debug, Clone)]
+#[must_use = "TestGame is a builder; call .build() to produce a GameState"]
+pub struct TestGame {
+    investigators: BTreeMap<InvestigatorId, Investigator>,
+    locations: BTreeMap<crate::state::LocationId, Location>,
+    chaos_bag: ChaosBag,
+    phase: Phase,
+    round: u32,
+    active_investigator: Option<InvestigatorId>,
+    turn_order: Vec<InvestigatorId>,
+}
+
+impl TestGame {
+    /// Start a new builder with empty investigators / locations / chaos
+    /// bag, `Phase::Mythos`, round 0, no active investigator.
+    pub fn new() -> Self {
+        Self {
+            investigators: BTreeMap::new(),
+            locations: BTreeMap::new(),
+            chaos_bag: ChaosBag::new([]),
+            phase: Phase::Mythos,
+            round: 0,
+            active_investigator: None,
+            turn_order: Vec::new(),
+        }
+    }
+
+    /// Add an investigator to the state. Replaces any existing entry
+    /// with the same id.
+    pub fn with_investigator(mut self, investigator: Investigator) -> Self {
+        self.investigators.insert(investigator.id, investigator);
+        self
+    }
+
+    /// Add a location to the state. Replaces any existing entry with
+    /// the same id.
+    pub fn with_location(mut self, location: Location) -> Self {
+        self.locations.insert(location.id, location);
+        self
+    }
+
+    /// Set the chaos bag. Replaces any prior bag.
+    pub fn with_chaos_bag(mut self, chaos_bag: ChaosBag) -> Self {
+        self.chaos_bag = chaos_bag;
+        self
+    }
+
+    /// Set the current phase.
+    pub fn with_phase(mut self, phase: Phase) -> Self {
+        self.phase = phase;
+        self
+    }
+
+    /// Set the round counter.
+    pub fn with_round(mut self, round: u32) -> Self {
+        self.round = round;
+        self
+    }
+
+    /// Mark an investigator as the active one. The id must refer to an
+    /// investigator already added via [`with_investigator`]; this is
+    /// not enforced at build time but later [`apply`](crate::apply)
+    /// calls will surface state-corruption invariant violations
+    /// loudly.
+    ///
+    /// [`with_investigator`]: Self::with_investigator
+    pub fn with_active_investigator(mut self, id: InvestigatorId) -> Self {
+        self.active_investigator = Some(id);
+        self
+    }
+
+    /// Set the turn order (lead-investigator-decided sequence in which
+    /// investigators take their turns during the Investigation phase).
+    pub fn with_turn_order(mut self, order: impl IntoIterator<Item = InvestigatorId>) -> Self {
+        self.turn_order = order.into_iter().collect();
+        self
+    }
+
+    /// Materialize the configured [`GameState`].
+    pub fn build(self) -> GameState {
+        GameState {
+            investigators: self.investigators,
+            locations: self.locations,
+            chaos_bag: self.chaos_bag,
+            phase: self.phase,
+            round: self.round,
+            active_investigator: self.active_investigator,
+            turn_order: self.turn_order,
+        }
+    }
+}
+
+impl Default for TestGame {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -1,0 +1,54 @@
+//! Stock fixture constructors for tests.
+//!
+//! Tests constantly need a "reasonable" investigator or location to
+//! place into a state. These helpers produce one with default-y values;
+//! callers tweak fields after construction when something specific is
+//! needed.
+
+use crate::state::{Investigator, InvestigatorId, Location, LocationId, Skills};
+
+/// A stock investigator with reasonable defaults.
+///
+/// - 3/3/3/3 skills, 8 health, 8 sanity, no damage or horror.
+/// - 5 starting resources, 0 clues.
+/// - 3 actions remaining.
+/// - Not placed at any location (`current_location: None`).
+///
+/// Mutate fields directly after construction to customize.
+#[must_use]
+pub fn test_investigator(id: u32) -> Investigator {
+    Investigator {
+        id: InvestigatorId(id),
+        name: format!("Test Investigator {id}"),
+        current_location: None,
+        skills: Skills {
+            willpower: 3,
+            intellect: 3,
+            combat: 3,
+            agility: 3,
+        },
+        max_health: 8,
+        damage: 0,
+        max_sanity: 8,
+        horror: 0,
+        clues: 0,
+        resources: 5,
+        actions_remaining: 3,
+    }
+}
+
+/// A stock location with reasonable defaults.
+///
+/// - Shroud 2, 0 clues, revealed.
+/// - No connections (caller adds them).
+#[must_use]
+pub fn test_location(id: u32, name: impl Into<String>) -> Location {
+    Location {
+        id: LocationId(id),
+        name: name.into(),
+        shroud: 2,
+        clues: 0,
+        revealed: true,
+        connections: Vec::new(),
+    }
+}

--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -4,6 +4,18 @@
 //! place into a state. These helpers produce one with default-y values;
 //! callers tweak fields after construction when something specific is
 //! needed.
+//!
+//! # `#[non_exhaustive]` interaction
+//!
+//! [`Investigator`] and [`Location`] are `#[non_exhaustive]`, so
+//! downstream test crates cannot construct them via struct literal —
+//! they MUST go through these fixtures. That's deliberate (it forces
+//! a single source of test defaults) but it also means **adding a
+//! field to those structs requires updating these fixtures in the
+//! same PR**, otherwise the new field defaults to whatever
+//! `test_investigator` / `test_location` set, which may not match the
+//! field's intent. Phase-2+ reviewers: flag missing fixture updates
+//! when a field addition lands.
 
 use crate::state::{Investigator, InvestigatorId, Location, LocationId, Skills};
 

--- a/crates/game-core/src/test_support/mod.rs
+++ b/crates/game-core/src/test_support/mod.rs
@@ -1,0 +1,15 @@
+//! Test-only support: fluent state builder, fixtures, event-assertion
+//! macros.
+//!
+//! Available always inside `game-core`'s own tests (via `cfg(test)`)
+//! and to downstream crates that enable the `test-support` feature.
+//! The macros are exported at the crate root via `#[macro_export]`,
+//! so callers see [`assert_event!`](crate::assert_event) regardless of
+//! where they import the supporting types from.
+
+pub mod assertions;
+pub mod builder;
+pub mod fixtures;
+
+pub use builder::TestGame;
+pub use fixtures::{test_investigator, test_location};


### PR DESCRIPTION
## Summary

Test infrastructure every later card / scenario / engine test depends on: a fluent `TestGame` builder, stock fixture constructors, and order-insensitive event assertion macros. The plan calls this out as the highest-leverage Phase 1 work — get it ergonomic now or every later test pays the cost.

## What changed

**New `test_support` module** (`crates/game-core/src/test_support/`), gated behind a new `test-support` feature in game-core's `Cargo.toml`. game-core's own tests get it via `cfg(test)`; downstream crates opt in by enabling the feature in dev-dependencies.

- `builder.rs`: `TestGame` — fluent `GameState` builder. `.with_phase`, `.with_round`, `.with_investigator`, `.with_location`, `.with_chaos_bag`, `.with_active_investigator`, `.with_turn_order`, `.build()`. Marked `#[must_use]` so a caller can't accidentally drop the builder before `.build()`.
- `fixtures.rs`: `test_investigator(id)` and `test_location(id, name)` produce stock instances with reasonable defaults; callers mutate fields after construction when a specific value matters.
- `assertions.rs`: `assert_event!`, `assert_no_event!`, `assert_event_count!`. Each takes a slice or `Vec<Event>` plus a Rust pattern with optional `if` guard — `matches!()`-based, so any pattern that works in `matches!` works here. Failure messages dump the full event list.

**Existing engine tests ported to the new harness** as proof of ergonomics — the 9 tests in `engine/mod.rs::tests` now use `TestGame` and the assertion macros. Two doc-test examples (in `builder.rs` and `assertions.rs`) double as runnable usage demos.

## What's NOT in this PR

**#19 (deterministic `ChoiceResolver`) was intentionally dropped from PR-C** and moved to `phase-3-skill-test-end-to-end`. The resolver specifies how tests answer `AwaitingInput` outcomes from the engine, but Phase 1's apply loop / RNG / phase machine all produce `Done` / `Rejected` only. Zero `AwaitingInput` sites means designing the resolver API against no real call sites — risky. The first such sites appear in Phase 3 with skill-test commits and reaction prompts. Plan file and issue #19 milestone updated accordingly.

## Test notes

Locally:
- `cargo test -p game-core` — 9 unit + 0 doc tests pass.
- `cargo test -p game-core --features test-support` — 9 unit + 2 doc tests pass.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps --all-features` — clean.

## Linked issues

Closes #18
Closes #20