### PR TITLE
card: Magnifying Glass (01030)

### DIFF
--- a/crates/cards/src/impls/magnifying_glass.rs
+++ b/crates/cards/src/impls/magnifying_glass.rs
@@ -1,0 +1,68 @@
+//! Magnifying Glass (Seeker asset, 01030).
+//!
+//! ```text
+//! Hand. Item. Tool.
+//! Fast.
+//! You get +1 [intellect] while investigating.
+//! ```
+//!
+//! # Fast
+//!
+//! The "Fast" keyword means the card costs no action to play. This is
+//! a play-cost concern, not a DSL concern — the play-cost layer (lands
+//! alongside cost primitives in #53) will read a card-level `is_fast`
+//! flag. Until then, [`PlayerAction::PlayCard`](game_core::PlayerAction::PlayCard)
+//! doesn't gate on action cost at all, so Fast is effectively the
+//! ambient default. Document and move on.
+//!
+//! # Why `WhileInPlayDuring`, not `WhileInPlay`
+//!
+//! The bonus is qualified ("while investigating"). A bare
+//! `Modify(Intellect, +1, WhileInPlay)` would add +1 to every
+//! intellect test — including treacheries that test intellect to
+//! resist (Frozen in Fear, Crypt Chill, …) — which is wrong per the
+//! rules. `WhileInPlayDuring(SkillTestKind::Investigate)` (#45) gates
+//! the contribution to the Investigate action's intellect test.
+
+use game_core::dsl::{constant, modify, Ability, ModifierScope, SkillTestKind, Stat};
+
+/// `ArkhamDB` code for the original-Core printing.
+pub const CODE: &str = "01030";
+
+/// Magnifying Glass's +1 intellect while investigating constant ability.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![constant(modify(
+        Stat::Intellect,
+        1,
+        ModifierScope::WhileInPlayDuring(SkillTestKind::Investigate),
+    ))]
+}
+
+#[cfg(test)]
+mod tests {
+    use game_core::dsl::{Effect, ModifierScope, SkillTestKind, Stat, Trigger};
+
+    #[test]
+    fn abilities_are_one_constant_intellect_while_investigating_modifier() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(abilities[0].trigger, Trigger::Constant);
+        assert!(matches!(
+            abilities[0].effect,
+            Effect::Modify {
+                stat: Stat::Intellect,
+                delta: 1,
+                scope: ModifierScope::WhileInPlayDuring(SkillTestKind::Investigate),
+            }
+        ));
+    }
+
+    /// Catches a `pub mod` rename or a fat-fingered match arm in
+    /// `impls::abilities_for` — the registry must dispatch CODE to
+    /// this module's `abilities()`.
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(super::CODE), Some(super::abilities()));
+    }
+}

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -20,14 +20,18 @@
 //! are the disambiguator at the registry level; filenames just stay
 //! greppable.
 //!
-//! # Phase-2 status
+//! # Implemented so far
 //!
-//! Phase 2 lands the framework + two DSL-only cards (Holy Rosary,
-//! Working a Hunch). Magnifying Glass (#37) was originally planned
-//! for this PR but blocks on the per-skill-test-kind scope DSL
-//! extension (#45). Activated-ability cards (Hyperawareness) and
-//! triggered-effect cards (Deduction) get separate Rust-impl
-//! placeholders in PR-J.
+//! - Holy Rosary (01059) — `Trigger::Constant` + unqualified
+//!   `WhileInPlay`.
+//! - Working a Hunch (01037) — `Trigger::OnPlay` + `DiscoverClue`.
+//! - Magnifying Glass (01030) — `Trigger::Constant` +
+//!   `WhileInPlayDuring(SkillTestKind::Investigate)`.
+//!
+//! Remaining Phase-3 cards (Hyperawareness #38, Deduction #39,
+//! Roland Banks #55, Study #56) each block on a DSL primitive the
+//! cards crate doesn't yet emit — activated triggers, commit
+//! windows, `OnEvent` reactions, location-state shape.
 
 use game_core::dsl::Ability;
 

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -32,6 +32,7 @@
 use game_core::dsl::Ability;
 
 pub mod holy_rosary;
+pub mod magnifying_glass;
 pub mod working_a_hunch;
 
 /// Look up a card's hand-implemented abilities by code. Returns
@@ -40,6 +41,7 @@ pub mod working_a_hunch;
 pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
     match code {
         holy_rosary::CODE => Some(holy_rosary::abilities()),
+        magnifying_glass::CODE => Some(magnifying_glass::abilities()),
         working_a_hunch::CODE => Some(working_a_hunch::abilities()),
         _ => None,
     }

--- a/crates/cards/src/lib.rs
+++ b/crates/cards/src/lib.rs
@@ -128,31 +128,30 @@ mod tests {
     }
 
     #[test]
