### PR TITLE
engine: Investigate action

### DIFF
--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -59,6 +59,19 @@ pub enum PlayerAction {
         /// Difficulty: total to meet or exceed for success.
         difficulty: i8,
     },
+    /// Investigate at the active investigator's current location:
+    /// spend 1 action, make an intellect test against the location's
+    /// shroud value, and on success discover 1 clue at the location.
+    ///
+    /// Card-derived investigate variants (Rite of Seeking's "Action.
+    /// Spend 1 charge: Investigate using willpower instead of intellect",
+    /// Working a Hunch's discover-without-test) are the cards' concern,
+    /// not this action.
+    Investigate {
+        /// Investigator performing the action. Must be the active
+        /// investigator during the Investigation phase.
+        investigator: InvestigatorId,
+    },
     /// Respond to an `AwaitingInput` prompt the engine emitted. The
     /// shape of `response` is dictated by the active prompt. (The
     /// `EngineOutcome::AwaitingInput` variant lands in a later PR.)

--- a/crates/game-core/src/dsl.rs
+++ b/crates/game-core/src/dsl.rs
@@ -20,17 +20,17 @@
 //! land:
 //!
 //! - **Activated abilities** (`[action]` / `[fast]` symbols on
-//!   asset abilities — Hyperawareness's "[fast] Spend 1 resource:
-//!   You get +1 [intellect] for this skill test", etc.). Need a
+//!   asset abilities — Hyperawareness's `[fast] Spend 1 resource:
+//!   You get +1 [intellect] for this skill test`, etc.). Need a
 //!   `Trigger::Activated { action_cost: u8, costs: Vec<Cost> }` plus
 //!   cost primitives.
-//! - **Forced / leave-play triggers** (Harold Walsted's "Forced — when
-//!   Harold Walsted leaves play: Remove him from the game and add..."
+//! - **Forced / leave-play triggers** (Harold Walsted's `Forced — when
+//!   Harold Walsted leaves play: Remove him from the game and add...`
 //!   from the Dunwich cycle). Need `Trigger::OnLeavePlay` plus
 //!   ability-specific effect machinery.
-//! - **Reaction abilities** (Roland Banks's "[reaction] After you
+//! - **Reaction abilities** (Roland Banks's `[reaction] After you
 //!   defeat an enemy: Discover 1 clue at your location. (Limit once
-//!   per round.)"). Need `Trigger::Reaction(EventPattern)` with the
+//!   per round.)`). Need `Trigger::Reaction(EventPattern)` with the
 //!   engine's event-window plumbing plus per-round limit tracking.
 //! - **Stat-comparison / location-state conditions** (`LocationHasClues`,
 //!   `AnyEnemyEngaged`, `SkillSucceededByAtLeast(N)`). Phase-2 only
@@ -390,6 +390,22 @@ mod tests {
             constant(modify(Stat::MaxHealth, 1, ModifierScope::WhileInPlay)),
         ];
         assert_eq!(abilities.len(), 2);
+        assert!(matches!(
+            abilities[0].effect,
+            Effect::Modify {
+                stat: Stat::Willpower,
+                delta: 1,
+                scope: ModifierScope::WhileInPlay,
+            }
+        ));
+        assert!(matches!(
+            abilities[1].effect,
+            Effect::Modify {
+                stat: Stat::MaxHealth,
+                delta: 1,
+                scope: ModifierScope::WhileInPlay,
+            }
+        ));
     }
 
     /// Working a Hunch's "fast event: discover 1 clue at your location"

--- a/crates/game-core/src/dsl.rs
+++ b/crates/game-core/src/dsl.rs
@@ -20,17 +20,18 @@
 //! land:
 //!
 //! - **Activated abilities** (`[action]` / `[fast]` symbols on
