### PR TITLE
engine: constant-modifier query during skill-test resolution

### DIFF
--- a/crates/cards/tests/holy_rosary.rs
+++ b/crates/cards/tests/holy_rosary.rs
@@ -1,0 +1,178 @@
+//! End-to-end test that Holy Rosary's +1 willpower applies during a
+//! real skill test once the card is in play.
+//!
+//! This is the Phase-3 demonstration the project has been building
+//! toward: a real card's `Trigger::Constant` ability contributes to
+//! skill-test totals through the registry (#88), via the in-play
+//! state populated by `PlayCard` (#89), summed by the constant-
+//! modifier query (#92). Setup uses `PlayCard` to land the rosary in
+//! `cards_in_play` so the action log mirrors a real session.
+
+use std::sync::Once;
+
+use game_core::engine::{apply, EngineOutcome};
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, ChaosBag, ChaosToken, InvestigatorId, Phase, SkillKind, TokenModifiers,
+};
+use game_core::test_support::{test_investigator, TestGame};
+use game_core::{assert_event, Action, PlayerAction};
+
+const HOLY_ROSARY: &str = "01059";
+
+fn install_real_registry() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// Build a state where the controller has Holy Rosary in hand, is the
+/// active investigator in the Investigation phase, has a non-empty
+/// chaos bag (a single Zero token so the skill-test arithmetic is
+/// trivially `skill + 0 vs. difficulty`), and starts with 3 willpower
+/// + 3 intellect from the fixture defaults.
+fn state_with_rosary_in_hand() -> (game_core::GameState, InvestigatorId) {
+    install_real_registry();
+
+    let id = InvestigatorId(1);
+    let mut inv = test_investigator(1);
+    inv.hand = vec![CardCode::new(HOLY_ROSARY)];
+
+    let state = TestGame::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(inv)
+        .with_active_investigator(id)
+        // Single-token bag → token-modifier is always 0; the skill
+        // test outcome is decided entirely by the base + constant
+        // contribution vs. difficulty.
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default())
+        .build();
+    (state, id)
+}
+
+#[test]
+fn willpower_test_succeeds_at_difficulty_4_after_playing_holy_rosary() {
+    // Test investigator has 3 willpower. Without the rosary, a
+    // difficulty-4 willpower test fails (3 + 0 < 4). With the rosary
+    // in play (+1 willpower constant), it succeeds (4 + 0 >= 4).
+    let (state, id) = state_with_rosary_in_hand();
+
+    // Play Holy Rosary out of hand.
+    let after_play = apply(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        }),
+    );
+    assert_eq!(after_play.outcome, EngineOutcome::Done);
+    assert_eq!(
+        after_play.state.investigators[&id].cards_in_play,
+        vec![CardCode::new(HOLY_ROSARY)],
+    );
+
+    // Difficulty-4 willpower test — +1 from the rosary should carry it.
+    let result = apply(
+        after_play.state,
+        Action::Player(PlayerAction::PerformSkillTest {
+            investigator: id,
+            skill: SkillKind::Willpower,
+            difficulty: 4,
+        }),
+    );
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestSucceeded { investigator, skill: SkillKind::Willpower, margin: 0 }
+            if *investigator == id
+    );
+}
+
+#[test]
+fn willpower_test_fails_at_difficulty_5_even_with_holy_rosary() {
+    // +1 isn't a free pass: 3 + 1 + 0 < 5 still fails.
+    let (state, id) = state_with_rosary_in_hand();
+
+    let after_play = apply(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        }),
+    );
+    assert_eq!(after_play.outcome, EngineOutcome::Done);
+
+    let result = apply(
+        after_play.state,
+        Action::Player(PlayerAction::PerformSkillTest {
+            investigator: id,
+            skill: SkillKind::Willpower,
+            difficulty: 5,
+        }),
+    );
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestFailed { investigator, skill: SkillKind::Willpower, by: 1, .. }
+            if *investigator == id
+    );
+}
+
+#[test]
+fn intellect_test_unaffected_by_holy_rosary_in_play() {
+    // Holy Rosary modifies Stat::Willpower, not Stat::Intellect.
+    // A difficulty-4 intellect test fails (3 + 0 < 4) regardless of
+    // the rosary being in play.
+    let (state, id) = state_with_rosary_in_hand();
+
+    let after_play = apply(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        }),
+    );
+    assert_eq!(after_play.outcome, EngineOutcome::Done);
+
+    let result = apply(
+        after_play.state,
+        Action::Player(PlayerAction::PerformSkillTest {
+            investigator: id,
+            skill: SkillKind::Intellect,
+            difficulty: 4,
+        }),
+    );
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestFailed { investigator, skill: SkillKind::Intellect, by: 1, .. }
+            if *investigator == id
+    );
+}
+
+#[test]
+fn willpower_test_without_rosary_in_play_uses_base_value_only() {
+    // Belt-and-suspenders: with the rosary still in hand (not played),
+    // a difficulty-4 willpower test fails just like the no-card case.
+    // Confirms the modifier query reads cards_in_play, not hand.
+    let (state, id) = state_with_rosary_in_hand();
+    assert!(!state.investigators[&id].hand.is_empty());
+    assert!(state.investigators[&id].cards_in_play.is_empty());
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::PerformSkillTest {
+            investigator: id,
+            skill: SkillKind::Willpower,
+            difficulty: 4,
+        }),
+    );
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestFailed { investigator, skill: SkillKind::Willpower, by: 1, .. }
+            if *investigator == id
+    );
+}

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -18,7 +18,7 @@ use crate::state::{
     Phase, SkillKind, Status, TokenResolution, Zone,
 };
 
