### PR TITLE
test: deterministic ChoiceResolver for AwaitingInput round-trips

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,4 +135,12 @@ Follow this order for every non-trivial PR. Skipping steps has cost real iterati
 
 6. **Address CI failures by pushing follow-up commits to the same branch.** Don't amend / force-push unless the user asks. CI re-runs automatically; the second watch can usually be foregrounded since it's only one job re-running.
 
-7. **Merge only after explicit user approval**, via `gh pr merge <PR#> --squash --delete-branch`. Confirm the issue auto-closed and `git pull` on `main` to sync.
+7. **Update the relevant `docs/phases/phase-N-<slug>.md` once the PR is ready to merge.** Land it as a final commit on the same branch so the doc reflects what actually ships — including review-driven fixes, scope changes, or new decisions surfaced during review. Skipping this step has cost real iterations; the next person hits a stale doc and re-derives context. Specifically:
+   - Move the closing issue from the **Open** table to the **Closed** table; bump the closed/open counts in the Status section.
+   - Flip the Ordering / Arc table's row to `✅ PR #N`.
+   - Add an entry to **Decisions made** for any non-obvious choice the PR cemented (design pattern, intentional divergence from the issue, scope split, review-surfaced rephrasings, etc.) — include the PR number.
+   - Remove any **Open question** the PR settled.
+
+   The `docs/phases/README.md` "Maintaining these docs" section is the authoritative spec; this step is the enforcement.
+
+8. **Merge only after explicit user approval**, via `gh pr merge <PR#> --squash --delete-branch`. Confirm the issue auto-closed and `git pull` on `main` to sync.

--- a/crates/game-core/src/dsl.rs
+++ b/crates/game-core/src/dsl.rs
@@ -112,9 +112,11 @@ pub enum Cost {
     /// with a `[fast] no exhaust` ability simply don't list this cost.)
     Exhaust,
     /// Discard a card from the controller's hand. Requires a target
-    /// selection via [`AwaitingInput`](crate::EngineOutcome::AwaitingInput),
-    /// which lands with the `ChoiceResolver` (#19). Until then,
-    /// activations with this cost reject with a TODO.
+    /// selection via [`AwaitingInput`](crate::EngineOutcome::AwaitingInput)
+    /// and a `ResolveInput` dispatch. No card uses this cost yet, so
+    /// the engine consumer hasn't landed; activations with this cost
+    /// reject with a TODO. Test-side seam is
+    /// [`ChoiceResolver`](crate::test_support::ChoiceResolver).
     DiscardCardFromHand,
 }
 

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -1625,8 +1625,10 @@ fn play_card(
 ///   not already exhausted, flips `cards_in_play[i].exhausted`,
 ///   emits [`Event::CardExhausted`].
 /// - [`Cost::DiscardCardFromHand`](crate::dsl::Cost::DiscardCardFromHand):
-///   rejects with a TODO — target-card selection needs the
-///   `ChoiceResolver` (#19).
+///   rejects with a TODO — target-card selection needs an engine
+///   `AwaitingInput` producer + `ResolveInput` dispatch. No card on
+///   the roadmap uses this cost yet, so the consumer hasn't landed.
+///   Test-side seam is [`ChoiceResolver`](crate::test_support::ChoiceResolver).
 ///
 /// # State-mutation contract
 ///
@@ -1879,8 +1881,8 @@ fn check_cost_payable(
             Ok(())
         }
         Cost::DiscardCardFromHand => Err(
-            "TODO(#19): Cost::DiscardCardFromHand requires AwaitingInput plumbing + \
-             ResolveInput; lands with the ChoiceResolver."
+            "TODO: Cost::DiscardCardFromHand requires AwaitingInput + ResolveInput \
+             dispatch; no card uses this cost yet so the engine consumer hasn't landed."
                 .to_string(),
         ),
     }

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -202,13 +202,14 @@ fn modify(
 }
 
 /// Standard rejection message for effect variants whose evaluator
-/// needs `AwaitingInput` plumbing (`ChoiceResolver` / `ResolveInput`
+/// needs `AwaitingInput` plumbing (engine-side producer + `ResolveInput`
 /// resume). Centralizes the message so the un-stub path is one grep.
