### PR TITLE
card: Hyperawareness (01034)

### DIFF
--- a/crates/cards/src/impls/hyperawareness.rs
+++ b/crates/cards/src/impls/hyperawareness.rs
@@ -1,0 +1,111 @@
+//! Hyperawareness (Seeker asset, 01034).
+//!
+//! ```text
+//! Talent.
+//! [fast] Spend 1 resource: You get +1 [intellect] for this skill test.
+//! [fast] Spend 1 resource: You get +1 [agility] for this skill test.
+//! ```
+//!
+//! Two `[fast]` activated abilities, each paying 1 resource for a
+//! `+1` push to the corresponding stat with
+//! [`ModifierScope::ThisSkillTest`] scope. The DSL primitives that
+//! make this expressible:
+//!
+//! - `Trigger::Activated { action_cost: 0 }` (#53) — `[fast]` means no
+//!   action cost.
+//! - `Cost::Resources(1)` (#53) — the per-ability payment.
+//! - `ModifierScope::ThisSkillTest` evaluator push path (#102) —
+//!   queues the modifier into [`GameState::pending_skill_modifiers`]
+//!   for the next skill-test resolution to consume.
+//!
+//! [`GameState::pending_skill_modifiers`]: game_core::state::GameState::pending_skill_modifiers
+//!
+//! # Two abilities, two indices
+//!
+//! The intellect ability is at `ability_index: 0`; the agility
+//! ability is at `ability_index: 1`. The order is significant — the
+//! [`PlayerAction::ActivateAbility`] action carries the index, so
+//! tests and clients must pick the matching slot.
+//!
+//! [`PlayerAction::ActivateAbility`]: game_core::PlayerAction::ActivateAbility
+
+use game_core::dsl::{activated, modify, Ability, Cost, ModifierScope, Stat};
+
+/// `ArkhamDB` code for the original-Core printing.
+pub const CODE: &str = "01034";
+
+/// Hyperawareness's two activated `[fast]` abilities.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![
+        // Index 0: +1 intellect for this skill test.
+        activated(
+            0,
+            vec![Cost::Resources(1)],
+            modify(Stat::Intellect, 1, ModifierScope::ThisSkillTest),
+        ),
+        // Index 1: +1 agility for this skill test.
+        activated(
+            0,
+            vec![Cost::Resources(1)],
+            modify(Stat::Agility, 1, ModifierScope::ThisSkillTest),
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use game_core::dsl::{Cost, Effect, ModifierScope, Stat, Trigger};
+
+    #[test]
+    fn abilities_are_two_fast_activated_resource_costed_modifies() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 2);
+        for (idx, ability) in abilities.iter().enumerate() {
+            assert_eq!(
+                ability.trigger,
+                Trigger::Activated { action_cost: 0 },
+                "ability {idx} must be [fast] (action_cost = 0)",
+            );
+            assert_eq!(
+                ability.costs,
+                vec![Cost::Resources(1)],
+                "ability {idx} must cost exactly 1 resource",
+            );
+        }
+    }
+
+    #[test]
+    fn intellect_ability_pushes_intellect_for_this_skill_test() {
+        let intellect = &super::abilities()[0];
+        assert!(matches!(
+            intellect.effect,
+            Effect::Modify {
+                stat: Stat::Intellect,
+                delta: 1,
+                scope: ModifierScope::ThisSkillTest,
+            }
+        ));
+    }
+
+    #[test]
+    fn agility_ability_pushes_agility_for_this_skill_test() {
+        let agility = &super::abilities()[1];
+        assert!(matches!(
+            agility.effect,
+            Effect::Modify {
+                stat: Stat::Agility,
+                delta: 1,
+                scope: ModifierScope::ThisSkillTest,
+            }
+        ));
+    }
+
+    /// Catches a `pub mod` rename or a fat-fingered match arm in
+    /// `impls::abilities_for` — the registry must dispatch CODE to
+    /// this module's `abilities()`.
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(super::CODE), Some(super::abilities()));
+    }
+}

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -27,15 +27,19 @@
 //! - Working a Hunch (01037) — `Trigger::OnPlay` + `DiscoverClue`.
 //! - Magnifying Glass (01030) — `Trigger::Constant` +
 //!   `WhileInPlayDuring(SkillTestKind::Investigate)`.
+//! - Hyperawareness (01034) — two `Trigger::Activated { action_cost: 0 }`
+//!   abilities with `Cost::Resources(1)` and `ThisSkillTest`-scoped
+//!   `Modify`.
 //!