-//!   asset abilities — Hyperawareness, Magnifying Glass's "spend X
-//!   resources for Y" abilities, etc.). Need a `Trigger::Activated
-//!   { action_cost: u8, costs: Vec<Cost> }` plus cost primitives.
-//! - **Forced / leave-play triggers** (Beat Cop's "Forced — when
-//!   leaves play, deal 1 damage to a non-elite enemy at your
-//!   location"). Need `Trigger::OnLeavePlay`, plus enemy targeting
-//!   and trait/elite filters.
-//! - **Reaction abilities** (Roland's "After you defeat an enemy:
-//!   discover 1 clue at your location"). Need
-//!   `Trigger::Reaction(EventPattern)` with the engine's event-window
-//!   plumbing.
+//!   asset abilities — Hyperawareness's "[fast] Spend 1 resource:
+//!   You get +1 [intellect] for this skill test", etc.). Need a
+//!   `Trigger::Activated { action_cost: u8, costs: Vec<Cost> }` plus
+//!   cost primitives.
+//! - **Forced / leave-play triggers** (Harold Walsted's "Forced — when
+//!   Harold Walsted leaves play: Remove him from the game and add..."
+//!   from the Dunwich cycle). Need `Trigger::OnLeavePlay` plus
+//!   ability-specific effect machinery.
+//! - **Reaction abilities** (Roland Banks's "[reaction] After you
+//!   defeat an enemy: Discover 1 clue at your location. (Limit once
+//!   per round.)"). Need `Trigger::Reaction(EventPattern)` with the
+//!   engine's event-window plumbing plus per-round limit tracking.
 //! - **Stat-comparison / location-state conditions** (`LocationHasClues`,
 //!   `AnyEnemyEngaged`, `SkillSucceededByAtLeast(N)`). Phase-2 only
 //!   has [`Condition::SkillTest`] with success/failure granularity.
@@ -376,14 +377,17 @@ mod tests {
         ));
     }
 
-    /// Holy Rosary's full shape: two constant modifiers (willpower
-    /// and max-sanity), naturally expressed as two separate Ability
-    /// declarations on the card.
+    /// A multi-ability card naturally expressed as two separate
+    /// `Ability` declarations: one constant willpower modifier plus a
+    /// constant max-health buff. Illustrative shape only — not a real
+    /// printed card. (Holy Rosary's `sanity: 2` is *horror-soak*
+    /// capacity, NOT a max-sanity modifier; that's a redirect-and-
+    /// discard mechanic the DSL doesn't yet model — see #44.)
     #[test]
-    fn holy_rosary_full_shape_compiles_as_two_abilities() {
+    fn vec_of_abilities_supports_multiple_constant_modifiers() {
         let abilities = [
             constant(modify(Stat::Willpower, 1, ModifierScope::WhileInPlay)),
-            constant(modify(Stat::MaxSanity, 2, ModifierScope::WhileInPlay)),
+            constant(modify(Stat::MaxHealth, 1, ModifierScope::WhileInPlay)),
         ];
         assert_eq!(abilities.len(), 2);
     }

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -9,9 +9,11 @@
 //! ones.
 
 use crate::action::{EngineRecord, PlayerAction};
+use crate::dsl::{discover_clue, LocationTarget};
 use crate::event::{Event, FailureReason};
 use crate::state::{resolve_token, GameState, InvestigatorId, Phase, SkillKind, TokenResolution};
 
+use super::evaluator::{apply_effect, EvalContext};
 use super::outcome::EngineOutcome;
 
 /// Action points granted to an investigator at the start of their
@@ -38,6 +40,7 @@ pub fn apply_player_action(
             skill,
             difficulty,
         } => perform_skill_test(state, events, *investigator, *skill, *difficulty),
+        PlayerAction::Investigate { investigator } => investigate(state, events, *investigator),
         PlayerAction::ResolveInput { .. } => EngineOutcome::Rejected {
             reason: "TODO(#63): ResolveInput dispatch lands with the skill-test commit \
                      window; no AwaitingInput sites exist yet."
@@ -196,49 +199,69 @@ fn rotate_to_active(state: &mut GameState, events: &mut Vec<Event>, id: Investig
     });
 }
 
-/// Handler for [`PlayerAction::PerformSkillTest`].
+/// The outcome of resolving a skill test, when the test runs at all.
+/// Returned by [`resolve_skill_test`] so callers (the
+/// `PerformSkillTest` dispatch wrapper, `Investigate`, future Fight /
+/// Evade) can branch on success vs failure to apply action-specific
+/// follow-on effects.
 ///
