### PR TITLE
engine: ThisSkillTest modifier accumulator

### DIFF
--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -18,7 +18,9 @@ use crate::state::{
     Investigator, InvestigatorId, LocationId, Phase, SkillKind, Status, TokenResolution, Zone,
 };
 
-use super::evaluator::{apply_effect, constant_skill_modifier, EvalContext};
+use super::evaluator::{
+    apply_effect, constant_skill_modifier, pending_skill_modifier, EvalContext,
+};
 use super::outcome::EngineOutcome;
 
 /// Action points granted to an investigator at the start of their
@@ -456,14 +458,19 @@ pub(super) fn resolve_skill_test(
     }
     let base_skill = inv.skills.value(skill);
     // Drop the `inv` borrow before re-borrowing state for the
-    // constant-modifier query (it walks state.investigators[*].cards_in_play).
-    // The modifier contribution is 0 when no card registry is installed —
-    // most engine unit tests don't install one, and a skill test with no
-    // card effects in play is the correct fallback.
-    let modifier = card_registry::current().map_or(0, |reg| {
+    // modifier queries. The constant query walks
+    // state.investigators[*].cards_in_play; the pending query walks
+    // state.pending_skill_modifiers. The constant query contributes 0
+    // when no registry is installed (most engine unit tests don't
+    // install one, and a skill test with no card effects in play is
+    // the correct fallback).
+    let constant_mod = card_registry::current().map_or(0, |reg| {
         constant_skill_modifier(state, reg, investigator, skill, kind)
     });
-    let skill_value = base_skill.saturating_add(modifier);
+    let pending_mod = pending_skill_modifier(state, investigator, skill);
+    let skill_value = base_skill
+        .saturating_add(constant_mod)
+        .saturating_add(pending_mod);
 
     // Mutate-second: advance RNG, derive token, emit events.
     events.push(Event::SkillTestStarted {
@@ -507,6 +514,14 @@ pub(super) fn resolve_skill_test(
     };
 
     events.push(Event::SkillTestEnded { investigator });
+
+    // ModifierScope::ThisSkillTest contributions expire when the test
+    // ends. Drain pending entries for *this* investigator only —
+    // entries queued for other investigators' future tests stay.
+    state
+        .pending_skill_modifiers
+        .retain(|m| m.investigator != investigator);
+
     Ok(outcome)
 }
 
@@ -1735,7 +1750,7 @@ fn activate_ability(
         ability_index,
     });
 
-    let ctx = EvalContext::for_controller(investigator);
+    let ctx = EvalContext::for_controller_with_source(investigator, instance_id);
     apply_effect(state, events, &effect, ctx)
 }
 

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -11,12 +11,23 @@
 //! variants return [`EngineOutcome::Rejected`] with a TODO message
 //! pointing at the issue or PR that fills them in:
 //!
-//! - [`Effect::Modify`] is **queried**, not applied: the cards-in-play
-//!   state landed with #62 and the constant-modifier query (this
-//!   module's [`constant_skill_modifier`]) reads it during skill-test
-//!   resolution. The `Effect::Modify` arm of [`apply_effect`] still
-//!   rejects — `Modify` isn't directly *applied*; it's a passive
-//!   contribution surfaced by query.
+//! - [`Effect::Modify`] splits by scope. [`WhileInPlay`] and
+//!   [`WhileInPlayDuring`] contributions are passive and surfaced
+//!   by [`constant_skill_modifier`] from card abilities directly —
+//!   reaching `apply_effect` with one of those means the card
+//!   author put a constant-flavored modifier under a non-constant
+//!   trigger, which rejects. [`ThisSkillTest`] is **pushed** into
+//!   [`GameState::pending_skill_modifiers`] for the active skill
+//!   test to consume via [`pending_skill_modifier`]; the skill-
+//!   test handler drains it after `SkillTestEnded`. [`ThisTurn`]
+//!   is not yet wired; rejects with TODO until a card or test
+//!   demands the turn-scoped accumulator.
+//!
+//! [`WhileInPlay`]: crate::dsl::ModifierScope::WhileInPlay
+//! [`WhileInPlayDuring`]: crate::dsl::ModifierScope::WhileInPlayDuring
+//! [`ThisSkillTest`]: crate::dsl::ModifierScope::ThisSkillTest
+//! [`ThisTurn`]: crate::dsl::ModifierScope::ThisTurn
+//! [`GameState::pending_skill_modifiers`]: crate::state::GameState::pending_skill_modifiers
 //! - [`Effect::If`] dispatches but its [`Condition`](crate::dsl::Condition)
 //!   evaluator is skill-test-aware
 //!   ([`SkillTest`](crate::dsl::Condition::SkillTest) reads the
@@ -50,13 +61,12 @@ use super::outcome::EngineOutcome;
 /// Per-evaluation context the effect needs to resolve targets and
 /// reference in-flight game state (current skill test, etc.).
 ///
-/// Phase-3 minimal: just the controller's id. Grows fields as
-/// effects demand them — current skill test (for
-/// [`SkillTest`](crate::dsl::Condition::SkillTest) condition),
-/// current target (for [`Effect::ForEach`] body), reaction-window
-/// context (for `OnEvent` triggers), etc. Keep the surface narrow
-/// and add fields only when an effect's evaluator actually reads
-/// them.
+/// Phase-3 minimal. Grows fields as effects demand them — current
+/// skill test (for [`SkillTest`](crate::dsl::Condition::SkillTest)
+/// condition), current target (for [`Effect::ForEach`] body),
+/// reaction-window context (for `OnEvent` triggers), etc. Keep the
+/// surface narrow and add fields only when an effect's evaluator
+/// actually reads them.
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub struct EvalContext {
@@ -64,13 +74,41 @@ pub struct EvalContext {
     /// "you" in card text. Resolves [`InvestigatorTarget::Controller`]
     /// and [`LocationTarget::ControllerLocation`].
     pub controller: crate::state::InvestigatorId,
+    /// The in-play card-instance that triggered this effect, if any.
+    /// Set by [`activate_ability`](crate::engine) so pushed
+    /// [`PendingSkillModifier`](crate::state::PendingSkillModifier)
+    /// entries can name their source (for replay clarity and future
+    /// limit-once-per-test logic). `None` for evaluations not
+    /// originating from a specific in-play instance (events played
+    /// from hand, scenario forced effects, …).
+    pub source: Option<crate::state::CardInstanceId>,
 }
 
 impl EvalContext {
-    /// Construct a context for the given controller.
+    /// Construct a context for the given controller with no source
+    /// card. Use [`for_controller_with_source`](Self::for_controller_with_source)
+    /// when the effect originates from a specific in-play instance.
     #[must_use]
     pub fn for_controller(controller: crate::state::InvestigatorId) -> Self {
-        Self { controller }
+        Self {
+            controller,
+            source: None,
+        }
+    }
+
+    /// Construct a context for an effect triggered from a specific
+    /// in-play card instance. Used by
+    /// [`activate_ability`](crate::engine) so pushed
+    /// `PendingSkillModifier`s carry their source.
+    #[must_use]
+    pub fn for_controller_with_source(
+        controller: crate::state::InvestigatorId,
+        source: crate::state::CardInstanceId,
+    ) -> Self {
+        Self {
+            controller,
+            source: Some(source),
+        }
     }
 }
 
@@ -99,11 +137,7 @@ pub fn apply_effect(
         }
         Effect::DiscoverClue { from, count } => discover_clue(state, events, ctx, *from, *count),
         Effect::Seq(effects) => apply_seq(state, events, effects, ctx),
-        Effect::Modify { .. } => EngineOutcome::Rejected {
-            reason: "TODO(#47): Modify evaluator needs a cards-in-play state + modifier query \
-                     mechanism. Lands later in Phase 3 alongside the skill-test resolution flow."
-                .into(),
-        },
+        Effect::Modify { stat, delta, scope } => modify(state, ctx, *stat, *delta, *scope),
         Effect::If { .. } => EngineOutcome::Rejected {
             reason: "TODO(#47): If evaluator dispatches but Condition::SkillTest needs the \
                      in-flight skill test in EvalContext (lands with #49)."
@@ -111,6 +145,59 @@ pub fn apply_effect(
         },
         Effect::ForEach { .. } => awaiting_input_stub("ForEach"),
         Effect::ChooseOne(_) => awaiting_input_stub("ChooseOne"),
+    }
+}
+
+/// Apply an [`Effect::Modify`].
+///
+/// Most scopes are passive contributions queried elsewhere:
+///
+/// - [`ModifierScope::WhileInPlay`] / [`ModifierScope::WhileInPlayDuring`]:
+///   the constant-modifier query walks `cards_in_play` and reads
+///   abilities directly. Reaching `apply_effect` with one of these
+///   means a card author put a constant-flavored modifier under a
+///   non-constant trigger (an `OnPlay`/`Activated` ability whose
+///   effect *is* a `Modify` with constant scope), which doesn't fit
+///   either path cleanly. Reject loudly so the card author notices.
+/// - [`ModifierScope::ThisSkillTest`]: pushed onto
+///   [`GameState::pending_skill_modifiers`]; consumed and drained
+///   by the skill-test resolution flow.
+/// - [`ModifierScope::ThisTurn`]: not yet wired; rejects with TODO
+///   until a card or test demands it.
+fn modify(
+    state: &mut GameState,
+    ctx: EvalContext,
+    stat: crate::dsl::Stat,
+    delta: i8,
+    scope: ModifierScope,
+) -> EngineOutcome {
+    match scope {
+        ModifierScope::ThisSkillTest => {
+            state
+                .pending_skill_modifiers
+                .push(crate::state::PendingSkillModifier {
+                    investigator: ctx.controller,
+                    stat,
+                    delta,
+                    source: ctx.source,
+                });
+            EngineOutcome::Done
+        }
+        ModifierScope::WhileInPlay | ModifierScope::WhileInPlayDuring(_) => {
+            EngineOutcome::Rejected {
+                reason: format!(
+                    "Modify with constant scope ({scope:?}) under a non-constant trigger isn't \
+                     applied via the evaluator; declare it under Trigger::Constant so the \
+                     constant-modifier query picks it up. Stat = {stat:?}, delta = {delta}."
+                )
+                .into(),
+            }
+        }
+        ModifierScope::ThisTurn => EngineOutcome::Rejected {
+            reason: "TODO(#102-followup): ThisTurn scope not yet wired; needs a turn-scoped \
+                     accumulator that drains on TurnEnded."
+                .into(),
+        },
     }
 }
 
@@ -398,6 +485,36 @@ pub fn constant_skill_modifier(
             if stat_matches_skill(*stat, skill) {
                 total = total.saturating_add(*delta);
             }
+        }
+    }
+    total
+}
+
+/// Sum the [`PendingSkillModifier`](crate::state::PendingSkillModifier)
+/// contributions queued for `controller`'s in-flight skill test
+/// against `skill`.
+///
+/// These are the modifiers pushed by
+/// [`ModifierScope::ThisSkillTest`]-scoped `Effect::Modify`
+/// evaluations from activated / triggered abilities (Hyperawareness's
+/// `[fast] Spend 1 resource: You get +1 [intellect] for this skill
+/// test` is the canonical example). The skill-test handler drains
+/// the entries for the resolving investigator after
+/// [`Event::SkillTestEnded`] fires;
+/// stale entries from a prior test never leak into the next.
+#[must_use]
+pub fn pending_skill_modifier(
+    state: &GameState,
+    controller: InvestigatorId,
+    skill: SkillKind,
+) -> i8 {
+    let mut total: i8 = 0;
+    for pending in &state.pending_skill_modifiers {
+        if pending.investigator != controller {
+            continue;
+        }
+        if stat_matches_skill(pending.stat, skill) {
+            total = total.saturating_add(pending.delta);
         }
     }
     total
@@ -702,7 +819,10 @@ mod tests {
     }
 
     #[test]
-    fn modify_is_rejected_with_todo_message() {
+    fn modify_with_while_in_play_scope_under_non_constant_trigger_rejects() {
+        // WhileInPlay belongs under Trigger::Constant; reaching the
+        // evaluator with this combination means the card author
+        // wired the ability wrong. Reject loudly.
         let mut state = TestGame::new().build();
         let mut events = Vec::new();
         let outcome = apply_effect(
@@ -711,11 +831,66 @@ mod tests {
             &modify(Stat::Willpower, 1, ModifierScope::WhileInPlay),
             ctx(1),
         );
+        assert!(matches!(outcome, EngineOutcome::Rejected { .. }));
+    }
+
+    #[test]
+    fn modify_with_this_skill_test_scope_pushes_pending_modifier() {
+        let id = InvestigatorId(1);
+        let mut state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .build();
+        let mut events = Vec::new();
+        let outcome = apply_effect(
+            &mut state,
+            &mut events,
+            &modify(Stat::Intellect, 1, ModifierScope::ThisSkillTest),
+            ctx(1),
+        );
+        assert_eq!(outcome, EngineOutcome::Done);
+        assert!(events.is_empty(), "push doesn't emit an event");
+        assert_eq!(state.pending_skill_modifiers.len(), 1);
+        let m = &state.pending_skill_modifiers[0];
+        assert_eq!(m.investigator, id);
+        assert_eq!(m.stat, Stat::Intellect);
+        assert_eq!(m.delta, 1);
+        assert_eq!(m.source, None, "no source on a bare for_controller ctx");
+    }
+
+    #[test]
+    fn modify_pushes_source_when_ctx_has_one() {
+        let id = InvestigatorId(1);
+        let src = CardInstanceId(42);
+        let mut state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .build();
+        let mut events = Vec::new();
+        let ctx_with_src = EvalContext::for_controller_with_source(id, src);
+        let outcome = apply_effect(
+            &mut state,
+            &mut events,
+            &modify(Stat::Combat, 2, ModifierScope::ThisSkillTest),
+            ctx_with_src,
+        );
+        assert_eq!(outcome, EngineOutcome::Done);
+        assert_eq!(state.pending_skill_modifiers[0].source, Some(src));
+    }
+
+    #[test]
+    fn modify_with_this_turn_scope_rejects_with_todo() {
+        let mut state = TestGame::new().build();
+        let mut events = Vec::new();
+        let outcome = apply_effect(
+            &mut state,
+            &mut events,
+            &modify(Stat::Willpower, 1, ModifierScope::ThisTurn),
+            ctx(1),
+        );
         match outcome {
             EngineOutcome::Rejected { reason } => {
                 assert!(
-                    reason.contains("Modify"),
-                    "reason should mention Modify: {reason:?}"
+                    reason.contains("ThisTurn"),
+                    "reason should mention ThisTurn: {reason:?}",
                 );
             }
             _ => panic!("expected Rejected"),
@@ -998,5 +1173,91 @@ mod tests {
             ),
             0,
         );
+    }
+
+    // ---- pending_skill_modifier tests ----------------------------
+
+    use super::pending_skill_modifier;
+    use crate::state::PendingSkillModifier;
+
+    fn state_with_pending(pending: Vec<PendingSkillModifier>) -> crate::state::GameState {
+        let mut state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .build();
+        state.pending_skill_modifiers = pending;
+        state
+    }
+
+    #[test]
+    fn pending_modifier_is_zero_with_empty_accumulator() {
+        let state = state_with_pending(vec![]);
+        assert_eq!(
+            pending_skill_modifier(&state, InvestigatorId(1), SkillKind::Willpower),
+            0,
+        );
+    }
+
+    #[test]
+    fn pending_modifier_sums_matching_investigator_and_stat() {
+        let id = InvestigatorId(1);
+        let state = state_with_pending(vec![
+            PendingSkillModifier {
+                investigator: id,
+                stat: Stat::Intellect,
+                delta: 1,
+                source: None,
+            },
+            PendingSkillModifier {
+                investigator: id,
+                stat: Stat::Intellect,
+                delta: 2,
+                source: None,
+            },
+        ]);
+        assert_eq!(pending_skill_modifier(&state, id, SkillKind::Intellect), 3,);
+    }
+
+    #[test]
+    fn pending_modifier_ignores_other_investigators() {
+        let me = InvestigatorId(1);
+        let them = InvestigatorId(2);
+        let state = state_with_pending(vec![PendingSkillModifier {
+            investigator: them,
+            stat: Stat::Willpower,
+            delta: 5,
+            source: None,
+        }]);
+        assert_eq!(pending_skill_modifier(&state, me, SkillKind::Willpower), 0,);
+    }
+
+    #[test]
+    fn pending_modifier_ignores_non_matching_stat() {
+        let id = InvestigatorId(1);
+        let state = state_with_pending(vec![PendingSkillModifier {
+            investigator: id,
+            stat: Stat::Intellect,
+            delta: 1,
+            source: None,
+        }]);
+        assert_eq!(pending_skill_modifier(&state, id, SkillKind::Willpower), 0,);
+    }
+
+    #[test]
+    fn pending_modifier_ignores_non_skill_stats() {
+        let id = InvestigatorId(1);
+        let state = state_with_pending(vec![PendingSkillModifier {
+            investigator: id,
+            stat: Stat::MaxHealth,
+            delta: 1,
+            source: None,
+        }]);
+        for skill in [
+            SkillKind::Willpower,
+            SkillKind::Intellect,
+            SkillKind::Combat,
+            SkillKind::Agility,
+        ] {
+            assert_eq!(pending_skill_modifier(&state, id, skill), 0);
+        }
     }
 }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -537,6 +537,50 @@ mod tests {
     }
 
     #[test]
+    fn perform_skill_test_drains_only_resolving_investigators_pending_modifiers() {
+        // Two investigators each have a pending ThisSkillTest entry.
+        // Running a skill test for inv1 must drain inv1's entry but
+        // leave inv2's intact for their own future test.
+        let id1 = InvestigatorId(1);
+        let id2 = InvestigatorId(2);
+        let mut state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_investigator(test_investigator(2))
+            .with_chaos_bag(bag_only_zero())
+            .build();
+        state.pending_skill_modifiers = vec![
+            crate::state::PendingSkillModifier {
+                investigator: id1,
+                stat: crate::dsl::Stat::Willpower,
+                delta: 1,
+                source: None,
+            },
+            crate::state::PendingSkillModifier {
+                investigator: id2,
+                stat: crate::dsl::Stat::Willpower,
+                delta: 1,
+                source: None,
+            },
+        ];
+
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id1,
+                skill: SkillKind::Willpower,
+                difficulty: 0,
+            }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_eq!(
+            result.state.pending_skill_modifiers.len(),
+            1,
+            "inv2's entry must survive inv1's test",
+        );
+        assert_eq!(result.state.pending_skill_modifiers[0].investigator, id2);
+    }
+
+    #[test]
     fn perform_skill_test_advances_rng_and_log_round_trips() {
         // Determinism: applying the same PerformSkillTest action twice
         // from identical initial state produces identical post-state.

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -36,6 +36,6 @@ pub use event::{Event, FailureReason};
 pub use rng::RngState;
 pub use state::{
     resolve_token, CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, DefeatCause, Enemy,
-    EnemyId, GameState, Investigator, InvestigatorId, Location, LocationId, Phase, SkillKind,
-    Skills, Status, TokenModifiers, TokenResolution, UseKind, Zone,
+    EnemyId, GameState, Investigator, InvestigatorId, Location, LocationId, PendingSkillModifier,
+    Phase, SkillKind, Skills, Status, TokenModifiers, TokenResolution, UseKind, Zone,
 };

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -5,12 +5,14 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use super::{
+    card::CardInstanceId,
     chaos_bag::{ChaosBag, TokenModifiers},
     enemy::{Enemy, EnemyId},
     investigator::{Investigator, InvestigatorId},
     location::{Location, LocationId},
     phase::Phase,
 };
+use crate::dsl::Stat;
 use crate::rng::RngState;
 
 /// The full state of a scenario at a single point in time.
@@ -73,7 +75,41 @@ pub struct GameState {
     /// enter play. Starts at 0 and increments after each assignment;
     /// guarantees uniqueness within a scenario and deterministic ids
     /// across replays.
-    ///
-    /// [`CardInstanceId`]: super::card::CardInstanceId
     pub next_card_instance_id: u32,
+    /// In-flight skill modifiers contributed by activated / triggered
+    /// abilities with [`ModifierScope::ThisSkillTest`] scope.
+    /// Accumulates between activation and skill-test resolution; the
+    /// skill-test handler drains the entries for the resolving
+    /// investigator after [`Event::SkillTestEnded`] fires.
+    ///
+    /// [`ModifierScope::ThisSkillTest`]: crate::dsl::ModifierScope::ThisSkillTest
+    /// [`Event::SkillTestEnded`]: crate::Event::SkillTestEnded
+    pub pending_skill_modifiers: Vec<PendingSkillModifier>,
+}
+
+/// A queued [`ModifierScope::ThisSkillTest`] contribution waiting to
+/// apply to a skill test.
+///
+/// Pushed by [`apply_effect`](crate::engine::apply_effect) when an
+/// activated or triggered ability resolves a `Modify { scope:
+/// ThisSkillTest, … }` effect. Consumed (and cleared) by the next
+/// skill-test resolution for the same investigator.
+///
+/// [`ModifierScope::ThisSkillTest`]: crate::dsl::ModifierScope::ThisSkillTest
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PendingSkillModifier {
+    /// The investigator whose skill test this contributes to.
+    pub investigator: InvestigatorId,
+    /// Which stat the modifier targets (the skill-test handler
+    /// maps `SkillKind` → `Stat` for matching).
+    pub stat: Stat,
+    /// Signed magnitude.
+    pub delta: i8,
+    /// The in-play instance that produced the modifier, if any.
+    /// `None` for modifiers from non-activated paths (e.g. an
+    /// `OnPlay` ability that pushes a per-test buff). Limit-once-
+    /// per-test logic in later cycles (Roland Banks, Hard Knocks
+    /// upgrades) will key off this.
+    pub source: Option<CardInstanceId>,
 }

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -16,7 +16,7 @@ pub mod phase;
 pub use card::{CardCode, CardInPlay, CardInstanceId, UseKind, Zone};
 pub use chaos_bag::{resolve_token, ChaosBag, ChaosToken, TokenModifiers, TokenResolution};
 pub use enemy::{Enemy, EnemyId};
-pub use game_state::GameState;
+pub use game_state::{GameState, PendingSkillModifier};
 pub use investigator::{DefeatCause, Investigator, InvestigatorId, SkillKind, Skills, Status};
 pub use location::{Location, LocationId};
 pub use phase::Phase;

--- a/crates/game-core/src/test_support/builder.rs
+++ b/crates/game-core/src/test_support/builder.rs
@@ -176,6 +176,7 @@ impl TestGame {
             rng: self.rng,
             mulligan_window: self.mulligan_window,
             next_card_instance_id: 0,
+            pending_skill_modifiers: Vec::new(),
         }
     }
 }

