### PR TITLE
engine: add deterministic RNG + ChaosTokenDrawn handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,6 +534,7 @@ dependencies = [
 name = "game-core"
 version = "0.1.0"
 dependencies = [
+ "rand_chacha",
  "serde",
 ]
 
@@ -1213,6 +1214,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,6 +1323,22 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 
 [[package]]
 name = "reactive_graph"
@@ -2405,6 +2431,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/game-core/Cargo.toml
+++ b/crates/game-core/Cargo.toml
@@ -18,3 +18,4 @@ test-support = []
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
+rand_chacha = { version = "0.9", default-features = false }

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -10,7 +10,7 @@
 
 use crate::action::{EngineRecord, PlayerAction};
 use crate::event::Event;
-use crate::state::{GameState, Phase};
+use crate::state::{ChaosToken, GameState, Phase};
 
 use super::outcome::EngineOutcome;
 
@@ -37,25 +37,17 @@ pub fn apply_player_action(
 }
 
 /// Apply an [`EngineRecord`] to the state, pushing events.
-///
-/// Phase-1: all variants return [`EngineOutcome::Rejected`] with a TODO
-/// message. Engine-recorded actions only flow once the RNG and skill-test
-/// machinery exist (issues #16, #3 in the plan).
 pub fn apply_engine_record(
-    _state: &mut GameState,
-    _events: &mut Vec<Event>,
+    state: &mut GameState,
+    events: &mut Vec<Event>,
     record: &EngineRecord,
 ) -> EngineOutcome {
-    let reason = match record {
-        EngineRecord::ChaosTokenDrawn { .. } => {
-            "TODO(#16): ChaosTokenDrawn dispatch lands with the deterministic RNG."
-        }
-        EngineRecord::DeckShuffled { .. } => {
-            "TODO(#16): DeckShuffled dispatch lands with the deterministic RNG."
-        }
-    };
-    EngineOutcome::Rejected {
-        reason: reason.into(),
+    match record {
+        EngineRecord::ChaosTokenDrawn { token } => chaos_token_drawn(state, events, *token),
+        EngineRecord::DeckShuffled { .. } => EngineOutcome::Rejected {
+            reason: "TODO: DeckShuffled dispatch lands when decks exist (#15+ scenario plumbing)"
+                .into(),
+        },
     }
 }
 
@@ -110,5 +102,43 @@ fn end_turn(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome {
     events.push(Event::TurnEnded {
         investigator: active_id,
     });
+    EngineOutcome::Done
+}
+
+/// Handler for [`EngineRecord::ChaosTokenDrawn`].
+///
+/// Validate-first pattern: clone the RNG, draw an index, check the
+/// recorded token matches `chaos_bag[index]`. Only on match do we
+/// commit the RNG advance and emit the event. A mismatch indicates
+/// log corruption — return `Rejected` without mutating state.
+///
+/// Modifier resolution (token symbols → numeric modifier per scenario)
+/// lands later. For Phase 1 we emit `modifier: 0` so the event shape
+/// is right; downstream consumers will pick up the real modifier when
+/// scenario-aware token effects exist.
+fn chaos_token_drawn(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    token: ChaosToken,
+) -> EngineOutcome {
+    if state.chaos_bag.tokens.is_empty() {
+        return EngineOutcome::Rejected {
+            reason: "ChaosTokenDrawn requires a non-empty chaos bag".into(),
+        };
+    }
+    let mut probe = state.rng.clone();
+    let idx = probe.next_index(state.chaos_bag.tokens.len());
+    let derived = state.chaos_bag.tokens[idx];
+    if derived != token {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "ChaosTokenDrawn: recorded token {token:?} does not match RNG-derived \
+                 {derived:?} (log corruption or wrong seed)"
+            )
+            .into(),
+        };
+    }
+    state.rng = probe;
+    events.push(Event::ChaosTokenRevealed { token, modifier: 0 });
     EngineOutcome::Done
 }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -176,7 +176,7 @@ mod tests {
     }
 
     #[test]
-    fn chaos_token_drawn_engine_record_is_rejected_phase_one() {
+    fn chaos_token_drawn_with_empty_bag_is_rejected() {
         let state = TestGame::new().build();
         let result = apply(
             state,
@@ -186,6 +186,106 @@ mod tests {
         );
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
         assert!(result.events.is_empty());
+    }
+
+    fn bag_with_three_tokens() -> crate::state::ChaosBag {
+        crate::state::ChaosBag::new([
+            ChaosToken::Skull,
+            ChaosToken::Numeric(1),
+            ChaosToken::Numeric(-2),
+        ])
+    }
+
+    /// Drive the RNG forward to figure out which token *will* be drawn
+    /// next. Used by tests to construct a `ChaosTokenDrawn` action with
+    /// a token that matches the RNG's expectation.
+    fn peek_next_token(state: &crate::state::GameState) -> ChaosToken {
+        let mut probe = state.rng.clone();
+        let idx = probe.next_index(state.chaos_bag.tokens.len());
+        state.chaos_bag.tokens[idx]
+    }
+
+    #[test]
+    fn chaos_token_drawn_with_matching_token_succeeds_and_advances_rng() {
+        let state = TestGame::new()
+            .with_chaos_bag(bag_with_three_tokens())
+            .with_rng_seed(42)
+            .build();
+        let token = peek_next_token(&state);
+        let draws_before = state.rng.draws;
+
+        let result = apply(
+            state,
+            Action::Engine(EngineRecord::ChaosTokenDrawn { token }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::ChaosTokenRevealed { token: t, modifier: 0 } if *t == token
+        );
+        assert_eq!(result.state.rng.draws, draws_before + 1);
+    }
+
+    #[test]
+    fn chaos_token_drawn_with_wrong_token_is_rejected_and_does_not_advance_rng() {
+        let state = TestGame::new()
+            .with_chaos_bag(bag_with_three_tokens())
+            .with_rng_seed(42)
+            .build();
+        let correct = peek_next_token(&state);
+        // Pick any token from the bag that ISN'T the correct one.
+        let wrong = state
+            .chaos_bag
+            .tokens
+            .iter()
+            .copied()
+            .find(|t| *t != correct)
+            .expect("bag contains at least two distinct tokens");
+        let rng_before = state.rng.clone();
+
+        let result = apply(
+            state,
+            Action::Engine(EngineRecord::ChaosTokenDrawn { token: wrong }),
+        );
+
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+        assert_eq!(result.state.rng, rng_before);
+    }
+
+    #[test]
+    fn chaos_token_drawn_log_round_trips() {
+        // Build a five-draw log against an initial state, then replay
+        // the log from scratch and assert the resulting RNG state
+        // matches. This is the core determinism property.
+        let initial = TestGame::new()
+            .with_chaos_bag(bag_with_three_tokens())
+            .with_rng_seed(123)
+            .build();
+
+        let mut state = initial.clone();
+        let mut log = Vec::new();
+        for _ in 0..5 {
+            let token = peek_next_token(&state);
+            let action = Action::Engine(EngineRecord::ChaosTokenDrawn { token });
+            log.push(action.clone());
+            let result = apply(state, action);
+            assert_eq!(result.outcome, EngineOutcome::Done);
+            state = result.state;
+        }
+        let after_first_pass = state;
+
+        // Replay against the original initial state.
+        let mut replay = initial;
+        for action in log {
+            let result = apply(replay, action);
+            assert_eq!(result.outcome, EngineOutcome::Done);
+            replay = result.state;
+        }
+
+        assert_eq!(after_first_pass.rng, replay.rng);
+        assert_eq!(after_first_pass.rng.draws, 5);
     }
 
     #[test]

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -20,6 +20,7 @@
 pub mod action;
 pub mod engine;
 pub mod event;
+pub mod rng;
 pub mod state;
 
 #[cfg(any(test, feature = "test-support"))]
@@ -28,6 +29,7 @@ pub mod test_support;
 pub use action::{Action, EngineRecord, InputResponse, PlayerAction};
 pub use engine::{apply, ApplyResult, EngineOutcome, InputRequest, ResumeToken};
 pub use event::Event;
+pub use rng::RngState;
 pub use state::{
     ChaosBag, ChaosToken, GameState, Investigator, InvestigatorId, Location, LocationId, Phase,
     Skills,

--- a/crates/game-core/src/rng.rs
+++ b/crates/game-core/src/rng.rs
@@ -1,0 +1,132 @@
+//! Deterministic RNG state for the engine.
+//!
+//! All randomness in the engine flows through [`RngState`]. The state
+//! itself is a tuple of `(seed, draws)` — both serializable, both
+//! trivially copyable into a snapshot — and the actual RNG is
+//! reconstructed on demand from those two numbers via
+//! [`rand_chacha::ChaCha8Rng`]. This keeps `GameState` cleanly
+//! serializable and means the RNG state in a snapshot is just two
+//! `u64`s, not a chunk of opaque RNG implementation.
+//!
+//! # Replay invariant
+//!
+//! Each `next_u64` draw advances `draws` by exactly one and consumes
+//! exactly one 64-bit word from the `ChaCha8` stream. Higher-level
+//! helpers (e.g. `next_index`) build on `next_u64` without consuming
+//! variable bytes — that's required so replaying an action log produces
+//! bit-identical state regardless of how the higher-level helpers are
+//! layered.
+//!
+//! # Bias
+//!
+//! `next_index` uses simple modulo, which is biased for non-power-of-2
+//! moduli. For the small moduli the engine actually uses (chaos bag
+//! sizes ≤ 20, deck sizes ≤ ~50) the bias is negligible. Avoiding it
+//! via rejection sampling would mean variable byte consumption per
+//! draw, which breaks the replay invariant above.
+
+use rand_chacha::rand_core::{RngCore, SeedableRng};
+use serde::{Deserialize, Serialize};
+
+/// Deterministic RNG state for [`GameState`](crate::GameState).
+///
+/// Constructed via [`new`](Self::new) with a seed; the engine advances
+/// `draws` as it consumes random values.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct RngState {
+    /// Seed used to initialize the underlying `ChaCha8` stream.
+    pub seed: u64,
+    /// Number of `next_u64` draws performed so far.
+    pub draws: u64,
+}
+
+impl RngState {
+    /// Create a new RNG state at draw 0 from the given seed.
+    #[must_use]
+    pub fn new(seed: u64) -> Self {
+        Self { seed, draws: 0 }
+    }
+
+    /// Reconstruct the underlying `ChaCha8Rng` positioned at the current
+    /// draw count.
+    fn rng_at_current_pos(&self) -> rand_chacha::ChaCha8Rng {
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(self.seed);
+        // Each `next_u64` call consumes 2 32-bit words from the
+        // `ChaCha8` stream. `set_word_pos` is O(1).
+        rng.set_word_pos(u128::from(self.draws) * 2);
+        rng
+    }
+
+    /// Advance the stream by one 64-bit word and return it.
+    ///
+    /// Crate-private so all RNG access goes through engine-controlled
+    /// paths; downstream code reads the result via `Event`s.
+    pub(crate) fn next_u64(&mut self) -> u64 {
+        let mut rng = self.rng_at_current_pos();
+        let v = rng.next_u64();
+        self.draws += 1;
+        v
+    }
+
+    /// Pick an index in `[0, n)`. Panics if `n == 0`.
+    ///
+    /// Modulo-biased; see module docs for why that's deliberate.
+    pub(crate) fn next_index(&mut self, n: usize) -> usize {
+        assert!(n > 0, "RngState::next_index requires n > 0");
+        let v_mod = self.next_u64() % n as u64;
+        // v_mod is in [0, n), and n was originally a usize, so v_mod
+        // fits in usize on every target.
+        usize::try_from(v_mod).expect("v_mod < n which fits in usize")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RngState;
+
+    #[test]
+    fn same_seed_same_draws_produces_same_value() {
+        let mut a = RngState::new(42);
+        let mut b = RngState::new(42);
+        assert_eq!(a.next_u64(), b.next_u64());
+        assert_eq!(a.next_u64(), b.next_u64());
+        assert_eq!(a.draws, 2);
+        assert_eq!(b.draws, 2);
+    }
+
+    #[test]
+    fn different_seeds_diverge() {
+        let mut a = RngState::new(42);
+        let mut b = RngState::new(43);
+        assert_ne!(a.next_u64(), b.next_u64());
+    }
+
+    #[test]
+    fn advancing_draws_field_skips_ahead() {
+        // Two RngStates: one drawn 5 times the slow way, one constructed
+        // with draws = 5. The next draw on each should match.
+        let mut slow = RngState::new(99);
+        for _ in 0..5 {
+            slow.next_u64();
+        }
+        let mut fast = RngState { seed: 99, draws: 5 };
+        assert_eq!(slow.next_u64(), fast.next_u64());
+    }
+
+    #[test]
+    fn next_index_stays_in_range() {
+        let mut rng = RngState::new(7);
+        for _ in 0..50 {
+            let i = rng.next_index(13);
+            assert!(i < 13);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "n > 0")]
+    fn next_index_panics_on_zero() {
+        let mut rng = RngState::new(7);
+        let _ = rng.next_index(0);
+    }
+}

--- a/crates/game-core/src/rng.rs
+++ b/crates/game-core/src/rng.rs
@@ -21,9 +21,10 @@
 //!
 //! `next_index` uses simple modulo, which is biased for non-power-of-2
 //! moduli. For the small moduli the engine actually uses (chaos bag
-//! sizes ≤ 20, deck sizes ≤ ~50) the bias is negligible. Avoiding it
-//! via rejection sampling would mean variable byte consumption per
-//! draw, which breaks the replay invariant above.
+//! sizes up to ~30 in late cycles, deck sizes ≤ ~50) the bias against
+//! a 64-bit value is on the order of 1 in 2^59 — clearly negligible.
+//! Avoiding it via rejection sampling would mean variable byte
+//! consumption per draw, which breaks the replay invariant above.
 
 use rand_chacha::rand_core::{RngCore, SeedableRng};
 use serde::{Deserialize, Serialize};
@@ -48,12 +49,27 @@ impl RngState {
         Self { seed, draws: 0 }
     }
 
+    /// Construct an RNG state mid-stream — at the given seed advanced
+    /// past `draws` prior `next_u64` calls. Useful for restoring a
+    /// snapshot or for integration tests that want to start partway
+    /// through a stream without driving the engine to that point.
+    #[must_use]
+    pub fn at(seed: u64, draws: u64) -> Self {
+        Self { seed, draws }
+    }
+
     /// Reconstruct the underlying `ChaCha8Rng` positioned at the current
     /// draw count.
+    ///
+    /// Relies on `rand_chacha`'s documented reproducibility contract:
+    /// `ChaCha8Rng::next_u64` consumes exactly two 32-bit words from
+    /// the stream, and `set_word_pos` measures position in 32-bit
+    /// words. A future `rand_chacha` bump that ever changed either
+    /// would silently break replay determinism — that's why the
+    /// frozen `chacha_stream_is_stable` test pins a specific
+    /// `(seed, n) → next_u64` mapping.
     fn rng_at_current_pos(&self) -> rand_chacha::ChaCha8Rng {
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(self.seed);
-        // Each `next_u64` call consumes 2 32-bit words from the
-        // `ChaCha8` stream. `set_word_pos` is O(1).
         rng.set_word_pos(u128::from(self.draws) * 2);
         rng
     }
@@ -128,5 +144,36 @@ mod tests {
     fn next_index_panics_on_zero() {
         let mut rng = RngState::new(7);
         let _ = rng.next_index(0);
+    }
+
+    #[test]
+    fn at_constructs_a_mid_stream_state() {
+        let mut a = RngState::new(99);
+        for _ in 0..7 {
+            a.next_u64();
+        }
+        let mut b = RngState::at(99, 7);
+        assert_eq!(a.next_u64(), b.next_u64());
+        assert_eq!(b.draws, 8);
+    }
+
+    /// Frozen contract test: pins specific `(seed, draw_index) →
+    /// next_u64` outputs against the current `rand_chacha::ChaCha8`
+    /// stream. If any future `rand_chacha` bump silently changes its
+    /// output, replay determinism breaks — and this test catches it
+    /// before the round-trip tests start failing in mysterious ways.
+    /// If the test ever fails after a dependency bump: do NOT just
+    /// update the constants — the bump has broken the action-log
+    /// contract and needs to be either reverted or accompanied by a
+    /// migration plan.
+    #[test]
+    fn chacha_stream_is_stable() {
+        let mut r = RngState::new(0);
+        assert_eq!(r.next_u64(), 0xb585_f767_a79a_3b6c);
+        assert_eq!(r.next_u64(), 0x7746_a55f_bad8_c037);
+
+        let mut r = RngState::new(42);
+        assert_eq!(r.next_u64(), 0xae90_bfb5_395d_5ba1);
+        assert_eq!(r.next_u64(), 0xf345_3fc6_2579_9188);
     }
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -10,6 +10,7 @@ use super::{
     location::{Location, LocationId},
     phase::Phase,
 };
+use crate::rng::RngState;
 
 /// The full state of a scenario at a single point in time.
 ///
@@ -48,4 +49,8 @@ pub struct GameState {
     /// Investigation phase, as decided by the lead investigator each
     /// round. The first entry is the first to act.
     pub turn_order: Vec<InvestigatorId>,
+    /// Deterministic RNG state. Carries `(seed, draws)` only; the
+    /// underlying [`rand_chacha::ChaCha8Rng`] is reconstructed on
+    /// demand by [`RngState`] methods.
+    pub rng: RngState,
 }

--- a/crates/game-core/src/test_support/builder.rs
+++ b/crates/game-core/src/test_support/builder.rs
@@ -25,6 +25,7 @@
 
 use std::collections::BTreeMap;
 
+use crate::rng::RngState;
 use crate::state::{ChaosBag, GameState, Investigator, InvestigatorId, Location, Phase};
 
 /// Fluent builder for a [`GameState`].
@@ -42,11 +43,14 @@ pub struct TestGame {
     round: u32,
     active_investigator: Option<InvestigatorId>,
     turn_order: Vec<InvestigatorId>,
+    rng: RngState,
 }
 
 impl TestGame {
     /// Start a new builder with empty investigators / locations / chaos
-    /// bag, `Phase::Mythos`, round 0, no active investigator.
+    /// bag, `Phase::Mythos`, round 0, no active investigator, RNG
+    /// seeded at zero. Most tests override the seed explicitly via
+    /// [`with_rng_seed`](Self::with_rng_seed).
     pub fn new() -> Self {
         Self {
             investigators: BTreeMap::new(),
@@ -56,6 +60,7 @@ impl TestGame {
             round: 0,
             active_investigator: None,
             turn_order: Vec::new(),
+            rng: RngState::new(0),
         }
     }
 
@@ -110,6 +115,19 @@ impl TestGame {
         self
     }
 
+    /// Seed the deterministic RNG. Resets `draws` to 0.
+    pub fn with_rng_seed(mut self, seed: u64) -> Self {
+        self.rng = RngState::new(seed);
+        self
+    }
+
+    /// Set the full RNG state (seed + draws). Useful for tests that
+    /// want to start mid-stream.
+    pub fn with_rng(mut self, rng: RngState) -> Self {
+        self.rng = rng;
+        self
+    }
+
     /// Materialize the configured [`GameState`].
     pub fn build(self) -> GameState {
         GameState {
@@ -120,6 +138,7 @@ impl TestGame {
             round: self.round,
             active_investigator: self.active_investigator,
             turn_order: self.turn_order,
+            rng: self.rng,
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #16. Deterministic RNG state on `GameState` plus the canonical RNG-using handler (`EngineRecord::ChaosTokenDrawn`). The action log replays into bit-identical state — this is the determinism property the rest of the event-sourced architecture rests on.

## What changed

**New `crates/game-core/src/rng.rs`**

- `RngState { seed: u64, draws: u64 }` — option A from the design discussion. The underlying `rand_chacha::ChaCha8Rng` is reconstructed on demand via `seed_from_u64` + `set_word_pos((draws * 2) as u128)`. Snapshots stay clean (two u64s instead of opaque RNG bytes), and seeking is O(1).
- Crate-private `next_u64` and `next_index(n)`. Higher-level helpers compose on `next_u64` with no variable byte consumption — required for the replay invariant. Modulo bias on `next_index` is deliberate (rejection sampling would break determinism); negligible for the small moduli the engine uses.

**`GameState.rng`** — new `RngState` field.

**`EngineRecord::ChaosTokenDrawn` handler** (`crates/game-core/src/engine/dispatch.rs`)

Validate-first / mutate-second pattern (the structural fix the PR-B review flagged as a future cleanup):
1. Clone the rng, draw an index, look up the chaos bag entry.
2. If the recorded token does NOT match the RNG-derived one → `Rejected`, no state mutation.
3. If it matches → commit the rng advance and emit `Event::ChaosTokenRevealed { token, modifier: 0 }`.

Modifier resolution (symbol tokens → scenario-specific modifier) is intentionally deferred; `modifier: 0` for now so the event shape is right when scenario-aware effects land later.

`DeckShuffled` remains stubbed pending decks (Phase 4+).

**`TestGame`** — `with_rng_seed(seed)` and `with_rng(state)` setters added.

**Cargo.toml** — `rand_chacha = \"0.9\"` (no default features) added to game-core.

## Test notes

Test count: 9 → 17.

- 5 RNG unit tests: same-seed determinism, different-seed divergence, draws-field skip equivalence, `next_index` range invariant, `n == 0` panic.
- `ChaosTokenDrawn` happy path: matching token succeeds, emits `ChaosTokenRevealed`, advances `draws`.
- `ChaosTokenDrawn` wrong-token: rejected with no state mutation (verified `state.rng` is unchanged).
- `ChaosTokenDrawn` empty-bag: rejected.
- **Round-trip test**: build a 5-draw action log against an initial state, replay the log against a fresh initial state, assert resulting `RngState` is bit-identical. This is the canonical determinism property.

Locally:
- `cargo test -p game-core --features test-support` — 17 unit + 2 doc tests pass.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps --all-features` — clean.

## Linked issues

Closes #16