### PR TITLE
cards: implement Holy Rosary + Working a Hunch (DSL pair)

### DIFF
--- a/crates/cards/src/impls/holy_rosary.rs
+++ b/crates/cards/src/impls/holy_rosary.rs
@@ -1,7 +1,9 @@
 //! Holy Rosary (Mystic asset, 01059).
 //!
-//! > Hand. Item. Charm.
-//! > You get +1 \[willpower\].
+//! ```text
+//! Hand. Item. Charm.
+//! You get +1 [willpower].
+//! ```
 //!
 //! # Horror-soak gap
 //!
@@ -53,5 +55,13 @@ mod tests {
                 scope: ModifierScope::WhileInPlay,
             }
         ));
+    }
+
+    /// Catches a `pub mod` rename or a fat-fingered match arm in
+    /// `impls::abilities_for` — the registry must dispatch CODE to
+    /// this module's `abilities()`.
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(super::CODE), Some(super::abilities()));
     }
 }

--- a/crates/cards/src/impls/holy_rosary.rs
+++ b/crates/cards/src/impls/holy_rosary.rs
@@ -1,0 +1,57 @@
+//! Holy Rosary (Mystic asset, 01059).
+//!
+//! > Hand. Item. Charm.
+//! > You get +1 \[willpower\].
+//!
+//! # Horror-soak gap
+//!
+//! Card metadata gives the asset `sanity: 2`. This is **not** a max-
+//! sanity boost on the controller — it's the asset's horror-soak
+//! capacity. While in play, horror that would hit the controller is
+//! redirected to the asset; once it has absorbed 2 horror it's
+//! discarded. That's a redirect-and-discard mechanic with state on
+//! the asset itself, not a passive stat modifier.
+//!
+//! The DSL v0 doesn't model horror soak. This impl ships only the
+//! "+1 willpower while in play" half. The soak half lands when the
+//! DSL grows a soak / damage-redirect primitive (also unblocks Beat
+//! Cop and other allies, which work the same way). The deck-import
+//! gate will still treat Holy Rosary as playable on the strength of
+//! the willpower ability; soak missing means the card is mechanically
+//! weaker than printed in the simulator until the gap closes.
+
+use game_core::dsl::{constant, modify, Ability, ModifierScope, Stat};
+
+/// `ArkhamDB` code for the original-Core printing.
+pub const CODE: &str = "01059";
+
+/// Holy Rosary's +1 willpower constant ability. The 2-horror-soak
+/// capacity printed on the card is not yet modeled (see module doc).
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![constant(modify(
+        Stat::Willpower,
+        1,
+        ModifierScope::WhileInPlay,
+    ))]
+}
+
+#[cfg(test)]
+mod tests {
+    use game_core::dsl::{Effect, ModifierScope, Stat, Trigger};
+
+    #[test]
+    fn abilities_are_one_constant_willpower_modifier() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(abilities[0].trigger, Trigger::Constant);
+        assert!(matches!(
+            abilities[0].effect,
+            Effect::Modify {
+                stat: Stat::Willpower,
+                delta: 1,
+                scope: ModifierScope::WhileInPlay,
+            }
+        ));
+    }
+}

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -11,9 +11,23 @@
 //! `abilities_for(code).is_some()`, so the two queries can never go
 //! out of sync.
 //!
-//! Phase 2 lands the framework + the three DSL-only cards. Activated-
-//! ability cards (Hyperawareness) and triggered-effect cards
-//! (Deduction) get separate Rust-impl placeholders in PR-J.
+//! # Module-naming convention
+//!
+//! Filenames are the card's lowercase snake-case name. When two
+//! printings share a name (revised core / Chapter 2 reprints), the
+//! later printings get a set suffix: `holy_rosary` for the original
+//! core, `holy_rosary_rcore` if a revised-core variant lands. Codes
+//! are the disambiguator at the registry level; filenames just stay
+//! greppable.
+//!
+//! # Phase-2 status
+//!
+//! Phase 2 lands the framework + two DSL-only cards (Holy Rosary,
+//! Working a Hunch). Magnifying Glass (#37) was originally planned
+//! for this PR but blocks on the per-skill-test-kind scope DSL
+//! extension (#45). Activated-ability cards (Hyperawareness) and
+//! triggered-effect cards (Deduction) get separate Rust-impl
+//! placeholders in PR-J.
 
 use game_core::dsl::Ability;
 

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -1,24 +1,32 @@
 //! Hand-implemented card effects.
 //!
-//! The card-data-pipeline emits *metadata* (name, cost, traits, …) for
-//! every card in the snapshot, but the engine can't *play* a card
-//! until someone writes its effect — either as a DSL declaration or a
-//! Rust trait impl for the weird ones the DSL can't express.
+//! Each implemented card lives in its own submodule, exposing a
+//! [`CODE`](holy_rosary::CODE) constant and an `abilities()` function
+//! returning that card's [`Vec<Ability>`](game_core::dsl::Ability).
 //!
