### PR TITLE
engine: per-instance card state for cards in play

### DIFF
--- a/crates/cards/tests/holy_rosary.rs
+++ b/crates/cards/tests/holy_rosary.rs
@@ -68,10 +68,9 @@ fn willpower_test_succeeds_at_difficulty_4_after_playing_holy_rosary() {
         }),
     );
     assert_eq!(after_play.outcome, EngineOutcome::Done);
-    assert_eq!(
-        after_play.state.investigators[&id].cards_in_play,
-        vec![CardCode::new(HOLY_ROSARY)],
-    );
+    let in_play = &after_play.state.investigators[&id].cards_in_play;
+    assert_eq!(in_play.len(), 1);
+    assert_eq!(in_play[0].code, CardCode::new(HOLY_ROSARY));
 
     // Difficulty-4 willpower test — +1 from the rosary should carry it.
     let result = apply(

--- a/crates/cards/tests/play_card.rs
+++ b/crates/cards/tests/play_card.rs
@@ -94,9 +94,14 @@ fn play_holy_rosary_emits_card_played_and_lands_in_play() {
     let inv = &result.state.investigators[&id];
     assert!(inv.hand.is_empty(), "hand should be empty after play");
     assert_eq!(
-        inv.cards_in_play,
-        vec![CardCode::new(HOLY_ROSARY)],
-        "asset should land in cards_in_play",
+        inv.cards_in_play.len(),
+        1,
+        "asset should land in cards_in_play"
+    );
+    assert_eq!(inv.cards_in_play[0].code, CardCode::new(HOLY_ROSARY));
+    assert!(
+        !inv.cards_in_play[0].exhausted,
+        "asset enters play ready, not exhausted",
     );
     assert!(inv.discard.is_empty(), "asset should not land in discard");
 
@@ -107,6 +112,44 @@ fn play_holy_rosary_emits_card_played_and_lands_in_play() {
             if *investigator == id && code.as_str() == HOLY_ROSARY
     );
     assert_no_event!(result.events, Event::CardDiscarded { .. });
+}
+
+#[test]
+fn asset_enters_play_with_instance_id_from_state_counter() {
+    // The per-state counter assigns a fresh CardInstanceId to each
+    // asset entering play and advances after each assignment.
+    //
+    // TODO: a two-copies-simultaneously variant proves the uniqueness
+    // path more directly, but Holy Rosary takes the single Accessory
+    // slot so playing two at once is rules-invalid. Add that test
+    // when Magnifying Glass (#37) lands — it's a Hand-slot deck-limit-2
+    // asset, so two copies in play simultaneously IS rules-valid
+    // (one Hand slot each, both slots filled).
+    use game_core::state::CardInstanceId;
+
+    let (state, id, _loc) = play_state(vec![HOLY_ROSARY]);
+    assert_eq!(state.next_card_instance_id, 0, "counter starts at 0");
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        }),
+    );
+    assert_eq!(result.outcome, EngineOutcome::Done);
+
+    let in_play = &result.state.investigators[&id].cards_in_play;
+    assert_eq!(in_play.len(), 1);
+    assert_eq!(
+        in_play[0].instance_id,
+        CardInstanceId(0),
+        "first asset gets id 0",
+    );
+    assert_eq!(
+        result.state.next_card_instance_id, 1,
+        "counter advances after assigning",
+    );
 }
 
 #[test]

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -14,8 +14,8 @@ use crate::card_registry;
 use crate::dsl::{discover_clue, LocationTarget, Trigger};
 use crate::event::{Event, FailureReason};
 use crate::state::{
-    resolve_token, CardCode, DefeatCause, Enemy, EnemyId, GameState, InvestigatorId, LocationId,
-    Phase, SkillKind, Status, TokenResolution, Zone,
+    resolve_token, CardCode, CardInPlay, CardInstanceId, DefeatCause, Enemy, EnemyId, GameState,
+    InvestigatorId, LocationId, Phase, SkillKind, Status, TokenResolution, Zone,
 };
 
 use super::evaluator::{apply_effect, constant_skill_modifier, EvalContext};
@@ -1554,13 +1554,24 @@ fn play_card(
             return outcome;
         }
     }
