### PR TITLE
engine: skill-test card commits from hand

### DIFF
--- a/crates/cards/tests/holy_rosary.rs
+++ b/crates/cards/tests/holy_rosary.rs
@@ -15,7 +15,7 @@ use game_core::event::Event;
 use game_core::state::{
     CardCode, ChaosBag, ChaosToken, InvestigatorId, Phase, SkillKind, TokenModifiers,
 };
-use game_core::test_support::{test_investigator, TestGame};
+use game_core::test_support::{apply_no_commits, test_investigator, TestGame};
 use game_core::{assert_event, Action, PlayerAction};
 
 const HOLY_ROSARY: &str = "01059";
@@ -73,7 +73,7 @@ fn willpower_test_succeeds_at_difficulty_4_after_playing_holy_rosary() {
     assert_eq!(in_play[0].code, CardCode::new(HOLY_ROSARY));
 
     // Difficulty-4 willpower test — +1 from the rosary should carry it.
-    let result = apply(
+    let result = apply_no_commits(
         after_play.state,
         Action::Player(PlayerAction::PerformSkillTest {
             investigator: id,
@@ -103,7 +103,7 @@ fn willpower_test_fails_at_difficulty_5_even_with_holy_rosary() {
     );
     assert_eq!(after_play.outcome, EngineOutcome::Done);
 
-    let result = apply(
+    let result = apply_no_commits(
         after_play.state,
         Action::Player(PlayerAction::PerformSkillTest {
             investigator: id,
@@ -135,7 +135,7 @@ fn intellect_test_unaffected_by_holy_rosary_in_play() {
     );
     assert_eq!(after_play.outcome, EngineOutcome::Done);
 
-    let result = apply(
+    let result = apply_no_commits(
         after_play.state,
         Action::Player(PlayerAction::PerformSkillTest {
             investigator: id,
@@ -160,7 +160,7 @@ fn willpower_test_without_rosary_in_play_uses_base_value_only() {
     assert!(!state.investigators[&id].hand.is_empty());
     assert!(state.investigators[&id].cards_in_play.is_empty());
 
-    let result = apply(
+    let result = apply_no_commits(
         state,
         Action::Player(PlayerAction::PerformSkillTest {
             investigator: id,

--- a/crates/cards/tests/hyperawareness.rs
+++ b/crates/cards/tests/hyperawareness.rs
@@ -17,7 +17,7 @@ use game_core::state::{
     CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, InvestigatorId, Phase, SkillKind,
     TokenModifiers,
 };
-use game_core::test_support::{test_investigator, TestGame};
+use game_core::test_support::{apply_no_commits, test_investigator, TestGame};
 use game_core::{assert_event, Action, PlayerAction};
 
 const HYPERAWARENESS: &str = "01034";
@@ -81,7 +81,7 @@ fn intellect_ability_buffs_an_intellect_test_at_difficulty_4() {
         "1 resource paid",
     );
 
-    let after_test = apply(
+    let after_test = apply_no_commits(
         after_activate.state,
         Action::Player(PlayerAction::PerformSkillTest {
             investigator: id,
@@ -116,7 +116,7 @@ fn agility_ability_buffs_an_agility_test_at_difficulty_4() {
     );
     assert_eq!(after_activate.outcome, EngineOutcome::Done);
 
-    let after_test = apply(
+    let after_test = apply_no_commits(
         after_activate.state,
         Action::Player(PlayerAction::PerformSkillTest {
             investigator: id,
@@ -148,7 +148,7 @@ fn intellect_ability_does_not_buff_an_agility_test() {
     );
     assert_eq!(after_activate.outcome, EngineOutcome::Done);
 
-    let after_test = apply(
+    let after_test = apply_no_commits(
         after_activate.state,
         Action::Player(PlayerAction::PerformSkillTest {
             investigator: id,

--- a/crates/cards/tests/magnifying_glass.rs
+++ b/crates/cards/tests/magnifying_glass.rs
@@ -13,7 +13,7 @@ use game_core::event::Event;
 use game_core::state::{
     CardCode, ChaosBag, ChaosToken, InvestigatorId, LocationId, Phase, SkillKind, TokenModifiers,
 };
-use game_core::test_support::{test_investigator, test_location, TestGame};
+use game_core::test_support::{apply_no_commits, test_investigator, test_location, TestGame};
 use game_core::{assert_event, Action, PlayerAction};
 
 const MAGNIFYING_GLASS: &str = "01030";
@@ -73,7 +73,7 @@ fn investigate_succeeds_at_shroud_4_after_playing_magnifying_glass() {
         CardCode::new(MAGNIFYING_GLASS),
     );
 
-    let result = apply(
+    let result = apply_no_commits(
         after_play.state,
         Action::Player(PlayerAction::Investigate { investigator: id }),
     );
@@ -91,7 +91,7 @@ fn investigate_fails_at_shroud_4_without_magnifying_glass_in_play() {
     let (state, id, _loc) = state_with_mg_in_hand();
     assert!(state.investigators[&id].cards_in_play.is_empty());
 
-    let result = apply(
+    let result = apply_no_commits(
         state,
         Action::Player(PlayerAction::Investigate { investigator: id }),
     );
@@ -121,7 +121,7 @@ fn bare_intellect_test_unaffected_by_magnifying_glass_in_play() {
     );
     assert_eq!(after_play.outcome, EngineOutcome::Done);
 
-    let result = apply(
+    let result = apply_no_commits(
         after_play.state,
         Action::Player(PlayerAction::PerformSkillTest {
             investigator: id,

--- a/crates/cards/tests/skill_test_commits.rs
+++ b/crates/cards/tests/skill_test_commits.rs
@@ -1,0 +1,205 @@
+//! End-to-end test that real-card skill icons contribute to a skill
+//! test's total when committed from hand.
+//!
+//! This is the Phase-3 acceptance demo for #63: commit Perception
+//! (`01090`, two intellect icons) and/or Unexpected Courage (`01093`,
+//! two wild icons) to a difficulty-5 intellect test for an
+//! investigator with base intellect 3. The bag is a single
+//! `Numeric(0)`, so the only thing that can push the total over the
+//! line is the committed cards.
+//!
+//! Lives at `crates/cards/tests/` so it can install
+//! [`cards::REGISTRY`] without colliding with `game-core`'s in-crate
+//! tests (which deliberately don't install one and would see
+//! `metadata_for == None`, contributing zero icons).
+
+use std::sync::Once;
+
+use game_core::engine::{apply, EngineOutcome};
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, ChaosBag, ChaosToken, InvestigatorId, SkillKind, TokenModifiers, Zone,
+};
+use game_core::test_support::{drive, test_investigator, ScriptedResolver, TestGame};
+use game_core::{assert_event, assert_event_count, assert_no_event, Action, PlayerAction};
+
+const PERCEPTION: &str = "01090";
+const UNEXPECTED_COURAGE: &str = "01093";
+/// Overpower — `01091`, two combat icons. Used as a "non-matching
+/// icons contribute 0" control.
+const OVERPOWER: &str = "01091";
+
+fn install_real_registry() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// Hand contents for the test. Builds a state with the named cards in
+/// the active investigator's hand, base intellect 3, and a single-
+/// `Numeric(0)` chaos bag (so the token-modifier contribution is
+/// always 0).
+fn state_with_hand(hand: &[&str]) -> (game_core::GameState, InvestigatorId) {
+    install_real_registry();
+    let id = InvestigatorId(1);
+    let mut inv = test_investigator(1);
+    inv.hand = hand.iter().map(|c| CardCode::new(*c)).collect();
+    let state = TestGame::new()
+        .with_investigator(inv)
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default())
+        .build();
+    (state, id)
+}
+
+fn intellect_test_difficulty_5(id: InvestigatorId) -> Action {
+    Action::Player(PlayerAction::PerformSkillTest {
+        investigator: id,
+        skill: SkillKind::Intellect,
+        difficulty: 5,
+    })
+}
+
+/// Drive one `PerformSkillTest` through with the supplied commit codes.
+/// Uses `drive` directly so the resolver can translate codes →
+/// indices using the in-flight state at resolve time.
+fn drive_with_commits(
+    state: game_core::GameState,
+    action: Action,
+    commit: &[&str],
+) -> game_core::ApplyResult {
+    let mut resolver = ScriptedResolver::new();
+    let codes: Vec<CardCode> = commit.iter().map(|c| CardCode::new(*c)).collect();
+    resolver.commit_cards(&codes);
+    drive(state, action, resolver)
+}
+
+#[test]
+fn empty_commit_against_difficulty_5_intellect_fails() {
+    // Base 3 + 0 (token) + 0 (no commits) < 5 — fails by 2.
+    let (state, id) = state_with_hand(&[PERCEPTION, UNEXPECTED_COURAGE]);
+    let result = drive_with_commits(state, intellect_test_difficulty_5(id), &[]);
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestFailed { investigator, skill: SkillKind::Intellect, by: 2, .. }
+            if *investigator == id
+    );
+    // No commit → no discards.
+    assert_no_event!(result.events, Event::CardDiscarded { .. });
+}
+
+#[test]
+fn committing_perception_contributes_two_intellect_icons() {
+    // Base 3 + 0 (token) + 2 (Perception's intellect icons) = 5,
+    // meets difficulty 5 → success with margin 0.
+    let (state, id) = state_with_hand(&[PERCEPTION, UNEXPECTED_COURAGE]);
+    let result = drive_with_commits(state, intellect_test_difficulty_5(id), &[PERCEPTION]);
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestSucceeded { investigator, skill: SkillKind::Intellect, margin: 0 }
+            if *investigator == id
+    );
+    // Perception lands in discard; Unexpected Courage stays in hand.
+    let inv = &result.state.investigators[&id];
+    assert_eq!(inv.hand, vec![CardCode::new(UNEXPECTED_COURAGE)]);
+    assert_eq!(inv.discard, vec![CardCode::new(PERCEPTION)]);
+    assert_event!(
+        result.events,
+        Event::CardDiscarded { investigator, code, from: Zone::Hand }
+            if *investigator == id && *code == CardCode::new(PERCEPTION)
+    );
+}
+
+#[test]
+fn committing_unexpected_courage_contributes_two_wild_icons() {
+    // Wild icons count toward whichever skill the test is against.
+    // Base 3 + 0 + 2 (UC's two wild) = 5 → success.
+    let (state, id) = state_with_hand(&[PERCEPTION, UNEXPECTED_COURAGE]);
+    let result = drive_with_commits(
+        state,
+        intellect_test_difficulty_5(id),
+        &[UNEXPECTED_COURAGE],
+    );
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestSucceeded { investigator, skill: SkillKind::Intellect, margin: 0 }
+            if *investigator == id
+    );
+    let inv = &result.state.investigators[&id];
+    assert_eq!(inv.discard, vec![CardCode::new(UNEXPECTED_COURAGE)]);
+}
+
+#[test]
+fn committing_two_cards_sums_both_contributions_and_discards_both() {
+    // Phase-3 acceptance demo: commit two cards, verify icons
+    // counted, both discarded after the test.
+    //
+    // Base 3 + 0 + 2 (Perception intellect) + 2 (UC wild) = 7 vs
+    // difficulty 5 → success with margin 2.
+    let (state, id) = state_with_hand(&[PERCEPTION, UNEXPECTED_COURAGE]);
+    let result = drive_with_commits(
+        state,
+        intellect_test_difficulty_5(id),
+        &[PERCEPTION, UNEXPECTED_COURAGE],
+    );
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestSucceeded { investigator, skill: SkillKind::Intellect, margin: 2 }
+            if *investigator == id
+    );
+    let inv = &result.state.investigators[&id];
+    assert!(inv.hand.is_empty(), "both cards removed from hand");
+    // Both ended up in discard. (Order: descending-index removal, so
+    // index 1 (UC) goes first, then index 0 (Perception). discard is
+    // pushed back in that order.)
+    assert_eq!(
+        inv.discard,
+        vec![CardCode::new(UNEXPECTED_COURAGE), CardCode::new(PERCEPTION),],
+    );
+    assert_event_count!(result.events, 2, Event::CardDiscarded { .. });
+}
+
+#[test]
+fn committing_overpower_to_an_intellect_test_contributes_zero_icons() {
+    // Non-matching skill icons + no wild = 0 contribution. Overpower
+    // has two combat icons; committing it to an intellect test adds
+    // nothing, so 3 + 0 + 0 = 3 < 5 still fails by 2.
+    let (state, id) = state_with_hand(&[OVERPOWER]);
+    let result = drive_with_commits(state, intellect_test_difficulty_5(id), &[OVERPOWER]);
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestFailed { investigator, skill: SkillKind::Intellect, by: 2, .. }
+            if *investigator == id
+    );
+    // The committed card still discards even though it contributed
+    // nothing — commit-then-discard is the rule, regardless of
+    // outcome or contribution.
+    let inv = &result.state.investigators[&id];
+    assert!(inv.hand.is_empty());
+    assert_eq!(inv.discard, vec![CardCode::new(OVERPOWER)]);
+}
+
+#[test]
+fn awaiting_input_emits_between_started_and_revealed_for_real_card_state() {
+    // Sanity check that the pause point lands in the right spot when
+    // the registry is installed and the hand has real cards. First
+    // `apply` returns AwaitingInput; the chaos token hasn't been
+    // drawn yet.
+    let (state, id) = state_with_hand(&[PERCEPTION]);
+    let paused = apply(state, intellect_test_difficulty_5(id));
+    assert!(matches!(
+        paused.outcome,
+        EngineOutcome::AwaitingInput { .. }
+    ));
+    assert_event!(
+        paused.events,
+        Event::SkillTestStarted { investigator, .. } if *investigator == id
+    );
+    assert_no_event!(paused.events, Event::ChaosTokenRevealed { .. });
+}

--- a/crates/cards/tests/skill_test_commits.rs
+++ b/crates/cards/tests/skill_test_commits.rs
@@ -165,6 +165,33 @@ fn committing_two_cards_sums_both_contributions_and_discards_both() {
 }
 
 #[test]
+fn mixing_matching_and_non_matching_commits_only_counts_the_matching_card() {
+    // Commit Perception (intellect 2) + Overpower (combat 2, no
+    // wild) together against an intellect test. Only Perception's
+    // icons contribute: 3 + 0 + 2 + 0 = 5 vs difficulty 5 → success
+    // with margin 0. Both cards still discard regardless of
+    // contribution.
+    let (state, id) = state_with_hand(&[PERCEPTION, OVERPOWER]);
+    let result = drive_with_commits(
+        state,
+        intellect_test_difficulty_5(id),
+        &[PERCEPTION, OVERPOWER],
+    );
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestSucceeded { investigator, skill: SkillKind::Intellect, margin: 0 }
+            if *investigator == id
+    );
+    let inv = &result.state.investigators[&id];
+    assert!(inv.hand.is_empty(), "both cards removed from hand");
+    assert_eq!(
+        inv.discard,
+        vec![CardCode::new(OVERPOWER), CardCode::new(PERCEPTION)],
+    );
+}
+
+#[test]
 fn committing_overpower_to_an_intellect_test_contributes_zero_icons() {
     // Non-matching skill icons + no wild = 0 contribution. Overpower
     // has two combat icons; committing it to an intellect test adds

--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -275,4 +275,19 @@ pub enum InputResponse {
     PickInvestigator(InvestigatorId),
     /// Pick a specific location.
     PickLocation(LocationId),
+    /// Commit cards from hand to a skill test's commit window. Each
+    /// entry is a zero-based index into the active investigator's hand
+    /// at the moment of the prompt; the engine reads the matching
+    /// `CardCode`s, sums their printed skill icons (matching skill +
+    /// wild) into the test total, and discards them as part of the
+    /// test's cleanup. Empty `indices` is a legal "commit nothing"
+    /// signal.
+    ///
+    /// `u32` rather than `u8` for wire-format symmetry with
+    /// [`PickIndex`](Self::PickIndex); hand sizes never approach `u8`
+    /// limits in practice, the field is downcast at validation time.
+    CommitCards {
+        /// Hand indices to commit.
+        indices: Vec<u32>,
+    },
 }

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -585,9 +585,8 @@ fn validate_commit_indices(
         }
         if (i as usize) >= hand_len {
             return Err(EngineOutcome::Rejected {
-                reason:
-                    format!("CommitCards: hand index {i} out of bounds (hand size {hand_len})",)
-                        .into(),
+                reason: format!("CommitCards: hand index {i} out of bounds (hand size {hand_len})")
+                    .into(),
             });
         }
         indices_u8.push(

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -569,6 +569,11 @@ fn validate_commit_indices(
              was in flight; this is a state-corruption invariant violation"
         )
     });
+    // Arkham's upkeep hand-size limit caps hands well below 256 cards
+    // in practice (#111 tracks the engine-side enforcement of the
+    // discard-to-max-hand-size step), so the `u8::try_from` below
+    // succeeds for every index that passed the bounds check. No
+    // defensive overflow-rejection branch needed.
     let hand_len = inv.hand.len();
     let mut indices_u8: Vec<u8> = Vec::with_capacity(indices.len());
     let mut seen: BTreeSet<u32> = BTreeSet::new();
@@ -578,20 +583,17 @@ fn validate_commit_indices(
                 reason: format!("CommitCards: duplicate hand index {i}").into(),
             });
         }
-        let Ok(i_u8) = u8::try_from(i) else {
+        if (i as usize) >= hand_len {
             return Err(EngineOutcome::Rejected {
-                reason: format!("CommitCards: hand index {i} exceeds u8 range").into(),
-            });
-        };
-        if usize::from(i_u8) >= hand_len {
-            return Err(EngineOutcome::Rejected {
-                reason: format!(
-                    "CommitCards: hand index {i_u8} out of bounds (hand size {hand_len})",
-                )
-                .into(),
+                reason:
+                    format!("CommitCards: hand index {i} out of bounds (hand size {hand_len})",)
+                        .into(),
             });
         }
-        indices_u8.push(i_u8);
+        indices_u8.push(
+            u8::try_from(i)
+                .expect("bounds check above guarantees i < hand_len <= u8::MAX (see #111)"),
+        );
     }
     Ok(indices_u8)
 }

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -534,7 +534,7 @@ fn finish_skill_test(
         .committed_by_active
         .clone_from(&indices_u8);
 
-    let (succeeded, _margin) =
+    let succeeded =
         resolve_chaos_token_and_emit(state, events, investigator, skill, difficulty, skill_value);
 
     if succeeded {
@@ -599,7 +599,7 @@ fn validate_commit_indices(
 /// Sum the four skill-value contributions: investigator's printed
 /// stat, constant modifiers from cards in play, queued
 /// [`ModifierScope::ThisSkillTest`] pushes, and the committed cards'
-/// matching + wild icon icons.
+/// matching + wild icons.
 ///
 /// Cards / scopes not addressed by an installed registry contribute
 /// 0 — the same silent-skip policy `constant_skill_modifier` uses.
@@ -658,8 +658,8 @@ fn sum_committed_icons(hand: &[CardCode], indices: &[u8], skill: SkillKind) -> i
 /// Advance the RNG, draw a chaos token, compute the clamped total
 /// against `difficulty`, and emit the per-step events
 /// (`ChaosTokenRevealed` + either `SkillTestSucceeded` or
-/// `SkillTestFailed`). Returns `(succeeded, margin)` for the caller to
-/// branch its follow-up on.
+/// `SkillTestFailed`). Returns `true` on success so the caller can
+/// branch its follow-up.
 ///
 /// All arithmetic stays in `i8` with saturating ops: realistic
 /// gameplay values (skill 1–8, modifier ±8, difficulty ≤ ~6) fit far
@@ -672,7 +672,7 @@ fn resolve_chaos_token_and_emit(
     skill: SkillKind,
     difficulty: i8,
     skill_value: i8,
-) -> (bool, i8) {
+) -> bool {
     let token_idx = state.rng.next_index(state.chaos_bag.tokens.len());
     let token = state.chaos_bag.tokens[token_idx];
     let resolution = resolve_token(token, &state.token_modifiers);
@@ -701,7 +701,7 @@ fn resolve_chaos_token_and_emit(
             by,
         });
     }
-    (succeeded, margin)
+    succeeded
 }
 
 /// Move every committed hand card to the controller's discard pile,

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -8,20 +8,23 @@
 //! human-initiated actions, [`apply_engine_record`] for engine-emitted
 //! ones.
 
-use crate::action::{EngineRecord, PlayerAction};
+use std::collections::BTreeSet;
+
+use crate::action::{EngineRecord, InputResponse, PlayerAction};
 use crate::card_data::CardType;
 use crate::card_registry;
 use crate::dsl::{discover_clue, Cost, LocationTarget, SkillTestKind, Trigger};
 use crate::event::{Event, FailureReason};
 use crate::state::{
     resolve_token, CardCode, CardInPlay, CardInstanceId, DefeatCause, Enemy, EnemyId, GameState,
-    Investigator, InvestigatorId, LocationId, Phase, SkillKind, Status, TokenResolution, Zone,
+    InFlightSkillTest, Investigator, InvestigatorId, LocationId, Phase, SkillKind,
+    SkillTestFollowUp, Status, TokenResolution, Zone,
 };
 
 use super::evaluator::{
     apply_effect, constant_skill_modifier, pending_skill_modifier, EvalContext,
 };
-use super::outcome::EngineOutcome;
+use super::outcome::{EngineOutcome, InputRequest, ResumeToken};
 
 /// Action points granted to an investigator at the start of their
 /// turn during the Investigation phase. Per the Arkham Horror LCG
@@ -63,6 +66,19 @@ pub fn apply_player_action(
         };
     }
 
+    // While a skill test is paused at its commit window, only
+    // `ResolveInput` can advance the engine. Mirrors the
+    // `mulligan_window` guard above.
+    if state.in_flight_skill_test.is_some() && !matches!(action, PlayerAction::ResolveInput { .. })
+    {
+        return EngineOutcome::Rejected {
+            reason: "a skill test is paused at its commit window; submit a \
+                     PlayerAction::ResolveInput with an InputResponse::CommitCards \
+                     (empty indices commits no cards) before any other action"
+                .into(),
+        };
+    }
+
     let outcome = match action {
         PlayerAction::StartScenario => start_scenario(state, events),
         PlayerAction::EndTurn => end_turn(state, events),
@@ -98,11 +114,7 @@ pub fn apply_player_action(
             instance_id,
             ability_index,
         } => activate_ability(state, events, *investigator, *instance_id, *ability_index),
-        PlayerAction::ResolveInput { .. } => EngineOutcome::Rejected {
-            reason: "TODO(#63): ResolveInput dispatch lands with the skill-test commit \
-                     window; no AwaitingInput sites exist yet."
-                .into(),
-        },
+        PlayerAction::ResolveInput { response } => resolve_input(state, events, response),
     };
 
     // After a successful Mulligan, check whether every investigator
@@ -381,126 +393,304 @@ fn rotate_to_active(state: &mut GameState, events: &mut Vec<Event>, id: Investig
     });
 }
 
-/// The outcome of resolving a skill test, when the test runs at all.
-/// Returned by [`resolve_skill_test`] so callers (the
-/// `PerformSkillTest` dispatch wrapper, `Investigate`, future Fight /
-/// Evade) can branch on success vs failure to apply action-specific
-/// follow-on effects.
+/// Open the commit window for a skill test.
 ///
-/// `Succeeded.margin` and `Failed.{reason, by}` carry the same numbers
-/// as the corresponding events; callers that don't need them can
-/// match `Ok(SkillTestResolution::Succeeded { .. })`. Fields are
-/// `allow(dead_code)` until Fight/Evade (which want fail-by-X logic)
-/// land.
-#[allow(dead_code)]
-pub(super) enum SkillTestResolution {
-    /// The investigator's clamped total met or exceeded the difficulty.
-    Succeeded {
-        /// `total - difficulty` (always `>= 0`).
-        margin: i8,
-    },
-    /// The test failed.
-    Failed {
-        /// Why it failed.
-        reason: FailureReason,
-        /// Margin of failure (always `>= 0`).
-        by: i8,
-    },
-}
-
-/// Run the skill-test resolution sequence and return the outcome to
-/// the caller. Pushes the bracketing `SkillTestStarted` / `…Ended`
-/// events plus the per-step events (`ChaosTokenRevealed`,
-/// `SkillTestSucceeded` or `SkillTestFailed`).
+/// Validates the test (investigator exists and is Active, chaos bag is
+/// non-empty, difficulty non-negative, no other test already in
+/// flight), pushes [`Event::SkillTestStarted`], stores an
+/// [`InFlightSkillTest`] on `state`, and returns
+/// [`EngineOutcome::AwaitingInput`]. The active investigator finishes
+/// the test by submitting a
+/// [`PlayerAction::ResolveInput`](crate::action::PlayerAction::ResolveInput)
+/// carrying [`InputResponse::CommitCards`].
 ///
-/// Returns `Err(EngineOutcome::Rejected { .. })` on validation failure
-/// without pushing any events.
-///
-/// **`AutoFail`** forces the investigator's total to 0 per the Rules
-/// Reference; **`ElderSign`** is treated as `Modifier(0)` until per-
-/// investigator ability dispatch lands; **negative** `skill + modifier`
-/// clamps to 0.
-pub(super) fn resolve_skill_test(
+/// On validation failure, returns [`EngineOutcome::Rejected`] with no
+/// state change and no events pushed.
+pub(super) fn start_skill_test(
     state: &mut GameState,
     events: &mut Vec<Event>,
     investigator: InvestigatorId,
     skill: SkillKind,
     kind: SkillTestKind,
     difficulty: i8,
-) -> Result<SkillTestResolution, EngineOutcome> {
+    follow_up: SkillTestFollowUp,
+) -> EngineOutcome {
     // Validate-first: investigator must exist and be Active; chaos
     // bag must be non-empty so we can draw; difficulty must be non-
     // negative (FFG difficulties are always ≥ 0). Defeated
     // investigators can't take skill tests — they're out of play.
+    // A second test cannot overlap an in-flight one.
     let Some(inv) = state.investigators.get(&investigator) else {
-        return Err(EngineOutcome::Rejected {
+        return EngineOutcome::Rejected {
             reason: format!("skill test: investigator {investigator:?} not in state").into(),
-        });
+        };
     };
     if inv.status != Status::Active {
-        return Err(EngineOutcome::Rejected {
+        return EngineOutcome::Rejected {
             reason: format!(
                 "skill test: {investigator:?} is not Active (status {:?})",
                 inv.status,
             )
             .into(),
-        });
+        };
     }
     if state.chaos_bag.tokens.is_empty() {
-        return Err(EngineOutcome::Rejected {
+        return EngineOutcome::Rejected {
             reason: "skill test requires a non-empty chaos bag".into(),
-        });
+        };
     }
     if difficulty < 0 {
-        return Err(EngineOutcome::Rejected {
+        return EngineOutcome::Rejected {
             reason: format!("skill test: difficulty {difficulty} must be >= 0").into(),
-        });
+        };
     }
-    let base_skill = inv.skills.value(skill);
-    // Drop the `inv` borrow before re-borrowing state for the
-    // modifier queries. The constant query walks
-    // state.investigators[*].cards_in_play; the pending query walks
-    // state.pending_skill_modifiers. The constant query contributes 0
-    // when no registry is installed (most engine unit tests don't
-    // install one, and a skill test with no card effects in play is
-    // the correct fallback).
-    let constant_mod = card_registry::current().map_or(0, |reg| {
-        constant_skill_modifier(state, reg, investigator, skill, kind)
-    });
-    let pending_mod = pending_skill_modifier(state, investigator, skill);
-    let skill_value = base_skill
-        .saturating_add(constant_mod)
-        .saturating_add(pending_mod);
+    if state.in_flight_skill_test.is_some() {
+        return EngineOutcome::Rejected {
+            reason: "skill test: another skill test is already in flight; only one test \
+                     may pause at a commit window at a time"
+                .into(),
+        };
+    }
 
-    // Mutate-second: advance RNG, derive token, emit events.
+    // Mutate-second: stash the in-flight record and announce the test.
+    state.in_flight_skill_test = Some(InFlightSkillTest {
+        investigator,
+        skill,
+        kind,
+        difficulty,
+        committed_by_active: Vec::new(),
+        follow_up,
+    });
     events.push(Event::SkillTestStarted {
         investigator,
         skill,
         difficulty,
     });
 
-    let idx = state.rng.next_index(state.chaos_bag.tokens.len());
-    let token = state.chaos_bag.tokens[idx];
+    EngineOutcome::AwaitingInput {
+        request: InputRequest {
+            prompt: format!(
+                "Commit cards from hand for {investigator:?}'s {skill:?} skill test \
+                 (difficulty {difficulty}). Empty indices commits no cards.",
+            ),
+        },
+        // Routing keys off `state.in_flight_skill_test`, not the
+        // token, so any opaque value is fine here. ResumeToken(0) is
+        // the conventional "no extra context needed" choice for the
+        // first AwaitingInput site.
+        resume_token: ResumeToken(0),
+    }
+}
+
+/// Finish the in-flight skill test using the supplied commit indices.
+///
+/// Drives the rest of the resolution sequence the legacy
+/// `resolve_skill_test` did synchronously: validate the commit
+/// indices, sum the committed cards' icon contribution (matching
+/// skill + wild), draw a chaos token, compute the clamped total,
+/// emit the per-step events, apply the action-specific
+/// [`SkillTestFollowUp`] on success, discard the committed cards, and
+/// drain the in-flight record plus stale pending modifiers.
+///
+/// On invalid input (no in-flight test, malformed indices) returns
+/// [`EngineOutcome::Rejected`] with no state change and no events
+/// pushed — the engine stays paused at the commit window so the
+/// caller can submit a fixed-up response.
+fn finish_skill_test(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    indices: &[u32],
+) -> EngineOutcome {
+    // Snapshot the in-flight record (Copy-able primitives only) so
+    // later mutation paths can re-borrow state freely.
+    let Some(in_flight) = state.in_flight_skill_test.as_ref() else {
+        return EngineOutcome::Rejected {
+            reason: "ResolveInput::CommitCards: no in-flight skill test to resume".into(),
+        };
+    };
+    let investigator = in_flight.investigator;
+    let skill = in_flight.skill;
+    let kind = in_flight.kind;
+    let difficulty = in_flight.difficulty;
+    let follow_up = in_flight.follow_up;
+
+    // Validate the commit indices against the resolving
+    // investigator's hand. On Err, state is untouched and the engine
+    // stays paused so the client can retry.
+    let indices_u8 = match validate_commit_indices(state, investigator, indices) {
+        Ok(v) => v,
+        Err(rejected) => return rejected,
+    };
+
+    let skill_value = sum_skill_value(state, investigator, skill, kind, &indices_u8);
+
+    // Persist the committed indices into the in-flight record for
+    // replay clarity. Safe to expect: we read `in_flight_skill_test`
+    // immediately above and nothing has cleared it since.
+    state
+        .in_flight_skill_test
+        .as_mut()
+        .expect("in_flight_skill_test was Some immediately above")
+        .committed_by_active
+        .clone_from(&indices_u8);
+
+    let (succeeded, _margin) =
+        resolve_chaos_token_and_emit(state, events, investigator, skill, difficulty, skill_value);
+
+    if succeeded {
+        apply_skill_test_follow_up(state, events, investigator, follow_up);
+    }
+    discard_committed_cards(state, events, investigator, &indices_u8);
+
+    events.push(Event::SkillTestEnded { investigator });
+
+    // ModifierScope::ThisSkillTest contributions expire when the
+    // test ends. Drain pending entries for *this* investigator only —
+    // entries queued for other investigators' future tests stay.
+    state
+        .pending_skill_modifiers
+        .retain(|m| m.investigator != investigator);
+    state.in_flight_skill_test = None;
+
+    EngineOutcome::Done
+}
+
+/// Validate that every entry in `indices` is a unique in-bounds hand
+/// index for `investigator`, and return them downcast to `u8` (the
+/// width hand indices use elsewhere in state).
+fn validate_commit_indices(
+    state: &GameState,
+    investigator: InvestigatorId,
+    indices: &[u32],
+) -> Result<Vec<u8>, EngineOutcome> {
+    let inv = state.investigators.get(&investigator).unwrap_or_else(|| {
+        unreachable!(
+            "validate_commit_indices: investigator {investigator:?} disappeared while test \
+             was in flight; this is a state-corruption invariant violation"
+        )
+    });
+    let hand_len = inv.hand.len();
+    let mut indices_u8: Vec<u8> = Vec::with_capacity(indices.len());
+    let mut seen: BTreeSet<u32> = BTreeSet::new();
+    for &i in indices {
+        if !seen.insert(i) {
+            return Err(EngineOutcome::Rejected {
+                reason: format!("CommitCards: duplicate hand index {i}").into(),
+            });
+        }
+        let Ok(i_u8) = u8::try_from(i) else {
+            return Err(EngineOutcome::Rejected {
+                reason: format!("CommitCards: hand index {i} exceeds u8 range").into(),
+            });
+        };
+        if usize::from(i_u8) >= hand_len {
+            return Err(EngineOutcome::Rejected {
+                reason: format!(
+                    "CommitCards: hand index {i_u8} out of bounds (hand size {hand_len})",
+                )
+                .into(),
+            });
+        }
+        indices_u8.push(i_u8);
+    }
+    Ok(indices_u8)
+}
+
+/// Sum the four skill-value contributions: investigator's printed
+/// stat, constant modifiers from cards in play, queued
+/// [`ModifierScope::ThisSkillTest`] pushes, and the committed cards'
+/// matching + wild icon icons.
+///
+/// Cards / scopes not addressed by an installed registry contribute
+/// 0 — the same silent-skip policy `constant_skill_modifier` uses.
+///
+/// [`ModifierScope::ThisSkillTest`]: crate::dsl::ModifierScope::ThisSkillTest
+fn sum_skill_value(
+    state: &GameState,
+    investigator: InvestigatorId,
+    skill: SkillKind,
+    kind: SkillTestKind,
+    committed_indices: &[u8],
+) -> i8 {
+    let inv = state.investigators.get(&investigator).unwrap_or_else(|| {
+        unreachable!(
+            "sum_skill_value: investigator {investigator:?} disappeared while test was in \
+             flight; this is a state-corruption invariant violation"
+        )
+    });
+    let base = inv.skills.value(skill);
+    let icon_mod = sum_committed_icons(&inv.hand, committed_indices, skill);
+    let constant_mod = card_registry::current().map_or(0, |reg| {
+        constant_skill_modifier(state, reg, investigator, skill, kind)
+    });
+    let pending_mod = pending_skill_modifier(state, investigator, skill);
+    base.saturating_add(constant_mod)
+        .saturating_add(pending_mod)
+        .saturating_add(icon_mod)
+}
+
+/// Sum the skill-icon contribution from the cards at `indices` in
+/// `hand`: each card adds its matching-skill icons plus its wild
+/// icons. Cards whose code isn't in the installed registry contribute
+/// 0; no registry installed = 0 contribution overall.
+fn sum_committed_icons(hand: &[CardCode], indices: &[u8], skill: SkillKind) -> i8 {
+    let Some(reg) = card_registry::current() else {
+        return 0;
+    };
+    indices
+        .iter()
+        .map(|&idx| {
+            let code = &hand[usize::from(idx)];
+            (reg.metadata_for)(code).map_or(0_i8, |meta| {
+                let matching = match skill {
+                    SkillKind::Willpower => meta.skill_icons.willpower,
+                    SkillKind::Intellect => meta.skill_icons.intellect,
+                    SkillKind::Combat => meta.skill_icons.combat,
+                    SkillKind::Agility => meta.skill_icons.agility,
+                };
+                let raw = matching.saturating_add(meta.skill_icons.wild);
+                i8::try_from(raw).unwrap_or(i8::MAX)
+            })
+        })
+        .fold(0_i8, i8::saturating_add)
+}
+
+/// Advance the RNG, draw a chaos token, compute the clamped total
+/// against `difficulty`, and emit the per-step events
+/// (`ChaosTokenRevealed` + either `SkillTestSucceeded` or
+/// `SkillTestFailed`). Returns `(succeeded, margin)` for the caller to
+/// branch its follow-up on.
+///
+/// All arithmetic stays in `i8` with saturating ops: realistic
+/// gameplay values (skill 1–8, modifier ±8, difficulty ≤ ~6) fit far
+/// inside `i8`, but saturation defends against absurd state
+/// configurations without needing a wider integer type.
+fn resolve_chaos_token_and_emit(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+    skill: SkillKind,
+    difficulty: i8,
+    skill_value: i8,
+) -> (bool, i8) {
+    let token_idx = state.rng.next_index(state.chaos_bag.tokens.len());
+    let token = state.chaos_bag.tokens[token_idx];
     let resolution = resolve_token(token, &state.token_modifiers);
     events.push(Event::ChaosTokenRevealed { token, resolution });
 
-    // All arithmetic stays in i8 with saturating ops: realistic
-    // gameplay values (skill 1–8, modifier ±8, difficulty ≤ ~6) fit
-    // far inside i8, but saturation defends against absurd state
-    // configurations without needing a wider integer type.
     let (total, fail_reason) = match resolution {
         TokenResolution::Modifier(n) => (skill_value.saturating_add(n).max(0), None),
         TokenResolution::ElderSign => (skill_value.max(0), None),
         TokenResolution::AutoFail => (0, Some(FailureReason::AutoFail)),
     };
     let margin = total.saturating_sub(difficulty);
-    let outcome = if margin >= 0 && fail_reason.is_none() {
+    let succeeded = margin >= 0 && fail_reason.is_none();
+    if succeeded {
         events.push(Event::SkillTestSucceeded {
             investigator,
             skill,
             margin,
         });
-        SkillTestResolution::Succeeded { margin }
     } else {
         let reason = fail_reason.unwrap_or(FailureReason::Total);
         let by = difficulty.saturating_sub(total);
@@ -510,27 +700,128 @@ pub(super) fn resolve_skill_test(
             reason,
             by,
         });
-        SkillTestResolution::Failed { reason, by }
-    };
+    }
+    (succeeded, margin)
+}
 
-    events.push(Event::SkillTestEnded { investigator });
+/// Move every committed hand card to the controller's discard pile,
+/// emitting [`Event::CardDiscarded`] for each. Per the
+/// [`Event::SkillTestEnded`] docs, these discards precede the
+/// `SkillTestEnded` cleanup marker. Walk indices in descending order
+/// so each `remove` keeps the still-pending indices stable.
+fn discard_committed_cards(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+    indices_u8: &[u8],
+) {
+    let mut sorted: Vec<u8> = indices_u8.to_vec();
+    sorted.sort_by(|a, b| b.cmp(a));
+    let inv = state
+        .investigators
+        .get_mut(&investigator)
+        .unwrap_or_else(|| {
+            unreachable!(
+                "discard_committed_cards: investigator {investigator:?} vanished after \
+                 follow-up; this is a state-corruption invariant violation"
+            )
+        });
+    for idx in sorted {
+        let code = inv.hand.remove(usize::from(idx));
+        inv.discard.push(code.clone());
+        events.push(Event::CardDiscarded {
+            investigator,
+            code,
+            from: Zone::Hand,
+        });
+    }
+}
 
-    // ModifierScope::ThisSkillTest contributions expire when the test
-    // ends. Drain pending entries for *this* investigator only —
-    // entries queued for other investigators' future tests stay.
-    state
-        .pending_skill_modifiers
-        .retain(|m| m.investigator != investigator);
+/// Dispatch the action-specific on-success effect for the resolving
+/// skill test. Failure-path follow-ups (none today) would route here
+/// too if we grow them.
+fn apply_skill_test_follow_up(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+    follow_up: SkillTestFollowUp,
+) {
+    match follow_up {
+        SkillTestFollowUp::None => {}
+        SkillTestFollowUp::Investigate => {
+            let effect = discover_clue(LocationTarget::ControllerLocation, 1);
+            let ctx = EvalContext::for_controller(investigator);
+            // Same caveat as the pre-refactor `investigate`: the only
+            // remaining rejection path inside `discover_clue` is
+            // "controller is between locations", which the Investigate
+            // action validates before starting the test. Empty-
+            // location is a silent no-op by design. Any rejection
+            // here is a state-corruption invariant violation.
+            let outcome = apply_effect(state, events, &effect, ctx);
+            if let EngineOutcome::Rejected { reason } = outcome {
+                unreachable!(
+                    "Investigate follow-up: discover_clue rejected unexpectedly after \
+                     validation: {reason}"
+                );
+            }
+        }
+        SkillTestFollowUp::Fight { enemy } => {
+            // Mid-test enemy disappearance isn't possible in Phase 3
+            // (no commit-window effects mutate enemies), so
+            // damage_enemy's enemy-missing panic stays loud.
+            damage_enemy(state, events, enemy, 1, Some(investigator));
+        }
+        SkillTestFollowUp::Evade { enemy } => {
+            let e = state.enemies.get_mut(&enemy).unwrap_or_else(|| {
+                unreachable!(
+                    "Evade follow-up: enemy {enemy:?} vanished while test was in flight; \
+                     this is a state-corruption invariant violation"
+                )
+            });
+            e.engaged_with = None;
+            e.exhausted = true;
+            events.push(Event::EnemyDisengaged {
+                enemy,
+                investigator,
+            });
+            events.push(Event::EnemyExhausted { enemy });
+        }
+    }
+}
 
-    Ok(outcome)
+/// Dispatch a [`PlayerAction::ResolveInput`].
+///
+/// Today the only `AwaitingInput` site is the skill-test commit
+/// window, so this routes [`InputResponse::CommitCards`] through
+/// [`finish_skill_test`] and rejects everything else. Future
+/// `AwaitingInput` sites (`ChooseOne`, target picks, …) extend this
+/// dispatch.
+fn resolve_input(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    response: &InputResponse,
+) -> EngineOutcome {
+    if state.in_flight_skill_test.is_none() {
+        return EngineOutcome::Rejected {
+            reason: "ResolveInput: no AwaitingInput prompt is currently outstanding".into(),
+        };
+    }
+    match response {
+        InputResponse::CommitCards { indices } => finish_skill_test(state, events, indices),
+        other => EngineOutcome::Rejected {
+            reason: format!(
+                "ResolveInput: skill-test commit window expects InputResponse::CommitCards, \
+                 got {other:?}",
+            )
+            .into(),
+        },
+    }
 }
 
 /// Public dispatch wrapper for [`PlayerAction::PerformSkillTest`].
 ///
-/// Card commits, the commit-window `AwaitingInput`, and the after-
-/// resolution trigger window are downstream (#63 / #64). The skill-
-/// test machinery itself lives in [`resolve_skill_test`], which other
-/// turn-actions (Investigate, future Fight / Evade) invoke directly.
+/// Opens the commit window with no action-specific follow-up. The
+/// after-resolution trigger window (#64) is downstream.
 fn perform_skill_test(
     state: &mut GameState,
     events: &mut Vec<Event>,
@@ -538,17 +829,15 @@ fn perform_skill_test(
     skill: SkillKind,
     difficulty: i8,
 ) -> EngineOutcome {
-    match resolve_skill_test(
+    start_skill_test(
         state,
         events,
         investigator,
         skill,
         SkillTestKind::Plain,
         difficulty,
-    ) {
-        Ok(_) => EngineOutcome::Done,
-        Err(rejected) => rejected,
-    }
+        SkillTestFollowUp::None,
+    )
 }
 
 /// Handler for [`PlayerAction::Investigate`].
@@ -653,34 +942,15 @@ fn investigate(
         return EngineOutcome::Done;
     }
 
-    match resolve_skill_test(
+    start_skill_test(
         state,
         events,
         investigator,
         SkillKind::Intellect,
         SkillTestKind::Investigate,
         difficulty,
-    ) {
-        Ok(SkillTestResolution::Succeeded { .. }) => {
-            let effect = discover_clue(LocationTarget::ControllerLocation, 1);
-            let ctx = EvalContext::for_controller(investigator);
-            // The remaining rejection path inside `discover_clue` is
-            // "controller is between locations," which we already
-            // validated above. Empty-location is a silent no-op by
-            // design. So any rejection here is a state-corruption
-            // invariant violation — surface it loudly, not as a
-            // half-applied Rejected outcome.
-            let outcome = apply_effect(state, events, &effect, ctx);
-            if let EngineOutcome::Rejected { reason } = outcome {
-                unreachable!(
-                    "Investigate: discover_clue rejected unexpectedly after validation: {reason}"
-                );
-            }
-            EngineOutcome::Done
-        }
-        Ok(SkillTestResolution::Failed { .. }) => EngineOutcome::Done,
-        Err(rejected) => rejected,
-    }
+        SkillTestFollowUp::Investigate,
+    )
 }
 
 /// Handler for [`PlayerAction::Move`].
@@ -945,21 +1215,15 @@ fn fight(
         Err(rejected) => return rejected,
     };
     spend_one_action(state, events, investigator);
-    match resolve_skill_test(
+    start_skill_test(
         state,
         events,
         investigator,
         SkillKind::Combat,
         SkillTestKind::Fight,
         fight_difficulty,
-    ) {
-        Ok(SkillTestResolution::Succeeded { .. }) => {
-            damage_enemy(state, events, enemy_id, 1, Some(investigator));
-            EngineOutcome::Done
-        }
-        Ok(SkillTestResolution::Failed { .. }) => EngineOutcome::Done,
-        Err(rejected) => rejected,
-    }
+        SkillTestFollowUp::Fight { enemy: enemy_id },
+    )
 }
 
 /// Handler for [`PlayerAction::Evade`].
@@ -988,33 +1252,15 @@ fn evade(
         Err(rejected) => return rejected,
     };
     spend_one_action(state, events, investigator);
-    match resolve_skill_test(
+    start_skill_test(
         state,
         events,
         investigator,
         SkillKind::Agility,
         SkillTestKind::Evade,
         evade_difficulty,
-    ) {
-        Ok(SkillTestResolution::Succeeded { .. }) => {
-            let enemy = state.enemies.get_mut(&enemy_id).unwrap_or_else(|| {
-                unreachable!(
-                    "Evade: enemy {enemy_id:?} disappeared between validation and resolution; \
-                     this is a state-corruption invariant violation"
-                )
-            });
-            enemy.engaged_with = None;
-            enemy.exhausted = true;
-            events.push(Event::EnemyDisengaged {
-                enemy: enemy_id,
-                investigator,
-            });
-            events.push(Event::EnemyExhausted { enemy: enemy_id });
-            EngineOutcome::Done
-        }
-        Ok(SkillTestResolution::Failed { .. }) => EngineOutcome::Done,
-        Err(rejected) => rejected,
-    }
+        SkillTestFollowUp::Evade { enemy: enemy_id },
+    )
 }
 
 /// Apply `amount` damage to an enemy. If the new damage reaches or

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -54,6 +54,15 @@ pub struct ApplyResult {
 /// TODO(#17+): once non-trivial handlers exist, refactor to a strict
 /// validate-first / apply-second two-phase shape so this is structural
 /// rather than a per-handler convention.
+///
+/// On [`EngineOutcome::AwaitingInput`], the returned state and event
+/// list reflect the work done up to the pause point — e.g. a
+/// `PerformSkillTest` apply that suspends at the commit window has
+/// already emitted [`Event::SkillTestStarted`] and populated
+/// [`GameState::in_flight_skill_test`]. The resume action
+/// ([`PlayerAction::ResolveInput`](crate::action::PlayerAction::ResolveInput))
+/// drives the rest of resolution in a subsequent `apply` call. While
+/// paused, every non-`ResolveInput` player action rejects.
 pub fn apply(state: GameState, action: Action) -> ApplyResult {
     let mut state = state;
     let mut events = Vec::new();
@@ -3341,6 +3350,9 @@ mod tests {
             }
             other => panic!("expected Rejected, got {other:?}"),
         }
+        // State stays paused so the client can submit a fixed-up
+        // response without re-initiating the test.
+        assert!(bad.state.in_flight_skill_test.is_some());
     }
 
     #[test]
@@ -3415,5 +3427,33 @@ mod tests {
             }),
         );
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    }
+
+    #[test]
+    fn investigate_canonical_event_sequence_pins_followup_before_test_ended() {
+        // Pins the post-#63 ordering: on a successful Investigate the
+        // discover-clue events fire *before* SkillTestEnded, matching
+        // the `SkillTestEnded` event-doc text that cleanup precedes
+        // the end marker. The pre-#63 ordering ran the follow-up
+        // after the bracketing end event — silently flipping that
+        // back would break downstream listeners that key off the end
+        // marker as "all sub-effects already applied."
+        let (inv_id, _loc_id, state) = investigate_scenario(2, 2);
+        let result = apply_no_commits(
+            state,
+            Action::Player(PlayerAction::Investigate {
+                investigator: inv_id,
+            }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        crate::assert_event_sequence!(
+            result.events,
+            Event::SkillTestStarted { .. },
+            Event::ChaosTokenRevealed { .. },
+            Event::SkillTestSucceeded { .. },
+            Event::CluePlaced { .. },
+            Event::LocationCluesChanged { .. },
+            Event::SkillTestEnded { .. },
+        );
     }
 }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -81,9 +81,11 @@ mod tests {
     use crate::state::EnemyId;
     use crate::state::{
         CardCode, ChaosToken, DefeatCause, GameState, InvestigatorId, Phase, SkillKind, Status,
-        TokenModifiers, TokenResolution,
+        TokenModifiers, TokenResolution, Zone,
     };
-    use crate::test_support::{test_enemy, test_investigator, test_location, TestGame};
+    use crate::test_support::{
+        apply_no_commits, test_enemy, test_investigator, test_location, TestGame,
+    };
     use crate::{assert_event, assert_event_count, assert_no_event};
 
     use super::{apply, EngineOutcome};
@@ -229,7 +231,7 @@ mod tests {
     #[test]
     fn perform_skill_test_with_unknown_investigator_is_rejected() {
         let state = TestGame::new().with_chaos_bag(bag_only_zero()).build();
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::PerformSkillTest {
                 investigator: InvestigatorId(999),
@@ -247,7 +249,7 @@ mod tests {
         let state = TestGame::new()
             .with_investigator(test_investigator(1))
             .build();
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::PerformSkillTest {
                 investigator: id,
@@ -266,7 +268,7 @@ mod tests {
             .with_investigator(test_investigator(1))
             .with_chaos_bag(bag_only_zero())
             .build();
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::PerformSkillTest {
                 investigator: id,
@@ -287,7 +289,7 @@ mod tests {
             .with_investigator(test_investigator(1))
             .with_chaos_bag(bag_only_zero())
             .build();
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::PerformSkillTest {
                 investigator: id,
@@ -331,7 +333,7 @@ mod tests {
             .with_investigator(strong)
             .with_chaos_bag(bag_only_zero())
             .build();
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::PerformSkillTest {
                 investigator: id,
@@ -357,7 +359,7 @@ mod tests {
             .with_investigator(test_investigator(1))
             .with_chaos_bag(bag_only_zero())
             .build();
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::PerformSkillTest {
                 investigator: id,
@@ -392,7 +394,7 @@ mod tests {
             .with_investigator(high)
             .with_chaos_bag(crate::state::ChaosBag::new([ChaosToken::AutoFail]))
             .build();
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::PerformSkillTest {
                 investigator: id,
@@ -423,7 +425,7 @@ mod tests {
             .with_investigator(test_investigator(1))
             .with_chaos_bag(crate::state::ChaosBag::new([ChaosToken::AutoFail]))
             .build();
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::PerformSkillTest {
                 investigator: id,
@@ -457,7 +459,7 @@ mod tests {
                 ..TokenModifiers::default()
             })
             .build();
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::PerformSkillTest {
                 investigator: id,
@@ -486,7 +488,7 @@ mod tests {
             .with_investigator(test_investigator(1))
             .with_chaos_bag(crate::state::ChaosBag::new([ChaosToken::ElderSign]))
             .build();
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::PerformSkillTest {
                 investigator: id,
@@ -516,7 +518,7 @@ mod tests {
             .with_chaos_bag(crate::state::ChaosBag::new([ChaosToken::Skull]))
             .with_token_modifiers(night_of_the_zealot_standard())
             .build();
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::PerformSkillTest {
                 investigator: id,
@@ -563,7 +565,7 @@ mod tests {
             },
         ];
 
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::PerformSkillTest {
                 investigator: id1,
@@ -601,8 +603,8 @@ mod tests {
             difficulty: 3,
         });
 
-        let first = apply(initial.clone(), action.clone());
-        let second = apply(initial, action);
+        let first = apply_no_commits(initial.clone(), action.clone());
+        let second = apply_no_commits(initial, action);
 
         assert_eq!(first.outcome, EngineOutcome::Done);
         assert_eq!(first.state.rng, second.state.rng);
@@ -641,7 +643,7 @@ mod tests {
     fn investigate_succeeds_and_moves_one_clue_to_investigator() {
         // Default intellect 3, shroud 2 → margin 1 → success.
         let (inv_id, loc_id, state) = investigate_scenario(2, 2);
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Investigate {
                 investigator: inv_id,
@@ -680,7 +682,7 @@ mod tests {
     fn investigate_failure_spends_action_but_moves_no_clue() {
         // Intellect 3, shroud 5 → fails by 2; action still spent.
         let (inv_id, loc_id, state) = investigate_scenario(2, 5);
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Investigate {
                 investigator: inv_id,
@@ -702,7 +704,7 @@ mod tests {
         // the location is empty without trying), the action is still
         // spent, and discover_clue is a silent no-op on success.
         let (inv_id, loc_id, state) = investigate_scenario(0, 2);
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Investigate {
                 investigator: inv_id,
@@ -721,7 +723,7 @@ mod tests {
     fn investigate_outside_investigation_phase_is_rejected() {
         let (inv_id, _, mut state) = investigate_scenario(2, 2);
         state.phase = Phase::Mythos;
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Investigate {
                 investigator: inv_id,
@@ -737,7 +739,7 @@ mod tests {
         // Add a second investigator but keep the first active.
         let other = InvestigatorId(2);
         state.investigators.insert(other, test_investigator(2));
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Investigate {
                 investigator: other,
@@ -755,7 +757,7 @@ mod tests {
             .get_mut(&inv_id)
             .unwrap()
             .actions_remaining = 0;
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Investigate {
                 investigator: inv_id,
@@ -773,7 +775,7 @@ mod tests {
             .get_mut(&inv_id)
             .unwrap()
             .current_location = None;
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Investigate {
                 investigator: inv_id,
@@ -1380,7 +1382,7 @@ mod tests {
         // Set investigator combat = 3 (default already is 3) so the
         // test just barely passes.
         state.investigators.get_mut(&inv_id).unwrap().skills.combat = 3;
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Fight {
                 investigator: inv_id,
@@ -1416,7 +1418,7 @@ mod tests {
     fn fight_failure_spends_action_but_deals_no_damage() {
         let (inv_id, enemy_id, mut state) = fight_evade_scenario();
         state.investigators.get_mut(&inv_id).unwrap().skills.combat = 1;
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Fight {
                 investigator: inv_id,
@@ -1438,7 +1440,7 @@ mod tests {
         // removed from state, engagement cleared.
         let (inv_id, enemy_id, mut state) = fight_evade_scenario();
         state.enemies.get_mut(&enemy_id).unwrap().damage = 1;
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Fight {
                 investigator: inv_id,
@@ -1463,7 +1465,7 @@ mod tests {
     fn evade_succeeds_disengages_and_exhausts() {
         // Default agility 3, evade 3 → margin 0 → success.
         let (inv_id, enemy_id, state) = fight_evade_scenario();
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Evade {
                 investigator: inv_id,
@@ -1499,7 +1501,7 @@ mod tests {
     fn evade_failure_leaves_engagement_intact() {
         let (inv_id, enemy_id, mut state) = fight_evade_scenario();
         state.investigators.get_mut(&inv_id).unwrap().skills.agility = 1;
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Evade {
                 investigator: inv_id,
@@ -1519,7 +1521,7 @@ mod tests {
     fn fight_when_not_engaged_with_target_is_rejected() {
         let (inv_id, enemy_id, mut state) = fight_evade_scenario();
         state.enemies.get_mut(&enemy_id).unwrap().engaged_with = None;
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Fight {
                 investigator: inv_id,
@@ -1534,7 +1536,7 @@ mod tests {
     fn evade_when_not_engaged_with_target_is_rejected() {
         let (inv_id, enemy_id, mut state) = fight_evade_scenario();
         state.enemies.get_mut(&enemy_id).unwrap().engaged_with = None;
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Evade {
                 investigator: inv_id,
@@ -1548,7 +1550,7 @@ mod tests {
     #[test]
     fn fight_with_unknown_enemy_is_rejected() {
         let (inv_id, _, state) = fight_evade_scenario();
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Fight {
                 investigator: inv_id,
@@ -1563,7 +1565,7 @@ mod tests {
     fn fight_outside_investigation_phase_is_rejected() {
         let (inv_id, enemy_id, mut state) = fight_evade_scenario();
         state.phase = Phase::Mythos;
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Fight {
                 investigator: inv_id,
@@ -1579,7 +1581,7 @@ mod tests {
         let (_, enemy_id, mut state) = fight_evade_scenario();
         let other = InvestigatorId(2);
         state.investigators.insert(other, test_investigator(2));
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Fight {
                 investigator: other,
@@ -1598,7 +1600,7 @@ mod tests {
             .get_mut(&inv_id)
             .unwrap()
             .actions_remaining = 0;
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Fight {
                 investigator: inv_id,
@@ -1617,7 +1619,7 @@ mod tests {
         let (inv_id, enemy_id, mut state) = fight_evade_scenario();
         state.enemies.get_mut(&enemy_id).unwrap().fight = -1;
         let actions_before = state.investigators[&inv_id].actions_remaining;
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Fight {
                 investigator: inv_id,
@@ -1637,7 +1639,7 @@ mod tests {
         let (inv_id, enemy_id, mut state) = fight_evade_scenario();
         state.enemies.get_mut(&enemy_id).unwrap().evade = -1;
         let actions_before = state.investigators[&inv_id].actions_remaining;
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Evade {
                 investigator: inv_id,
@@ -1660,7 +1662,7 @@ mod tests {
         // `exhausted = true`.
         let (inv_id, enemy_id, mut state) = fight_evade_scenario();
         state.enemies.get_mut(&enemy_id).unwrap().exhausted = true;
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Evade {
                 investigator: inv_id,
@@ -1687,7 +1689,7 @@ mod tests {
         // full attribution + removal path while the other is untouched.
         state.enemies.get_mut(&enemy_id).unwrap().damage = 1;
 
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Fight {
                 investigator: inv_id,
@@ -1846,7 +1848,7 @@ mod tests {
         enemy.attack_horror = 1;
         let mut state = state;
         state.enemies.insert(enemy_id, enemy);
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Investigate {
                 investigator: inv_id,
@@ -1875,7 +1877,7 @@ mod tests {
         bystander.engaged_with = Some(inv_id);
         bystander.attack_damage = 5;
         state.enemies.insert(bystander_id, bystander);
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Fight {
                 investigator: inv_id,
@@ -1898,7 +1900,7 @@ mod tests {
         bystander.engaged_with = Some(inv_id);
         bystander.attack_damage = 5;
         state.enemies.insert(bystander_id, bystander);
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Evade {
                 investigator: inv_id,
@@ -2068,7 +2070,7 @@ mod tests {
         enemy.attack_damage = 0;
         enemy.attack_horror = 1;
         state.enemies.insert(enemy_id, enemy);
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Investigate {
                 investigator: inv_id,
@@ -2214,7 +2216,7 @@ mod tests {
     fn defeated_investigator_cannot_investigate() {
         let (inv_id, _, mut state) = investigate_scenario(2, 2);
         state.investigators.get_mut(&inv_id).unwrap().status = Status::Insane;
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Investigate {
                 investigator: inv_id,
@@ -2228,7 +2230,7 @@ mod tests {
     fn defeated_investigator_cannot_fight() {
         let (inv_id, enemy_id, mut state) = fight_evade_scenario();
         state.investigators.get_mut(&inv_id).unwrap().status = Status::Killed;
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Fight {
                 investigator: inv_id,
@@ -2243,7 +2245,7 @@ mod tests {
     fn defeated_investigator_cannot_evade() {
         let (inv_id, enemy_id, mut state) = fight_evade_scenario();
         state.investigators.get_mut(&inv_id).unwrap().status = Status::Insane;
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Evade {
                 investigator: inv_id,
@@ -2263,7 +2265,7 @@ mod tests {
             .with_investigator(inv)
             .with_chaos_bag(bag_only_zero())
             .build();
-        let result = apply(
+        let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::PerformSkillTest {
                 investigator: id,
@@ -3124,5 +3126,294 @@ mod tests {
         );
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
         assert!(result.events.is_empty());
+    }
+
+    // ---- skill-test commit window (#63) -----------------------------
+
+    #[test]
+    fn perform_skill_test_awaits_input_between_started_and_revealed() {
+        // Acceptance: AwaitingInput must fire between SkillTestStarted
+        // and ChaosTokenRevealed. The first `apply` returns
+        // AwaitingInput with only SkillTestStarted on the events list.
+        let id = InvestigatorId(1);
+        let state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_chaos_bag(bag_only_zero())
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Intellect,
+                difficulty: 3,
+            }),
+        );
+
+        assert!(matches!(
+            result.outcome,
+            EngineOutcome::AwaitingInput { .. }
+        ));
+        assert_event!(
+            result.events,
+            Event::SkillTestStarted { investigator, .. } if *investigator == id
+        );
+        // The chaos token has NOT been drawn yet — that fires on the
+        // resume path after the commit response arrives.
+        assert_no_event!(result.events, Event::ChaosTokenRevealed { .. });
+        assert!(
+            result.state.in_flight_skill_test.is_some(),
+            "in_flight_skill_test must be populated while paused",
+        );
+    }
+
+    #[test]
+    fn resolve_input_with_empty_commits_resumes_the_test() {
+        // Pause → resume with `CommitCards { indices: [] }` →
+        // ChaosTokenRevealed and the rest of resolution fire on the
+        // second apply.
+        let id = InvestigatorId(1);
+        let state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_chaos_bag(bag_only_zero())
+            .build();
+        let paused = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Intellect,
+                difficulty: 3,
+            }),
+        );
+
+        let resumed = apply(
+            paused.state,
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::CommitCards { indices: vec![] },
+            }),
+        );
+
+        assert_eq!(resumed.outcome, EngineOutcome::Done);
+        assert_event!(resumed.events, Event::ChaosTokenRevealed { .. });
+        assert_event!(
+            resumed.events,
+            Event::SkillTestSucceeded { investigator, .. } if *investigator == id
+        );
+        assert_event!(
+            resumed.events,
+            Event::SkillTestEnded { investigator } if *investigator == id
+        );
+        assert!(
+            resumed.state.in_flight_skill_test.is_none(),
+            "in_flight_skill_test must clear after resolution",
+        );
+    }
+
+    #[test]
+    fn commit_window_discards_committed_cards_into_discard_pile() {
+        // Two cards in hand; commit both. After resolution, both are
+        // in the discard pile, neither in hand, and CardDiscarded
+        // events fired with `from: Hand`. Icon counting is exercised
+        // separately via the cards integration test (this one
+        // doesn't install a registry, so icon contribution is 0).
+        let id = InvestigatorId(1);
+        let mut inv = test_investigator(1);
+        inv.hand = vec![CardCode::new("A"), CardCode::new("B")];
+        let state = TestGame::new()
+            .with_investigator(inv)
+            .with_chaos_bag(bag_only_zero())
+            .build();
+
+        let result = apply_no_commits_with_response(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Intellect,
+                difficulty: 3,
+            }),
+            InputResponse::CommitCards {
+                indices: vec![0, 1],
+            },
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        let inv_after = &result.state.investigators[&id];
+        assert!(
+            inv_after.hand.is_empty(),
+            "hand must be empty after commit + discard"
+        );
+        assert_eq!(
+            inv_after.discard,
+            vec![CardCode::new("B"), CardCode::new("A")],
+            "committed cards land in discard (descending-index removal order)",
+        );
+        assert_event_count!(result.events, 2, Event::CardDiscarded { .. });
+        assert_event!(
+            result.events,
+            Event::CardDiscarded { investigator, code, from: Zone::Hand }
+                if *investigator == id && *code == CardCode::new("A")
+        );
+        assert_event!(
+            result.events,
+            Event::CardDiscarded { investigator, code, from: Zone::Hand }
+                if *investigator == id && *code == CardCode::new("B")
+        );
+    }
+
+    /// Helper: drive a skill-test-initiating action through with the
+    /// given `InputResponse`. Used by commit-window tests that don't
+    /// fit `apply_no_commits` (which always submits an empty commit).
+    fn apply_no_commits_with_response(
+        state: GameState,
+        action: Action,
+        response: InputResponse,
+    ) -> crate::engine::ApplyResult {
+        use crate::test_support::ScriptedResolver;
+        let mut resolver = ScriptedResolver::new();
+        resolver.push(response);
+        crate::test_support::drive(state, action, resolver)
+    }
+
+    #[test]
+    fn commit_window_rejects_out_of_bounds_index() {
+        let id = InvestigatorId(1);
+        let mut inv = test_investigator(1);
+        inv.hand = vec![CardCode::new("A")];
+        let state = TestGame::new()
+            .with_investigator(inv)
+            .with_chaos_bag(bag_only_zero())
+            .build();
+        let paused = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Intellect,
+                difficulty: 3,
+            }),
+        );
+        let bad = apply(
+            paused.state,
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::CommitCards { indices: vec![5] },
+            }),
+        );
+        match bad.outcome {
+            EngineOutcome::Rejected { reason } => {
+                assert!(
+                    reason.contains("out of bounds"),
+                    "unexpected reason: {reason}"
+                );
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+        // State stays paused (engine still in-flight) so a client
+        // can submit a fixed-up response without re-initiating.
+        assert!(bad.state.in_flight_skill_test.is_some());
+    }
+
+    #[test]
+    fn commit_window_rejects_duplicate_indices() {
+        let id = InvestigatorId(1);
+        let mut inv = test_investigator(1);
+        inv.hand = vec![CardCode::new("A"), CardCode::new("B")];
+        let state = TestGame::new()
+            .with_investigator(inv)
+            .with_chaos_bag(bag_only_zero())
+            .build();
+        let paused = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Intellect,
+                difficulty: 3,
+            }),
+        );
+        let bad = apply(
+            paused.state,
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::CommitCards {
+                    indices: vec![0, 0],
+                },
+            }),
+        );
+        match bad.outcome {
+            EngineOutcome::Rejected { reason } => {
+                assert!(reason.contains("duplicate"), "unexpected reason: {reason}");
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_resolve_input_action_rejects_while_skill_test_paused() {
+        // While a test is paused at its commit window, the engine
+        // rejects every other player action (mirrors the
+        // mulligan_window guard).
+        let id = InvestigatorId(1);
+        let state = TestGame::new()
+            .with_phase(Phase::Investigation)
+            .with_investigator(test_investigator(1))
+            .with_active_investigator(id)
+            .with_chaos_bag(bag_only_zero())
+            .build();
+        let paused = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Intellect,
+                difficulty: 3,
+            }),
+        );
+        let rejected = apply(paused.state, Action::Player(PlayerAction::EndTurn));
+        match rejected.outcome {
+            EngineOutcome::Rejected { reason } => {
+                assert!(
+                    reason.contains("commit window"),
+                    "unexpected reason: {reason}",
+                );
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+        // The pause must survive the rejected action.
+        assert!(rejected.state.in_flight_skill_test.is_some());
+    }
+
+    #[test]
+    fn resolve_input_with_wrong_response_variant_rejects() {
+        let id = InvestigatorId(1);
+        let state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_chaos_bag(bag_only_zero())
+            .build();
+        let paused = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Intellect,
+                difficulty: 3,
+            }),
+        );
+        let bad = apply(
+            paused.state,
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::Confirm,
+            }),
+        );
+        assert!(matches!(bad.outcome, EngineOutcome::Rejected { .. }));
+        // Test still paused.
+        assert!(bad.state.in_flight_skill_test.is_some());
+    }
+
+    #[test]
+    fn resolve_input_without_any_outstanding_prompt_rejects() {
+        // No prior `apply` opened a commit window — the engine has
+        // nothing to resume.
+        let state = TestGame::new().build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::CommitCards { indices: vec![] },
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
     }
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -8,11 +8,11 @@ use super::{
     card::CardInstanceId,
     chaos_bag::{ChaosBag, TokenModifiers},
     enemy::{Enemy, EnemyId},
-    investigator::{Investigator, InvestigatorId},
+    investigator::{Investigator, InvestigatorId, SkillKind},
     location::{Location, LocationId},
     phase::Phase,
 };
-use crate::dsl::Stat;
+use crate::dsl::{SkillTestKind, Stat};
 use crate::rng::RngState;
 
 /// The full state of a scenario at a single point in time.
@@ -85,6 +85,91 @@ pub struct GameState {
     /// [`ModifierScope::ThisSkillTest`]: crate::dsl::ModifierScope::ThisSkillTest
     /// [`Event::SkillTestEnded`]: crate::Event::SkillTestEnded
     pub pending_skill_modifiers: Vec<PendingSkillModifier>,
+    /// The skill test currently paused between [`SkillTestStarted`] and
+    /// [`ChaosTokenRevealed`] awaiting commit-window input from the
+    /// active investigator. `Some` whenever the engine has emitted
+    /// [`EngineOutcome::AwaitingInput`] for a commit window and is
+    /// waiting on a
+    /// [`PlayerAction::ResolveInput`](crate::action::PlayerAction::ResolveInput)
+    /// with a
+    /// [`CommitCards`](crate::action::InputResponse::CommitCards)
+    /// response. While set, every non-`ResolveInput` player action
+    /// rejects (mirrors the [`mulligan_window`](Self::mulligan_window)
+    /// guard).
+    ///
+    /// [`SkillTestStarted`]: crate::Event::SkillTestStarted
+    /// [`ChaosTokenRevealed`]: crate::Event::ChaosTokenRevealed
+    /// [`EngineOutcome::AwaitingInput`]: crate::EngineOutcome::AwaitingInput
+    pub in_flight_skill_test: Option<InFlightSkillTest>,
+}
+
+/// A skill test paused mid-resolution at the commit window.
+///
+/// Pushed by the skill-test initiator (`PerformSkillTest`, `Investigate`,
+/// `Fight`, `Evade`) after [`SkillTestStarted`] fires; consumed by the
+/// [`ResolveInput`](crate::action::PlayerAction::ResolveInput) dispatch
+/// once the active investigator submits their commit list. The follow-
+/// up describes the action-specific success path: discover a clue
+/// (Investigate), deal damage (Fight), disengage and exhaust (Evade),
+/// or nothing (bare `PerformSkillTest`).
+///
+/// [`SkillTestStarted`]: crate::Event::SkillTestStarted
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct InFlightSkillTest {
+    /// Investigator taking the test.
+    pub investigator: InvestigatorId,
+    /// Skill the test is against.
+    pub skill: SkillKind,
+    /// Test kind (Investigate / Fight / Evade / Plain). Drives
+    /// [`ModifierScope::WhileInPlayDuring`](crate::dsl::ModifierScope::WhileInPlayDuring)
+    /// matching during resolution.
+    pub kind: SkillTestKind,
+    /// Difficulty: total to meet or exceed for success.
+    pub difficulty: i8,
+    /// Hand indices the active investigator has committed to the test.
+    /// Populated on the [`ResolveInput`](crate::action::PlayerAction::ResolveInput)
+    /// dispatch; the finishing path reads card icons by hand index and
+    /// then discards each committed card. Multi-investigator commits
+    /// (the rule "any investigator at the same location may commit")
+    /// are a separate downstream issue; for now only the active
+    /// investigator's commits live here.
+    pub committed_by_active: Vec<u8>,
+    /// Action-specific resolution to apply on success.
+    pub follow_up: SkillTestFollowUp,
+}
+
+/// What to do after the bracketing skill test resolves, depending on
+/// which player action initiated it.
+///
+/// All variants are no-ops on failure (Fight / Evade / Investigate's
+/// on-success effects only fire when the test succeeds; the bare
+/// `PerformSkillTest` has no follow-up either way). The success-path
+/// effect is what each variant captures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum SkillTestFollowUp {
+    /// No action-specific follow-up. Used by bare
+    /// [`PerformSkillTest`](crate::action::PlayerAction::PerformSkillTest).
+    None,
+    /// On success, discover 1 clue at the investigator's current
+    /// location (via the
+    /// [`DiscoverClue`](crate::dsl::Effect::DiscoverClue) evaluator
+    /// path). Used by [`Investigate`](crate::action::PlayerAction::Investigate).
+    Investigate,
+    /// On success, deal 1 damage to the named enemy (and defeat it if
+    /// damage reaches `max_health`). Used by
+    /// [`Fight`](crate::action::PlayerAction::Fight).
+    Fight {
+        /// The enemy the Fight action targeted.
+        enemy: EnemyId,
+    },
+    /// On success, disengage the named enemy from the investigator and
+    /// exhaust it. Used by [`Evade`](crate::action::PlayerAction::Evade).
+    Evade {
+        /// The enemy the Evade action targeted.
+        enemy: EnemyId,
+    },
 }
 
 /// A queued [`ModifierScope::ThisSkillTest`] contribution waiting to

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -129,11 +129,16 @@ pub struct InFlightSkillTest {
     pub difficulty: i8,
     /// Hand indices the active investigator has committed to the test.
     /// Populated on the [`ResolveInput`](crate::action::PlayerAction::ResolveInput)
-    /// dispatch; the finishing path reads card icons by hand index and
-    /// then discards each committed card. Multi-investigator commits
-    /// (the rule "any investigator at the same location may commit")
-    /// are a separate downstream issue; for now only the active
-    /// investigator's commits live here.
+    /// dispatch and snapshotted onto the in-flight record for replay
+    /// clarity and inspection of a saved mid-test state. The icon-sum
+    /// and discard paths read the indices off the local variable
+    /// computed during validation, not off this field — the field is
+    /// captured *afterward*, so it's not load-bearing for resolution
+    /// today.
+    ///
+    /// Multi-investigator commits (the rule "any investigator at the
+    /// same location may commit") are a separate downstream issue; for
+    /// now only the active investigator's commits live here.
     pub committed_by_active: Vec<u8>,
     /// Action-specific resolution to apply on success.
     pub follow_up: SkillTestFollowUp,

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -16,7 +16,7 @@ pub mod phase;
 pub use card::{CardCode, CardInPlay, CardInstanceId, UseKind, Zone};
 pub use chaos_bag::{resolve_token, ChaosBag, ChaosToken, TokenModifiers, TokenResolution};
 pub use enemy::{Enemy, EnemyId};
-pub use game_state::{GameState, PendingSkillModifier};
+pub use game_state::{GameState, InFlightSkillTest, PendingSkillModifier, SkillTestFollowUp};
 pub use investigator::{DefeatCause, Investigator, InvestigatorId, SkillKind, Skills, Status};
 pub use location::{Location, LocationId};
 pub use phase::Phase;

--- a/crates/game-core/src/test_support/builder.rs
+++ b/crates/game-core/src/test_support/builder.rs
@@ -190,6 +190,7 @@ impl TestGame {
             mulligan_window: self.mulligan_window,
             next_card_instance_id: 0,
             pending_skill_modifiers: Vec::new(),
+            in_flight_skill_test: None,
         }
     }
 }

--- a/crates/game-core/src/test_support/mod.rs
+++ b/crates/game-core/src/test_support/mod.rs
@@ -12,4 +12,4 @@ pub mod resolver;
 
 pub use builder::TestGame;
 pub use fixtures::{test_enemy, test_investigator, test_location};
-pub use resolver::{drive, ChoiceResolver, ScriptedResolver, TestSession};
+pub use resolver::{apply_no_commits, drive, ChoiceResolver, ScriptedResolver, TestSession};

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -14,28 +14,30 @@
 //! [`Rejected`](crate::EngineOutcome::Rejected). [`TestSession`] is the
 //! fluent wrapper that pairs a [`GameState`] with a resolver script.
 //!
-//! # Status
+//! # Engine consumers
 //!
-//! No engine path emits `AwaitingInput` yet — the first consumer is
-//! the skill-test commit window (#63). This module ships the test
-//! infrastructure ahead of that work so the API has a stable home.
-//! [`ScriptedResolver::commit_cards`] is intentionally a stub until #63
-//! finalizes the commit-window response shape.
+//! The first (and currently only) `AwaitingInput` site is the skill-
+//! test commit window (#63). When the engine prompts, the active
+//! investigator must reply with [`InputResponse::CommitCards`].
+//! [`ScriptedResolver::commit_cards`] is the ergonomic helper: tests
+//! pass card codes, the resolver translates them to hand indices using
+//! [`GameState`] at resolve time.
+//!
+//! [`InputResponse::CommitCards`]: crate::action::InputResponse::CommitCards
 //!
 //! # Example
 //!
 //! ```
-//! use game_core::action::{Action, InputResponse, PlayerAction};
+//! use game_core::action::{Action, PlayerAction};
 //! use game_core::engine::EngineOutcome;
 //! use game_core::test_support::TestGame;
 //!
-//! // `ResolveInput` rejects today (TODO(#63)); use it as a no-resolver
-//! // smoke test for the fluent API.
+//! // A skill-test action with no investigator in state still rejects
+//! // — useful as a tiny smoke test for the fluent API without needing
+//! // a real chaos bag.
 //! let result = TestGame::new()
 //!     .session()
-//!     .apply(Action::Player(PlayerAction::ResolveInput {
-//!         response: InputResponse::Confirm,
-//!     }))
+//!     .apply(Action::Player(PlayerAction::EndTurn))
 //!     .run();
 //! assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
 //! ```
@@ -126,16 +128,16 @@ impl ScriptedResolver {
         self.push(InputResponse::PickLocation(id))
     }
 
-    /// Commit cards (by code) from the active investigator's hand to
-    /// the current skill test.
+    /// Commit cards (by code) from the in-flight skill test's
+    /// investigator's hand. The resolver translates each code to the
+    /// first matching not-yet-committed hand index at resolve time
+    /// using the [`GameState`] passed into [`next`](Self::next).
+    /// Duplicate codes pick distinct indices in left-to-right order;
+    /// a missing code panics.
     ///
-    /// TODO(#63): stub until the commit-window prompt shape is
-    /// finalized. The codes are recorded but never converted into
-    /// responses; if the engine ever prompts a [`ScriptedResolver`]
-    /// whose next step is `CommitCards`, [`next`](Self::next) panics
-    /// with the request prompt and the recorded codes. Once #63 lands,
-    /// this helper will translate codes to the real commit-window
-    /// response variant(s) using the engine state passed into `next`.
+    /// Pass `&[]` to commit nothing — the canonical empty-commit
+    /// helper for tests that aren't exercising the commit-window
+    /// itself.
     pub fn commit_cards(&mut self, codes: &[CardCode]) -> &mut Self {
         self.steps
             .push_back(ScriptedStep::CommitCards(codes.to_vec()));
@@ -151,7 +153,7 @@ impl ScriptedResolver {
 }
 
 impl ChoiceResolver for ScriptedResolver {
-    fn next(&mut self, request: &InputRequest, _state: &GameState) -> InputResponse {
+    fn next(&mut self, request: &InputRequest, state: &GameState) -> InputResponse {
         let step = self.steps.pop_front().unwrap_or_else(|| {
             panic!(
                 "ScriptedResolver: no scripted response for prompt: {:?}",
@@ -160,14 +162,83 @@ impl ChoiceResolver for ScriptedResolver {
         });
         match step {
             ScriptedStep::Response(r) => r,
-            ScriptedStep::CommitCards(codes) => panic!(
-                "ScriptedResolver::commit_cards: TODO(#63) — commit-window response \
-                 shape not yet finalized; helper is a stub. Codes recorded: {:?}, \
-                 prompt was: {:?}",
-                codes, request.prompt,
-            ),
+            ScriptedStep::CommitCards(codes) => InputResponse::CommitCards {
+                indices: resolve_commit_codes(&codes, state, &request.prompt),
+            },
         }
     }
+}
+
+/// Translate scripted commit-card codes to hand indices using the
+/// in-flight skill test's investigator on `state`.
+///
+/// Returns an empty vec for an empty code list (the canonical
+/// commit-nothing case). Each code is matched against the
+/// investigator's hand left-to-right; duplicate codes claim distinct
+/// indices so `&[CardCode("X"), CardCode("X")]` against a hand with
+/// two `X`s yields `[i, j]`. Panics with the prompt and remaining
+/// state if any code can't be matched — that's a test-author error.
+fn resolve_commit_codes(codes: &[CardCode], state: &GameState, prompt: &str) -> Vec<u32> {
+    if codes.is_empty() {
+        return Vec::new();
+    }
+    let in_flight = state.in_flight_skill_test.as_ref().unwrap_or_else(|| {
+        panic!(
+            "ScriptedResolver::commit_cards: state has no in-flight skill test at \
+             resolve time; prompt was: {prompt:?}",
+        )
+    });
+    let inv = state
+        .investigators
+        .get(&in_flight.investigator)
+        .unwrap_or_else(|| {
+            panic!(
+                "ScriptedResolver::commit_cards: in-flight investigator {:?} not in \
+                 state.investigators; prompt was: {prompt:?}",
+                in_flight.investigator,
+            )
+        });
+    let mut used = vec![false; inv.hand.len()];
+    let mut indices = Vec::with_capacity(codes.len());
+    for code in codes {
+        let idx = inv
+            .hand
+            .iter()
+            .enumerate()
+            .find_map(|(i, c)| (!used[i] && c == code).then_some(i))
+            .unwrap_or_else(|| {
+                panic!(
+                    "ScriptedResolver::commit_cards: code {code:?} not found in \
+                     {:?}'s hand (hand = {:?}, already-used indices = {:?}); \
+                     prompt was: {prompt:?}",
+                    in_flight.investigator, inv.hand, used,
+                )
+            });
+        used[idx] = true;
+        indices.push(u32::try_from(idx).expect("hand index fits in u32"));
+    }
+    indices
+}
+
+/// Drive a single skill-test-initiating action through the engine
+/// with an empty commit submitted to the commit window.
+///
+/// Tests that don't care about the commit window (they're exercising
+/// the rest of skill-test resolution) call this instead of
+/// [`apply`] and treat the returned
+/// [`ApplyResult`] exactly as they used to — `events` accumulates
+/// across `SkillTestStarted`, the empty `ResolveInput`, and the
+/// post-commit resolution chain; `outcome` is the terminal
+/// [`Done`](EngineOutcome::Done) or [`Rejected`](EngineOutcome::Rejected).
+///
+/// Equivalent to:
+/// ```ignore
+/// drive(state, action, { let mut r = ScriptedResolver::new(); r.commit_cards(&[]); r })
+/// ```
+pub fn apply_no_commits(state: GameState, action: Action) -> ApplyResult {
+    let mut resolver = ScriptedResolver::new();
+    resolver.commit_cards(&[]);
+    drive(state, action, resolver)
 }
 
 /// Run `action` against `state`, draining
@@ -365,12 +436,81 @@ mod tests {
         let _ = r.next(&req("oops"), &empty_state());
     }
 
+    /// Build a tiny state with one investigator who has a non-empty
+    /// hand and an in-flight skill test parked on it. Used by the
+    /// commit-card resolution tests below.
+    fn state_with_in_flight_hand(hand: &[&str]) -> GameState {
+        use crate::dsl::SkillTestKind;
+        use crate::state::{InFlightSkillTest, SkillTestFollowUp};
+        let id = InvestigatorId(1);
+        let mut inv = crate::test_support::test_investigator(1);
+        inv.hand = hand.iter().map(|c| CardCode::new(*c)).collect();
+        let mut state = TestGame::new().with_investigator(inv).build();
+        state.in_flight_skill_test = Some(InFlightSkillTest {
+            investigator: id,
+            skill: crate::state::SkillKind::Intellect,
+            kind: SkillTestKind::Plain,
+            difficulty: 1,
+            committed_by_active: Vec::new(),
+            follow_up: SkillTestFollowUp::None,
+        });
+        state
+    }
+
     #[test]
-    #[should_panic(expected = "TODO(#63)")]
-    fn commit_cards_is_a_stub_until_issue_63() {
+    fn commit_cards_empty_resolves_to_empty_indices() {
         let mut r = ScriptedResolver::new();
-        r.commit_cards(&[CardCode::new("01001")]);
+        r.commit_cards(&[]);
+        // Empty doesn't even consult `in_flight_skill_test` — symmetric
+        // with the engine's "empty commits is the no-op" semantics.
+        let state = empty_state();
+        let response = r.next(&req("commit"), &state);
+        assert_eq!(response, InputResponse::CommitCards { indices: vec![] });
+    }
+
+    #[test]
+    fn commit_cards_translates_codes_to_hand_indices_in_order() {
+        let mut r = ScriptedResolver::new();
+        r.commit_cards(&[CardCode::new("X"), CardCode::new("Y")]);
+        let state = state_with_in_flight_hand(&["X", "Y", "Z"]);
+        let response = r.next(&req("commit"), &state);
+        assert_eq!(
+            response,
+            InputResponse::CommitCards {
+                indices: vec![0, 1],
+            }
+        );
+    }
+
+    #[test]
+    fn commit_cards_duplicate_code_picks_distinct_indices_left_to_right() {
+        let mut r = ScriptedResolver::new();
+        r.commit_cards(&[CardCode::new("X"), CardCode::new("X")]);
+        let state = state_with_in_flight_hand(&["A", "X", "B", "X"]);
+        let response = r.next(&req("commit"), &state);
+        assert_eq!(
+            response,
+            InputResponse::CommitCards {
+                indices: vec![1, 3],
+            }
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "no in-flight skill test")]
+    fn commit_cards_panics_when_no_in_flight_skill_test() {
+        let mut r = ScriptedResolver::new();
+        r.commit_cards(&[CardCode::new("X")]);
         let _ = r.next(&req("commit"), &empty_state());
+    }
+
+    #[test]
+    #[should_panic(expected = "not found")]
+    fn commit_cards_panics_when_code_not_in_hand() {
+        let mut r = ScriptedResolver::new();
+        r.commit_cards(&[CardCode::new("MISSING")]);
+        let state = state_with_in_flight_hand(&["X", "Y"]);
+        let _ = r.next(&req("commit"), &state);
     }
 
     #[test]

--- a/crates/game-core/tests/activate_ability.rs
+++ b/crates/game-core/tests/activate_ability.rs
@@ -24,7 +24,7 @@ use game_core::state::{
     CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, InvestigatorId, Phase, SkillKind,
     Status, TokenModifiers,
 };
-use game_core::test_support::{test_investigator, TestGame};
+use game_core::test_support::{apply_no_commits, test_investigator, TestGame};
 use game_core::{assert_event, assert_event_count, assert_no_event};
 use game_core::{Action, PlayerAction};
 
@@ -360,7 +360,7 @@ fn this_skill_test_modifier_contributes_to_next_skill_test() {
         "ThisSkillTest push should leave one pending entry",
     );
 
-    let after_test = apply(
+    let after_test = apply_no_commits(
         after_activate.state,
         Action::Player(PlayerAction::PerformSkillTest {
             investigator: id,
@@ -399,7 +399,7 @@ fn this_skill_test_modifier_does_not_leak_into_a_second_test() {
     );
     assert_eq!(after_activate.outcome, EngineOutcome::Done);
 
-    let after_first_test = apply(
+    let after_first_test = apply_no_commits(
         after_activate.state,
         Action::Player(PlayerAction::PerformSkillTest {
             investigator: id,
@@ -409,7 +409,7 @@ fn this_skill_test_modifier_does_not_leak_into_a_second_test() {
     );
     assert_eq!(after_first_test.outcome, EngineOutcome::Done);
 
-    let after_second_test = apply(
+    let after_second_test = apply_no_commits(
         after_first_test.state,
         Action::Player(PlayerAction::PerformSkillTest {
             investigator: id,

--- a/docs/phases/phase-3-skill-test-end-to-end.md
+++ b/docs/phases/phase-3-skill-test-end-to-end.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-🟡 In progress. 15 closed / 7 open as of 2026-05-17.
+🟡 In progress. 16 closed / 6 open as of 2026-05-17.
 
 ## Goal
 
@@ -10,11 +10,12 @@ Full skill test sequence runs through the engine in tests — with real-card met
 
 ## Issues
 
-### Closed (15)
+### Closed (16)
 
 | # | Title | Notes |
 |---|---|---|
 | `#19` | deterministic `ChoiceResolver` | Test infra; ships ahead of first engine consumer (`#63`). `commit_cards` stubbed pending commit-window response shape. |
+| `#63` | skill-test card commits from hand | First engine consumer of `#19`. Splits `resolve_skill_test` → `start_skill_test` + `finish_skill_test`; adds `state.in_flight_skill_test`, `SkillTestFollowUp`, `InputResponse::CommitCards`. |
 | `#37` | Magnifying Glass (01030) | First new card after the Phase-3 demo; composes `#87` + `#45`. |
 | `#38` | Hyperawareness (01034) | Exercises `Trigger::Activated` + `ThisSkillTest` push end-to-end. |
 | `#45` | per-skill-test-kind modifier scope | Adds `ModifierScope::WhileInPlayDuring(SkillTestKind)`. |
@@ -30,7 +31,7 @@ Full skill test sequence runs through the engine in tests — with real-card met
 | `#92` | constant-modifier query during skill-test resolution | Closes the Phase-3 demo: Holy Rosary `+1 willpower` actually applies. |
 | `#102` | `ThisSkillTest` modifier accumulator | Pushed + drained on `SkillTestEnded`. |
 
-### Open (7)
+### Open (6)
 
 | # | Title | Notes |
 |---|---|---|
@@ -39,7 +40,6 @@ Full skill test sequence runs through the engine in tests — with real-card met
 | `#54` | DSL `OnEvent` trigger | Small extension; unblocks `#52` and `#55` Roland Banks. |
 | `#55` | Roland Banks investigator (01001) | Needs `#54` + `#52`. |
 | `#56` | Study location (01111) | Needs a location-state shape decision; thinnest issue body. |
-| `#63` | skill-test card commits from hand | First engine consumer of `#19`. Finalizes the commit-window response shape and un-stubs `ScriptedResolver::commit_cards`. |
 | `#64` | skill-test after-resolution trigger window | Needs `#54` (OnEvent) + `#19`. |
 
 ## Ordering (Shape B)
@@ -69,7 +69,7 @@ Cards rather than infra-first. Build the minimal infra each card needs, ship the
 | 5 | `#102` `ThisSkillTest` accumulator | ✅ PR #105 |
 | 6 | `#38` Hyperawareness | ✅ PR #106 |
 | 7 | `#19` ChoiceResolver | ✅ PR #109 |
-| 8 | `#63` skill-test commits | needs `#19` |
+| 8 | `#63` skill-test commits | ✅ PR #110 |
 | 9 | `#39` Deduction | needs `#63` (or `#64`) |
 | 10 | `#54` OnEvent trigger | small |
 | 11 | `#52` reaction windows | needs `#54` + `#19`; largest remaining piece |
@@ -90,6 +90,11 @@ Cards rather than infra-first. Build the minimal infra each card needs, ship the
 - **`test-support` Cargo feature dropped (PR #104).** `pub mod test_support` is now unconditional. Surfaced during `#53` review when the integration-test binary failed to compile without `--all-features`. The feature gated nothing in practice (only consumer was `cards`, which always enabled it).
 - **Event-sequence macro `assert_event_sequence!` added (PR #95).** The file's own "don't add preemptively" note had been waiting for a concrete first user; Working a Hunch's ordering test was that user.
 - **`ChoiceResolver` shipped ahead of consumer (`#19`, PR #109).** Test seam (trait + `ScriptedResolver` + `drive` + `TestSession` + `TestGame::session()`) lands now; no engine path emits `AwaitingInput` yet. `ScriptedResolver::commit_cards` is a recorded stub that panics on resolve until `#63` finalizes the commit-window response variant(s). Diverged from the issue's `pick_target(id)` to concrete `pick_investigator` / `pick_location` matching the existing `InputResponse` variants. Pre-existing `#19` forward references in `dispatch.rs` / `dsl.rs` / `evaluator.rs` were rephrased to "no engine consumer landed yet" so they don't dangle after merge.
+- **Always-suspend at the commit window (`#63`, PR #110).** Every skill test routes through `AwaitingInput` even when the active investigator's hand is empty. Engine uniformity over a "suspend only when hand non-empty" shortcut — the alternative would force every client and test to branch on whether the apply needs a resume. Test side absorbs the cost via `test_support::apply_no_commits`; every new skill-test-initiating action follows this pattern.
+- **`SkillTestFollowUp` is an enum, not an `Effect` (`#63`, PR #110).** The action-specific success path (discover clue / damage enemy / disengage+exhaust / none) is captured as an enum on the in-flight record rather than a DSL `Effect`. The DSL doesn't yet have primitives for `damage_enemy` or "disengage + exhaust"; introducing them just to route Fight/Evade follow-ups would be premature DSL expansion. Revisit if a third primitive use case emerges or if `#39` Deduction's OnCommit logic wants a DSL effect.
+- **Event ordering: action-specific follow-up fires BEFORE `SkillTestEnded` (`#63`, PR #110).** `SkillTestSucceeded → follow-up events → CardDiscarded* → SkillTestEnded`. Matches the `SkillTestEnded` event-doc text ("Cleanup events … precede this"); load-bearing for `#64`'s after-resolution trigger window and any future listener keying off the end marker as "all sub-effects already applied." Pinned by `investigate_canonical_event_sequence_pins_followup_before_test_ended`.
+- **"Max 1 committed per skill test" not enforced (`#63`, PR #110).** Perception, Overpower, and Unexpected Courage all carry the constraint in their printed text but the engine accepts duplicate commits today. The general "card-level commit-limit constraint" needs the DSL to grow a primitive — wait until the second card with a non-trivial commit restriction lands before designing it. No separate tracking issue; resurfaces naturally when needed.
+- **Upkeep hand-size limit tracked as `#111` (`#63`, PR #110).** `InputResponse::CommitCards` carries `u32` indices for wire-format symmetry with `PickIndex`. The engine assumes hand size stays below 256 (a `u8::try_from(...).expect(...)` justified by the preceding bound check); `#111` makes that structural by implementing the Arkham upkeep discard-to-max-hand-size step.
 
 ## Open questions
 


### PR DESCRIPTION
## Summary

- First engine consumer of #19's `ChoiceResolver`. The active investigator pauses a skill test at a commit window between `SkillTestStarted` and `ChaosTokenRevealed`, submits hand indices via `InputResponse::CommitCards { indices }`, and the engine sums matching + wild icons into the test total before drawing the chaos token.
- Splits `resolve_skill_test` → `start_skill_test` (validate, push `SkillTestStarted`, set `state.in_flight_skill_test`, return `AwaitingInput`) + `finish_skill_test` (`ResolveInput::CommitCards` resume path: validate indices, sum icons, draw token, emit per-step events, apply follow-up, discard, drain).
- Adds a `SkillTestFollowUp` enum (`None` / `Investigate` / `Fight { enemy }` / `Evade { enemy }`) so `Investigate` / `Fight` / `Evade` can carry their on-success effect through the resume path without each handler owning its own `ResolveInput` branch.
- New gate in `apply_player_action`: while `state.in_flight_skill_test.is_some()`, every non-`ResolveInput` player action rejects (mirrors the `mulligan_window` guard).
- `ScriptedResolver::commit_cards(&[CardCode])` now translates codes → hand indices using the in-flight investigator's hand at resolve time (previously panicked with a `TODO(#63)` stub message).
- New `test_support::apply_no_commits` helper wraps `drive` with one empty commit so existing tests migrate with a mechanical rename instead of each adopting `TestSession`.

## Acceptance

- [x] `AwaitingInput` emitted between `SkillTestStarted` and `ChaosTokenRevealed` (engine-level test + integration test).
- [x] `ResolveInput::CommitCards` advances the test (single-submit shape covers both commit/uncommit in one response).
- [x] Committed cards' icons added to the test total (matching skill + wild).
- [x] End-to-end integration test (`crates/cards/tests/skill_test_commits.rs`): commit Perception (intellect icons) and Unexpected Courage (wild icons) against difficulty-5 intellect, verify icons counted and both cards discarded.

## Design decisions

- **Always suspend.** Every skill test goes through the commit window, even when the investigator's hand is empty — chosen over a "suspend only when hand non-empty" shortcut for a uniform engine state machine. Cost is one `apply_no_commits`-style rename in tests; benefit is no conditional client-side handling.
- **Single-submit commit response.** `InputResponse::CommitCards { indices: Vec<u32> }` arrives in one call rather than commit/uncommit being two separate actions. Matches the existing `InputResponse` style and the `ScriptedResolver::commit_cards` shape.
- **Follow-up via enum, not closure.** Storing an action-tag (`SkillTestFollowUp`) on the in-flight record keeps the resume path's behavior derivable from state alone (no closures in `GameState`, which serializes).
- **Helpers split for readability.** `finish_skill_test` dispatches to `validate_commit_indices`, `sum_skill_value`, `sum_committed_icons`, `resolve_chaos_token_and_emit`, `discard_committed_cards`. Each is small and testable in isolation; the orchestrator stays under the 100-line clippy threshold.

## Out of scope (downstream issues)

- Other-investigator commits — "any investigator at the same location may commit" lands separately; for now only the active investigator's commits are stored in `in_flight_skill_test.committed_by_active`.
- After-resolution trigger window (#64).
- `OnCommit` trigger (#39 Deduction, depending on `#54` `OnEvent` or `#64` after-success trigger).

## Test plan

- [x] `RUSTFLAGS="-D warnings" cargo test --all --all-features` — 266 tests pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` clean.
- [x] `cargo build -p web --target wasm32-unknown-unknown` clean.

Closes #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)