### PR TITLE
engine: DSL Activated trigger + cost primitives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ Three layers, in this order of importance:
 2. **Engine unit tests** in `crates/game-core/src/engine/mod.rs` and per-module `#[cfg(test)]` blocks. Use the `TestGame` builder (`game-core/src/test_support/`) — fluent `.with_phase(...).with_investigator(...).with_active_investigator(...).build()` shape with `test_investigator(id)` / `test_location(id, name)` / `test_enemy(id, name)` fixtures. **Use the event-assertion macros**: `assert_event!`, `assert_no_event!`, `assert_event_count!`, `assert_event_sequence!` — order-insensitive by default; the `_sequence` variant for subsequence-in-order checks. Use `assert_eq!` on the events slice only when you need exact contiguous order.
 3. **Integration tests in `crates/cards/tests/`**. Each file is a separate cargo binary, gets its own process, so it can `install(cards::REGISTRY)` without colliding with other test runs. This is the right home for any test that needs real card metadata + abilities — `game-core` itself can't reach the corpus by crate-dependency direction. See `crates/cards/tests/play_card.rs` for the pattern.
 
-`game-core` exposes `test_support` behind the `test-support` feature flag; the `cards` Cargo.toml enables it in `[dev-dependencies]`.
+`game-core::test_support` is unconditionally `pub` — integration tests in `tests/*.rs` and downstream crates (e.g. `cards`) use it without any feature flag.
 
 ### Card-data pipeline
 

--- a/crates/cards/Cargo.toml
+++ b/crates/cards/Cargo.toml
@@ -14,7 +14,3 @@ workspace = true
 game-core = { path = "../game-core" }
 serde = { version = "1", features = ["derive"] }
 
-[dev-dependencies]
-# Enable game-core's TestGame builder + fixtures so integration tests
-# in tests/ can build scenario states for real-card play tests.
-game-core = { path = "../game-core", features = ["test-support"] }

--- a/crates/game-core/Cargo.toml
+++ b/crates/game-core/Cargo.toml
@@ -10,12 +10,6 @@ description = "Eldritch rules engine: game state, actions, events, effect system
 [lints]
 workspace = true
 
-[features]
-# Exposes the `test_support` module (TestGame builder, fixtures, event
-# assertion macros) for downstream crates' own tests. Always available
-# inside game-core's own test runs via `cfg(test)`.
-test-support = []
-
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 rand_chacha = { version = "0.10", default-features = false }

--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -16,7 +16,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::state::{EnemyId, InvestigatorId, LocationId, SkillKind};
+use crate::state::{CardInstanceId, EnemyId, InvestigatorId, LocationId, SkillKind};
 
 /// A single entry in the action log.
 ///
@@ -194,6 +194,32 @@ pub enum PlayerAction {
         investigator: InvestigatorId,
         /// Zero-based position in the investigator's hand.
         hand_index: u8,
+    },
+    /// Activate a [`Trigger::Activated`](crate::dsl::Trigger::Activated)
+    /// ability on a specific in-play card instance.
+    ///
+    /// Validation: Investigation phase, investigator is active and
+    /// `Status::Active`, the named card instance is in
+    /// `cards_in_play`, the indexed ability exists and has an
+    /// `Activated` trigger, sufficient action points for the
+    /// trigger's `action_cost`, and every entry in
+    /// [`Ability::costs`](crate::dsl::Ability::costs) is payable
+    /// (resources available, source not yet exhausted, etc.).
+    ///
+    /// On apply: pay every cost (emitting the matching events), emit
+    /// [`AbilityActivated`](crate::Event::AbilityActivated), then
+    /// resolve the ability's effect through the DSL evaluator.
+    ActivateAbility {
+        /// Investigator activating the ability. Must be the active
+        /// investigator during the Investigation phase, with status
+        /// `Active`.
+        investigator: InvestigatorId,
+        /// Which copy of the in-play card is the source.
+        instance_id: CardInstanceId,
+        /// Zero-based index into the card's
+        /// [`abilities`](crate::dsl::Ability) vec. Must point at an
+        /// `Activated`-triggered ability.
+        ability_index: u8,
     },
     /// Respond to an `AwaitingInput` prompt the engine emitted. The
     /// shape of `response` is dictated by the active prompt. (The

--- a/crates/game-core/src/dsl.rs
+++ b/crates/game-core/src/dsl.rs
@@ -58,11 +58,9 @@ use serde::{Deserialize, Serialize};
 
 /// When an [`Ability`] is active.
 ///
-/// Phase-2 minimal set. Later phases add `OnEvent(EventPattern)`,
-/// `AtPhaseStart`/`AtPhaseEnd`, `DuringSkillTest`, `OnLeavePlay`,
-/// `Activated { action_cost: u8, ... }` (covering both `[action]` and
-/// `[fast]` activated abilities), and reaction triggers.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+/// Phase-3 set. Later phases add `OnEvent(EventPattern)`,
+/// `AtPhaseStart`/`AtPhaseEnd`, `OnLeavePlay`, and reaction triggers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Trigger {
     /// Always-on while the card is in play. The ability's `effect`
