### PR TITLE
engine: PlayCard with metadata-driven destination + Trigger::OnPlay

### DIFF
--- a/crates/cards/Cargo.toml
+++ b/crates/cards/Cargo.toml
@@ -13,3 +13,8 @@ workspace = true
 [dependencies]
 game-core = { path = "../game-core" }
 serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+# Enable game-core's TestGame builder + fixtures so integration tests
+# in tests/ can build scenario states for real-card play tests.
+game-core = { path = "../game-core", features = ["test-support"] }

--- a/crates/cards/tests/play_card.rs
+++ b/crates/cards/tests/play_card.rs
@@ -1,0 +1,297 @@
+//! End-to-end `PlayCard` integration tests with the real card corpus.
+//!
+//! These tests install the `cards::REGISTRY` global once and exercise
+//! the engine's `PlayCard` handler against actual Phase-2 cards (Holy
+//! Rosary, Working a Hunch). Lives in `cards/tests/` rather than
+//! `game-core/src/engine/`'s unit tests because:
+//!
+//! - The engine crate can't depend on `cards` (cycle) so it has no
+//!   way to access real card metadata or abilities.
+//! - Installing `REGISTRY` is process-global. As an integration test
+//!   binary this file gets its own process, so its install doesn't
+//!   collide with `game-core`'s own tests (which deliberately don't
+//!   install a registry, exercising only validation paths that
+//!   short-circuit before the registry lookup).
+
+use std::sync::Once;
+
+use game_core::engine::{apply, EngineOutcome};
+use game_core::event::Event;
+use game_core::state::{CardCode, InvestigatorId, Phase, Status, Zone};
+use game_core::test_support::{test_investigator, test_location, TestGame};
+use game_core::PlayerAction;
+use game_core::{assert_event, assert_event_count, assert_event_sequence, assert_no_event};
+use game_core::{Action, LocationId};
+
+/// Holy Rosary (01059) — Mystic asset, +1 willpower constant.
+const HOLY_ROSARY: &str = "01059";
+
+/// Working a Hunch (01037) — Seeker event, on-play "discover 1 clue
+/// at your location."
+const WORKING_A_HUNCH: &str = "01037";
+
+/// Magnifying Glass (01030) — Seeker asset, in the corpus but
+/// unimplemented (no `abilities()` impl). Used as the "unimplemented
+/// but known" rejection case.
+const MAGNIFYING_GLASS: &str = "01030";
+
+/// Roland Banks (01001) — investigator card. Represents the player
+/// character itself; never legally in hand. Used as the
+/// "investigator-type-from-hand" rejection case.
+const ROLAND_BANKS: &str = "01001";
+
+const UNKNOWN_CODE: &str = "99999";
+
+/// Install the real card registry exactly once for this integration-
+/// test binary. Idempotent at the `OnceLock` level; this `Once`
+/// wrapper additionally avoids the futile second `install` call.
+fn install_real_registry() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        // It's fine if this is `Err` — another test in this binary
+        // already installed. The function-pointer struct is `Copy`
+        // and stateless, so re-install attempts are harmless.
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// Build a one-investigator scenario state at the controller's
+/// location, mid-investigation, with `hand` already in hand.
+fn play_state(hand: Vec<&str>) -> (game_core::GameState, InvestigatorId, LocationId) {
+    install_real_registry();
+
+    let id = InvestigatorId(1);
+    let loc_id = LocationId(101);
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(loc_id);
+    inv.hand = hand.into_iter().map(CardCode::new).collect();
+
+    let location = test_location(101, "Study");
+
+    let state = TestGame::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(inv)
+        .with_active_investigator(id)
+        .with_location(location)
+        .build();
+
+    (state, id, loc_id)
+}
+
+#[test]
+fn play_holy_rosary_emits_card_played_and_lands_in_play() {
+    let (state, id, _loc) = play_state(vec![HOLY_ROSARY]);
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        }),
+    );
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    let inv = &result.state.investigators[&id];
+    assert!(inv.hand.is_empty(), "hand should be empty after play");
+    assert_eq!(
+        inv.cards_in_play,
+        vec![CardCode::new(HOLY_ROSARY)],
+        "asset should land in cards_in_play",
+    );
+    assert!(inv.discard.is_empty(), "asset should not land in discard");
+
+    assert_event_count!(
+        result.events,
+        1,
+        Event::CardPlayed { investigator, code }
+            if *investigator == id && code.as_str() == HOLY_ROSARY
+    );
+    assert_no_event!(result.events, Event::CardDiscarded { .. });
+}
+
+#[test]
+fn play_working_a_hunch_resolves_on_play_and_discards() {
+    let (mut state, id, loc_id) = play_state(vec![WORKING_A_HUNCH]);
+
+    // Working a Hunch's OnPlay is "discover 1 clue at your location."
+    // Seed the location with a clue so the discover is visible in the
+    // event stream (rulebook lets you play with 0 clues too — that's
+    // a separate no-op test below).
+    state.locations.get_mut(&loc_id).unwrap().clues = 1;
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        }),
+    );
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    let inv = &result.state.investigators[&id];
+    assert!(inv.hand.is_empty(), "hand should be empty after play");
+    assert!(
+        inv.cards_in_play.is_empty(),
+        "event should not land in cards_in_play",
+    );
+    assert_eq!(
+        inv.discard,
+        vec![CardCode::new(WORKING_A_HUNCH)],
+        "event should land in discard after on-play",
+    );
+    assert_eq!(inv.clues, 1, "discovered 1 clue from location");
+    assert_eq!(
+        result.state.locations[&loc_id].clues, 0,
+        "location's clue moved to investigator",
+    );
+
+    // Each expected event fires exactly once. Ordering is asserted
+    // separately below because the macros are order-insensitive.
+    assert_event_count!(
+        result.events,
+        1,
+        Event::CardPlayed { code, .. } if code.as_str() == WORKING_A_HUNCH
+    );
+    assert_event_count!(
+        result.events,
+        1,
+        Event::CluePlaced { investigator, count: 1 } if *investigator == id
+    );
+    assert_event_count!(
+        result.events,
+        1,
+        Event::CardDiscarded { code, from: Zone::Hand, investigator }
+            if *investigator == id && code.as_str() == WORKING_A_HUNCH
+    );
+
+    // Ordering: CardPlayed < CluePlaced < CardDiscarded. Matters
+    // because event listeners building causal chains (#52 reaction
+    // windows) will key off the order.
+    assert_event_sequence!(
+        result.events,
+        Event::CardPlayed { .. },
+        Event::CluePlaced { .. },
+        Event::CardDiscarded { .. },
+    );
+}
+
+#[test]
+fn play_working_a_hunch_on_empty_location_is_still_done() {
+    // The rulebook says "if there are no clues, no clues are
+    // discovered." DSL DiscoverClue treats empty-location as a no-op
+    // and returns Done — so the play still resolves cleanly and the
+    // card still discards.
+    let (state, id, loc_id) = play_state(vec![WORKING_A_HUNCH]);
+    assert_eq!(state.locations[&loc_id].clues, 0);
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        }),
+    );
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    let inv = &result.state.investigators[&id];
+    assert_eq!(inv.discard, vec![CardCode::new(WORKING_A_HUNCH)]);
+    assert_eq!(inv.clues, 0, "no clues to discover");
+    // DSL DiscoverClue is a no-op on an empty location — it doesn't
+    // emit CluePlaced for a 0-clue discover.
+    assert_no_event!(result.events, Event::CluePlaced { .. });
+    assert_event!(
+        result.events,
+        Event::CardPlayed { code, .. } if code.as_str() == WORKING_A_HUNCH
+    );
+    assert_event!(
+        result.events,
+        Event::CardDiscarded { from: Zone::Hand, code, .. } if code.as_str() == WORKING_A_HUNCH
+    );
+}
+
+#[test]
+fn play_unknown_card_code_is_rejected() {
+    let (state, id, _loc) = play_state(vec![UNKNOWN_CODE]);
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        }),
+    );
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert!(result.events.is_empty());
+    // Hand untouched.
+    assert_eq!(
+        result.state.investigators[&id].hand,
+        vec![CardCode::new(UNKNOWN_CODE)],
+    );
+}
+
+#[test]
+fn play_non_event_or_asset_card_is_rejected() {
+    // Only Asset and Event are playable from hand. Investigator
+    // (and skill, treachery, enemy, location, agenda, act, scenario,
+    // story) all reject. Roland Banks (01001) is the in-corpus
+    // sample for the non-playable case.
+    let (state, id, _loc) = play_state(vec![ROLAND_BANKS]);
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        }),
+    );
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert!(result.events.is_empty());
+    // Hand untouched.
+    assert_eq!(
+        result.state.investigators[&id].hand,
+        vec![CardCode::new(ROLAND_BANKS)],
+    );
+}
+
+#[test]
+fn play_unimplemented_card_is_rejected() {
+    // Magnifying Glass is in the corpus (metadata resolves) but has
+    // no ability implementation yet (#37). The deck-import gate
+    // (Phase 9) will refuse decks containing it; PlayCard double-
+    // checks rather than silently no-op.
+    let (state, id, _loc) = play_state(vec![MAGNIFYING_GLASS]);
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        }),
+    );
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert!(result.events.is_empty());
+}
+
+#[test]
+fn play_card_after_defeat_is_rejected() {
+    // Belt-and-suspenders: even with REGISTRY installed, the status
+    // check should reject before the registry lookup runs.
+    install_real_registry();
+    let id = InvestigatorId(1);
+    let mut inv = test_investigator(1);
+    inv.hand = vec![CardCode::new(HOLY_ROSARY)];
+    inv.status = Status::Killed;
+
+    let state = TestGame::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(inv)
+        .with_active_investigator(id)
+        .build();
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        }),
+    );
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert!(result.events.is_empty());
+}