--- a/crates/game-core/tests/activate_ability.rs
+++ b/crates/game-core/tests/activate_ability.rs
@@ -21,8 +21,8 @@ use game_core::dsl::{
 use game_core::engine::{apply, EngineOutcome};
 use game_core::event::Event;
 use game_core::state::{
-    CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, InvestigatorId, Phase, Status,
-    TokenModifiers,
+    CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, InvestigatorId, Phase, SkillKind,
+    Status, TokenModifiers,
 };
 use game_core::test_support::{test_investigator, TestGame};
 use game_core::{assert_event, assert_event_count, assert_no_event};
@@ -46,6 +46,11 @@ const CONSTANT_ONLY: &str = "MOCK3";
 /// Mock card code: activated ability whose ONLY cost is the
 /// `DiscardCardFromHand` stub. Used to test the TODO-reject path.
 const DISCARD_COST_ABILITY: &str = "MOCK4";
+
+/// Mock card code: Hyperawareness-shaped `[fast] Spend 1 resource:
+/// you get +1 intellect for this skill test.` Exercises the
+/// `ThisSkillTest` push path + accumulator drain across resolution.
+const SKILL_BOOST: &str = "MOCK5";
 
 fn mock_metadata_for(_: &CardCode) -> Option<&'static CardMetadata> {
     None
@@ -72,6 +77,11 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
             0,
             vec![Cost::DiscardCardFromHand],
             gain_resources(InvestigatorTarget::Controller, 1),
+        )]),
+        SKILL_BOOST => Some(vec![activated(
+            0,
+            vec![Cost::Resources(1)],
+            modify(Stat::Intellect, 1, ModifierScope::ThisSkillTest),
         )]),
         _ => None,
     }