-    fn dsl_pair_is_playable() {
-        // PR-I lands Holy Rosary (01059) and Working a Hunch (01037).
-        // Magnifying Glass needs a per-skill-test scope DSL extension
-        // (its bonus is "while investigating", not flat). Hyperawareness
-        // (01034) and Deduction (01039) need activated/triggered DSL
-        // primitives — both come in PR-J as Rust-impl placeholders.
+    fn implemented_cards_are_playable() {
+        // Phase-2 PR-I: Holy Rosary (01059), Working a Hunch (01037).
+        // Phase-3 #37: Magnifying Glass (01030) once #45 (per-skill-
+        // test scope) landed.
         assert!(is_playable("01037"));
         assert!(is_playable("01059"));
+        assert!(is_playable("01030"));
     }
 
     #[test]
     fn unimplemented_cards_are_not_playable() {
-        // Magnifying Glass (01030), Hyperawareness (01034), Deduction
-        // (01039) all blocked on DSL extensions — not yet playable.
-        assert!(!is_playable("01030"));
+        // Hyperawareness (01034) needs Trigger::Activated + cost
+        // primitives (#53). Deduction (01039) needs the skill-test
+        // commit window (#63) or the after-resolution trigger (#64).
         assert!(!is_playable("01034"));
         assert!(!is_playable("01039"));
-        // Phase-2 doesn't touch most of the corpus.
+        // Phase-3 doesn't touch most of the corpus.
         assert!(!is_playable("01001")); // Roland Banks
         assert!(!is_playable("99999")); // unknown code
     }
 
     #[test]
     fn abilities_for_returns_some_for_implemented() {
-        for code in ["01037", "01059"] {
+        for code in ["01030", "01037", "01059"] {
             let abilities = super::abilities_for(code)
                 .unwrap_or_else(|| panic!("expected abilities for {code}"));
             assert!(

--- a/crates/cards/tests/magnifying_glass.rs
+++ b/crates/cards/tests/magnifying_glass.rs
@@ -28,9 +28,9 @@ fn install_real_registry() {
 /// Build a state with Magnifying Glass in hand, the controller in the
 /// Investigation phase placed at a 4-shroud location with a clue, and
 /// a single-Numeric(0) chaos bag so the token modifier is always 0.
-/// Skill defaults (3 intellect) plus the rosary's bonus (when in
-/// play) cleanly cross / miss difficulty 4 depending on whether the
-/// bonus applies.
+/// Skill defaults (3 intellect) plus the card's bonus (when in play)
+/// cleanly cross / miss difficulty 4 depending on whether the bonus
+/// applies.
 fn state_with_mg_in_hand() -> (game_core::GameState, InvestigatorId, LocationId) {
     install_real_registry();
 
@@ -57,7 +57,7 @@ fn state_with_mg_in_hand() -> (game_core::GameState, InvestigatorId, LocationId)
 
 #[test]
 fn investigate_succeeds_at_shroud_4_after_playing_magnifying_glass() {
-    // 3 intellect + 1 (rosary, sorry, Magnifying Glass) + 0 (token) = 4 vs shroud 4 → succeed by 0.
+    // 3 intellect + 1 (Magnifying Glass) + 0 (token) = 4 vs shroud 4 → succeed by 0.
     let (state, id, _loc) = state_with_mg_in_hand();
 
     let after_play = apply(

--- a/crates/cards/tests/magnifying_glass.rs
+++ b/crates/cards/tests/magnifying_glass.rs
@@ -1,0 +1,138 @@
+//! End-to-end test that Magnifying Glass's +1 intellect applies
+//! during Investigate but not during a bare intellect test.
+//!
+//! The acceptance criterion from #45 (per-skill-test-kind scope) was
+//! "Magnifying Glass's full impl lands and the simulator applies +1
+//! intellect to investigate tests but not to other intellect tests."
+//! This file closes that loop with the real card and real registry.
+
+use std::sync::Once;
+
+use game_core::engine::{apply, EngineOutcome};
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, ChaosBag, ChaosToken, InvestigatorId, LocationId, Phase, SkillKind, TokenModifiers,
+};
+use game_core::test_support::{test_investigator, test_location, TestGame};
+use game_core::{assert_event, Action, PlayerAction};
+
+const MAGNIFYING_GLASS: &str = "01030";
+
+fn install_real_registry() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// Build a state with Magnifying Glass in hand, the controller in the
+/// Investigation phase placed at a 4-shroud location with a clue, and
+/// a single-Numeric(0) chaos bag so the token modifier is always 0.
+/// Skill defaults (3 intellect) plus the rosary's bonus (when in
+/// play) cleanly cross / miss difficulty 4 depending on whether the
+/// bonus applies.
+fn state_with_mg_in_hand() -> (game_core::GameState, InvestigatorId, LocationId) {
+    install_real_registry();
+
+    let id = InvestigatorId(1);
+    let loc_id = LocationId(101);
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(loc_id);
+    inv.hand = vec![CardCode::new(MAGNIFYING_GLASS)];
+
+    let mut location = test_location(101, "Study");
+    location.shroud = 4;
+    location.clues = 1;
+
+    let state = TestGame::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(inv)
+        .with_active_investigator(id)
+        .with_location(location)
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default())
+        .build();
+    (state, id, loc_id)
+}
+
+#[test]
+fn investigate_succeeds_at_shroud_4_after_playing_magnifying_glass() {
+    // 3 intellect + 1 (rosary, sorry, Magnifying Glass) + 0 (token) = 4 vs shroud 4 → succeed by 0.
+    let (state, id, _loc) = state_with_mg_in_hand();
+
+    let after_play = apply(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        }),
+    );
+    assert_eq!(after_play.outcome, EngineOutcome::Done);
+    assert_eq!(
+        after_play.state.investigators[&id].cards_in_play[0].code,
+        CardCode::new(MAGNIFYING_GLASS),
+    );
+
+    let result = apply(
+        after_play.state,
+        Action::Player(PlayerAction::Investigate { investigator: id }),
+    );
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestSucceeded { investigator, skill: SkillKind::Intellect, margin: 0 }
+            if *investigator == id
+    );
+}
+
+#[test]
+fn investigate_fails_at_shroud_4_without_magnifying_glass_in_play() {
+    // Same setup minus the card in play — 3 + 0 < 4 → fail by 1.
+    let (state, id, _loc) = state_with_mg_in_hand();
+    assert!(state.investigators[&id].cards_in_play.is_empty());
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::Investigate { investigator: id }),
+    );
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestFailed { investigator, skill: SkillKind::Intellect, by: 1, .. }
+            if *investigator == id
+    );
+}
+
+#[test]
+fn bare_intellect_test_unaffected_by_magnifying_glass_in_play() {
+    // The bonus is gated to `SkillTestKind::Investigate`. A bare
+    // intellect test (e.g. a treachery testing intellect) goes
+    // through `PerformSkillTest` with `SkillTestKind::Plain` —
+    // the Magnifying Glass contribution must NOT apply. 3 + 0 < 4
+    // → fail by 1, even with the card in play.
+    let (state, id, _loc) = state_with_mg_in_hand();
+
+    let after_play = apply(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        }),
+    );
+    assert_eq!(after_play.outcome, EngineOutcome::Done);
+
+    let result = apply(
+        after_play.state,
+        Action::Player(PlayerAction::PerformSkillTest {
+            investigator: id,
+            skill: SkillKind::Intellect,
+            difficulty: 4,
+        }),
+    );
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestFailed { investigator, skill: SkillKind::Intellect, by: 1, .. }
+            if *investigator == id
+    );
+}

