### PR TITLE
engine: phase machine + action points

### DIFF
--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -10,7 +10,7 @@
 
 use crate::action::{EngineRecord, PlayerAction};
 use crate::event::Event;
-use crate::state::{ChaosToken, GameState, Phase};
+use crate::state::{ChaosToken, GameState, InvestigatorId, Phase};
 
 use super::outcome::EngineOutcome;
 
@@ -62,8 +62,23 @@ fn start_scenario(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutco
             reason: "StartScenario applied to a state that is already in progress".into(),
         };
     }
+    // Round 1 begins at Mythos. We emit the entry event explicitly here
+    // (rather than letting `step_phase` do it) because there is no
+    // "previous" phase to emit a `PhaseEnded` for.
     state.round = 1;
+    state.phase = Phase::Mythos;
     events.push(Event::ScenarioStarted);
+    events.push(Event::PhaseStarted {
+        phase: Phase::Mythos,
+    });
+
+    // Phase 1: Mythos / Enemy / Upkeep have no content yet, so we
+    // tick straight through them. Once the engine grows real Mythos
+    // draws and Enemy attacks, these phases stop being free skips.
+    step_phase(state, events); // Mythos → Investigation
+    if let Some(&first) = state.turn_order.first() {
+        rotate_to_active(state, events, first);
+    }
     EngineOutcome::Done
 }
 
@@ -89,9 +104,7 @@ fn end_turn(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome {
         )
     });
 