@@ -81,19 +79,66 @@ pub enum Trigger {
     /// of player cards with commit-time effects (e.g. Deduction's
     /// "if your skill test is successful while investigating, …").
     OnCommit,
+    /// Fires when the controller activates the ability via
+    /// [`PlayerAction::ActivateAbility`](crate::action::PlayerAction::ActivateAbility).
+    ///
+    /// `action_cost` mirrors the printed activation cost: `0` for the
+    /// `[fast]` symbol (no action), `1` for `[action]`, `N` for multi-
+    /// action abilities. Additional costs (resources, exhaust, named-
+    /// uses spending) live on [`Ability::costs`], not here — separating
+    /// the action-economy cost from arbitrary payment costs keeps
+    /// validation and event-emission straightforward.
+    Activated {
+        /// Number of action points required to activate. `0` = Fast.
+        action_cost: u8,
+    },
+}
+
+// ---- costs -----------------------------------------------------
+
+/// A payment required to activate an [`Trigger::Activated`] ability.
+///
+/// All costs on an ability pay together (all-or-nothing) before the
+/// ability's effect resolves. The engine validates every cost is
+/// payable *before* mutating any state, then pays them in order.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum Cost {
+    /// Spend `n` resources from the controller's wallet. Insufficient
+    /// resources reject the activation.
+    Resources(u8),
+    /// Exhaust the source card. Already-exhausted source rejects.
+    /// (Most activated abilities self-exhaust per the rulebook; cards
+    /// with a `[fast] no exhaust` ability simply don't list this cost.)
+    Exhaust,
+    /// Discard a card from the controller's hand. Requires a target
+    /// selection via [`AwaitingInput`](crate::EngineOutcome::AwaitingInput),
+    /// which lands with the `ChoiceResolver` (#19). Until then,
+    /// activations with this cost reject with a TODO.
+    DiscardCardFromHand,
 }
 
 // ---- abilities -------------------------------------------------
 
-/// One ability on a card: a trigger paired with the effect that
-/// resolves when the trigger fires.
+/// One ability on a card: a trigger paired with payment costs and
+/// the effect that resolves once the costs are paid.
 ///
 /// A card may have multiple [`Ability`] entries — e.g. a constant
-/// modifier plus a forced-on-leave-play effect.
+/// modifier plus an activated `[fast]` ability.
+///
+/// `costs` carries any non-action-economy payment (resources, exhaust,
+/// named-uses spent) the ability demands. Constant / on-play / on-
+/// commit abilities use an empty `costs` vec. Activated abilities
+/// list their payment here in addition to the `action_cost` baked
+/// into [`Trigger::Activated`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct Ability {
     pub trigger: Trigger,
+    /// Payment costs (besides action cost). Defaults to empty on
+    /// deserialize so older saved logs still load cleanly.
+    #[serde(default)]
+    pub costs: Vec<Cost>,
     pub effect: Effect,
 }
 
