### PR TITLE
engine: DSL per-skill-test-kind modifier scope

### DIFF
--- a/crates/game-core/src/dsl.rs
+++ b/crates/game-core/src/dsl.rs
@@ -35,9 +35,6 @@
 //! - **Stat-comparison / location-state conditions** (`LocationHasClues`,
 //!   `AnyEnemyEngaged`, `SkillSucceededByAtLeast(N)`). Phase-2 only
 //!   has [`Condition::SkillTest`] with success/failure granularity.
-//! - **Per-test scope-of-effect details** (Magnifying Glass's
-//!   "+1 intellect WHILE INVESTIGATING" rather than constant +1).
-//!   Needs a richer scope predicate than [`ModifierScope::WhileInPlay`].
 //!
 //! Cards needing any of these go to a Rust impl until the DSL grows
 //! the relevant primitive.
@@ -171,20 +168,57 @@ pub enum Stat {
 
 /// How long an [`Effect::Modify`] applies.
 ///
-/// Phase-2 minimal set. Mid-test buffs would need `ThisSkillTest`;
-/// turn-scoped ones use `ThisTurn`. The most common scope by far is
-/// `WhileInPlay` (constant modifiers from assets).
+/// Phase-3 set. Most cards land in `WhileInPlay` (Holy Rosary's
+/// unconditional +1 willpower) or `WhileInPlayDuring(...)` (Magnifying
+/// Glass's "+1 intellect *while investigating*" — the qualifier
+/// that gates most +stat assets in Core+Dunwich). Commit-time and
+/// turn-scoped buffs use `ThisSkillTest` / `ThisTurn`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum ModifierScope {
     /// Active for as long as the source card is in play. Used by
-    /// constant abilities (Holy Rosary, Magnifying Glass).
+    /// unqualified constant abilities (Holy Rosary).
     WhileInPlay,
+    /// Like [`WhileInPlay`](Self::WhileInPlay) but the modifier only
+    /// contributes when the current skill test is of the given kind.
+    /// Magnifying Glass's "+1 intellect while investigating" is
+    /// `WhileInPlayDuring(SkillTestKind::Investigate)`.
+    WhileInPlayDuring(SkillTestKind),
     /// Active until the current skill test resolves. Used by
     /// commit-time bonuses and action abilities like Hyperawareness.
     ThisSkillTest,
     /// Active until the end of the current investigator turn.
     ThisTurn,
+}
+
+/// Which kind of skill test is running.
+///
+/// Cards routinely qualify their bonuses on the test's *kind*, not
+/// just the underlying stat — Magnifying Glass's "+1 intellect while
+/// investigating" applies to Investigate but **not** to a treachery
+/// that tests intellect. Engine-side, every test-initiating action
+/// (Investigate, Fight, Evade, the generic
+/// [`PerformSkillTest`](crate::action::PlayerAction::PerformSkillTest))
+/// passes the matching kind to skill-test resolution.
+///
+/// Add a variant when a new test-initiating action lands (Parley /
+/// Engage will need their own; treacheries that *force* an investigate-
+/// flavored test could reuse `Investigate`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum SkillTestKind {
+    /// The Investigate action's intellect test against a location's
+    /// shroud.
+    Investigate,
+    /// The Fight action's combat test against an enemy.
+    Fight,
+    /// The Evade action's agility test against an enemy.
+    Evade,
+    /// Any other skill test: treachery effects, agenda effects, or
+    /// [`PlayerAction::PerformSkillTest`](crate::action::PlayerAction::PerformSkillTest)
+    /// invoked directly. Cards qualifying their bonus with one of the
+    /// named-action variants will NOT contribute here.
+    Plain,
 }
 
 // ---- targets --------------------------------------------------

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -11,7 +11,7 @@
 use crate::action::{EngineRecord, PlayerAction};
 use crate::card_data::CardType;
 use crate::card_registry;