-/// Phase-1 foundation: declares the test, draws a chaos token, computes
-/// total = investigator's skill value + token numeric modifier vs.
-/// difficulty, and emits success/failure plus the bracketing
-/// `SkillTestStarted` / `SkillTestEnded` events — all in one apply call.
+/// `Succeeded.margin` and `Failed.{reason, by}` carry the same numbers
+/// as the corresponding events; callers that don't need them can
+/// match `Ok(SkillTestResolution::Succeeded { .. })`. Fields are
+/// `allow(dead_code)` until Fight/Evade (which want fail-by-X logic)
+/// land.
+#[allow(dead_code)]
+pub(super) enum SkillTestResolution {
+    /// The investigator's clamped total met or exceeded the difficulty.
+    Succeeded {
+        /// `total - difficulty` (always `>= 0`).
+        margin: i8,
+    },
+    /// The test failed.
+    Failed {
+        /// Why it failed.
+        reason: FailureReason,
+        /// Margin of failure (always `>= 0`).
+        by: i8,
+    },
+}
+
+/// Run the skill-test resolution sequence and return the outcome to
+/// the caller. Pushes the bracketing `SkillTestStarted` / `…Ended`
+/// events plus the per-step events (`ChaosTokenRevealed`,
+/// `SkillTestSucceeded` or `SkillTestFailed`).
 ///
-/// Card commits, the commit-window `AwaitingInput`, and the after-
-/// resolution trigger window are downstream (#63 / #64).
+/// Returns `Err(EngineOutcome::Rejected { .. })` on validation failure
+/// without pushing any events.
 ///