@@ -290,21 +335,26 @@ pub enum TestOutcome {
 // ---- builders --------------------------------------------------
 
 /// Construct a [`Trigger::Constant`]-driven [`Ability`] wrapping the
-/// given effect.
+/// given effect. Costs are empty — constant abilities don't pay
+/// anything to "fire."
 #[must_use]
 pub fn constant(effect: Effect) -> Ability {
     Ability {
         trigger: Trigger::Constant,
+        costs: Vec::new(),
         effect,
     }
 }
 
 /// Construct a [`Trigger::OnPlay`]-driven [`Ability`] wrapping the
-/// given effect.
+/// given effect. Costs are empty — the card's play cost (resources to
+/// play, action point) is a play-time concern handled elsewhere; the
+/// on-play *ability* itself doesn't pay anything additional.
 #[must_use]
 pub fn on_play(effect: Effect) -> Ability {
     Ability {
         trigger: Trigger::OnPlay,
+        costs: Vec::new(),
         effect,
     }
 }
@@ -315,6 +365,25 @@ pub fn on_play(effect: Effect) -> Ability {
 pub fn on_commit(effect: Effect) -> Ability {
     Ability {
         trigger: Trigger::OnCommit,
+        costs: Vec::new(),
+        effect,
+    }
+}
+
+/// Construct a [`Trigger::Activated`] ability with the given action
+/// cost, payment costs, and effect.
+///
+/// `action_cost`: `0` for `[fast]`, `1` for `[action]`, higher for
+/// multi-action abilities.
+///
+/// `costs`: the non-action payment (resources, exhaust, …). An empty
+/// vec is legal — some activated abilities have no payment besides
+/// the action cost itself.
+#[must_use]
+pub fn activated(action_cost: u8, costs: Vec<Cost>, effect: Effect) -> Ability {
+    Ability {
+        trigger: Trigger::Activated { action_cost },
+        costs,
         effect,
     }
 }

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -11,11 +11,11 @@
 use crate::action::{EngineRecord, PlayerAction};
 use crate::card_data::CardType;
 use crate::card_registry;
-use crate::dsl::{discover_clue, LocationTarget, SkillTestKind, Trigger};
+use crate::dsl::{discover_clue, Cost, LocationTarget, SkillTestKind, Trigger};
 use crate::event::{Event, FailureReason};
 use crate::state::{
     resolve_token, CardCode, CardInPlay, CardInstanceId, DefeatCause, Enemy, EnemyId, GameState,
-    InvestigatorId, LocationId, Phase, SkillKind, Status, TokenResolution, Zone,
+    Investigator, InvestigatorId, LocationId, Phase, SkillKind, Status, TokenResolution, Zone,
 };
 
 use super::evaluator::{apply_effect, constant_skill_modifier, EvalContext};
@@ -91,6 +91,11 @@ pub fn apply_player_action(
             investigator,
             hand_index,
         } => play_card(state, events, *investigator, *hand_index),
+        PlayerAction::ActivateAbility {
+            investigator,
+            instance_id,
+            ability_index,
+        } => activate_ability(state, events, *investigator, *instance_id, *ability_index),
         PlayerAction::ResolveInput { .. } => EngineOutcome::Rejected {
             reason: "TODO(#63): ResolveInput dispatch lands with the skill-test commit \
                      window; no AwaitingInput sites exist yet."
@@ -1587,4 +1592,281 @@ fn play_card(
         }
     }
     EngineOutcome::Done
+}
+
+/// Handler for [`PlayerAction::ActivateAbility`].
+///
+/// Validates the standard player-action prefix, the named card
+/// instance, the indexed ability's trigger, and every cost-payability
+/// precondition. On success, pays every cost (emitting cost events
+/// per primitive), emits [`Event::AbilityActivated`], and dispatches
+/// the ability's effect through the DSL evaluator.
+///
+/// # Cost coverage
+///
+/// - [`Cost::Resources`](crate::dsl::Cost::Resources): validates
+///   wallet, deducts on payment, emits [`Event::ResourcesPaid`].
+/// - [`Cost::Exhaust`](crate::dsl::Cost::Exhaust): validates source
+///   not already exhausted, flips `cards_in_play[i].exhausted`,
+///   emits [`Event::CardExhausted`].
+/// - [`Cost::DiscardCardFromHand`](crate::dsl::Cost::DiscardCardFromHand):
+///   rejects with a TODO — target-card selection needs the
+///   `ChoiceResolver` (#19).
+///
+/// # State-mutation contract
+///
+/// Same caveat as `play_card`: costs are paid and `AbilityActivated`
+/// is emitted before `apply_effect` runs, so a mid-resolution
+/// rejection inside the effect leaves the costs paid. The apply
+/// loop's belt-and-suspenders `events.clear()` still wipes the event
+/// stream on rejection. Phase-3 in-scope effects (`GainResources`,
+/// `DiscoverClue`, `Seq` of those, future `Modify`/`ThisSkillTest`
+/// push) can't reject mid-flight once the standard prefix passes.
+///
+/// # Known simplification: Investigation-phase + active-investigator gate
+///
+/// This handler requires the acting investigator to be the active
+/// one during the Investigation phase. That's correct for
+/// `[action]`-cost abilities, but **overly strict for `[fast]` ones**
+/// (`Trigger::Activated { action_cost: 0 }`): in real Arkham, Fast
+/// abilities are legal in any player window — between phases,
+/// during another investigator's turn, between enemy attacks. No
+/// phase outside Investigation exists yet, so this simplification
+/// is a no-op for Phase-3 scope; #103 lifts the gate when phase
+/// content (#69 / #70 / #71) lands.
+fn activate_ability(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+    instance_id: CardInstanceId,
+    ability_index: u8,
+) -> EngineOutcome {
+    if state.phase != Phase::Investigation {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "ActivateAbility is only valid during the Investigation phase (was {:?})",
+                state.phase,
+            )
+            .into(),
+        };
+    }
+    if state.active_investigator != Some(investigator) {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "ActivateAbility: {investigator:?} is not the active investigator ({:?})",
+                state.active_investigator,
+            )
+            .into(),
+        };
+    }
+    let Some(inv) = state.investigators.get(&investigator) else {
+        return EngineOutcome::Rejected {
+            reason: format!("ActivateAbility: investigator {investigator:?} is not in state")
+                .into(),
+        };
+    };
+    if inv.status != Status::Active {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "ActivateAbility: {investigator:?} is not Active (status {:?})",
+                inv.status,
+            )
+            .into(),
+        };
+    }
+    let Some(in_play_pos) = inv
+        .cards_in_play
+        .iter()
+        .position(|c| c.instance_id == instance_id)
+    else {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "ActivateAbility: {investigator:?} has no in-play instance {instance_id:?}",
+            )
+            .into(),
+        };
+    };
+    let source_code = inv.cards_in_play[in_play_pos].code.clone();
+    let source_exhausted = inv.cards_in_play[in_play_pos].exhausted;
+
+    let (action_cost, costs, effect) = match resolve_activated_ability(&source_code, ability_index)
+    {
+        Ok(v) => v,
+        Err(reject) => return reject,
+    };
+
+    // Action-economy check.
+    if inv.actions_remaining < action_cost {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "ActivateAbility: needs {action_cost} action(s); investigator has {}",
+                inv.actions_remaining,
+            )
+            .into(),
+        };
+    }
+
+    // Validate every payment cost is payable. Done as a pure read
+    // before any mutation so an all-or-nothing reject leaves state
+    // untouched.
+    for cost in &costs {
+        if let Err(reason) = check_cost_payable(cost, inv, source_exhausted) {
+            return EngineOutcome::Rejected {
+                reason: reason.into(),
+            };
+        }
+    }
+
+    // Mutate.
+    pay_activation_costs(
+        state,
+        events,
+        investigator,
+        instance_id,
+        in_play_pos,
+        &source_code,
+        action_cost,
+        &costs,
+    );
+    events.push(Event::AbilityActivated {
+        investigator,
+        instance_id,
+        code: source_code,
+        ability_index,
+    });
+
+    let ctx = EvalContext::for_controller(investigator);
+    apply_effect(state, events, &effect, ctx)
+}
+
+/// Pay the action cost and every payment cost of an activated
+/// ability. Mutates state in place and pushes the matching events.
+/// Caller has already validated that every cost is payable.
+#[allow(clippy::too_many_arguments)]
+fn pay_activation_costs(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+    instance_id: CardInstanceId,
+    in_play_pos: usize,
+    source_code: &CardCode,
+    action_cost: u8,
+    costs: &[Cost],
+) {
+    let inv_mut = state
+        .investigators
+        .get_mut(&investigator)
+        .expect("validated above");
+    if action_cost > 0 {
+        inv_mut.actions_remaining = inv_mut.actions_remaining.saturating_sub(action_cost);
+        events.push(Event::ActionsRemainingChanged {
+            investigator,
+            new_count: inv_mut.actions_remaining,
+        });
+    }
+    for cost in costs {
+        match cost {
+            Cost::Resources(n) => {
+                inv_mut.resources = inv_mut.resources.saturating_sub(*n);
+                events.push(Event::ResourcesPaid {
+                    investigator,
+                    amount: *n,
+                });
+            }
+            Cost::Exhaust => {
+                inv_mut.cards_in_play[in_play_pos].exhausted = true;
+                events.push(Event::CardExhausted {
+                    investigator,
+                    instance_id,
+                    code: source_code.clone(),
+                });
+            }
+            Cost::DiscardCardFromHand => {
+                unreachable!("DiscardCardFromHand rejected earlier in check_cost_payable")
+            }
+        }
+    }
+}
+
+/// Resolve the activated ability at `(code, ability_index)` from the
+/// installed [`card_registry`], returning its `(action_cost, costs,
+/// effect)` triple or the rejection reason.
+///
+/// Split out so [`activate_ability`] stays under the function-size
+/// lint, and to mirror [`resolve_play_target`]'s role for
+/// [`play_card`].
+fn resolve_activated_ability(
+    code: &CardCode,
+    ability_index: u8,
+) -> Result<(u8, Vec<Cost>, crate::dsl::Effect), EngineOutcome> {
+    let Some(registry) = card_registry::current() else {
+        return Err(EngineOutcome::Rejected {
+            reason: "ActivateAbility: no card registry installed; engine cannot resolve abilities."
+                .into(),
+        });
+    };
+    let Some(abilities) = (registry.abilities_for)(code) else {
+        return Err(EngineOutcome::Rejected {
+            reason: format!("ActivateAbility: card {code} has no effect implementation").into(),
+        });
+    };
+    let idx = usize::from(ability_index);
+    let Some(ability) = abilities.get(idx) else {
+        return Err(EngineOutcome::Rejected {
+            reason: format!(
+                "ActivateAbility: ability_index {ability_index} out of bounds for {code} \
+                 (has {} abilities)",
+                abilities.len(),
+            )
+            .into(),
+        });
+    };
+    let Trigger::Activated { action_cost } = ability.trigger else {
+        return Err(EngineOutcome::Rejected {
+            reason: format!(
+                "ActivateAbility: ability {ability_index} on {code} is not an Activated \
+                 trigger (got {:?})",
+                ability.trigger,
+            )
+            .into(),
+        });
+    };
+    Ok((action_cost, ability.costs.clone(), ability.effect.clone()))
+}
+
+/// Validate a single [`Cost`] is currently payable against `inv` /
+/// `source_exhausted`. Returns the reject reason on failure. Does
+/// NOT mutate; the caller does the actual deduction after all costs
+/// are checked.
+fn check_cost_payable(
+    cost: &Cost,
+    inv: &Investigator,
+    source_exhausted: bool,
+) -> Result<(), String> {
+    match cost {
+        Cost::Resources(n) => {
+            if inv.resources < *n {
+                return Err(format!(
+                    "ActivateAbility: needs {n} resources; investigator has {}",
+                    inv.resources,
+                ));
+            }
+            Ok(())
+        }
+        Cost::Exhaust => {
+            if source_exhausted {
+                return Err(
+                    "ActivateAbility: source card is already exhausted; Exhaust cost \
+                     cannot be paid"
+                        .to_string(),
+                );
+            }
+            Ok(())
+        }
+        Cost::DiscardCardFromHand => Err(
+            "TODO(#19): Cost::DiscardCardFromHand requires AwaitingInput plumbing + \
+             ResolveInput; lands with the ChoiceResolver."
+                .to_string(),
+        ),
+    }
 }

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -781,6 +781,7 @@ mod tests {
             ))]),
             "non-constant-willpower" => Some(vec![Ability {
                 trigger: Trigger::OnPlay,
+                costs: Vec::new(),
                 effect: modify(Stat::Willpower, 5, ModifierScope::WhileInPlay),
             }]),
             "max-health-plus-1" => Some(vec![constant(modify(

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -2972,4 +2972,113 @@ mod tests {
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
         assert!(result.events.is_empty());
     }
+
+    // ---- ActivateAbility rejection tests --------------------------
+    //
+    // State-side rejection prefix only. The full activation flow
+    // (registry → ability dispatch → cost payment → effect) needs
+    // a registry, which lives in crates/game-core/tests/activate_ability.rs
+    // as a separate integration-test binary.
+
+    use crate::state::CardInstanceId;
+
+    fn activate_ability_state(active: bool) -> (GameState, InvestigatorId, CardInstanceId) {
+        let id = InvestigatorId(1);
+        let instance_id = CardInstanceId(7);
+        let mut inv = test_investigator(1);
+        inv.cards_in_play.push(crate::state::CardInPlay::enter_play(
+            CardCode::new("01059"),
+            instance_id,
+        ));
+        let mut builder = TestGame::new()
+            .with_phase(Phase::Investigation)
+            .with_investigator(inv);
+        if active {
+            builder = builder.with_active_investigator(id);
+        }
+        (builder.build(), id, instance_id)
+    }
+
+    #[test]
+    fn activate_ability_outside_investigation_phase_is_rejected() {
+        let id = InvestigatorId(1);
+        let instance_id = CardInstanceId(0);
+        let mut inv = test_investigator(1);
+        inv.cards_in_play.push(crate::state::CardInPlay::enter_play(
+            CardCode::new("01059"),
+            instance_id,
+        ));
+        let state = TestGame::new()
+            .with_phase(Phase::Mythos)
+            .with_investigator(inv)
+            .with_active_investigator(id)
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::ActivateAbility {
+                investigator: id,
+                instance_id,
+                ability_index: 0,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn activate_ability_by_non_active_investigator_is_rejected() {
+        let (state, id, instance_id) = activate_ability_state(false);
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::ActivateAbility {
+                investigator: id,
+                instance_id,
+                ability_index: 0,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn activate_ability_with_unknown_instance_id_is_rejected() {
+        let (state, id, _real_instance) = activate_ability_state(true);
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::ActivateAbility {
+                investigator: id,
+                instance_id: CardInstanceId(9999),
+                ability_index: 0,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
+
+    #[test]
+    fn activate_ability_when_defeated_is_rejected() {
+        let id = InvestigatorId(1);
+        let instance_id = CardInstanceId(0);
+        let mut inv = test_investigator(1);
+        inv.status = Status::Killed;
+        inv.cards_in_play.push(crate::state::CardInPlay::enter_play(
+            CardCode::new("01059"),
+            instance_id,
+        ));
+        let state = TestGame::new()
+            .with_phase(Phase::Investigation)
+            .with_investigator(inv)
+            .with_active_investigator(id)
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::ActivateAbility {
+                investigator: id,
+                instance_id,
+                ability_index: 0,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert!(result.events.is_empty());
+    }
 }

--- a/crates/game-core/src/event.rs
+++ b/crates/game-core/src/event.rs
@@ -14,8 +14,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::state::{
-    CardCode, ChaosToken, DefeatCause, EnemyId, InvestigatorId, LocationId, Phase, SkillKind,
-    TokenResolution, Zone,
+    CardCode, CardInstanceId, ChaosToken, DefeatCause, EnemyId, InvestigatorId, LocationId, Phase,
+    SkillKind, TokenResolution, Zone,
 };
 
 /// One state-change record emitted by the engine.
@@ -293,6 +293,33 @@ pub enum Event {
         code: CardCode,
         /// Where the card came from before landing in discard.
         from: Zone,
+    },
+    /// An in-play card was exhausted (turned 90°). Fires as part of
+    /// activation cost payment when a card's
+    /// [`Cost::Exhaust`](crate::dsl::Cost::Exhaust) resolves, and
+    /// from future ready/exhaust effects.
+    CardExhausted {
+        /// The card's controller.
+        investigator: InvestigatorId,
+        /// The exhausted in-play instance.
+        instance_id: CardInstanceId,
+        /// The card code (for log readability; redundant with state).
+        code: CardCode,
+    },
+    /// An activated ability resolved its costs and is about to apply
+    /// its effect. Fires after every cost-payment event and before
+    /// the ability's own effect events. Downstream reactions that
+    /// key on "after an ability is activated" use this as their
+    /// trigger point.
+    AbilityActivated {
+        /// Who activated the ability.
+        investigator: InvestigatorId,
+        /// The in-play source's instance.
+        instance_id: CardInstanceId,
+        /// The source card's code.
+        code: CardCode,
+        /// Which ability on the card fired.
+        ability_index: u8,
     },
 }
 

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -26,7 +26,6 @@ pub mod event;
 pub mod rng;
 pub mod state;
 
-#[cfg(any(test, feature = "test-support"))]
 pub mod test_support;
 
 pub use action::{Action, EngineRecord, InputResponse, PlayerAction};

--- a/crates/game-core/src/test_support/mod.rs
+++ b/crates/game-core/src/test_support/mod.rs
@@ -1,11 +1,9 @@
 //! Test-only support: fluent state builder, fixtures, event-assertion
 //! macros.
 //!
-//! Available always inside `game-core`'s own tests (via `cfg(test)`)
-//! and to downstream crates that enable the `test-support` feature.
 //! The macros are exported at the crate root via `#[macro_export]`,
-//! so callers see [`assert_event!`](crate::assert_event) regardless of
-//! where they import the supporting types from.
+//! so callers see [`assert_event!`](crate::assert_event) regardless
+//! of where they import the supporting types from.
 
 pub mod assertions;
 pub mod builder;

--- a/crates/game-core/tests/activate_ability.rs
+++ b/crates/game-core/tests/activate_ability.rs
@@ -1,0 +1,326 @@
+//! End-to-end `PlayerAction::ActivateAbility` flow with a mock
+//! `CardRegistry` covering one made-up activated ability.
+//!
+//! Lives at `crates/game-core/tests/` (a separate integration-test
+//! binary, hence its own process and its own `OnceLock<CardRegistry>`)
+//! so installing a mock registry here doesn't collide with game-core's
+//! in-crate tests (which deliberately don't install one).
+//!
+//! No real card has a `Trigger::Activated` ability yet — `#38`
+//! Hyperawareness will be the first. Until then, mock cards are the
+//! only way to exercise the full activation flow.
+
+use std::sync::OnceLock;
+
+use game_core::card_data::CardMetadata;
+use game_core::card_registry::CardRegistry;
+use game_core::dsl::{
+    activated, constant, gain_resources, modify, Ability, Cost, InvestigatorTarget, ModifierScope,
+    Stat,
+};
+use game_core::engine::{apply, EngineOutcome};
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, InvestigatorId, Phase, Status,
+    TokenModifiers,
+};
+use game_core::test_support::{test_investigator, TestGame};
+use game_core::{assert_event, assert_event_count, assert_no_event};
+use game_core::{Action, PlayerAction};
+
+/// Mock card code: `[fast] Spend 1 resource: gain 1 resource.` —
+/// economically meaningless (pay 1 to gain 1) but exercises the
+/// Resources cost + `[fast]` (0 action cost) + `GainResources` effect.
+const FAST_RESOURCE_LOOP: &str = "MOCK1";
+
+/// Mock card code: `[action] Exhaust: gain 1 resource.` — exercises
+/// the `[action]` cost (1 action), Exhaust cost, and the source-
+/// exhaust check that blocks re-activation.
+const ACTION_EXHAUST_GAIN: &str = "MOCK2";
+
+/// Mock card code: holds only a `Trigger::Constant` modifier, no
+/// activated abilities. Used to test "`ability_index` points at non-
+/// Activated trigger" rejection.
+const CONSTANT_ONLY: &str = "MOCK3";
+
+/// Mock card code: activated ability whose ONLY cost is the
+/// `DiscardCardFromHand` stub. Used to test the TODO-reject path.
+const DISCARD_COST_ABILITY: &str = "MOCK4";
+
+fn mock_metadata_for(_: &CardCode) -> Option<&'static CardMetadata> {
+    None
+}
+
+fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
+    match code.as_str() {
+        FAST_RESOURCE_LOOP => Some(vec![activated(
+            0,
+            vec![Cost::Resources(1)],
+            gain_resources(InvestigatorTarget::Controller, 1),
+        )]),
+        ACTION_EXHAUST_GAIN => Some(vec![activated(
+            1,
+            vec![Cost::Exhaust],
+            gain_resources(InvestigatorTarget::Controller, 1),
+        )]),
+        CONSTANT_ONLY => Some(vec![constant(modify(
+            Stat::Willpower,
+            1,
+            ModifierScope::WhileInPlay,
+        ))]),
+        DISCARD_COST_ABILITY => Some(vec![activated(
+            0,
+            vec![Cost::DiscardCardFromHand],
+            gain_resources(InvestigatorTarget::Controller, 1),
+        )]),
+        _ => None,
+    }
+}
+
+fn install_mock_registry() {
+    static INSTALL: OnceLock<()> = OnceLock::new();
+    INSTALL.get_or_init(|| {
+        let _ = game_core::card_registry::install(CardRegistry {
+            metadata_for: mock_metadata_for,
+            abilities_for: mock_abilities_for,
+        });
+    });
+}
+
+/// Build a state with one in-play instance of `code` (instance id 0),
+/// in the Investigation phase, the controller active and Active,
+/// 3 actions remaining, 5 starting resources (per the test fixture).
+fn state_with_in_play(code: &str) -> (game_core::GameState, InvestigatorId, CardInstanceId) {
+    install_mock_registry();
+
+    let id = InvestigatorId(1);
+    let instance_id = CardInstanceId(0);
+    let mut inv = test_investigator(1);
+    inv.cards_in_play
+        .push(CardInPlay::enter_play(CardCode::new(code), instance_id));
+
+    let state = TestGame::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(inv)
+        .with_active_investigator(id)
+        // Chaos bag content doesn't matter here — no skill test fires.
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default())
+        .build();
+    (state, id, instance_id)
+}
+
+#[test]
+fn fast_resource_loop_activates_and_resolves_effect() {
+    // Pay 1 resource, gain 1 resource: net zero, but proves the full
+    // cost-then-effect ordering and that a `[fast]` ability costs no
+    // action.
+    let (state, id, instance_id) = state_with_in_play(FAST_RESOURCE_LOOP);
+    let actions_before = state.investigators[&id].actions_remaining;
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id,
+            ability_index: 0,
+        }),
+    );
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    let inv = &result.state.investigators[&id];
+    assert_eq!(
+        inv.actions_remaining, actions_before,
+        "fast (action_cost = 0) doesn't spend an action",
+    );
+    // Net: 5 - 1 (paid) + 1 (gained) = 5.
+    assert_eq!(inv.resources, 5);
+
+    // Cost-then-effect ordering: ResourcesPaid → AbilityActivated →
+    // ResourcesGained.
+    assert_event_count!(
+        result.events,
+        1,
+        Event::ResourcesPaid { investigator, amount: 1 } if *investigator == id
+    );
+    assert_event_count!(
+        result.events,
+        1,
+        Event::AbilityActivated {
+            investigator,
+            ability_index: 0,
+            code,
+            ..
+        } if *investigator == id && code.as_str() == FAST_RESOURCE_LOOP
+    );
+    assert_event_count!(
+        result.events,
+        1,
+        Event::ResourcesGained { investigator, amount: 1 } if *investigator == id
+    );
+}
+
+#[test]
+fn action_exhaust_gain_exhausts_source_and_blocks_reactivation() {
+    let (state, id, instance_id) = state_with_in_play(ACTION_EXHAUST_GAIN);
+    let actions_before = state.investigators[&id].actions_remaining;
+
+    let after_first = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id,
+            ability_index: 0,
+        }),
+    );
+    assert_eq!(after_first.outcome, EngineOutcome::Done);
+    let inv = &after_first.state.investigators[&id];
+    assert_eq!(inv.actions_remaining, actions_before - 1);
+    assert_eq!(inv.resources, 5 + 1);
+    assert!(
+        inv.cards_in_play[0].exhausted,
+        "source must exhaust after activation",
+    );
+    assert_event!(
+        after_first.events,
+        Event::CardExhausted { investigator, instance_id: iid, .. }
+            if *investigator == id && *iid == instance_id
+    );
+
+    // Second activation: source is exhausted; Cost::Exhaust check
+    // rejects without mutating state.
+    let after_second = apply(
+        after_first.state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id,
+            ability_index: 0,
+        }),
+    );
+    assert!(matches!(
+        after_second.outcome,
+        EngineOutcome::Rejected { .. }
+    ));
+    assert!(after_second.events.is_empty());
+}
+
+#[test]
+fn insufficient_resources_reject_without_payment() {
+    let (mut state, id, instance_id) = state_with_in_play(FAST_RESOURCE_LOOP);
+    state.investigators.get_mut(&id).unwrap().resources = 0;
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id,
+            ability_index: 0,
+        }),
+    );
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert!(result.events.is_empty());
+    // Wallet untouched.
+    assert_eq!(result.state.investigators[&id].resources, 0);
+}
+
+#[test]
+fn insufficient_actions_reject_action_cost_ability() {
+    let (mut state, id, instance_id) = state_with_in_play(ACTION_EXHAUST_GAIN);
+    state.investigators.get_mut(&id).unwrap().actions_remaining = 0;
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id,
+            ability_index: 0,
+        }),
+    );
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert!(result.events.is_empty());
+    // Source still ready (not exhausted), resources untouched.
+    let inv = &result.state.investigators[&id];
+    assert!(!inv.cards_in_play[0].exhausted);
+    assert_eq!(inv.resources, 5);
+}
+
+#[test]
+fn ability_index_pointing_at_non_activated_trigger_rejects() {
+    let (state, id, instance_id) = state_with_in_play(CONSTANT_ONLY);
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id,
+            ability_index: 0,
+        }),
+    );
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert!(result.events.is_empty());
+}
+
+#[test]
+fn ability_index_out_of_bounds_rejects() {
+    let (state, id, instance_id) = state_with_in_play(FAST_RESOURCE_LOOP);
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id,
+            ability_index: 9,
+        }),
+    );
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert!(result.events.is_empty());
+}
+
+#[test]
+fn discard_card_from_hand_cost_rejects_with_todo() {
+    let (state, id, instance_id) = state_with_in_play(DISCARD_COST_ABILITY);
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id,
+            ability_index: 0,
+        }),
+    );
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    // No partial mutation: source still ready, no events fired.
+    assert!(result.events.is_empty());
+    assert!(!result.state.investigators[&id].cards_in_play[0].exhausted);
+}
+
+#[test]
+fn activating_with_defeated_status_doesnt_need_registry() {
+    // Belt-and-suspenders: even with registry installed, the status
+    // check rejects before the registry lookup runs.
+    install_mock_registry();
+    let id = InvestigatorId(1);
+    let instance_id = CardInstanceId(0);
+    let mut inv = test_investigator(1);
+    inv.status = Status::Killed;
+    inv.cards_in_play.push(CardInPlay::enter_play(
+        CardCode::new(FAST_RESOURCE_LOOP),
+        instance_id,
+    ));
+
+    let state = TestGame::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(inv)
+        .with_active_investigator(id)
+        .build();
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id,
+            ability_index: 0,
+        }),
+    );
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert_no_event!(result.events, Event::AbilityActivated { .. });
+}