-//! Remaining Phase-3 cards (Hyperawareness #38, Deduction #39,
-//! Roland Banks #55, Study #56) each block on a DSL primitive the
-//! cards crate doesn't yet emit — activated triggers, commit
-//! windows, `OnEvent` reactions, location-state shape.
+//! Remaining Phase-3 cards (Deduction #39, Roland Banks #55,
+//! Study #56) each block on a DSL primitive the cards crate doesn't
+//! yet emit — commit windows, `OnEvent` reactions, location-state
+//! shape.
 
 use game_core::dsl::Ability;
 
 pub mod holy_rosary;
+pub mod hyperawareness;
 pub mod magnifying_glass;
 pub mod working_a_hunch;
 
@@ -45,6 +49,7 @@ pub mod working_a_hunch;
 pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
     match code {
         holy_rosary::CODE => Some(holy_rosary::abilities()),
+        hyperawareness::CODE => Some(hyperawareness::abilities()),
         magnifying_glass::CODE => Some(magnifying_glass::abilities()),
         working_a_hunch::CODE => Some(working_a_hunch::abilities()),
         _ => None,

--- a/crates/cards/src/lib.rs
+++ b/crates/cards/src/lib.rs
@@ -130,28 +130,28 @@ mod tests {
     #[test]
     fn implemented_cards_are_playable() {
         // Phase-2 PR-I: Holy Rosary (01059), Working a Hunch (01037).
-        // Phase-3 #37: Magnifying Glass (01030) once #45 (per-skill-
-        // test scope) landed.
+        // Phase-3 #37: Magnifying Glass (01030).
+        // Phase-3 #38: Hyperawareness (01034).
         assert!(is_playable("01037"));
         assert!(is_playable("01059"));
         assert!(is_playable("01030"));
+        assert!(is_playable("01034"));
     }
 
     #[test]
     fn unimplemented_cards_are_not_playable() {
-        // Hyperawareness (01034) needs Trigger::Activated + cost
-        // primitives (#53). Deduction (01039) needs the skill-test
-        // commit window (#63) or the after-resolution trigger (#64).
-        assert!(!is_playable("01034"));
+        // Deduction (01039) needs the skill-test commit window (#63)
+        // or the after-resolution trigger (#64).
         assert!(!is_playable("01039"));
         // Phase-3 doesn't touch most of the corpus.
         assert!(!is_playable("01001")); // Roland Banks
+        assert!(!is_playable("01017")); // Physical Training
         assert!(!is_playable("99999")); // unknown code
     }
 
     #[test]
     fn abilities_for_returns_some_for_implemented() {
-        for code in ["01030", "01037", "01059"] {
+        for code in ["01030", "01034", "01037", "01059"] {
             let abilities = super::abilities_for(code)
                 .unwrap_or_else(|| panic!("expected abilities for {code}"));
             assert!(

--- a/crates/cards/tests/hyperawareness.rs
+++ b/crates/cards/tests/hyperawareness.rs
@@ -1,0 +1,221 @@
+//! End-to-end test for Hyperawareness (01034): the two `[fast]`
+//! activated abilities push a `ThisSkillTest`-scoped modifier for
+//! intellect (index 0) or agility (index 1).
+//!
+//! Demonstrates the composition of three Phase-3 mechanisms with a
+//! real card:
+//! - `Trigger::Activated { action_cost: 0 }` + `Cost::Resources(1)` (#53)
+//! - `ModifierScope::ThisSkillTest` push + drain (#102)
+//! - The skill-test resolution path that sums pending modifiers
+//!   alongside constants and the base skill (#92).
+
+use std::sync::Once;
+
+use game_core::engine::{apply, EngineOutcome};
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, InvestigatorId, Phase, SkillKind,
+    TokenModifiers,
+};
+use game_core::test_support::{test_investigator, TestGame};
+use game_core::{assert_event, Action, PlayerAction};
+
+const HYPERAWARENESS: &str = "01034";
+
+const INTELLECT_ABILITY: u8 = 0;
+const AGILITY_ABILITY: u8 = 1;
+
+fn install_real_registry() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// Build a state with one Hyperawareness already in play (instance
+/// id 0), the controller mid-investigation, 5 resources, a single
+/// `Numeric(0)` chaos bag for predictable arithmetic. We seed in
+/// play (rather than playing from hand) because the activation flow
+/// is what this file tests; `PlayCard` is exercised elsewhere.
+fn state_with_hyperawareness() -> (game_core::GameState, InvestigatorId, CardInstanceId) {
+    install_real_registry();
+
+    let id = InvestigatorId(1);
+    let instance_id = CardInstanceId(0);
+    let mut inv = test_investigator(1);
+    inv.cards_in_play.push(CardInPlay::enter_play(
+        CardCode::new(HYPERAWARENESS),
+        instance_id,
+    ));
+
+    let state = TestGame::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(inv)
+        .with_active_investigator(id)
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default())
+        .build();
+    (state, id, instance_id)
+}
+
+#[test]
+fn intellect_ability_buffs_an_intellect_test_at_difficulty_4() {
+    // 3 intellect + 1 (Hyperawareness push) + 0 (token) = 4 vs
+    // difficulty 4 → succeed by 0. The base 3-intellect investigator
+    // would fail without the activation.
+    let (state, id, instance_id) = state_with_hyperawareness();
+    let resources_before = state.investigators[&id].resources;
+
+    let after_activate = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id,
+            ability_index: INTELLECT_ABILITY,
+        }),
+    );
+    assert_eq!(after_activate.outcome, EngineOutcome::Done);
+    assert_eq!(
+        after_activate.state.investigators[&id].resources,
+        resources_before - 1,
+        "1 resource paid",
+    );
+
+    let after_test = apply(
+        after_activate.state,
+        Action::Player(PlayerAction::PerformSkillTest {
+            investigator: id,
+            skill: SkillKind::Intellect,
+            difficulty: 4,
+        }),
+    );
+    assert_eq!(after_test.outcome, EngineOutcome::Done);
+    assert_event!(
+        after_test.events,
+        Event::SkillTestSucceeded { investigator, skill: SkillKind::Intellect, margin: 0 }
+            if *investigator == id
+    );
+    assert!(
+        after_test.state.pending_skill_modifiers.is_empty(),
+        "ThisSkillTest push must drain after the test ends",
+    );
+}
+
+#[test]
+fn agility_ability_buffs_an_agility_test_at_difficulty_4() {
+    // Same as above but ability_index = 1 buffs agility.
+    let (state, id, instance_id) = state_with_hyperawareness();
+
+    let after_activate = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id,
+            ability_index: AGILITY_ABILITY,
+        }),
+    );
+    assert_eq!(after_activate.outcome, EngineOutcome::Done);
+
+    let after_test = apply(
+        after_activate.state,
+        Action::Player(PlayerAction::PerformSkillTest {
+            investigator: id,
+            skill: SkillKind::Agility,
+            difficulty: 4,
+        }),
+    );
+    assert_eq!(after_test.outcome, EngineOutcome::Done);
+    assert_event!(
+        after_test.events,
+        Event::SkillTestSucceeded { investigator, skill: SkillKind::Agility, margin: 0 }
+            if *investigator == id
+    );
+}
+
+#[test]
+fn intellect_ability_does_not_buff_an_agility_test() {
+    // The pushed modifier targets `Stat::Intellect`; an agility test
+    // ignores it. 3 + 0 < 4 → fail by 1.
+    let (state, id, instance_id) = state_with_hyperawareness();
+
+    let after_activate = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id,
+            ability_index: INTELLECT_ABILITY,
+        }),
+    );
+    assert_eq!(after_activate.outcome, EngineOutcome::Done);
+
+    let after_test = apply(
+        after_activate.state,
+        Action::Player(PlayerAction::PerformSkillTest {
+            investigator: id,
+            skill: SkillKind::Agility,
+            difficulty: 4,
+        }),
+    );
+    assert_eq!(after_test.outcome, EngineOutcome::Done);
+    assert_event!(
+        after_test.events,
+        Event::SkillTestFailed { investigator, skill: SkillKind::Agility, by: 1, .. }
+            if *investigator == id
+    );
+}
+
+#[test]
+fn activation_rejects_when_controller_lacks_a_resource() {
+    let (mut state, id, instance_id) = state_with_hyperawareness();
+    state.investigators.get_mut(&id).unwrap().resources = 0;
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id,
+            ability_index: INTELLECT_ABILITY,
+        }),
+    );
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert!(result.events.is_empty());
+    // No partial mutation: resources still 0, no pending modifier.
+    assert_eq!(result.state.investigators[&id].resources, 0);
+    assert!(result.state.pending_skill_modifiers.is_empty());
+}
+
+#[test]
+fn both_abilities_cost_no_action_points() {
+    // `[fast]` activation must not spend an action. Confirm both
+    // abilities behave this way.
+    let (state, id, instance_id) = state_with_hyperawareness();
+    let actions_before = state.investigators[&id].actions_remaining;
+
+    let after_intellect = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id,
+            ability_index: INTELLECT_ABILITY,
+        }),
+    );
+    assert_eq!(after_intellect.outcome, EngineOutcome::Done);
+    assert_eq!(
+        after_intellect.state.investigators[&id].actions_remaining,
+        actions_before,
+    );
+
+    let after_agility = apply(
+        after_intellect.state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id,
+            ability_index: AGILITY_ABILITY,
+        }),
+    );
+    assert_eq!(after_agility.outcome, EngineOutcome::Done);
+    assert_eq!(
+        after_agility.state.investigators[&id].actions_remaining,
+        actions_before,
+    );
+}