+/// Test-side seam is [`ChoiceResolver`](crate::test_support::ChoiceResolver).
 fn awaiting_input_stub(name: &'static str) -> EngineOutcome {
     EngineOutcome::Rejected {
         reason: format!(
-            "TODO(#47): {name} evaluator needs AwaitingInput plumbing + ResolveInput resume; \
-             lands with the ChoiceResolver (#19) alongside skill tests (#49)."
+            "TODO: {name} evaluator needs AwaitingInput + ResolveInput resume; \
+             no engine consumer has landed yet."
         )
         .into(),
     }
@@ -385,10 +386,9 @@ fn resolve_investigator_target(
             .ok_or("InvestigatorTarget::Active but no active investigator (outside Investigation)"),
         InvestigatorTarget::ChosenByController => {
             // Same shape as ChooseOne — needs AwaitingInput + a
-            // ResolveInput round-trip carrying the chosen id. Land
-            // with the ChoiceResolver (#19) in PR-M alongside skill
-            // tests.
-            Err("InvestigatorTarget::ChosenByController requires AwaitingInput plumbing (PR-M)")
+            // ResolveInput round-trip carrying the chosen id. No
+            // engine consumer landed yet.
+            Err("InvestigatorTarget::ChosenByController requires AwaitingInput plumbing")
         }
     }
 }
@@ -405,7 +405,7 @@ fn resolve_location_target(
             .and_then(|i| i.current_location)
             .ok_or("LocationTarget::ControllerLocation but the controller is between locations"),
         LocationTarget::ChosenByController => {
-            Err("LocationTarget::ChosenByController requires AwaitingInput plumbing (PR-M)")
+            Err("LocationTarget::ChosenByController requires AwaitingInput plumbing")
         }
     }
 }

--- a/crates/game-core/src/test_support/builder.rs
+++ b/crates/game-core/src/test_support/builder.rs
@@ -161,6 +161,19 @@ impl TestGame {
         self
     }
 