### PR DESCRIPTION
Closes #53.

## What it does

Adds the activation machinery that unblocks cards with \`[action]\` / \`[fast]\` abilities. The DSL gains \`Trigger::Activated\`, a \`Cost\` enum, and an \`Ability.costs\` field; the engine gains \`PlayerAction::ActivateAbility\` plus the dispatch handler that pays costs and runs the ability's effect.

## DSL changes

- \`Trigger::Activated { action_cost: u8 }\` — 0 = \`[fast]\`, 1 = \`[action]\`, N = multi-action.
- New \`Cost\` enum: \`Resources(u8) | Exhaust | DiscardCardFromHand\`. \`#[non_exhaustive]\`. \`DiscardCardFromHand\` rejects with TODO (needs ChoiceResolver #19).
- \`Ability\` gains \`costs: Vec<Cost>\` with \`#[serde(default)]\`.
- New \`activated(action_cost, costs, effect)\` builder; existing builders default \`costs\` to empty.

## New surface

- \`PlayerAction::ActivateAbility { investigator, instance_id, ability_index }\`
- \`Event::AbilityActivated { investigator, instance_id, code, ability_index }\` — after every cost is paid, before effect resolves.
- \`Event::CardExhausted { investigator, instance_id, code }\` — fires from \`Cost::Exhaust\` payment.

## Handler design

\`activate_ability\` follows validate-first / mutate-second. Split into three helpers to keep under the function-size lint, mirroring \`play_card\`'s \`resolve_play_target\` factoring:
- \`resolve_activated_ability\` — registry lookup → ability triple
- \`check_cost_payable\` — per-cost validation, no mutation
- \`pay_activation_costs\` — mutate + emit

Same state-rollback caveat as \`play_card\`.

The handler documents one known simplification: the Investigation-phase + active-investigator gate is correct for \`[action]\`-cost abilities but **overly strict for \`[fast]\` ones** (real Arkham lets Fast abilities fire in any player window). Tracked in #103 as Phase 4 work — no phase outside Investigation exists yet, so it's a no-op for Phase-3 scope.

## Two follow-ups split out from the issue's original acceptance

- **#102** — ThisSkillTest modifier accumulator (so activated abilities that buff the current skill test actually fire). Lands before Hyperawareness (#38) so #38 stays a pure card impl.
- **#103** — player windows + Fast-ability gating across windows. Lands with Phase 4 phase content.

Keeps each PR focused, mirrors the \`#45\` + \`#37\` and \`#88\` + \`#89\` patterns.

## Tests (+12, total 214)

- 4 state-side rejection tests in \`engine/mod.rs\` (no registry needed).
- 8 integration tests in new \`crates/game-core/tests/activate_ability.rs\` installing a mock \`CardRegistry\` with four fake cards: full fast-loop flow, action+exhaust + reactivation block, insufficient resources, insufficient actions, non-Activated trigger at index, ability_index OOB, DiscardCardFromHand TODO-reject, defeated short-circuit.

## Test plan

- [x] All five CI jobs green locally with strict flags
- [ ] CI green on the PR
- [ ] Independent review

🤖 Generated with [Claude Code](https://claude.com/claude-code)