-//! Each implemented card lives in its own submodule here. The registry
-//! function below lists the codes of every implemented card; the
-//! crate's [`is_playable`](super::is_playable) check looks them up.
+//! The registry is the [`abilities_for`] dispatch — adding a card
+//! means: drop a `crates/cards/src/impls/<name>.rs` file, declare the
+//! `pub mod <name>;` here, and add a match arm in [`abilities_for`].
+//! The crate's [`is_playable`](super::is_playable) check derives from
+//! `abilities_for(code).is_some()`, so the two queries can never go
+//! out of sync.
 //!
-//! Phase 2 lands the registry framework; the first cards arrive in
-//! subsequent PRs (Holy Rosary, Working a Hunch, etc.).
+//! Phase 2 lands the framework + the three DSL-only cards. Activated-
+//! ability cards (Hyperawareness) and triggered-effect cards
+//! (Deduction) get separate Rust-impl placeholders in PR-J.
 
-/// Returns the codes of all hand-implemented cards, sorted.
-///
-/// Used by [`super::is_playable`] to refuse decks containing
-/// unimplemented cards (so we never let a player into a scenario
-/// with cards the engine cannot resolve).
+use game_core::dsl::Ability;
+
+pub mod holy_rosary;
+pub mod working_a_hunch;
+
+/// Look up a card's hand-implemented abilities by code. Returns
+/// `None` for unimplemented cards.
 #[must_use]
-pub fn implementations() -> &'static [&'static str] {
-    // Sorted so binary search is valid.
-    &[]
+pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
+    match code {
+        holy_rosary::CODE => Some(holy_rosary::abilities()),
+        working_a_hunch::CODE => Some(working_a_hunch::abilities()),
+        _ => None,
+    }
 }

--- a/crates/cards/src/impls/working_a_hunch.rs
+++ b/crates/cards/src/impls/working_a_hunch.rs
@@ -1,0 +1,43 @@
+//! Working a Hunch (Seeker event, 01037).
+//!
+//! > Insight. Fast.
+//! > Discover 1 clue at your location.
+//!
+//! The "Fast." keyword (no-action-cost-to-play) is a card-level play
+//! cost concern, not a DSL concern. It'll be encoded on the card
+//! declaration alongside `abilities()` once the play-cost layer
+//! exists; for now `abilities()` only describes what the `OnPlay`
+//! trigger does.
+
+use game_core::dsl::{discover_clue, on_play, Ability, LocationTarget};
+
+/// `ArkhamDB` code for the original-Core printing.
+pub const CODE: &str = "01037";
+
+/// On play, discover 1 clue at the controller's location.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![on_play(discover_clue(
+        LocationTarget::ControllerLocation,
+        1,
+    ))]
+}
+
+#[cfg(test)]
+mod tests {
+    use game_core::dsl::{Effect, LocationTarget, Trigger};
+
+    #[test]
+    fn abilities_are_one_on_play_discover_clue() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(abilities[0].trigger, Trigger::OnPlay);
+        assert!(matches!(
+            abilities[0].effect,
+            Effect::DiscoverClue {
+                from: LocationTarget::ControllerLocation,
+                count: 1,
+            }
+        ));
+    }
+}

--- a/crates/cards/src/impls/working_a_hunch.rs
+++ b/crates/cards/src/impls/working_a_hunch.rs
@@ -1,7 +1,9 @@
 //! Working a Hunch (Seeker event, 01037).
 //!
-//! > Insight. Fast.
-//! > Discover 1 clue at your location.
+//! ```text
+//! Insight. Fast.
+//! Discover 1 clue at your location.
+//! ```
 //!
 //! The "Fast." keyword (no-action-cost-to-play) is a card-level play
 //! cost concern, not a DSL concern. It'll be encoded on the card
@@ -39,5 +41,13 @@ mod tests {
                 count: 1,
             }
         ));
+    }
+
+    /// Catches a `pub mod` rename or a fat-fingered match arm in
+    /// `impls::abilities_for` — the registry must dispatch CODE to
+    /// this module's `abilities()`.
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(super::CODE), Some(super::abilities()));
     }
 }

--- a/crates/cards/src/lib.rs
+++ b/crates/cards/src/lib.rs
@@ -43,18 +43,22 @@ pub fn by_code(code: &str) -> Option<&'static CardMetadata> {
         .map(|i| &all()[i])
 }
 
+/// Look up a card's hand-implemented abilities by code. Returns
+/// `None` for unimplemented cards. Re-exported from
+/// [`impls::abilities_for`].
+#[must_use]
+pub fn abilities_for(code: &str) -> Option<Vec<game_core::dsl::Ability>> {
+    impls::abilities_for(code)
+}
+
 /// Whether a card has an effect implementation and can therefore be
