### PR TITLE
engine: Mulligan action (Phase-1 simplified)

### DIFF
--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -116,6 +116,26 @@ pub enum PlayerAction {
         /// investigator.
         enemy: EnemyId,
     },
+    /// Redraw a subset of an investigator's starting hand. One-shot
+    /// per investigator per scenario; only valid while the engine's
+    /// mulligan window is open (set at `StartScenario`, cleared by
+    /// the first non-Mulligan `Done` player action).
+    ///
+    /// `indices_to_redraw` names zero-based positions in the hand to
+    /// put into discard. An empty vec is a legal no-op-style
+    /// mulligan ("keep my hand") that still consumes the one-shot.
+    /// Indices must be in bounds (`< hand.len()`) and unique.
+    ///
+    /// On apply: named cards move hand → discard, the discard
+    /// reshuffles back into the deck, the investigator draws
+    /// replacement cards equal to the redraw count.
+    Mulligan {
+        /// Investigator mulliganing. Must be `Status::Active` and
+        /// not have already used their mulligan this scenario.
+        investigator: InvestigatorId,
+        /// Hand indices to redraw; empty = no-op-but-consumes.
+        indices_to_redraw: Vec<u8>,
+    },
     /// Draw a card from the player deck. Standard turn-action:
     /// spends 1 action, draws 1 card.
     ///

--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -118,17 +118,22 @@ pub enum PlayerAction {
     },
     /// Redraw a subset of an investigator's starting hand. One-shot
     /// per investigator per scenario; only valid while the engine's
-    /// mulligan window is open (set at `StartScenario`, cleared by
-    /// the first non-Mulligan `Done` player action).
+    /// mulligan window is open. The window opens at `StartScenario`
+    /// and closes once every investigator has `mulligan_used == true`
+    /// (per the Rules Reference: "after all players have completed
+    /// their mulligans, the game begins").
     ///
     /// `indices_to_redraw` names zero-based positions in the hand to
-    /// put into discard. An empty vec is a legal no-op-style
-    /// mulligan ("keep my hand") that still consumes the one-shot.
-    /// Indices must be in bounds (`< hand.len()`) and unique.
+    /// redraw. An empty vec is a legal "keep my hand" signal that
+    /// still consumes the one-shot. Indices must be in bounds
+    /// (`< hand.len()`) and unique.
     ///