--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -170,6 +170,31 @@ pub enum PlayerAction {
         /// investigator during the Investigation phase.
         investigator: InvestigatorId,
     },
+    /// Play a card from an investigator's hand. Spends no action
+    /// point at this stage — play-cost gating (resource cost,
+    /// action cost, "Fast" exemption) lives on the card and lands
+    /// with the cost-primitive DSL work (#53).
+    ///
+    /// Validation: Investigation phase, investigator is active and
+    /// `Status::Active`, `hand_index < hand.len()`, the registry is
+    /// installed, the card code resolves to known metadata, and the
+    /// card's type is one of the two hand-playable types — Asset or
+    /// Event. Every other type rejects.
+    ///
+    /// On apply: emit [`CardPlayed`](crate::Event::CardPlayed), run
+    /// every [`Trigger::OnPlay`](crate::dsl::Trigger::OnPlay) ability
+    /// through the DSL evaluator, then move the card to its
+    /// destination zone — `cards_in_play` for assets, `discard` for
+    /// events (the latter emitting
+    /// [`CardDiscarded`](crate::Event::CardDiscarded) with `from: Hand`).
+    PlayCard {
+        /// Investigator playing the card. Must be the active
+        /// investigator during the Investigation phase, with status
+        /// `Active`.
+        investigator: InvestigatorId,
+        /// Zero-based position in the investigator's hand.
+        hand_index: u8,
+    },
     /// Respond to an `AwaitingInput` prompt the engine emitted. The
     /// shape of `response` is dictated by the active prompt. (The
     /// `EngineOutcome::AwaitingInput` variant lands in a later PR.)

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -9,11 +9,13 @@
 //! ones.
 
 use crate::action::{EngineRecord, PlayerAction};
