### PR TITLE
infra: add docs/phases/ plan docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ When citing card text or behavior, verify against `data/arkhamdb-snapshot/pack/*
 
 ### Phase plan and milestones
 
-Work is tracked against GitHub milestones (`phase-0-foundations` → `phase-10-dunwich-and-iteration`). Current phase is **3** (`phase-3-skill-test-end-to-end`), focused on running a full skill test through the engine with real-card effects. Issues are labeled by priority (`p0-blocker` / `p1-next` / `p2-later`) and category (`engine` / `card` / `scenario` / `infra` / `test`). The PR template's `Closes #` line auto-closes the issue on merge.
+Work is tracked against GitHub milestones (`phase-0-foundations` → `phase-10-dunwich-and-iteration`). Each phase has a plan doc at **`docs/phases/phase-N-<slug>.md`** capturing the ordered work, design decisions made along the way, and open questions — read the relevant one when picking up a new issue. The index at `docs/phases/README.md` covers the full arc and the unmilestoned cross-cutting work. Issues are labeled by priority (`p0-blocker` / `p1-next` / `p2-later`) and category (`engine` / `card` / `scenario` / `infra` / `test`). The PR template's `Closes #` line auto-closes the issue on merge.
 
 PRs use squash-merge; commit subject convention is `scope: description` (e.g. `engine: cards-registry binding via static OnceLock`).
 

--- a/docs/phases/README.md
+++ b/docs/phases/README.md
@@ -1,0 +1,62 @@
+# Phase plans
+
+Eldritch is broken into 11 phases, milestone-tracked on GitHub. Each one's plan, status, decisions, and open questions lives in its own file in this directory. Closed phases get short retrospectives; the active phase has full detail; future phases capture what's been decided and what's still open.
+
+## Why this exists
+
+The plan-of-record for the project is GitHub (milestones, issues, labels). These docs sit on top: they capture **cross-issue context** that doesn't fit naturally in any single issue body — the *ordering* between issues in a phase, the *design decisions* made along the way that shape later work, the *open questions* the phase will need to settle.
+
+When starting work on a new issue, read the relevant phase doc first. It's faster than re-deriving the context from chat history or git log.
+
+## The 11 phases
+
+| Phase | Title | Status | Doc |
+|---|---|---|---|
+| 0 | Foundations | ✅ closed | [phase-0-foundations.md](phase-0-foundations.md) |
+| 1 | Engine bones | ✅ closed | [phase-1-engine-bones.md](phase-1-engine-bones.md) |
+| 2 | Card data + DSL | ✅ closed | [phase-2-card-data-and-dsl.md](phase-2-card-data-and-dsl.md) |
+| 3 | Skill-test end-to-end | 🟡 in progress | [phase-3-skill-test-end-to-end.md](phase-3-skill-test-end-to-end.md) |
+| 4 | Scenario plumbing | ⏳ planned | [phase-4-scenario-plumbing.md](phase-4-scenario-plumbing.md) |
+| 5 | Server + persistence | 📐 architecture only | [phase-5-server-and-persistence.md](phase-5-server-and-persistence.md) |
+| 6 | Web client v0 | 📐 architecture only | [phase-6-web-client-v0.md](phase-6-web-client-v0.md) |
+| 7 | The Gathering | 📐 architecture only | [phase-7-the-gathering.md](phase-7-the-gathering.md) |
+| 8 | Multiplayer + auth | 📐 architecture only | [phase-8-multiplayer-and-auth.md](phase-8-multiplayer-and-auth.md) |
+| 9 | Campaign + Night of the Zealot | 📐 architecture only | [phase-9-campaign-and-night-of-the-zealot.md](phase-9-campaign-and-night-of-the-zealot.md) |
+| 10 | Dunwich + iteration | 📐 architecture only | [phase-10-dunwich-and-iteration.md](phase-10-dunwich-and-iteration.md) |
+
+**Status legend:**
+- ✅ **closed** — milestone closed; docs are retrospective.
+- 🟡 **in progress** — issues filed and being worked; doc has live status.
+- ⏳ **planned** — issues filed but work not started; doc has issue list + dependency notes; ordering may be TBD.
+- 📐 **architecture only** — no issues filed yet; doc captures the strategy-phase decisions and explicit scoping TBDs.
+
+## Cross-cutting / unmilestoned work
+
+Some issues don't belong to a single phase. They live unmilestoned with `p2-later` labels and get picked up when convenient:
+
+- `#26`, `#27`, `#28` — test-harness ergonomics (rename adders, total-event-count macro, with-investigator-at convenience).
+- `#31` — turn-order management cleanup (empty `turn_order` / `EndTurn` gracefully).
+- `#42` — card-data-pipeline test coverage expansion.
+- `#44` — DSL horror-soak / damage-redirect primitive (needed when soak-bearing cards land; tracked from PR-I).
+- `#83` — `enemy_attack` cleanup (apply both damage and horror when one defeats).
+- `#93` — split DSL types into a shared `card-dsl` crate (architectural improvement; not phase-gated).
+
+## Template
+
+Each phase doc follows this shape:
+
+1. **Status** — closed / in progress / planned / architecture only, with a date stamp.
+2. **Goal** — the milestone's one-liner.
+3. **Issues** — every issue in the milestone, linked, with current state.
+4. **Ordering** — Shape-B-style ordered plan, or "TBD" with rationale.
+5. **Decisions made** — settled architecture or design choices that shape later work.
+6. **Open questions** — what's not yet scoped.
+7. **Dependencies** — which prior phases this needs.
+8. **What "done" looks like** — the concrete demonstration that closes the phase.
+
+## Maintaining these docs
+
+- **When a phase issue closes:** update its line in the phase doc's Issues section (✅ closed) and add any design decision it cemented to the Decisions section.
+- **When a phase milestone closes:** flip the phase's Status to ✅, trim Open Questions to closed-out items only, and the doc becomes a retrospective.
+- **When the next phase starts:** flip its Status from ⏳ to 🟡, add Shape B if not already there.
+- **PR convention:** doc updates happen in the same PR that touches the underlying issue when natural; standalone "update phase docs" PRs are fine too.