--- a/crates/cards/tests/play_card.rs
+++ b/crates/cards/tests/play_card.rs
@@ -30,9 +30,14 @@ const HOLY_ROSARY: &str = "01059";
 /// at your location."
 const WORKING_A_HUNCH: &str = "01037";
 
-/// Magnifying Glass (01030) — Seeker asset, in the corpus but
-/// unimplemented (no `abilities()` impl). Used as the "unimplemented
-/// but known" rejection case.
+/// Hyperawareness (01034) — Seeker Talent asset, in the corpus but
+/// unimplemented (no `abilities()` impl until #38 lands the activated-
+/// ability DSL). Used as the "unimplemented but known" rejection case.
+const UNIMPLEMENTED_ASSET: &str = "01034";
+
+/// Magnifying Glass (01030) — Seeker Hand-slot, deck-limit 2. Two
+/// copies in play simultaneously is rules-valid (one Hand slot each,
+/// both slots filled); used here for the multi-copy counter test.
 const MAGNIFYING_GLASS: &str = "01030";
 
 /// Roland Banks (01001) — investigator card. Represents the player
@@ -118,13 +123,6 @@ fn play_holy_rosary_emits_card_played_and_lands_in_play() {
 fn asset_enters_play_with_instance_id_from_state_counter() {
     // The per-state counter assigns a fresh CardInstanceId to each
     // asset entering play and advances after each assignment.
-    //
-    // TODO: a two-copies-simultaneously variant proves the uniqueness
-    // path more directly, but Holy Rosary takes the single Accessory
-    // slot so playing two at once is rules-invalid. Add that test
-    // when Magnifying Glass (#37) lands — it's a Hand-slot deck-limit-2
-    // asset, so two copies in play simultaneously IS rules-valid
-    // (one Hand slot each, both slots filled).
     use game_core::state::CardInstanceId;
 
     let (state, id, _loc) = play_state(vec![HOLY_ROSARY]);
@@ -149,6 +147,43 @@ fn asset_enters_play_with_instance_id_from_state_counter() {
     assert_eq!(
         result.state.next_card_instance_id, 1,
         "counter advances after assigning",
+    );
+}
+
+#[test]
+fn two_copies_of_magnifying_glass_get_distinct_instance_ids() {
+    // Magnifying Glass: Hand slot, deck_limit 2 — playing both copies
+    // is rules-valid (two Hand slots per investigator). The counter
+    // must assign distinct ids so per-instance state stays separable.
+    use game_core::state::CardInstanceId;
+
+    let (state, id, _loc) = play_state(vec![MAGNIFYING_GLASS, MAGNIFYING_GLASS]);
+
+    let after_first = apply(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        }),
+    );
+    assert_eq!(after_first.outcome, EngineOutcome::Done);
+
+    let after_second = apply(
+        after_first.state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        }),
+    );
+    assert_eq!(after_second.outcome, EngineOutcome::Done);
+
+    let in_play = &after_second.state.investigators[&id].cards_in_play;
+    assert_eq!(in_play.len(), 2);
+    assert_eq!(in_play[0].instance_id, CardInstanceId(0));
+    assert_eq!(in_play[1].instance_id, CardInstanceId(1));
+    assert_eq!(
+        after_second.state.next_card_instance_id, 2,
+        "counter advances once per play",
     );
 }
 
