### PR TITLE
engine: enemy state + Fight + Evade actions

### DIFF
--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -16,7 +16,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::state::{InvestigatorId, LocationId, SkillKind};
+use crate::state::{EnemyId, InvestigatorId, LocationId, SkillKind};
 
 /// A single entry in the action log.
 ///
@@ -79,6 +79,42 @@ pub enum PlayerAction {
         /// The destination location. Must be in `state.locations` and
         /// connected to the investigator's current location.
         destination: LocationId,
+    },
+    /// Engage an enemy with a combat skill test. Spends 1 action.
+    /// On success, deals 1 damage to the enemy; if damage reaches
+    /// `max_health`, the enemy is defeated and removed from play.
+    ///
+    /// Validate: Investigation phase, investigator is active,
+    /// `actions_remaining >= 1`, enemy exists, and the investigator
+    /// is currently engaged with that enemy.
+    ///
+    /// Damage > 1 (weapons, card buffs) and after-success / after-
+    /// failure triggers (#64) land downstream. `AoO` does NOT fire on
+    /// Fight (Fight is on the `AoO`-exempt list per the Rules
+    /// Reference).
+    Fight {
+        /// Investigator performing the Fight action. Must be the
+        /// active investigator during the Investigation phase.
+        investigator: InvestigatorId,
+        /// The enemy to fight. Must be currently engaged with the
+        /// investigator.
+        enemy: EnemyId,
+    },
+    /// Evade an engaged enemy with an agility skill test. Spends
+    /// 1 action. On success, the enemy disengages and exhausts.
+    ///
+    /// Validate: Investigation phase, investigator is active,
+    /// `actions_remaining >= 1`, enemy exists, and the investigator
+    /// is currently engaged with that enemy.
+    ///
+    /// `AoO` does NOT fire on Evade (also on the `AoO`-exempt list).
+    Evade {
+        /// Investigator performing the Evade action. Must be the
+        /// active investigator.
+        investigator: InvestigatorId,
+        /// The enemy to evade. Must be currently engaged with the
+        /// investigator.
+        enemy: EnemyId,
     },
     /// Investigate at the active investigator's current location:
     /// spend 1 action, make an intellect test against the location's

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -12,7 +12,7 @@ use crate::action::{EngineRecord, PlayerAction};
 use crate::dsl::{discover_clue, LocationTarget};
 use crate::event::{Event, FailureReason};
 use crate::state::{
-    resolve_token, EnemyId, GameState, InvestigatorId, LocationId, Phase, SkillKind,
+    resolve_token, Enemy, EnemyId, GameState, InvestigatorId, LocationId, Phase, SkillKind,
     TokenResolution,
 };
 
