### PR TITLE
engine: Draw action with empty-deck reshuffle + horror penalty

### DIFF
--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -116,6 +116,22 @@ pub enum PlayerAction {
         /// investigator.
         enemy: EnemyId,
     },
+    /// Draw a card from the player deck. Standard turn-action:
+    /// spends 1 action, draws 1 card.
+    ///
+    /// **Empty-deck reshuffle:** if the deck is empty and the
+    /// discard is non-empty, shuffle the discard into the deck (via
+    /// the shared RNG, emitting `DeckShuffled`), draw, then take
+    /// 1 horror.
+    ///
+    /// **Both empty:** no shuffle, no card drawn, but the 1 horror
+    /// still applies as the safer reading of "would-draw-from-empty-
+    /// deck."
+    Draw {
+        /// Investigator drawing. Must be the active investigator
+        /// during the Investigation phase, with status `Active`.
+        investigator: InvestigatorId,
+    },
     /// Investigate at the active investigator's current location:
     /// spend 1 action, make an intellect test against the location's
     /// shroud value, and on success discover 1 clue at the location.

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -52,6 +52,7 @@ pub fn apply_player_action(
             investigator,
             destination,
         } => move_action(state, events, *investigator, *destination),
+        PlayerAction::Draw { investigator } => draw(state, events, *investigator),
         PlayerAction::Fight {
             investigator,
             enemy,
@@ -143,9 +144,9 @@ pub(super) fn shuffle_player_deck(
 }
 
 /// Draw up to `count` cards from the named investigator's deck top
-/// into their hand. Stops early (without panic) if the deck runs out;
-/// no reshuffle in this PR — that lands with the Draw action (#84),
-/// which also handles the empty-both-take-1-horror rule.
+/// into their hand. Stops early (without panic) if the deck runs out
+/// — this helper is just the structural move; reshuffle / horror
+/// penalty logic for an empty deck lives in [`draw`].
 ///
 /// Emits a single [`Event::CardsDrawn`] with the actually-drawn
 /// count, even if that's zero. A zero-count draw is informative for
@@ -1142,4 +1143,114 @@ fn fire_attacks_of_opportunity(
     for enemy_id in attackers {
         enemy_attack(state, events, enemy_id, investigator);
     }
+}
+
+/// Reshuffle the discard pile back into the deck for the named
+/// investigator. Used by [`draw`] when the deck runs empty. Drains
+/// `discard` into `deck`, then calls [`shuffle_player_deck`] (which
+/// emits [`Event::DeckShuffled`] when ≥ 2 cards land in the deck).
+fn reshuffle_discard_into_deck(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+) {
+    let inv = state
+        .investigators
+        .get_mut(&investigator)
+        .unwrap_or_else(|| {
+            unreachable!(
+                "reshuffle_discard_into_deck: investigator {investigator:?} is not in the \
+             investigators map; this is a state-corruption invariant violation"
+            )
+        });
+    let cards: Vec<_> = inv.discard.drain(..).collect();
+    inv.deck.extend(cards);
+    shuffle_player_deck(state, events, investigator);
+}
+
+/// Handler for [`PlayerAction::Draw`].
+///
+/// Validate-first: Investigation phase, investigator is active and
+/// `Status::Active`, has at least 1 action remaining. Then spend the
+/// action and resolve the draw per the Rules Reference:
+///
+/// - **Non-empty deck**: draw 1 to hand.
+/// - **Empty deck, non-empty discard**: shuffle discard into deck,
+///   draw 1, then take 1 horror — the horror penalty fires when an
+///   investigator with an empty deck needs to draw.
+/// - **Both empty**: no shuffle (per the Rules Reference's "any
+///   ability that would shuffle a discard pile of zero cards back
+///   into a deck does not shuffle the deck"), no card drawn — but
+///   the 1 horror still applies. The rules don't explicitly address
+///   this corner case; we apply the horror as the safer reading
+///   ("would-draw-from-empty triggers the penalty"), and the case
+///   is rare enough in practice (only high-cycle decks burn through
+///   both zones) that the difference is mostly theoretical.
+fn draw(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+) -> EngineOutcome {
+    if state.phase != Phase::Investigation {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Draw is only valid during the Investigation phase (was {:?})",
+                state.phase
+            )
+            .into(),
+        };
+    }
+    if state.active_investigator != Some(investigator) {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Draw: {investigator:?} is not the active investigator ({:?})",
+                state.active_investigator,
+            )
+            .into(),
+        };
+    }
+    let inv = state.investigators.get(&investigator).unwrap_or_else(|| {
+        unreachable!(
+            "Draw: active_investigator {investigator:?} is not in the investigators map; \
+             this is a state-corruption invariant violation"
+        )
+    });
+    if inv.status != Status::Active {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Draw: {investigator:?} is not Active (status {:?})",
+                inv.status,
+            )
+            .into(),
+        };
+    }
+    if inv.actions_remaining < 1 {
+        return EngineOutcome::Rejected {
+            reason: "Draw requires at least 1 action point".into(),
+        };
+    }
+
+    // Mutate.
+    spend_one_action(state, events, investigator);
+
+    let inv = state.investigators.get(&investigator).expect("checked");
+    let deck_empty = inv.deck.is_empty();
+    let discard_empty = inv.discard.is_empty();
+    if deck_empty {
+        if !discard_empty {
+            reshuffle_discard_into_deck(state, events, investigator);
+        }
+        // After the (possibly no-op) reshuffle, attempt the draw.
+        // draw_cards handles a still-empty deck by emitting
+        // CardsDrawn { count: 0 } without moving cards.
+        draw_cards(state, events, investigator, 1);
+        // Horror penalty fires on any "would-draw-from-empty-deck"
+        // (the reshuffle did happen if discard was non-empty; if it
+        // was also empty, the rules don't strictly require horror
+        // but we apply it as the safer reading).
+        take_horror(state, events, investigator, 1);
+    } else {
+        draw_cards(state, events, investigator, 1);
+    }
+    EngineOutcome::Done
 }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -2382,4 +2382,32 @@ mod tests {
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
         assert!(result.events.is_empty());
     }