@@ -323,4 +333,114 @@ fn activating_with_defeated_status_doesnt_need_registry() {
     );
     assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
     assert_no_event!(result.events, Event::AbilityActivated { .. });
+}
+
+// ---- ThisSkillTest accumulator (#102) ------------------------------
+
+#[test]
+fn this_skill_test_modifier_contributes_to_next_skill_test() {
+    // Activate the SKILL_BOOST mock card: pay 1 resource, push +1
+    // intellect for this skill test. Then run an intellect skill
+    // test at difficulty 4 — the base 3 intellect + 1 from the
+    // pushed modifier exactly clears it.
+    let (state, id, instance_id) = state_with_in_play(SKILL_BOOST);
+
+    let after_activate = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id,
+            ability_index: 0,
+        }),
+    );
+    assert_eq!(after_activate.outcome, EngineOutcome::Done);
+    assert_eq!(
+        after_activate.state.pending_skill_modifiers.len(),
+        1,
+        "ThisSkillTest push should leave one pending entry",
+    );
+
+    let after_test = apply(
+        after_activate.state,
+        Action::Player(PlayerAction::PerformSkillTest {
+            investigator: id,
+            skill: SkillKind::Intellect,
+            difficulty: 4,
+        }),
+    );
+    assert_eq!(after_test.outcome, EngineOutcome::Done);
+    assert_event!(
+        after_test.events,
+        Event::SkillTestSucceeded { investigator, skill: SkillKind::Intellect, margin: 0 }
+            if *investigator == id
+    );
+    // Drain: pending list empty after the test ends.
+    assert!(
+        after_test.state.pending_skill_modifiers.is_empty(),
+        "ThisSkillTest accumulator must drain after SkillTestEnded",
+    );
+}
+
+#[test]
+fn this_skill_test_modifier_does_not_leak_into_a_second_test() {
+    // Activate the boost, run an intellect test (consumes + drains
+    // the pending entry), then run a second intellect test at the
+    // same difficulty. Without the boost re-activating, the second
+    // test fails — proving the prior modifier didn't carry over.
+    let (state, id, instance_id) = state_with_in_play(SKILL_BOOST);
+
+    let after_activate = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id,
+            ability_index: 0,
+        }),
+    );
+    assert_eq!(after_activate.outcome, EngineOutcome::Done);
+
+    let after_first_test = apply(
+        after_activate.state,
+        Action::Player(PlayerAction::PerformSkillTest {
+            investigator: id,
+            skill: SkillKind::Intellect,
+            difficulty: 4,
+        }),
+    );
+    assert_eq!(after_first_test.outcome, EngineOutcome::Done);
+
+    let after_second_test = apply(
+        after_first_test.state,
+        Action::Player(PlayerAction::PerformSkillTest {
+            investigator: id,
+            skill: SkillKind::Intellect,
+            difficulty: 4,
+        }),
+    );
+    assert_eq!(after_second_test.outcome, EngineOutcome::Done);
+    assert_event!(
+        after_second_test.events,
+        Event::SkillTestFailed { investigator, skill: SkillKind::Intellect, by: 1, .. }
+            if *investigator == id
+    );
+}
+
+#[test]
+fn this_skill_test_modifier_carries_source_instance_id() {
+    // Activated abilities push with ctx.source = Some(instance_id)
+    // so future limit-once-per-test logic can key off the source.
+    let (state, id, instance_id) = state_with_in_play(SKILL_BOOST);
+    let after_activate = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id,
+            ability_index: 0,
+        }),
+    );
+    assert_eq!(after_activate.outcome, EngineOutcome::Done);
+    let pending = &after_activate.state.pending_skill_modifiers[0];
+    assert_eq!(pending.investigator, id);
+    assert_eq!(pending.delta, 1);
+    assert_eq!(pending.source, Some(instance_id));
 }


