### PR TITLE
engine: skill-test resolution foundation

### DIFF
--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -10,13 +10,13 @@
 //!   messages as `PlayerAction`, so a client cannot fabricate
 //!   engine-only events.
 //! - [`Action::Engine`] wraps an [`EngineRecord`] — recorded output of
-//!   engine-side randomness or system events (chaos token draws, deck
-//!   shuffles). The engine generates these itself so the action log is
-//!   replayable; clients never construct them.
+//!   engine-side randomness or system events (deck shuffles). The
+//!   engine generates these itself so the action log is replayable;
+//!   clients never construct them.
 
 use serde::{Deserialize, Serialize};
 
-use crate::state::{ChaosToken, InvestigatorId, LocationId};
+use crate::state::{InvestigatorId, LocationId, SkillKind};
 
 /// A single entry in the action log.
 ///
@@ -44,6 +44,21 @@ pub enum PlayerAction {
     StartScenario,
     /// Active investigator ends their turn during the Investigation phase.
     EndTurn,
+    /// Perform a skill test on `investigator` against `difficulty`,
+    /// using the named `skill`.
+    ///
+    /// Phase-1 foundation: resolves in one apply call as base skill +
+    /// chaos token modifier vs. difficulty. Card commits, the commit
+    /// window's `AwaitingInput`, and the after-resolution trigger
+    /// window land in #63 / #64.
+    PerformSkillTest {
+        /// Investigator taking the test.
+        investigator: InvestigatorId,
+        /// Which of the four skills the test is against.
+        skill: SkillKind,
+        /// Difficulty: total to meet or exceed for success.
+        difficulty: i8,
+    },
     /// Respond to an `AwaitingInput` prompt the engine emitted. The
     /// shape of `response` is dictated by the active prompt. (The
     /// `EngineOutcome::AwaitingInput` variant lands in a later PR.)
@@ -55,24 +70,21 @@ pub enum PlayerAction {
 
 /// Engine-recorded events.
 ///
-/// Anything non-deterministic from the engine's perspective (RNG draws,
-/// timer-derived values) goes into the log as one of these variants so
-/// replay produces identical results.
+/// Anything non-deterministic from the engine's perspective (timer-
+/// derived values, deck shuffles) goes into the log as one of these
+/// variants so replay produces identical results. Chaos token draws
+/// are NOT recorded here — they happen inline as part of the action
+/// that triggered them (e.g. `PerformSkillTest`); RNG determinism plus
+/// the per-draw `Event::ChaosTokenRevealed` give replay equivalence.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum EngineRecord {
-    /// A chaos token was drawn from the bag.
-    ChaosTokenDrawn {
-        /// The token that was drawn.
-        token: ChaosToken,
-    },
     /// A deck was shuffled with the given seed. Replays use the same seed
     /// to reproduce the order.
     //
-    // TODO(#15): once there are multiple decks (encounter deck, each
+    // TODO(#62): once there are multiple decks (encounter deck, each
     // investigator's deck, act/agenda decks), this needs a `deck:
-    // DeckId` field to disambiguate. Punted to the apply-loop PR where
-    // DeckId will be defined.
+    // DeckId` field to disambiguate.
     DeckShuffled {
         /// Seed used for the shuffle.
         seed: u64,

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -223,7 +223,8 @@ fn perform_skill_test(
     difficulty: i8,
 ) -> EngineOutcome {
     // Validate-first: investigator must exist; chaos bag must be
-    // non-empty so we can draw.
+    // non-empty so we can draw; difficulty must be non-negative (FFG
+    // difficulties are always ≥ 0).
     let Some(inv) = state.investigators.get(&investigator) else {
         return EngineOutcome::Rejected {
             reason: format!("PerformSkillTest: investigator {investigator:?} not in state").into(),
@@ -232,6 +233,11 @@ fn perform_skill_test(
     if state.chaos_bag.tokens.is_empty() {
         return EngineOutcome::Rejected {
             reason: "PerformSkillTest requires a non-empty chaos bag".into(),
+        };
+    }
+    if difficulty < 0 {
+        return EngineOutcome::Rejected {
+            reason: format!("PerformSkillTest: difficulty {difficulty} must be >= 0").into(),
         };
     }
     let skill_value = inv.skills.value(skill);
@@ -256,39 +262,34 @@ fn perform_skill_test(
     //      never negative for margin-of-failure purposes.
     // ElderSign is a placeholder Modifier(0) until per-investigator
     // ability dispatch lands; that's a no-op for the math here.
-    let (raw_total, fail_reason) = match resolution {
-        TokenResolution::Modifier(n) => (i16::from(skill_value) + i16::from(n), None),
-        TokenResolution::ElderSign => (i16::from(skill_value), None),
+    //
+    // All arithmetic stays in i8 with saturating ops: realistic
+    // gameplay values (skill 1–8, modifier ±8, difficulty ≤ ~6) fit
+    // far inside i8, but saturation defends against absurd state
+    // configurations without needing a wider integer type.
+    let (total, fail_reason) = match resolution {
+        TokenResolution::Modifier(n) => (skill_value.saturating_add(n).max(0), None),
+        TokenResolution::ElderSign => (skill_value.max(0), None),
         TokenResolution::AutoFail => (0, Some(FailureReason::AutoFail)),
     };
-    let total = raw_total.max(0);
-    let margin = total - i16::from(difficulty);
+    let margin = total.saturating_sub(difficulty);
     if margin >= 0 && fail_reason.is_none() {
         events.push(Event::SkillTestSucceeded {
             investigator,
             skill,
-            margin: clamp_to_i8(margin),
+            margin,
         });
     } else {
         let reason = fail_reason.unwrap_or(FailureReason::Total);
-        let by = clamp_to_i8(i16::from(difficulty) - total);
+        let by = difficulty.saturating_sub(total);
         events.push(Event::SkillTestFailed {
             investigator,
             skill,
             reason,
-            by: by.max(0),
+            by,
         });
     }
 
     events.push(Event::SkillTestEnded { investigator });
     EngineOutcome::Done
-}
-
-/// Saturating cast `i16 -> i8`. Skill totals are computed in `i16` to
-/// avoid overflow when stacking very negative tokens with very low
-/// skills (e.g. `-8 - 5 = -13`, fits in `i16` cleanly), then narrowed
-/// for the event payload.
-fn clamp_to_i8(n: i16) -> i8 {
-    i8::try_from(n.clamp(i16::from(i8::MIN), i16::from(i8::MAX)))
-        .expect("clamped value is always within i8 range")
 }

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -9,8 +9,8 @@
 //! ones.
 
 use crate::action::{EngineRecord, PlayerAction};
-use crate::event::Event;
-use crate::state::{resolve_token, ChaosToken, GameState, InvestigatorId, Phase};
+use crate::event::{Event, FailureReason};
+use crate::state::{resolve_token, GameState, InvestigatorId, Phase, SkillKind, TokenResolution};
 
 use super::outcome::EngineOutcome;
 
@@ -33,9 +33,14 @@ pub fn apply_player_action(
     match action {
         PlayerAction::StartScenario => start_scenario(state, events),
         PlayerAction::EndTurn => end_turn(state, events),
+        PlayerAction::PerformSkillTest {
+            investigator,
+            skill,
+            difficulty,
+        } => perform_skill_test(state, events, *investigator, *skill, *difficulty),
         PlayerAction::ResolveInput { .. } => EngineOutcome::Rejected {
-            reason: "TODO(#18-#20): ResolveInput dispatch lands with the test \
-                     harness; no AwaitingInput sites exist yet."
+            reason: "TODO(#63): ResolveInput dispatch lands with the skill-test commit \
+                     window; no AwaitingInput sites exist yet."
                 .into(),
         },
     }
@@ -47,11 +52,10 @@ pub fn apply_engine_record(
     events: &mut Vec<Event>,
     record: &EngineRecord,
 ) -> EngineOutcome {
+    let _ = (state, events);
     match record {
-        EngineRecord::ChaosTokenDrawn { token } => chaos_token_drawn(state, events, *token),
         EngineRecord::DeckShuffled { .. } => EngineOutcome::Rejected {
-            reason: "TODO: DeckShuffled dispatch lands when decks exist (#15+ scenario plumbing)"
-                .into(),
+            reason: "TODO(#62): DeckShuffled dispatch lands when decks exist".into(),
         },
     }
 }
@@ -192,44 +196,99 @@ fn rotate_to_active(state: &mut GameState, events: &mut Vec<Event>, id: Investig
     });
 }
 
-/// Handler for [`EngineRecord::ChaosTokenDrawn`].
+/// Handler for [`PlayerAction::PerformSkillTest`].
 ///
-/// Validate-first pattern: clone the RNG, draw an index, check the
-/// recorded token matches `chaos_bag[index]`. Only on match do we
-/// commit the RNG advance and emit the event. A mismatch indicates
-/// log corruption — return `Rejected` without mutating state.
+/// Phase-1 foundation: declares the test, draws a chaos token, computes
+/// total = investigator's skill value + token numeric modifier vs.
+/// difficulty, and emits success/failure plus the bracketing
+/// `SkillTestStarted` / `SkillTestEnded` events — all in one apply call.
 ///
-/// The emitted event carries a [`TokenResolution`] resolved against the
-/// scenario's `token_modifiers`. Symbol-token *effects* beyond the
-/// numeric modifier (e.g. "Cultist: −2 and an enemy spawns") and the
-/// elder-sign ability dispatch are downstream of this handler; they
-/// hook into the skill-test resolution flow that consumes the event.
+/// Card commits, the commit-window `AwaitingInput`, and the after-
+/// resolution trigger window are downstream (#63 / #64).
 ///
-/// [`TokenResolution`]: crate::state::TokenResolution
-fn chaos_token_drawn(
+/// **`AutoFail`** short-circuits the outcome to failure regardless of
+/// numeric total — `FailureReason::AutoFail`.
+///
+/// **`ElderSign`** is treated as `Modifier(0)` for now, with a TODO:
+/// the canonical behavior is "trigger the active investigator's elder
+/// sign ability," which depends on per-investigator ability dispatch.
+/// Modifier 0 + a TODO is a safe no-op default — Daisy Walker's "+0"
+/// elder sign already matches this; other investigators will be
+/// honored when ability dispatch lands.
+fn perform_skill_test(
     state: &mut GameState,
     events: &mut Vec<Event>,
-    token: ChaosToken,
+    investigator: InvestigatorId,
+    skill: SkillKind,
+    difficulty: i8,
 ) -> EngineOutcome {
+    // Validate-first: investigator must exist; chaos bag must be
+    // non-empty so we can draw.
+    let Some(inv) = state.investigators.get(&investigator) else {
+        return EngineOutcome::Rejected {
+            reason: format!("PerformSkillTest: investigator {investigator:?} not in state").into(),
+        };
+    };
     if state.chaos_bag.tokens.is_empty() {
         return EngineOutcome::Rejected {
-            reason: "ChaosTokenDrawn requires a non-empty chaos bag".into(),
+            reason: "PerformSkillTest requires a non-empty chaos bag".into(),
         };
     }
-    let mut probe = state.rng.clone();
-    let idx = probe.next_index(state.chaos_bag.tokens.len());
-    let derived = state.chaos_bag.tokens[idx];
-    if derived != token {
-        return EngineOutcome::Rejected {
-            reason: format!(
-                "ChaosTokenDrawn: recorded token {token:?} does not match RNG-derived \
-                 {derived:?} (log corruption or wrong seed)"
-            )
-            .into(),
-        };
-    }
-    state.rng = probe;
+    let skill_value = inv.skills.value(skill);
+
+    // Mutate-second: advance RNG, derive token, emit events.
+    events.push(Event::SkillTestStarted {
+        investigator,
+        skill,
+        difficulty,
+    });
+
+    let idx = state.rng.next_index(state.chaos_bag.tokens.len());
+    let token = state.chaos_bag.tokens[idx];
     let resolution = resolve_token(token, &state.token_modifiers);
     events.push(Event::ChaosTokenRevealed { token, resolution });
+
+    // Two related rules from the Rules Reference + FAQ:
+    //   1. AutoFail forces the investigator's total to 0 (not just
+    //      "test fails regardless of total"); the failure margin is
+    //      computed against that 0.
+    //   2. A negative (skill + modifier) clamps to 0 — totals are
+    //      never negative for margin-of-failure purposes.
+    // ElderSign is a placeholder Modifier(0) until per-investigator
+    // ability dispatch lands; that's a no-op for the math here.
+    let (raw_total, fail_reason) = match resolution {
+        TokenResolution::Modifier(n) => (i16::from(skill_value) + i16::from(n), None),
+        TokenResolution::ElderSign => (i16::from(skill_value), None),
+        TokenResolution::AutoFail => (0, Some(FailureReason::AutoFail)),
+    };
+    let total = raw_total.max(0);
+    let margin = total - i16::from(difficulty);
+    if margin >= 0 && fail_reason.is_none() {
+        events.push(Event::SkillTestSucceeded {
+            investigator,
+            skill,
+            margin: clamp_to_i8(margin),
+        });
+    } else {
+        let reason = fail_reason.unwrap_or(FailureReason::Total);
+        let by = clamp_to_i8(i16::from(difficulty) - total);
+        events.push(Event::SkillTestFailed {
+            investigator,
+            skill,
+            reason,
+            by: by.max(0),
+        });
+    }
+
+    events.push(Event::SkillTestEnded { investigator });
     EngineOutcome::Done
+}
+
+/// Saturating cast `i16 -> i8`. Skill totals are computed in `i16` to
+/// avoid overflow when stacking very negative tokens with very low
+/// skills (e.g. `-8 - 5 = -13`, fits in `i16` cleanly), then narrowed
+/// for the event payload.
+fn clamp_to_i8(n: i16) -> i8 {
+    i8::try_from(n.clamp(i16::from(i8::MIN), i16::from(i8::MAX)))
+        .expect("clamped value is always within i8 range")
 }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -258,6 +258,25 @@ mod tests {
     }
 
     #[test]
+    fn perform_skill_test_with_negative_difficulty_is_rejected() {
+        let id = InvestigatorId(1);
+        let state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_chaos_bag(bag_only_zero())
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Willpower,
+                difficulty: -1,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
     fn perform_skill_test_succeeds_when_total_meets_difficulty() {
         // Default skills are 3/3/3/3; bag only has Numeric(0), so total=3.
         // Difficulty 3 → margin 0 → success.
@@ -298,6 +317,33 @@ mod tests {
             Event::SkillTestEnded { investigator } if *investigator == id
         );
         assert_no_event!(result.events, Event::SkillTestFailed { .. });
+    }
+
+    #[test]
+    fn perform_skill_test_succeeds_with_positive_margin() {
+        // Skill 5 + Numeric(0) vs difficulty 2 → margin 3.
+        let id = InvestigatorId(1);
+        let mut strong = test_investigator(1);
+        strong.skills.combat = 5;
+        let state = TestGame::new()
+            .with_investigator(strong)
+            .with_chaos_bag(bag_only_zero())
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Combat,
+                difficulty: 2,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::SkillTestSucceeded { investigator, skill: SkillKind::Combat, margin: 3 }
+                if *investigator == id
+        );
     }
 
     #[test]
@@ -363,6 +409,37 @@ mod tests {
                 by: 4,
             } if *investigator == id
         );
+    }
+
+    #[test]
+    fn perform_skill_test_autofail_at_difficulty_zero_still_fails() {
+        // Edge case: difficulty 0 would normally succeed at margin 0,
+        // but AutoFail forces total = 0 AND tags the result as a
+        // failure regardless. by = 0 here, reason = AutoFail.
+        let id = InvestigatorId(1);
+        let state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_chaos_bag(crate::state::ChaosBag::new([ChaosToken::AutoFail]))
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Willpower,
+                difficulty: 0,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::SkillTestFailed {
+                reason: FailureReason::AutoFail,
+                by: 0,
+                ..
+            }
+        );
+        assert_no_event!(result.events, Event::SkillTestSucceeded { .. });
     }
 
     #[test]

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -77,8 +77,10 @@ pub fn apply(state: GameState, action: Action) -> ApplyResult {
 #[cfg(test)]
 mod tests {
     use crate::action::{Action, EngineRecord, InputResponse, PlayerAction};
-    use crate::event::Event;
-    use crate::state::{ChaosToken, InvestigatorId, Phase, TokenModifiers, TokenResolution};
+    use crate::event::{Event, FailureReason};
+    use crate::state::{
+        ChaosToken, InvestigatorId, Phase, SkillKind, TokenModifiers, TokenResolution,
+    };
     use crate::test_support::{test_investigator, TestGame};
     use crate::{assert_event, assert_event_count, assert_no_event};
 
@@ -206,78 +208,6 @@ mod tests {
         assert_eq!(result.state.active_investigator, active_before);
     }
 
-    #[test]
-    fn chaos_token_drawn_with_empty_bag_is_rejected() {
-        let state = TestGame::new().build();
-        let result = apply(
-            state,
-            Action::Engine(EngineRecord::ChaosTokenDrawn {
-                token: ChaosToken::Skull,
-            }),
-        );
-        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
-        assert!(result.events.is_empty());
-    }
-
-    fn bag_with_three_tokens() -> crate::state::ChaosBag {
-        crate::state::ChaosBag::new([
-            ChaosToken::Skull,
-            ChaosToken::Numeric(1),
-            ChaosToken::Numeric(-2),
-        ])
-    }
-
-    /// Drive the RNG forward to figure out which token *will* be drawn
-    /// next. Used by tests to construct a `ChaosTokenDrawn` action with
-    /// a token that matches the RNG's expectation.
-    fn peek_next_token(state: &crate::state::GameState) -> ChaosToken {
-        let mut probe = state.rng.clone();
-        let idx = probe.next_index(state.chaos_bag.tokens.len());
-        state.chaos_bag.tokens[idx]
-    }
-
-    #[test]
-    fn chaos_token_drawn_with_matching_token_succeeds_and_advances_rng() {
-        let state = TestGame::new()
-            .with_chaos_bag(bag_with_three_tokens())
-            .with_rng_seed(42)
-            .build();
-        let token = peek_next_token(&state);
-        let draws_before = state.rng.draws;
-
-        let result = apply(
-            state,
-            Action::Engine(EngineRecord::ChaosTokenDrawn { token }),
-        );
-
-        assert_eq!(result.outcome, EngineOutcome::Done);
-        // The bag has only Skull and Numeric tokens — both resolve to
-        // Modifier(_), no AutoFail/ElderSign should ever appear here.
-        // Asserting the variant guards against a future bug that emits
-        // AutoFail unconditionally.
-        assert_event!(
-            result.events,
-            Event::ChaosTokenRevealed { token: t, resolution: TokenResolution::Modifier(_) }
-                if *t == token
-        );
-        assert_eq!(result.state.rng.draws, draws_before + 1);
-    }
-
-    /// All seven `ChaosToken` variants (with `Numeric` exercised at two
-    /// values), so a draw across this bag covers every resolution branch.
-    fn bag_with_all_token_kinds() -> crate::state::ChaosBag {
-        crate::state::ChaosBag::new([
-            ChaosToken::Numeric(1),
-            ChaosToken::Numeric(-2),
-            ChaosToken::Skull,
-            ChaosToken::Cultist,
-            ChaosToken::Tablet,
-            ChaosToken::ElderThing,
-            ChaosToken::AutoFail,
-            ChaosToken::ElderSign,
-        ])
-    }
-
     /// Standard-difficulty Night of the Zealot symbol-token values.
     fn night_of_the_zealot_standard() -> TokenModifiers {
         TokenModifiers {
@@ -288,106 +218,273 @@ mod tests {
         }
     }
 
-    #[test]
-    fn chaos_token_drawn_emits_resolution_for_each_token_kind() {
-        // Drive the engine across all seven token kinds and assert each
-        // one's emitted resolution matches the scenario modifiers and
-        // the AutoFail/ElderSign special variants.
-        let mut state = TestGame::new()
-            .with_chaos_bag(bag_with_all_token_kinds())
-            .with_token_modifiers(night_of_the_zealot_standard())
-            .with_rng_seed(7)
-            .build();
-
-        let mut seen: std::collections::HashMap<ChaosToken, TokenResolution> =
-            std::collections::HashMap::new();
-        // The dispatch handler doesn't yet remove drawn tokens from the
-        // bag (depletion lands with skill-test sequencing in #49), so
-        // the same bag is sampled on each iteration and we just loop
-        // until every distinct kind has been seen.
-        let kinds_to_cover = [
-            ChaosToken::Numeric(1),
-            ChaosToken::Numeric(-2),
-            ChaosToken::Skull,
-            ChaosToken::Cultist,
-            ChaosToken::Tablet,
-            ChaosToken::ElderThing,
-            ChaosToken::AutoFail,
-            ChaosToken::ElderSign,
-        ];
-        let mut iters = 0;
-        while seen.len() < kinds_to_cover.len() {
-            iters += 1;
-            assert!(iters < 200, "RNG never produced full token coverage");
-            let token = peek_next_token(&state);
-            let result = apply(
-                state,
-                Action::Engine(EngineRecord::ChaosTokenDrawn { token }),
-            );
-            assert_eq!(result.outcome, EngineOutcome::Done);
-            let resolution = result
-                .events
-                .iter()
-                .find_map(|e| match e {
-                    Event::ChaosTokenRevealed { resolution, .. } => Some(*resolution),
-                    _ => None,
-                })
-                .expect("ChaosTokenRevealed event missing");
-            seen.entry(token).or_insert(resolution);
-            state = result.state;
-        }
-
-        let mods = night_of_the_zealot_standard();
-        assert_eq!(seen[&ChaosToken::Numeric(1)], TokenResolution::Modifier(1));
-        assert_eq!(
-            seen[&ChaosToken::Numeric(-2)],
-            TokenResolution::Modifier(-2),
-        );
-        assert_eq!(
-            seen[&ChaosToken::Skull],
-            TokenResolution::Modifier(mods.skull),
-        );
-        assert_eq!(
-            seen[&ChaosToken::Cultist],
-            TokenResolution::Modifier(mods.cultist),
-        );
-        assert_eq!(
-            seen[&ChaosToken::Tablet],
-            TokenResolution::Modifier(mods.tablet),
-        );
-        assert_eq!(
-            seen[&ChaosToken::ElderThing],
-            TokenResolution::Modifier(mods.elder_thing),
-        );
-        assert_eq!(seen[&ChaosToken::AutoFail], TokenResolution::AutoFail);
-        assert_eq!(seen[&ChaosToken::ElderSign], TokenResolution::ElderSign);
+    /// Bag of a single `Numeric(0)` token — the next draw is always a
+    /// no-op modifier, so test totals = skill exactly.
+    fn bag_only_zero() -> crate::state::ChaosBag {
+        crate::state::ChaosBag::new([ChaosToken::Numeric(0)])
     }
 
     #[test]
-    fn chaos_token_drawn_with_wrong_token_is_rejected_and_does_not_advance_rng() {
-        let state = TestGame::new()
-            .with_chaos_bag(bag_with_three_tokens())
-            .with_rng_seed(42)
-            .build();
-        let correct = peek_next_token(&state);
-        // Pick any token from the bag that ISN'T the correct one.
-        let wrong = state
-            .chaos_bag
-            .tokens
-            .iter()
-            .copied()
-            .find(|t| *t != correct)
-            .expect("bag contains at least two distinct tokens");
-        let rng_before = state.rng.clone();
-
+    fn perform_skill_test_with_unknown_investigator_is_rejected() {
+        let state = TestGame::new().with_chaos_bag(bag_only_zero()).build();
         let result = apply(
             state,
-            Action::Engine(EngineRecord::ChaosTokenDrawn { token: wrong }),
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: InvestigatorId(999),
+                skill: SkillKind::Willpower,
+                difficulty: 0,
+            }),
         );
-
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
         assert!(result.events.is_empty());
-        assert_eq!(result.state.rng, rng_before);
+    }
+
+    #[test]
+    fn perform_skill_test_with_empty_bag_is_rejected() {
+        let id = InvestigatorId(1);
+        let state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Willpower,
+                difficulty: 0,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn perform_skill_test_succeeds_when_total_meets_difficulty() {
+        // Default skills are 3/3/3/3; bag only has Numeric(0), so total=3.
+        // Difficulty 3 → margin 0 → success.
+        let id = InvestigatorId(1);
+        let state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_chaos_bag(bag_only_zero())
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Intellect,
+                difficulty: 3,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::SkillTestStarted { investigator, skill: SkillKind::Intellect, difficulty: 3 }
+                if *investigator == id
+        );
+        assert_event!(
+            result.events,
+            Event::ChaosTokenRevealed {
+                token: ChaosToken::Numeric(0),
+                resolution: TokenResolution::Modifier(0),
+            }
+        );
+        assert_event!(
+            result.events,
+            Event::SkillTestSucceeded { investigator, skill: SkillKind::Intellect, margin: 0 }
+                if *investigator == id
+        );
+        assert_event!(
+            result.events,
+            Event::SkillTestEnded { investigator } if *investigator == id
+        );
+        assert_no_event!(result.events, Event::SkillTestFailed { .. });
+    }
+
+    #[test]
+    fn perform_skill_test_fails_when_total_below_difficulty() {
+        // Skills 3/3/3/3, bag Numeric(0), difficulty 5 → margin -2 →
+        // FailureReason::Total, by: 2.
+        let id = InvestigatorId(1);
+        let state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_chaos_bag(bag_only_zero())
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Combat,
+                difficulty: 5,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::SkillTestFailed {
+                investigator,
+                skill: SkillKind::Combat,
+                reason: FailureReason::Total,
+                by: 2,
+            } if *investigator == id
+        );
+        assert_no_event!(result.events, Event::SkillTestSucceeded { .. });
+    }
+
+    #[test]
+    fn perform_skill_test_autofail_forces_total_to_zero() {
+        // Per the Rules Reference: AutoFail makes the investigator's
+        // total = 0 (not just "test fails"), so the failure margin is
+        // computed against 0. Skill 99 + AutoFail vs difficulty 4 →
+        // total 0, by = 4, reason AutoFail.
+        let id = InvestigatorId(1);
+        let mut high = test_investigator(1);
+        high.skills.willpower = 99;
+        let state = TestGame::new()
+            .with_investigator(high)
+            .with_chaos_bag(crate::state::ChaosBag::new([ChaosToken::AutoFail]))
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Willpower,
+                difficulty: 4,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::SkillTestFailed {
+                investigator,
+                skill: SkillKind::Willpower,
+                reason: FailureReason::AutoFail,
+                by: 4,
+            } if *investigator == id
+        );
+    }
+
+    #[test]
+    fn perform_skill_test_clamps_negative_total_to_zero() {
+        // skill 3 + Skull(−6) = −3, clamped to 0. Difficulty 2 →
+        // by = 2, reason Total (NOT AutoFail).
+        let id = InvestigatorId(1);
+        let state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_chaos_bag(crate::state::ChaosBag::new([ChaosToken::Skull]))
+            .with_token_modifiers(TokenModifiers {
+                skull: -6,
+                ..TokenModifiers::default()
+            })
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Willpower,
+                difficulty: 2,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::SkillTestFailed {
+                reason: FailureReason::Total,
+                by: 2,
+                ..
+            }
+        );
+    }
+
+    #[test]
+    fn perform_skill_test_elder_sign_treated_as_modifier_zero() {
+        // ElderSign as +0 placeholder until per-investigator ability
+        // dispatch lands. Skill 3, difficulty 3 → margin 0 → success.
+        let id = InvestigatorId(1);
+        let state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_chaos_bag(crate::state::ChaosBag::new([ChaosToken::ElderSign]))
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Agility,
+                difficulty: 3,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::ChaosTokenRevealed {
+                token: ChaosToken::ElderSign,
+                resolution: TokenResolution::ElderSign,
+            }
+        );
+        assert_event!(result.events, Event::SkillTestSucceeded { margin: 0, .. });
+    }
+
+    #[test]
+    fn perform_skill_test_symbol_token_modifier_applies() {
+        // Bag is one Skull. Standard-difficulty NotZ: skull = -1.
+        // Skill 3 + (-1) = 2 vs difficulty 2 → margin 0 → success.
+        let id = InvestigatorId(1);
+        let state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_chaos_bag(crate::state::ChaosBag::new([ChaosToken::Skull]))
+            .with_token_modifiers(night_of_the_zealot_standard())
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Willpower,
+                difficulty: 2,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::ChaosTokenRevealed {
+                token: ChaosToken::Skull,
+                resolution: TokenResolution::Modifier(-1),
+            }
+        );
+        assert_event!(result.events, Event::SkillTestSucceeded { margin: 0, .. });
+    }
+
+    #[test]
+    fn perform_skill_test_advances_rng_and_log_round_trips() {
+        // Determinism: applying the same PerformSkillTest action twice
+        // from identical initial state produces identical post-state.
+        let id = InvestigatorId(1);
+        let initial = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_chaos_bag(crate::state::ChaosBag::new([
+                ChaosToken::Numeric(1),
+                ChaosToken::Numeric(-1),
+                ChaosToken::Skull,
+            ]))
+            .with_token_modifiers(night_of_the_zealot_standard())
+            .with_rng_seed(123)
+            .build();
+        let action = Action::Player(PlayerAction::PerformSkillTest {
+            investigator: id,
+            skill: SkillKind::Willpower,
+            difficulty: 3,
+        });
+
+        let first = apply(initial.clone(), action.clone());
+        let second = apply(initial, action);
+
+        assert_eq!(first.outcome, EngineOutcome::Done);
+        assert_eq!(first.state.rng, second.state.rng);
+        assert_eq!(first.state.rng.draws, 1);
+        assert_eq!(first.events, second.events);
     }
 
     #[test]
@@ -490,40 +587,6 @@ mod tests {
         assert_eq!(result.state.investigators[&id].actions_remaining, 3);
         assert_event_count!(result.events, 4, Event::PhaseEnded { .. });
         assert_event_count!(result.events, 4, Event::PhaseStarted { .. });
-    }
-
-    #[test]
-    fn chaos_token_drawn_log_round_trips() {
-        // Build a five-draw log against an initial state, then replay
-        // the log from scratch and assert the resulting RNG state
-        // matches. This is the core determinism property.
-        let initial = TestGame::new()
-            .with_chaos_bag(bag_with_three_tokens())
-            .with_rng_seed(123)
-            .build();
-
-        let mut state = initial.clone();
-        let mut log = Vec::new();
-        for _ in 0..5 {
-            let token = peek_next_token(&state);
-            let action = Action::Engine(EngineRecord::ChaosTokenDrawn { token });
-            log.push(action.clone());
-            let result = apply(state, action);
-            assert_eq!(result.outcome, EngineOutcome::Done);
-            state = result.state;
-        }
-        let after_first_pass = state;
-
-        // Replay against the original initial state.
-        let mut replay = initial;
-        for action in log {
-            let result = apply(replay, action);
-            assert_eq!(result.outcome, EngineOutcome::Done);
-            replay = result.state;
-        }
-
-        assert_eq!(after_first_pass.rng, replay.rng);
-        assert_eq!(after_first_pass.rng.draws, 5);
     }
 
     #[test]

--- a/crates/game-core/src/event.rs
+++ b/crates/game-core/src/event.rs
@@ -13,7 +13,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::state::{ChaosToken, InvestigatorId, LocationId, Phase, TokenResolution};
+use crate::state::{ChaosToken, InvestigatorId, LocationId, Phase, SkillKind, TokenResolution};
 
 /// One state-change record emitted by the engine.
 ///
@@ -110,4 +110,66 @@ pub enum Event {
         /// Amount paid.
         amount: u8,
     },
+    /// A skill test was declared and resolution has begun.
+    SkillTestStarted {
+        /// Investigator taking the test.
+        investigator: InvestigatorId,
+        /// Skill the test is against.
+        skill: SkillKind,
+        /// Difficulty: total to meet or exceed for success.
+        difficulty: i8,
+    },
+    /// A skill test succeeded. The investigator's total met or
+    /// exceeded the difficulty.
+    SkillTestSucceeded {
+        /// Investigator who passed the test.
+        investigator: InvestigatorId,
+        /// Skill the test was against.
+        skill: SkillKind,
+        /// `total - difficulty`. Always `>= 0` for a success.
+        margin: i8,
+    },
+    /// A skill test failed. Either the total fell short of the
+    /// difficulty, or an `AutoFail` chaos token forced the total to 0.
+    ///
+    /// Note: per the Rules Reference, the investigator's total is
+    /// clamped to a minimum of 0 before the margin is computed (a
+    /// negative `skill + modifier` is treated as 0). `AutoFail` short-
+    /// circuits to the same total = 0 regardless of skill or modifier.
+    /// In both cases `by` reflects the clamped margin.
+    SkillTestFailed {
+        /// Investigator who failed the test.
+        investigator: InvestigatorId,
+        /// Skill the test was against.
+        skill: SkillKind,
+        /// Why the test failed.
+        reason: FailureReason,
+        /// Amount the test failed by (`difficulty - clamped_total`,
+        /// always `>= 0`). Effects keying on "if you fail by X+" read
+        /// this directly.
+        by: i8,
+    },
+    /// The skill-test resolution sequence finished. Cleanup events
+    /// (committed-card discards, etc.) precede this; downstream
+    /// listeners use it as a "test is fully over" signal.
+    SkillTestEnded {
+        /// Investigator the test was for.
+        investigator: InvestigatorId,
+    },
+}
+
+/// Why a skill test failed.
+///
+/// Both variants produce a `by` margin on the bracketing
+/// [`SkillTestFailed`](Event::SkillTestFailed) event; this enum names
+/// the *cause*, which some card effects key off independently of the
+/// numeric margin.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum FailureReason {
+    /// The investigator's clamped total fell short of the difficulty.
+    Total,
+    /// An `AutoFail` chaos token forced the total to 0, regardless of
+    /// skill value or other modifiers.
+    AutoFail,
 }

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -29,9 +29,9 @@ pub mod test_support;
 
 pub use action::{Action, EngineRecord, InputResponse, PlayerAction};
 pub use engine::{apply, ApplyResult, EngineOutcome, InputRequest, ResumeToken};
-pub use event::Event;
+pub use event::{Event, FailureReason};
 pub use rng::RngState;
 pub use state::{
     resolve_token, ChaosBag, ChaosToken, GameState, Investigator, InvestigatorId, Location,
-    LocationId, Phase, Skills, TokenModifiers, TokenResolution,
+    LocationId, Phase, SkillKind, Skills, TokenModifiers, TokenResolution,
 };

--- a/crates/game-core/src/state/investigator.rs
+++ b/crates/game-core/src/state/investigator.rs
@@ -65,3 +65,32 @@ pub struct Skills {
     /// Used for evade tests.
     pub agility: i8,
 }
+
+impl Skills {
+    /// Lookup the value for a given [`SkillKind`].
+    #[must_use]
+    pub fn value(&self, kind: SkillKind) -> i8 {
+        match kind {
+            SkillKind::Willpower => self.willpower,
+            SkillKind::Intellect => self.intellect,
+            SkillKind::Combat => self.combat,
+            SkillKind::Agility => self.agility,
+        }
+    }
+}
+
+/// Which of the four skill values a skill test is being made against.
+///
+/// Deliberately NOT `#[non_exhaustive]` — same rationale as [`Skills`]:
+/// the four skill kinds are fixed by FFG's rules.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum SkillKind {
+    /// Tests against the will, fear, sanity-eroding effects.
+    Willpower,
+    /// Tests for investigating, deduction, lore.
+    Intellect,
+    /// Tests for fighting, combat, physical strength.
+    Combat,
+    /// Tests for evading, dexterity, speed.
+    Agility,
+}

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -13,6 +13,6 @@ pub mod phase;
 
 pub use chaos_bag::{resolve_token, ChaosBag, ChaosToken, TokenModifiers, TokenResolution};
 pub use game_state::GameState;