-use super::evaluator::{apply_effect, EvalContext};
+use super::evaluator::{apply_effect, constant_skill_modifier, EvalContext};
 use super::outcome::EngineOutcome;
 
 /// Action points granted to an investigator at the start of their
@@ -448,7 +448,16 @@ pub(super) fn resolve_skill_test(
             reason: format!("skill test: difficulty {difficulty} must be >= 0").into(),
         });
     }
-    let skill_value = inv.skills.value(skill);
+    let base_skill = inv.skills.value(skill);
+    // Drop the `inv` borrow before re-borrowing state for the
+    // constant-modifier query (it walks state.investigators[*].cards_in_play).
+    // The modifier contribution is 0 when no card registry is installed —
+    // most engine unit tests don't install one, and a skill test with no
+    // card effects in play is the correct fallback.
+    let modifier = card_registry::current().map_or(0, |reg| {
+        constant_skill_modifier(state, reg, investigator, skill)
+    });
+    let skill_value = base_skill.saturating_add(modifier);
 
     // Mutate-second: advance RNG, derive token, emit events.
     events.push(Event::SkillTestStarted {

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -36,9 +36,10 @@
 //! change and no events pushed. The outer apply loop's belt-and-
 //! suspenders `events.clear()` on rejection backs this up.
 
-use crate::dsl::{Effect, InvestigatorTarget, LocationTarget};
+use crate::card_registry::CardRegistry;
+use crate::dsl::{Effect, InvestigatorTarget, LocationTarget, ModifierScope, Stat, Trigger};
 use crate::event::Event;
-use crate::state::GameState;
+use crate::state::{GameState, InvestigatorId, SkillKind};
 
 use super::outcome::EngineOutcome;
 
@@ -316,6 +317,88 @@ fn resolve_location_target(
             Err("LocationTarget::ChosenByController requires AwaitingInput plumbing (PR-M)")
         }
     }
+}
+
+// ---- constant-modifier query ----------------------------------
+
+/// Sum the constant skill-modifier contributions from every card in
+/// `controller`'s `cards_in_play`.
+///
+/// Walks each in-play card code, looks up its abilities via the
+/// supplied [`CardRegistry`], and sums every
+/// [`Effect::Modify`] under a [`Trigger::Constant`] ability where the
+/// scope is [`ModifierScope::WhileInPlay`] and the stat matches the
+/// queried `skill`. This is the "Holy Rosary contributes +1 willpower
+/// while in play" query the skill-test handler consumes.
+///
+/// # Why only the controller's cards
+///
+/// Constant modifiers on player cards are scoped to their controller
+/// ("you get +1 willpower"). Solo coincides with "every investigator"
+/// but multi-investigator does not — a controller's Holy Rosary must
+/// not give every other investigator +1 willpower. Cards that DO
+/// modify all investigators ("each investigator at your location gets
+/// +1 …") need a new `ModifierScope` variant; out of scope here.
+///
+/// # What this deliberately does NOT cover
+///
+/// - **Per-skill-test-kind scoping** ("while investigating" — #45):
+///   only the bare stat match is checked; richer scope predicates
+///   need a different `ModifierScope` variant.
+/// - **Conditional constants** (`Effect::If` under a `Trigger::Constant`):
+///   not yet wired; this helper ignores them.
+/// - **Commit-time bonuses** (`ModifierScope::ThisSkillTest`): not in
+///   scope for constants; the skill-test commit window (#63) handles
+///   those.
+/// - **Unimplemented cards**: cards in `cards_in_play` whose code
+///   isn't in the registry's `abilities_for` return None; we skip
+///   them silently. In practice the deck-import gate (Phase 9) keeps
+///   unimplemented codes out of play, so silent-skip is the safest
+///   v1 behavior.
+#[must_use]
+pub fn constant_skill_modifier(
+    state: &GameState,
+    registry: &CardRegistry,
+    controller: InvestigatorId,
+    skill: SkillKind,
+) -> i8 {
+    let Some(inv) = state.investigators.get(&controller) else {
+        return 0;
+    };
+    let mut total: i8 = 0;
+    for code in &inv.cards_in_play {
+        let Some(abilities) = (registry.abilities_for)(code) else {
+            continue;
+        };
+        for ability in &abilities {
+            if ability.trigger != Trigger::Constant {
+                continue;
+            }
+            let Effect::Modify { stat, delta, scope } = &ability.effect else {
+                continue;
+            };
+            if *scope != ModifierScope::WhileInPlay {
+                continue;
+            }
+            if stat_matches_skill(*stat, skill) {
+                total = total.saturating_add(*delta);
+            }
+        }
+    }
+    total
+}
+
+/// Whether a DSL [`Stat`] refers to the same axis as a state-side
+/// [`SkillKind`]. Non-skill stats ([`Stat::MaxHealth`] / [`Stat::MaxSanity`])
+/// never match.
+fn stat_matches_skill(stat: Stat, skill: SkillKind) -> bool {
+    matches!(
+        (stat, skill),
+        (Stat::Willpower, SkillKind::Willpower)
+            | (Stat::Intellect, SkillKind::Intellect)
+            | (Stat::Combat, SkillKind::Combat)
+            | (Stat::Agility, SkillKind::Agility)
+    )
 }
 
 #[cfg(test)]