+
+    #[test]
+    fn draw_with_low_sanity_investigator_defeated_by_reshuffle_horror() {
+        // Interaction: 1-sanity investigator + empty deck + empty
+        // discard → the 1-horror penalty defeats the investigator
+        // via take_horror's defeat path (#80). Verifies the Draw
+        // flow correctly composes with the defeat helpers.
+        let (id, mut state) = draw_scenario();
+        let inv = state.investigators.get_mut(&id).unwrap();
+        inv.max_sanity = 1;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Draw { investigator: id }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::HorrorTaken { investigator, amount: 1 } if *investigator == id
+        );
+        assert_event!(
+            result.events,
+            Event::InvestigatorDefeated {
+                investigator,
+                cause: DefeatCause::Horror,
+            } if *investigator == id
+        );
+        assert_eq!(result.state.investigators[&id].status, Status::Insane);
+    }
 }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -2199,4 +2199,187 @@ mod tests {
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
         assert!(result.events.is_empty());
     }
+
+    // ------------------------------------------------------------------
+    // Draw tests (#84)
+    // ------------------------------------------------------------------
+
+    /// Build a Draw scenario: one investigator at A, in Investigation
+    /// phase, active, 3 actions. The caller mutates deck/hand/discard
+    /// before the test.
+    fn draw_scenario() -> (InvestigatorId, GameState) {
+        let id = InvestigatorId(1);
+        let a = crate::state::LocationId(10);
+        let mut inv = test_investigator(1);
+        inv.current_location = Some(a);
+        inv.actions_remaining = 3;
+        let state = TestGame::new()
+            .with_investigator(inv)
+            .with_location(test_location(10, "A"))
+            .with_phase(Phase::Investigation)
+            .with_active_investigator(id)
+            .with_rng_seed(13)
+            .build();
+        (id, state)
+    }
+
+    #[test]
+    fn draw_with_non_empty_deck_draws_one_and_spends_action() {
+        let (id, mut state) = draw_scenario();
+        state.investigators.get_mut(&id).unwrap().deck =
+            vec![CardCode::new("test-001"), CardCode::new("test-002")];
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Draw { investigator: id }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::ActionsRemainingChanged { investigator, new_count: 2 }
+                if *investigator == id
+        );
+        assert_event!(
+            result.events,
+            Event::CardsDrawn { investigator, count: 1 } if *investigator == id
+        );
+        assert_no_event!(result.events, Event::DeckShuffled { .. });
+        let inv = &result.state.investigators[&id];
+        assert_eq!(inv.hand.len(), 1);
+        assert_eq!(inv.deck.len(), 1);
+        assert_eq!(inv.hand[0], CardCode::new("test-001"));
+        assert_eq!(inv.actions_remaining, 2);
+    }
+
+    #[test]
+    fn draw_with_empty_deck_reshuffles_discard_draws_and_takes_one_horror() {
+        // Per the Rules Reference: empty deck on draw triggers
+        // reshuffle, then draw, then 1 horror penalty.
+        let (id, mut state) = draw_scenario();
+        state.investigators.get_mut(&id).unwrap().discard = vec![
+            CardCode::new("test-A"),
+            CardCode::new("test-B"),
+            CardCode::new("test-C"),
+        ];
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Draw { investigator: id }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::DeckShuffled { investigator } if *investigator == id
+        );
+        assert_event!(
+            result.events,
+            Event::CardsDrawn { investigator, count: 1 } if *investigator == id
+        );
+        assert_event!(
+            result.events,
+            Event::HorrorTaken { investigator, amount: 1 } if *investigator == id
+        );
+        let shuffle_idx = result
+            .events
+            .iter()
+            .position(|e| matches!(e, Event::DeckShuffled { .. }))
+            .expect("DeckShuffled missing");
+        let draw_idx = result
+            .events
+            .iter()
+            .position(|e| matches!(e, Event::CardsDrawn { .. }))
+            .expect("CardsDrawn missing");
+        let horror_idx = result
+            .events
+            .iter()
+            .position(|e| matches!(e, Event::HorrorTaken { .. }))
+            .expect("HorrorTaken missing");
+        assert!(
+            shuffle_idx < draw_idx && draw_idx < horror_idx,
+            "Expected order DeckShuffled ({shuffle_idx}) < CardsDrawn ({draw_idx}) < \
+             HorrorTaken ({horror_idx})"
+        );
+        let inv = &result.state.investigators[&id];
+        assert_eq!(inv.hand.len(), 1);
+        assert_eq!(inv.deck.len(), 2);
+        assert!(inv.discard.is_empty());
+        assert_eq!(inv.horror, 1);
+    }
+
+    #[test]
+    fn draw_with_both_empty_deals_one_horror_no_shuffle_no_card() {
+        // Per the Rules Reference: empty discard means no shuffle
+        // happens. We still apply the 1-horror penalty as the safer
+        // reading of "would-draw-from-empty-deck" (see handler doc).
+        let (id, state) = draw_scenario();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Draw { investigator: id }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::HorrorTaken { investigator, amount: 1 } if *investigator == id
+        );
+        assert_event!(
+            result.events,
+            Event::CardsDrawn { investigator, count: 0 } if *investigator == id
+        );
+        assert_no_event!(result.events, Event::DeckShuffled { .. });
+        let inv = &result.state.investigators[&id];
+        assert_eq!(inv.horror, 1);
+        assert_eq!(inv.actions_remaining, 2);
+        assert!(inv.hand.is_empty());
+        assert!(inv.deck.is_empty());
+        assert!(inv.discard.is_empty());
+    }
+
+    #[test]
+    fn draw_outside_investigation_phase_is_rejected() {
+        let (id, mut state) = draw_scenario();
+        state.phase = Phase::Mythos;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Draw { investigator: id }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn draw_by_non_active_investigator_is_rejected() {
+        let (_, mut state) = draw_scenario();
+        let other = InvestigatorId(2);
+        state.investigators.insert(other, test_investigator(2));
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Draw {
+                investigator: other,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn draw_with_zero_actions_is_rejected() {
+        let (id, mut state) = draw_scenario();
+        state.investigators.get_mut(&id).unwrap().actions_remaining = 0;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Draw { investigator: id }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn draw_by_defeated_investigator_is_rejected() {
+        let (id, mut state) = draw_scenario();
+        state.investigators.get_mut(&id).unwrap().status = Status::Killed;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Draw { investigator: id }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

Closes #84. Adds \`PlayerAction::Draw\` — the standard turn-action that spends 1 action and draws 1 card from the player deck. Empty-deck reshuffle and horror penalty per the Rules Reference.

Originally scoped to include PlayCard too, but the play destination (asset → in-play, event → discard) depends on card metadata the engine can't look up without the cards-registry binding. Split mid-stream: registry binding tracked at **#88**, PlayCard at **#89** (depends on #88).

## Behavior

- **Non-empty deck:** spend 1 action, draw 1 to hand.
- **Empty deck, non-empty discard:** shuffle discard into deck (deterministic via shared RNG, emits \`DeckShuffled\`), draw 1, **then take 1 horror**. Per the Rules Reference, the horror penalty fires upon completion of an empty-deck draw.
- **Both empty:** per the Rules Reference's "any ability that would shuffle a discard pile of zero cards back into a deck does not shuffle the deck" — no shuffle, no card drawn. We apply the 1 horror anyway as the safer reading of "would-draw-from-empty-deck"; the rules don't strictly address this corner case, but the difference is mostly theoretical since only high-cycle decks ever reach it. Documented in the handler.

## What's in

- \`PlayerAction::Draw { investigator }\`.
- Handler with the validate-first prefix shared across player actions: Investigation phase, active investigator, status \`Active\`, ≥1 action point.
- New helper \`reshuffle_discard_into_deck\` (drains discard into deck, calls \`shuffle_player_deck\`).

## Out of scope

- **PlayCard** — #89 (depends on #88).
- **Mulligan** — #85 (next in the #62 split chain).
- **\`CardPlayed\` / \`CardDiscarded\` events** — added by the PlayCard issue.

## Test plan

- [x] \`RUSTFLAGS="-D warnings" cargo test --all --all-features\` — 120 game-core tests pass (was 113), 7 new: happy-path draw with action spend, empty-deck reshuffle + draw + horror (with positional event ordering assertion: DeckShuffled → CardsDrawn → HorrorTaken), both-empty takes-horror-no-shuffle-no-card, plus four gating rejections (wrong phase, non-active, zero actions, defeated).
- [x] \`RUSTFLAGS="-D warnings" cargo clippy --all-targets --all-features -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.
- [x] \`RUSTDOCFLAGS="-D warnings" cargo doc\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)