-pub use investigator::{Investigator, InvestigatorId, Skills};
+pub use investigator::{Investigator, InvestigatorId, SkillKind, Skills};
 pub use location::{Location, LocationId};
 pub use phase::Phase;


### PR DESCRIPTION
## Summary

Closes #49. Skill-test resolution flow as a single-apply foundation:
declare → token reveal → calculate (clamped) → succeed/fail → end.

The full skill-test feature is split across four issues; card commits,
the commit-window \`AwaitingInput\`, and the after-resolution trigger
window are downstream (#63 / #64 / #65).

## What's in

- **\`PlayerAction::PerformSkillTest { investigator, skill, difficulty }\`**.
- **\`SkillKind\`** enum (Willpower / Intellect / Combat / Agility), plus a \`Skills::value(SkillKind)\` lookup helper.
- New events: **\`SkillTestStarted\`**, **\`SkillTestSucceeded { margin }\`**, **\`SkillTestFailed { reason, by }\`** (with \`FailureReason: Total | AutoFail\`), **\`SkillTestEnded\`**.
- Two Rules-Reference rules baked into margin computation (the user caught these in review of the early draft):
  - **AutoFail forces total = 0** (not just "test fails regardless of total"); margin is computed against 0.
  - **Negative \`skill + modifier\` clamps to 0**; e.g. skill 3 + Skull(−6) → total 0, not −3.
- ElderSign is a placeholder \`Modifier(0)\` with a TODO until per-investigator ability dispatch lands. (Daisy Walker's "+0" matches this; others will be honored when ability dispatch arrives.)

## What's removed

- \`EngineRecord::ChaosTokenDrawn\` and its handler / tests. Pre-skill-test scaffolding; redundant once the chaos bag is drawn inline. RNG determinism plus \`Event::ChaosTokenRevealed\` give replay equivalence (and naturally support multi-draw scenarios — N draws produce N events from a single triggering action).

## Out of scope (downstream)

- Card commits from hand (#63, blocked on #62 hand state).
- Commit-window \`AwaitingInput\` (lands with #63).
- After-resolution trigger window (#64, blocked on #54 OnEvent).
- Other-investigator commits (#65, p2-later).
- ElderSign ability dispatch (per-investigator abilities, downstream).

## Test plan

- [x] \`cargo test --all\` — 51 game-core tests pass (was 47), including new skill-test tests covering: success at margin 0, failure with by-margin, AutoFail forces total=0 (test asserts \`by: 4\` against difficulty 4 with skill 99), negative-clamp rule (skill 3 + Skull(−6) clamps to 0), ElderSign as Modifier(0), symbol-token modifier wiring, replay determinism, unknown investigator rejected, empty bag rejected.
- [x] \`cargo clippy --all -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)