### PR TITLE
engine: chaos bag draw + token modifier resolution

### DIFF
--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -10,7 +10,7 @@
 
 use crate::action::{EngineRecord, PlayerAction};
 use crate::event::Event;
-use crate::state::{ChaosToken, GameState, InvestigatorId, Phase};
+use crate::state::{resolve_token, ChaosToken, GameState, InvestigatorId, Phase};
 
 use super::outcome::EngineOutcome;
 
@@ -199,10 +199,13 @@ fn rotate_to_active(state: &mut GameState, events: &mut Vec<Event>, id: Investig
 /// commit the RNG advance and emit the event. A mismatch indicates
 /// log corruption — return `Rejected` without mutating state.
 ///
-/// Modifier resolution (token symbols → numeric modifier per scenario)
-/// lands later. For Phase 1 we emit `modifier: 0` so the event shape
-/// is right; downstream consumers will pick up the real modifier when
-/// scenario-aware token effects exist.
+/// The emitted event carries a [`TokenResolution`] resolved against the
+/// scenario's `token_modifiers`. Symbol-token *effects* beyond the
+/// numeric modifier (e.g. "Cultist: −2 and an enemy spawns") and the
+/// elder-sign ability dispatch are downstream of this handler; they
+/// hook into the skill-test resolution flow that consumes the event.
+///
+/// [`TokenResolution`]: crate::state::TokenResolution
 fn chaos_token_drawn(
     state: &mut GameState,
     events: &mut Vec<Event>,
@@ -226,6 +229,7 @@ fn chaos_token_drawn(
         };
     }
     state.rng = probe;
-    events.push(Event::ChaosTokenRevealed { token, modifier: 0 });
+    let resolution = resolve_token(token, &state.token_modifiers);
+    events.push(Event::ChaosTokenRevealed { token, resolution });
     EngineOutcome::Done
 }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -251,15 +251,20 @@ mod tests {
         );
 
         assert_eq!(result.outcome, EngineOutcome::Done);
+        // The bag has only Skull and Numeric tokens — both resolve to
+        // Modifier(_), no AutoFail/ElderSign should ever appear here.
+        // Asserting the variant guards against a future bug that emits
+        // AutoFail unconditionally.
         assert_event!(
             result.events,
-            Event::ChaosTokenRevealed { token: t, .. } if *t == token
+            Event::ChaosTokenRevealed { token: t, resolution: TokenResolution::Modifier(_) }
+                if *t == token
         );
         assert_eq!(result.state.rng.draws, draws_before + 1);
     }
 