-use crate::dsl::{discover_clue, LocationTarget, Trigger};
+use crate::dsl::{discover_clue, LocationTarget, SkillTestKind, Trigger};
 use crate::event::{Event, FailureReason};
 use crate::state::{
     resolve_token, CardCode, CardInPlay, CardInstanceId, DefeatCause, Enemy, EnemyId, GameState,
@@ -418,6 +418,7 @@ pub(super) fn resolve_skill_test(
     events: &mut Vec<Event>,
     investigator: InvestigatorId,
     skill: SkillKind,
+    kind: SkillTestKind,
     difficulty: i8,
 ) -> Result<SkillTestResolution, EngineOutcome> {
     // Validate-first: investigator must exist and be Active; chaos
@@ -455,7 +456,7 @@ pub(super) fn resolve_skill_test(
     // most engine unit tests don't install one, and a skill test with no
     // card effects in play is the correct fallback.
     let modifier = card_registry::current().map_or(0, |reg| {
-        constant_skill_modifier(state, reg, investigator, skill)
+        constant_skill_modifier(state, reg, investigator, skill, kind)
     });
     let skill_value = base_skill.saturating_add(modifier);
 
@@ -517,7 +518,14 @@ fn perform_skill_test(
     skill: SkillKind,
     difficulty: i8,
 ) -> EngineOutcome {
-    match resolve_skill_test(state, events, investigator, skill, difficulty) {
+    match resolve_skill_test(
+        state,
+        events,
+        investigator,
+        skill,
+        SkillTestKind::Plain,
+        difficulty,
+    ) {
         Ok(_) => EngineOutcome::Done,
         Err(rejected) => rejected,
     }
@@ -630,6 +638,7 @@ fn investigate(
         events,
         investigator,
         SkillKind::Intellect,
+        SkillTestKind::Investigate,
         difficulty,
     ) {
         Ok(SkillTestResolution::Succeeded { .. }) => {
@@ -921,6 +930,7 @@ fn fight(
         events,
         investigator,
         SkillKind::Combat,
+        SkillTestKind::Fight,
         fight_difficulty,
     ) {
         Ok(SkillTestResolution::Succeeded { .. }) => {
@@ -963,6 +973,7 @@ fn evade(
         events,
         investigator,
         SkillKind::Agility,
+        SkillTestKind::Evade,
         evade_difficulty,
     ) {
         Ok(SkillTestResolution::Succeeded { .. }) => {

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -39,7 +39,9 @@
 //! suspenders `events.clear()` on rejection backs this up.
 
 use crate::card_registry::CardRegistry;
-use crate::dsl::{Effect, InvestigatorTarget, LocationTarget, ModifierScope, Stat, Trigger};
+use crate::dsl::{
+    Effect, InvestigatorTarget, LocationTarget, ModifierScope, SkillTestKind, Stat, Trigger,
+};
 use crate::event::Event;
 use crate::state::{GameState, InvestigatorId, SkillKind};
 
@@ -324,14 +326,23 @@ fn resolve_location_target(
 // ---- constant-modifier query ----------------------------------
 
 /// Sum the constant skill-modifier contributions from every card in
-/// `controller`'s `cards_in_play`.
+/// `controller`'s `cards_in_play` that apply to a skill test of the
+/// given `skill` + `kind`.
 ///
 /// Walks each in-play card code, looks up its abilities via the
-/// supplied [`CardRegistry`], and sums every
-/// [`Effect::Modify`] under a [`Trigger::Constant`] ability where the
-/// scope is [`ModifierScope::WhileInPlay`] and the stat matches the
-/// queried `skill`. This is the "Holy Rosary contributes +1 willpower
-/// while in play" query the skill-test handler consumes.
+/// supplied [`CardRegistry`], and sums every [`Effect::Modify`] under
+/// a [`Trigger::Constant`] ability where the stat matches `skill` and
+/// the scope is either:
+///
+/// - [`ModifierScope::WhileInPlay`] — applies to any skill test (Holy
+///   Rosary's unqualified +1 willpower).
+/// - [`ModifierScope::WhileInPlayDuring(k)`](ModifierScope::WhileInPlayDuring)
+///   where `k == kind` — Magnifying Glass's +1 intellect *while
+///   investigating* contributes during `SkillTestKind::Investigate`
+///   but NOT during `SkillTestKind::Plain`.
+///
+/// Other scopes (`ThisSkillTest`, `ThisTurn`) are not constant
+/// contributions and are skipped here.
 ///
 /// # Why only the controller's cards
 ///
@@ -344,14 +355,15 @@ fn resolve_location_target(
 ///
 /// # What this deliberately does NOT cover
 ///
-/// - **Per-skill-test-kind scoping** ("while investigating" — #45):
-///   only the bare stat match is checked; richer scope predicates
-///   need a different `ModifierScope` variant.
 /// - **Conditional constants** (`Effect::If` under a `Trigger::Constant`):
 ///   not yet wired; this helper ignores them.
 /// - **Commit-time bonuses** (`ModifierScope::ThisSkillTest`): not in
 ///   scope for constants; the skill-test commit window (#63) handles
 ///   those.
+/// - **Ready/exhaust gating** on constant sources: most rulebook
+///   constants apply regardless of the source asset's ready/exhaust
+///   state. When a ready-gated constant card lands, filter on
+///   `in_play.exhausted` here.
 /// - **Unimplemented cards**: cards in `cards_in_play` whose code
 ///   isn't in the registry's `abilities_for` return None; we skip
 ///   them silently. In practice the deck-import gate (Phase 9) keeps
@@ -363,16 +375,13 @@ pub fn constant_skill_modifier(
     registry: &CardRegistry,
     controller: InvestigatorId,
     skill: SkillKind,
+    kind: SkillTestKind,
 ) -> i8 {
     let Some(inv) = state.investigators.get(&controller) else {
         return 0;
     };
     let mut total: i8 = 0;
     for in_play in &inv.cards_in_play {
-        // Constant modifiers apply regardless of the source asset's
-        // ready/exhaust state — most rulebook constants are "while
-        // in play" full-stop, not "while ready." When a card with a
-        // ready-gated constant lands, gate here.
         let Some(abilities) = (registry.abilities_for)(&in_play.code) else {
             continue;
         };
@@ -383,7 +392,7 @@ pub fn constant_skill_modifier(
             let Effect::Modify { stat, delta, scope } = &ability.effect else {
                 continue;
             };
-            if *scope != ModifierScope::WhileInPlay {
+            if !scope_applies(*scope, kind) {
                 continue;
             }
             if stat_matches_skill(*stat, skill) {
@@ -392,6 +401,21 @@ pub fn constant_skill_modifier(
         }
     }
     total
+}
+
+/// Whether a constant-trigger [`ModifierScope`] contributes to a
+/// skill test of the given [`SkillTestKind`].
+///
+/// [`WhileInPlay`](ModifierScope::WhileInPlay) is unqualified — it
+/// applies to every test. [`WhileInPlayDuring`](ModifierScope::WhileInPlayDuring)
+/// only fires when the in-flight test's kind matches the scope's
+/// kind. Non-constant scopes never apply through this query path.
+fn scope_applies(scope: ModifierScope, kind: SkillTestKind) -> bool {
+    match scope {
+        ModifierScope::WhileInPlay => true,
+        ModifierScope::WhileInPlayDuring(k) => k == kind,
+        ModifierScope::ThisSkillTest | ModifierScope::ThisTurn => false,
+    }
 }
 
 /// Whether a DSL [`Stat`] refers to the same axis as a state-side
@@ -412,7 +436,7 @@ mod tests {
     use crate::card_registry::CardRegistry;
     use crate::dsl::{
         constant, discover_clue, gain_resources, modify, seq, Ability, Effect, InvestigatorTarget,
-        LocationTarget, ModifierScope, Stat, Trigger,
+        LocationTarget, ModifierScope, SkillTestKind, Stat, Trigger,
     };
     use crate::event::Event;
     use crate::state::{
@@ -740,6 +764,11 @@ mod tests {
                 2,
                 ModifierScope::WhileInPlay,
             ))]),
+            "intellect-plus-1-while-investigating" => Some(vec![constant(modify(
+                Stat::Intellect,
+                1,
+                ModifierScope::WhileInPlayDuring(SkillTestKind::Investigate),
+            ))]),
             "willpower-plus-1-this-test-only" => Some(vec![constant(modify(
                 Stat::Willpower,
                 1,
@@ -793,7 +822,7 @@ mod tests {
         let (state, id) = state_with_cards_in_play(&[]);
         let reg = fake_registry();
         assert_eq!(
-            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower),
+            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower, SkillTestKind::Plain),
             0
         );
     }
@@ -803,14 +832,14 @@ mod tests {
         let (state, id) = state_with_cards_in_play(&["willpower-plus-1", "willpower-minus-1"]);
         let reg = fake_registry();
         assert_eq!(
-            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower),
+            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower, SkillTestKind::Plain),
             0
         );
 
         let (state, id) =
             state_with_cards_in_play(&["willpower-plus-1", "willpower-plus-1", "willpower-plus-1"]);
         assert_eq!(
-            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower),
+            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower, SkillTestKind::Plain),
             3
         );
     }
@@ -820,11 +849,11 @@ mod tests {
         let (state, id) = state_with_cards_in_play(&["intellect-plus-2"]);
         let reg = fake_registry();
         assert_eq!(
-            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower),
+            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower, SkillTestKind::Plain),
             0
         );
         assert_eq!(
-            constant_skill_modifier(&state, &reg, id, SkillKind::Intellect),
+            constant_skill_modifier(&state, &reg, id, SkillKind::Intellect, SkillTestKind::Plain),
             2
         );
     }
@@ -836,7 +865,7 @@ mod tests {
         let (state, id) = state_with_cards_in_play(&["willpower-plus-1-this-test-only"]);
         let reg = fake_registry();
         assert_eq!(
-            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower),
+            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower, SkillTestKind::Plain),
             0
         );
     }
@@ -848,7 +877,7 @@ mod tests {
         let (state, id) = state_with_cards_in_play(&["non-constant-willpower"]);
         let reg = fake_registry();
         assert_eq!(
-            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower),
+            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower, SkillTestKind::Plain),
             0
         );
     }
@@ -866,7 +895,10 @@ mod tests {
             SkillKind::Combat,
             SkillKind::Agility,
         ] {
-            assert_eq!(constant_skill_modifier(&state, &reg, id, skill), 0);
+            assert_eq!(
+                constant_skill_modifier(&state, &reg, id, skill, SkillTestKind::Plain),
+                0,
+            );
         }
     }
 
@@ -878,7 +910,7 @@ mod tests {
         let (state, id) = state_with_cards_in_play(&["willpower-plus-1", "unknown-card"]);
         let reg = fake_registry();
         assert_eq!(
-            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower),
+            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower, SkillTestKind::Plain),
             1
         );
     }
@@ -888,8 +920,82 @@ mod tests {
         let state = TestGame::new().build();
         let reg = fake_registry();
         assert_eq!(
-            constant_skill_modifier(&state, &reg, InvestigatorId(99), SkillKind::Willpower),
-            0
+            constant_skill_modifier(
+                &state,
+                &reg,
+                InvestigatorId(99),
+                SkillKind::Willpower,
+                SkillTestKind::Plain,
+            ),
+            0,
+        );
+    }
+
+    // ---- WhileInPlayDuring scope tests ---------------------------
+
+    #[test]
+    fn while_in_play_during_contributes_only_to_matching_kind() {
+        // A Magnifying-Glass-shaped card: "+1 intellect while
+        // investigating." Contributes during Investigate; does NOT
+        // contribute during Plain or Fight tests of intellect.
+        let (state, id) = state_with_cards_in_play(&["intellect-plus-1-while-investigating"]);
+        let reg = fake_registry();
+        assert_eq!(
+            constant_skill_modifier(
+                &state,
+                &reg,
+                id,
+                SkillKind::Intellect,
+                SkillTestKind::Investigate,
+            ),
+            1,
+        );
+        assert_eq!(
+            constant_skill_modifier(&state, &reg, id, SkillKind::Intellect, SkillTestKind::Plain,),
+            0,
+        );
+        assert_eq!(
+            constant_skill_modifier(&state, &reg, id, SkillKind::Intellect, SkillTestKind::Fight,),
+            0,
+        );
+    }
+
+    #[test]
+    fn while_in_play_modifier_applies_to_every_kind() {
+        // Holy Rosary–shaped: unqualified `WhileInPlay`. Should
+        // contribute during every test kind.
+        let (state, id) = state_with_cards_in_play(&["willpower-plus-1"]);
+        let reg = fake_registry();
+        for kind in [
+            SkillTestKind::Investigate,
+            SkillTestKind::Fight,
+            SkillTestKind::Evade,
+            SkillTestKind::Plain,
+        ] {
+            assert_eq!(
+                constant_skill_modifier(&state, &reg, id, SkillKind::Willpower, kind),
+                1,
+                "WhileInPlay should apply during {kind:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn while_in_play_during_with_wrong_stat_still_does_not_contribute() {
+        // The intellect-while-investigating card must NOT contribute
+        // to a willpower test even during Investigate. Scope and
+        // stat are independent filters.
+        let (state, id) = state_with_cards_in_play(&["intellect-plus-1-while-investigating"]);
+        let reg = fake_registry();
+        assert_eq!(
+            constant_skill_modifier(
+                &state,
+                &reg,
+                id,
+                SkillKind::Willpower,
+                SkillTestKind::Investigate,
+            ),
+            0,
         );
     }
 }


### PR DESCRIPTION
Closes #45.

## What it does

Adds the scope predicate that gates **most +stat assets in Core+Dunwich** — Magnifying Glass's "+1 intellect *while investigating*" can't be expressed as the existing unqualified `WhileInPlay`, because the bonus must NOT apply to treacheries that test intellect.

## New DSL pieces (`dsl.rs`)

- `SkillTestKind` enum: `Investigate | Fight | Evade | Plain`. The four test-initiating paths each pass their matching kind to skill-test resolution; treacheries and the generic `PerformSkillTest` action use `Plain`. `#[non_exhaustive]` so Parley/Engage can extend it later.
- `ModifierScope::WhileInPlayDuring(SkillTestKind)` — like `WhileInPlay` but the contribution gates on the in-flight test's kind.

## Plumbing

- `resolve_skill_test` takes a `kind: SkillTestKind` parameter and forwards it to the constant-modifier query.
- The four call sites pass the matching kind: Investigate → `Investigate`, Fight → `Fight`, Evade → `Evade`, PerformSkillTest → `Plain`.
- `constant_skill_modifier` gains a `kind` parameter and the filter: `WhileInPlay` always applies, `WhileInPlayDuring(k)` only when `k == kind`. Non-constant scopes still skip.

## Tests (+3, total 196)

Mock card `intellect-plus-1-while-investigating` in the fake-abilities table for direct unit-test coverage:
- `while_in_play_during_contributes_only_to_matching_kind` — contributes during `Investigate` but not `Plain` or `Fight`.
- `while_in_play_modifier_applies_to_every_kind` — Holy-Rosary-shaped `WhileInPlay` works across every kind (backward-compat).
- `while_in_play_during_with_wrong_stat_still_does_not_contribute` — scope and stat filters are independent.

The end-to-end "WhileInPlayDuring + real card" path will be exercised when #37 Magnifying Glass lands (next in the Shape B order).

## Test plan

- [x] All five CI jobs green locally with strict flags (test/clippy/fmt/doc/wasm)
- [ ] CI green on the PR
- [ ] Independent review

🤖 Generated with [Claude Code](https://claude.com/claude-code)