@@ -296,11 +331,11 @@ fn play_non_event_or_asset_card_is_rejected() {
 
 #[test]
 fn play_unimplemented_card_is_rejected() {
-    // Magnifying Glass is in the corpus (metadata resolves) but has
-    // no ability implementation yet (#37). The deck-import gate
-    // (Phase 9) will refuse decks containing it; PlayCard double-
-    // checks rather than silently no-op.
-    let (state, id, _loc) = play_state(vec![MAGNIFYING_GLASS]);
+    // Hyperawareness is in the corpus (metadata resolves) but has
+    // no ability implementation yet (blocked on #38). The deck-import
+    // gate (Phase 9) will refuse decks containing unimplemented
+    // cards; PlayCard double-checks rather than silently no-op.
+    let (state, id, _loc) = play_state(vec![UNIMPLEMENTED_ASSET]);
     let result = apply(
         state,
         Action::Player(PlayerAction::PlayCard {


### PR DESCRIPTION
Closes #37.

## What it does

First new card impl after the Phase 3 demonstration. Magnifying Glass's single `Trigger::Constant` ability:

```
+1 [intellect] while investigating
```

→ `constant(modify(Intellect, +1, WhileInPlayDuring(SkillTestKind::Investigate)))`

A direct test of the two prereqs (`#87` per-instance state — enables the `cards_in_play` shape; `#45` per-skill-test-kind scope — enables the `WhileInPlayDuring(Investigate)` qualifier) composing end-to-end.

## Tests

End-to-end integration tests in `crates/cards/tests/magnifying_glass.rs` prove the bonus discriminates correctly:
- Investigate at shroud 4 **succeeds** with card in play (3 + 1 + 0 = 4 vs 4).
- Investigate at shroud 4 **fails** without it (3 + 0 = 3, fail by 1).
- Bare `PerformSkillTest` of intellect at difficulty 4 **still fails** even with card in play — proves the bonus is scope-gated to Investigate, not all intellect tests. This is the acceptance criterion from #45 closed end-to-end with a real card.

## Test-ergonomics cleanups

- `cards/src/lib.rs` test `dsl_pair_is_playable` renamed to `implemented_cards_are_playable` and now covers 01030 alongside 01037 / 01059. `unimplemented_cards_are_not_playable` drops 01030.
- `cards/tests/play_card.rs` swaps its "unimplemented but known" rejection canary from Magnifying Glass to Hyperawareness (01034, still blocked on #38).
- `play_card.rs` fulfills the TODO left by #87 by adding the two-copies counter test using Magnifying Glass — Hand-slot deck-limit-2 makes two copies in play rules-valid, unlike Holy Rosary's single Accessory slot.

## Deferred

"Fast" (no-action-to-play) gating is still unmodeled; lands with the cost-primitives DSL in #53. Documented in the card module's doc.

## Test plan

- [x] All five CI jobs green locally with strict flags (test +6 / 202 total, clippy, fmt, doc, wasm)
- [ ] CI green on the PR
- [ ] Independent review

🤖 Generated with [Claude Code](https://claude.com/claude-code)