-    // Drain remaining actions and announce the turn ended. The phase
-    // machine + turn rotation lands in #17; for now EndTurn ends only
-    // the active investigator's turn without advancing phase.
+    // Drain remaining actions and announce the turn ended.
     if active.actions_remaining != 0 {
         active.actions_remaining = 0;
         events.push(Event::ActionsRemainingChanged {
@@ -102,8 +115,66 @@ fn end_turn(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome {
     events.push(Event::TurnEnded {
         investigator: active_id,
     });
+
+    // If there's another investigator after this one in turn order,
+    // rotate. Otherwise the Investigation phase ends and we tick
+    // through the rest of the round automatically (Phase 1: empty
+    // Enemy/Upkeep/Mythos), arriving back at Investigation with the
+    // first investigator active.
+    let next = state
+        .turn_order
+        .iter()
+        .position(|id| *id == active_id)
+        .and_then(|idx| state.turn_order.get(idx + 1).copied());
+
+    if let Some(next_id) = next {
+        rotate_to_active(state, events, next_id);
+    } else {
+        state.active_investigator = None;
+        step_phase(state, events); // Investigation → Enemy
+        step_phase(state, events); // Enemy → Upkeep
+        step_phase(state, events); // Upkeep → Mythos (round bumps)
+        step_phase(state, events); // Mythos → Investigation
+        if let Some(&first) = state.turn_order.first() {
+            rotate_to_active(state, events, first);
+        }
+    }
+
     EngineOutcome::Done
 }
+
+/// Transition to the next phase: emit `PhaseEnded` for the current
+/// phase, advance, emit `PhaseStarted` for the new one. Bumps the
+/// round counter when entering [`Phase::Mythos`] (which is the start
+/// of a new round).
+fn step_phase(state: &mut GameState, events: &mut Vec<Event>) {
+    let from = state.phase;
+    let to = from.next();
+    events.push(Event::PhaseEnded { phase: from });
+    state.phase = to;
+    if to == Phase::Mythos {
+        state.round += 1;
+    }
+    events.push(Event::PhaseStarted { phase: to });
+}
+
+/// Set `active_investigator` to `id` and refresh that investigator's
+/// action points to the per-turn cap (3). Emits `ActionsRemainingChanged`.
+fn rotate_to_active(state: &mut GameState, events: &mut Vec<Event>, id: InvestigatorId) {
+    state.active_investigator = Some(id);
+    if let Some(inv) = state.investigators.get_mut(&id) {
+        inv.actions_remaining = ACTIONS_PER_TURN;
+        events.push(Event::ActionsRemainingChanged {
+            investigator: id,
+            new_count: ACTIONS_PER_TURN,
+        });
+    }
+}
+
+/// Action points granted to an investigator at the start of their
+/// turn during the Investigation phase. Per the Arkham Horror LCG
+/// rulebook.
+const ACTIONS_PER_TURN: u8 = 3;
 
 /// Handler for [`EngineRecord::ChaosTokenDrawn`].
 ///

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -14,6 +14,11 @@ use crate::state::{ChaosToken, GameState, InvestigatorId, Phase};
 
 use super::outcome::EngineOutcome;
 
+/// Action points granted to an investigator at the start of their
+/// turn during the Investigation phase. Per the Arkham Horror LCG
+/// rulebook.
+const ACTIONS_PER_TURN: u8 = 3;
+
 /// Apply a [`PlayerAction`] to the state, pushing events.
 ///
 /// Phase-1 minimal coverage: [`StartScenario`](PlayerAction::StartScenario)
@@ -147,6 +152,12 @@ fn end_turn(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome {
 /// phase, advance, emit `PhaseStarted` for the new one. Bumps the
 /// round counter when entering [`Phase::Mythos`] (which is the start
 /// of a new round).
+///
+/// **Round-bump invariant:** this is the only path that bumps
+/// `state.round` post-`StartScenario`. A future caller that wants to
+/// step phases for a non-round-cycle reason (e.g. a scenario effect
+/// that skips a phase) will need to suppress the bump here, or the
+/// round counter will drift. Revisit when such a use case appears.
 fn step_phase(state: &mut GameState, events: &mut Vec<Event>) {
     let from = state.phase;
     let to = from.next();
@@ -160,21 +171,26 @@ fn step_phase(state: &mut GameState, events: &mut Vec<Event>) {
 
 /// Set `active_investigator` to `id` and refresh that investigator's
 /// action points to the per-turn cap (3). Emits `ActionsRemainingChanged`.
+///
+/// `id` must refer to an investigator in `state.investigators` —
+/// callers that pass an id from `state.turn_order` are guaranteed
+/// this by the whole-program invariant "every id in `turn_order`
+/// exists in `investigators`." A missing entry would be state
+/// corruption, not a normal error.
 fn rotate_to_active(state: &mut GameState, events: &mut Vec<Event>, id: InvestigatorId) {
     state.active_investigator = Some(id);
-    if let Some(inv) = state.investigators.get_mut(&id) {
-        inv.actions_remaining = ACTIONS_PER_TURN;
-        events.push(Event::ActionsRemainingChanged {
-            investigator: id,
-            new_count: ACTIONS_PER_TURN,
-        });
-    }
+    let inv = state.investigators.get_mut(&id).unwrap_or_else(|| {
+        unreachable!(
+            "rotate_to_active: investigator {id:?} is not in the investigators map; \
+             this is a state-corruption invariant violation"
+        )
+    });
+    inv.actions_remaining = ACTIONS_PER_TURN;
+    events.push(Event::ActionsRemainingChanged {
+        investigator: id,
+        new_count: ACTIONS_PER_TURN,
+    });
 }
-
-/// Action points granted to an investigator at the start of their
-/// turn during the Investigation phase. Per the Arkham Horror LCG
-/// rulebook.
-const ACTIONS_PER_TURN: u8 = 3;
 
 /// Handler for [`EngineRecord::ChaosTokenDrawn`].
 ///

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -78,19 +78,48 @@ mod tests {
     use crate::event::Event;
     use crate::state::{ChaosToken, InvestigatorId, Phase};
     use crate::test_support::{test_investigator, TestGame};
-    use crate::{assert_event, assert_event_count, assert_no_event};
+    use crate::{assert_event, assert_no_event};
 
     use super::{apply, EngineOutcome};
 
     #[test]
-    fn start_scenario_emits_scenario_started_and_sets_round_to_one() {
-        let state = TestGame::new().build();
+    fn start_scenario_advances_to_investigation_with_round_one() {
+        let id = InvestigatorId(1);
+        let state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_turn_order([id])
+            .build();
         let result = apply(state, Action::Player(PlayerAction::StartScenario));
 
         assert_eq!(result.outcome, EngineOutcome::Done);
-        assert_event!(result.events, Event::ScenarioStarted);
-        assert_event_count!(result.events, 1, _);
         assert_eq!(result.state.round, 1);
+        assert_eq!(result.state.phase, Phase::Investigation);
+        assert_eq!(result.state.active_investigator, Some(id));
+        assert_eq!(result.state.investigators[&id].actions_remaining, 3);
+
+        assert_event!(result.events, Event::ScenarioStarted);
+        assert_event!(
+            result.events,
+            Event::PhaseStarted {
+                phase: Phase::Mythos
+            }
+        );
+        assert_event!(
+            result.events,
+            Event::PhaseEnded {
+                phase: Phase::Mythos
+            }
+        );
+        assert_event!(
+            result.events,
+            Event::PhaseStarted {
+                phase: Phase::Investigation
+            }
+        );
+        assert_event!(
+            result.events,
+            Event::ActionsRemainingChanged { investigator, new_count: 3 } if *investigator == id
+        );
     }
 
     #[test]
@@ -252,6 +281,75 @@ mod tests {
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
         assert!(result.events.is_empty());
         assert_eq!(result.state.rng, rng_before);
+    }
+
+    #[test]
+    fn full_round_advances_through_all_phases_with_two_investigators() {
+        let inv1 = InvestigatorId(1);
+        let inv2 = InvestigatorId(2);
+        let state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_investigator(test_investigator(2))
+            .with_turn_order([inv1, inv2])
+            .build();
+
+        // StartScenario: round 0 → 1, phase Mythos → Investigation,
+        // first investigator becomes active with 3 actions.
+        let result = apply(state, Action::Player(PlayerAction::StartScenario));
+        let state = result.state;
+        assert_eq!(state.round, 1);
+        assert_eq!(state.phase, Phase::Investigation);
+        assert_eq!(state.active_investigator, Some(inv1));
+        assert_eq!(state.investigators[&inv1].actions_remaining, 3);
+
+        // First EndTurn: rotate to inv2 within Investigation.
+        let result = apply(state, Action::Player(PlayerAction::EndTurn));
+        let state = result.state;
+        assert_eq!(state.round, 1);
+        assert_eq!(state.phase, Phase::Investigation);
+        assert_eq!(state.active_investigator, Some(inv2));
+        assert_eq!(state.investigators[&inv1].actions_remaining, 0);
+        assert_eq!(state.investigators[&inv2].actions_remaining, 3);
+        assert_event!(
+            result.events,
+            Event::TurnEnded { investigator } if *investigator == inv1
+        );
+        assert_event!(
+            result.events,
+            Event::ActionsRemainingChanged { investigator, new_count: 3 } if *investigator == inv2
+        );
+        // No phase transition yet.
+        assert_no_event!(result.events, Event::PhaseEnded { .. });
+
+        // Second EndTurn: tick through Enemy → Upkeep → Mythos (round
+        // bumps) → Investigation, with inv1 active again at full
+        // actions.
+        let result = apply(state, Action::Player(PlayerAction::EndTurn));
+        let state = result.state;
+        assert_eq!(state.round, 2);
+        assert_eq!(state.phase, Phase::Investigation);
+        assert_eq!(state.active_investigator, Some(inv1));
+        assert_eq!(state.investigators[&inv1].actions_remaining, 3);
+        assert_eq!(state.investigators[&inv2].actions_remaining, 0);
+
+        // All four phase-end / phase-start pairs fired during the
+        // second EndTurn's auto-advance.
+        for phase in [
+            Phase::Investigation,
+            Phase::Enemy,
+            Phase::Upkeep,
+            Phase::Mythos,
+        ] {
+            assert_event!(result.events, Event::PhaseEnded { phase: p } if *p == phase);
+        }
+        for phase in [
+            Phase::Enemy,
+            Phase::Upkeep,
+            Phase::Mythos,
+            Phase::Investigation,
+        ] {
+            assert_event!(result.events, Event::PhaseStarted { phase: p } if *p == phase);
+        }
     }
 
     #[test]

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -78,7 +78,7 @@ mod tests {
     use crate::event::Event;
     use crate::state::{ChaosToken, InvestigatorId, Phase};
     use crate::test_support::{test_investigator, TestGame};
-    use crate::{assert_event, assert_no_event};
+    use crate::{assert_event, assert_event_count, assert_no_event};
 
     use super::{apply, EngineOutcome};
 
@@ -318,8 +318,11 @@ mod tests {
             result.events,
             Event::ActionsRemainingChanged { investigator, new_count: 3 } if *investigator == inv2
         );
-        // No phase transition yet.
+        // No phase transition yet, and EndTurn must never re-emit
+        // ScenarioStarted.
         assert_no_event!(result.events, Event::PhaseEnded { .. });
+        assert_no_event!(result.events, Event::PhaseStarted { .. });
+        assert_no_event!(result.events, Event::ScenarioStarted);
 
         // Second EndTurn: tick through Enemy → Upkeep → Mythos (round
         // bumps) → Investigation, with inv1 active again at full
@@ -333,7 +336,10 @@ mod tests {
         assert_eq!(state.investigators[&inv2].actions_remaining, 0);
 
         // All four phase-end / phase-start pairs fired during the
-        // second EndTurn's auto-advance.
+        // second EndTurn's auto-advance — exactly four of each, no more
+        // and no less.
+        assert_event_count!(result.events, 4, Event::PhaseEnded { .. });
+        assert_event_count!(result.events, 4, Event::PhaseStarted { .. });
         for phase in [
             Phase::Investigation,
             Phase::Enemy,
@@ -350,6 +356,33 @@ mod tests {
         ] {
             assert_event!(result.events, Event::PhaseStarted { phase: p } if *p == phase);
         }
+        // EndTurn must never re-emit ScenarioStarted.
+        assert_no_event!(result.events, Event::ScenarioStarted);
+    }
+
+    #[test]
+    fn solo_investigator_round_advances_on_single_end_turn() {
+        // Degenerate edge: with only one investigator in turn_order,
+        // their EndTurn is also the *last* EndTurn, so it must trigger
+        // the full phase auto-advance plus round bump in one step.
+        let id = InvestigatorId(1);
+        let state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_turn_order([id])
+            .build();
+
+        let after_start = apply(state, Action::Player(PlayerAction::StartScenario)).state;
+        assert_eq!(after_start.round, 1);
+        assert_eq!(after_start.active_investigator, Some(id));
+
+        let result = apply(after_start, Action::Player(PlayerAction::EndTurn));
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_eq!(result.state.round, 2);
+        assert_eq!(result.state.phase, Phase::Investigation);
+        assert_eq!(result.state.active_investigator, Some(id));
+        assert_eq!(result.state.investigators[&id].actions_remaining, 3);
+        assert_event_count!(result.events, 4, Event::PhaseEnded { .. });
+        assert_event_count!(result.events, 4, Event::PhaseStarted { .. });
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #17. Last issue in Phase 1. Auto-advance through Mythos → Investigation → Enemy → Upkeep → next round's Mythos, plus action-point refresh on becoming active.

Per the design discussion: no separate \`AdvancePhase\` action. The engine ticks itself forward whenever the active phase has no work left. Mythos/Enemy/Upkeep have no Phase-1 content so they're free skips today; once those phases grow real work, the auto-advance will pause inside them. Undo covers the "I wasn't done" cases.

## What changed

**\`StartScenario\`** now sets up round 1 fully:
- round 0 → 1, phase Mythos → Investigation
- first investigator from \`turn_order\` becomes active with 3 actions
- emits \`ScenarioStarted\`, \`PhaseStarted\`/\`PhaseEnded\` pairs, and \`ActionsRemainingChanged\`

**\`EndTurn\`** rotates within Investigation when there's a next investigator in \`turn_order\`. When the last investigator ends their turn, the engine ticks Investigation → Enemy → Upkeep → Mythos (round bumps) → Investigation, and the first investigator becomes active again with refreshed actions.

**Round counter** bumps on entering \`Phase::Mythos\` (start of a new round per the Arkham rulebook). \`StartScenario\` sets round 1 directly because there's no preceding Mythos to transition out of.

**New private helpers in \`dispatch.rs\`:**
- \`step_phase\` — emit \`PhaseEnded(prev)\`, advance, emit \`PhaseStarted(next)\`, bump round on Mythos entry.
- \`rotate_to_active\` — set \`active_investigator\`, refresh their \`actions_remaining\` to \`ACTIONS_PER_TURN\` (= 3), emit \`ActionsRemainingChanged\`.

## Test notes

- Existing \`start_scenario_emits_scenario_started_and_sets_round_to_one\` rewritten as \`start_scenario_advances_to_investigation_with_round_one\` to assert the new setup (phase, active investigator, action refresh).
- New \`full_round_advances_through_all_phases_with_two_investigators\`: drives two investigators through their Investigation turns, asserts the last \`EndTurn\` triggers all four phase-end / phase-start pairs and arrives at round 2 Investigation with the first investigator active again.

Locally:
- \`cargo test -p game-core --features test-support\` — 20 unit + 2 doc tests pass.
- \`cargo clippy --all-targets --all-features -- -D warnings\` — clean.
- \`cargo fmt --all -- --check\` — clean.
- \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps --all-features\` — clean.

## Linked issues

Closes #17