-    /// All seven token kinds, so a draw across this bag exercises every
-    /// resolution branch.
+    /// All seven `ChaosToken` variants (with `Numeric` exercised at two
+    /// values), so a draw across this bag covers every resolution branch.
     fn bag_with_all_token_kinds() -> crate::state::ChaosBag {
         crate::state::ChaosBag::new([
             ChaosToken::Numeric(1),
@@ -296,10 +301,10 @@ mod tests {
 
         let mut seen: std::collections::HashMap<ChaosToken, TokenResolution> =
             std::collections::HashMap::new();
-        // Eight tokens in the bag; loop until we've witnessed each kind.
-        // RNG draws with replacement (see ChaosBag::tokens semantics:
-        // order doesn't matter, draw via RNG), so this terminates
-        // quickly without us pre-computing the sequence.
+        // The dispatch handler doesn't yet remove drawn tokens from the
+        // bag (depletion lands with skill-test sequencing in #49), so
+        // the same bag is sampled on each iteration and we just loop
+        // until every distinct kind has been seen.
         let kinds_to_cover = [
             ChaosToken::Numeric(1),
             ChaosToken::Numeric(-2),

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -78,7 +78,7 @@ pub fn apply(state: GameState, action: Action) -> ApplyResult {
 mod tests {
     use crate::action::{Action, EngineRecord, InputResponse, PlayerAction};
     use crate::event::Event;
-    use crate::state::{ChaosToken, InvestigatorId, Phase};
+    use crate::state::{ChaosToken, InvestigatorId, Phase, TokenModifiers, TokenResolution};
     use crate::test_support::{test_investigator, TestGame};
     use crate::{assert_event, assert_event_count, assert_no_event};
 
@@ -253,9 +253,109 @@ mod tests {
         assert_eq!(result.outcome, EngineOutcome::Done);
         assert_event!(
             result.events,
-            Event::ChaosTokenRevealed { token: t, modifier: 0 } if *t == token
+            Event::ChaosTokenRevealed { token: t, .. } if *t == token
         );
         assert_eq!(result.state.rng.draws, draws_before + 1);
+    }
+
+    /// All seven token kinds, so a draw across this bag exercises every
+    /// resolution branch.
+    fn bag_with_all_token_kinds() -> crate::state::ChaosBag {
+        crate::state::ChaosBag::new([
+            ChaosToken::Numeric(1),
+            ChaosToken::Numeric(-2),
+            ChaosToken::Skull,
+            ChaosToken::Cultist,
+            ChaosToken::Tablet,
+            ChaosToken::ElderThing,
+            ChaosToken::AutoFail,
+            ChaosToken::ElderSign,
+        ])
+    }
+
+    /// Standard-difficulty Night of the Zealot symbol-token values.
+    fn night_of_the_zealot_standard() -> TokenModifiers {
+        TokenModifiers {
+            skull: -1,
+            cultist: -2,
+            tablet: -3,
+            elder_thing: -4,
+        }
+    }
+
+    #[test]
+    fn chaos_token_drawn_emits_resolution_for_each_token_kind() {
+        // Drive the engine across all seven token kinds and assert each
+        // one's emitted resolution matches the scenario modifiers and
+        // the AutoFail/ElderSign special variants.
+        let mut state = TestGame::new()
+            .with_chaos_bag(bag_with_all_token_kinds())
+            .with_token_modifiers(night_of_the_zealot_standard())
+            .with_rng_seed(7)
+            .build();
+
+        let mut seen: std::collections::HashMap<ChaosToken, TokenResolution> =
+            std::collections::HashMap::new();
+        // Eight tokens in the bag; loop until we've witnessed each kind.
+        // RNG draws with replacement (see ChaosBag::tokens semantics:
+        // order doesn't matter, draw via RNG), so this terminates
+        // quickly without us pre-computing the sequence.
+        let kinds_to_cover = [
+            ChaosToken::Numeric(1),
+            ChaosToken::Numeric(-2),
+            ChaosToken::Skull,
+            ChaosToken::Cultist,
+            ChaosToken::Tablet,
+            ChaosToken::ElderThing,
+            ChaosToken::AutoFail,
+            ChaosToken::ElderSign,
+        ];
+        let mut iters = 0;
+        while seen.len() < kinds_to_cover.len() {
+            iters += 1;
+            assert!(iters < 200, "RNG never produced full token coverage");
+            let token = peek_next_token(&state);
+            let result = apply(
+                state,
+                Action::Engine(EngineRecord::ChaosTokenDrawn { token }),
+            );
+            assert_eq!(result.outcome, EngineOutcome::Done);
+            let resolution = result
+                .events
+                .iter()
+                .find_map(|e| match e {
+                    Event::ChaosTokenRevealed { resolution, .. } => Some(*resolution),
+                    _ => None,
+                })
+                .expect("ChaosTokenRevealed event missing");
+            seen.entry(token).or_insert(resolution);
+            state = result.state;
+        }
+
+        let mods = night_of_the_zealot_standard();
+        assert_eq!(seen[&ChaosToken::Numeric(1)], TokenResolution::Modifier(1));
+        assert_eq!(
+            seen[&ChaosToken::Numeric(-2)],
+            TokenResolution::Modifier(-2),
+        );
+        assert_eq!(
+            seen[&ChaosToken::Skull],
+            TokenResolution::Modifier(mods.skull),
+        );
+        assert_eq!(
+            seen[&ChaosToken::Cultist],
+            TokenResolution::Modifier(mods.cultist),
+        );
+        assert_eq!(
+            seen[&ChaosToken::Tablet],
+            TokenResolution::Modifier(mods.tablet),
+        );
+        assert_eq!(
+            seen[&ChaosToken::ElderThing],
+            TokenResolution::Modifier(mods.elder_thing),
+        );
+        assert_eq!(seen[&ChaosToken::AutoFail], TokenResolution::AutoFail);
+        assert_eq!(seen[&ChaosToken::ElderSign], TokenResolution::ElderSign);
     }
 
     #[test]

--- a/crates/game-core/src/event.rs
+++ b/crates/game-core/src/event.rs
@@ -13,7 +13,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::state::{ChaosToken, InvestigatorId, LocationId, Phase};
+use crate::state::{ChaosToken, InvestigatorId, LocationId, Phase, TokenResolution};
 
 /// One state-change record emitted by the engine.
 ///
@@ -60,8 +60,12 @@ pub enum Event {
     ChaosTokenRevealed {
         /// The token revealed.
         token: ChaosToken,
-        /// Numeric modifier applied to the test's skill total.
-        modifier: i8,
+        /// How the token resolves against the scenario's modifier table:
+        /// a numeric modifier, [`AutoFail`], or [`ElderSign`].
+        ///
+        /// [`AutoFail`]: TokenResolution::AutoFail
+        /// [`ElderSign`]: TokenResolution::ElderSign
+        resolution: TokenResolution,
     },
     /// One or more clues moved to an investigator.
     CluePlaced {

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -32,6 +32,6 @@ pub use engine::{apply, ApplyResult, EngineOutcome, InputRequest, ResumeToken};
 pub use event::Event;
 pub use rng::RngState;
 pub use state::{
-    ChaosBag, ChaosToken, GameState, Investigator, InvestigatorId, Location, LocationId, Phase,
-    Skills,
+    resolve_token, ChaosBag, ChaosToken, GameState, Investigator, InvestigatorId, Location,
+    LocationId, Phase, Skills, TokenModifiers, TokenResolution,
 };

--- a/crates/game-core/src/state/chaos_bag.rs
+++ b/crates/game-core/src/state/chaos_bag.rs
@@ -52,3 +52,122 @@ impl ChaosBag {
         }
     }
 }
+
+/// Per-scenario numeric modifiers for the four symbol tokens.
+///
+/// Skull/Cultist/Tablet/ElderThing don't have intrinsic numeric values
+/// — each scenario (and difficulty) sets its own. This struct is set
+/// at scenario setup and is immutable for the duration of the scenario.
+///
+/// Symbol tokens may also trigger non-numeric scenario effects (e.g.
+/// "Cultist: −2 and an enemy spawns"). Only the numeric modifier lives
+/// here; effect triggering is a separate, downstream concern.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct TokenModifiers {
+    /// Numeric modifier for [`ChaosToken::Skull`].
+    pub skull: i8,
+    /// Numeric modifier for [`ChaosToken::Cultist`].
+    pub cultist: i8,
+    /// Numeric modifier for [`ChaosToken::Tablet`].
+    pub tablet: i8,
+    /// Numeric modifier for [`ChaosToken::ElderThing`].
+    pub elder_thing: i8,
+}
+
+/// The result of resolving a drawn chaos token against the scenario's
+/// modifier table.
+///
+/// Numeric/symbol tokens collapse to a [`Modifier`](Self::Modifier) (the
+/// integer added to the test's skill total). [`AutoFail`](Self::AutoFail)
+/// short-circuits the test to a guaranteed failure regardless of total.
+/// [`ElderSign`](Self::ElderSign) hands control to the active
+/// investigator's elder-sign ability, whose dispatch is downstream of
+/// this resolution step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TokenResolution {
+    /// Numeric modifier contributed to the skill-test total.
+    Modifier(i8),
+    /// Test fails regardless of skill total.
+    AutoFail,
+    /// Active investigator's elder-sign ability triggers.
+    ElderSign,
+}
+
+/// Resolve a drawn chaos token to its [`TokenResolution`] given the
+/// scenario's symbol-token modifiers.
+#[must_use]
+pub fn resolve_token(token: ChaosToken, modifiers: &TokenModifiers) -> TokenResolution {
+    match token {
+        ChaosToken::Numeric(n) => TokenResolution::Modifier(n),
+        ChaosToken::Skull => TokenResolution::Modifier(modifiers.skull),
+        ChaosToken::Cultist => TokenResolution::Modifier(modifiers.cultist),
+        ChaosToken::Tablet => TokenResolution::Modifier(modifiers.tablet),
+        ChaosToken::ElderThing => TokenResolution::Modifier(modifiers.elder_thing),
+        ChaosToken::AutoFail => TokenResolution::AutoFail,
+        ChaosToken::ElderSign => TokenResolution::ElderSign,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Standard-difficulty Night of the Zealot symbol-token values, as
+    /// a representative scenario configuration to exercise resolution
+    /// against non-zero modifiers.
+    fn night_of_the_zealot_standard() -> TokenModifiers {
+        TokenModifiers {
+            skull: -1,
+            cultist: -2,
+            tablet: -3,
+            elder_thing: -4,
+        }
+    }
+
+    #[test]
+    fn numeric_token_resolves_to_its_value() {
+        let mods = night_of_the_zealot_standard();
+        assert_eq!(
+            resolve_token(ChaosToken::Numeric(1), &mods),
+            TokenResolution::Modifier(1),
+        );
+        assert_eq!(
+            resolve_token(ChaosToken::Numeric(-2), &mods),
+            TokenResolution::Modifier(-2),
+        );
+    }
+
+    #[test]
+    fn symbol_tokens_resolve_to_scenario_modifiers() {
+        let mods = night_of_the_zealot_standard();
+        assert_eq!(
+            resolve_token(ChaosToken::Skull, &mods),
+            TokenResolution::Modifier(-1),
+        );
+        assert_eq!(
+            resolve_token(ChaosToken::Cultist, &mods),
+            TokenResolution::Modifier(-2),
+        );
+        assert_eq!(
+            resolve_token(ChaosToken::Tablet, &mods),
+            TokenResolution::Modifier(-3),
+        );
+        assert_eq!(
+            resolve_token(ChaosToken::ElderThing, &mods),
+            TokenResolution::Modifier(-4),
+        );
+    }
+
+    #[test]
+    fn autofail_and_elder_sign_resolve_to_their_special_variants() {
+        let mods = night_of_the_zealot_standard();
+        assert_eq!(
+            resolve_token(ChaosToken::AutoFail, &mods),
+            TokenResolution::AutoFail,
+        );
+        assert_eq!(
+            resolve_token(ChaosToken::ElderSign, &mods),
+            TokenResolution::ElderSign,
+        );
+    }
+}

--- a/crates/game-core/src/state/chaos_bag.rs
+++ b/crates/game-core/src/state/chaos_bag.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 /// negative) is added to the test's skill total. Symbol tokens
 /// ([`Skull`], [`Cultist`], [`Tablet`], [`ElderThing`]) have scenario- or
 /// effect-specific modifiers that are resolved by separate logic, not by
-/// this enum directly.
+/// this enum directly. See [`resolve_token`] for the resolver and
+/// [`TokenResolution`] for the result type.
 ///
 /// [`Skull`]: ChaosToken::Skull
 /// [`Cultist`]: ChaosToken::Cultist
@@ -63,6 +64,7 @@ impl ChaosBag {
 /// "Cultist: −2 and an enemy spawns"). Only the numeric modifier lives
 /// here; effect triggering is a separate, downstream concern.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct TokenModifiers {
     /// Numeric modifier for [`ChaosToken::Skull`].
     pub skull: i8,
@@ -84,6 +86,7 @@ pub struct TokenModifiers {
 /// investigator's elder-sign ability, whose dispatch is downstream of
 /// this resolution step.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum TokenResolution {
     /// Numeric modifier contributed to the skill-test total.
     Modifier(i8),

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    chaos_bag::ChaosBag,
+    chaos_bag::{ChaosBag, TokenModifiers},
     investigator::{Investigator, InvestigatorId},
     location::{Location, LocationId},
     phase::Phase,
@@ -36,6 +36,10 @@ pub struct GameState {
     pub locations: BTreeMap<LocationId, Location>,
     /// The chaos bag at this scenario's difficulty.
     pub chaos_bag: ChaosBag,
+    /// Per-scenario numeric values for the four symbol tokens
+    /// (Skull/Cultist/Tablet/ElderThing). Set at scenario setup,
+    /// immutable for the scenario.
+    pub token_modifiers: TokenModifiers,
     /// Current round phase.
     pub phase: Phase,
     /// 1-based round counter, incremented on each Mythos phase entry.

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -11,7 +11,7 @@ pub mod investigator;
 pub mod location;
 pub mod phase;
 
-pub use chaos_bag::{ChaosBag, ChaosToken};
+pub use chaos_bag::{resolve_token, ChaosBag, ChaosToken, TokenModifiers, TokenResolution};
 pub use game_state::GameState;
 pub use investigator::{Investigator, InvestigatorId, Skills};
 pub use location::{Location, LocationId};

--- a/crates/game-core/src/test_support/builder.rs
+++ b/crates/game-core/src/test_support/builder.rs
@@ -26,7 +26,9 @@
 use std::collections::BTreeMap;
 
 use crate::rng::RngState;
-use crate::state::{ChaosBag, GameState, Investigator, InvestigatorId, Location, Phase};
+use crate::state::{
+    ChaosBag, GameState, Investigator, InvestigatorId, Location, Phase, TokenModifiers,
+};
 
 /// Fluent builder for a [`GameState`].
 ///
@@ -39,6 +41,7 @@ pub struct TestGame {
     investigators: BTreeMap<InvestigatorId, Investigator>,
     locations: BTreeMap<crate::state::LocationId, Location>,
     chaos_bag: ChaosBag,
+    token_modifiers: TokenModifiers,
     phase: Phase,
     round: u32,
     active_investigator: Option<InvestigatorId>,
@@ -56,6 +59,7 @@ impl TestGame {
             investigators: BTreeMap::new(),
             locations: BTreeMap::new(),
             chaos_bag: ChaosBag::new([]),
+            token_modifiers: TokenModifiers::default(),
             phase: Phase::Mythos,
             round: 0,
             active_investigator: None,
@@ -81,6 +85,13 @@ impl TestGame {
     /// Set the chaos bag. Replaces any prior bag.
     pub fn with_chaos_bag(mut self, chaos_bag: ChaosBag) -> Self {
         self.chaos_bag = chaos_bag;
+        self
+    }
+
+    /// Set the per-scenario symbol-token modifiers. Defaults to all
+    /// zeros if not called.
+    pub fn with_token_modifiers(mut self, modifiers: TokenModifiers) -> Self {
+        self.token_modifiers = modifiers;
         self
     }
 
@@ -134,6 +145,7 @@ impl TestGame {
             investigators: self.investigators,
             locations: self.locations,
             chaos_bag: self.chaos_bag,
+            token_modifiers: self.token_modifiers,
             phase: self.phase,
             round: self.round,
             active_investigator: self.active_investigator,


### PR DESCRIPTION
## Summary

Closes #48. Replaces the placeholder `modifier: 0` on `ChaosTokenRevealed` with a real resolution against the scenario's symbol-token modifier table.

- New `TokenModifiers` (named-field struct, `i8` per symbol) lives on `GameState` next to `chaos_bag`. Set at scenario setup, immutable for the scenario.
- New `TokenResolution` enum: `Modifier(i8) | AutoFail | ElderSign`. AutoFail/ElderSign as variants — not sentinel ints — forces every future skill-test consumer to handle the special cases.
- `resolve_token(token, &TokenModifiers) -> TokenResolution` is a free function in `state/chaos_bag.rs`.
- `Event::ChaosTokenRevealed.modifier: i8` becomes `resolution: TokenResolution`. Single emit site, single test reader; small blast radius right now and locks in the right shape before #49 builds on top.
- `TestGame::with_token_modifiers(...)` for tests.

## Out of scope (downstream)

- Symbol-token non-numeric scenario effects ("Cultist: −2 and an enemy spawns"). Those hook into the skill-test resolution flow (#49) that consumes the event.
- Elder-sign ability dispatch (per-investigator).
- Sealed tokens / draw-time replacements (Olive McBride etc.).

## Test plan

- [x] `cargo test --all` — 47 game-core tests pass, including new `state::chaos_bag::tests::*` for pure resolution and `engine::tests::chaos_token_drawn_emits_resolution_for_each_token_kind` end-to-end.
- [x] `cargo clippy --all -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)