@@ -625,5 +708,174 @@ mod tests {
             }
             _ => panic!("expected Rejected"),
         }
+    }
+
+    // ---- constant-modifier query tests --------------------------
+
+    use super::constant_skill_modifier;
+    use crate::card_registry::CardRegistry;
+    use crate::dsl::{constant, Ability, Trigger};
+    use crate::state::{CardCode, SkillKind};
+
+    /// Mock registry that maps a small hardcoded set of codes to
+    /// abilities. Keeps the constant-modifier query tests isolated
+    /// from the global `OnceLock` and from the cards crate.
+    fn mock_registry(_: &CardCode) -> Option<&'static crate::card_data::CardMetadata> {
+        None
+    }
+
+    fn fake_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
+        match code.as_str() {
+            "willpower-plus-1" => Some(vec![constant(modify(
+                Stat::Willpower,
+                1,
+                ModifierScope::WhileInPlay,
+            ))]),
+            "intellect-plus-2" => Some(vec![constant(modify(
+                Stat::Intellect,
+                2,
+                ModifierScope::WhileInPlay,
+            ))]),
+            "willpower-plus-1-this-test-only" => Some(vec![constant(modify(
+                Stat::Willpower,
+                1,
+                ModifierScope::ThisSkillTest,
+            ))]),
+            "willpower-minus-1" => Some(vec![constant(modify(
+                Stat::Willpower,
+                -1,
+                ModifierScope::WhileInPlay,
+            ))]),
+            "non-constant-willpower" => Some(vec![Ability {
+                trigger: Trigger::OnPlay,
+                effect: modify(Stat::Willpower, 5, ModifierScope::WhileInPlay),
+            }]),
+            "max-health-plus-1" => Some(vec![constant(modify(
+                Stat::MaxHealth,
+                1,
+                ModifierScope::WhileInPlay,
+            ))]),
+            _ => None,
+        }
+    }
+
+    fn fake_registry() -> CardRegistry {
+        CardRegistry {
+            metadata_for: mock_registry,
+            abilities_for: fake_abilities_for,
+        }
+    }
+
+    fn state_with_cards_in_play(codes: &[&str]) -> (crate::state::GameState, InvestigatorId) {
+        let id = InvestigatorId(1);
+        let mut inv = test_investigator(1);
+        inv.cards_in_play = codes.iter().map(|c| CardCode::new(*c)).collect();
+        let state = TestGame::new().with_investigator(inv).build();
+        (state, id)
+    }
+
+    #[test]
+    fn constant_modifier_is_zero_with_empty_cards_in_play() {
+        let (state, id) = state_with_cards_in_play(&[]);
+        let reg = fake_registry();
+        assert_eq!(
+            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower),
+            0
+        );
+    }
+
+    #[test]
+    fn constant_modifier_sums_matching_skill_contributions() {
+        let (state, id) = state_with_cards_in_play(&["willpower-plus-1", "willpower-minus-1"]);
+        let reg = fake_registry();
+        assert_eq!(
+            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower),
+            0
+        );
+
+        let (state, id) =
+            state_with_cards_in_play(&["willpower-plus-1", "willpower-plus-1", "willpower-plus-1"]);
+        assert_eq!(
+            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower),
+            3
+        );
+    }
+
+    #[test]
+    fn constant_modifier_ignores_non_matching_skill() {
+        let (state, id) = state_with_cards_in_play(&["intellect-plus-2"]);
+        let reg = fake_registry();
+        assert_eq!(
+            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower),
+            0
+        );
+        assert_eq!(
+            constant_skill_modifier(&state, &reg, id, SkillKind::Intellect),
+            2
+        );
+    }
+
+    #[test]
+    fn constant_modifier_ignores_non_while_in_play_scope() {
+        // ThisSkillTest scope shouldn't fire from constant in-play
+        // query — that scope belongs to commit-time bonuses.
+        let (state, id) = state_with_cards_in_play(&["willpower-plus-1-this-test-only"]);
+        let reg = fake_registry();
+        assert_eq!(
+            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower),
+            0
+        );
+    }
+
+    #[test]
+    fn constant_modifier_ignores_non_constant_trigger() {
+        // OnPlay-triggered Modify isn't a constant contribution; it
+        // resolved once when the card was played.
+        let (state, id) = state_with_cards_in_play(&["non-constant-willpower"]);
+        let reg = fake_registry();
+        assert_eq!(
+            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower),
+            0
+        );
+    }
+
+    #[test]
+    fn constant_modifier_ignores_non_skill_stats() {
+        // MaxHealth / MaxSanity aren't skills; they should never
+        // contribute to a skill-test total regardless of how the
+        // helper is queried.
+        let (state, id) = state_with_cards_in_play(&["max-health-plus-1"]);
+        let reg = fake_registry();
+        for skill in [
+            SkillKind::Willpower,
+            SkillKind::Intellect,
+            SkillKind::Combat,
+            SkillKind::Agility,
+        ] {
+            assert_eq!(constant_skill_modifier(&state, &reg, id, skill), 0);
+        }
+    }
+
+    #[test]
+    fn constant_modifier_skips_unknown_codes() {
+        // Cards in play whose code the registry doesn't know are
+        // silently skipped — the deck-import gate (Phase 9) keeps
+        // unimplemented codes out of play, so silent-skip is safe.
+        let (state, id) = state_with_cards_in_play(&["willpower-plus-1", "unknown-card"]);
+        let reg = fake_registry();
+        assert_eq!(
+            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower),
+            1
+        );
+    }
+
+    #[test]
+    fn constant_modifier_zero_for_unknown_controller() {
+        let state = TestGame::new().build();
+        let reg = fake_registry();
+        assert_eq!(
+            constant_skill_modifier(&state, &reg, InvestigatorId(99), SkillKind::Willpower),
+            0
+        );
     }
 }

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -11,10 +11,12 @@
 //! variants return [`EngineOutcome::Rejected`] with a TODO message
 //! pointing at the issue or PR that fills them in:
 //!