--- a/docs/phases/phase-0-foundations.md
+++ b/docs/phases/phase-0-foundations.md
@@ -1,0 +1,36 @@
+# Phase 0 — Foundations
+
+## Status
+
+✅ Closed.
+
+## Goal
+
+Empty repo with green CI and a working dev loop.
+
+## Issues (all closed)
+
+- `#1` — license + replace stub README with disclaimer + quick-start.
+- `#2` — `.gitignore` + `rust-toolchain.toml`.
+- `#3` — cargo workspace skeleton with six crates (`game-core`, `cards`, `scenarios`, `server`, `web`, `card-data-pipeline`).
+- `#4` — hello-world Axum endpoint on `server` crate.
+- `#5` — hello-world Leptos page on `web` crate.
+- `#6` — choose Leptos toolchain (Trunk vs. cargo-leptos), document dev loop.
+- `#7` — CI workflow (`fmt`, `clippy`, `test`, `doc`, `wasm-build`).
+- `#8` — issue + PR templates.
+- `#9` — Dependabot config.
+
+## Decisions made
+
+- **Workspace layout** of six crates, organized by work-type seams: engine churn (`game-core`) vs. content (`cards`, `scenarios`) vs. UI (`web`) vs. server (`server`) vs. tooling (`card-data-pipeline`). Each crate boundary lets that kind of work iterate without forcing the others to recompile.
+- **Toolchain pinned via `rust-toolchain.toml`** so contributors and CI use the same Rust version.
+- **Dev loop** is two terminals (server on `:8000`, Trunk serving the web dep on `:3000` with proxy back to the server) — pure CSR, no SSR. The web crate is behind auth in production; SEO isn't a concern.
+- **CI matrix** is five jobs (`fmt`, `clippy`, `test`, `doc`, `wasm-build`), all with warnings-as-errors. `--all-features` is on for `test` so feature-gated test-support modules build.
+
+## Dependencies
+
+None. This is the bottom of the stack.
+
+## What "done" looked like
+
+`cargo test --all --all-features` green; `cargo build -p web --target wasm32-unknown-unknown` green; CI on every PR green.

--- a/docs/phases/phase-1-engine-bones.md
+++ b/docs/phases/phase-1-engine-bones.md
@@ -1,0 +1,34 @@
+# Phase 1 — Engine bones
+
+## Status
+
+✅ Closed.
+
+## Goal
+
+Engine can apply actions and emit events; test harness ready.
+
+## Issues (all closed)
+
+- `#14` — core state types + `Action` / `Event` enums.
+- `#15` — `apply()` loop + `EngineOutcome`.
+- `#16` — deterministic RNG + RNG actions.
+- `#17` — phase machine + action points.
+- `#18` — fluent `TestGame` builder.
+- `#20` — event-assertion macros.
+
+## Decisions made
+
+- **`apply(state, action) -> ApplyResult`** is the only entry point for state mutation. The action log is a flat `Vec<Action>`; replaying from initial state reproduces current state bit-for-bit.
+- **Validate-first / mutate-second** as the per-handler convention: every dispatch handler checks every precondition before any mutation. On rejection, neither state nor events should be touched. The apply loop has a belt-and-suspenders `events.clear()` on `Rejected`. (Convention, not yet structurally enforced; tracked in the `apply()` doc as a TODO.)
+- **Deterministic RNG** via `RngState { seed, draws }` + ChaCha8. Reconstructed on demand from the state; deck shuffles and chaos-token draws are reproducible from the action log.
+- **Fluent `TestGame` builder** as the single source of test-state-construction defaults. Adders are `with_*`; build is terminal. Fixtures `test_investigator(id)`, `test_location(id, name)`, `test_enemy(id, name)` provide reasonable defaults.
+- **Event-assertion macros** are order-insensitive by default: `assert_event!`, `assert_no_event!`, `assert_event_count!`. Plain `assert_eq!` on the events slice when exact contiguous order matters. (`assert_event_sequence!` for subsequence-in-order checks landed later, in PR `#95`.)
+
+## Dependencies
+
+Phase 0 (foundations).
+
+## What "done" looked like
+
+Engine compiles to native + wasm32; `apply` round-trips deterministically; `TestGame` builder + macros + fixtures available; first test cases pass.

--- a/docs/phases/phase-10-dunwich-and-iteration.md
+++ b/docs/phases/phase-10-dunwich-and-iteration.md
@@ -21,7 +21,7 @@ From the 2026-05-01/02 strategy phase:
 ⏳ **Scoping TBD.** When Phase 9 closes, file:
 
 - **The Dunwich Legacy campaign module.** Eight scenarios: Extracurricular Activity, The House Always Wins, The Miskatonic Museum, The Essex County Express, Blood on the Altar, Undimensioned and Unseen, Where Doom Awaits, Lost in Time and Space. Plus the Lita Chantler / Jenny Barnes etc. campaign-wide investigator availability.
-- **Dunwich card implementations.** All ~~330+ cards across the cycle. Substantial.~~ The unimplemented cards are scoped at deck-import time per the project's "no manual-resolution fallback" rule — every card a player wants to use needs an implementation. Iterative.
+- **Dunwich card implementations.** Substantial volume — hundreds of cards across the cycle. Per the project's "no manual-resolution fallback" rule, every card a player wants to use needs an implementation; the deck-import gate enforces this. Iterative.
 - **Encounter sets specific to Dunwich.** New encounter sets per scenario.
 - **New DSL primitives surfaced by Dunwich cards.** Some Dunwich cards will need primitives that Core didn't (horror redirect / damage soak with state — `#44` already filed; conditional `Effect::If` consumers with richer predicates; etc.).
 - **Polish backlog.** Whatever rough edges Phases 5–9 left. UX improvements, error-message tweaks, performance.