@@ -545,19 +545,25 @@ fn move_action(
 
 /// Validate the prefix shared by Fight and Evade: phase, active
 /// investigator, action point available, enemy exists, engaged with
-/// the named enemy. Returns the enemy's (fight, evade) difficulties
-/// for the caller to pass into [`resolve_skill_test`]; the caller
-/// picks which to use.
+/// the named enemy. Returns the borrowed enemy so the caller can pick
+/// which difficulty (fight / evade) and read any other fields it
+/// needs.
 ///
 /// On `Err`, returns the rejection; the caller should propagate it
 /// without further state mutation. State-corruption invariants
 /// (active investigator missing from map) panic via `unreachable!`.
-fn validate_engaged_action(
-    state: &GameState,
+///
+/// Does NOT validate the chosen difficulty is non-negative — the
+/// caller must do that after picking, because Fight and Evade each
+/// only care about one of the two values, and validating both
+/// upfront would reject legitimate states (an enemy with `fight: -1`
+/// the investigator only ever Evades).
+fn validate_engaged_action<'a>(
+    state: &'a GameState,
     action_name: &'static str,
     investigator: InvestigatorId,
     enemy_id: EnemyId,
-) -> Result<(i8, i8), EngineOutcome> {
+) -> Result<&'a Enemy, EngineOutcome> {
     if state.phase != Phase::Investigation {
         return Err(EngineOutcome::Rejected {
             reason: format!(
@@ -601,7 +607,7 @@ fn validate_engaged_action(
             .into(),
         });
     }
-    Ok((enemy.fight, enemy.evade))
+    Ok(enemy)
 }
 
 /// Spend 1 action point from the active investigator and emit
@@ -636,11 +642,21 @@ fn fight(
     investigator: InvestigatorId,
     enemy_id: EnemyId,
 ) -> EngineOutcome {
-    let (fight_difficulty, _) =
-        match validate_engaged_action(state, "Fight", investigator, enemy_id) {
-            Ok(d) => d,
-            Err(rejected) => return rejected,
-        };
+    let fight_difficulty = match validate_engaged_action(state, "Fight", investigator, enemy_id) {
+        Ok(enemy) => {
+            if enemy.fight < 0 {
+                return EngineOutcome::Rejected {
+                    reason: format!(
+                        "Fight: enemy {enemy_id:?} has negative fight value {} (malformed state)",
+                        enemy.fight,
+                    )
+                    .into(),
+                };
+            }
+            enemy.fight
+        }
+        Err(rejected) => return rejected,
+    };
     spend_one_action(state, events, investigator);
     match resolve_skill_test(
         state,
@@ -668,11 +684,21 @@ fn evade(
     investigator: InvestigatorId,
     enemy_id: EnemyId,
 ) -> EngineOutcome {
-    let (_, evade_difficulty) =
-        match validate_engaged_action(state, "Evade", investigator, enemy_id) {
-            Ok(d) => d,
-            Err(rejected) => return rejected,
-        };
+    let evade_difficulty = match validate_engaged_action(state, "Evade", investigator, enemy_id) {
+        Ok(enemy) => {
+            if enemy.evade < 0 {
+                return EngineOutcome::Rejected {
+                    reason: format!(
+                        "Evade: enemy {enemy_id:?} has negative evade value {} (malformed state)",
+                        enemy.evade,
+                    )
+                    .into(),
+                };
+            }
+            enemy.evade
+        }
+        Err(rejected) => return rejected,
+    };
     spend_one_action(state, events, investigator);
     match resolve_skill_test(
         state,

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -12,7 +12,8 @@ use crate::action::{EngineRecord, PlayerAction};
 use crate::dsl::{discover_clue, LocationTarget};
 use crate::event::{Event, FailureReason};
 use crate::state::{
-    resolve_token, GameState, InvestigatorId, LocationId, Phase, SkillKind, TokenResolution,
+    resolve_token, EnemyId, GameState, InvestigatorId, LocationId, Phase, SkillKind,
+    TokenResolution,
 };
 
 use super::evaluator::{apply_effect, EvalContext};
@@ -47,6 +48,14 @@ pub fn apply_player_action(
             investigator,
             destination,
         } => move_action(state, events, *investigator, *destination),
+        PlayerAction::Fight {
+            investigator,
+            enemy,
+        } => fight(state, events, *investigator, *enemy),
+        PlayerAction::Evade {
+            investigator,
+            enemy,
+        } => evade(state, events, *investigator, *enemy),
         PlayerAction::ResolveInput { .. } => EngineOutcome::Rejected {
             reason: "TODO(#63): ResolveInput dispatch lands with the skill-test commit \
                      window; no AwaitingInput sites exist yet."
@@ -408,16 +417,7 @@ fn investigate(
     let difficulty = i8::try_from(location.shroud).unwrap_or(i8::MAX);
 
     // Mutate-second: spend the action, then resolve the test.
-    let new_actions = inv.actions_remaining - 1;
-    state
-        .investigators
-        .get_mut(&investigator)
-        .expect("investigator existence checked above")
-        .actions_remaining = new_actions;
-    events.push(Event::ActionsRemainingChanged {
-        investigator,
-        new_count: new_actions,
-    });
+    spend_one_action(state, events, investigator);
 
     match resolve_skill_test(
         state,
@@ -529,21 +529,209 @@ fn move_action(
     }
 
     // Mutate-second.
-    let new_actions = inv.actions_remaining - 1;
-    let inv_mut = state
+    spend_one_action(state, events, investigator);
+    state
         .investigators
         .get_mut(&investigator)
-        .expect("investigator existence checked above");
-    inv_mut.actions_remaining = new_actions;
-    inv_mut.current_location = Some(destination);
-    events.push(Event::ActionsRemainingChanged {
-        investigator,
-        new_count: new_actions,
-    });
+        .expect("investigator existence checked above")
+        .current_location = Some(destination);
     events.push(Event::InvestigatorMoved {
         investigator,
         from,
         to: destination,
     });
     EngineOutcome::Done
+}
+
+/// Validate the prefix shared by Fight and Evade: phase, active
+/// investigator, action point available, enemy exists, engaged with
+/// the named enemy. Returns the enemy's (fight, evade) difficulties
+/// for the caller to pass into [`resolve_skill_test`]; the caller
+/// picks which to use.
+///
+/// On `Err`, returns the rejection; the caller should propagate it
+/// without further state mutation. State-corruption invariants
+/// (active investigator missing from map) panic via `unreachable!`.
+fn validate_engaged_action(
+    state: &GameState,
+    action_name: &'static str,
+    investigator: InvestigatorId,
+    enemy_id: EnemyId,
+) -> Result<(i8, i8), EngineOutcome> {
+    if state.phase != Phase::Investigation {
+        return Err(EngineOutcome::Rejected {
+            reason: format!(
+                "{action_name} is only valid during the Investigation phase (was {:?})",
+                state.phase
+            )
+            .into(),
+        });
+    }
+    if state.active_investigator != Some(investigator) {
+        return Err(EngineOutcome::Rejected {
+            reason: format!(
+                "{action_name}: {investigator:?} is not the active investigator ({:?})",
+                state.active_investigator,
+            )
+            .into(),
+        });
+    }
+    let inv = state.investigators.get(&investigator).unwrap_or_else(|| {
+        unreachable!(
+            "{action_name}: active_investigator {investigator:?} is not in the investigators \
+             map; this is a state-corruption invariant violation"
+        )
+    });
+    if inv.actions_remaining < 1 {
+        return Err(EngineOutcome::Rejected {
+            reason: format!("{action_name} requires at least 1 action point").into(),
+        });
+    }
+    let Some(enemy) = state.enemies.get(&enemy_id) else {
+        return Err(EngineOutcome::Rejected {
+            reason: format!("{action_name}: enemy {enemy_id:?} is not in state").into(),
+        });
+    };
+    if enemy.engaged_with != Some(investigator) {
+        return Err(EngineOutcome::Rejected {
+            reason: format!(
+                "{action_name}: {investigator:?} is not engaged with {enemy_id:?} (engaged_with = {:?})",
+                enemy.engaged_with,
+            )
+            .into(),
+        });
+    }
+    Ok((enemy.fight, enemy.evade))
+}
+
+/// Spend 1 action point from the active investigator and emit
+/// `ActionsRemainingChanged`. Caller has already validated that
+/// `actions_remaining >= 1`.
+fn spend_one_action(state: &mut GameState, events: &mut Vec<Event>, investigator: InvestigatorId) {
+    let inv = state
+        .investigators
+        .get_mut(&investigator)
+        .expect("investigator existence checked before spend_one_action");
+    let new_count = inv.actions_remaining - 1;
+    inv.actions_remaining = new_count;
+    events.push(Event::ActionsRemainingChanged {
+        investigator,
+        new_count,
+    });
+}
+
+/// Handler for [`PlayerAction::Fight`].
+///
+/// Spends 1 action, runs a Combat skill test against the enemy's
+/// fight value, and on success deals 1 damage. If damage reaches
+/// `max_health`, the enemy is defeated and removed from play.
+///
+/// Damage > 1 (weapons, card buffs), after-success / after-failure
+/// triggers (#64), and `AoO` from *other* engaged enemies (#78) are all
+/// downstream. `AoO` does NOT fire on Fight itself per the Rules
+/// Reference's `AoO`-exempt list.
+fn fight(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+    enemy_id: EnemyId,
+) -> EngineOutcome {
+    let (fight_difficulty, _) =
+        match validate_engaged_action(state, "Fight", investigator, enemy_id) {
+            Ok(d) => d,
+            Err(rejected) => return rejected,
+        };
+    spend_one_action(state, events, investigator);
+    match resolve_skill_test(
+        state,
+        events,
+        investigator,
+        SkillKind::Combat,
+        fight_difficulty,
+    ) {
+        Ok(SkillTestResolution::Succeeded { .. }) => {
+            damage_enemy(state, events, enemy_id, 1, Some(investigator));
+            EngineOutcome::Done
+        }
+        Ok(SkillTestResolution::Failed { .. }) => EngineOutcome::Done,
+        Err(rejected) => rejected,
+    }
+}
+
+/// Handler for [`PlayerAction::Evade`].
+///
+/// Spends 1 action, runs an Agility skill test against the enemy's
+/// evade value, and on success disengages and exhausts the enemy.
+fn evade(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+    enemy_id: EnemyId,
+) -> EngineOutcome {
+    let (_, evade_difficulty) =
+        match validate_engaged_action(state, "Evade", investigator, enemy_id) {
+            Ok(d) => d,
+            Err(rejected) => return rejected,
+        };
+    spend_one_action(state, events, investigator);
+    match resolve_skill_test(
+        state,
+        events,
+        investigator,
+        SkillKind::Agility,
+        evade_difficulty,
+    ) {
+        Ok(SkillTestResolution::Succeeded { .. }) => {
+            let enemy = state.enemies.get_mut(&enemy_id).unwrap_or_else(|| {
+                unreachable!(
+                    "Evade: enemy {enemy_id:?} disappeared between validation and resolution; \
+                     this is a state-corruption invariant violation"
+                )
+            });
+            enemy.engaged_with = None;
+            enemy.exhausted = true;
+            events.push(Event::EnemyDisengaged {
+                enemy: enemy_id,
+                investigator,
+            });
+            events.push(Event::EnemyExhausted { enemy: enemy_id });
+            EngineOutcome::Done
+        }
+        Ok(SkillTestResolution::Failed { .. }) => EngineOutcome::Done,
+        Err(rejected) => rejected,
+    }
+}
+
+/// Apply `amount` damage to an enemy. If the new damage reaches or
+/// exceeds `max_health`, emit `EnemyDefeated` and remove the enemy
+/// from `state.enemies`. `by` attributes the defeat for
+/// trigger-window consumers (e.g. Roland's reaction). Used by Fight
+/// today; will be reused by future damage-dealing card effects.
+fn damage_enemy(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    enemy_id: EnemyId,
+    amount: u8,
+    by: Option<InvestigatorId>,
+) {
+    let enemy = state.enemies.get_mut(&enemy_id).unwrap_or_else(|| {
+        unreachable!(
+            "damage_enemy: enemy {enemy_id:?} is not in state.enemies; \
+             this is a state-corruption invariant violation"
+        )
+    });
+    let new_damage = enemy.damage.saturating_add(amount).min(enemy.max_health);
+    enemy.damage = new_damage;
+    events.push(Event::EnemyDamaged {
+        enemy: enemy_id,
+        amount,
+        new_damage,
+    });
+    if new_damage >= enemy.max_health {
+        events.push(Event::EnemyDefeated {
+            enemy: enemy_id,
+            by,
+        });
+        state.enemies.remove(&enemy_id);
+    }
 }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -1352,4 +1352,100 @@ mod tests {
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
         assert!(result.events.is_empty());
     }
+
+    #[test]
+    fn fight_with_negative_fight_value_is_rejected_without_mutating_state() {
+        // Malformed scenario data: fight = -1. validate-first must
+        // reject BEFORE spend_one_action runs, otherwise the action
+        // is silently lost without a rejection event.
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.enemies.get_mut(&enemy_id).unwrap().fight = -1;
+        let actions_before = state.investigators[&inv_id].actions_remaining;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+        assert_eq!(
+            result.state.investigators[&inv_id].actions_remaining,
+            actions_before
+        );
+    }
+
+    #[test]
+    fn evade_with_negative_evade_value_is_rejected_without_mutating_state() {
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.enemies.get_mut(&enemy_id).unwrap().evade = -1;
+        let actions_before = state.investigators[&inv_id].actions_remaining;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Evade {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+        assert_eq!(
+            result.state.investigators[&inv_id].actions_remaining,
+            actions_before
+        );
+    }
+
+    #[test]
+    fn evade_on_already_exhausted_enemy_is_idempotent_on_exhaust() {
+        // Edge: enemy is already exhausted but still engaged (e.g.
+        // attacked the investigator earlier this round, now the
+        // investigator Evades). Success disengages and leaves
+        // `exhausted = true`.
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.enemies.get_mut(&enemy_id).unwrap().exhausted = true;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Evade {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(result.events, Event::SkillTestSucceeded { .. });
+        assert_event!(result.events, Event::EnemyDisengaged { .. });
+        assert!(result.state.enemies[&enemy_id].exhausted);
+        assert_eq!(result.state.enemies[&enemy_id].engaged_with, None);
+    }
+
+    #[test]
+    fn fight_engaged_with_two_enemies_only_touches_the_target() {
+        // Investigator engaged with two enemies. Fight one. The other
+        // engagement must stay intact and its state untouched.
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        let other_id = EnemyId(101);
+        let mut other = test_enemy(101, "Bystander Ghoul");
+        other.engaged_with = Some(inv_id);
+        state.enemies.insert(other_id, other);
+        // Make sure the Fight defeats the target so we observe the
+        // full attribution + removal path while the other is untouched.
+        state.enemies.get_mut(&enemy_id).unwrap().damage = 1;
+
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert!(!result.state.enemies.contains_key(&enemy_id));
+        // Other enemy untouched.
+        assert!(result.state.enemies.contains_key(&other_id));
+        let other_after = &result.state.enemies[&other_id];
+        assert_eq!(other_after.engaged_with, Some(inv_id));
+        assert_eq!(other_after.damage, 0);
+        assert!(!other_after.exhausted);
+    }
 }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -78,10 +78,11 @@ pub fn apply(state: GameState, action: Action) -> ApplyResult {
 mod tests {
     use crate::action::{Action, EngineRecord, InputResponse, PlayerAction};
     use crate::event::{Event, FailureReason};
+    use crate::state::EnemyId;
     use crate::state::{
         ChaosToken, GameState, InvestigatorId, Phase, SkillKind, TokenModifiers, TokenResolution,
     };
-    use crate::test_support::{test_investigator, test_location, TestGame};
+    use crate::test_support::{test_enemy, test_investigator, test_location, TestGame};
     use crate::{assert_event, assert_event_count, assert_no_event};
 
     use super::{apply, EngineOutcome};
@@ -1089,5 +1090,266 @@ mod tests {
                 investigator: inv_id,
             }),
         );
+    }
+
+    /// Build a scenario suitable for Fight/Evade tests: one
+    /// investigator engaged with one enemy. Bag is `Numeric(0)` so
+    /// the test outcome is determined purely by (skill vs
+    /// fight/evade). Investigation phase, investigator is active,
+    /// 3 actions. Returns (investigator id, enemy id, state).
+    fn fight_evade_scenario() -> (InvestigatorId, EnemyId, GameState) {
+        let inv_id = InvestigatorId(1);
+        let enemy_id = EnemyId(100);
+        let mut inv = test_investigator(1);
+        inv.actions_remaining = 3;
+        let mut enemy = test_enemy(100, "Test Ghoul");
+        enemy.fight = 3;
+        enemy.evade = 3;
+        enemy.max_health = 2;
+        enemy.engaged_with = Some(inv_id);
+        let state = TestGame::new()
+            .with_investigator(inv)
+            .with_enemy(enemy)
+            .with_chaos_bag(bag_only_zero())
+            .with_phase(Phase::Investigation)
+            .with_active_investigator(inv_id)
+            .build();
+        (inv_id, enemy_id, state)
+    }
+
+    #[test]
+    fn fight_succeeds_deals_one_damage_and_spends_action() {
+        // Combat 3, fight 3, modifier 0 → margin 0 → success.
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        // Set investigator combat = 3 (default already is 3) so the
+        // test just barely passes.
+        state.investigators.get_mut(&inv_id).unwrap().skills.combat = 3;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::ActionsRemainingChanged { investigator, new_count: 2 }
+                if *investigator == inv_id
+        );
+        assert_event!(
+            result.events,
+            Event::SkillTestStarted {
+                skill: SkillKind::Combat,
+                difficulty: 3,
+                ..
+            }
+        );
+        assert_event!(result.events, Event::SkillTestSucceeded { .. });
+        assert_event!(
+            result.events,
+            Event::EnemyDamaged { enemy: e, amount: 1, new_damage: 1 } if *e == enemy_id
+        );
+        assert_no_event!(result.events, Event::EnemyDefeated { .. });
+        assert_eq!(result.state.enemies[&enemy_id].damage, 1);
+        assert_eq!(result.state.investigators[&inv_id].actions_remaining, 2);
+    }
+
+    #[test]
+    fn fight_failure_spends_action_but_deals_no_damage() {
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.investigators.get_mut(&inv_id).unwrap().skills.combat = 1;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(result.events, Event::SkillTestFailed { .. });
+        assert_no_event!(result.events, Event::EnemyDamaged { .. });
+        assert_no_event!(result.events, Event::EnemyDefeated { .. });
+        assert_eq!(result.state.enemies[&enemy_id].damage, 0);
+        assert_eq!(result.state.investigators[&inv_id].actions_remaining, 2);
+    }
+
+    #[test]
+    fn fight_defeats_enemy_when_damage_reaches_max_health() {
+        // Enemy at 1/2 already; Fight success → damage 2, defeated,
+        // removed from state, engagement cleared.
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.enemies.get_mut(&enemy_id).unwrap().damage = 1;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::EnemyDamaged { enemy: e, amount: 1, new_damage: 2 } if *e == enemy_id
+        );
+        assert_event!(
+            result.events,
+            Event::EnemyDefeated { enemy: e, by: Some(by) }
+                if *e == enemy_id && *by == inv_id
+        );
+        assert!(!result.state.enemies.contains_key(&enemy_id));
+    }
+
+    #[test]
+    fn evade_succeeds_disengages_and_exhausts() {
+        // Default agility 3, evade 3 → margin 0 → success.
+        let (inv_id, enemy_id, state) = fight_evade_scenario();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Evade {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::SkillTestStarted {
+                skill: SkillKind::Agility,
+                difficulty: 3,
+                ..
+            }
+        );
+        assert_event!(result.events, Event::SkillTestSucceeded { .. });
+        assert_event!(
+            result.events,
+            Event::EnemyDisengaged { enemy: e, investigator: i }
+                if *e == enemy_id && *i == inv_id
+        );
+        assert_event!(
+            result.events,
+            Event::EnemyExhausted { enemy: e } if *e == enemy_id
+        );
+        assert_eq!(result.state.enemies[&enemy_id].engaged_with, None);
+        assert!(result.state.enemies[&enemy_id].exhausted);
+        assert_eq!(result.state.investigators[&inv_id].actions_remaining, 2);
+    }
+
+    #[test]
+    fn evade_failure_leaves_engagement_intact() {
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.investigators.get_mut(&inv_id).unwrap().skills.agility = 1;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Evade {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(result.events, Event::SkillTestFailed { .. });
+        assert_no_event!(result.events, Event::EnemyDisengaged { .. });
+        assert_no_event!(result.events, Event::EnemyExhausted { .. });
+        assert_eq!(result.state.enemies[&enemy_id].engaged_with, Some(inv_id));
+        assert!(!result.state.enemies[&enemy_id].exhausted);
+    }
+
+    #[test]
+    fn fight_when_not_engaged_with_target_is_rejected() {
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.enemies.get_mut(&enemy_id).unwrap().engaged_with = None;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn evade_when_not_engaged_with_target_is_rejected() {
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.enemies.get_mut(&enemy_id).unwrap().engaged_with = None;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Evade {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn fight_with_unknown_enemy_is_rejected() {
+        let (inv_id, _, state) = fight_evade_scenario();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: EnemyId(9999),
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn fight_outside_investigation_phase_is_rejected() {
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.phase = Phase::Mythos;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn fight_by_non_active_investigator_is_rejected() {
+        let (_, enemy_id, mut state) = fight_evade_scenario();
+        let other = InvestigatorId(2);
+        state.investigators.insert(other, test_investigator(2));
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: other,
+                enemy: enemy_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn fight_with_zero_actions_is_rejected() {
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state
+            .investigators
+            .get_mut(&inv_id)
+            .unwrap()
+            .actions_remaining = 0;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
     }
 }

--- a/crates/game-core/src/event.rs
+++ b/crates/game-core/src/event.rs
@@ -206,6 +206,15 @@ pub enum Event {
     /// An enemy was defeated (damage reached `max_health` or a card
     /// effect explicitly defeated it). The enemy is removed from
     /// `GameState::enemies` after this event fires.
+    ///
+    /// Per the Rules Reference, defeat takes the enemy out of play
+    /// entirely — it does NOT emit a paired [`EnemyDisengaged`] for
+    /// an enemy that was engaged at the time of defeat. Engagement
+    /// implicitly terminates because the enemy is gone. Consumers
+    /// tracking engagement via the event stream should treat
+    /// `EnemyDefeated` as terminating any engagement the enemy had.
+    ///
+    /// [`EnemyDisengaged`]: Event::EnemyDisengaged
     EnemyDefeated {
         /// The defeated enemy.
         enemy: EnemyId,

--- a/crates/game-core/src/event.rs
+++ b/crates/game-core/src/event.rs
@@ -13,7 +13,9 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::state::{ChaosToken, InvestigatorId, LocationId, Phase, SkillKind, TokenResolution};
+use crate::state::{
+    ChaosToken, EnemyId, InvestigatorId, LocationId, Phase, SkillKind, TokenResolution,
+};
 
 /// One state-change record emitted by the engine.
 ///
@@ -155,6 +157,62 @@ pub enum Event {
     SkillTestEnded {
         /// Investigator the test was for.
         investigator: InvestigatorId,
+    },
+    /// An enemy entered play at a location. (Spawning logic lands
+    /// with the encounter deck and Mythos phase; this event slot
+    /// exists so card effects that react to spawns have something to
+    /// listen for from day one.)
+    EnemySpawned {
+        /// The newly-spawned enemy.
+        enemy: EnemyId,
+        /// Where it spawned.
+        location: LocationId,
+    },
+    /// An enemy became engaged with an investigator.
+    EnemyEngaged {
+        /// The engaged enemy.
+        enemy: EnemyId,
+        /// The investigator the enemy is now engaged with.
+        investigator: InvestigatorId,
+    },
+    /// An enemy disengaged from an investigator (e.g. via a
+    /// successful Evade).
+    EnemyDisengaged {
+        /// The enemy that disengaged.
+        enemy: EnemyId,
+        /// The investigator it was previously engaged with.
+        investigator: InvestigatorId,
+    },
+    /// An enemy was exhausted (e.g. via a successful Evade or after
+    /// attacking).
+    EnemyExhausted {
+        /// The enemy that exhausted.
+        enemy: EnemyId,
+    },
+    /// An enemy was readied (e.g. during the Upkeep phase).
+    EnemyReadied {
+        /// The enemy that readied.
+        enemy: EnemyId,
+    },
+    /// An enemy took damage.
+    EnemyDamaged {
+        /// The damaged enemy.
+        enemy: EnemyId,
+        /// Amount of damage applied.
+        amount: u8,
+        /// The enemy's new accumulated damage after the application.
+        new_damage: u8,
+    },
+    /// An enemy was defeated (damage reached `max_health` or a card
+    /// effect explicitly defeated it). The enemy is removed from
+    /// `GameState::enemies` after this event fires.
+    EnemyDefeated {
+        /// The defeated enemy.
+        enemy: EnemyId,
+        /// Who defeated it, if attributable. `None` for non-
+        /// investigator-attributed defeats (e.g. effects that just
+        /// say "defeat this enemy").
+        by: Option<InvestigatorId>,
     },
 }
 

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -32,6 +32,6 @@ pub use engine::{apply, ApplyResult, EngineOutcome, InputRequest, ResumeToken};
 pub use event::{Event, FailureReason};
 pub use rng::RngState;
 pub use state::{
-    resolve_token, ChaosBag, ChaosToken, GameState, Investigator, InvestigatorId, Location,
-    LocationId, Phase, SkillKind, Skills, TokenModifiers, TokenResolution,
+    resolve_token, ChaosBag, ChaosToken, Enemy, EnemyId, GameState, Investigator, InvestigatorId,
+    Location, LocationId, Phase, SkillKind, Skills, TokenModifiers, TokenResolution,
 };

--- a/crates/game-core/src/state/enemy.rs
+++ b/crates/game-core/src/state/enemy.rs
@@ -1,0 +1,65 @@
+//! Enemies: hostile creatures that engage investigators, attack, and
+//! are defeated through combat.
+
+use serde::{Deserialize, Serialize};
+
+use super::{investigator::InvestigatorId, location::LocationId};
+
+/// Stable identifier for an enemy within a scenario.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct EnemyId(pub u32);
+
+/// An enemy in play during a scenario.
+///
+/// Minimal shape needed for Fight / Evade actions in this PR. Fields
+/// that don't influence those actions are deferred to the issues that
+/// will exercise them:
+/// - `aloof`, `prey`: spawn-time engagement rule (separate issue).
+/// - `hunter`, `prey`: hunter movement during the enemy phase (#71).
+///
+/// Adding each field with its real shape when its consumer lands keeps
+/// us from baking placeholder semantics that turn out to be wrong.
+///
+/// # Invariants
+///
+/// - `damage <= max_health`. Reaching equality means the enemy is
+///   defeated and should be removed from `GameState::enemies`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Enemy {
+    /// Stable identifier within this scenario.
+    pub id: EnemyId,
+    /// Display name.
+    pub name: String,
+    /// Difficulty for Fight tests against this enemy.
+    pub fight: i8,
+    /// Difficulty for Evade tests against this enemy.
+    pub evade: i8,
+    /// Maximum health.
+    pub max_health: u8,
+    /// Current damage suffered. Invariant: `<= max_health`.
+    pub damage: u8,
+    /// Damage this enemy deals on an attack (`AoO` + enemy phase).
+    pub attack_damage: u8,
+    /// Horror this enemy deals on an attack.
+    pub attack_horror: u8,
+    /// Where the enemy is on the location map. `None` for enemies
+    /// that haven't spawned (or have left play).
+    pub current_location: Option<LocationId>,
+    /// Whether the enemy is exhausted. Exhausted enemies don't make
+    /// attacks of opportunity and don't activate during the enemy phase.
+    pub exhausted: bool,
+    /// Card-text traits (Monster, Humanoid, Cultist, Elite, etc.).
+    /// "Elite" is a trait, not a separate field — it's how cards
+    /// filter ("deal 1 damage to a non-Elite enemy", "automatically
+    /// evade a non-Elite enemy at your location", etc.), and the same
+    /// mechanism handles every other trait filter uniformly. Same
+    /// encoding as in the upstream card JSON's `traits` field.
+    pub traits: Vec<String>,
+    /// Which investigator (if any) the enemy is currently engaged
+    /// with. Engagement is stored on the enemy because the rulebook
+    /// frames enemies as engaging investigators, not vice versa, and
+    /// the lookup "which enemies is this investigator engaged with"
+    /// is just a scan of `state.enemies`.
+    pub engaged_with: Option<InvestigatorId>,
+}

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     chaos_bag::{ChaosBag, TokenModifiers},
+    enemy::{Enemy, EnemyId},
     investigator::{Investigator, InvestigatorId},
     location::{Location, LocationId},
     phase::Phase,
@@ -34,6 +35,9 @@ pub struct GameState {
     pub investigators: BTreeMap<InvestigatorId, Investigator>,
     /// All locations laid out (revealed and unrevealed alike), keyed by ID.
     pub locations: BTreeMap<LocationId, Location>,
+    /// All enemies currently in play, keyed by ID. Defeated enemies are
+    /// removed; the map is the source of truth for "this enemy exists."
+    pub enemies: BTreeMap<EnemyId, Enemy>,
     /// The chaos bag at this scenario's difficulty.
     pub chaos_bag: ChaosBag,
     /// Per-scenario numeric values for the four symbol tokens

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -6,12 +6,14 @@
 //! they don't run the game.
 
 pub mod chaos_bag;
+pub mod enemy;
 pub mod game_state;
 pub mod investigator;
 pub mod location;
 pub mod phase;
 
 pub use chaos_bag::{resolve_token, ChaosBag, ChaosToken, TokenModifiers, TokenResolution};
+pub use enemy::{Enemy, EnemyId};
 pub use game_state::GameState;
 pub use investigator::{Investigator, InvestigatorId, SkillKind, Skills};
 pub use location::{Location, LocationId};

--- a/crates/game-core/src/test_support/builder.rs
+++ b/crates/game-core/src/test_support/builder.rs
@@ -27,7 +27,8 @@ use std::collections::BTreeMap;
 
 use crate::rng::RngState;
 use crate::state::{
-    ChaosBag, GameState, Investigator, InvestigatorId, Location, Phase, TokenModifiers,
+    ChaosBag, Enemy, EnemyId, GameState, Investigator, InvestigatorId, Location, Phase,
+    TokenModifiers,
 };
 
 /// Fluent builder for a [`GameState`].
@@ -40,6 +41,7 @@ use crate::state::{
 pub struct TestGame {
     investigators: BTreeMap<InvestigatorId, Investigator>,
     locations: BTreeMap<crate::state::LocationId, Location>,
+    enemies: BTreeMap<EnemyId, Enemy>,
     chaos_bag: ChaosBag,
     token_modifiers: TokenModifiers,
     phase: Phase,
@@ -58,6 +60,7 @@ impl TestGame {
         Self {
             investigators: BTreeMap::new(),
             locations: BTreeMap::new(),
+            enemies: BTreeMap::new(),
             chaos_bag: ChaosBag::new([]),
             token_modifiers: TokenModifiers::default(),
             phase: Phase::Mythos,
@@ -79,6 +82,13 @@ impl TestGame {
     /// the same id.
     pub fn with_location(mut self, location: Location) -> Self {
         self.locations.insert(location.id, location);
+        self
+    }
+
+    /// Add an enemy to the state. Replaces any existing entry with the
+    /// same id.
+    pub fn with_enemy(mut self, enemy: Enemy) -> Self {
+        self.enemies.insert(enemy.id, enemy);
         self
     }
 
@@ -144,6 +154,7 @@ impl TestGame {
         GameState {
             investigators: self.investigators,
             locations: self.locations,
+            enemies: self.enemies,
             chaos_bag: self.chaos_bag,
             token_modifiers: self.token_modifiers,
             phase: self.phase,

--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -17,7 +17,7 @@
 //! field's intent. Phase-2+ reviewers: flag missing fixture updates
 //! when a field addition lands.
 
-use crate::state::{Investigator, InvestigatorId, Location, LocationId, Skills};
+use crate::state::{Enemy, EnemyId, Investigator, InvestigatorId, Location, LocationId, Skills};
 
 /// A stock investigator with reasonable defaults.
 ///
@@ -62,5 +62,34 @@ pub fn test_location(id: u32, name: impl Into<String>) -> Location {
         clues: 0,
         revealed: true,
         connections: Vec::new(),
+    }
+}
+
+/// A stock enemy with reasonable defaults.
+///
+/// - Fight 2, Evade 2, max-health 2, no damage.
+/// - Attack pattern: 1 damage / 0 horror.
+/// - Not spawned (`current_location: None`), ready, unengaged, no
+///   traits.
+///
+/// Mutate fields directly after construction to customize. The
+/// `#[non_exhaustive]` interaction note from the module-level docs
+/// applies to `Enemy` as well — adding a field to the struct requires
+/// updating this fixture in the same PR.
+#[must_use]
+pub fn test_enemy(id: u32, name: impl Into<String>) -> Enemy {
+    Enemy {
+        id: EnemyId(id),
+        name: name.into(),
+        fight: 2,
+        evade: 2,
+        max_health: 2,
+        damage: 0,
+        attack_damage: 1,
+        attack_horror: 0,
+        current_location: None,
+        exhausted: false,
+        traits: Vec::new(),
+        engaged_with: None,
     }
 }

--- a/crates/game-core/src/test_support/mod.rs
+++ b/crates/game-core/src/test_support/mod.rs
@@ -12,4 +12,4 @@ pub mod builder;
 pub mod fixtures;
 
 pub use builder::TestGame;
-pub use fixtures::{test_investigator, test_location};
+pub use fixtures::{test_enemy, test_investigator, test_location};


### PR DESCRIPTION
## Summary

Closes #67. First pass of enemy modeling and the two skill-test-driven attacking actions.

## State (\`state/enemy.rs\`)

- \`EnemyId(pub u32)\` and the \`Enemy\` struct.
- Minimal-for-this-PR fields: id, name, fight, evade, max_health, damage, attack_damage, attack_horror, current_location, exhausted, traits, engaged_with.
- Fields deferred until their consumer issue lands (no placeholder semantics): \`aloof\`/\`prey\` (spawn engagement, separate issue), \`hunter\` (#71).
- \`traits: Vec<String>\` stays because "Elite" is a real card-filtering target across many cards and the upstream JSON encodes it as a trait alongside Monster / Humanoid / etc. — diverging here would create a second-encoding tax later.
- Engagement is stored on the enemy (rulebook framing: enemies engage investigators). Lookups in the other direction are scans.
- \`enemies: BTreeMap<EnemyId, Enemy>\` on \`GameState\`. Defeated enemies are removed from the map.

## Events

\`EnemySpawned\`, \`EnemyEngaged\`, \`EnemyDisengaged\`, \`EnemyExhausted\`, \`EnemyReadied\`, \`EnemyDamaged\`, \`EnemyDefeated\` (last carries optional \`by\` for attribution).

## Fight action

\`PlayerAction::Fight { investigator, enemy }\`: validate phase/active/actions/enemy-exists/engaged → spend 1 action → \`resolve_skill_test(Combat, enemy.fight)\` → on success \`damage_enemy(1, by: Some(investigator))\`. Helper applies damage, emits \`EnemyDamaged\`, checks defeat (\`damage >= max_health\`), and on defeat emits \`EnemyDefeated\` + removes the enemy from state.

## Evade action

\`PlayerAction::Evade { investigator, enemy }\`: same validate prefix → \`resolve_skill_test(Agility, enemy.evade)\` → on success clear \`engaged_with\`, set \`exhausted = true\`, emit \`EnemyDisengaged\` + \`EnemyExhausted\`.

## Refactor

Two small extractions while shipping these:
- **\`validate_engaged_action\`**: shared Fight/Evade validation prefix returning the enemy's (fight, evade) difficulties.
- **\`spend_one_action\`**: centralizes the 1-action-spend pattern. Investigate and Move are refactored to use it, removing their inline copies.

## Out of scope (downstream)

- **AoO + engaged-enemies-follow-on-move** (#78). Fight and Evade are AoO-exempt per the Rules Reference, so this PR is correct as-is on Fight/Evade themselves.
- Damage > 1 (weapons / card buffs).
- After-success / after-failure trigger windows (#64).
- Spawn-time engagement rule, hunter movement (#71, separate issue).
- Cancel / replace effects on attacks.

## Test plan

- [x] \`cargo test --all\` — 84 game-core tests pass (was 73), 11 new Fight/Evade tests covering: happy path success each, failure each, Fight defeats enemy when damage reaches max_health (verified \`EnemyDefeated\` with attribution + enemy removed from state), Evade leaves engagement intact on failure, validation rejections for each (wrong phase, non-active, no actions, not engaged with target, unknown enemy).
- [x] \`cargo clippy --all -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)