-//! - [`Effect::Modify`] needs a "cards in play" state on
-//!   [`GameState`] to register passive modifiers against, plus a
-//!   query mechanism that the skill-test resolution flow consumes.
-//!   Both land later in Phase 3.
+//! - [`Effect::Modify`] is **queried**, not applied: the cards-in-play
+//!   state landed with #62 and the constant-modifier query (this
+//!   module's [`constant_skill_modifier`]) reads it during skill-test
+//!   resolution. The `Effect::Modify` arm of [`apply_effect`] still
+//!   rejects — `Modify` isn't directly *applied*; it's a passive
+//!   contribution surfaced by query.
 //! - [`Effect::If`] dispatches but its [`Condition`](crate::dsl::Condition)
 //!   evaluator is skill-test-aware
 //!   ([`SkillTest`](crate::dsl::Condition::SkillTest) reads the
@@ -403,16 +405,17 @@ fn stat_matches_skill(stat: Stat, skill: SkillKind) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use crate::card_registry::CardRegistry;
     use crate::dsl::{
-        discover_clue, gain_resources, modify, seq, Effect, InvestigatorTarget, LocationTarget,
-        ModifierScope, Stat,
+        constant, discover_clue, gain_resources, modify, seq, Ability, Effect, InvestigatorTarget,
+        LocationTarget, ModifierScope, Stat, Trigger,
     };
     use crate::event::Event;