--- a/docs/phases/phase-10-dunwich-and-iteration.md
+++ b/docs/phases/phase-10-dunwich-and-iteration.md
@@ -1,0 +1,50 @@
+# Phase 10 — Dunwich + iteration
+
+## Status
+
+📐 Architecture only. No issues filed.
+
+## Goal
+
+Full Core + Dunwich coverage; ongoing polish.
+
+## Decisions made
+
+From the 2026-05-01/02 strategy phase:
+
+- **Scope (POC):** Core Set + Dunwich Legacy cycle only. Don't pre-build infrastructure for cycles beyond Dunwich, but the effect system must be extensible enough that adding cycles later is mechanical work, not a rewrite.
+- **Old-format Dunwich** (deluxe expansion + 6 mythos packs: `dwl`, `tmm`, `bota`, `uau`, `wda`, `litas`, `tece`) is what `data/arkhamdb-snapshot/` carries. Old format is the source of truth.
+- **Dunwich-specific mechanics that didn't exist in Core:** investigator-skill commits across distances, more complex enemy abilities, multi-phase scenarios with new structural patterns. Each gets scoped when its first card / scenario needs it.
+
+## Open questions
+
+⏳ **Scoping TBD.** When Phase 9 closes, file:
+
+- **The Dunwich Legacy campaign module.** Eight scenarios: Extracurricular Activity, The House Always Wins, The Miskatonic Museum, The Essex County Express, Blood on the Altar, Undimensioned and Unseen, Where Doom Awaits, Lost in Time and Space. Plus the Lita Chantler / Jenny Barnes etc. campaign-wide investigator availability.
+- **Dunwich card implementations.** All ~~330+ cards across the cycle. Substantial.~~ The unimplemented cards are scoped at deck-import time per the project's "no manual-resolution fallback" rule — every card a player wants to use needs an implementation. Iterative.
+- **Encounter sets specific to Dunwich.** New encounter sets per scenario.
+- **New DSL primitives surfaced by Dunwich cards.** Some Dunwich cards will need primitives that Core didn't (horror redirect / damage soak with state — `#44` already filed; conditional `Effect::If` consumers with richer predicates; etc.).
+- **Polish backlog.** Whatever rough edges Phases 5–9 left. UX improvements, error-message tweaks, performance.
+- **CI strictness expansion.** Add test coverage gates? Property-test infrastructure?
+
+## Dependencies
+
+- All prior phases. This is the endgame for the POC.
+
+## What "done" looks like
+
+A friend group can pick any investigator from Core + Dunwich, build a legal deck on arkham.build, import it, and play through any Core or Dunwich Legacy scenario. The Dunwich Legacy campaign can be played start-to-finish. The simulator becomes a credible "play Arkham Horror with my friends online without owning the cards" experience.
+
+## Beyond Phase 10
+
+Out of scope for the POC; revisit only if the project grows past friends-only:
+
+- The Path to Carcosa (later cycle).
+- The Forgotten Age, Circle Undone, etc.
+- 2026 Chapter 2 Core Set (new investigators, new mechanics — separate game generation).
+- Revised Core Set (functionally identical to original Core; would just be a card-code remap).
+- The new-format Investigator Expansion / Campaign Expansion split.
+- Public hosting, account self-service, abuse handling.
+- Mobile UX.
+
+These all stay deferred until they're concretely needed, per the "build to a 'make game night work' bar" posture.

--- a/docs/phases/phase-2-card-data-and-dsl.md
+++ b/docs/phases/phase-2-card-data-and-dsl.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-✅ Closed (5/8). Cards `#37` Magnifying Glass, `#38` Hyperawareness, `#39` Deduction, and the per-skill-test scope extension `#45` moved to phase-3-skill-test-end-to-end where their blocking primitives land naturally with the engine evaluator.
+✅ Closed. Original scope had 8 issues; 4 (`#37`, `#38`, `#39`, `#45`) migrated to Phase 3 where their blocking primitives land naturally with the engine evaluator, leaving 5 issues in the milestone proper (all closed).
 
 ## Goal
 

--- a/docs/phases/phase-2-card-data-and-dsl.md
+++ b/docs/phases/phase-2-card-data-and-dsl.md
@@ -1,0 +1,48 @@
+# Phase 2 — Card data + DSL
+
+## Status
+
+✅ Closed (5/8). Cards `#37` Magnifying Glass, `#38` Hyperawareness, `#39` Deduction, and the per-skill-test scope extension `#45` moved to phase-3-skill-test-end-to-end where their blocking primitives land naturally with the engine evaluator.
+
+## Goal
+
+Framework + DSL v0 + 2 validating cards.
+
+## Issues
+
+| Issue | Status |
+|---|---|
+| `#32` — commit pinned ArkhamDB JSON snapshot | ✅ closed |
+| `#33` — `card-data-pipeline` binary + generated module layout | ✅ closed |
+| `#34` — DSL v0 primitive set | ✅ closed |
+| `#35` — Holy Rosary (01059) | ✅ closed |
+| `#36` — Working a Hunch (01037) | ✅ closed |
+| `#37` — Magnifying Glass (01030) | ➡️ moved to Phase 3 (closed there) |
+| `#38` — Hyperawareness (01034) | ➡️ moved to Phase 3 (closed there) |
+| `#39` — Deduction (01039) | ➡️ moved to Phase 3 (still open there) |
+| `#45` — per-skill-test-kind modifier scope | ➡️ moved to Phase 3 (closed there) |
+
+## Decisions made
+
+- **Card-data sourcing** is a pinned snapshot of `Kamalisk/arkhamdb-json-data` under `data/arkhamdb-snapshot/`. Updates are manual, not auto-synced — a malformed upstream entry can't surprise the build.
+- **Scope** is original Core + Dunwich Legacy cycle only. Other packs land in later phases.
+- **Generated card metadata** lives in `crates/cards/src/generated/cards.rs`, produced by `cargo run -p card-data-pipeline`. Hand-edits are overwritten on the next pipeline run; the file is marked GENERATED.
+- **DSL primitives v0**:
+  - Triggers: `Constant`, `OnPlay`, `OnCommit`. (Phase-3 adds `Activated`; later phases add `OnEvent`, `OnLeavePlay`, reactions.)
+  - Effects: `GainResources`, `DiscoverClue`, `Modify`, `Seq`, `If`, `ForEach`, `ChooseOne`.
+  - Scopes: `WhileInPlay`, `ThisSkillTest`, `ThisTurn`. (Phase-3 adds `WhileInPlayDuring(SkillTestKind)`.)
+  - Targets: `Controller`, `Active`, `ChosenByController` (investigator); `ControllerLocation`, `ChosenByController` (location).
+- **Cards are Rust source**, typed and compiler-checked. Each card has a `crates/cards/src/impls/<name>.rs` module exposing `CODE: &str` + `abilities() -> Vec<Ability>`. The registry dispatch `cards::abilities_for(code)` is the single source of "what does this card do."
+- **A card is *playable* iff it has an `abilities()` implementation.** Cards without one are in the corpus (for deckbuilding visibility) but refused by PlayCard and the future deck-import gate.
+
+## Dependencies
+
+Phases 0–1.
+
+## What "done" looked like
+
+`cards::abilities_for("01059")` returns Holy Rosary's `+1 willpower while in play` ability; `cards::abilities_for("01037")` returns Working a Hunch's `on-play discover-clue` ability. Pipeline regeneration is idempotent.
+
+## Retrospective notes
+
+The `#37`/`#38`/`#39`/`#45` move to Phase 3 was the right call. The DSL extensions they needed (per-skill-test scope, `Activated` trigger, `OnCommit` consumer) belong with the evaluator wire-up that Phase 3 was already going to do — separating them would have meant duplicate test scaffolding.