-    let inv_mut = state.investigators.get_mut(&investigator).expect("checked");
-    let card = inv_mut.hand.remove(idx);
     match destination {
         PlayDestination::InPlay => {
-            inv_mut.cards_in_play.push(card);
+            // Mint a fresh instance id from the per-state counter
+            // before re-borrowing the investigator. `state.investigators`
+            // and `state.next_card_instance_id` are separate fields but
+            // `get_mut` borrows state as a whole, so the counter
+            // mutation must precede the inv_mut borrow.
+            let instance_id = CardInstanceId(state.next_card_instance_id);
+            state.next_card_instance_id = state.next_card_instance_id.saturating_add(1);
+            let inv_mut = state.investigators.get_mut(&investigator).expect("checked");
+            let card = inv_mut.hand.remove(idx);
+            inv_mut
+                .cards_in_play
+                .push(CardInPlay::enter_play(card, instance_id));
         }
         PlayDestination::Discard => {
+            let inv_mut = state.investigators.get_mut(&investigator).expect("checked");
+            let card = inv_mut.hand.remove(idx);
             inv_mut.discard.push(card.clone());
             events.push(Event::CardDiscarded {
                 investigator,

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -1556,11 +1556,6 @@ fn play_card(
     }
     match destination {
         PlayDestination::InPlay => {
-            // Mint a fresh instance id from the per-state counter
-            // before re-borrowing the investigator. `state.investigators`
-            // and `state.next_card_instance_id` are separate fields but
-            // `get_mut` borrows state as a whole, so the counter
-            // mutation must precede the inv_mut borrow.
             let instance_id = CardInstanceId(state.next_card_instance_id);
             state.next_card_instance_id = state.next_card_instance_id.saturating_add(1);
             let inv_mut = state.investigators.get_mut(&investigator).expect("checked");

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -368,8 +368,12 @@ pub fn constant_skill_modifier(
         return 0;
     };
     let mut total: i8 = 0;
-    for code in &inv.cards_in_play {
-        let Some(abilities) = (registry.abilities_for)(code) else {
+    for in_play in &inv.cards_in_play {
+        // Constant modifiers apply regardless of the source asset's
+        // ready/exhaust state — most rulebook constants are "while
+        // in play" full-stop, not "while ready." When a card with a
+        // ready-gated constant lands, gate here.
+        let Some(abilities) = (registry.abilities_for)(&in_play.code) else {
             continue;
         };
         for ability in &abilities {
@@ -411,7 +415,9 @@ mod tests {
         LocationTarget, ModifierScope, Stat, Trigger,
     };
     use crate::event::Event;
-    use crate::state::{CardCode, InvestigatorId, LocationId, SkillKind};
+    use crate::state::{
+        CardCode, CardInPlay, CardInstanceId, InvestigatorId, LocationId, SkillKind,
+    };
     use crate::test_support::{test_investigator, test_location, TestGame};
     use crate::{assert_event, assert_no_event};
 
@@ -767,7 +773,17 @@ mod tests {
     fn state_with_cards_in_play(codes: &[&str]) -> (crate::state::GameState, InvestigatorId) {
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
-        inv.cards_in_play = codes.iter().map(|c| CardCode::new(*c)).collect();
+        inv.cards_in_play = codes
+            .iter()
+            .enumerate()
+            .map(|(i, c)| {
+                CardInPlay::enter_play(
+                    CardCode::new(*c),
+                    #[allow(clippy::cast_possible_truncation)]
+                    CardInstanceId(i as u32),
+                )
+            })
+            .collect();
         let state = TestGame::new().with_investigator(inv).build();
         (state, id)
     }

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -36,7 +36,7 @@ pub use engine::{apply, ApplyResult, EngineOutcome, InputRequest, ResumeToken};
 pub use event::{Event, FailureReason};
 pub use rng::RngState;
 pub use state::{
-    resolve_token, CardCode, ChaosBag, ChaosToken, DefeatCause, Enemy, EnemyId, GameState,
-    Investigator, InvestigatorId, Location, LocationId, Phase, SkillKind, Skills, Status,
-    TokenModifiers, TokenResolution, Zone,
+    resolve_token, CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, DefeatCause, Enemy,
+    EnemyId, GameState, Investigator, InvestigatorId, Location, LocationId, Phase, SkillKind,
+    Skills, Status, TokenModifiers, TokenResolution, UseKind, Zone,
 };

--- a/crates/game-core/src/state/card.rs
+++ b/crates/game-core/src/state/card.rs
@@ -1,4 +1,6 @@
-//! Card identifiers used throughout state.
+//! Card identifiers and per-instance in-play state.
+
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
@@ -63,4 +65,99 @@ pub enum Zone {
     Deck,
     /// Cards currently in play under an investigator's control.
     InPlay,
+}
+
+/// Unique identifier for a specific copy of a card in play.
+///
+/// Assigned by the engine when a card enters play (via the per-state
+/// [`next_card_instance_id`](crate::state::GameState::next_card_instance_id)
+/// counter). Lets card effects target a specific copy when an
+/// investigator has multiple of the same card in play (e.g. two
+/// copies of Magnifying Glass — exhausting one shouldn't exhaust the
+/// other).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CardInstanceId(pub u32);
+
+/// A named-uses kind for asset cards that track a finite resource.
+///
+/// Translation of the rulebook's typed-uses taxonomy. Cards declare
+/// what flavor of uses they have ("Uses (3 charges)", "Uses (1 ammo)")
+/// and effects spend them with primitives that take a [`UseKind`].
+///
+/// Phase-3 minimal set; cards using exotic uses (Time on some Dunwich
+/// cards, Resource on a few Mystic effects) add their variant when
+/// they land.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum UseKind {
+    /// Charges — most spell assets (Rite of Seeking, Shrivelling).
+    Charges,
+    /// Ammo — firearms (.38 Special, .45 Automatic).
+    Ammo,
+    /// Secrets — Seeker investigation aids (Encyclopedia, Old Book of
+    /// Lore in some cycles).
+    Secrets,
+    /// Supplies — Survivor tools (First Aid in some cycles, expedition
+    /// caches).
+    Supplies,
+}
+
+/// State for a single copy of a card in play under an investigator's
+/// control.
+///
+/// Replaces the bare [`CardCode`] entries that lived in
+/// [`Investigator::cards_in_play`](crate::state::Investigator::cards_in_play)
+/// through Phase-3. Carries the per-instance fields that activated
+/// abilities, soak effects, and identity-aware queries need:
+///
+/// - `instance_id` so effects can name a specific copy.
+/// - `exhausted` for ready/exhaust dispatch.
+/// - `uses` for typed named-uses tracking (charges, ammo, …).
+/// - `accumulated_damage` / `accumulated_horror` for asset soak
+///   (the soak mechanic itself is #44; this struct just owns the
+///   storage).
+///
+/// Construction goes through [`CardInPlay::enter_play`] so all the
+/// defaults flow from one place.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CardInPlay {
+    /// Which card this instance represents.
+    pub code: CardCode,
+    /// Per-instance identifier; unique within a scenario.
+    pub instance_id: CardInstanceId,
+    /// Whether the card is currently exhausted (turned 90°). Blocks
+    /// activated abilities (which un-ready on activation); does
+    /// **not** block passive constant modifiers — those apply
+    /// regardless of ready/exhaust state per the rules.
+    pub exhausted: bool,
+    /// Named-uses pool: kind → remaining count. Empty if the card has
+    /// no typed uses. A card can in principle carry multiple kinds at
+    /// once (rare); each kind has its own counter.
+    pub uses: BTreeMap<UseKind, u8>,
+    /// Damage accumulated on this asset (for damage-soak / ally
+    /// health). Distinct from the controlling investigator's damage
+    /// — assets soak damage on themselves until they discard.
+    pub accumulated_damage: u8,
+    /// Horror accumulated on this asset (for horror-soak / ally
+    /// sanity). Distinct from the controlling investigator's horror.
+    pub accumulated_horror: u8,
+}
+
+impl CardInPlay {
+    /// Construct a fresh in-play instance: ready, no uses, no
+    /// accumulated damage or horror. Caller threads the `instance_id`
+    /// from the per-state counter.
+    #[must_use]
+    pub fn enter_play(code: CardCode, instance_id: CardInstanceId) -> Self {
+        Self {
+            code,
+            instance_id,
+            exhausted: false,
+            uses: BTreeMap::new(),
+            accumulated_damage: 0,
+            accumulated_horror: 0,
+        }
+    }
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -69,4 +69,11 @@ pub struct GameState {
     /// to redraw a subset of their starting hand; the engine rejects
     /// every non-Mulligan player action until the window closes.
     pub mulligan_window: bool,
+    /// Monotonic counter for assigning [`CardInstanceId`]s when cards
+    /// enter play. Starts at 0 and increments after each assignment;
+    /// guarantees uniqueness within a scenario and deterministic ids
+    /// across replays.
+    ///
+    /// [`CardInstanceId`]: super::card::CardInstanceId
+    pub next_card_instance_id: u32,
 }

--- a/crates/game-core/src/state/investigator.rs
+++ b/crates/game-core/src/state/investigator.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::card::CardCode;
+use super::card::{CardCode, CardInPlay};
 use super::location::LocationId;
 
 /// Stable identifier for an investigator within a scenario.
@@ -70,13 +70,14 @@ pub struct Investigator {
     pub discard: Vec<CardCode>,
     /// Cards currently in play under this investigator's control.
     ///
-    /// **Phase-1 minimal shape:** just card codes. Per-instance
-    /// asset state (exhausted, accumulated horror/damage on the asset,
-    /// remaining uses/charges) is tracked at **#87** and will replace
-    /// this with a richer `CardInPlay` type when the first asset card
-    /// demands it. The DSL evaluator's existing `Trigger::Constant`
-    /// query for in-play modifiers iterates these codes.
-    pub cards_in_play: Vec<CardCode>,
+    /// Each entry is a [`CardInPlay`] carrying the card code plus
+    /// per-instance state (exhaust, named-uses, accumulated horror /
+    /// damage on the asset itself). Instance ids are assigned by the
+    /// engine from
+    /// [`GameState::next_card_instance_id`](crate::state::GameState::next_card_instance_id)
+    /// at enter-play time so duplicate codes are still individually
+    /// addressable.
+    pub cards_in_play: Vec<CardInPlay>,
     /// Whether this investigator has used their one-shot mulligan
     /// during scenario setup. Set true after a successful Mulligan
     /// action; remains true for the rest of the scenario so a second

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -13,7 +13,7 @@ pub mod investigator;
 pub mod location;
 pub mod phase;
 
-pub use card::{CardCode, Zone};
+pub use card::{CardCode, CardInPlay, CardInstanceId, UseKind, Zone};
 pub use chaos_bag::{resolve_token, ChaosBag, ChaosToken, TokenModifiers, TokenResolution};
 pub use enemy::{Enemy, EnemyId};
 pub use game_state::GameState;

--- a/crates/game-core/src/test_support/builder.rs
+++ b/crates/game-core/src/test_support/builder.rs
@@ -175,6 +175,7 @@ impl TestGame {
             turn_order: self.turn_order,
             rng: self.rng,
             mulligan_window: self.mulligan_window,
+            next_card_instance_id: 0,
         }
     }
 }


### PR DESCRIPTION
Closes #87.

## What it does

Replaces `Investigator.cards_in_play: Vec<CardCode>` with `Vec<CardInPlay>`, where `CardInPlay` carries the per-instance state that asset-with-state cards need: identity (`instance_id`), exhaust state, named-uses tracking, and accumulated damage/horror for asset soak.

## New types (in `state/card.rs`)

- `CardInstanceId(u32)` — newtype matching `InvestigatorId`/`LocationId`/`EnemyId` shape. Unique within a scenario.
- `UseKind` enum: `Charges | Ammo | Secrets | Supplies`. `#[non_exhaustive]` for future variants.
- `CardInPlay` struct with `code`/`instance_id`/`exhausted`/`uses`/`accumulated_damage`/`accumulated_horror`. Construct via `CardInPlay::enter_play` so defaults flow through one place.

## State changes

- `Investigator.cards_in_play: Vec<CardCode>` → `Vec<CardInPlay>`.
- `GameState.next_card_instance_id: u32` — monotonic counter, advances on each enter-play assignment. Deterministic across replays.

## Handler updates

- `PlayCard` for assets: mint a fresh `CardInstanceId` from the counter, construct `CardInPlay::enter_play`, push to `cards_in_play`. Counter advances even if a future on-play mid-resolves a reject — ids only need to be unique, not dense.
- `constant_skill_modifier` walks each entry's `.code` field. Doc notes that constant modifiers apply regardless of exhaust state (the rulebook gates activated abilities on ready/exhaust, not passive constants); a future "ready-gated constant" card would filter there.

## Deferred from the original issue scope

Neither has a current consumer; pre-building infrastructure for hypothetical future requirements violates the project pattern.

- **Pipeline metadata for typed uses** (`uses_kind` / `uses_count` on `CardMetadata`, populated from upstream JSON). Lands when the first card with named uses lands (#38 Hyperawareness uses Charges).
- **Filter-out-exhausted-source for constants.** Most rulebook constants apply regardless of ready/exhaust state — no implemented card today requires the gate. Doc-comment in `constant_skill_modifier` flags where it would live.

## Tests (+1, total 193)

- New `asset_enters_play_with_instance_id_from_state_counter` proves the counter assigns ids correctly and advances. TODO in the file points at a "two copies of the same card in play" variant once `#37` Magnifying Glass (Hand-slot, `deck_limit 2`) lands — rules-valid for two-in-play, unlike Holy Rosary's single Accessory slot.
- Other existing tests migrate mechanically from `Vec<CardCode>` comparisons to reading `.code` on the per-instance struct.

## Two-commit history

The first commit on this branch (`baafc07`) only had the dispatch + test tweaks because the bulk of the staged changes were missed by `git add`. The second commit (`e56dc12`) folds in the actual body — new types, state migration, query update. Squashes to a single commit on merge.

## Test plan

- [x] All five CI jobs green locally with strict flags
- [ ] CI green on the PR
- [ ] Independent review

🤖 Generated with [Claude Code](https://claude.com/claude-code)