-    use crate::state::{InvestigatorId, LocationId};
+    use crate::state::{CardCode, InvestigatorId, LocationId, SkillKind};
     use crate::test_support::{test_investigator, test_location, TestGame};
     use crate::{assert_event, assert_no_event};
 
-    use super::{apply_effect, EngineOutcome, EvalContext};
+    use super::{apply_effect, constant_skill_modifier, EngineOutcome, EvalContext};
 
     fn ctx(id: u32) -> EvalContext {
         EvalContext::for_controller(InvestigatorId(id))
@@ -711,11 +714,6 @@ mod tests {
     }
 
     // ---- constant-modifier query tests --------------------------
-
-    use super::constant_skill_modifier;
-    use crate::card_registry::CardRegistry;
-    use crate::dsl::{constant, Ability, Trigger};
-    use crate::state::{CardCode, SkillKind};
 
     /// Mock registry that maps a small hardcoded set of codes to
     /// abilities. Keeps the constant-modifier query tests isolated


### PR DESCRIPTION
Closes #92.

## What it does

Closes the `evaluator.rs` `Modify`-query gap: in-play cards' constant skill modifiers now contribute to skill-test totals. **With this PR, Holy Rosary's +1 willpower applies during a real willpower skill test — the Phase 3 demonstration end-state.**

## The helper

```rust
pub fn constant_skill_modifier(
    state: &GameState,
    registry: &CardRegistry,
    controller: InvestigatorId,
    skill: SkillKind,
) -> i8
```

Walks the **controller's** `cards_in_play` (not every investigator's — "You get +1 willpower" scopes to the controller; multi-investigator Holy Rosary must not give every other investigator +1), looks up each card's abilities via the registry, filters `Trigger::Constant` + `Effect::Modify` under `ModifierScope::WhileInPlay` where the `Stat` matches the queried `SkillKind`, and sums `i8` deltas with saturating arithmetic.

Skill-test resolution adds the modifier to the base skill before chaos-token resolution. **If no registry is installed** (game-core's own unit tests don't install one), the modifier defaults to 0 — every pre-existing skill test still computes its untouched total.

## Deliberately out of scope

Each tracked separately:
- Per-skill-test-kind scoping ("while investigating") — #45.
- Conditional constants (`Effect::If` under `Trigger::Constant`) — needs the `Effect::If` evaluator first.
- Commit-time bonuses (`ModifierScope::ThisSkillTest`) — #63.
- "Applies to all investigators" scoping — needs new `ModifierScope` variant when a Core/Dunwich card actually requires it.

## Tests (+12, total 192)

- **8 unit tests** in `evaluator.rs` with a mock registry: empty `cards_in_play`, sum-of-contributions (including negative), non-matching skill, non-`WhileInPlay` scope, non-`Constant` trigger, non-skill stats (`MaxHealth`/`MaxSanity`), unknown card codes, unknown controller.
- **4 integration tests** in `crates/cards/tests/holy_rosary.rs` using the real `REGISTRY`:
  - PlayCard Holy Rosary → difficulty-4 willpower test **succeeds** (3+1 base+0 token = 4 vs 4).
  - PlayCard Holy Rosary → difficulty-5 willpower test **fails by 1** (proves +1 isn't unbounded).
  - PlayCard Holy Rosary → difficulty-4 intellect test **fails** (proves stat-specific).
  - Holy Rosary in **hand** only → difficulty-4 willpower test **fails** (proves the query reads `cards_in_play`, not `hand`).

## Phase 3 status

With #88 (registry), #89 (PlayCard), and this — the engine runs a real skill test against real-card metadata + abilities end-to-end. The original Phase-3 milestone goal ("Full skill test sequence runs through the engine in tests") is met.

## Test plan

- [x] All five CI jobs green locally with strict flags
- [ ] CI green on the PR
- [ ] Independent review

🤖 Generated with [Claude Code](https://claude.com/claude-code)