### PR DESCRIPTION
Closes #102.

## What it does

Wires \`ModifierScope::ThisSkillTest\` to actually contribute to skill-test totals. Until now the scope existed in the DSL but nothing consumed it — \`constant_skill_modifier\` filtered it out (correctly — it's not a constant) and the evaluator rejected.

After this lands, **#38 Hyperawareness** becomes a pure card impl consuming the new push path + the cost primitives from #53.

## State (state/game_state.rs)

- \`GameState.pending_skill_modifiers: Vec<PendingSkillModifier>\`.
- \`PendingSkillModifier { investigator, stat, delta, source: Option<CardInstanceId> }\`. Source field readied for limit-once-per-test logic in later cycles; defaults to None for non-activated paths.

## Evaluator (engine/evaluator.rs)

- \`EvalContext.source: Option<CardInstanceId>\` plus a new \`for_controller_with_source\` constructor; \`activate_ability\` uses it so pushed modifiers carry the source instance.
- \`Effect::Modify\` arm now dispatches by scope:
  - \`WhileInPlay\` / \`WhileInPlayDuring\` → rejects (card author wired a constant-flavored modifier under a non-constant trigger).
  - \`ThisSkillTest\` → pushes a \`PendingSkillModifier\`.
  - \`ThisTurn\` → rejects with TODO (turn-scoped accumulator out of scope; #102 only covers \`ThisSkillTest\` per the issue body).
- New \`pending_skill_modifier(state, controller, skill) -> i8\` query helper, mirroring \`constant_skill_modifier\`'s shape.

## Skill-test resolution (engine/dispatch.rs)

- \`resolve_skill_test\` sums the pending contribution alongside the constant contribution: \`base + constants + pending + token\`.
- Drains pending entries for the resolving investigator after \`Event::SkillTestEnded\` fires. Cross-investigator entries (queued for someone else's future test) stay.

## Tests (+11, total 225)

- 8 unit tests in evaluator.rs:
  - \`Modify\` with constant scopes under non-constant trigger rejects.
  - \`ThisSkillTest\` pushes the right tuple.
  - Source is captured when the context has one.
  - \`ThisTurn\` rejects with TODO.
  - \`pending_skill_modifier\`: empty / sum-matching / wrong-investigator ignored / wrong-stat ignored / non-skill stats ignored.
- 3 integration tests in \`tests/activate_ability.rs\`:
  - Activated \`[fast]\` ability pushes +1 intellect; subsequent Investigate at difficulty 4 succeeds (3 + 1 + 0 = 4).
  - Second skill test after drain fails (3 + 0 = 3, fail by 1) — proves the prior modifier doesn't leak.
  - Pushed modifier carries \`source = Some(instance_id)\`.

## Test plan

- [x] All five CI jobs green locally with strict flags
- [ ] CI green on the PR
- [ ] Independent review

🤖 Generated with [Claude Code](https://claude.com/claude-code)