-use crate::dsl::{discover_clue, LocationTarget};
+use crate::card_data::CardType;
+use crate::card_registry;
+use crate::dsl::{discover_clue, LocationTarget, Trigger};
 use crate::event::{Event, FailureReason};
 use crate::state::{
-    resolve_token, DefeatCause, Enemy, EnemyId, GameState, InvestigatorId, LocationId, Phase,
-    SkillKind, Status, TokenResolution,
+    resolve_token, CardCode, DefeatCause, Enemy, EnemyId, GameState, InvestigatorId, LocationId,
+    Phase, SkillKind, Status, TokenResolution, Zone,
 };
 
 use super::evaluator::{apply_effect, EvalContext};
@@ -85,6 +87,10 @@ pub fn apply_player_action(
             investigator,
             enemy,
         } => evade(state, events, *investigator, *enemy),
+        PlayerAction::PlayCard {
+            investigator,
+            hand_index,
+        } => play_card(state, events, *investigator, *hand_index),
         PlayerAction::ResolveInput { .. } => EngineOutcome::Rejected {
             reason: "TODO(#63): ResolveInput dispatch lands with the skill-test commit \
                      window; no AwaitingInput sites exist yet."
@@ -1385,5 +1391,174 @@ fn mulligan(
         investigator,
         redrawn_count,
     });
