### PR TITLE
engine: attack of opportunity + engaged-enemy follow-on-move

### DIFF
--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -416,8 +416,12 @@ fn investigate(
     // at i8::MAX for the absurd case; realistic shrouds are 0–6.
     let difficulty = i8::try_from(location.shroud).unwrap_or(i8::MAX);
 
-    // Mutate-second: spend the action, then resolve the test.
+    // Mutate-second: spend the action, fire AoO, then resolve the
+    // test. Investigate is NOT on the AoO-exempt list (only Fight,
+    // Evade, Parley, Engage, Resign are), so each ready engaged
+    // enemy attacks before the test resolves.
     spend_one_action(state, events, investigator);
+    fire_attacks_of_opportunity(state, events, investigator);
 
     match resolve_skill_test(
         state,
@@ -530,11 +534,32 @@ fn move_action(
 
     // Mutate-second.
     spend_one_action(state, events, investigator);
+
+    // Move triggers attacks of opportunity from each ready engaged
+    // enemy. Per the Rules Reference, this happens BEFORE the move
+    // resolves.
+    fire_attacks_of_opportunity(state, events, investigator);
+
+    // Engaged enemies move with the investigator. Capture the
+    // engagement set before mutating any locations, then update each
+    // engaged enemy's `current_location` to the destination
+    // alongside the investigator's own move.
+    let engaged: Vec<EnemyId> = state
+        .enemies
+        .iter()
+        .filter(|(_, e)| e.engaged_with == Some(investigator))
+        .map(|(id, _)| *id)
+        .collect();
     state
         .investigators
         .get_mut(&investigator)
         .expect("investigator existence checked above")
         .current_location = Some(destination);
+    for enemy_id in engaged {
+        if let Some(enemy) = state.enemies.get_mut(&enemy_id) {
+            enemy.current_location = Some(destination);
+        }
+    }
     events.push(Event::InvestigatorMoved {
         investigator,
         from,
@@ -759,5 +784,93 @@ fn damage_enemy(
             by,
         });
         state.enemies.remove(&enemy_id);
+    }
+}
+
+/// Apply an enemy's attack pattern (damage + horror) to an
+/// investigator. Used by attacks of opportunity today; will be reused
+/// by the enemy-phase handler (#71) when that lands.
+///
+/// Per the Rules Reference, an enemy making an attack of opportunity
+/// does NOT exhaust. Enemy-phase attacks DO exhaust the attacker.
+/// This helper therefore does NOT touch the attacker's `exhausted`
+/// flag — callers that need exhaustion (i.e. the enemy phase) apply
+/// it separately.
+///
+/// Investigator-defeat handling (damage > `max_health`, horror >
+/// `max_sanity`) is deferred to its own issue. For now, we
+/// `saturating_add` so we don't wrap, but allow the value to exceed
+/// the cap; the eventual defeat flow will reconcile.
+fn enemy_attack(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    enemy_id: EnemyId,
+    investigator: InvestigatorId,
+) {
+    let enemy = state.enemies.get(&enemy_id).unwrap_or_else(|| {
+        unreachable!(
+            "enemy_attack: enemy {enemy_id:?} is not in state.enemies; \
+             this is a state-corruption invariant violation"
+        )
+    });
+    let damage = enemy.attack_damage;
+    let horror = enemy.attack_horror;
+
+    if damage > 0 {
+        let inv = state
+            .investigators
+            .get_mut(&investigator)
+            .unwrap_or_else(|| {
+                unreachable!(
+                    "enemy_attack: investigator {investigator:?} is not in the investigators map; \
+                 this is a state-corruption invariant violation"
+                )
+            });
+        inv.damage = inv.damage.saturating_add(damage);
+        events.push(Event::DamageTaken {
+            investigator,
+            amount: damage,
+        });
+    }
+    if horror > 0 {
+        let inv = state
+            .investigators
+            .get_mut(&investigator)
+            .unwrap_or_else(|| {
+                unreachable!(
+                    "enemy_attack: investigator {investigator:?} is not in the investigators map; \
+                 this is a state-corruption invariant violation"
+                )
+            });
+        inv.horror = inv.horror.saturating_add(horror);
+        events.push(Event::HorrorTaken {
+            investigator,
+            amount: horror,
+        });
+    }
+}
+
+/// Fire attacks of opportunity from every ready enemy engaged with
+/// `investigator`. Each attacker resolves via [`enemy_attack`]; order
+/// is deterministic by `EnemyId` (`BTreeMap` iteration).
+///
+/// Per the Rules Reference, the active player chooses the order of
+/// `AoOs` from multiple engaged ready enemies; v1 uses deterministic
+/// `EnemyId` order. We'll revisit when an actual ordering choice
+/// matters (e.g. a card reacts to "the second attack of opportunity
+/// this turn").
+fn fire_attacks_of_opportunity(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+) {
+    let attackers: Vec<EnemyId> = state
+        .enemies
+        .iter()
+        .filter(|(_, e)| e.engaged_with == Some(investigator) && !e.exhausted)
+        .map(|(id, _)| *id)
+        .collect();
+    for enemy_id in attackers {
+        enemy_attack(state, events, enemy_id, investigator);
     }
 }

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -798,9 +798,9 @@ fn damage_enemy(
 /// it separately.
 ///
 /// Investigator-defeat handling (damage > `max_health`, horror >
-/// `max_sanity`) is deferred to its own issue. For now, we
-/// `saturating_add` so we don't wrap, but allow the value to exceed
-/// the cap; the eventual defeat flow will reconcile.
+/// `max_sanity`) is deferred to #80. For now, we `saturating_add` so
+/// we don't wrap, but allow the value to exceed the cap; the defeat
+/// flow installed by #80 will reconcile.
 fn enemy_attack(
     state: &mut GameState,
     events: &mut Vec<Event>,

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -1486,10 +1486,26 @@ mod tests {
         );
 
         assert_eq!(result.outcome, EngineOutcome::Done);
-        // AoO damage event fires before InvestigatorMoved.
         assert_event!(
             result.events,
             Event::DamageTaken { investigator, amount: 1 } if *investigator == inv_id
+        );
+        // AoO damage must fire BEFORE the move resolves per the Rules
+        // Reference. assert_event! is existence-only, so check the
+        // positions explicitly.
+        let damage_idx = result
+            .events
+            .iter()
+            .position(|e| matches!(e, Event::DamageTaken { .. }))
+            .expect("DamageTaken event missing");
+        let moved_idx = result
+            .events
+            .iter()
+            .position(|e| matches!(e, Event::InvestigatorMoved { .. }))
+            .expect("InvestigatorMoved event missing");
+        assert!(
+            damage_idx < moved_idx,
+            "AoO DamageTaken (idx {damage_idx}) must precede InvestigatorMoved (idx {moved_idx})"
         );
         // Investigator damaged.
         assert_eq!(result.state.investigators[&inv_id].damage, 1);
@@ -1655,5 +1671,65 @@ mod tests {
         );
         assert_eq!(result.outcome, EngineOutcome::Done);
         assert_no_event!(result.events, Event::DamageTaken { .. });
+    }
+
+    #[test]
+    fn aoo_fires_in_enemy_id_order_for_multiple_attackers() {
+        // Lock in the v1 ordering contract (deterministic by EnemyId
+        // via BTreeMap iteration). Three engaged ready enemies with
+        // distinct attack_damage values; the sequence of DamageTaken
+        // amounts must match EnemyId ordering.
+        let (inv_id, _, b, state) = move_scenario();
+        let mut state = state;
+        for (id, dmg) in [(300, 1), (301, 2), (302, 4)] {
+            let mut e = test_enemy(id, "");
+            e.engaged_with = Some(inv_id);
+            e.attack_damage = dmg;
+            state.enemies.insert(EnemyId(id), e);
+        }
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: inv_id,
+                destination: b,
+            }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        let damages: Vec<u8> = result
+            .events
+            .iter()
+            .filter_map(|e| match e {
+                Event::DamageTaken { amount, .. } => Some(*amount),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(damages, vec![1, 2, 4]);
+        assert_eq!(result.state.investigators[&inv_id].damage, 7);
+    }
+
+    #[test]
+    fn aoo_from_zero_damage_zero_horror_enemy_emits_no_events() {
+        // Edge: an engaged ready enemy with attack_damage = 0 and
+        // attack_horror = 0 still "attacks" but the helper's `if > 0`
+        // guards must skip both event emissions.
+        let (inv_id, _, b, state) = move_scenario();
+        let mut state = state;
+        let mut e = test_enemy(310, "Quiet Watcher");
+        e.engaged_with = Some(inv_id);
+        e.attack_damage = 0;
+        e.attack_horror = 0;
+        state.enemies.insert(EnemyId(310), e);
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: inv_id,
+                destination: b,
+            }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_no_event!(result.events, Event::DamageTaken { .. });
+        assert_no_event!(result.events, Event::HorrorTaken { .. });
+        assert_eq!(result.state.investigators[&inv_id].damage, 0);
+        assert_eq!(result.state.investigators[&inv_id].horror, 0);
     }
 }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -1448,4 +1448,212 @@ mod tests {
         assert_eq!(other_after.damage, 0);
         assert!(!other_after.exhausted);
     }
+
+    // ------------------------------------------------------------------
+    // Attack-of-opportunity tests (#78)
+    // ------------------------------------------------------------------
+
+    /// Move scenario with a ready enemy engaged with the active
+    /// investigator at the origin. A connects to B (one-way).
+    /// Returns (inv id, A, B, enemy id, state).
+    fn move_scenario_with_engaged_enemy() -> (
+        InvestigatorId,
+        crate::state::LocationId,
+        crate::state::LocationId,
+        EnemyId,
+        GameState,
+    ) {
+        let (inv_id, a, b, mut state) = move_scenario();
+        let enemy_id = EnemyId(200);
+        let mut enemy = test_enemy(200, "Engaged Ghoul");
+        enemy.current_location = Some(a);
+        enemy.engaged_with = Some(inv_id);
+        enemy.attack_damage = 1;
+        enemy.attack_horror = 0;
+        state.enemies.insert(enemy_id, enemy);
+        (inv_id, a, b, enemy_id, state)
+    }
+
+    #[test]
+    fn move_with_ready_engaged_enemy_fires_aoo_and_enemy_follows() {
+        let (inv_id, a, b, enemy_id, state) = move_scenario_with_engaged_enemy();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: inv_id,
+                destination: b,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        // AoO damage event fires before InvestigatorMoved.
+        assert_event!(
+            result.events,
+            Event::DamageTaken { investigator, amount: 1 } if *investigator == inv_id
+        );
+        // Investigator damaged.
+        assert_eq!(result.state.investigators[&inv_id].damage, 1);
+        // Investigator moved.
+        assert_eq!(
+            result.state.investigators[&inv_id].current_location,
+            Some(b)
+        );
+        assert_event!(
+            result.events,
+            Event::InvestigatorMoved { from, to, .. } if *from == a && *to == b
+        );
+        // Engaged enemy followed.
+        assert_eq!(result.state.enemies[&enemy_id].current_location, Some(b));
+        assert_eq!(result.state.enemies[&enemy_id].engaged_with, Some(inv_id));
+        // AoO does NOT exhaust per the Rules Reference.
+        assert!(!result.state.enemies[&enemy_id].exhausted);
+    }
+
+    #[test]
+    fn move_with_exhausted_engaged_enemy_does_not_fire_aoo() {
+        let (inv_id, _, b, enemy_id, mut state) = move_scenario_with_engaged_enemy();
+        state.enemies.get_mut(&enemy_id).unwrap().exhausted = true;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: inv_id,
+                destination: b,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_no_event!(result.events, Event::DamageTaken { .. });
+        assert_no_event!(result.events, Event::HorrorTaken { .. });
+        assert_eq!(result.state.investigators[&inv_id].damage, 0);
+        // Exhausted enemy still follows the investigator.
+        assert_eq!(result.state.enemies[&enemy_id].current_location, Some(b));
+    }
+
+    #[test]
+    fn move_with_unengaged_enemy_at_origin_leaves_enemy_behind() {
+        let (inv_id, a, b, _, mut state) = move_scenario_with_engaged_enemy();
+        // Convert the engagement into a non-engagement: enemy is at A
+        // but not engaged with anyone.
+        let other_id = EnemyId(201);
+        let mut other = test_enemy(201, "Bystander");
+        other.current_location = Some(a);
+        // engaged_with stays None.
+        state.enemies.insert(other_id, other);
+        // Remove the engaged enemy so the move doesn't trigger AoO,
+        // keeping the focus on the unengaged enemy.
+        state.enemies.remove(&EnemyId(200));
+
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: inv_id,
+                destination: b,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        // Investigator moved.
+        assert_eq!(
+            result.state.investigators[&inv_id].current_location,
+            Some(b)
+        );
+        // Unengaged enemy stayed put.
+        assert_eq!(result.state.enemies[&other_id].current_location, Some(a));
+    }
+
+    #[test]
+    fn investigate_with_ready_engaged_enemy_fires_aoo() {
+        // Set up an Investigate scenario, then attach an engaged
+        // enemy at the investigator's location.
+        let (inv_id, loc_id, state) = investigate_scenario(2, 2);
+        let enemy_id = EnemyId(300);
+        let mut enemy = test_enemy(300, "Engaged at Study");
+        enemy.current_location = Some(loc_id);
+        enemy.engaged_with = Some(inv_id);
+        enemy.attack_damage = 0;
+        enemy.attack_horror = 1;
+        let mut state = state;
+        state.enemies.insert(enemy_id, enemy);
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Investigate {
+                investigator: inv_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::HorrorTaken { investigator, amount: 1 } if *investigator == inv_id
+        );
+        // Skill test still runs after AoO.
+        assert_event!(result.events, Event::SkillTestStarted { .. });
+        assert_eq!(result.state.investigators[&inv_id].horror, 1);
+    }
+
+    #[test]
+    fn fight_does_not_fire_aoo_from_other_engaged_enemy() {
+        // Investigator engaged with the Fight target AND a second
+        // ready engaged enemy. Fight is on the AoO-exempt list, so
+        // no AoO fires — neither from the target nor from the
+        // bystander.
+        let (inv_id, target_id, mut state) = fight_evade_scenario();
+        let bystander_id = EnemyId(202);
+        let mut bystander = test_enemy(202, "Other Ghoul");
+        bystander.engaged_with = Some(inv_id);
+        bystander.attack_damage = 5;
+        state.enemies.insert(bystander_id, bystander);
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: target_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_no_event!(result.events, Event::DamageTaken { .. });
+        assert_no_event!(result.events, Event::HorrorTaken { .. });
+        assert_eq!(result.state.investigators[&inv_id].damage, 0);
+        assert_eq!(result.state.investigators[&inv_id].horror, 0);
+    }
+
+    #[test]
+    fn evade_does_not_fire_aoo_from_other_engaged_enemy() {
+        let (inv_id, target_id, mut state) = fight_evade_scenario();
+        let bystander_id = EnemyId(203);
+        let mut bystander = test_enemy(203, "Other Ghoul");
+        bystander.engaged_with = Some(inv_id);
+        bystander.attack_damage = 5;
+        state.enemies.insert(bystander_id, bystander);
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Evade {
+                investigator: inv_id,
+                enemy: target_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_no_event!(result.events, Event::DamageTaken { .. });
+        assert_no_event!(result.events, Event::HorrorTaken { .. });
+        assert_eq!(result.state.investigators[&inv_id].damage, 0);
+    }
+
+    #[test]
+    fn move_with_no_engaged_enemy_does_not_fire_aoo() {
+        // Regression: the AoO step is a no-op when no engaged
+        // enemies exist; pre-existing Move tests should not have
+        // started failing.
+        let (inv_id, _, b, state) = move_scenario();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: inv_id,
+                destination: b,
+            }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_no_event!(result.events, Event::DamageTaken { .. });
+    }
 }


### PR DESCRIPTION
## Summary

Closes #78. Wires engagement consequences into the two AoO-triggering turn-actions. Per the [Rules Reference](https://cdn.1j1ju.com/medias/7b/15/e6-arkham-horror-the-card-game-rules-reference.pdf), when an investigator engaged with ≥1 ready enemies takes any action other than Fight, Evade, Parley, Engage, or Resign, each ready engaged enemy makes an AoO BEFORE the action resolves. Also: engaged enemies follow on Move.

## What's in

- **\`enemy_attack(state, events, enemy, investigator)\`** helper: applies \`attack_damage\` + \`attack_horror\`, emits \`DamageTaken\` + \`HorrorTaken\`. Does NOT exhaust per the Rules Reference (AoO is non-exhausting; enemy-phase attacks DO exhaust — #71 will handle that separately).
- **\`fire_attacks_of_opportunity\`**: collects ready engaged enemies in \`EnemyId\` order and fires \`enemy_attack\` for each. v1 deterministic ordering; "active player chooses order" is a follow-up.
- **Move handler**: AoO fires after \`spend_one_action\`, before the move. Then each engaged enemy's \`current_location\` updates to the destination alongside the investigator's.
- **Investigate handler**: AoO fires after \`spend_one_action\`, before \`resolve_skill_test\`.
- **Fight / Evade unchanged**: on the AoO-exempt list per rules.

## Gap (deferred to #80)

An AoO that deals enough damage to defeat the investigator (\`damage >= max_health\` / \`horror >= max_sanity\`) currently lets the action proceed anyway — the move/investigate goes through despite the investigator being conceptually out of play. Investigator-defeat is a substantial cross-cutting concern (detection at multiple sources, status enum, action-cancellation semantics, all-defeated scenario impact, after-defeat trigger window), so it's its own issue: **#80**. The state-doc on \`Investigator\` already flags the invariant as "enforced by the apply loop, not by the type system" — #80 installs that enforcement.

## Test plan

- [x] \`cargo test --all\` — 95 game-core tests pass (was 88), seven new AoO tests covering: AoO fires on Move + engaged enemy follows to destination; AoO doesn't fire from exhausted enemy (but exhausted enemy still follows); unengaged enemy at origin stays behind; AoO fires on Investigate; Fight does NOT fire AoO from a second engaged enemy; Evade likewise; Move with no engagement emits no \`DamageTaken\` (regression).
- [x] \`cargo clippy --all -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)