-/// taken into a scenario. Cards without an implementation appear in
-/// [`all`] (so deckbuilding tools can list them) but are refused by
-/// the deck-import gate.
+/// taken into a scenario. Derived from [`abilities_for`] so the two
+/// queries can never go out of sync. Cards without an implementation
+/// still appear in [`all`] (deckbuilding tools list them) but are
+/// refused by the deck-import gate.
 #[must_use]
 pub fn is_playable(code: &str) -> bool {
-    let impls = impls::implementations();
-    debug_assert!(
-        impls.windows(2).all(|w| w[0] < w[1]),
-        "impls::implementations() must return a sorted, deduplicated slice for binary_search to be valid"
-    );
-    impls.binary_search(&code).is_ok()
+    abilities_for(code).is_some()
 }
 
 #[cfg(test)]
@@ -92,10 +96,42 @@ mod tests {
     }
 
     #[test]
-    fn no_cards_are_playable_yet() {
-        // Phase-2 PR-G ships the framework; the 5 Phase-2 card impls
-        // land in PR-I onward. Until then nothing is playable.
+    fn dsl_pair_is_playable() {
+        // PR-I lands Holy Rosary (01059) and Working a Hunch (01037).
+        // Magnifying Glass needs a per-skill-test scope DSL extension
+        // (its bonus is "while investigating", not flat). Hyperawareness
+        // (01034) and Deduction (01039) need activated/triggered DSL
+        // primitives — both come in PR-J as Rust-impl placeholders.
+        assert!(is_playable("01037"));
+        assert!(is_playable("01059"));
+    }
+
+    #[test]
+    fn unimplemented_cards_are_not_playable() {
+        // Magnifying Glass (01030), Hyperawareness (01034), Deduction
+        // (01039) all blocked on DSL extensions — not yet playable.
         assert!(!is_playable("01030"));
-        assert!(!is_playable("01059"));
+        assert!(!is_playable("01034"));
+        assert!(!is_playable("01039"));
+        // Phase-2 doesn't touch most of the corpus.
+        assert!(!is_playable("01001")); // Roland Banks
+        assert!(!is_playable("99999")); // unknown code
+    }
+
+    #[test]
+    fn abilities_for_returns_some_for_implemented() {
+        for code in ["01037", "01059"] {
+            let abilities = super::abilities_for(code)
+                .unwrap_or_else(|| panic!("expected abilities for {code}"));
+            assert!(
+                !abilities.is_empty(),
+                "abilities for {code} should be non-empty"
+            );
+        }
+    }
+
+    #[test]
+    fn abilities_for_returns_none_for_unimplemented() {
+        assert!(super::abilities_for("99999").is_none());
     }
 }


### PR DESCRIPTION
## Summary

Closes #35 and #36. Lands the per-card impl framework alongside the two Phase-2 cards that fit the DSL v0 cleanly.

**Deferred from the original 3-card plan:** Magnifying Glass (#37) was supposed to be in this PR but its bonus is "+1 intellect *while investigating*" — DSL v0 doesn't have a per-skill-test-kind scope predicate, and approximating as flat +1 intellect would over-apply to non-investigate intellect tests (treacheries, encounter cards). Filed as **#45**; #37 stays in the Phase-2 milestone, blocked.

## What changed

**Framework:**
- Each implemented card lives in `crates/cards/src/impls/<name>.rs` with a `CODE` constant and an `abilities()` function.
- `impls/mod.rs` dispatches via `abilities_for(code)` using a match over the per-card `CODE` constants.
- Top-level `cards::is_playable(code)` is now derived from `abilities_for(code).is_some()` — the previous separate sorted-slice registry is replaced. Playability and abilities views can never go out of sync.

**Cards:**

| Card | Code | Class | Ability |
|---|---|---|---|
| Holy Rosary | 01059 | Mystic asset | Constant +1 willpower (WhileInPlay) |
| Working a Hunch | 01037 | Seeker event | OnPlay → DiscoverClue from ControllerLocation, count 1 |

**Two real bugs caught during the user's review of my draft impls:**

1. I initially wrote Holy Rosary as `+1 willpower AND +2 max sanity`. The user pointed out the `sanity: 2` field on the card metadata is **horror-soak capacity**, not a max-sanity boost on the controller — different mechanic entirely (redirect-and-discard with state on the asset). The DSL v0 doesn't model soak. Filed as **#44**; the impl ships only the willpower half.
2. Magnifying Glass's "while investigating" qualifier (above) — leading to its deferral.

## Test notes

- `cards::tests::dsl_pair_is_playable` — 01037 and 01059 are playable.
- `cards::tests::unimplemented_cards_are_not_playable` — 01030 (Magnifying Glass), 01034 (Hyperawareness), 01039 (Deduction), 01001 (Roland), 99999 (unknown) all return false.
- `cards::tests::abilities_for_returns_some_for_implemented` / `..._none_for_unimplemented`.
- Per-card module tests pinning each card's exact `abilities()` shape.

Test count cards: 4 → 9. All clippy / fmt / doc green.

## Linked

Closes #35  
Closes #36

Filed during this PR:
- #44 (DSL horror-soak / damage-redirect primitive — blocks Holy Rosary's full impl, Beat Cop, and ally cards)
- #45 (DSL per-skill-test-kind scope — blocks Magnifying Glass full impl and a sizable chunk of the Seeker / Survivor pool)