+    EngineOutcome::Done
+}
+
+/// Internal helper: where a played card lands after on-play effects
+/// resolve. Mirrors the Arkham rule that assets stay in play while
+/// events resolve and go to the discard.
+enum PlayDestination {
+    /// Card stays in play (asset).
+    InPlay,
+    /// Card moves to the discard after on-play effects resolve (event).
+    Discard,
+}
+
+/// Resolve the card's destination + abilities via the registry, or
+/// produce the appropriate rejection.
+///
+/// Split out so [`play_card`] stays under the function-size lint —
+/// and because the registry-side validations are conceptually
+/// separate from the state-side prefix.
+fn resolve_play_target(
+    code: &CardCode,
+) -> Result<(PlayDestination, Vec<crate::dsl::Ability>), EngineOutcome> {
+    let Some(registry) = card_registry::current() else {
+        return Err(EngineOutcome::Rejected {
+            reason: "PlayCard: no card registry installed; engine cannot resolve card \
+                     metadata or abilities. Install game_core::card_registry before \
+                     dispatching PlayCard."
+                .into(),
+        });
+    };
+    let Some(metadata) = (registry.metadata_for)(code) else {
+        return Err(EngineOutcome::Rejected {
+            reason: format!("PlayCard: unknown card code {code}").into(),
+        });
+    };
+    let destination = match metadata.card_type {
+        CardType::Asset => PlayDestination::InPlay,
+        CardType::Event => PlayDestination::Discard,
+        other => {
+            return Err(EngineOutcome::Rejected {
+                reason: format!(
+                    "PlayCard: card_type {other:?} is not playable from hand (card {code})",
+                )
+                .into(),
+            });
+        }
+    };
+    let Some(abilities) = (registry.abilities_for)(code) else {
+        return Err(EngineOutcome::Rejected {
+            reason: format!(
+                "PlayCard: card {code} has no effect implementation; the deck-import \
+                 gate (#73-era) should refuse decks containing unimplemented cards.",
+            )
+            .into(),
+        });
+    };
+    Ok((destination, abilities))
+}
+
+/// Handler for [`PlayerAction::PlayCard`].
+///
+/// Validates the standard player-action prefix, looks up the card's
+/// metadata and abilities via the installed [`card_registry`], routes
+/// the card to its destination zone based on its
+/// [`CardType`](crate::card_data::CardType), and runs every
+/// [`Trigger::OnPlay`] ability through the DSL evaluator.
+///
+/// # Ordering
+///
+/// [`Event::CardPlayed`] fires first (the play *causes* any on-play
+/// effects, so it's correct for the play event to precede the
+/// effects' own events in the stream). Then each [`Trigger::OnPlay`]
+/// ability runs through [`apply_effect`]; if any returns non-`Done`,
+/// the handler propagates that outcome. Finally the card moves out
+/// of `hand` — into `cards_in_play` for assets / investigators, or
+/// into `discard` (with an emitted [`Event::CardDiscarded`]) for
+/// events.
+///
+/// # State-mutation contract caveat
+///
+/// For the Phase-3-scoped Core cards the on-play effects in scope
+/// (`DiscoverClue`, `GainResources`) can't reject after the standard
+/// validation prefix passes. If a future on-play effect can reject
+/// mid-resolution, the partial mutation between [`Event::CardPlayed`]
+/// and the destination move violates the engine's "no state change on
+/// rejection" contract. The apply loop's belt-and-suspenders
+/// `events.clear()` still clears the event stream on a rejected
+/// outcome; the state-rollback hardening is out of scope here.
+fn play_card(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+    hand_index: u8,
+) -> EngineOutcome {
+    if state.phase != Phase::Investigation {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "PlayCard is only valid during the Investigation phase (was {:?})",
+                state.phase,
+            )
+            .into(),
+        };
+    }
+    if state.active_investigator != Some(investigator) {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "PlayCard: {investigator:?} is not the active investigator ({:?})",
+                state.active_investigator,
+            )
+            .into(),
+        };
+    }
+    let Some(inv) = state.investigators.get(&investigator) else {
+        return EngineOutcome::Rejected {
+            reason: format!("PlayCard: investigator {investigator:?} is not in state").into(),
+        };
+    };
+    if inv.status != Status::Active {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "PlayCard: {investigator:?} is not Active (status {:?})",
+                inv.status,
+            )
+            .into(),
+        };
+    }
+    let idx = usize::from(hand_index);
+    if idx >= inv.hand.len() {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "PlayCard: hand_index {hand_index} out of bounds (hand size {})",
+                inv.hand.len(),
+            )
+            .into(),
+        };
+    }
+    let code: CardCode = inv.hand[idx].clone();
+    let (destination, abilities) = match resolve_play_target(&code) {
+        Ok(v) => v,
+        Err(reject) => return reject,
+    };
+
+    // Mutate.
+    events.push(Event::CardPlayed {
+        investigator,
+        code: code.clone(),
+    });
+    let ctx = EvalContext::for_controller(investigator);
+    for ability in abilities.iter().filter(|a| a.trigger == Trigger::OnPlay) {
+        let outcome = apply_effect(state, events, &ability.effect, ctx);
+        if !matches!(outcome, EngineOutcome::Done) {
+            return outcome;
+        }
+    }
+    let inv_mut = state.investigators.get_mut(&investigator).expect("checked");
+    let card = inv_mut.hand.remove(idx);
+    match destination {
+        PlayDestination::InPlay => {
+            inv_mut.cards_in_play.push(card);
+        }
+        PlayDestination::Discard => {
+            inv_mut.discard.push(card.clone());
+            events.push(Event::CardDiscarded {
+                investigator,
+                code: card,
+                from: Zone::Hand,
+            });
+        }
+    }
     EngineOutcome::Done
 }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -2861,4 +2861,115 @@ mod tests {
         assert_eq!(inv2_after.deck, original_inv2_deck);
         assert!(inv2_after.mulligan_used);
     }
