### PR TITLE
engine: investigator-defeat detection + action gating

### DIFF
--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -12,8 +12,8 @@ use crate::action::{EngineRecord, PlayerAction};
 use crate::dsl::{discover_clue, LocationTarget};
 use crate::event::{Event, FailureReason};
 use crate::state::{
-    resolve_token, Enemy, EnemyId, GameState, InvestigatorId, LocationId, Phase, SkillKind,
-    TokenResolution,
+    resolve_token, DefeatCause, Enemy, EnemyId, GameState, InvestigatorId, LocationId, Phase,
+    SkillKind, Status, TokenResolution,
 };
 
 use super::evaluator::{apply_effect, EvalContext};
@@ -260,14 +260,24 @@ pub(super) fn resolve_skill_test(
     skill: SkillKind,
     difficulty: i8,
 ) -> Result<SkillTestResolution, EngineOutcome> {
-    // Validate-first: investigator must exist; chaos bag must be
-    // non-empty so we can draw; difficulty must be non-negative (FFG
-    // difficulties are always ≥ 0).
+    // Validate-first: investigator must exist and be Active; chaos
+    // bag must be non-empty so we can draw; difficulty must be non-
+    // negative (FFG difficulties are always ≥ 0). Defeated
+    // investigators can't take skill tests — they're out of play.
     let Some(inv) = state.investigators.get(&investigator) else {
         return Err(EngineOutcome::Rejected {
             reason: format!("skill test: investigator {investigator:?} not in state").into(),
         });
     };
+    if inv.status != Status::Active {
+        return Err(EngineOutcome::Rejected {
+            reason: format!(
+                "skill test: {investigator:?} is not Active (status {:?})",
+                inv.status,
+            )
+            .into(),
+        });
+    }
     if state.chaos_bag.tokens.is_empty() {
         return Err(EngineOutcome::Rejected {
             reason: "skill test requires a non-empty chaos bag".into(),
@@ -391,6 +401,15 @@ fn investigate(
              map; this is a state-corruption invariant violation"
         )
     });
+    if inv.status != Status::Active {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Investigate: {investigator:?} is not Active (status {:?})",
+                inv.status,
+            )
+            .into(),
+        };
+    }
     if inv.actions_remaining < 1 {
         return EngineOutcome::Rejected {
             reason: "Investigate requires at least 1 action point".into(),
@@ -422,6 +441,14 @@ fn investigate(
     // enemy attacks before the test resolves.
     spend_one_action(state, events, investigator);
     fire_attacks_of_opportunity(state, events, investigator);
+
+    // If AoO defeated the investigator, the action's primary effect
+    // (the skill test) is suppressed. The action point and AoO events
+    // already fired — they stay. The action declaration was legal;
+    // the investigator just can't complete it.
+    if state.investigators[&investigator].status != Status::Active {
+        return EngineOutcome::Done;
+    }
 
     match resolve_skill_test(
         state,
@@ -494,6 +521,15 @@ fn move_action(
              this is a state-corruption invariant violation"
         )
     });
+    if inv.status != Status::Active {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Move: {investigator:?} is not Active (status {:?})",
+                inv.status,
+            )
+            .into(),
+        };
+    }
     if inv.actions_remaining < 1 {
         return EngineOutcome::Rejected {
             reason: "Move requires at least 1 action point".into(),
@@ -539,6 +575,13 @@ fn move_action(
     // enemy. Per the Rules Reference, this happens BEFORE the move
     // resolves.
     fire_attacks_of_opportunity(state, events, investigator);
+
+    // If AoO defeated the investigator, the move is cancelled. The
+    // action point and AoO events stay; the investigator (and any
+    // engaged enemies) don't change location.
+    if state.investigators[&investigator].status != Status::Active {
+        return EngineOutcome::Done;
+    }
 
     // Engaged enemies move with the investigator. Capture the
     // engagement set before mutating any locations, then update each
@@ -613,6 +656,15 @@ fn validate_engaged_action<'a>(
              map; this is a state-corruption invariant violation"
         )
     });