-/// **`AutoFail`** short-circuits the outcome to failure regardless of
-/// numeric total — `FailureReason::AutoFail`.
-///
-/// **`ElderSign`** is treated as `Modifier(0)` for now, with a TODO:
-/// the canonical behavior is "trigger the active investigator's elder
-/// sign ability," which depends on per-investigator ability dispatch.
-/// Modifier 0 + a TODO is a safe no-op default — Daisy Walker's "+0"
-/// elder sign already matches this; other investigators will be
-/// honored when ability dispatch lands.
-fn perform_skill_test(
+/// **`AutoFail`** forces the investigator's total to 0 per the Rules
+/// Reference; **`ElderSign`** is treated as `Modifier(0)` until per-
+/// investigator ability dispatch lands; **negative** `skill + modifier`
+/// clamps to 0.
+pub(super) fn resolve_skill_test(
     state: &mut GameState,
     events: &mut Vec<Event>,
     investigator: InvestigatorId,
     skill: SkillKind,
     difficulty: i8,
-) -> EngineOutcome {
+) -> Result<SkillTestResolution, EngineOutcome> {
     // Validate-first: investigator must exist; chaos bag must be
     // non-empty so we can draw; difficulty must be non-negative (FFG
     // difficulties are always ≥ 0).
     let Some(inv) = state.investigators.get(&investigator) else {
-        return EngineOutcome::Rejected {
-            reason: format!("PerformSkillTest: investigator {investigator:?} not in state").into(),
-        };
+        return Err(EngineOutcome::Rejected {
+            reason: format!("skill test: investigator {investigator:?} not in state").into(),
+        });
     };
     if state.chaos_bag.tokens.is_empty() {
-        return EngineOutcome::Rejected {
-            reason: "PerformSkillTest requires a non-empty chaos bag".into(),
-        };
+        return Err(EngineOutcome::Rejected {
+            reason: "skill test requires a non-empty chaos bag".into(),
+        });
     }
     if difficulty < 0 {
-        return EngineOutcome::Rejected {
-            reason: format!("PerformSkillTest: difficulty {difficulty} must be >= 0").into(),
-        };
+        return Err(EngineOutcome::Rejected {
+            reason: format!("skill test: difficulty {difficulty} must be >= 0").into(),
+        });
     }
     let skill_value = inv.skills.value(skill);
 
@@ -254,15 +277,6 @@ fn perform_skill_test(
     let resolution = resolve_token(token, &state.token_modifiers);
     events.push(Event::ChaosTokenRevealed { token, resolution });
 
-    // Two related rules from the Rules Reference + FAQ:
-    //   1. AutoFail forces the investigator's total to 0 (not just
-    //      "test fails regardless of total"); the failure margin is
-    //      computed against that 0.
-    //   2. A negative (skill + modifier) clamps to 0 — totals are
-    //      never negative for margin-of-failure purposes.
-    // ElderSign is a placeholder Modifier(0) until per-investigator
-    // ability dispatch lands; that's a no-op for the math here.
-    //
     // All arithmetic stays in i8 with saturating ops: realistic
     // gameplay values (skill 1–8, modifier ±8, difficulty ≤ ~6) fit
     // far inside i8, but saturation defends against absurd state
@@ -273,12 +287,13 @@ fn perform_skill_test(
         TokenResolution::AutoFail => (0, Some(FailureReason::AutoFail)),
     };
     let margin = total.saturating_sub(difficulty);
-    if margin >= 0 && fail_reason.is_none() {
+    let outcome = if margin >= 0 && fail_reason.is_none() {
         events.push(Event::SkillTestSucceeded {
             investigator,
             skill,
             margin,
         });
+        SkillTestResolution::Succeeded { margin }
     } else {
         let reason = fail_reason.unwrap_or(FailureReason::Total);
         let by = difficulty.saturating_sub(total);
@@ -288,8 +303,138 @@ fn perform_skill_test(
             reason,
             by,
         });
-    }
+        SkillTestResolution::Failed { reason, by }
+    };
 
     events.push(Event::SkillTestEnded { investigator });
-    EngineOutcome::Done
+    Ok(outcome)
+}
+
+/// Public dispatch wrapper for [`PlayerAction::PerformSkillTest`].
+///
+/// Card commits, the commit-window `AwaitingInput`, and the after-
+/// resolution trigger window are downstream (#63 / #64). The skill-
+/// test machinery itself lives in [`resolve_skill_test`], which other
+/// turn-actions (Investigate, future Fight / Evade) invoke directly.
+fn perform_skill_test(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+    skill: SkillKind,
+    difficulty: i8,
+) -> EngineOutcome {
+    match resolve_skill_test(state, events, investigator, skill, difficulty) {
+        Ok(_) => EngineOutcome::Done,
+        Err(rejected) => rejected,
+    }
+}
+
+/// Handler for [`PlayerAction::Investigate`].
+///
+/// Spends 1 action, runs an intellect skill test against the location's
+/// shroud, and on success applies [`Effect::DiscoverClue`] to move 1
+/// clue from the location to the investigator. The discover-clue
+/// evaluator handles the location-empty edge case as a silent no-op,
+/// so an investigation at a 0-clue location costs the action and runs
+/// the test but yields nothing — consistent with the rules.
+///
+/// Card-derived investigate variants (Rite of Seeking's "Action:
+/// Investigate using willpower instead of intellect", Working a
+/// Hunch's discover-without-test) implement their own paths; this
+/// handler is the bare turn-action.
+///
+/// [`Effect::DiscoverClue`]: crate::dsl::Effect::DiscoverClue
+fn investigate(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+) -> EngineOutcome {
+    // Validate-first.
+    if state.phase != Phase::Investigation {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Investigate is only valid during the Investigation phase (was {:?})",
+                state.phase
+            )
+            .into(),
+        };
+    }
+    if state.active_investigator != Some(investigator) {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Investigate: {investigator:?} is not the active investigator ({:?})",
+                state.active_investigator,
+            )
+            .into(),
+        };
+    }
+    let Some(inv) = state.investigators.get(&investigator) else {
+        return EngineOutcome::Rejected {
+            reason: format!("Investigate: investigator {investigator:?} not in state").into(),
+        };
+    };
+    if inv.actions_remaining < 1 {
+        return EngineOutcome::Rejected {
+            reason: "Investigate requires at least 1 action point".into(),
+        };
+    }
+    let Some(location_id) = inv.current_location else {
+        return EngineOutcome::Rejected {
+            reason: format!("Investigate: {investigator:?} has no current_location to investigate")
+                .into(),
+        };
+    };
+    let Some(location) = state.locations.get(&location_id) else {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Investigate: location {location_id:?} (investigator's current_location) is not in state"
+            )
+            .into(),
+        };
+    };
+    // Shroud is u8 in state but skill-test difficulty is i8. Saturate
+    // at i8::MAX for the absurd case; realistic shrouds are 0–6.
+    let difficulty = i8::try_from(location.shroud).unwrap_or(i8::MAX);
+
+    // Mutate-second: spend the action, then resolve the test.
+    let new_actions = inv.actions_remaining - 1;
+    state
+        .investigators
+        .get_mut(&investigator)
+        .expect("investigator existence checked above")
+        .actions_remaining = new_actions;
+    events.push(Event::ActionsRemainingChanged {
+        investigator,
+        new_count: new_actions,
+    });
+
+    match resolve_skill_test(
+        state,
+        events,
+        investigator,
+        SkillKind::Intellect,
+        difficulty,
+    ) {
+        Ok(SkillTestResolution::Succeeded { .. }) => {
+            let effect = discover_clue(LocationTarget::ControllerLocation, 1);
+            let ctx = EvalContext::for_controller(investigator);
+            // discover_clue's evaluator handles empty-location as a
+            // silent no-op; any rejection here would indicate the
+            // investigator is between locations, which we already
+            // validated. Treat any unexpected rejection as a hard
+            // engine error rather than a silent failure.
+            let outcome = apply_effect(state, events, &effect, ctx);
+            if let EngineOutcome::Rejected { reason } = outcome {
+                return EngineOutcome::Rejected {
+                    reason: format!(
+                        "Investigate: discover_clue effect rejected unexpectedly: {reason}"
+                    )
+                    .into(),
+                };
+            }
+            EngineOutcome::Done
+        }
+        Ok(SkillTestResolution::Failed { .. }) => EngineOutcome::Done,
+        Err(rejected) => rejected,
+    }
 }

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -384,14 +384,16 @@ fn investigate(
                 .into(),
         };
     };