+
+    // ---- PlayCard rejection tests --------------------------------
+    //
+    // These exercise the validations that fire *before* the registry
+    // lookup. Tests that need real-card metadata / abilities live in
+    // crates/cards/tests/play_card.rs — that crate can install the
+    // real REGISTRY in its own integration-test process without
+    // polluting game-core's OnceLock.
+
+    fn play_card_state(active: bool, hand: Vec<CardCode>) -> (GameState, InvestigatorId) {
+        let id = InvestigatorId(1);
+        let mut inv = test_investigator(1);
+        inv.hand = hand;
+        let mut builder = TestGame::new()
+            .with_phase(Phase::Investigation)
+            .with_investigator(inv);
+        if active {
+            builder = builder.with_active_investigator(id);
+        }
+        (builder.build(), id)
+    }
+
+    #[test]
+    fn play_card_outside_investigation_phase_is_rejected() {
+        let id = InvestigatorId(1);
+        let mut inv = test_investigator(1);
+        inv.hand = vec![CardCode::new("01059")];
+        let state = TestGame::new()
+            .with_phase(Phase::Mythos)
+            .with_investigator(inv)
+            .with_active_investigator(id)
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::PlayCard {
+                investigator: id,
+                hand_index: 0,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+        // Hand untouched.
+        assert_eq!(
+            result.state.investigators[&id].hand,
+            vec![CardCode::new("01059")]
+        );
+    }
+
+    #[test]
+    fn play_card_by_non_active_investigator_is_rejected() {
+        let (state, id) = play_card_state(false, vec![CardCode::new("01059")]);
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::PlayCard {
+                investigator: id,
+                hand_index: 0,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn play_card_by_defeated_investigator_is_rejected() {
+        let id = InvestigatorId(1);
+        let mut inv = test_investigator(1);
+        inv.hand = vec![CardCode::new("01059")];
+        inv.status = Status::Killed;
+        let state = TestGame::new()
+            .with_phase(Phase::Investigation)
+            .with_investigator(inv)
+            .with_active_investigator(id)
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::PlayCard {
+                investigator: id,
+                hand_index: 0,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn play_card_with_out_of_bounds_hand_index_is_rejected() {
+        let (state, id) = play_card_state(true, vec![CardCode::new("01059")]);
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::PlayCard {
+                investigator: id,
+                hand_index: 5,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn play_card_with_empty_hand_is_rejected() {
+        let (state, id) = play_card_state(true, vec![]);
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::PlayCard {
+                investigator: id,
+                hand_index: 0,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
 }

--- a/crates/game-core/src/event.rs
+++ b/crates/game-core/src/event.rs
@@ -14,7 +14,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::state::{
-    ChaosToken, DefeatCause, EnemyId, InvestigatorId, LocationId, Phase, SkillKind, TokenResolution,
+    CardCode, ChaosToken, DefeatCause, EnemyId, InvestigatorId, LocationId, Phase, SkillKind,
+    TokenResolution, Zone,
 };
 
 /// One state-change record emitted by the engine.
@@ -269,6 +270,30 @@ pub enum Event {
     ///
     /// [`InvestigatorDefeated`]: Event::InvestigatorDefeated
     AllInvestigatorsDefeated,
+    /// An investigator played a card from their hand. Fires before
+    /// any `Trigger::OnPlay` effects resolve (the play *causes* the
+    /// effects), and before the card lands in its destination zone.
+    /// State inspection has the post-play hand / `cards_in_play` /
+    /// discard contents.
+    CardPlayed {
+        /// Who played the card.
+        investigator: InvestigatorId,
+        /// The card code that was played.
+        code: CardCode,
+    },
+    /// A card was discarded — moved from `from` to the investigator's
+    /// discard pile. Fires for played events after their on-play
+    /// effects resolve; future card effects ("discard a card from
+    /// your hand", "discard top of deck") emit this with the
+    /// matching `from` zone.
+    CardDiscarded {
+        /// The card's controller.
+        investigator: InvestigatorId,
+        /// The discarded card code.
+        code: CardCode,
+        /// Where the card came from before landing in discard.
+        from: Zone,
+    },
 }
 
 /// Why a skill test failed.

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -38,5 +38,5 @@ pub use rng::RngState;
 pub use state::{
     resolve_token, CardCode, ChaosBag, ChaosToken, DefeatCause, Enemy, EnemyId, GameState,
     Investigator, InvestigatorId, Location, LocationId, Phase, SkillKind, Skills, Status,
-    TokenModifiers, TokenResolution,
+    TokenModifiers, TokenResolution, Zone,
 };

--- a/crates/game-core/src/state/card.rs
+++ b/crates/game-core/src/state/card.rs
@@ -46,3 +46,21 @@ impl std::fmt::Display for CardCode {
         std::fmt::Display::fmt(&self.0, f)
     }
 }
+
+/// A card-bearing zone, used as the `from` field on movement events
+/// (e.g. [`Event::CardDiscarded`](crate::Event::CardDiscarded)).
+///
+/// Phase-3 minimal set. Discard is a destination but never a `from`
+/// in the current event set; encounter / weakness / out-of-game zones
+/// land when they're needed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum Zone {
+    /// A player's hand.
+    Hand,
+    /// A player's deck (top or bottom — events that need the
+    /// distinction can record it separately).
+    Deck,
+    /// Cards currently in play under an investigator's control.
+    InPlay,
+}

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -13,7 +13,7 @@ pub mod investigator;
 pub mod location;
 pub mod phase;
 
-pub use card::CardCode;
+pub use card::{CardCode, Zone};
 pub use chaos_bag::{resolve_token, ChaosBag, ChaosToken, TokenModifiers, TokenResolution};
 pub use enemy::{Enemy, EnemyId};
 pub use game_state::GameState;

--- a/crates/game-core/src/test_support/assertions.rs
+++ b/crates/game-core/src/test_support/assertions.rs
@@ -1,20 +1,17 @@
-//! Order-insensitive event assertion macros.
+//! Event assertion macros.
 //!
-//! Tests assert on what happened, not on the order events fired in.
-//! The macros below take a slice or `Vec<Event>` as the first argument
-//! and a Rust pattern (with optional `if` guard) as the second; on
-//! failure they print the actual event list to make the mismatch
-//! obvious.
+//! The order-insensitive macros ([`assert_event!`], [`assert_no_event!`],
+//! [`assert_event_count!`]) take a slice or `Vec<Event>` as the first
+//! argument and a Rust pattern (with optional `if` guard) as the
+//! second. Most tests assert on what happened, not on the order
+//! events fired in; reach for these first.
 //!
-//! **When event order matters**, fall back to plain `assert_eq!` on the
-//! slice (e.g. `assert_eq!(result.events, vec![Event::A, Event::B])`).
-//! The macros here intentionally do not enforce ordering, because most
-//! tests are about the set of effects rather than their sequence.
-//!
-//! If `assert_eq!` ever becomes unwieldy (e.g. several tests want to
-//! assert "these N events appeared in this order, ignoring others
-//! interleaved between them"), we can add an `assert_event_sequence!`
-//! macro then. Don't add one preemptively.
+//! **When event order matters** between a few specific events with
+//! others interleaved (e.g. "`CardPlayed` precedes `CluePlaced`
+//! precedes `CardDiscarded`, with arbitrary events in between"), use
+//! [`assert_event_sequence!`]. When you need an exact sequence with no
+//! events allowed between or around, fall back to plain `assert_eq!`
+//! on the slice.
 //!
 //! # Examples
 //!
@@ -104,4 +101,136 @@ macro_rules! assert_event_count {
             );
         }
     }};
+}
+
+/// Assert that the listed patterns each match at least one event in
+/// the slice **and** that a matching event for the first pattern
+/// precedes a matching event for the second, the second precedes the
+/// third, and so on.
+///
+/// Other events may appear before, between, or after the matched
+/// ones — this is a *subsequence* check, not a contiguous-sequence
+/// check. Use plain `assert_eq!` on the slice if you need an exact
+/// contiguous order with no events between or around.
+///
+/// On failure, panics with the pattern source plus a debug-printed
+/// list of all events.
+///
+/// # Example
+///
+/// ```ignore
+/// assert_event_sequence!(
+///     result.events,
+///     Event::CardPlayed { .. },
+///     Event::CluePlaced { .. },
+///     Event::CardDiscarded { .. },
+/// );
+/// ```
+#[macro_export]
+macro_rules! assert_event_sequence {
+    ($events:expr, $($pat:pat $(if $guard:expr)?),+ $(,)?) => {{
+        let events = &$events;
+        // The cursor advances past each match; the last iteration's
+        // assignment is naturally unused (there are no more patterns
+        // after it), so allow the dead-store warning that fires on
+        // that last assignment.
+        #[allow(unused_assignments)]
+        {
+            let mut cursor: usize = 0;
+            $(
+                let found = events
+                    .iter()
+                    .enumerate()
+                    .skip(cursor)
+                    .find(|(_, __event)| matches!(__event, $pat $(if $guard)?));
+                match found {
+                    Some((idx, _)) => {
+                        cursor = idx + 1;
+                    }
+                    None => {
+                        panic!(
+                            "assert_event_sequence!: no event matching `{}` found at or after \
+                             position {} in:\n{:#?}",
+                            stringify!($pat $(if $guard)?),
+                            cursor,
+                            events,
+                        );
+                    }
+                }
+            )+
+        }
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::event::Event;
+    use crate::state::{InvestigatorId, LocationId};
+
+    fn investigator_id() -> InvestigatorId {
+        InvestigatorId(1)
+    }
+
+    fn sample_events() -> Vec<Event> {
+        let id = investigator_id();
+        vec![
+            Event::ResourcesGained {
+                investigator: id,
+                amount: 1,
+            },
+            Event::CluePlaced {
+                investigator: id,
+                count: 1,
+            },
+            Event::LocationCluesChanged {
+                location: LocationId(101),
+                new_count: 0,
+            },
+            Event::TurnEnded { investigator: id },
+        ]
+    }
+
+    #[test]
+    fn assert_event_sequence_passes_when_subsequence_in_order() {
+        let events = sample_events();
+        crate::assert_event_sequence!(
+            events,
+            Event::ResourcesGained { .. },
+            Event::CluePlaced { .. },
+            Event::TurnEnded { .. },
+        );
+    }
+
+    #[test]
+    fn assert_event_sequence_passes_with_single_pattern() {
+        let events = sample_events();
+        crate::assert_event_sequence!(events, Event::CluePlaced { .. });
+    }
+
+    #[test]
+    #[should_panic(expected = "no event matching")]
+    fn assert_event_sequence_panics_when_pattern_missing() {
+        let events = sample_events();
+        crate::assert_event_sequence!(events, Event::ScenarioStarted);
+    }
+
+    #[test]
+    #[should_panic(expected = "no event matching")]
+    fn assert_event_sequence_panics_when_order_is_wrong() {
+        let events = sample_events();
+        // TurnEnded fires after CluePlaced in `sample_events`, so this
+        // order is impossible to satisfy as a subsequence.
+        crate::assert_event_sequence!(events, Event::TurnEnded { .. }, Event::CluePlaced { .. },);
+    }
+
+    #[test]
+    fn assert_event_sequence_respects_guards() {
+        let events = sample_events();
+        let id = investigator_id();
+        crate::assert_event_sequence!(
+            events,
+            Event::ResourcesGained { investigator, amount: 1 } if *investigator == id,
+            Event::CluePlaced { investigator, .. } if *investigator == id,
+        );
+    }
 }

--- a/crates/game-core/src/test_support/assertions.rs
+++ b/crates/game-core/src/test_support/assertions.rs
@@ -1,17 +1,18 @@
 //! Event assertion macros.
 //!
-//! The order-insensitive macros ([`assert_event!`], [`assert_no_event!`],
-//! [`assert_event_count!`]) take a slice or `Vec<Event>` as the first
-//! argument and a Rust pattern (with optional `if` guard) as the
-//! second. Most tests assert on what happened, not on the order
-//! events fired in; reach for these first.
+//! The order-insensitive macros — [`assert_event!`](crate::assert_event),
+//! [`assert_no_event!`](crate::assert_no_event), and
+//! [`assert_event_count!`](crate::assert_event_count) — take a slice
+//! or `Vec<Event>` as the first argument and a Rust pattern (with
+//! optional `if` guard) as the second. Most tests assert on what
+//! happened, not on the order events fired in; reach for these first.
 //!
 //! **When event order matters** between a few specific events with
 //! others interleaved (e.g. "`CardPlayed` precedes `CluePlaced`
 //! precedes `CardDiscarded`, with arbitrary events in between"), use
-//! [`assert_event_sequence!`]. When you need an exact sequence with no
-//! events allowed between or around, fall back to plain `assert_eq!`
-//! on the slice.
+//! [`assert_event_sequence!`](crate::assert_event_sequence). When you
+//! need an exact sequence with no events allowed between or around,
+//! fall back to plain `assert_eq!` on the slice.
 //!
 //! # Examples
 //!


### PR DESCRIPTION
Closes #89.

## What it does

Adds `PlayerAction::PlayCard { investigator, hand_index }`. Uses the card registry (`#88`) to look up the card's metadata + abilities, routes by card type, and runs every `Trigger::OnPlay` ability through the existing DSL evaluator.

**Card-type routing:** only Asset and Event are playable from hand. Assets land in `cards_in_play` and stay; events resolve their on-play effects, then move to the discard with a `CardDiscarded` event reporting `from: Zone::Hand`. Every other `CardType` variant rejects with a single generic message — no special-case explanations for skills, investigators, or scenario-bag types until a specific failure mode shows up.

## New surface

- `PlayerAction::PlayCard { investigator, hand_index }`
- `Event::CardPlayed { investigator, code }` — fires before any on-play effects so listeners see the play *cause* its own effects.
- `Event::CardDiscarded { investigator, code, from: Zone }` — fires for events after their on-play effects resolve; reusable for future "discard from deck / hand" effects.
- `state::Zone` enum (`Hand | Deck | InPlay`) as the from-zone discriminator.
- `assert_event_sequence!` macro — subsequence-in-order check. The file's own "don't add preemptively" note had been waiting for a concrete first user; the Working a Hunch ordering test is that user.

## Tests (180 total, +13 from this PR)

- 5 rejection-prefix tests in `game-core` that don't need a registry (state-side validations short-circuit before the lookup).
- 7 integration tests in `crates/cards/tests/play_card.rs` install the real `cards::REGISTRY` and exercise end-to-end behavior:
  - Holy Rosary (01059) → `CardPlayed` + lands in `cards_in_play`.
  - Working a Hunch (01037) → `CardPlayed` + `CluePlaced` + `CardDiscarded` with correct event ordering and from-zone.
  - Working a Hunch on a 0-clue location → resolves cleanly, no `CluePlaced` emitted.
  - Unknown card code → rejected.
  - Unimplemented asset (Magnifying Glass 01030) → rejected.
  - Non-event/asset (Roland Banks 01001 investigator) → rejected.
  - Defeated investigator → rejected (status check beats registry).
- 5 unit tests for `assert_event_sequence!`.

## Known limitation

On-play effects can't currently roll back state if they mid-resolve reject. Phase-2 cards in scope (`DiscoverClue`, `GainResources`) can't trigger this. Broader hardening is out of scope; the apply loop's belt-and-suspenders `events.clear()` still clears the event stream on a rejected outcome.

## Test plan

- [ ] `RUSTFLAGS=-D warnings cargo test --all` — 180 tests pass
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] `cargo fmt --check` — clean
- [ ] `cargo build -p web --target wasm32-unknown-unknown` — green
- [ ] Holy Rosary and Working a Hunch test pass via real `REGISTRY` integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)