-    /// On apply: named cards move hand → discard, the discard
-    /// reshuffles back into the deck, the investigator draws
-    /// replacement cards equal to the redraw count.
+    /// On apply: named cards move hand → deck directly (per the
+    /// Rules Reference's "shuffles them back into his or her deck",
+    /// NOT via the discard pile), the deck is shuffled, and the
+    /// investigator draws replacement cards equal to the redraw
+    /// count. An empty mulligan skips both the shuffle and the
+    /// redraw — the deck stays untouched.
     Mulligan {
         /// Investigator mulliganing. Must be `Status::Active` and
         /// not have already used their mulligan this scenario.

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -94,7 +94,10 @@ pub fn apply_player_action(
 
     // After a successful Mulligan, check whether every investigator
     // has now mulliganed. If so, the setup window closes and normal
-    // play begins.
+    // play begins. Assumes `mulligan()` only ever returns `Done` or
+    // `Rejected` (never `AwaitingInput`) — if it ever grows an
+    // input-prompt path, this gate must be revisited so the window
+    // doesn't silently stay open across a partial mulligan.
     if matches!(outcome, EngineOutcome::Done)
         && matches!(action, PlayerAction::Mulligan { .. })
         && state.investigators.values().all(|inv| inv.mulligan_used)
@@ -245,8 +248,9 @@ fn start_scenario(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutco
 
     // Open the mulligan window. Each investigator may now submit a
     // single `PlayerAction::Mulligan` to redraw a subset of their
-    // starting hand. The window closes the first time any other
-    // player action resolves successfully (see `apply_player_action`).
+    // starting hand. The window closes once every investigator has
+    // `mulligan_used == true` (see `apply_player_action`); other
+    // player actions are rejected until then.
     state.mulligan_window = true;
 
     // Phase 1: Mythos / Enemy / Upkeep have no content yet, so we
@@ -1315,8 +1319,8 @@ fn mulligan(
 ) -> EngineOutcome {
     if !state.mulligan_window {
         return EngineOutcome::Rejected {
-            reason: "Mulligan: setup window has closed (a non-Mulligan action has already \
-                     resolved)"
+            reason: "Mulligan: setup window has closed (every investigator has already \
+                     mulliganed and normal play has begun)"
                 .into(),
         };
     }

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -39,7 +39,27 @@ pub fn apply_player_action(
     events: &mut Vec<Event>,
     action: &PlayerAction,
 ) -> EngineOutcome {
-    match action {
+    // While the mulligan window is open, only Mulligan (and the
+    // already-rejected re-StartScenario) is valid. Per the Rules
+    // Reference, "after all players have completed their mulligans,
+    // the game begins" — the engine enforces that by gating other
+    // actions until every investigator has signaled their mulligan
+    // choice.
+    if state.mulligan_window
+        && !matches!(
+            action,
+            PlayerAction::Mulligan { .. } | PlayerAction::StartScenario
+        )
+    {
+        return EngineOutcome::Rejected {
+            reason: "mulligan window is still open; all investigators must submit \
+                     PlayerAction::Mulligan (with an empty indices_to_redraw to \
+                     keep their hand) before any other action"
+                .into(),
+        };
+    }
+
+    let outcome = match action {
         PlayerAction::StartScenario => start_scenario(state, events),
         PlayerAction::EndTurn => end_turn(state, events),
         PlayerAction::PerformSkillTest {
@@ -53,6 +73,10 @@ pub fn apply_player_action(
             destination,
         } => move_action(state, events, *investigator, *destination),
         PlayerAction::Draw { investigator } => draw(state, events, *investigator),
+        PlayerAction::Mulligan {
+            investigator,
+            indices_to_redraw,
+        } => mulligan(state, events, *investigator, indices_to_redraw),
         PlayerAction::Fight {
             investigator,
             enemy,
@@ -66,7 +90,18 @@ pub fn apply_player_action(
                      window; no AwaitingInput sites exist yet."
                 .into(),
         },
+    };
+
+    // After a successful Mulligan, check whether every investigator
+    // has now mulliganed. If so, the setup window closes and normal
+    // play begins.
+    if matches!(outcome, EngineOutcome::Done)
+        && matches!(action, PlayerAction::Mulligan { .. })
+        && state.investigators.values().all(|inv| inv.mulligan_used)
+    {
+        state.mulligan_window = false;
     }
+    outcome
 }
 
 /// Apply an [`EngineRecord`] to the state, pushing events.
@@ -201,13 +236,18 @@ fn start_scenario(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutco
     });
 
     // For each investigator (sorted by id for determinism), shuffle
-    // their deck and deal an initial hand of up to 5. Cards-in-hand
-    // mechanics (Draw action, Mulligan, PlayCard) land in #84 / #85.
+    // their deck and deal an initial hand of up to 5.
     let inv_ids: Vec<InvestigatorId> = state.investigators.keys().copied().collect();
     for inv_id in inv_ids {
         shuffle_player_deck(state, events, inv_id);
         draw_cards(state, events, inv_id, INITIAL_HAND_SIZE);
     }
+
+    // Open the mulligan window. Each investigator may now submit a
+    // single `PlayerAction::Mulligan` to redraw a subset of their
+    // starting hand. The window closes the first time any other
+    // player action resolves successfully (see `apply_player_action`).
+    state.mulligan_window = true;
 
     // Phase 1: Mythos / Enemy / Upkeep have no content yet, so we
     // tick straight through them. Once the engine grows real Mythos
@@ -1252,5 +1292,94 @@ fn draw(
     } else {
         draw_cards(state, events, investigator, 1);
     }
+    EngineOutcome::Done
+}
+
+/// Handler for [`PlayerAction::Mulligan`].
+///
+/// Per the Rules Reference, the redrawn cards shuffle directly back
+/// into the deck (not via the discard pile). Validates the mulligan
+/// window is open, the investigator is Active and hasn't already
+/// mulliganed, and the redraw indices are in bounds and unique.
+///
+/// On success: move named hand cards to the deck, shuffle, draw the
+/// same count back, set `mulligan_used = true`, emit
+/// `MulliganPerformed`. An empty `indices_to_redraw` is a legal
+/// "keep my hand" mulligan that consumes the one-shot without
+/// touching the deck.
+fn mulligan(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+    indices_to_redraw: &[u8],
+) -> EngineOutcome {
+    if !state.mulligan_window {
+        return EngineOutcome::Rejected {
+            reason: "Mulligan: setup window has closed (a non-Mulligan action has already \
+                     resolved)"
+                .into(),
+        };
+    }
+    let Some(inv) = state.investigators.get(&investigator) else {
+        return EngineOutcome::Rejected {
+            reason: format!("Mulligan: investigator {investigator:?} is not in state").into(),
+        };
+    };
+    if inv.status != Status::Active {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Mulligan: {investigator:?} is not Active (status {:?})",
+                inv.status,
+            )
+            .into(),
+        };
+    }
+    if inv.mulligan_used {
+        return EngineOutcome::Rejected {
+            reason: format!("Mulligan: {investigator:?} has already used their mulligan").into(),
+        };
+    }
+    // Validate indices: each must be in bounds and unique.
+    let hand_len = inv.hand.len();
+    for &idx in indices_to_redraw {
+        if usize::from(idx) >= hand_len {
+            return EngineOutcome::Rejected {
+                reason: format!("Mulligan: hand_index {idx} out of bounds (hand size {hand_len})")
+                    .into(),
+            };
+        }
+    }
+    let mut sorted: Vec<usize> = indices_to_redraw.iter().map(|&i| usize::from(i)).collect();
+    sorted.sort_unstable();
+    if sorted.windows(2).any(|w| w[0] == w[1]) {
+        return EngineOutcome::Rejected {
+            reason: format!("Mulligan: duplicate index in {indices_to_redraw:?}").into(),
+        };
+    }
+
+    // Mutate.
+    let redrawn_count = u8::try_from(indices_to_redraw.len())
+        .expect("indices_to_redraw.len() <= hand.len() <= u8::MAX in practice");
+    let inv_mut = state.investigators.get_mut(&investigator).expect("checked");
+    // Walk indices high-to-low so smaller positions remain valid as
+    // we remove. Move named cards directly into the deck — they
+    // shuffle back in per the rules, not through the discard pile.
+    for &i in sorted.iter().rev() {
+        let card = inv_mut.hand.remove(i);
+        inv_mut.deck.push(card);
+    }
+    inv_mut.mulligan_used = true;
+    // If anything actually moved, shuffle the deck (which now contains
+    // the redrawn cards mixed with the rest) and draw replacements.
+    // For an empty "keep my hand" mulligan, skip both — there's
+    // nothing to put back, so no shuffle and no draw.
+    if redrawn_count > 0 {
+        shuffle_player_deck(state, events, investigator);
+        draw_cards(state, events, investigator, redrawn_count);
+    }
+    events.push(Event::MulliganPerformed {
+        investigator,
+        redrawn_count,
+    });
     EngineOutcome::Done
 }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -2756,25 +2756,109 @@ mod tests {
     }
 
     #[test]
-    fn rejected_action_does_not_close_mulligan_window() {
-        // Try a Move with a bogus destination (rejected). The window
-        // should stay open so the investigator can still mulligan.
-        let (id, mut state) = mulligan_scenario();
-        state.investigators.get_mut(&id).unwrap().current_location =
-            Some(crate::state::LocationId(99));
-        state.phase = Phase::Investigation;
-        state.active_investigator = Some(id);
-        // Note: no location 99 exists in state, so Move panics
-        // unreachable!. Instead, try a Move with a missing
-        // destination on a real-from-but-no-connection setup.
-        // Simpler: use an action that rejects without panicking,
-        // like Investigate without a location.
-        state.investigators.get_mut(&id).unwrap().current_location = None;
-        let result = apply(
+    fn multi_investigator_mulligan_order_does_not_matter() {
+        // Same shape as the previous test but with the second
+        // investigator mulliganing first — exercises that the
+        // window-closure predicate is order-independent.
+        let inv1 = InvestigatorId(1);
+        let inv2 = InvestigatorId(2);
+        let mut a = test_investigator(1);
+        let mut b = test_investigator(2);
+        a.hand = vec![CardCode::new("a-0")];
+        b.hand = vec![CardCode::new("b-0")];
+        let state = TestGame::new()
+            .with_investigator(a)
+            .with_investigator(b)
+            .with_mulligan_window_open()
+            .build();
+
+        let after_inv2 = apply(
             state,
-            Action::Player(PlayerAction::Investigate { investigator: id }),
+            Action::Player(PlayerAction::Mulligan {
+                investigator: inv2,
+                indices_to_redraw: vec![],
+            }),
         );
-        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
-        assert!(result.state.mulligan_window);
+        assert!(after_inv2.state.mulligan_window);
+        let after_inv1 = apply(
+            after_inv2.state,
+            Action::Player(PlayerAction::Mulligan {
+                investigator: inv1,
+                indices_to_redraw: vec![],
+            }),
+        );
+        assert!(!after_inv1.state.mulligan_window);
+    }
+
+    #[test]
+    fn multi_investigator_real_redraw_plus_empty_mulligan_combo() {
+        // One investigator does a real redraw, the other keeps their
+        // hand. Both signal Mulligan; window closes after the
+        // second.
+        let inv1 = InvestigatorId(1);
+        let inv2 = InvestigatorId(2);
+        let mut a = test_investigator(1);
+        let mut b = test_investigator(2);
+        a.hand = vec![
+            CardCode::new("a-h-0"),
+            CardCode::new("a-h-1"),
+            CardCode::new("a-h-2"),
+        ];
+        a.deck = vec![
+            CardCode::new("a-d-0"),
+            CardCode::new("a-d-1"),
+            CardCode::new("a-d-2"),
+        ];
+        b.hand = vec![CardCode::new("b-h-0"), CardCode::new("b-h-1")];
+        b.deck = vec![CardCode::new("b-d-0")];
+        let state = TestGame::new()
+            .with_investigator(a)
+            .with_investigator(b)
+            .with_mulligan_window_open()
+            .with_rng_seed(99)
+            .build();
+
+        // inv1 redraws indices [0, 2] → those two go to deck, deck
+        // shuffles, two new cards come back.
+        let after_inv1 = apply(
+            state,
+            Action::Player(PlayerAction::Mulligan {
+                investigator: inv1,
+                indices_to_redraw: vec![0, 2],
+            }),
+        );
+        assert_eq!(after_inv1.outcome, EngineOutcome::Done);
+        assert!(after_inv1.state.mulligan_window); // inv2 hasn't yet
+        let inv1_after = &after_inv1.state.investigators[&inv1];
+        assert_eq!(inv1_after.hand.len(), 3);
+        assert_eq!(inv1_after.deck.len(), 3);
+        assert_event!(
+            after_inv1.events,
+            Event::MulliganPerformed { investigator, redrawn_count: 2 }
+                if *investigator == inv1
+        );
+
+        // inv2 keeps hand (empty redraw). Window now closes.
+        let original_inv2_hand = after_inv1.state.investigators[&inv2].hand.clone();
+        let original_inv2_deck = after_inv1.state.investigators[&inv2].deck.clone();
+        let after_inv2 = apply(
+            after_inv1.state,
+            Action::Player(PlayerAction::Mulligan {
+                investigator: inv2,
+                indices_to_redraw: vec![],
+            }),
+        );
+        assert_eq!(after_inv2.outcome, EngineOutcome::Done);
+        assert!(!after_inv2.state.mulligan_window);
+        assert_event!(
+            after_inv2.events,
+            Event::MulliganPerformed { investigator, redrawn_count: 0 }
+                if *investigator == inv2
+        );
+        // inv2's zones untouched by their no-op mulligan.
+        let inv2_after = &after_inv2.state.investigators[&inv2];
+        assert_eq!(inv2_after.hand, original_inv2_hand);
+        assert_eq!(inv2_after.deck, original_inv2_deck);
+        assert!(inv2_after.mulligan_used);
     }
 }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -758,6 +758,27 @@ mod tests {
         assert_eq!(state.active_investigator, Some(inv1));
         assert_eq!(state.investigators[&inv1].actions_remaining, 3);
 
+        // Mulligan past the window for both investigators (empty
+        // redraws = "keep my hand"). The engine requires every
+        // investigator to mulligan before non-Mulligan actions are
+        // accepted.
+        let state = apply(
+            state,
+            Action::Player(PlayerAction::Mulligan {
+                investigator: inv1,
+                indices_to_redraw: vec![],
+            }),
+        )
+        .state;
+        let state = apply(
+            state,
+            Action::Player(PlayerAction::Mulligan {
+                investigator: inv2,
+                indices_to_redraw: vec![],
+            }),
+        )
+        .state;
+
         // First EndTurn: rotate to inv2 within Investigation.
         let result = apply(state, Action::Player(PlayerAction::EndTurn));
         let state = result.state;
@@ -831,7 +852,17 @@ mod tests {
         assert_eq!(after_start.round, 1);
         assert_eq!(after_start.active_investigator, Some(id));
 
-        let result = apply(after_start, Action::Player(PlayerAction::EndTurn));
+        // Mulligan past the setup window.
+        let after_mulligan = apply(
+            after_start,
+            Action::Player(PlayerAction::Mulligan {
+                investigator: id,
+                indices_to_redraw: vec![],
+            }),
+        )
+        .state;
+
+        let result = apply(after_mulligan, Action::Player(PlayerAction::EndTurn));
         assert_eq!(result.outcome, EngineOutcome::Done);
         assert_eq!(result.state.round, 2);
         assert_eq!(result.state.phase, Phase::Investigation);
@@ -2409,5 +2440,341 @@ mod tests {
             } if *investigator == id
         );
         assert_eq!(result.state.investigators[&id].status, Status::Insane);
+    }
+
+    // ------------------------------------------------------------------
+    // Mulligan tests (#85)
+    // ------------------------------------------------------------------
+
+    /// Build a Mulligan scenario: one investigator with a known hand
+    /// of 5 cards + a remaining deck of 5, mulligan window open.
+    /// Bypasses `StartScenario` so tests can control the exact hand
+    /// composition.
+    fn mulligan_scenario() -> (InvestigatorId, GameState) {
+        let id = InvestigatorId(1);
+        let mut inv = test_investigator(1);
+        inv.hand = vec![
+            CardCode::new("h-0"),
+            CardCode::new("h-1"),
+            CardCode::new("h-2"),
+            CardCode::new("h-3"),
+            CardCode::new("h-4"),
+        ];
+        inv.deck = vec![
+            CardCode::new("d-0"),
+            CardCode::new("d-1"),
+            CardCode::new("d-2"),
+            CardCode::new("d-3"),
+            CardCode::new("d-4"),
+        ];
+        let state = TestGame::new()
+            .with_investigator(inv)
+            .with_rng_seed(2026)
+            .with_mulligan_window_open()
+            .build();
+        (id, state)
+    }
+
+    #[test]
+    fn mulligan_redraw_subset_swaps_named_cards() {
+        // Redraw indices [1, 3] → those two move to deck, deck
+        // shuffles, two new cards come back.
+        let (id, state) = mulligan_scenario();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Mulligan {
+                investigator: id,
+                indices_to_redraw: vec![1, 3],
+            }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::MulliganPerformed { investigator, redrawn_count: 2 }
+                if *investigator == id
+        );
+        let inv = &result.state.investigators[&id];
+        assert_eq!(inv.hand.len(), 5);
+        assert_eq!(inv.deck.len(), 5);
+        assert!(inv.mulligan_used);
+        // h-0, h-2, h-4 stay at relative positions 0/1/2 of the hand
+        // (since 1 and 3 got removed, the survivors are in original
+        // order at positions 0/1/2). The last 2 hand slots are new
+        // draws.
+        assert_eq!(inv.hand[0], CardCode::new("h-0"));
+        assert_eq!(inv.hand[1], CardCode::new("h-2"));
+        assert_eq!(inv.hand[2], CardCode::new("h-4"));
+    }
+
+    #[test]
+    fn mulligan_redraw_none_keeps_hand_and_consumes_one_shot() {
+        let (id, state) = mulligan_scenario();
+        let original_hand = state.investigators[&id].hand.clone();
+        let original_deck = state.investigators[&id].deck.clone();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Mulligan {
+                investigator: id,
+                indices_to_redraw: vec![],
+            }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::MulliganPerformed { investigator, redrawn_count: 0 }
+                if *investigator == id
+        );
+        let inv = &result.state.investigators[&id];
+        // Hand unchanged.
+        assert_eq!(inv.hand, original_hand);
+        // Deck unchanged (no shuffle happens when nothing moves into it).
+        assert_eq!(inv.deck, original_deck);
+        // One-shot consumed.
+        assert!(inv.mulligan_used);
+        // No DeckShuffled (deck wasn't touched).
+        assert_no_event!(result.events, Event::DeckShuffled { .. });
+    }
+
+    #[test]
+    fn mulligan_redraw_all_replaces_entire_hand() {
+        let (id, state) = mulligan_scenario();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Mulligan {
+                investigator: id,
+                indices_to_redraw: vec![0, 1, 2, 3, 4],
+            }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::MulliganPerformed { investigator, redrawn_count: 5 }
+                if *investigator == id
+        );
+        let inv = &result.state.investigators[&id];
+        assert_eq!(inv.hand.len(), 5);
+        assert_eq!(inv.deck.len(), 5);
+        // None of the original hand cards are in the new hand —
+        // because all 5 went to deck and the shuffle + redraw could
+        // theoretically reproduce the same hand by chance, but
+        // verify that the hand-as-set is a subset of the union.
+        // Stronger check: hand + deck (multiset) equals the original
+        // hand + deck (multiset).
+        let mut all: Vec<_> = inv.hand.iter().chain(inv.deck.iter()).cloned().collect();
+        all.sort();
+        let mut expected: Vec<CardCode> = [
+            "h-0", "h-1", "h-2", "h-3", "h-4", "d-0", "d-1", "d-2", "d-3", "d-4",
+        ]
+        .iter()
+        .map(|s| CardCode::new(*s))
+        .collect();
+        expected.sort();
+        assert_eq!(all, expected);
+    }
+
+    #[test]
+    fn mulligan_second_attempt_is_rejected() {
+        let (id, state) = mulligan_scenario();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Mulligan {
+                investigator: id,
+                indices_to_redraw: vec![0],
+            }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        // Try again on the post-mulligan state.
+        let result2 = apply(
+            result.state,
+            Action::Player(PlayerAction::Mulligan {
+                investigator: id,
+                indices_to_redraw: vec![0],
+            }),
+        );
+        assert!(matches!(result2.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result2.events.is_empty());
+    }
+
+    #[test]
+    fn mulligan_after_window_closed_is_rejected() {
+        let (id, mut state) = mulligan_scenario();
+        state.mulligan_window = false;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Mulligan {
+                investigator: id,
+                indices_to_redraw: vec![0],
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn mulligan_by_defeated_investigator_is_rejected() {
+        let (id, mut state) = mulligan_scenario();
+        state.investigators.get_mut(&id).unwrap().status = Status::Killed;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Mulligan {
+                investigator: id,
+                indices_to_redraw: vec![0],
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn mulligan_with_out_of_bounds_index_is_rejected() {
+        let (id, state) = mulligan_scenario();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Mulligan {
+                investigator: id,
+                indices_to_redraw: vec![10],
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn mulligan_with_duplicate_indices_is_rejected() {
+        let (id, state) = mulligan_scenario();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Mulligan {
+                investigator: id,
+                indices_to_redraw: vec![1, 1],
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn start_scenario_opens_mulligan_window() {
+        let id = InvestigatorId(1);
+        let mut inv = test_investigator(1);
+        inv.deck = make_test_deck(10);
+        let state = TestGame::new()
+            .with_investigator(inv)
+            .with_turn_order([id])
+            .build();
+        let result = apply(state, Action::Player(PlayerAction::StartScenario));
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert!(result.state.mulligan_window);
+    }
+
+    #[test]
+    fn non_mulligan_action_during_mulligan_window_is_rejected() {
+        // Non-Mulligan player actions are gated by the mulligan
+        // window: the engine refuses Move/Investigate/etc. until
+        // every investigator has signaled their mulligan choice.
+        let id = InvestigatorId(1);
+        let a = crate::state::LocationId(10);
+        let b = crate::state::LocationId(11);
+        let mut inv = test_investigator(1);
+        inv.current_location = Some(a);
+        inv.actions_remaining = 3;
+        let mut loc_a = test_location(10, "A");
+        loc_a.connections = vec![b];
+        let state = TestGame::new()
+            .with_investigator(inv)
+            .with_location(loc_a)
+            .with_location(test_location(11, "B"))
+            .with_phase(Phase::Investigation)
+            .with_active_investigator(id)
+            .with_mulligan_window_open()
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: id,
+                destination: b,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn solo_mulligan_closes_the_window() {
+        // Single-investigator scenario: as soon as that one
+        // investigator mulligans (empty redraw counts), all
+        // investigators have mulliganed and the window closes.
+        let (id, state) = mulligan_scenario();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Mulligan {
+                investigator: id,
+                indices_to_redraw: vec![],
+            }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert!(!result.state.mulligan_window);
+    }
+
+    #[test]
+    fn multi_investigator_first_mulligan_keeps_window_open() {
+        // Two investigators; only one mulligans. Window stays open
+        // until the other one also submits Mulligan.
+        let inv1 = InvestigatorId(1);
+        let inv2 = InvestigatorId(2);
+        let mut a = test_investigator(1);
+        let mut b = test_investigator(2);
+        a.hand = vec![CardCode::new("a-0")];
+        b.hand = vec![CardCode::new("b-0")];
+        let state = TestGame::new()
+            .with_investigator(a)
+            .with_investigator(b)
+            .with_mulligan_window_open()
+            .build();
+
+        let after_first = apply(
+            state,
+            Action::Player(PlayerAction::Mulligan {
+                investigator: inv1,
+                indices_to_redraw: vec![],
+            }),
+        );
+        assert_eq!(after_first.outcome, EngineOutcome::Done);
+        assert!(after_first.state.mulligan_window);
+        assert!(after_first.state.investigators[&inv1].mulligan_used);
+        assert!(!after_first.state.investigators[&inv2].mulligan_used);
+
+        let after_second = apply(
+            after_first.state,
+            Action::Player(PlayerAction::Mulligan {
+                investigator: inv2,
+                indices_to_redraw: vec![],
+            }),
+        );
+        assert_eq!(after_second.outcome, EngineOutcome::Done);
+        assert!(!after_second.state.mulligan_window);
+    }
+
+    #[test]
+    fn rejected_action_does_not_close_mulligan_window() {
+        // Try a Move with a bogus destination (rejected). The window
+        // should stay open so the investigator can still mulligan.
+        let (id, mut state) = mulligan_scenario();
+        state.investigators.get_mut(&id).unwrap().current_location =
+            Some(crate::state::LocationId(99));
+        state.phase = Phase::Investigation;
+        state.active_investigator = Some(id);
+        // Note: no location 99 exists in state, so Move panics
+        // unreachable!. Instead, try a Move with a missing
+        // destination on a real-from-but-no-connection setup.
+        // Simpler: use an action that rejects without panicking,
+        // like Investigate without a location.
+        state.investigators.get_mut(&id).unwrap().current_location = None;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Investigate { investigator: id }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.state.mulligan_window);
     }
 }

--- a/crates/game-core/src/event.rs
+++ b/crates/game-core/src/event.rs
@@ -252,6 +252,15 @@ pub enum Event {
         /// How many cards were drawn.
         count: u8,
     },
+    /// An investigator completed a mulligan. `redrawn_count` is the
+    /// number of cards swapped (0 if the player kept their hand).
+    /// State inspection has the new hand contents.
+    MulliganPerformed {
+        /// Who mulliganed.
+        investigator: InvestigatorId,
+        /// How many cards were redrawn.
+        redrawn_count: u8,
+    },
     /// Every investigator in `state.investigators` is now non-Active.
     /// Fires immediately after the [`InvestigatorDefeated`] that
     /// flipped the last active investigator. Scenario-resolution

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -63,9 +63,10 @@ pub struct GameState {
     pub rng: RngState,
     /// Whether the mulligan setup window is open. Set true at the end
     /// of [`PlayerAction::StartScenario`](crate::action::PlayerAction::StartScenario)
-    /// processing; cleared at the end of the first non-Mulligan
-    /// `Done` player action. While open, investigators may submit
+    /// processing; cleared once every investigator has
+    /// `mulligan_used == true`. While open, investigators may submit
     /// [`PlayerAction::Mulligan`](crate::action::PlayerAction::Mulligan)
-    /// to redraw a subset of their starting hand.
+    /// to redraw a subset of their starting hand; the engine rejects
+    /// every non-Mulligan player action until the window closes.
     pub mulligan_window: bool,
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -61,4 +61,11 @@ pub struct GameState {
     /// underlying [`rand_chacha::ChaCha8Rng`] is reconstructed on
     /// demand by [`RngState`] methods.
     pub rng: RngState,
+    /// Whether the mulligan setup window is open. Set true at the end
+    /// of [`PlayerAction::StartScenario`](crate::action::PlayerAction::StartScenario)
+    /// processing; cleared at the end of the first non-Mulligan
+    /// `Done` player action. While open, investigators may submit
+    /// [`PlayerAction::Mulligan`](crate::action::PlayerAction::Mulligan)
+    /// to redraw a subset of their starting hand.
+    pub mulligan_window: bool,
 }

--- a/crates/game-core/src/state/investigator.rs
+++ b/crates/game-core/src/state/investigator.rs
@@ -77,6 +77,11 @@ pub struct Investigator {
     /// demands it. The DSL evaluator's existing `Trigger::Constant`
     /// query for in-play modifiers iterates these codes.
     pub cards_in_play: Vec<CardCode>,
+    /// Whether this investigator has used their one-shot mulligan
+    /// during scenario setup. Set true after a successful Mulligan
+    /// action; remains true for the rest of the scenario so a second
+    /// mulligan rejects.
+    pub mulligan_used: bool,
 }
 
 /// Whether an investigator is still active in the scenario, and if not,

--- a/crates/game-core/src/test_support/builder.rs
+++ b/crates/game-core/src/test_support/builder.rs
@@ -49,6 +49,7 @@ pub struct TestGame {
     active_investigator: Option<InvestigatorId>,
     turn_order: Vec<InvestigatorId>,
     rng: RngState,
+    mulligan_window: bool,
 }
 
 impl TestGame {
@@ -68,6 +69,7 @@ impl TestGame {
             active_investigator: None,
             turn_order: Vec::new(),
             rng: RngState::new(0),
+            mulligan_window: false,
         }
     }
 
@@ -149,6 +151,16 @@ impl TestGame {
         self
     }
 
+    /// Open the mulligan window. By default the window is closed so
+    /// tests don't accidentally exercise Mulligan paths; opt in by
+    /// calling this on the builder when a test wants to fire the
+    /// Mulligan action directly without going through
+    /// `StartScenario`.
+    pub fn with_mulligan_window_open(mut self) -> Self {
+        self.mulligan_window = true;
+        self
+    }
+
     /// Materialize the configured [`GameState`].
     pub fn build(self) -> GameState {
         GameState {
@@ -162,6 +174,7 @@ impl TestGame {
             active_investigator: self.active_investigator,
             turn_order: self.turn_order,
             rng: self.rng,
+            mulligan_window: self.mulligan_window,
         }
     }
 }

--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -53,6 +53,7 @@ pub fn test_investigator(id: u32) -> Investigator {
         hand: Vec::new(),
         discard: Vec::new(),
         cards_in_play: Vec::new(),
+        mulligan_used: false,
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #85. Third and final PR of the #62 split chain. After this the deck/hand foundation is complete; next track is card-effect plumbing (#88 registry → #89 PlayCard → DSL extensions → cards).

## What's in

### State
- **\`mulligan_window: bool\`** on \`GameState\`. Opened at the end of \`StartScenario\`; closed when every investigator has mulliganed.
- **\`mulligan_used: bool\`** on \`Investigator\`. One-shot per scenario.

### Action: \`PlayerAction::Mulligan { investigator, indices_to_redraw }\`
- Choice baked into the action payload — host gathers it client-side, **no \`AwaitingInput\` needed**. Mulligan is player-driven, not engine-coordinated; same shape as Move/Investigate/Fight where the player's decision arrives fully-formed.
- Empty \`indices_to_redraw\` is a legal "keep my hand" signal that still consumes the one-shot.

### Window enforcement
Per the [Rules Reference](https://images-cdn.fantasyflightgames.com/filer_public/c4/b0/c4b0d66c-d79e-411b-bdb5-b5d8c457d4bc/ahc01_rules_reference_web.pdf): "after all players have completed their mulligans, the game begins."

- The dispatch wrapper **rejects every non-Mulligan, non-StartScenario player action while the window is open**. Solo investigators just submit one Mulligan; multi-investigator scenarios require Mulligan from every investigator before any other action is accepted.
- After a successful Mulligan, the wrapper checks if every investigator now has \`mulligan_used == true\` — if so, the window closes and normal play begins.

### Mutation
Walk indices high-to-low, move named hand cards **directly into the deck** (per the Rules Reference's "shuffles them back into his or her deck", not via the discard pile), shuffle the deck, redraw the same count. For an empty mulligan, skip shuffle + draw entirely so a "keep my hand" leaves the deck untouched.

### Event
\`MulliganPerformed { investigator, redrawn_count }\`.

## Existing test updates

Two existing phase-mechanics tests called \`StartScenario\` then immediately exercised \`EndTurn\`; they now need to mulligan past the setup window first. Surgical: insert empty-Mulligan calls between \`StartScenario\` and the test's intent.

## Test plan

- [x] \`RUSTFLAGS="-D warnings" cargo test --all --all-features\` — 134 game-core tests pass (was 121), 13 new: redraw subset / none / all, second-attempt reject, post-window reject, defeated reject, out-of-bounds reject, duplicate-index reject, StartScenario opens window, non-Mulligan-during-window rejected, solo Mulligan closes window, multi-investigator first-keeps + second-closes, rejected action doesn't close window.
- [x] \`RUSTFLAGS="-D warnings" cargo clippy --all-targets --all-features -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.
- [x] \`RUSTDOCFLAGS="-D warnings" cargo doc\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)