-    let Some(location) = state.locations.get(&location_id) else {
-        return EngineOutcome::Rejected {
-            reason: format!(
-                "Investigate: location {location_id:?} (investigator's current_location) is not in state"
-            )
-            .into(),
-        };
-    };
+    // A `current_location` that doesn't exist in `state.locations` is
+    // a state-corruption invariant violation, not a user-facing
+    // rejection — match `end_turn` and `rotate_to_active` and surface
+    // it loudly.
+    let location = state.locations.get(&location_id).unwrap_or_else(|| {
+        unreachable!(
+            "Investigate: location {location_id:?} (investigator's current_location) \
+             is not in the locations map; this is a state-corruption invariant violation"
+        )
+    });
     // Shroud is u8 in state but skill-test difficulty is i8. Saturate
     // at i8::MAX for the absurd case; realistic shrouds are 0–6.
     let difficulty = i8::try_from(location.shroud).unwrap_or(i8::MAX);
@@ -418,19 +420,17 @@ fn investigate(
         Ok(SkillTestResolution::Succeeded { .. }) => {
             let effect = discover_clue(LocationTarget::ControllerLocation, 1);
             let ctx = EvalContext::for_controller(investigator);
-            // discover_clue's evaluator handles empty-location as a
-            // silent no-op; any rejection here would indicate the
-            // investigator is between locations, which we already
-            // validated. Treat any unexpected rejection as a hard
-            // engine error rather than a silent failure.
+            // The remaining rejection path inside `discover_clue` is
+            // "controller is between locations," which we already
+            // validated above. Empty-location is a silent no-op by
+            // design. So any rejection here is a state-corruption
+            // invariant violation — surface it loudly, not as a
+            // half-applied Rejected outcome.
             let outcome = apply_effect(state, events, &effect, ctx);
             if let EngineOutcome::Rejected { reason } = outcome {
-                return EngineOutcome::Rejected {
-                    reason: format!(
-                        "Investigate: discover_clue effect rejected unexpectedly: {reason}"
-                    )
-                    .into(),
-                };
+                unreachable!(
+                    "Investigate: discover_clue rejected unexpectedly after validation: {reason}"
+                );
             }
             EngineOutcome::Done
         }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -79,9 +79,9 @@ mod tests {
     use crate::action::{Action, EngineRecord, InputResponse, PlayerAction};
     use crate::event::{Event, FailureReason};
     use crate::state::{
-        ChaosToken, InvestigatorId, Phase, SkillKind, TokenModifiers, TokenResolution,
+        ChaosToken, GameState, InvestigatorId, Phase, SkillKind, TokenModifiers, TokenResolution,
     };
-    use crate::test_support::{test_investigator, TestGame};
+    use crate::test_support::{test_investigator, test_location, TestGame};
     use crate::{assert_event, assert_event_count, assert_no_event};
 
     use super::{apply, EngineOutcome};
@@ -562,6 +562,179 @@ mod tests {
         assert_eq!(first.state.rng, second.state.rng);
         assert_eq!(first.state.rng.draws, 1);
         assert_eq!(first.events, second.events);
+    }
+
+    /// Build a scenario suitable for Investigate tests: one investigator
+    /// at a location with `clues` clues and `shroud` shroud, in
+    /// Investigation phase, with the investigator active and 3 actions.
+    /// Bag is `Numeric(0)` so the test outcome depends purely on
+    /// (intellect vs shroud).
+    fn investigate_scenario(
+        clues: u8,
+        shroud: u8,
+    ) -> (InvestigatorId, crate::state::LocationId, GameState) {
+        let inv_id = InvestigatorId(1);
+        let loc_id = crate::state::LocationId(10);
+        let mut inv = test_investigator(1);
+        inv.current_location = Some(loc_id);
+        inv.actions_remaining = 3;
+        let mut loc = test_location(10, "Study");
+        loc.clues = clues;
+        loc.shroud = shroud;
+        let state = TestGame::new()
+            .with_investigator(inv)
+            .with_location(loc)
+            .with_chaos_bag(bag_only_zero())
+            .with_phase(Phase::Investigation)
+            .with_active_investigator(inv_id)
+            .build();
+        (inv_id, loc_id, state)
+    }
+
+    #[test]
+    fn investigate_succeeds_and_moves_one_clue_to_investigator() {
+        // Default intellect 3, shroud 2 → margin 1 → success.
+        let (inv_id, loc_id, state) = investigate_scenario(2, 2);
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Investigate {
+                investigator: inv_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::ActionsRemainingChanged { investigator, new_count: 2 }
+                if *investigator == inv_id
+        );
+        assert_event!(
+            result.events,
+            Event::SkillTestStarted {
+                skill: SkillKind::Intellect,
+                difficulty: 2,
+                ..
+            }
+        );
+        assert_event!(result.events, Event::SkillTestSucceeded { margin: 1, .. });
+        assert_event!(
+            result.events,
+            Event::CluePlaced { investigator, count: 1 } if *investigator == inv_id
+        );
+        assert_event!(
+            result.events,
+            Event::LocationCluesChanged { location, new_count: 1 } if *location == loc_id
+        );
+        assert_eq!(result.state.investigators[&inv_id].clues, 1);
+        assert_eq!(result.state.locations[&loc_id].clues, 1);
+        assert_eq!(result.state.investigators[&inv_id].actions_remaining, 2);
+    }
+
+    #[test]
+    fn investigate_failure_spends_action_but_moves_no_clue() {
+        // Intellect 3, shroud 5 → fails by 2; action still spent.
+        let (inv_id, loc_id, state) = investigate_scenario(2, 5);
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Investigate {
+                investigator: inv_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(result.events, Event::SkillTestFailed { by: 2, .. });
+        assert_no_event!(result.events, Event::CluePlaced { .. });
+        assert_no_event!(result.events, Event::LocationCluesChanged { .. });
+        assert_eq!(result.state.locations[&loc_id].clues, 2);
+        assert_eq!(result.state.investigators[&inv_id].clues, 0);
+        assert_eq!(result.state.investigators[&inv_id].actions_remaining, 2);
+    }
+
+    #[test]
+    fn investigate_at_empty_location_spends_action_and_runs_test_silently() {
+        // Location has 0 clues; the test still fires (you can't tell
+        // the location is empty without trying), the action is still
+        // spent, and discover_clue is a silent no-op on success.
+        let (inv_id, loc_id, state) = investigate_scenario(0, 2);
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Investigate {
+                investigator: inv_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(result.events, Event::SkillTestSucceeded { .. });
+        assert_no_event!(result.events, Event::CluePlaced { .. });
+        assert_eq!(result.state.investigators[&inv_id].actions_remaining, 2);
+        assert_eq!(result.state.locations[&loc_id].clues, 0);
+        assert_eq!(result.state.investigators[&inv_id].clues, 0);
+    }
+
+    #[test]
+    fn investigate_outside_investigation_phase_is_rejected() {
+        let (inv_id, _, mut state) = investigate_scenario(2, 2);
+        state.phase = Phase::Mythos;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Investigate {
+                investigator: inv_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn investigate_by_non_active_investigator_is_rejected() {
+        let (_, _, mut state) = investigate_scenario(2, 2);
+        // Add a second investigator but keep the first active.
+        let other = InvestigatorId(2);
+        state.investigators.insert(other, test_investigator(2));
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Investigate {
+                investigator: other,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn investigate_with_zero_actions_is_rejected() {
+        let (inv_id, _, mut state) = investigate_scenario(2, 2);
+        state
+            .investigators
+            .get_mut(&inv_id)
+            .unwrap()
+            .actions_remaining = 0;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Investigate {
+                investigator: inv_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn investigate_without_a_current_location_is_rejected() {
+        let (inv_id, _, mut state) = investigate_scenario(2, 2);
+        state
+            .investigators
+            .get_mut(&inv_id)
+            .unwrap()
+            .current_location = None;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Investigate {
+                investigator: inv_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
     }
 
     #[test]

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -849,4 +849,20 @@ mod tests {
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
         assert!(result.events.is_empty());
     }
+
+    #[test]
+    #[should_panic(expected = "state-corruption invariant violation")]
+    fn investigate_with_dangling_current_location_panics() {
+        // Corruption case: investigator's current_location references
+        // a location not in state.locations. Matches the loud-on-
+        // corruption pattern used by end_turn / rotate_to_active.
+        let (inv_id, loc_id, mut state) = investigate_scenario(2, 2);
+        state.locations.remove(&loc_id);
+        let _ = apply(
+            state,
+            Action::Player(PlayerAction::Investigate {
+                investigator: inv_id,
+            }),
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes #51. The first turn-action that uses the skill-test machinery from #66.

- **\`PlayerAction::Investigate { investigator }\`**: spend 1 action, run intellect vs shroud, on success discover 1 clue at the location.
- Validate-first: Investigation phase, investigator is active, ≥1 action remaining, has a \`current_location\`.
- Refactors the skill-test handler: extracts a private \`resolve_skill_test\` that returns \`Result<SkillTestResolution, EngineOutcome>\` so turn-actions can branch on success vs failure. \`PerformSkillTest\` dispatch wrapper now just calls into it.
- On success: applies \`Effect::DiscoverClue(LocationTarget::ControllerLocation, 1)\` via the existing evaluator. Empty-location is a silent no-op per the evaluator's design — consistent with the rules.

## Out of scope

- **Fight / Evade** depend on enemy state that doesn't yet exist; tracked in **#67**.
- **After-success trigger window** (Deduction's bonus clue, etc.) tracked in #64, blocked on #54 OnEvent.
- **Card-derived investigate variants** (Rite of Seeking's "Investigate using willpower instead of intellect", Working a Hunch's discover-without-test) live with the cards themselves.

## Bonus: card-effect doc audit

The user caught a confabulated "Magnifying Glass's Action: Investigate" reference in this PR's draft. Triggered a comprehensive audit of every card-name + effect claim across code, memory, and open issues. **10 errors found and fixed** — the most consequential being a DSL test that constructed Holy Rosary as having a \`Stat::MaxSanity\` modifier (Holy Rosary has only +1 willpower; the \`sanity: 2\` field is horror-soak — the exact mistake the project memory warns against). New memory entry \`feedback_verify_card_examples\` codifies the rule.

Issues corrected as part of the audit: #37 (Magnifying Glass text), #38 (Hyperawareness wrong code 01045 → 01034, wrong activation symbol), #39 (Deduction code "TBD/01040" → 01039, +2 → +1 intellect), #56 (Study clues 1 → 2 per investigator), #64 (Deduction paraphrase tightened).

## Test plan

- [x] \`cargo test --all\` — 61 game-core tests pass (was 54), 7 new Investigate tests covering: success moves clue + spends action, failure spends action without moving clue, empty-location silent no-op, validation rejections (wrong phase, non-active, 0 actions, no location).
- [x] \`cargo clippy --all -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)