+    /// Build into a [`TestSession`] for driving the engine with a
+    /// scripted [`ChoiceResolver`].
+    ///
+    /// Equivalent to `TestSession::new(self.build())`; sugar so
+    /// resolver-driven tests can write
+    /// `TestGame::new()...session().apply(...).resolve_choices(...).run()`.
+    ///
+    /// [`TestSession`]: super::resolver::TestSession
+    /// [`ChoiceResolver`]: super::resolver::ChoiceResolver
+    pub fn session(self) -> super::resolver::TestSession {
+        super::resolver::TestSession::new(self.build())
+    }
+
     /// Materialize the configured [`GameState`].
     pub fn build(self) -> GameState {
         GameState {

--- a/crates/game-core/src/test_support/mod.rs
+++ b/crates/game-core/src/test_support/mod.rs
@@ -8,6 +8,8 @@
 pub mod assertions;
 pub mod builder;
 pub mod fixtures;
+pub mod resolver;
 
 pub use builder::TestGame;
 pub use fixtures::{test_enemy, test_investigator, test_location};
+pub use resolver::{drive, ChoiceResolver, ScriptedResolver, TestSession};

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -1,0 +1,590 @@
+//! Deterministic [`ChoiceResolver`] for driving `AwaitingInput` round-trips.
+//!
+//! When the engine returns
+//! [`EngineOutcome::AwaitingInput`],
+//! it pauses mid-resolution waiting for a player response. A test needs
+//! a way to script that response without leaking engine internals into
+//! every assertion. The [`ChoiceResolver`] trait is the seam;
+//! [`ScriptedResolver`] is the deterministic test impl that feeds
+//! pre-recorded responses in FIFO order.
+//!
+//! [`drive`] runs an action through the engine and drains any
+//! `AwaitingInput` outcomes through the resolver until the engine
+//! returns [`Done`](crate::EngineOutcome::Done) or
+//! [`Rejected`](crate::EngineOutcome::Rejected). [`TestSession`] is the
+//! fluent wrapper that pairs a [`GameState`] with a resolver script.
+//!
+//! # Status
+//!
+//! No engine path emits `AwaitingInput` yet — the first consumer is
+//! the skill-test commit window (#63). This module ships the test
+//! infrastructure ahead of that work so the API has a stable home.
+//! [`ScriptedResolver::commit_cards`] is intentionally a stub until #63
+//! finalizes the commit-window response shape.
+//!
+//! # Example
+//!
+//! ```
+//! use game_core::action::{Action, InputResponse, PlayerAction};
+//! use game_core::engine::EngineOutcome;
+//! use game_core::test_support::TestGame;
+//!
+//! // `ResolveInput` rejects today (TODO(#63)); use it as a no-resolver
+//! // smoke test for the fluent API.
+//! let result = TestGame::new()
+//!     .session()
+//!     .apply(Action::Player(PlayerAction::ResolveInput {
+//!         response: InputResponse::Confirm,
+//!     }))
+//!     .run();
+//! assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+//! ```
+
+use std::collections::VecDeque;
+
+use crate::action::{Action, InputResponse, PlayerAction};
+use crate::engine::{apply, ApplyResult, EngineOutcome, InputRequest};
+use crate::event::Event;
+use crate::state::{CardCode, GameState, InvestigatorId, LocationId};
+
+/// Provide a response for an `AwaitingInput` prompt during a
+/// [`drive`]-style session.
+///
+/// Tests use [`ScriptedResolver`]. Future hosts (server, web client)
+/// will implement this trait against their own UI/transport layer; the
+/// trait is the boundary between the engine's pause-and-resume protocol
+/// and the consumer's input-collection mechanism.
+pub trait ChoiceResolver {
+    /// Produce the next response for the given prompt.
+    ///
+    /// `state` is the engine state at the moment of the prompt — useful
+    /// for resolvers that translate symbolic intents ("commit this card
+    /// by code") into engine indices.
+    fn next(&mut self, request: &InputRequest, state: &GameState) -> InputResponse;
+}
+
+/// Replayable [`ChoiceResolver`] backed by a FIFO of pre-recorded steps.
+///
+/// Build the script with the fluent helpers ([`confirm`](Self::confirm),
+/// [`skip`](Self::skip), [`pick`](Self::pick),
+/// [`pick_investigator`](Self::pick_investigator),
+/// [`pick_location`](Self::pick_location),
+/// [`commit_cards`](Self::commit_cards)). When the engine prompts and the
+/// script is empty, [`next`](Self::next) panics with the prompt text — a
+/// useful failure mode in tests.
+///
+/// Helpers take `&mut self` and return `&mut Self` so they chain inside
+/// a [`TestSession::resolve_choices`] closure.
+#[derive(Debug, Default, Clone)]
+pub struct ScriptedResolver {
+    steps: VecDeque<ScriptedStep>,
+}
+
+#[derive(Debug, Clone)]
+enum ScriptedStep {
+    Response(InputResponse),
+    /// Commit a set of cards from the active investigator's hand to a
+    /// skill test. TODO(#63): replace with the real commit-window
+    /// response variant(s) once finalized.
+    CommitCards(Vec<CardCode>),
+}
+
+impl ScriptedResolver {
+    /// Empty script.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append a literal [`InputResponse`] to the script.
+    pub fn push(&mut self, response: InputResponse) -> &mut Self {
+        self.steps.push_back(ScriptedStep::Response(response));
+        self
+    }
+
+    /// Respond with [`InputResponse::Confirm`].
+    pub fn confirm(&mut self) -> &mut Self {
+        self.push(InputResponse::Confirm)
+    }
+
+    /// Respond with [`InputResponse::Skip`].
+    pub fn skip(&mut self) -> &mut Self {
+        self.push(InputResponse::Skip)
+    }
+
+    /// Respond with [`InputResponse::PickIndex`].
+    pub fn pick(&mut self, index: u32) -> &mut Self {
+        self.push(InputResponse::PickIndex(index))
+    }
+
+    /// Respond with [`InputResponse::PickInvestigator`].
+    pub fn pick_investigator(&mut self, id: InvestigatorId) -> &mut Self {
+        self.push(InputResponse::PickInvestigator(id))
+    }
+
+    /// Respond with [`InputResponse::PickLocation`].
+    pub fn pick_location(&mut self, id: LocationId) -> &mut Self {
+        self.push(InputResponse::PickLocation(id))
+    }
+
+    /// Commit cards (by code) from the active investigator's hand to
+    /// the current skill test.
+    ///
+    /// TODO(#63): stub until the commit-window prompt shape is
+    /// finalized. The codes are recorded but never converted into
+    /// responses; if the engine ever prompts a [`ScriptedResolver`]
+    /// whose next step is `CommitCards`, [`next`](Self::next) panics
+    /// with the request prompt and the recorded codes. Once #63 lands,
+    /// this helper will translate codes to the real commit-window
+    /// response variant(s) using the engine state passed into `next`.
+    pub fn commit_cards(&mut self, codes: &[CardCode]) -> &mut Self {
+        self.steps
+            .push_back(ScriptedStep::CommitCards(codes.to_vec()));
+        self
+    }
+
+    /// Number of scripted steps remaining (literal responses plus
+    /// unexpanded `commit_cards` entries). Useful for asserting a test
+    /// consumed the script it set up.
+    pub fn remaining(&self) -> usize {
+        self.steps.len()
+    }
+}
+
+impl ChoiceResolver for ScriptedResolver {
+    fn next(&mut self, request: &InputRequest, _state: &GameState) -> InputResponse {
+        let step = self.steps.pop_front().unwrap_or_else(|| {
+            panic!(
+                "ScriptedResolver: no scripted response for prompt: {:?}",
+                request.prompt,
+            )
+        });
+        match step {
+            ScriptedStep::Response(r) => r,
+            ScriptedStep::CommitCards(codes) => panic!(
+                "ScriptedResolver::commit_cards: TODO(#63) — commit-window response \
+                 shape not yet finalized; helper is a stub. Codes recorded: {:?}, \
+                 prompt was: {:?}",
+                codes, request.prompt,
+            ),
+        }
+    }
+}
+
+/// Run `action` against `state`, draining
+/// [`AwaitingInput`](EngineOutcome::AwaitingInput) outcomes through
+/// `resolver` until the engine returns [`Done`](EngineOutcome::Done) or
+/// [`Rejected`](EngineOutcome::Rejected).
+///
+/// The returned [`ApplyResult`] aggregates state, events, and outcome
+/// across every sub-`apply` in the round trip:
+///
+/// - `state` is the final state after all sub-applies.
+/// - `events` concatenate every sub-apply's events in order.
+/// - `outcome` is the terminal [`Done`](EngineOutcome::Done) or
+///   [`Rejected`](EngineOutcome::Rejected) — `drive` never returns
+///   `AwaitingInput` (the resolver is consulted and the loop continues).
+///
+/// Panics if the resolver runs out of scripted responses while the
+/// engine is still emitting `AwaitingInput`, or if the loop exceeds an
+/// internal iteration cap (a sign of a broken resolver or engine cycle).
+pub fn drive<R: ChoiceResolver>(state: GameState, action: Action, mut resolver: R) -> ApplyResult {
+    drive_with_applier(state, action, &mut resolver, apply)
+}
+
+/// Loop body of [`drive`] with the engine entry point parameterized.
+///
+/// Tests in this module use this to substitute a fake `apply` that
+/// produces `AwaitingInput` (which no real engine path emits yet),
+/// exercising the drain logic without needing a real engine consumer.
+pub(crate) fn drive_with_applier<R, F>(
+    state: GameState,
+    action: Action,
+    resolver: &mut R,
+    mut applier: F,
+) -> ApplyResult
+where
+    R: ChoiceResolver + ?Sized,
+    F: FnMut(GameState, Action) -> ApplyResult,
+{
+    const MAX_ITERATIONS: u32 = 1024;
+
+    let mut state = state;
+    let mut events: Vec<Event> = Vec::new();
+    let mut next_action = Some(action);
+    let mut iterations = 0u32;
+
+    loop {
+        iterations += 1;
+        assert!(
+            iterations <= MAX_ITERATIONS,
+            "drive: exceeded {MAX_ITERATIONS} iterations without reaching Done/Rejected; \
+             resolver or engine appears to be cycling",
+        );
+
+        let act = next_action
+            .take()
+            .expect("drive: internal invariant — next_action set on every loop entry");
+        let result = applier(state, act);
+        state = result.state;
+        events.extend(result.events);
+
+        match result.outcome {
+            EngineOutcome::Done => {
+                return ApplyResult {
+                    state,
+                    events,
+                    outcome: EngineOutcome::Done,
+                };
+            }
+            EngineOutcome::Rejected { reason } => {
+                return ApplyResult {
+                    state,
+                    events,
+                    outcome: EngineOutcome::Rejected { reason },
+                };
+            }
+            EngineOutcome::AwaitingInput {
+                request,
+                resume_token: _,
+            } => {
+                let response = resolver.next(&request, &state);
+                next_action = Some(Action::Player(PlayerAction::ResolveInput { response }));
+            }
+        }
+    }
+}
+
+/// Fluent test driver: pair a [`GameState`] with an initial action and
+/// a scripted resolver, then [`run`](Self::run) the engine through to a
+/// terminal outcome.
+///
+/// Construct via [`TestGame::session`](super::TestGame::session) or
+/// [`TestSession::new`].
+#[derive(Debug)]
+#[must_use = "TestSession does nothing until you call .run()"]
+pub struct TestSession {
+    state: GameState,
+    action: Option<Action>,
+    resolver: ScriptedResolver,
+}
+
+impl TestSession {
+    /// Wrap a built state.
+    pub fn new(state: GameState) -> Self {
+        Self {
+            state,
+            action: None,
+            resolver: ScriptedResolver::new(),
+        }
+    }
+
+    /// Record the initial action to apply. Replaces any previous
+    /// recorded action — `apply` is the single entry point per session,
+    /// not a queue.
+    pub fn apply(mut self, action: Action) -> Self {
+        self.action = Some(action);
+        self
+    }
+
+    /// Record the resolver script. The closure receives `&mut
+    /// ScriptedResolver`; chain calls inside to build up the response
+    /// sequence:
+    ///
+    /// ```
+    /// # use game_core::test_support::TestGame;
+    /// # use game_core::action::{Action, PlayerAction};
+    /// let _session = TestGame::new()
+    ///     .session()
+    ///     .resolve_choices(|c| {
+    ///         c.confirm();
+    ///         c.skip();
+    ///     });
+    /// ```
+    pub fn resolve_choices(mut self, f: impl FnOnce(&mut ScriptedResolver)) -> Self {
+        f(&mut self.resolver);
+        self
+    }
+
+    /// Execute. Panics if [`apply`](Self::apply) was not called.
+    pub fn run(self) -> ApplyResult {
+        let action = self
+            .action
+            .expect("TestSession::run: call .apply(action) before .run()");
+        drive(self.state, action, self.resolver)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::action::{Action, InputResponse, PlayerAction};
+    use crate::engine::{InputRequest, ResumeToken};
+    use crate::state::{CardCode, InvestigatorId, LocationId, Phase};
+    use crate::test_support::{test_investigator, test_location, TestGame};
+
+    fn empty_state() -> GameState {
+        TestGame::new().build()
+    }
+
+    fn req(prompt: &str) -> InputRequest {
+        InputRequest {
+            prompt: prompt.to_string(),
+        }
+    }
+
+    #[test]
+    fn scripted_resolver_returns_responses_in_fifo_order() {
+        let mut r = ScriptedResolver::new();
+        r.confirm()
+            .skip()
+            .pick(7)
+            .pick_investigator(InvestigatorId(2))
+            .pick_location(LocationId(99));
+        assert_eq!(r.remaining(), 5);
+
+        let state = empty_state();
+        let p = req("pick");
+        assert_eq!(r.next(&p, &state), InputResponse::Confirm);
+        assert_eq!(r.next(&p, &state), InputResponse::Skip);
+        assert_eq!(r.next(&p, &state), InputResponse::PickIndex(7));
+        assert_eq!(
+            r.next(&p, &state),
+            InputResponse::PickInvestigator(InvestigatorId(2))
+        );
+        assert_eq!(
+            r.next(&p, &state),
+            InputResponse::PickLocation(LocationId(99))
+        );
+        assert_eq!(r.remaining(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "no scripted response")]
+    fn scripted_resolver_panics_when_script_exhausted() {
+        let mut r = ScriptedResolver::new();
+        let _ = r.next(&req("oops"), &empty_state());
+    }
+
+    #[test]
+    #[should_panic(expected = "TODO(#63)")]
+    fn commit_cards_is_a_stub_until_issue_63() {
+        let mut r = ScriptedResolver::new();
+        r.commit_cards(&[CardCode::new("01001")]);
+        let _ = r.next(&req("commit"), &empty_state());
+    }
+
+    #[test]
+    fn drive_passes_through_done_without_consulting_resolver() {
+        // Use `ResolveInput` purely as a no-op shape — it rejects today,
+        // but we substitute the applier so the test doesn't depend on
+        // engine specifics.
+        let applier = |state, action: Action| {
+            assert!(matches!(
+                action,
+                Action::Player(PlayerAction::ResolveInput { .. })
+            ));
+            ApplyResult {
+                state,
+                events: vec![],
+                outcome: EngineOutcome::Done,
+            }
+        };
+        let mut resolver = ScriptedResolver::new();
+        resolver.confirm(); // stale; must not be consumed
+        let result = drive_with_applier(
+            empty_state(),
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::Confirm,
+            }),
+            &mut resolver,
+            applier,
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Done));
+        assert_eq!(resolver.remaining(), 1);
+    }
+
+    #[test]
+    fn drive_passes_through_rejected_with_reason() {
+        let applier = |state, _action: Action| ApplyResult {
+            state,
+            events: vec![],
+            outcome: EngineOutcome::Rejected {
+                reason: "test rejection".into(),
+            },
+        };
+        let mut resolver = ScriptedResolver::new();
+        let result = drive_with_applier(
+            empty_state(),
+            Action::Player(PlayerAction::EndTurn),
+            &mut resolver,
+            applier,
+        );
+        match result.outcome {
+            EngineOutcome::Rejected { reason } => assert_eq!(reason, "test rejection"),
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn drive_drains_awaiting_input_until_done() {
+        let mut step = 0;
+        let applier = |state, action: Action| {
+            step += 1;
+            match step {
+                1 => {
+                    assert!(matches!(action, Action::Player(PlayerAction::EndTurn)));
+                    ApplyResult {
+                        state,
+                        events: vec![],
+                        outcome: EngineOutcome::AwaitingInput {
+                            request: req("pick first"),
+                            resume_token: ResumeToken(0),
+                        },
+                    }
+                }
+                2 => {
+                    assert!(matches!(
+                        action,
+                        Action::Player(PlayerAction::ResolveInput {
+                            response: InputResponse::Confirm
+                        })
+                    ));
+                    ApplyResult {
+                        state,
+                        events: vec![],
+                        outcome: EngineOutcome::AwaitingInput {
+                            request: req("pick second"),
+                            resume_token: ResumeToken(1),
+                        },
+                    }
+                }
+                3 => {
+                    assert!(matches!(
+                        action,
+                        Action::Player(PlayerAction::ResolveInput {
+                            response: InputResponse::Skip
+                        })
+                    ));
+                    ApplyResult {
+                        state,
+                        events: vec![],
+                        outcome: EngineOutcome::Done,
+                    }
+                }
+                _ => panic!("unexpected step {step}"),
+            }
+        };
+        let mut resolver = ScriptedResolver::new();
+        resolver.confirm().skip();
+        let result = drive_with_applier(
+            empty_state(),
+            Action::Player(PlayerAction::EndTurn),
+            &mut resolver,
+            applier,
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Done));
+        assert_eq!(resolver.remaining(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "no scripted response")]
+    fn drive_panics_with_useful_message_on_unhandled_prompt() {
+        let applier = |state, _action: Action| ApplyResult {
+            state,
+            events: vec![],
+            outcome: EngineOutcome::AwaitingInput {
+                request: req("nothing scripted for me"),
+                resume_token: ResumeToken(42),
+            },
+        };
+        let mut resolver = ScriptedResolver::new();
+        let _ = drive_with_applier(
+            empty_state(),
+            Action::Player(PlayerAction::EndTurn),
+            &mut resolver,
+            applier,
+        );
+    }
+
+    #[test]
+    fn drive_accumulates_events_across_sub_applies() {
+        let mut step = 0;
+        let id = InvestigatorId(1);
+        let applier = |state, _action: Action| {
+            step += 1;
+            match step {
+                1 => ApplyResult {
+                    state,
+                    events: vec![Event::ResourcesGained {
+                        investigator: id,
+                        amount: 1,
+                    }],
+                    outcome: EngineOutcome::AwaitingInput {
+                        request: req("pick"),
+                        resume_token: ResumeToken(0),
+                    },
+                },
+                2 => ApplyResult {
+                    state,
+                    events: vec![Event::TurnEnded { investigator: id }],
+                    outcome: EngineOutcome::Done,
+                },
+                _ => panic!("unexpected step {step}"),
+            }
+        };
+        let mut resolver = ScriptedResolver::new();
+        resolver.confirm();
+        let result = drive_with_applier(
+            empty_state(),
+            Action::Player(PlayerAction::EndTurn),
+            &mut resolver,
+            applier,
+        );
+        assert_eq!(result.events.len(), 2);
+        assert!(matches!(
+            result.events[0],
+            Event::ResourcesGained { amount: 1, .. }
+        ));
+        assert!(matches!(result.events[1], Event::TurnEnded { .. }));
+    }
+
+    #[test]
+    fn drive_real_engine_passes_through_rejected_action() {
+        // No `AwaitingInput` site exists in the engine yet, so the only
+        // real-engine path this test exercises is the trivial pass-
+        // through of a `Rejected` outcome (ResolveInput TODO-rejects).
+        let result = drive(
+            empty_state(),
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::Confirm,
+            }),
+            ScriptedResolver::new(),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    }
+
+    #[test]
+    fn test_session_fluent_round_trip() {
+        let id = InvestigatorId(1);
+        let result = TestGame::new()
+            .with_phase(Phase::Investigation)
+            .with_investigator(test_investigator(1))
+            .with_location(test_location(10, "Study"))
+            .with_active_investigator(id)
+            .with_turn_order([id])
+            .session()
+            .apply(Action::Player(PlayerAction::EndTurn))
+            .resolve_choices(|c| {
+                // Stale script: engine reaches Done without prompting.
+                c.confirm();
+            })
+            .run();
+        assert!(matches!(result.outcome, EngineOutcome::Done));
+    }
+
+    #[test]
+    #[should_panic(expected = "call .apply(action) before .run()")]
+    fn test_session_run_without_apply_panics() {
+        let _ = TestGame::new().session().run();
+    }
+}

--- a/docs/phases/phase-3-skill-test-end-to-end.md
+++ b/docs/phases/phase-3-skill-test-end-to-end.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-🟡 In progress. 14 closed / 8 open as of 2026-05-16.
+🟡 In progress. 15 closed / 7 open as of 2026-05-17.
 
 ## Goal
 
@@ -10,10 +10,11 @@ Full skill test sequence runs through the engine in tests — with real-card met
 
 ## Issues
 
-### Closed (14)
+### Closed (15)
 
 | # | Title | Notes |
 |---|---|---|
+| `#19` | deterministic `ChoiceResolver` | Test infra; ships ahead of first engine consumer (`#63`). `commit_cards` stubbed pending commit-window response shape. |
 | `#37` | Magnifying Glass (01030) | First new card after the Phase-3 demo; composes `#87` + `#45`. |
 | `#38` | Hyperawareness (01034) | Exercises `Trigger::Activated` + `ThisSkillTest` push end-to-end. |
 | `#45` | per-skill-test-kind modifier scope | Adds `ModifierScope::WhileInPlayDuring(SkillTestKind)`. |
@@ -29,17 +30,16 @@ Full skill test sequence runs through the engine in tests — with real-card met
 | `#92` | constant-modifier query during skill-test resolution | Closes the Phase-3 demo: Holy Rosary `+1 willpower` actually applies. |
 | `#102` | `ThisSkillTest` modifier accumulator | Pushed + drained on `SkillTestEnded`. |
 
-### Open (8)
+### Open (7)
 
 | # | Title | Notes |
 |---|---|---|
-| `#19` | deterministic `ChoiceResolver` | Test infra for `AwaitingInput` round-trips; foundational for `#63` and `#52`. |
 | `#39` | Deduction (01039) | Needs `#63` (skill-test commits) or `#64` (after-resolution trigger). |
 | `#52` | reaction windows + trigger ordering | Needs `#54` + `#19`. The largest remaining engine piece. |
 | `#54` | DSL `OnEvent` trigger | Small extension; unblocks `#52` and `#55` Roland Banks. |
 | `#55` | Roland Banks investigator (01001) | Needs `#54` + `#52`. |
 | `#56` | Study location (01111) | Needs a location-state shape decision; thinnest issue body. |
-| `#63` | skill-test card commits from hand | Needs `#19` (commit AwaitingInput). |
+| `#63` | skill-test card commits from hand | First engine consumer of `#19`. Finalizes the commit-window response shape and un-stubs `ScriptedResolver::commit_cards`. |
 | `#64` | skill-test after-resolution trigger window | Needs `#54` (OnEvent) + `#19`. |
 
 ## Ordering (Shape B)
@@ -68,7 +68,7 @@ Cards rather than infra-first. Build the minimal infra each card needs, ship the
 | 4 | `#53` Activated trigger + cost primitives | ✅ PR #104 |
 | 5 | `#102` `ThisSkillTest` accumulator | ✅ PR #105 |
 | 6 | `#38` Hyperawareness | ✅ PR #106 |
-| 7 | `#19` ChoiceResolver | ⏳ next |
+| 7 | `#19` ChoiceResolver | ✅ PR #109 |
 | 8 | `#63` skill-test commits | needs `#19` |
 | 9 | `#39` Deduction | needs `#63` (or `#64`) |
 | 10 | `#54` OnEvent trigger | small |
@@ -89,6 +89,7 @@ Cards rather than infra-first. Build the minimal infra each card needs, ship the
 - **Investigation-phase + active-investigator gate on `PlayCard`/`ActivateAbility` is overly strict for Fast abilities.** No-op for Phase-3 scope (only Investigation phase exists); `#103` lifts the gate when phase content lands.
 - **`test-support` Cargo feature dropped (PR #104).** `pub mod test_support` is now unconditional. Surfaced during `#53` review when the integration-test binary failed to compile without `--all-features`. The feature gated nothing in practice (only consumer was `cards`, which always enabled it).
 - **Event-sequence macro `assert_event_sequence!` added (PR #95).** The file's own "don't add preemptively" note had been waiting for a concrete first user; Working a Hunch's ordering test was that user.
+- **`ChoiceResolver` shipped ahead of consumer (`#19`, PR #109).** Test seam (trait + `ScriptedResolver` + `drive` + `TestSession` + `TestGame::session()`) lands now; no engine path emits `AwaitingInput` yet. `ScriptedResolver::commit_cards` is a recorded stub that panics on resolve until `#63` finalizes the commit-window response variant(s). Diverged from the issue's `pick_target(id)` to concrete `pick_investigator` / `pick_location` matching the existing `InputResponse` variants. Pre-existing `#19` forward references in `dispatch.rs` / `dsl.rs` / `evaluator.rs` were rephrased to "no engine consumer landed yet" so they don't dangle after merge.
 
 ## Open questions
 
@@ -97,8 +98,6 @@ Cards rather than infra-first. Build the minimal infra each card needs, ship the
   - Via `#63` commits from hand → `Trigger::OnCommit` + `Condition::SkillTest { outcome: Success }`.
   - Via `#64` after-resolution trigger window → reactive consumer of a `SkillTestSucceeded` event.
   Pick when implementing.
-- **`#19` ChoiceResolver scope.** A test helper for scripted `AwaitingInput` responses. Today no choice-point exists. Lands when the first consumer needs it (`#63` is the natural first).
-
 ## Dependencies
 
 Phases 0–2.


### PR DESCRIPTION
## Summary

- Adds `ChoiceResolver` trait + `ScriptedResolver` (FIFO test impl) in `crates/game-core/src/test_support/resolver.rs`.
- Adds `drive(state, action, resolver) -> ApplyResult` that drains `AwaitingInput` outcomes until `Done`/`Rejected`, accumulating events across sub-applies.
- Adds `TestSession` fluent wrapper and `TestGame::session()` sugar so resolver-driven tests write `TestGame::new()...session().apply(...).resolve_choices(...).run()`.

Closes #19.

## Design decisions

- **Ship ahead of the first consumer.** No engine path emits `AwaitingInput` yet — the first consumer is the skill-test commit window (#63). Per the open question in `docs/phases/phase-3-skill-test-end-to-end.md`, the resolver lands now so #63 / #64 / #52 can each pick it up without re-litigating the API shape.
- **`commit_cards(&[CardCode])` is a stub.** Records the codes but panics with a TODO(#63) message on `next()`. Once #63 finalizes the commit-window response variant(s), this helper translates codes to the real response shape using the engine state passed into `next`.
- **Tested via parameterized `drive_with_applier`.** Real engine has no `AwaitingInput` producer, so the drain logic is tested by substituting a fake applier that emits `AwaitingInput`. The single real-engine smoke test exercises the trivial `Rejected` pass-through.
- **Diverged from issue's `pick_target(id)`.** Replaced with concrete `pick_investigator(id)` / `pick_location(id)` matching the existing `InputResponse` variants — generic `pick_target` would be ambiguous about which variant to emit.
- **Helpers take `&mut self` and return `&mut Self`.** Needed so they chain inside the `resolve_choices(|c| { c.confirm(); c.skip(); })` closure receiving `&mut ScriptedResolver`.

## Test plan

- [x] `cargo fmt --check`
- [x] `RUSTFLAGS=\"-D warnings\" cargo test --all --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps --all-features`
- [x] `cargo build -p web --target wasm32-unknown-unknown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)