--- a/docs/phases/phase-3-skill-test-end-to-end.md
+++ b/docs/phases/phase-3-skill-test-end-to-end.md
@@ -1,0 +1,128 @@
+# Phase 3 — Skill-test end-to-end
+
+## Status
+
+🟡 In progress. 14 closed / 7 open as of 2026-05-16.
+
+## Goal
+
+Full skill test sequence runs through the engine in tests — with real-card metadata + abilities end-to-end.
+
+## Issues
+
+### Closed (14)
+
+| # | Title | Notes |
+|---|---|---|
+| `#37` | Magnifying Glass (01030) | First new card after the Phase-3 demo; composes `#87` + `#45`. |
+| `#38` | Hyperawareness (01034) | Exercises `Trigger::Activated` + `ThisSkillTest` push end-to-end. |
+| `#45` | per-skill-test-kind modifier scope | Adds `ModifierScope::WhileInPlayDuring(SkillTestKind)`. |
+| `#47` | DSL evaluator (Effect → state mutation) | Initial scaffold with stubs for non-leaf effects. |
+| `#48` | chaos bag draw + token modifier resolution | `resolve_token` + `TokenResolution`. |
+| `#49` | skill-test resolution flow | `resolve_skill_test`. |
+| `#50` | Move action + action-point spending | First non-trivial player action. |
+| `#51` | Investigate action | First skill-test-initiating action. |
+| `#53` | DSL Activated trigger + cost primitives | `Trigger::Activated`, `Cost` enum, `Ability.costs`. |
+| `#87` | per-instance card state | `CardInPlay` struct + `CardInstanceId` + counter. |
+| `#88` | cards-registry binding | Cross-crate bridge. Option 3 (static `OnceLock` + `fn`-pointer struct). |
+| `#89` | PlayCard action | Asset → in-play; event → discard. |
+| `#92` | constant-modifier query during skill-test resolution | Closes the Phase-3 demo: Holy Rosary `+1 willpower` actually applies. |
+| `#102` | `ThisSkillTest` modifier accumulator | Pushed + drained on `SkillTestEnded`. |
+
+### Open (7)
+
+| # | Title | Notes |
+|---|---|---|
+| `#19` | deterministic `ChoiceResolver` | Test infra for `AwaitingInput` round-trips; foundational for `#63` and `#52`. |
+| `#39` | Deduction (01039) | Needs `#63` (skill-test commits) or `#64` (after-resolution trigger). |
+| `#52` | reaction windows + trigger ordering | Needs `#54` + `#19`. The largest remaining engine piece. |
+| `#54` | DSL `OnEvent` trigger | Small extension; unblocks `#52` and `#55` Roland Banks. |
+| `#55` | Roland Banks investigator (01001) | Needs `#54` + `#52`. |
+| `#56` | Study location (01111) | Needs a location-state shape decision; thinnest issue body. |
+| `#63` | skill-test card commits from hand | Needs `#19` (commit AwaitingInput). |
+| `#64` | skill-test after-resolution trigger window | Needs `#54` (OnEvent) + `#19`. |
+
+## Ordering (Shape B)
+
+The Phase-3 work was split into two arcs:
+
+### Arc 1: the demonstration (closed 2026-05-15 to 2026-05-16)
+
+Three PRs to demonstrate "skill test runs through the engine on real cards":
+
+1. `#88` cards-registry binding (PR #94)
+2. `#89` PlayCard + OnPlay (PR #95)
+3. `#92` constant-modifier query (PR #98)
+
+End state: Holy Rosary's `+1 willpower` applies during a real willpower skill test; Working a Hunch resolves on-play end-to-end.
+
+### Arc 2: completing the milestone (in progress)
+
+Cards rather than infra-first. Build the minimal infra each card needs, ship the card, repeat. Gives steady "new card works" wins instead of ~8 infra PRs before any new card lands.
+
+| # | PR / planned step | Status |
+|---|---|---|
+| 1 | `#87` per-instance card state | ✅ PR #99 |
+| 2 | `#45` per-skill-test-kind scope | ✅ PR #100 |
+| 3 | `#37` Magnifying Glass | ✅ PR #101 |
+| 4 | `#53` Activated trigger + cost primitives | ✅ PR #104 |
+| 5 | `#102` `ThisSkillTest` accumulator | ✅ PR #105 |
+| 6 | `#38` Hyperawareness | ✅ PR #106 |
+| 7 | `#19` ChoiceResolver | ⏳ next |
+| 8 | `#63` skill-test commits | needs `#19` |
+| 9 | `#39` Deduction | needs `#63` (or `#64`) |
+| 10 | `#54` OnEvent trigger | small |
+| 11 | `#52` reaction windows | needs `#54` + `#19`; largest remaining piece |
+| 12 | `#55` Roland Banks | needs `#54` + `#52` |
+| 13 | `#56` Study | needs location-state design; defer or build alongside Phase 4 |
+| 14 | `#64` after-resolution trigger window | cleanup; alt path for Deduction was via `#63` |
+
+## Decisions made
+
+- **CardRegistry pattern (`#88`).** Engine cannot import the `cards` crate (would cycle); instead, `game_core::card_registry` holds a `OnceLock<CardRegistry>` with two `fn` pointers. `cards::REGISTRY` is the static value the host installs once at startup. Tests that don't touch card data don't need to install one. Considered four options; option 3 (static + `fn` pointer struct) won on test ergonomics. Tracked design alt-history: `#93` (three-crate `card-dsl` split) is the cleaner long-term layering; not blocked on by current work.
+- **`#[non_exhaustive]` lifted on `CardMetadata`.** The only construction site is the pipeline-generated corpus in a different crate. Other types (enums) keep their `#[non_exhaustive]` because their guard is different.
+- **`PlayCard` routing (`#89`).** Only `Asset` and `Event` are playable from hand. Every other `CardType` rejects with a single generic message — no special-case explanations. (User's call: "encoding future functionality in error messages.")
+- **Per-instance card state (`#87`).** `Investigator.cards_in_play: Vec<CardInPlay>` replaces `Vec<CardCode>`. `CardInPlay { code, instance_id, exhausted, uses: BTreeMap<UseKind, u8>, accumulated_damage, accumulated_horror }`. `GameState.next_card_instance_id: u32` counter.
+- **DSL `SkillTestKind` lives in `dsl.rs`**, not `state`. Keeps dsl's pure-types isolation (mirrors `Stat`'s position as a DSL classifier). The engine imports it.
+- **`Trigger::Activated { action_cost: u8 }` + `Cost` enum (`#53`).** Action cost separated from arbitrary payment costs so validation and event emission stay clean. `Cost::DiscardCardFromHand` exists as a variant but the handler stubs it pending `#19`.
+- **`#53` acceptance was split into two PRs.** The literal issue acceptance included "Hyperawareness lands using the new primitives." Splitting into `#53` (DSL + dispatch) + `#102` (`ThisSkillTest` accumulator) + `#38` (Hyperawareness card) keeps each PR focused, mirroring the `#88`/`#89` and `#45`/`#37` patterns.
+- **Investigation-phase + active-investigator gate on `PlayCard`/`ActivateAbility` is overly strict for Fast abilities.** No-op for Phase-3 scope (only Investigation phase exists); `#103` lifts the gate when phase content lands.
+- **`test-support` Cargo feature dropped (PR #104).** `pub mod test_support` is now unconditional. Surfaced during `#53` review when the integration-test binary failed to compile without `--all-features`. The feature gated nothing in practice (only consumer was `cards`, which always enabled it).
+- **Event-sequence macro `assert_event_sequence!` added (PR #95).** The file's own "don't add preemptively" note had been waiting for a concrete first user; Working a Hunch's ordering test was that user.
+
+## Open questions
+
+- **`#56` Study (location).** Locations have a state shape (shroud, clues, connections), but printed locations also have abilities — Reveal effects, on-enter triggers. The shape for location abilities isn't yet decided. Could land alongside Phase-4 scenario plumbing (`#74` scenario module skeleton) where the location-handling shape gets settled.
+- **`#39` Deduction routing.** The card text is "if your skill test is successful while investigating, discover 1 additional clue at that location" — fires after a successful Investigate, off a card committed from hand. Two viable paths:
+  - Via `#63` commits from hand → `Trigger::OnCommit` + `Condition::SkillTest { outcome: Success }`.
+  - Via `#64` after-resolution trigger window → reactive consumer of a `SkillTestSucceeded` event.
+  Pick when implementing.
+- **`#19` ChoiceResolver scope.** A test helper for scripted `AwaitingInput` responses. Today no choice-point exists. Lands when the first consumer needs it (`#63` is the natural first).
+
+## Dependencies
+
+Phases 0–2.
+
+## What "done" looks like
+
+Skill test runs through the engine in tests against real-card metadata + abilities, with the full Phase-3-tagged card set implemented:
+- Magnifying Glass `+1 intellect while investigating` ✓
+- Hyperawareness `[fast] Spend 1 resource: +1 stat for this skill test` ✓
+- Deduction commit-from-hand triggered effect
+- Roland Banks investigator with his reaction ability
+- Study location with whatever its printed abilities require
+
+End-to-end integration tests in `crates/cards/tests/` cover each card.
+
+## Side work shipped during the Phase-3 timeline
+
+Engine work that happened in parallel but isn't milestoned to Phase 3. Captured for narrative completeness; the milestone closure check doesn't gate on these.
+
+| # | Title | Status | Why during Phase 3 |
+|---|---|---|---|
+| `#62` | player decks + hands + cards-in-play state | ✅ | Foundational for `#87` + `#89`. |
+| `#67` | enemy state + Fight / Evade actions | ✅ | Natural continuation of `#50` Move. |
+| `#78` | attack of opportunity + engaged-enemy follow | ✅ | Combat completion. |
+| `#80` | investigator defeat: detection, state, action gating | ✅ | Combat side effect. |
+| `#84` | Draw action | ✅ | Player-deck consumer. |
+| `#85` | Mulligan | ✅ | Scenario-setup hand redraw. |

--- a/docs/phases/phase-3-skill-test-end-to-end.md
+++ b/docs/phases/phase-3-skill-test-end-to-end.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-🟡 In progress. 14 closed / 7 open as of 2026-05-16.
+🟡 In progress. 14 closed / 8 open as of 2026-05-16.
 
 ## Goal
 
@@ -29,7 +29,7 @@ Full skill test sequence runs through the engine in tests — with real-card met
 | `#92` | constant-modifier query during skill-test resolution | Closes the Phase-3 demo: Holy Rosary `+1 willpower` actually applies. |
 | `#102` | `ThisSkillTest` modifier accumulator | Pushed + drained on `SkillTestEnded`. |
 
-### Open (7)
+### Open (8)
 
 | # | Title | Notes |
 |---|---|---|

--- a/docs/phases/phase-4-scenario-plumbing.md
+++ b/docs/phases/phase-4-scenario-plumbing.md
@@ -1,0 +1,70 @@
+# Phase 4 — Scenario plumbing
+
+## Status
+
+⏳ Planned. Issues filed; no work started. Begins after Phase 3 closes.
+
+## Goal
+
+Toy scenario plays setup to resolution in tests.
+
+## Issues (8 open)
+
+| # | Title | Notes |
+|---|---|---|
+| `#74` | scenario module skeleton: setup, detect_resolution, apply_resolution | The architectural anchor; everything else attaches to this shape. |
+| `#72` | encounter deck state: shuffled deck of treacheries + enemies | The source mythos cards draw from. |
+| `#69` | Mythos phase content: encounter deck draw + treachery resolution | Consumes `#72`. |
+| `#70` | Upkeep phase content: ready cards, draw 1, gain 1 resource | Refreshes the round. |
+| `#71` | Enemy phase content: enemy attacks + hunter movement | Reuses the `enemy_attack` machinery already shipped during Phase 3. |
+| `#73` | act + agenda decks, doom counter, threshold-based agenda advance | The scenario-progression mechanic. |
+| `#75` | campaign log + `Fact` enum + scenario sequencing | Bridges to Phase 9 campaigns. |
+| `#103` | player windows + Fast-ability gating across windows | Filed during `#53` to lift the Investigation-phase-only gate once non-Investigation phases exist. |
+
+## Ordering
+
+⏳ **TBD.** Rough sketch based on dependency reasoning:
+
+1. `#74` scenario module skeleton — defines the shape everything else conforms to.
+2. `#72` encounter deck state — independent of #74's API beyond the state shape.
+3. `#69` / `#70` / `#71` — phase content (Mythos / Upkeep / Enemy), each adding a phase to the round cycle. Probably tackle one at a time.
+4. `#73` act + agenda + doom — scenario progression mechanic on top of phase content.
+5. `#75` campaign log + `Fact` enum + sequencing — wraps the scenario as a campaign step.
+6. `#103` player windows — lifts the Investigation-phase-only gate on `PlayCard` / `ActivateAbility` once non-Investigation phases are real.
+
+Refine when this phase opens. The actual order may interleave depending on what a "toy scenario" demonstration ends up requiring.
+
+## Decisions made
+
+From the 2026-05-01/02 strategy phase, locked in:
+
+- **Scenarios = code, not pure data.** Each scenario is a Rust module exposing `setup()`, `detect_resolution()`, `apply_resolution()`, and may register scenario-specific rules.
+- **Act + agenda cards** use the standard card DSL with scenario-specific verbs (`advance_act_deck`, `add_doom`).
+- **Encounter sets** are pure data — lists of card codes.
+- **`arkham-cards-data` is a great structured reference** but cannot be fed directly into the simulator (it's written for a guide app, not an executing engine). Read manually, write our own scenario modules.
+- **Mid-scenario resume** required. A scenario abandoned in progress must be resumable from the action log. (Already true at the engine level by virtue of the event-sourcing model.)
+
+## Open questions
+
+- **Toy scenario choice.** What's the simplest possible scenario for the "toy scenario plays setup to resolution" demonstration? Probably a custom 1-location, 1-enemy, 1-act, 1-agenda scenario used only for testing — not a real published scenario (those land in Phase 7).
+- **Treachery resolution shape.** Treacheries from the encounter deck don't yet have a DSL representation. `Trigger::OnEvent` (`#54`) and the on-draw effect path need scoping.
+- **Hunter movement rules.** Hunter enemies move toward the nearest investigator; how that target-selection plays with the existing location-connection graph needs design.
+- **Location-state shape.** Locations today have shroud / clues / connections / revealed. Phase 4 will need to surface reveal-effects, on-enter triggers, etc. — see also Phase-3 `#56` Study, which is in the awkward position of being a card without a defined home for its abilities.
+- **Player windows model (`#103`).** Filed but not yet designed in detail. Will share state shape with `#52` reaction windows (consider unifying).
+
+## Dependencies
+
+Phase 3 — needs the skill-test machinery, action handlers, and DSL evaluator. Specifically Phase-3 issues that gate Phase-4 work:
+- `#52` reaction windows — Phase-4 phase content emits events that triggered abilities react to.
+- `#54` `OnEvent` trigger — DSL extension for the above.
+- Everything else in Phase 3 should be closed by the time Phase 4 starts.
+
+## What "done" looks like
+
+A custom toy scenario (a few locations, a handful of encounter cards, an act and agenda deck) plays from setup through a resolution in tests:
+
+- Engine cycles through Mythos / Investigation / Enemy / Upkeep phases.
+- An act advances when a clue threshold is met; the scenario resolves.
+- Or doom advances on the agenda and the scenario resolves the other way.
+- `detect_resolution()` fires at the right moment; `apply_resolution()` writes campaign-log facts.
+- Mid-scenario state can be serialized + replayed identically.

--- a/docs/phases/phase-5-server-and-persistence.md
+++ b/docs/phases/phase-5-server-and-persistence.md
@@ -1,0 +1,45 @@
+# Phase 5 — Server + persistence
+
+## Status
+
+📐 Architecture only. No issues filed.
+
+## Goal
+
+Engine on Axum + SQLite event log; reconnect works.
+
+## Decisions made
+
+From the 2026-05-01/02 strategy phase:
+
+- **Wire protocol:** server-authoritative event streaming. Browsers send `PlayerAction`s; server validates, applies, emits events, appends to the log, broadcasts events to all connected browsers. Browsers apply events to a local view for rendering only — never authoritative.
+- **Persistence model:** event-sourced. Game state is *derived* by replaying the action log; periodic snapshots are a perf optimization, not the source of truth.
+- **Action log granularity:** fine-grained. Every token reveal, skill-test modifier, commit is its own event. Per-player UI-only actions (browsing hand, hovering cards) do NOT go in the global log.
+- **Two log streams:**
+  - **Action log** (in DB) — the gameplay event sequence per scenario, load-bearing for resume / undo / replay / debug.
+  - **Operational logs** (`tracing` crate) — server-application logs (connections, errors, timing). Different purposes; different homes.
+- **Hosting (v1):** smallest thing that works — single small VM ($5–10/mo) or self-host on home hardware. No k8s, no autoscaling, no CDN. A single Dockerfile is cheap insurance for portability but not required for v1.
+- **Production form:** the server binary serves the API/websocket and the static WASM bundle on one port. (Two ports only in dev.)
+
+## Open questions
+
+⏳ **Scoping TBD.** Issues for this phase haven't been filed. When Phase 4 closes, file:
+
+- **Database schema and migration tooling.** SQLite, likely with `sqlx` or `rusqlite`. Migration strategy.
+- **Event-log schema.** One table per scenario with `(scenario_id, sequence_number, action_json)` rows? Or normalized? Tradeoff between query convenience and replay simplicity (a flat blob is simpler).
+- **Periodic state snapshots** for resume performance. Every N actions? Every X minutes?
+- **Websocket session model.** One websocket per player per scenario? Reconnect-with-resume-token?
+- **Action validation flow.** `PlayerAction` parsing at the wire boundary, then `apply()`, then broadcast. Error paths for rejected actions.
+- **`game-core` ↔ server boundary.** `game-core` stays pure (no I/O); the server is the host that loads/saves state and applies actions. Define the trait or function surface server uses.
+- **Mid-scenario resume mechanics.** A scenario abandoned in progress reloads from log → state, players reconnect, engine continues.
+
+## Dependencies
+
+- Phase 4 (scenario plumbing) — server needs a complete-enough engine to actually persist meaningful state.
+- Phase 0 server hello-world (already shipped) gives us Axum + Tokio scaffolding to grow into.
+
+## What "done" looks like
+
+- Two browsers can connect to a running server, both see the same scenario state.
+- Closing both browsers, restarting the server, and reconnecting reproduces the exact state via action-log replay.
+- Reconnecting a single browser mid-scenario picks up where it left off without losing in-flight choices.

--- a/docs/phases/phase-6-web-client-v0.md
+++ b/docs/phases/phase-6-web-client-v0.md
@@ -1,0 +1,43 @@
+# Phase 6 — Web client v0
+
+## Status
+
+📐 Architecture only. No issues filed.
+
+## Goal
+
+Toy scenario playable in browser, solo.
+
+## Decisions made
+
+From the 2026-05-01/02 strategy phase:
+
+- **Frontend stack:** Rust + WASM, Leptos as the framework (leading candidate in the Rust UI space as of 2026-05). Language cohesion (same Rust everywhere, shared `game-core` types) over UI-ecosystem breadth.
+- **Trade-off acknowledged:** smaller UI ecosystem than React, larger bundles, slower iteration on UI work. Acceptable for the project's hobby-scale audience.
+- **Exit ramp:** if Rust/WASM proves to hinder the project too much, pivot to React. Plan accordingly — keep the boundary between `game-core` (forever, used by both server and client) and the UI layer (potentially replaceable) clean so a future pivot wouldn't require rewriting the engine.
+- **CSR-only, no SSR.** App is behind auth; no SEO concern. Dev loop uses Trunk's dev server proxying API/websocket to the server.
+- **Card art:** link to ArkhamDB's CDN URLs with text-only fallback. Do NOT re-host art (their CDN, their problem; also keeps us off the radar legally).
+- **The `web` crate is the only one that compiles to wasm32 in production.** `game-core` happens to also compile to wasm32 because it's pure — that's load-bearing (server and client share engine code).
+
+## Open questions
+
+⏳ **Scoping TBD.** Issues haven't been filed. When Phase 5 closes, file:
+
+- **Component model.** What's the granularity of a Leptos component? Per-card? Per-zone (hand, in-play, discard)? Per-investigator?
+- **State management.** How does the client maintain a derived view of `GameState` from the event stream? Direct `apply()` on a local copy?
+- **Player-input UX.** Click a card → submit `PlayerAction::PlayCard`. Drag-drop for commits? Hover for card text? Card-zoom on focus?
+- **Choice UX.** When the engine emits `AwaitingInput`, present the choice via modal? Inline? Per-prompt-kind component dispatch?
+- **Card image strategy.** Link to ArkhamDB CDN URLs; cache locally? Text-only fallback for missing art?
+- **Auth UX.** Phase 8 sets up OAuth; Phase 6 needs at least a stub login-or-bust gate (or be served behind the auth middleware that Phase 8 lands).
+- **Two-process dev loop ergonomics.** Document the standard developer dance (server + Trunk concurrently, what to restart when, common gotchas).
+
+## Dependencies
+
+- Phase 5 (server + persistence) — the client connects to and depends on a working server.
+- Phase 0 hello-world Leptos page (already shipped) gives us a Trunk-buildable skeleton.
+
+## What "done" looks like
+
+- Phase-4's toy scenario plays in the browser, solo, with the human-facing actions (Move / Investigate / PlayCard / EndTurn / Mulligan) all clickable.
+- The scenario runs to a resolution; resolution effects are visible in the campaign log (or wherever Phase 4 lands campaign-log surfacing).
+- Reconnect-mid-scenario works at the UX level — closing the tab and reopening picks up where the session left off.

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -1,0 +1,44 @@
+# Phase 7 — The Gathering
+
+## Status
+
+📐 Architecture only. Two issues filed (`#65`, `#77`) tagged here; the rest TBD.
+
+## Goal
+
+First real scenario playable in browser, solo, all 5 investigators.
+
+## Issues (filed)
+
+| # | Title | Notes |
+|---|---|---|
+| `#65` | skill-test other-investigator commits | Needed for multi-investigator commit scenarios; tagged Phase 7 because that's the first real-card consumer. |
+| `#77` | Parley + Engage actions | Basic player actions needed for full scenario coverage. |
+
+## Decisions made
+
+- **The Gathering** is the first scenario of the original Core Set's *Night of the Zealot* campaign. Three locations to start (Study + connections), with the campaign expanding from there.
+- **"Solo with 1–2 investigators" is the supported mode** for this phase. Multiplayer (two human investigators on different machines) is Phase 8.
+- **All 5 original-Core investigators implementable:** Roland Banks (`#55`, already filed in Phase 3), Daisy Walker, "Skids" O'Toole, Agnes Baker, Wendy Adams. Each needs their card impl + signature cards.
+
+## Open questions
+
+⏳ **Scoping TBD.** When Phase 6 closes, file:
+
+- **Scenario module: The Gathering.** Locations, encounter set wiring, act/agenda decks, resolution conditions.
+- **Card implementations** for every card in The Gathering's encounter sets and every card in the five investigators' starter decks. Substantial volume.
+- **Investigator card implementations** for the 5 original-Core investigators. Each has stats, max-health/sanity, signature card pairings.
+- **Story-asset/weakness implementations.** Cover Up, Lita Chantler, Hospital Debts, etc. — the campaign-driven mods.
+- **Difficulty selection.** Easy / Standard / Hard / Expert chaos bags.
+- **Solo-with-2 UX.** One player controls two investigators; how does the client present that?
+
+## Dependencies
+
+- Phase 4 (scenario plumbing) — the scenario module API.
+- Phase 5 (server + persistence) — backing store.
+- Phase 6 (web client v0) — UI.
+- Phase 3 (`#55` Roland Banks, `#56` Study) — already filed there; these spill into Phase 7's coverage.
+
+## What "done" looks like
+
+A solo human, in the browser, picks an investigator, sets up The Gathering, plays through the scenario to a resolution. All five investigators are picker-eligible. The campaign log records the resolution's facts. Standard difficulty works correctly; harder difficulties may land here or in a polish pass.

--- a/docs/phases/phase-8-multiplayer-and-auth.md
+++ b/docs/phases/phase-8-multiplayer-and-auth.md
@@ -1,0 +1,41 @@
+# Phase 8 — Multiplayer + auth
+
+## Status
+
+📐 Architecture only. No issues filed.
+
+## Goal
+
+Two-machine multiplayer playthrough of The Gathering.
+
+## Decisions made
+
+From the 2026-05-01/02 strategy phase:
+
+- **Multiplayer model:** synchronous-only. All players online together (same room or Discord call assumed). If someone is missing, the group can't play. Don't invest in async-specific UX (turn-deadline reminders, per-turn push notifications).
+- **The event log gives us resume + undo + debugging for free; async is just not a target use case.**
+- **Auth (v1):** invite-only via GitHub / Google OAuth + a manual email allowlist. No signup flow, password reset, email verification, or abuse handling at v1 — those are the first things to revisit if scope ever expands.
+- **Audience and posture:** hobby project for the user and a small group of friends. Not commercial, not a public service, no monetization, no SLA. Build to a "make game night work" bar.
+- **Legal posture:** repo is public under MIT; "unofficial fan tool" disclaimer in README. No re-hosted card art. The "Eldritch" name avoids the "Arkham Horror" trademark — keep it that way.
+
+## Open questions
+
+⏳ **Scoping TBD.** When Phase 7 closes, file:
+
+- **Session/group model.** A "group" is a stable set of players; a "session" is one scenario play. Database tables for both.
+- **Lobby UX.** How do players gather before starting a scenario? Pre-game-share-link? Group-saved-state?
+- **Sync semantics.** When inv1 takes an action, inv2's client updates by replaying the broadcast events. Order of player inputs across the websocket has to be deterministic — server is authoritative on ordering.
+- **Disconnection mid-scenario.** What if a player drops? Can the group continue, or is the scenario paused until they reconnect?
+- **Cross-investigator UI.** Each player sees their own hand, the shared board state, and the other players' public information.
+- **OAuth flow.** GitHub + Google. Manual email allowlist gate (stored where? Config file, env var, or DB table?).
+- **Out-of-game communication.** No. Players use Discord etc. The app doesn't try to be a chat platform.
+
+## Dependencies
+
+- Phase 5 (server + persistence) — the websocket sync layer.
+- Phase 6 (web client v0) — the UI to host multiplayer.
+- Phase 7 (The Gathering) — a real scenario to multiplayer-test against.
+
+## What "done" looks like
+
+Two browsers on two machines, each logged in via OAuth, play through The Gathering together. The action log is consistent across both; either can disconnect and reconnect mid-game. Server gracefully handles the dropped session.

--- a/docs/phases/phase-9-campaign-and-night-of-the-zealot.md
+++ b/docs/phases/phase-9-campaign-and-night-of-the-zealot.md
@@ -1,0 +1,44 @@
+# Phase 9 — Campaign + Night of the Zealot
+
+## Status
+
+📐 Architecture only. No issues filed.
+
+## Goal
+
+Full Night of the Zealot campaign with deck import + progression.
+
+## Decisions made
+
+From the 2026-05-01/02 strategy phase:
+
+- **Campaign log** is a typed `enum Fact { LitaJoined, GhoulPriestKilled, PrisonersSaved(u8), … }` — compile-time safety; scenarios can't read or write a fact that doesn't exist or has the wrong shape.
+- **A campaign module is the top-level orchestrator:** scenario sequence + branching rules (`next_scenario(prev, resolution, log) -> Option<ScenarioId>`), between-scenario flows (deck upgrades, weakness draws, side stories), investigator persistence (decks, XP, trauma, alive/dead/insane).
+- **Campaign state stored as snapshots** — XP, decks, campaign log, trauma, surviving investigators. Changes slowly, between scenarios. The fine-grained action log lives at the scenario level. Each campaign record links to N scenario records.
+- **Deckbuilder: don't build one. Import + own.** Players build decks on arkham.build (or ArkhamDB) — already comfortable for the user's group, and deckbuilding rules (faction restrictions, level caps, taboo, customizable, parallel investigators) are arkham.build's problem.
+- **Eldritch fetches deck data at import**, validates every card has an implementation (this is the gate that enforces "unimplemented = unplayable"), and stores a snapshot.
+- **From import onward, Eldritch's copy is canonical** — story modifications (Lita joins, story weakness added) are applied to Eldritch's snapshot directly.
+- **Between scenarios, players re-import** an updated arkham.build URL; Eldritch diffs the new deck against (old + persistent story mods) and validates.
+- **Skip XP-cost validation at friends-only scale** — trust players to upgrade honestly, same as at a physical table.
+
+## Open questions
+
+⏳ **Scoping TBD.** When Phase 8 closes, file:
+
+- **`Fact` enum scoping.** Every Night of the Zealot fact needs an enum variant. Audit the campaign rules to enumerate them.
+- **Campaign module structure.** Trait + impl, or function-table, or plain Rust module per campaign?
+- **Deck importer.** Read arkham.build / ArkhamDB JSON; parse into `Vec<CardCode>`; validate every code has an implementation; reject otherwise. UX for "your deck has unimplemented cards" — list them by name.
+- **Story modifications.** When Lita joins, she's added as a permanent ally to the investigator's deck snapshot. Storage model: a "persistent story-asset" list per investigator-per-campaign.
+- **Weakness draws between scenarios.** Some campaign step adds a basic weakness; the player draws one (or the engine assigns one). Determinism via the campaign-level RNG.
+- **Trauma model.** Physical / mental trauma carry over between scenarios; affect max-health / max-sanity at scenario setup. Storage.
+- **Per-scenario XP awards.** Each Night of the Zealot scenario's resolution carries an XP delta.
+
+## Dependencies
+
+- Phase 7 (The Gathering) — the first scenario.
+- The other two Night of the Zealot scenarios (The Midnight Masks, The Devourer Below) need scenario modules implementing the same patterns.
+- Phase 8 (multiplayer + auth) — campaigns are a group concept, so the auth/group model is in place.
+
+## What "done" looks like
+
+A friend group plays through the full Night of the Zealot campaign — three scenarios, with deck upgrades between, weakness draws, story branching based on resolutions. The campaign log records every load-bearing fact; the post-campaign state is queryable.


### PR DESCRIPTION
Closes #107.

## What it does

Adds \`docs/phases/\` — one plan doc per phase, plus an index. Captures the cross-issue context that doesn't fit naturally in any single issue body: ordering between issues in a phase, design decisions made along the way, open questions still to settle.

CLAUDE.md now points at \`docs/phases/\` as the plan source of truth. The stale Phase-3-status memory entry is removed.

## What's in each doc

Uniform template per phase:

- **Status** (closed / in progress / planned / architecture only, with date)
- **Goal** (one-liner from the milestone)
- **Issues** (linked, with current state)
- **Ordering** (Shape B-style if planned, or explicit "TBD")
- **Decisions made** (settled architecture / design choices)
- **Open questions** (what's not yet scoped)
- **Dependencies** (prior phases this needs)
- **What "done" looks like**

## Detail level by phase

- **Phases 0–2 (closed):** short retrospectives — what shipped, key decisions made along the way. Mostly from milestone descriptions + the strategy-phase memory.
- **Phase 3 (in progress, 14/21):** full detail — Shape B ordering of both arcs (the demonstration that closed last week and the in-progress completion arc), the design-decision log from the last 20-ish PRs (CardRegistry pattern, \`#[non_exhaustive]\` policy, \`#53\` acceptance split into \`#38\`/\`#102\`, \`test-support\` feature drop, the Investigation+active gate being too strict for Fast abilities — \`#103\`), open questions for the remaining 7 issues.
- **Phase 4 (planned, 8 issues):** issue list with dependency notes + explicit "ordering TBD."
- **Phases 5–10 (architecture only):** the strategy-phase decisions from \`project_eldritch.md\` memory, with explicit "scoping TBD — file issues when this phase gets close" markers.

## Why

Better tracking for the "session per issue" workflow. Opening a new session and saying "let's do #X" — the agent reads \`docs/phases/phase-N-...md\` for context (Shape B order, what's been decided, what's still open) instead of re-deriving from chat history. Memory stays for durable stuff (architecture, patterns, preferences); plan state lives in the repo where it can be edited, reviewed, and stays honest with reality.

## Test plan

- [x] All five CI jobs green locally with strict flags (no Rust changes, but fmt/doc/clippy still verify)
- [ ] CI green on the PR
- [ ] Independent review

🤖 Generated with [Claude Code](https://claude.com/claude-code)