--- a/crates/cards/tests/play_card.rs
+++ b/crates/cards/tests/play_card.rs
@@ -30,10 +30,11 @@ const HOLY_ROSARY: &str = "01059";
 /// at your location."
 const WORKING_A_HUNCH: &str = "01037";
 
-/// Hyperawareness (01034) — Seeker Talent asset, in the corpus but
-/// unimplemented (no `abilities()` impl until #38 lands the activated-
-/// ability DSL). Used as the "unimplemented but known" rejection case.
-const UNIMPLEMENTED_ASSET: &str = "01034";
+/// Physical Training (01017) — Guardian Talent asset, in the corpus
+/// but unimplemented. Not on the Phase-3 roadmap (waits for later
+/// cycles' broader asset coverage). Used as the "unimplemented but
+/// known" rejection case.
+const UNIMPLEMENTED_ASSET: &str = "01017";
 
 /// Magnifying Glass (01030) — Seeker Hand-slot, deck-limit 2. Two
 /// copies in play simultaneously is rules-valid (one Hand slot each,
@@ -331,10 +332,10 @@ fn play_non_event_or_asset_card_is_rejected() {
 
 #[test]
 fn play_unimplemented_card_is_rejected() {
-    // Hyperawareness is in the corpus (metadata resolves) but has
-    // no ability implementation yet (blocked on #38). The deck-import
-    // gate (Phase 9) will refuse decks containing unimplemented
-    // cards; PlayCard double-checks rather than silently no-op.
+    // The canary card is in the corpus (metadata resolves) but has
+    // no ability implementation yet. The deck-import gate (Phase 9)
+    // will refuse decks containing unimplemented cards; PlayCard
+    // double-checks rather than silently no-op.
     let (state, id, _loc) = play_state(vec![UNIMPLEMENTED_ASSET]);
     let result = apply(
         state,


### PR DESCRIPTION
Closes #38.

## What it does

First card to exercise **activated abilities + ThisSkillTest push** end-to-end. Two \`[fast]\` abilities pay 1 resource each: index 0 pushes +1 intellect, index 1 pushes +1 agility, both scoped to the current skill test.

## DSL declaration

\`\`\`rust
vec![
    activated(0, vec![Cost::Resources(1)], modify(Stat::Intellect, 1, ModifierScope::ThisSkillTest)),
    activated(0, vec![Cost::Resources(1)], modify(Stat::Agility,   1, ModifierScope::ThisSkillTest)),
]
\`\`\`

Direct composition of three Phase-3 prereqs:
- \`Trigger::Activated\` + \`Cost::Resources(1)\` from #53.
- \`ModifierScope::ThisSkillTest\` push + drain from #102.
- Skill-test resolution summing pending modifiers from #92.

## Tests

- 4 unit tests in the impl module: shape, intellect-targets-intellect, agility-targets-agility, registry dispatch.
- 5 integration tests in \`crates/cards/tests/hyperawareness.rs\` using the real \`REGISTRY\`: intellect ability buffs intellect test, agility ability buffs agility test, cross-stat doesn't apply, activation without 1 resource rejects, both abilities cost no actions.

## Test-corpus cleanup

- \`cards/src/lib.rs\`: 01034 moves from "unimplemented" to "implemented".
- \`cards/src/impls/mod.rs\`: module doc lists Hyperawareness in "implemented so far".
- \`cards/tests/play_card.rs\`: "unimplemented but known" rejection canary swaps from Hyperawareness (01034, now implemented) to Physical Training (01017, Guardian Talent asset, not on the Phase-3 roadmap).

## Test plan

- [x] All five CI jobs green locally with strict flags (test/clippy/fmt/doc/wasm)
- [ ] CI green on the PR
- [ ] Independent review

🤖 Generated with [Claude Code](https://claude.com/claude-code)