+    if inv.status != Status::Active {
+        return Err(EngineOutcome::Rejected {
+            reason: format!(
+                "{action_name}: {investigator:?} is not Active (status {:?})",
+                inv.status,
+            )
+            .into(),
+        });
+    }
     if inv.actions_remaining < 1 {
         return Err(EngineOutcome::Rejected {
             reason: format!("{action_name} requires at least 1 action point").into(),
@@ -787,6 +839,118 @@ fn damage_enemy(
     }
 }
 
+/// Apply `amount` damage to an investigator. If their accumulated
+/// damage reaches `max_health`, flip status to [`Status::Killed`],
+/// emit [`Event::InvestigatorDefeated`], and (if no `Active`
+/// investigators remain) emit [`Event::AllInvestigatorsDefeated`].
+///
+/// No-ops when `amount == 0` or the investigator is already defeated
+/// (status `!= Active`): defeated investigators are out of play and
+/// don't accumulate more damage.
+///
+/// All damage-application paths should funnel through this helper so
+/// defeat detection stays consistent. The first caller is
+/// [`enemy_attack`]; future damage-dealing card effects plug in here
+/// too.
+///
+/// [`Status::Killed`]: crate::state::Status::Killed
+fn take_damage(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+    amount: u8,
+) {
+    if amount == 0 {
+        return;
+    }
+    let inv = state
+        .investigators
+        .get_mut(&investigator)
+        .unwrap_or_else(|| {
+            unreachable!(
+                "take_damage: investigator {investigator:?} is not in the investigators map; \
+             this is a state-corruption invariant violation"
+            )
+        });
+    if inv.status != Status::Active {
+        return;
+    }
+    inv.damage = inv.damage.saturating_add(amount);
+    let max_health = inv.max_health;
+    let now_defeated = inv.damage >= max_health;
+    events.push(Event::DamageTaken {
+        investigator,
+        amount,
+    });
+    if now_defeated {
+        inv.status = Status::Killed;
+        events.push(Event::InvestigatorDefeated {
+            investigator,
+            cause: DefeatCause::Damage,
+        });
+        check_all_defeated(state, events);
+    }
+}
+
+/// Apply `amount` horror to an investigator. Symmetric to
+/// [`take_damage`] but against `horror` / `max_sanity`, defeating
+/// with [`Status::Insane`] and [`DefeatCause::Horror`].
+///
+/// [`Status::Insane`]: crate::state::Status::Insane
+fn take_horror(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+    amount: u8,
+) {
+    if amount == 0 {
+        return;
+    }
+    let inv = state
+        .investigators
+        .get_mut(&investigator)
+        .unwrap_or_else(|| {
+            unreachable!(
+                "take_horror: investigator {investigator:?} is not in the investigators map; \
+             this is a state-corruption invariant violation"
+            )
+        });
+    if inv.status != Status::Active {
+        return;
+    }
+    inv.horror = inv.horror.saturating_add(amount);
+    let max_sanity = inv.max_sanity;
+    let now_defeated = inv.horror >= max_sanity;
+    events.push(Event::HorrorTaken {
+        investigator,
+        amount,
+    });
+    if now_defeated {
+        inv.status = Status::Insane;
+        events.push(Event::InvestigatorDefeated {
+            investigator,
+            cause: DefeatCause::Horror,
+        });
+        check_all_defeated(state, events);
+    }
+}
+
+/// Emit [`Event::AllInvestigatorsDefeated`] when no `Active`
+/// investigator remains. Idempotent on subsequent defeats: the event
+/// fires whenever the predicate becomes true; consumers that care
+/// about exactly-once semantics dedupe themselves. Currently callers
+/// only invoke this immediately after flipping a status to non-
+/// `Active`, so it fires exactly once per scenario in practice.
+fn check_all_defeated(state: &GameState, events: &mut Vec<Event>) {
+    let any_active = state
+        .investigators
+        .values()
+        .any(|inv| inv.status == Status::Active);
+    if !any_active && !state.investigators.is_empty() {
+        events.push(Event::AllInvestigatorsDefeated);
+    }
+}
+
 /// Apply an enemy's attack pattern (damage + horror) to an
 /// investigator. Used by attacks of opportunity today; will be reused
 /// by the enemy-phase handler (#71) when that lands.
@@ -797,10 +961,12 @@ fn damage_enemy(
 /// flag — callers that need exhaustion (i.e. the enemy phase) apply
 /// it separately.
 ///
-/// Investigator-defeat handling (damage > `max_health`, horror >
-/// `max_sanity`) is deferred to #80. For now, we `saturating_add` so
-/// we don't wrap, but allow the value to exceed the cap; the defeat
-/// flow installed by #80 will reconcile.
+/// Defeat handling flows through [`take_damage`] / [`take_horror`].
+/// If damage defeats first, horror is a no-op (already defeated);
+/// per rules damage and horror from an attack are simultaneous, so
+/// the practical loss of information is minor (the cause field on
+/// [`Event::InvestigatorDefeated`] still identifies the lethal
+/// stat).
 fn enemy_attack(
     state: &mut GameState,
     events: &mut Vec<Event>,
@@ -816,38 +982,8 @@ fn enemy_attack(
     let damage = enemy.attack_damage;
     let horror = enemy.attack_horror;
 
-    if damage > 0 {
-        let inv = state
-            .investigators
-            .get_mut(&investigator)
-            .unwrap_or_else(|| {
-                unreachable!(
-                    "enemy_attack: investigator {investigator:?} is not in the investigators map; \
-                 this is a state-corruption invariant violation"
-                )
-            });
-        inv.damage = inv.damage.saturating_add(damage);
-        events.push(Event::DamageTaken {
-            investigator,
-            amount: damage,
-        });
-    }
-    if horror > 0 {
-        let inv = state
-            .investigators
-            .get_mut(&investigator)
-            .unwrap_or_else(|| {
-                unreachable!(
-                    "enemy_attack: investigator {investigator:?} is not in the investigators map; \
-                 this is a state-corruption invariant violation"
-                )
-            });
-        inv.horror = inv.horror.saturating_add(horror);
-        events.push(Event::HorrorTaken {
-            investigator,
-            amount: horror,
-        });
-    }
+    take_damage(state, events, investigator, damage);
+    take_horror(state, events, investigator, horror);
 }
 
 /// Fire attacks of opportunity from every ready enemy engaged with

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -446,7 +446,13 @@ fn investigate(
     // (the skill test) is suppressed. The action point and AoO events
     // already fired — they stay. The action declaration was legal;
     // the investigator just can't complete it.
-    if state.investigators[&investigator].status != Status::Active {
+    let inv_after_aoo = state.investigators.get(&investigator).unwrap_or_else(|| {
+        unreachable!(
+            "Investigate: investigator {investigator:?} disappeared between AoO and skill test; \
+             this is a state-corruption invariant violation"
+        )
+    });
+    if inv_after_aoo.status != Status::Active {
         return EngineOutcome::Done;
     }
 
@@ -579,7 +585,13 @@ fn move_action(
     // If AoO defeated the investigator, the move is cancelled. The
     // action point and AoO events stay; the investigator (and any
     // engaged enemies) don't change location.
-    if state.investigators[&investigator].status != Status::Active {
+    let inv_after_aoo = state.investigators.get(&investigator).unwrap_or_else(|| {
+        unreachable!(
+            "Move: investigator {investigator:?} disappeared between AoO and move resolution; \
+             this is a state-corruption invariant violation"
+        )
+    });
+    if inv_after_aoo.status != Status::Active {
         return EngineOutcome::Done;
     }
 
@@ -936,16 +948,28 @@ fn take_horror(
 }
 
 /// Emit [`Event::AllInvestigatorsDefeated`] when no `Active`
-/// investigator remains. Idempotent on subsequent defeats: the event
-/// fires whenever the predicate becomes true; consumers that care
-/// about exactly-once semantics dedupe themselves. Currently callers
-/// only invoke this immediately after flipping a status to non-
-/// `Active`, so it fires exactly once per scenario in practice.
+/// investigator remains.
+///
+/// **Contract for callers:** *any* code path that flips a
+/// `Status::Active` investigator to a non-`Active` status (Killed,
+/// Insane, Resigned) must call this helper afterwards. Currently
+/// only [`take_damage`] / [`take_horror`] flip status, so they're
+/// the only callers; future paths (the Resign action, scenario
+/// effects that defeat directly) need to add a call too — otherwise
+/// the event silently fails to fire when those paths cause the last
+/// `Active` to fall.
+///
+/// Idempotent on subsequent defeats: the predicate becomes true once
+/// and stays true. Callers only invoke it after a status flip, so it
+/// fires exactly once per scenario in practice.
 fn check_all_defeated(state: &GameState, events: &mut Vec<Event>) {
     let any_active = state
         .investigators
         .values()
         .any(|inv| inv.status == Status::Active);
+    // Empty-investigators is nonsense scenario state; suppress the
+    // event so we don't emit a meaningless "all defeated" when there
+    // was nobody to defeat in the first place.
     if !any_active && !state.investigators.is_empty() {
         events.push(Event::AllInvestigatorsDefeated);
     }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -1740,7 +1740,7 @@ mod tests {
 
     /// Build a Move scenario with one ready engaged enemy at the
     /// origin. The investigator is configured to be defeated by the
-    /// enemy's AoO: `max_health = 1`, `damage = 0`, enemy
+    /// enemy's `AoO`: `max_health = 1`, `damage = 0`, enemy
     /// `attack_damage = 1`. Returns (inv id, origin, dest, enemy id,
     /// state).
     fn move_scenario_with_lethal_aoo() -> (
@@ -1901,7 +1901,6 @@ mod tests {
         i1.actions_remaining = 3;
         let i2 = test_investigator(2);
         // i2 stays at default 8/8.
-        let enemy_id = EnemyId(500);
         let mut e = test_enemy(500, "Lethal Ghoul");
         e.engaged_with = Some(inv1);
         e.attack_damage = 1;

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -80,7 +80,8 @@ mod tests {
     use crate::event::{Event, FailureReason};
     use crate::state::EnemyId;
     use crate::state::{
-        ChaosToken, GameState, InvestigatorId, Phase, SkillKind, TokenModifiers, TokenResolution,
+        ChaosToken, DefeatCause, GameState, InvestigatorId, Phase, SkillKind, Status,
+        TokenModifiers, TokenResolution,
     };
     use crate::test_support::{test_enemy, test_investigator, test_location, TestGame};
     use crate::{assert_event, assert_event_count, assert_no_event};
@@ -1731,5 +1732,292 @@ mod tests {
         assert_no_event!(result.events, Event::HorrorTaken { .. });
         assert_eq!(result.state.investigators[&inv_id].damage, 0);
         assert_eq!(result.state.investigators[&inv_id].horror, 0);
+    }
+
+    // ------------------------------------------------------------------
+    // Investigator-defeat tests (#80)
+    // ------------------------------------------------------------------
+
+    /// Build a Move scenario with one ready engaged enemy at the
+    /// origin. The investigator is configured to be defeated by the
+    /// enemy's AoO: `max_health = 1`, `damage = 0`, enemy
+    /// `attack_damage = 1`. Returns (inv id, origin, dest, enemy id,
+    /// state).
+    fn move_scenario_with_lethal_aoo() -> (
+        InvestigatorId,
+        crate::state::LocationId,
+        crate::state::LocationId,
+        EnemyId,
+        GameState,
+    ) {
+        let (inv_id, a, b, enemy_id, mut state) = move_scenario_with_engaged_enemy();
+        state.investigators.get_mut(&inv_id).unwrap().max_health = 1;
+        // attack_damage = 1 is already the default from
+        // move_scenario_with_engaged_enemy, but be explicit.
+        state.enemies.get_mut(&enemy_id).unwrap().attack_damage = 1;
+        (inv_id, a, b, enemy_id, state)
+    }
+
+    #[test]
+    fn aoo_lethal_damage_defeats_investigator_during_move_and_cancels_move() {
+        let (inv_id, a, b, enemy_id, state) = move_scenario_with_lethal_aoo();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: inv_id,
+                destination: b,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        // Damage applied + defeat event fired.
+        assert_event!(
+            result.events,
+            Event::DamageTaken { investigator, amount: 1 } if *investigator == inv_id
+        );
+        assert_event!(
+            result.events,
+            Event::InvestigatorDefeated {
+                investigator,
+                cause: DefeatCause::Damage,
+            } if *investigator == inv_id
+        );
+        // Status flipped to Killed.
+        assert_eq!(result.state.investigators[&inv_id].status, Status::Killed);
+        // Action point still spent (the action declaration stays).
+        assert_eq!(result.state.investigators[&inv_id].actions_remaining, 2);
+        // Move suppressed: investigator and engaged enemy stay at the
+        // origin; no InvestigatorMoved event.
+        assert_no_event!(result.events, Event::InvestigatorMoved { .. });
+        assert_eq!(
+            result.state.investigators[&inv_id].current_location,
+            Some(a)
+        );
+        assert_eq!(result.state.enemies[&enemy_id].current_location, Some(a));
+        // Single-investigator scenario, so AllInvestigatorsDefeated
+        // also fires.
+        assert_event!(result.events, Event::AllInvestigatorsDefeated);
+    }
+
+    #[test]
+    fn aoo_lethal_horror_defeats_investigator_during_investigate_and_cancels_test() {
+        // Set up Investigate with an engaged enemy whose attack is
+        // pure horror. Investigator's max_sanity = 1, so 1 horror
+        // drives them insane.
+        let (inv_id, loc_id, mut state) = investigate_scenario(2, 2);
+        state.investigators.get_mut(&inv_id).unwrap().max_sanity = 1;
+        let enemy_id = EnemyId(400);
+        let mut enemy = test_enemy(400, "Tormenting Shade");
+        enemy.current_location = Some(loc_id);
+        enemy.engaged_with = Some(inv_id);
+        enemy.attack_damage = 0;
+        enemy.attack_horror = 1;
+        state.enemies.insert(enemy_id, enemy);
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Investigate {
+                investigator: inv_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::HorrorTaken { investigator, amount: 1 } if *investigator == inv_id
+        );
+        assert_event!(
+            result.events,
+            Event::InvestigatorDefeated {
+                investigator,
+                cause: DefeatCause::Horror,
+            } if *investigator == inv_id
+        );
+        assert_eq!(result.state.investigators[&inv_id].status, Status::Insane);
+        // Skill test suppressed: no SkillTestStarted event.
+        assert_no_event!(result.events, Event::SkillTestStarted { .. });
+        assert_no_event!(result.events, Event::CluePlaced { .. });
+    }
+
+    #[test]
+    fn aoo_damage_to_active_investigator_below_threshold_does_not_defeat() {
+        // Sanity check: AoO that doesn't reach max_health leaves the
+        // investigator Active. Same as the existing AoO test but
+        // explicit on the status field and absence of defeat events.
+        let (inv_id, _, b, _, mut state) = move_scenario_with_engaged_enemy();
+        // Bump max_health above the AoO damage (which is 1).
+        state.investigators.get_mut(&inv_id).unwrap().max_health = 5;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: inv_id,
+                destination: b,
+            }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_eq!(result.state.investigators[&inv_id].status, Status::Active);
+        assert_no_event!(result.events, Event::InvestigatorDefeated { .. });
+        // Move proceeds.
+        assert_event!(result.events, Event::InvestigatorMoved { .. });
+    }
+
+    #[test]
+    fn defeated_investigator_does_not_take_further_damage() {
+        // Two engaged ready enemies, both with attack_damage = 5.
+        // Investigator has max_health = 1. The first AoO defeats;
+        // the second is a no-op (take_damage skips defeated).
+        let (inv_id, _, b, _, mut state) = move_scenario_with_engaged_enemy();
+        state.investigators.get_mut(&inv_id).unwrap().max_health = 1;
+        state.enemies.get_mut(&EnemyId(200)).unwrap().attack_damage = 5;
+        // Add a second engaged ready enemy.
+        let mut e2 = test_enemy(201, "Second Ghoul");
+        e2.engaged_with = Some(inv_id);
+        e2.attack_damage = 5;
+        state.enemies.insert(EnemyId(201), e2);
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: inv_id,
+                destination: b,
+            }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        // Exactly one DamageTaken event (from the first AoO) and one
+        // InvestigatorDefeated.
+        assert_event_count!(result.events, 1, Event::DamageTaken { .. });
+        assert_event_count!(result.events, 1, Event::InvestigatorDefeated { .. });
+        // Damage saturates at the first AoO's amount; second AoO is
+        // skipped entirely.
+        assert_eq!(result.state.investigators[&inv_id].damage, 5);
+    }
+
+    #[test]
+    fn all_investigators_defeated_fires_only_when_last_active_falls() {
+        // Two investigators, one defeated, then the second defeated.
+        // AllInvestigatorsDefeated should fire only on the second.
+        let inv1 = InvestigatorId(1);
+        let inv2 = InvestigatorId(2);
+        let mut i1 = test_investigator(1);
+        i1.max_health = 1;
+        i1.actions_remaining = 3;
+        let i2 = test_investigator(2);
+        // i2 stays at default 8/8.
+        let enemy_id = EnemyId(500);
+        let mut e = test_enemy(500, "Lethal Ghoul");
+        e.engaged_with = Some(inv1);
+        e.attack_damage = 1;
+        let a = crate::state::LocationId(10);
+        let b = crate::state::LocationId(11);
+        let mut loc_a = test_location(10, "A");
+        loc_a.connections = vec![b];
+        let state = TestGame::new()
+            .with_investigator(i1)
+            .with_investigator(i2)
+            .with_location(loc_a)
+            .with_location(test_location(11, "B"))
+            .with_chaos_bag(bag_only_zero())
+            .with_phase(Phase::Investigation)
+            .with_active_investigator(inv1)
+            .with_enemy(e)
+            .build();
+        // First, place inv1 at A so the move scenario validates.
+        let mut state = state;
+        state.investigators.get_mut(&inv1).unwrap().current_location = Some(a);
+
+        // inv1 moves → AoO defeats them. inv2 is still Active.
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: inv1,
+                destination: b,
+            }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::InvestigatorDefeated { investigator, .. } if *investigator == inv1
+        );
+        assert_no_event!(result.events, Event::AllInvestigatorsDefeated);
+        assert_eq!(result.state.investigators[&inv1].status, Status::Killed);
+        assert_eq!(result.state.investigators[&inv2].status, Status::Active);
+    }
+
+    #[test]
+    fn defeated_investigator_cannot_move() {
+        let (inv_id, _, b, _, mut state) = move_scenario_with_engaged_enemy();
+        state.investigators.get_mut(&inv_id).unwrap().status = Status::Killed;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: inv_id,
+                destination: b,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn defeated_investigator_cannot_investigate() {
+        let (inv_id, _, mut state) = investigate_scenario(2, 2);
+        state.investigators.get_mut(&inv_id).unwrap().status = Status::Insane;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Investigate {
+                investigator: inv_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn defeated_investigator_cannot_fight() {
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.investigators.get_mut(&inv_id).unwrap().status = Status::Killed;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn defeated_investigator_cannot_evade() {
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.investigators.get_mut(&inv_id).unwrap().status = Status::Insane;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Evade {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn defeated_investigator_cannot_perform_skill_test() {
+        let id = InvestigatorId(1);
+        let mut inv = test_investigator(1);
+        inv.status = Status::Killed;
+        let state = TestGame::new()
+            .with_investigator(inv)
+            .with_chaos_bag(bag_only_zero())
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Willpower,
+                difficulty: 0,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
     }
 }

--- a/crates/game-core/src/event.rs
+++ b/crates/game-core/src/event.rs
@@ -14,7 +14,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::state::{
-    ChaosToken, EnemyId, InvestigatorId, LocationId, Phase, SkillKind, TokenResolution,
+    ChaosToken, DefeatCause, EnemyId, InvestigatorId, LocationId, Phase, SkillKind, TokenResolution,
 };
 
 /// One state-change record emitted by the engine.
@@ -223,6 +223,26 @@ pub enum Event {
         /// say "defeat this enemy").
         by: Option<InvestigatorId>,
     },
+    /// An investigator was defeated. The investigator's
+    /// [`Status`](crate::state::Status) has been flipped from
+    /// `Active` to `Killed` / `Insane` (or `Resigned` once the
+    /// Resign action lands). The investigator entry stays in
+    /// `state.investigators` so consumers can still identify them by
+    /// id; they just can't take actions or be targeted as "active."
+    InvestigatorDefeated {
+        /// The defeated investigator.
+        investigator: InvestigatorId,
+        /// What caused the defeat.
+        cause: DefeatCause,
+    },
+    /// Every investigator in `state.investigators` is now non-Active.
+    /// Fires immediately after the [`InvestigatorDefeated`] that
+    /// flipped the last active investigator. Scenario-resolution
+    /// flow (#74) consumes this when it lands; for now, downstream
+    /// listeners can use it as a "scenario lost" trigger.
+    ///
+    /// [`InvestigatorDefeated`]: Event::InvestigatorDefeated
+    AllInvestigatorsDefeated,
 }
 
 /// Why a skill test failed.

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -32,6 +32,7 @@ pub use engine::{apply, ApplyResult, EngineOutcome, InputRequest, ResumeToken};
 pub use event::{Event, FailureReason};
 pub use rng::RngState;
 pub use state::{
-    resolve_token, ChaosBag, ChaosToken, Enemy, EnemyId, GameState, Investigator, InvestigatorId,
-    Location, LocationId, Phase, SkillKind, Skills, TokenModifiers, TokenResolution,
+    resolve_token, ChaosBag, ChaosToken, DefeatCause, Enemy, EnemyId, GameState, Investigator,
+    InvestigatorId, Location, LocationId, Phase, SkillKind, Skills, Status, TokenModifiers,
+    TokenResolution,
 };

--- a/crates/game-core/src/state/investigator.rs
+++ b/crates/game-core/src/state/investigator.rs
@@ -16,9 +16,18 @@ pub struct InvestigatorId(pub u32);
 ///
 /// # Invariants
 ///
-/// `damage <= max_health` and `horror <= max_sanity` are enforced by the
-/// apply loop, not by the type system. Constructing an `Investigator`
-/// with damage exceeding max-health is a bug, not a defeat.
+/// - `damage` may exceed `max_health` transiently — when that happens
+///   the apply loop's damage helpers flip `status` to [`Status::Killed`]
+///   and emit [`Event::InvestigatorDefeated`]. Symmetric for `horror`
+///   / `max_sanity` / [`Status::Insane`]. The numeric fields are
+///   `u8` so they don't wrap; the threshold check is what defines
+///   defeat.
+/// - Once `status != Status::Active`, the investigator is "out of
+///   play": damage / horror helpers no-op, the engine doesn't let
+///   them take actions, and card effects targeting investigators
+///   should filter by status.
+///
+/// [`Event::InvestigatorDefeated`]: crate::event::Event::InvestigatorDefeated
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct Investigator {
@@ -34,11 +43,11 @@ pub struct Investigator {
     pub skills: Skills,
     /// Maximum health (physical hit points).
     pub max_health: u8,
-    /// Current physical damage suffered. Invariant: `<= max_health`.
+    /// Current physical damage suffered.
     pub damage: u8,
     /// Maximum sanity.
     pub max_sanity: u8,
-    /// Current horror suffered. Invariant: `<= max_sanity`.
+    /// Current horror suffered.
     pub horror: u8,
     /// Clues currently held by the investigator.
     pub clues: u8,
@@ -47,6 +56,45 @@ pub struct Investigator {
     /// Action points remaining this turn (refreshed at the start of each
     /// investigation phase).
     pub actions_remaining: u8,
+    /// Active / Killed / Insane / Resigned. See [`Status`].
+    pub status: Status,
+}
+
+/// Whether an investigator is still active in the scenario, and if not,
+/// how they left play.
+///
+/// Resigned is a placeholder slot until the Resign action lands; the
+/// engine doesn't currently produce that variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum Status {
+    /// Investigator is in play and can take actions.
+    #[default]
+    Active,
+    /// Investigator was killed (`damage >= max_health`).
+    Killed,
+    /// Investigator was driven insane (`horror >= max_sanity`).
+    Insane,
+    /// Investigator chose to resign from the scenario. Not yet
+    /// produced by the engine; the Resign action is downstream.
+    Resigned,
+}
+
+/// Why an investigator was defeated. Carried on
+/// [`Event::InvestigatorDefeated`] so consumers (campaign log,
+/// after-defeat triggers) know the cause without re-reading state.
+///
+/// [`Event::InvestigatorDefeated`]: crate::event::Event::InvestigatorDefeated
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum DefeatCause {
+    /// Damage reached `max_health`.
+    Damage,
+    /// Horror reached `max_sanity`.
+    Horror,
+    /// Investigator resigned. Not yet produced; reserved for the
+    /// Resign action.
+    Resigned,
 }
 
 /// The four base skill values.

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -15,6 +15,6 @@ pub mod phase;
 pub use chaos_bag::{resolve_token, ChaosBag, ChaosToken, TokenModifiers, TokenResolution};
 pub use enemy::{Enemy, EnemyId};
 pub use game_state::GameState;
-pub use investigator::{Investigator, InvestigatorId, SkillKind, Skills};
+pub use investigator::{DefeatCause, Investigator, InvestigatorId, SkillKind, Skills, Status};
 pub use location::{Location, LocationId};
 pub use phase::Phase;

--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -17,7 +17,9 @@
 //! field's intent. Phase-2+ reviewers: flag missing fixture updates
 //! when a field addition lands.
 
-use crate::state::{Enemy, EnemyId, Investigator, InvestigatorId, Location, LocationId, Skills};
+use crate::state::{
+    Enemy, EnemyId, Investigator, InvestigatorId, Location, LocationId, Skills, Status,
+};
 
 /// A stock investigator with reasonable defaults.
 ///
@@ -46,6 +48,7 @@ pub fn test_investigator(id: u32) -> Investigator {
         clues: 0,
         resources: 5,
         actions_remaining: 3,
+        status: Status::Active,
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #80. Closes the gap flagged when AoO shipped: an investigator whose damage reaches \`max_health\` or horror reaches \`max_sanity\` is now actually defeated, can't take subsequent actions, and an in-flight action where AoO killed them is cancelled. The \`Status\` invariant on \`Investigator\` was "enforced by the apply loop" — this PR installs that enforcement.

## State and types

- **\`Status\`** enum (Active / Killed / Insane / Resigned, default Active) on \`Investigator\`. Resigned is reserved for the Resign action, downstream.
- **\`DefeatCause\`** enum (Damage / Horror / Resigned).
- Two new events: **\`InvestigatorDefeated { investigator, cause }\`** and **\`AllInvestigatorsDefeated\`**.

## Helpers

- **\`take_damage\`** / **\`take_horror\`** funnel all damage/horror applications through a single defeat-detecting path. No-op on \`amount = 0\` or already-defeated investigator. Cross-threshold → flip status → emit \`InvestigatorDefeated\` → emit \`AllInvestigatorsDefeated\` if no Active investigator remains.
- **\`enemy_attack\`** migrated to use these helpers. AoO that crosses the defeat threshold now correctly flips status and emits the defeat event(s).

## Action gating (per the user's catch on review)

Per-handler validate-first check that the acting investigator is \`Active\`:

- **Move, Investigate, Fight, Evade, PerformSkillTest** all reject when the named investigator's status != Active.
- **Action cancellation** in Move and Investigate after AoO that defeats mid-action: action point + AoO events stay; the move / skill test itself is suppressed.
- **EndTurn intentionally NOT gated**: stays usable so a player can manually wrap up after defeat. Auto-end-on-defeat is a follow-up.

## Out of scope (deferred)

- Resign action.
- Auto-end-turn on mid-turn defeat.
- ScenarioEffect defeat cause (card-effect defeats).
- After-defeat trigger window (cards reacting to defeat) — #64 territory.
- "Defeated investigator's controlled enemies disengage" — needs rules clarification.

## Test plan

- [x] \`cargo test --all\` — 107 game-core tests pass (was 97), 10 new tests covering:
  - AoO lethal damage defeats during Move, cancels move, emits AllInvestigatorsDefeated for solo scenario.
  - AoO lethal horror defeats during Investigate, cancels skill test.
  - Below-threshold damage stays Active and Move proceeds.
  - Defeated investigator takes no further damage from a second AoO (helper no-ops).
  - AllInvestigatorsDefeated fires only when the *last* Active falls (multi-investigator scenario).
  - Defeated investigator rejected on Move / Investigate / Fight / Evade / PerformSkillTest.
- [x] \`cargo clippy --all -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)