### PR TITLE
engine: Trigger::OnSkillTestResolution + tested-location plumbing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Follow this order for every non-trivial PR. Skipping steps has cost real iterati
 7. **Update the relevant `docs/phases/phase-N-<slug>.md` once the PR is ready to merge.** Land it as a final commit on the same branch so the doc reflects what actually ships — including review-driven fixes, scope changes, or new decisions surfaced during review. Skipping this step has cost real iterations; the next person hits a stale doc and re-derives context. Specifically:
    - Move the closing issue from the **Open** table to the **Closed** table; bump the closed/open counts in the Status section.
    - Flip the Ordering / Arc table's row to `✅ PR #N`.
-   - Add an entry to **Decisions made** for any non-obvious choice the PR cemented (design pattern, intentional divergence from the issue, scope split, review-surfaced rephrasings, etc.) — include the PR number.
+   - Add an entry to **Decisions made** ONLY for choices that are load-bearing for future PRs — design-shape choices that constrain later work, intentional divergences from the issue body, significant scope splits, or review-surfaced rephrasings that shift the meaning. Skip routine field additions, mirroring of existing patterns, internal trade-offs settled within the PR, and anything a future contributor could grep from the code. If a future PR-author wouldn't need to know this to make their next decision, leave it out. Decisions entries are not a changelog; they're a context-saver for the next person. Include the PR number on each kept entry.
    - Remove any **Open question** the PR settled.
 
    The `docs/phases/README.md` "Maintaining these docs" section is the authoritative spec; this step is the enforcement.

--- a/crates/game-core/src/dsl.rs
+++ b/crates/game-core/src/dsl.rs
@@ -115,6 +115,13 @@ pub enum Trigger {
     /// over a kind-aware [`Condition`]. Triggers stay outcome-only
     /// so the surface stays small until a second card with a non-
     /// trivial kind narrowing lands.
+    ///
+    /// Distinct from the after-resolution reactive trigger window
+    /// tracked in [issue #64](https://github.com/talelburg/eldritch/issues/64),
+    /// which fires *after* the test ends with a player decision
+    /// window ("after a test succeeds, you may …"). This trigger
+    /// runs as part of the test's resolution machinery with no
+    /// player choice; route card text by which timing fits.
     OnSkillTestResolution {
         /// Whether the trigger fires on success or on failure of the
         /// resolving test.

--- a/crates/game-core/src/dsl.rs
+++ b/crates/game-core/src/dsl.rs
@@ -92,6 +92,34 @@ pub enum Trigger {
         /// Number of action points required to activate. `0` = Fast.
         action_cost: u8,
     },
+    /// Fires during the resolution of a skill test the card is
+    /// committed to, after the outcome is determined and gated on
+    /// `outcome` matching it.
+    ///
+    /// This is not a reaction window (no player decision, no "may");
+    /// it's part of the test's own resolution machinery. The effect
+    /// evaluates after the action-specific
+    /// [`SkillTestFollowUp`](crate::state::SkillTestFollowUp) and
+    /// before the committed cards discard, so the source card is
+    /// still in hand at evaluation time and
+    /// [`LocationTarget::TestedLocation`] resolves against the
+    /// in-flight test record.
+    ///
+    /// Canonical motivating card: Deduction (01039) — "If this skill
+    /// test is successful while investigating a location, discover 1
+    /// additional clue at that location." See
+    /// [issue #112](https://github.com/talelburg/eldritch/issues/112).
+    ///
+    /// Kind narrowing (the "while investigating" qualifier) is not
+    /// baked into the trigger; it's expressed as an [`Effect::If`]
+    /// over a kind-aware [`Condition`]. Triggers stay outcome-only
+    /// so the surface stays small until a second card with a non-
+    /// trivial kind narrowing lands.
+    OnSkillTestResolution {
+        /// Whether the trigger fires on success or on failure of the
+        /// resolving test.
+        outcome: TestOutcome,
+    },
 }
 
 // ---- costs -----------------------------------------------------
@@ -303,6 +331,18 @@ pub enum LocationTarget {
     ControllerLocation,
     /// The controller picks a location.
     ChosenByController,
+    /// The location associated with the in-flight skill test. For
+    /// Investigate that's the location being investigated; the engine
+    /// snapshots it onto
+    /// [`InFlightSkillTest`](crate::state::InFlightSkillTest) at the
+    /// commit window. The
+    /// [`OnSkillTestResolution`](Trigger::OnSkillTestResolution)
+    /// firing path reads this snapshot. Rejects when
+    /// no skill test is in flight or when the snapshotted location
+    /// is absent (controller was between locations at test start —
+    /// only reachable via [`PerformSkillTest`](crate::action::PlayerAction::PerformSkillTest)
+    /// from outside an Investigate path).
+    TestedLocation,
 }
 
 // ---- conditions -----------------------------------------------
@@ -367,6 +407,19 @@ pub fn on_play(effect: Effect) -> Ability {
 pub fn on_commit(effect: Effect) -> Ability {
     Ability {
         trigger: Trigger::OnCommit,
+        costs: Vec::new(),
+        effect,
+    }
+}
+
+/// Construct a [`Trigger::OnSkillTestResolution`] ability gated on
+/// the given outcome. Costs are empty — resolution-time triggers fire
+/// automatically as part of the test's machinery, not via player
+/// activation.
+#[must_use]
+pub fn on_skill_test_resolution(outcome: TestOutcome, effect: Effect) -> Ability {
+    Ability {
+        trigger: Trigger::OnSkillTestResolution { outcome },
         costs: Vec::new(),
         effect,
     }
@@ -545,6 +598,30 @@ mod tests {
         // every match site, which is the whole point of separating
         // them rather than reusing OnPlay.
         assert_ne!(ability.trigger, Trigger::OnPlay);
+    }
+
+    /// `on_skill_test_resolution` builds the outcome-gated trigger
+    /// and accepts `TestedLocation`-targeted effects.
+    #[test]
+    fn on_skill_test_resolution_builder() {
+        let ability = on_skill_test_resolution(
+            TestOutcome::Success,
+            discover_clue(LocationTarget::TestedLocation, 1),
+        );
+        assert_eq!(
+            ability.trigger,
+            Trigger::OnSkillTestResolution {
+                outcome: TestOutcome::Success,
+            },
+        );
+        assert!(matches!(
+            ability.effect,
+            Effect::DiscoverClue {
+                from: LocationTarget::TestedLocation,
+                count: 1,
+            },
+        ));
+        assert!(ability.costs.is_empty());
     }
 
     /// Sequence composition: a hypothetical "gain 1 resource AND

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -453,12 +453,19 @@ pub(super) fn start_skill_test(
     }
 
     // Mutate-second: stash the in-flight record and announce the test.
+    // Snapshot the investigator's location for
+    // `LocationTarget::TestedLocation` resolution during
+    // `Trigger::OnSkillTestResolution` firing. `inv` is `Some` (we
+    // checked above) and we haven't mutated state since the read, so
+    // re-borrowing is safe.
+    let tested_location = inv.current_location;
     state.in_flight_skill_test = Some(InFlightSkillTest {
         investigator,
         skill,
         kind,
         difficulty,
         committed_by_active: Vec::new(),
+        tested_location,
         follow_up,
     });
     events.push(Event::SkillTestStarted {
@@ -540,6 +547,7 @@ fn finish_skill_test(
     if succeeded {
         apply_skill_test_follow_up(state, events, investigator, follow_up);
     }
+    fire_on_skill_test_resolution(state, events, investigator, &indices_u8, succeeded);
     discard_committed_cards(state, events, investigator, &indices_u8);
 
     events.push(Event::SkillTestEnded { investigator });
@@ -786,6 +794,83 @@ fn apply_skill_test_follow_up(
                 investigator,
             });
             events.push(Event::EnemyExhausted { enemy });
+        }
+    }
+}
+
+/// Iterate the active investigator's committed cards and fire each
+/// matching [`Trigger::OnSkillTestResolution`] ability for the
+/// resolved outcome.
+///
+/// Called inside `finish_skill_test` after the action-specific
+/// [`SkillTestFollowUp`] has emitted its events and before the
+/// committed cards discard. At evaluation time the cards are still in
+/// hand at their hand indices and the in-flight record still holds
+/// the tested location, so
+/// [`LocationTarget::TestedLocation`] resolves cleanly.
+///
+/// **Rejections panic.** Card-impl bugs (e.g. an `OnSkillTestResolution`
+/// effect that uses `LocationTarget::ChosenByController` without
+/// `AwaitingInput` plumbing landing) are state-corruption invariant
+/// violations once a card's been imported through the deck gate;
+/// surface them loudly in tests rather than silently dropping the
+/// triggered effect. Mirrors `apply_skill_test_follow_up`'s
+/// `unreachable!` on a follow-up rejection.
+fn fire_on_skill_test_resolution(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+    indices_u8: &[u8],
+    succeeded: bool,
+) {
+    let Some(reg) = card_registry::current() else {
+        // No registry installed — engine-only tests that don't touch
+        // card data don't reach OnSkillTestResolution at all. Silent
+        // skip mirrors `constant_skill_modifier`'s behavior.
+        return;
+    };
+    let outcome_now = if succeeded {
+        crate::dsl::TestOutcome::Success
+    } else {
+        crate::dsl::TestOutcome::Failure
+    };
+
+    // Snapshot the (code, instance-eligible) pairs we'll iterate
+    // before re-borrowing state mutably during apply_effect calls.
+    // Each committed index resolves to a hand-position CardCode; the
+    // cards are still in hand at this point (discard happens next).
+    let codes: Vec<CardCode> = {
+        let inv = state.investigators.get(&investigator).unwrap_or_else(|| {
+            unreachable!(
+                "fire_on_skill_test_resolution: investigator {investigator:?} vanished while \
+                 test was in flight; this is a state-corruption invariant violation"
+            )
+        });
+        indices_u8
+            .iter()
+            .map(|&i| inv.hand[usize::from(i)].clone())
+            .collect()
+    };
+
+    for code in &codes {
+        let Some(abilities) = (reg.abilities_for)(code) else {
+            continue;
+        };
+        for ability in abilities {
+            let Trigger::OnSkillTestResolution { outcome } = ability.trigger else {
+                continue;
+            };
+            if outcome != outcome_now {
+                continue;
+            }
+            let ctx = EvalContext::for_controller(investigator);
+            let result = apply_effect(state, events, &ability.effect, ctx);
+            if let EngineOutcome::Rejected { reason } = result {
+                unreachable!(
+                    "OnSkillTestResolution: effect for card {code:?} rejected unexpectedly: \
+                     {reason}"
+                );
+            }
         }
     }
 }

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -455,9 +455,9 @@ pub(super) fn start_skill_test(
     // Mutate-second: stash the in-flight record and announce the test.
     // Snapshot the investigator's location for
     // `LocationTarget::TestedLocation` resolution during
-    // `Trigger::OnSkillTestResolution` firing. `inv` is `Some` (we
-    // checked above) and we haven't mutated state since the read, so
-    // re-borrowing is safe.
+    // `Trigger::OnSkillTestResolution` firing. `inv`'s immutable
+    // borrow from the validation block above is still live; reading
+    // `current_location` here doesn't extend it past this line.
     let tested_location = inv.current_location;
     state.in_flight_skill_test = Some(InFlightSkillTest {
         investigator,

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -407,6 +407,16 @@ fn resolve_location_target(
         LocationTarget::ChosenByController => {
             Err("LocationTarget::ChosenByController requires AwaitingInput plumbing")
         }
+        LocationTarget::TestedLocation => state
+            .in_flight_skill_test
+            .as_ref()
+            .ok_or("LocationTarget::TestedLocation but no skill test is in flight")
+            .and_then(|t| {
+                t.tested_location.ok_or(
+                    "LocationTarget::TestedLocation but the test's location is unset \
+                     (investigator was between locations at test start)",
+                )
+            }),
     }
 }
 
@@ -747,6 +757,105 @@ mod tests {
             &mut state,
             &mut events,
             &discover_clue(LocationTarget::ControllerLocation, 1),
+            ctx(1),
+        );
+
+        assert!(matches!(outcome, EngineOutcome::Rejected { .. }));
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn discover_clue_tested_location_resolves_to_in_flight_test_location() {
+        // LocationTarget::TestedLocation reads
+        // GameState::in_flight_skill_test.tested_location, regardless
+        // of where the controller currently is. Set the controller's
+        // current_location to a *different* location and confirm the
+        // discover lands at the tested location.
+        let tested = LocationId(20);
+        let elsewhere = LocationId(30);
+        let mut investigator = test_investigator(1);
+        investigator.current_location = Some(elsewhere);
+        let mut tested_loc = test_location(20, "Study");
+        tested_loc.clues = 2;
+        let elsewhere_loc = test_location(30, "Hall");
+
+        let mut state = TestGame::new()
+            .with_investigator(investigator)
+            .with_location(tested_loc)
+            .with_location(elsewhere_loc)
+            .build();
+        state.in_flight_skill_test = Some(crate::state::InFlightSkillTest {
+            investigator: InvestigatorId(1),
+            skill: SkillKind::Intellect,
+            kind: SkillTestKind::Investigate,
+            difficulty: 2,
+            committed_by_active: Vec::new(),
+            tested_location: Some(tested),
+            follow_up: crate::state::SkillTestFollowUp::Investigate,
+        });
+        let mut events = Vec::new();
+
+        let outcome = apply_effect(
+            &mut state,
+            &mut events,
+            &discover_clue(LocationTarget::TestedLocation, 1),
+            ctx(1),
+        );
+
+        assert_eq!(outcome, EngineOutcome::Done);
+        assert_eq!(state.locations[&tested].clues, 1);
+        assert_eq!(state.locations[&elsewhere].clues, 0);
+        assert_eq!(state.investigators[&InvestigatorId(1)].clues, 1);
+    }
+
+    #[test]
+    fn tested_location_rejects_without_in_flight_test() {
+        // No in-flight skill test → TestedLocation can't resolve.
+        let mut investigator = test_investigator(1);
+        investigator.current_location = Some(LocationId(10));
+        let mut state = TestGame::new()
+            .with_investigator(investigator)
+            .with_location({
+                let mut l = test_location(10, "Study");
+                l.clues = 1;
+                l
+            })
+            .build();
+        let mut events = Vec::new();
+
+        let outcome = apply_effect(
+            &mut state,
+            &mut events,
+            &discover_clue(LocationTarget::TestedLocation, 1),
+            ctx(1),
+        );
+
+        assert!(matches!(outcome, EngineOutcome::Rejected { .. }));
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn tested_location_rejects_when_test_has_no_location_snapshot() {
+        // In-flight test exists but tested_location is None (e.g.
+        // bare PerformSkillTest invoked while between locations).
+        let mut state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .build();
+        state.in_flight_skill_test = Some(crate::state::InFlightSkillTest {
+            investigator: InvestigatorId(1),
+            skill: SkillKind::Willpower,
+            kind: SkillTestKind::Plain,
+            difficulty: 2,
+            committed_by_active: Vec::new(),
+            tested_location: None,
+            follow_up: crate::state::SkillTestFollowUp::None,
+        });
+        let mut events = Vec::new();
+
+        let outcome = apply_effect(
+            &mut state,
+            &mut events,
+            &discover_clue(LocationTarget::TestedLocation, 1),
             ctx(1),
         );
 

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -140,6 +140,21 @@ pub struct InFlightSkillTest {
     /// same location may commit") are a separate downstream issue; for
     /// now only the active investigator's commits live here.
     pub committed_by_active: Vec<u8>,
+    /// The location the test is associated with, snapshotted at
+    /// skill-test start (`engine::dispatch::start_skill_test`) from
+    /// the investigator's current location. Used by
+    /// [`LocationTarget::TestedLocation`](crate::dsl::LocationTarget::TestedLocation)
+    /// during
+    /// [`Trigger::OnSkillTestResolution`](crate::dsl::Trigger::OnSkillTestResolution)
+    /// firing so "at that location" resolves to the location the
+    /// test was originally taken against, even if the investigator
+    /// has since moved (no Phase-3 path moves mid-test, but the
+    /// snapshot future-proofs against cards that will). `None` when
+    /// the investigator was between locations at test start —
+    /// only reachable via the bare
+    /// [`PerformSkillTest`](crate::action::PlayerAction::PerformSkillTest)
+    /// from outside an Investigate path.
+    pub tested_location: Option<LocationId>,
     /// Action-specific resolution to apply on success.
     pub follow_up: SkillTestFollowUp,
 }

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -452,6 +452,7 @@ mod tests {
             kind: SkillTestKind::Plain,
             difficulty: 1,
             committed_by_active: Vec::new(),
+            tested_location: None,
             follow_up: SkillTestFollowUp::None,
         });
         state

--- a/crates/game-core/tests/on_skill_test_resolution.rs
+++ b/crates/game-core/tests/on_skill_test_resolution.rs
@@ -1,0 +1,291 @@
+//! End-to-end `Trigger::OnSkillTestResolution` flow with a mock
+//! `CardRegistry` covering one success-gated and one failure-gated
+//! ability.
+//!
+//! Lives at `crates/game-core/tests/` so it runs in its own integration-
+//! test process (separate `OnceLock<CardRegistry>`), letting it install
+//! a mock registry without colliding with game-core's in-crate tests
+//! or with other `tests/*.rs` files. Mirrors `activate_ability.rs`.
+//!
+//! No real card carries `Trigger::OnSkillTestResolution` yet — the
+//! follow-up issue (#39 Deduction) is the first consumer. Until then,
+//! mock cards are the only way to exercise the full path.
+
+use std::sync::OnceLock;
+
+use game_core::card_data::CardMetadata;
+use game_core::card_registry::CardRegistry;
+use game_core::dsl::{
+    discover_clue, on_skill_test_resolution, Ability, LocationTarget, TestOutcome,
+};
+use game_core::engine::EngineOutcome;
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, ChaosBag, ChaosToken, InvestigatorId, LocationId, Phase, SkillKind, TokenModifiers,
+};
+use game_core::test_support::{
+    apply_no_commits, drive, test_investigator, test_location, ScriptedResolver, TestGame,
+};
+use game_core::{assert_event, assert_event_count, assert_no_event, Action, PlayerAction};
+
+/// Mock: success-gated `OnSkillTestResolution` → discover 1 clue at
+/// the tested location. The Deduction-shape (without kind narrowing,
+/// which the trigger doesn't yet support and the consumer card will
+/// add via an `If` over a kind condition).
+const BONUS_CLUE_SUCCESS: &str = "MOCK-OSR-S";
+
+/// Mock: failure-gated mirror.
+const BONUS_CLUE_FAILURE: &str = "MOCK-OSR-F";
+
+fn mock_metadata_for(_: &CardCode) -> Option<&'static CardMetadata> {
+    None
+}
+
+fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
+    match code.as_str() {
+        BONUS_CLUE_SUCCESS => Some(vec![on_skill_test_resolution(
+            TestOutcome::Success,
+            discover_clue(LocationTarget::TestedLocation, 1),
+        )]),
+        BONUS_CLUE_FAILURE => Some(vec![on_skill_test_resolution(
+            TestOutcome::Failure,
+            discover_clue(LocationTarget::TestedLocation, 1),
+        )]),
+        _ => None,
+    }
+}
+
+fn install_mock_registry() {
+    static INSTALL: OnceLock<()> = OnceLock::new();
+    INSTALL.get_or_init(|| {
+        let _ = game_core::card_registry::install(CardRegistry {
+            metadata_for: mock_metadata_for,
+            abilities_for: mock_abilities_for,
+        });
+    });
+}
+
+/// Build a state with the given hand, the investigator standing at
+/// `LocationId(10)` (3 clues by default), a single-`Numeric(0)` chaos
+/// bag (so token-modifier contribution is always 0), and clean
+/// pending modifiers.
+fn state_with_hand_and_location(
+    hand: &[&str],
+    initial_clues: u8,
+) -> (game_core::GameState, InvestigatorId, LocationId) {
+    install_mock_registry();
+    let id = InvestigatorId(1);
+    let loc = LocationId(10);
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(loc);
+    inv.hand = hand.iter().map(|c| CardCode::new(*c)).collect();
+    let mut location = test_location(10, "Study");
+    location.clues = initial_clues;
+    let state = TestGame::new()
+        .with_phase(Phase::Investigation)
+        .with_active_investigator(id)
+        .with_investigator(inv)
+        .with_location(location)
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default())
+        .build();
+    (state, id, loc)
+}
+
+fn intellect_test(id: InvestigatorId, difficulty: i8) -> Action {
+    Action::Player(PlayerAction::PerformSkillTest {
+        investigator: id,
+        skill: SkillKind::Intellect,
+        difficulty,
+    })
+}
+
+fn drive_with_commits(
+    state: game_core::GameState,
+    action: Action,
+    commit: &[&str],
+) -> game_core::ApplyResult {
+    let mut resolver = ScriptedResolver::new();
+    let codes: Vec<CardCode> = commit.iter().map(|c| CardCode::new(*c)).collect();
+    resolver.commit_cards(&codes);
+    drive(state, action, resolver)
+}
+
+#[test]
+fn success_gated_resolution_fires_on_a_passing_test() {
+    // Base 3 + 0 (token) + 0 (mock has no icons) = 3 vs difficulty 2:
+    // passes by 1. Committed BONUS_CLUE_SUCCESS triggers a 1-clue
+    // discover at the tested location.
+    let (state, id, loc) = state_with_hand_and_location(&[BONUS_CLUE_SUCCESS], 3);
+    let result = drive_with_commits(state, intellect_test(id, 2), &[BONUS_CLUE_SUCCESS]);
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestSucceeded { investigator, skill: SkillKind::Intellect, .. }
+            if *investigator == id
+    );
+    // OnSkillTestResolution-driven discover lands at the tested
+    // location. (Action follow-up is `None` for a bare
+    // PerformSkillTest — only the OnResolution effect runs.)
+    assert_eq!(result.state.locations[&loc].clues, 2);
+    assert_eq!(result.state.investigators[&id].clues, 1);
+    assert_event!(
+        result.events,
+        Event::CluePlaced { investigator, count: 1 } if *investigator == id
+    );
+}
+
+#[test]
+fn success_gated_resolution_does_not_fire_on_a_failing_test() {
+    // Difficulty 99: base 3 + 0 = 3, total 3 << 99, fails by 96.
+    // Even though BONUS_CLUE_SUCCESS is committed, its trigger is
+    // gated on Success — no fire.
+    let (state, id, loc) = state_with_hand_and_location(&[BONUS_CLUE_SUCCESS], 3);
+    let result = drive_with_commits(state, intellect_test(id, 99), &[BONUS_CLUE_SUCCESS]);
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestFailed { investigator, skill: SkillKind::Intellect, .. }
+            if *investigator == id
+    );
+    assert_eq!(result.state.locations[&loc].clues, 3, "no clue discovered");
+    assert_eq!(result.state.investigators[&id].clues, 0);
+    assert_no_event!(result.events, Event::CluePlaced { .. });
+}
+
+#[test]
+fn failure_gated_resolution_fires_on_a_failing_test() {
+    let (state, id, loc) = state_with_hand_and_location(&[BONUS_CLUE_FAILURE], 3);
+    let result = drive_with_commits(state, intellect_test(id, 99), &[BONUS_CLUE_FAILURE]);
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestFailed { investigator, skill: SkillKind::Intellect, .. }
+            if *investigator == id
+    );
+    assert_eq!(result.state.locations[&loc].clues, 2);
+    assert_eq!(result.state.investigators[&id].clues, 1);
+}
+
+#[test]
+fn failure_gated_resolution_does_not_fire_on_a_passing_test() {
+    let (state, id, loc) = state_with_hand_and_location(&[BONUS_CLUE_FAILURE], 3);
+    let result = drive_with_commits(state, intellect_test(id, 2), &[BONUS_CLUE_FAILURE]);
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestSucceeded { investigator, skill: SkillKind::Intellect, .. }
+            if *investigator == id
+    );
+    assert_eq!(result.state.locations[&loc].clues, 3);
+    assert_eq!(result.state.investigators[&id].clues, 0);
+    assert_no_event!(result.events, Event::CluePlaced { .. });
+}
+
+#[test]
+fn uncommitted_resolution_triggered_card_does_not_fire() {
+    // BONUS_CLUE_SUCCESS in hand but not committed → no fire.
+    let (state, id, loc) = state_with_hand_and_location(&[BONUS_CLUE_SUCCESS], 3);
+    // Apply with an empty commit list (apply_no_commits drives the
+    // commit window with `[]`).
+    let result = apply_no_commits(state, intellect_test(id, 2));
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestSucceeded { investigator, .. } if *investigator == id
+    );
+    assert_eq!(result.state.locations[&loc].clues, 3);
+    assert_no_event!(result.events, Event::CluePlaced { .. });
+    // The uncommitted card stays in hand.
+    assert_eq!(
+        result.state.investigators[&id].hand,
+        vec![CardCode::new(BONUS_CLUE_SUCCESS)]
+    );
+}
+
+#[test]
+fn two_committed_success_triggers_both_fire() {
+    // Two copies of the same trigger in hand, both committed: both
+    // fire, discovering 2 clues total (1 each).
+    let (state, id, loc) =
+        state_with_hand_and_location(&[BONUS_CLUE_SUCCESS, BONUS_CLUE_SUCCESS], 3);
+    let result = drive_with_commits(
+        state,
+        intellect_test(id, 2),
+        &[BONUS_CLUE_SUCCESS, BONUS_CLUE_SUCCESS],
+    );
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_eq!(result.state.locations[&loc].clues, 1);
+    assert_eq!(result.state.investigators[&id].clues, 2);
+    assert_event_count!(result.events, 2, Event::CluePlaced { .. });
+}
+
+#[test]
+fn investigate_canonical_event_order_with_on_resolution() {
+    // Investigate (action follow-up = `Investigate`) plus a committed
+    // BONUS_CLUE_SUCCESS. Verify the event order:
+    //   SkillTestSucceeded
+    //     → CluePlaced (action follow-up's 1 clue)
+    //     → LocationCluesChanged (after follow-up)
+    //     → CluePlaced (OnSkillTestResolution's bonus clue)
+    //     → LocationCluesChanged (after bonus)
+    //     → CardDiscarded (committed card)
+    //     → SkillTestEnded
+    //
+    // The two CluePlaced events distinguish their source by ordering
+    // alone (both name the same investigator + count = 1), so this
+    // pin is essential as the spec for downstream listeners.
+    let (state, id, loc) = state_with_hand_and_location(&[BONUS_CLUE_SUCCESS], 3);
+    let result = drive_with_commits(
+        state,
+        Action::Player(PlayerAction::Investigate { investigator: id }),
+        &[BONUS_CLUE_SUCCESS],
+    );
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_eq!(result.state.locations[&loc].clues, 1, "lost 2 clues total");
+    assert_eq!(result.state.investigators[&id].clues, 2);
+
+    // Find the indices of the milestone events to assert their order.
+    let mut succeeded_idx: Option<usize> = None;
+    let mut clue_indices: Vec<usize> = Vec::new();
+    let mut location_clue_indices: Vec<usize> = Vec::new();
+    let mut discarded_idx: Option<usize> = None;
+    let mut ended_idx: Option<usize> = None;
+    for (i, ev) in result.events.iter().enumerate() {
+        match ev {
+            Event::SkillTestSucceeded { .. } => succeeded_idx = Some(i),
+            Event::CluePlaced { .. } => clue_indices.push(i),
+            Event::LocationCluesChanged { .. } => location_clue_indices.push(i),
+            Event::CardDiscarded { .. } => discarded_idx = Some(i),
+            Event::SkillTestEnded { .. } => ended_idx = Some(i),
+            _ => {}
+        }
+    }
+    let succeeded = succeeded_idx.expect("expected SkillTestSucceeded");
+    let discarded = discarded_idx.expect("expected CardDiscarded");
+    let ended = ended_idx.expect("expected SkillTestEnded");
+    assert_eq!(clue_indices.len(), 2, "two CluePlaced (follow-up + bonus)");
+    assert_eq!(
+        location_clue_indices.len(),
+        2,
+        "two LocationCluesChanged (one per clue)"
+    );
+
+    assert!(succeeded < clue_indices[0]);
+    assert!(clue_indices[0] < clue_indices[1]);
+    assert!(clue_indices[1] < discarded);
+    assert!(discarded < ended);
+    // First LocationCluesChanged sits between the two CluePlaced;
+    // second sits between the second CluePlaced and CardDiscarded.
+    assert!(clue_indices[0] < location_clue_indices[0]);
+    assert!(location_clue_indices[0] < clue_indices[1]);
+    assert!(clue_indices[1] < location_clue_indices[1]);
+    assert!(location_clue_indices[1] < discarded);
+}

--- a/crates/game-core/tests/on_skill_test_resolution.rs
+++ b/crates/game-core/tests/on_skill_test_resolution.rs
@@ -16,7 +16,8 @@ use std::sync::OnceLock;
 use game_core::card_data::CardMetadata;
 use game_core::card_registry::CardRegistry;
 use game_core::dsl::{
-    discover_clue, on_skill_test_resolution, Ability, LocationTarget, TestOutcome,
+    constant, discover_clue, modify, on_skill_test_resolution, Ability, LocationTarget,
+    ModifierScope, Stat, TestOutcome,
 };
 use game_core::engine::EngineOutcome;
 use game_core::event::Event;
@@ -37,6 +38,12 @@ const BONUS_CLUE_SUCCESS: &str = "MOCK-OSR-S";
 /// Mock: failure-gated mirror.
 const BONUS_CLUE_FAILURE: &str = "MOCK-OSR-F";
 
+/// Mock: a constant +1 intellect modifier (passive, not a resolution
+/// trigger) PLUS a success-gated `OnSkillTestResolution`. Exercises
+/// the inner trigger-filter inside `fire_on_skill_test_resolution`:
+/// the constant ability must NOT fire as a resolution trigger.
+const MIXED_TRIGGERS: &str = "MOCK-OSR-MIXED";
+
 fn mock_metadata_for(_: &CardCode) -> Option<&'static CardMetadata> {
     None
 }
@@ -51,6 +58,13 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
             TestOutcome::Failure,
             discover_clue(LocationTarget::TestedLocation, 1),
         )]),
+        MIXED_TRIGGERS => Some(vec![
+            constant(modify(Stat::Intellect, 1, ModifierScope::WhileInPlay)),
+            on_skill_test_resolution(
+                TestOutcome::Success,
+                discover_clue(LocationTarget::TestedLocation, 1),
+            ),
+        ]),
         _ => None,
     }
 }
@@ -224,6 +238,31 @@ fn two_committed_success_triggers_both_fire() {
     assert_eq!(result.state.locations[&loc].clues, 1);
     assert_eq!(result.state.investigators[&id].clues, 2);
     assert_event_count!(result.events, 2, Event::CluePlaced { .. });
+}
+
+#[test]
+fn mixed_triggers_card_only_fires_the_resolution_ability() {
+    // A card carrying a constant modifier AND an OnSkillTestResolution
+    // ability: only the resolution ability should fire from the
+    // fire-loop. The constant modifier is already a passive
+    // contribution (would be queried via `constant_skill_modifier`
+    // if the card were in play, but it's in hand here so doesn't
+    // contribute to the test total either — the test just confirms
+    // the trigger-filter inside `fire_on_skill_test_resolution` skips
+    // non-matching trigger variants on the same card).
+    let (state, id, loc) = state_with_hand_and_location(&[MIXED_TRIGGERS], 3);
+    let result = drive_with_commits(state, intellect_test(id, 2), &[MIXED_TRIGGERS]);
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::SkillTestSucceeded { investigator, .. } if *investigator == id
+    );
+    // Exactly one bonus clue from the OnSkillTestResolution ability;
+    // the constant modifier doesn't emit anything.
+    assert_eq!(result.state.locations[&loc].clues, 2);
+    assert_eq!(result.state.investigators[&id].clues, 1);
+    assert_event_count!(result.events, 1, Event::CluePlaced { .. });
 }
 
 #[test]

--- a/docs/phases/phase-3-skill-test-end-to-end.md
+++ b/docs/phases/phase-3-skill-test-end-to-end.md
@@ -102,6 +102,7 @@ Cards rather than infra-first. Build the minimal infra each card needs, ship the
 ## Open questions
 
 - **`#56` Study (location).** Locations have a state shape (shroud, clues, connections), but printed locations also have abilities — Reveal effects, on-enter triggers. The shape for location abilities isn't yet decided. Could land alongside Phase-4 scenario plumbing (`#74` scenario module skeleton) where the location-handling shape gets settled.
+
 ## Dependencies
 
 Phases 0–2.

--- a/docs/phases/phase-3-skill-test-end-to-end.md
+++ b/docs/phases/phase-3-skill-test-end-to-end.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-🟡 In progress. 16 closed / 7 open as of 2026-05-17.
+🟡 In progress. 17 closed / 6 open as of 2026-05-17.
 
 ## Goal
 
@@ -10,7 +10,7 @@ Full skill test sequence runs through the engine in tests — with real-card met
 
 ## Issues
 
-### Closed (16)
+### Closed (17)
 
 | # | Title | Notes |
 |---|---|---|
@@ -30,8 +30,9 @@ Full skill test sequence runs through the engine in tests — with real-card met
 | `#89` | PlayCard action | Asset → in-play; event → discard. |
 | `#92` | constant-modifier query during skill-test resolution | Closes the Phase-3 demo: Holy Rosary `+1 willpower` actually applies. |
 | `#102` | `ThisSkillTest` modifier accumulator | Pushed + drained on `SkillTestEnded`. |
+| `#112` | DSL `Trigger::OnSkillTestResolution` + tested-location plumbing | Split out of `#39` so the trigger variant lands on its own; `#39` consumes it. |
 
-### Open (7)
+### Open (6)
 
 | # | Title | Notes |
 |---|---|---|
@@ -41,7 +42,6 @@ Full skill test sequence runs through the engine in tests — with real-card met
 | `#55` | Roland Banks investigator (01001) | Needs `#54` + `#52`. |
 | `#56` | Study location (01111) | Needs a location-state shape decision; thinnest issue body. |
 | `#64` | skill-test after-resolution trigger window | Needs `#54` (OnEvent) + `#19`. Distinct semantic from `#112` — `#64` is a player-window-driven reactive trigger after the test ends; `#112` is a resolution-machinery trigger on committed cards. |
-| `#112` | DSL `Trigger::OnSkillTestResolution` + tested-location plumbing | Split out of `#39` so the trigger variant lands on its own; `#39` consumes it. |
 
 ## Ordering (Shape B)
 
@@ -71,7 +71,7 @@ Cards rather than infra-first. Build the minimal infra each card needs, ship the
 | 6 | `#38` Hyperawareness | ✅ PR #106 |
 | 7 | `#19` ChoiceResolver | ✅ PR #109 |
 | 8 | `#63` skill-test commits | ✅ PR #110 |
-| 9 | `#112` `Trigger::OnSkillTestResolution` + tested-location plumbing | in flight |
+| 9 | `#112` `Trigger::OnSkillTestResolution` + tested-location plumbing | ✅ PR #113 |
 | 10 | `#39` Deduction | consumes `#112` |
 | 11 | `#54` OnEvent trigger | small |
 | 12 | `#52` reaction windows | needs `#54` + `#19`; largest remaining piece |
@@ -97,7 +97,7 @@ Cards rather than infra-first. Build the minimal infra each card needs, ship the
 - **Event ordering: action-specific follow-up fires BEFORE `SkillTestEnded` (`#63`, PR #110).** `SkillTestSucceeded → follow-up events → CardDiscarded* → SkillTestEnded`. Matches the `SkillTestEnded` event-doc text ("Cleanup events … precede this"); load-bearing for `#64`'s after-resolution trigger window and any future listener keying off the end marker as "all sub-effects already applied." Pinned by `investigate_canonical_event_sequence_pins_followup_before_test_ended`.
 - **"Max 1 committed per skill test" not enforced (`#63`, PR #110).** Perception, Overpower, and Unexpected Courage all carry the constraint in their printed text but the engine accepts duplicate commits today. The general "card-level commit-limit constraint" needs the DSL to grow a primitive — wait until the second card with a non-trivial commit restriction lands before designing it. No separate tracking issue; resurfaces naturally when needed.
 - **Upkeep hand-size limit tracked as `#111` (`#63`, PR #110).** `InputResponse::CommitCards` carries `u32` indices for wire-format symmetry with `PickIndex`. The engine assumes hand size stays below 256 (a `u8::try_from(...).expect(...)` justified by the preceding bound check); `#111` makes that structural by implementing the Arkham upkeep discard-to-max-hand-size step.
-- **`Trigger::OnSkillTestResolution` is resolution-machinery, not a reaction window (`#112`).** Deduction-shaped text ("if this skill test is successful while investigating, discover 1 additional clue at that location") doesn't fit `OnCommit` (outcome unknown at commit) and doesn't fit `#64`'s reactive window (no player decision). New variant fires inside `finish_skill_test` for committed cards, gated on actual outcome. Settles `#39` Deduction's routing question; keeps `#64` strictly for player-window-driven "after a test succeeds, you may …" cards. Event order pinned by `investigate_canonical_event_order_with_on_resolution`: action follow-up before OnResolution before discards, load-bearing for `#64` listeners that key off `SkillTestEnded` as "all sub-effects applied."
+- **`Trigger::OnSkillTestResolution` is resolution-machinery, not a reaction window (`#112`, PR #113).** Deduction-shaped text ("if this skill test is successful while investigating, discover 1 additional clue at that location") doesn't fit `OnCommit` (outcome unknown at commit) and doesn't fit `#64`'s reactive window (no player decision). New variant fires inside `finish_skill_test` for committed cards, gated on actual outcome. Settles `#39` Deduction's routing question; keeps `#64` strictly for player-window-driven "after a test succeeds, you may …" cards. Event order pinned by `investigate_canonical_event_order_with_on_resolution`: action follow-up before OnResolution before discards, load-bearing for `#64` listeners that key off `SkillTestEnded` as "all sub-effects applied."
 
 ## Open questions
 

--- a/docs/phases/phase-3-skill-test-end-to-end.md
+++ b/docs/phases/phase-3-skill-test-end-to-end.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-🟡 In progress. 16 closed / 6 open as of 2026-05-17.
+🟡 In progress. 16 closed / 7 open as of 2026-05-17.
 
 ## Goal
 
@@ -31,16 +31,17 @@ Full skill test sequence runs through the engine in tests — with real-card met
 | `#92` | constant-modifier query during skill-test resolution | Closes the Phase-3 demo: Holy Rosary `+1 willpower` actually applies. |
 | `#102` | `ThisSkillTest` modifier accumulator | Pushed + drained on `SkillTestEnded`. |
 
-### Open (6)
+### Open (7)
 
 | # | Title | Notes |
 |---|---|---|
-| `#39` | Deduction (01039) | Needs `#63` (skill-test commits) or `#64` (after-resolution trigger). |
+| `#39` | Deduction (01039) | Consumes `#112`; lands as the next PR. |
 | `#52` | reaction windows + trigger ordering | Needs `#54` + `#19`. The largest remaining engine piece. |
 | `#54` | DSL `OnEvent` trigger | Small extension; unblocks `#52` and `#55` Roland Banks. |
 | `#55` | Roland Banks investigator (01001) | Needs `#54` + `#52`. |
 | `#56` | Study location (01111) | Needs a location-state shape decision; thinnest issue body. |
-| `#64` | skill-test after-resolution trigger window | Needs `#54` (OnEvent) + `#19`. |
+| `#64` | skill-test after-resolution trigger window | Needs `#54` (OnEvent) + `#19`. Distinct semantic from `#112` — `#64` is a player-window-driven reactive trigger after the test ends; `#112` is a resolution-machinery trigger on committed cards. |
+| `#112` | DSL `Trigger::OnSkillTestResolution` + tested-location plumbing | Split out of `#39` so the trigger variant lands on its own; `#39` consumes it. |
 
 ## Ordering (Shape B)
 
@@ -70,12 +71,13 @@ Cards rather than infra-first. Build the minimal infra each card needs, ship the
 | 6 | `#38` Hyperawareness | ✅ PR #106 |
 | 7 | `#19` ChoiceResolver | ✅ PR #109 |
 | 8 | `#63` skill-test commits | ✅ PR #110 |
-| 9 | `#39` Deduction | needs `#63` (or `#64`) |
-| 10 | `#54` OnEvent trigger | small |
-| 11 | `#52` reaction windows | needs `#54` + `#19`; largest remaining piece |
-| 12 | `#55` Roland Banks | needs `#54` + `#52` |
-| 13 | `#56` Study | needs location-state design; defer or build alongside Phase 4 |
-| 14 | `#64` after-resolution trigger window | cleanup; alt path for Deduction was via `#63` |
+| 9 | `#112` `Trigger::OnSkillTestResolution` + tested-location plumbing | in flight |
+| 10 | `#39` Deduction | consumes `#112` |
+| 11 | `#54` OnEvent trigger | small |
+| 12 | `#52` reaction windows | needs `#54` + `#19`; largest remaining piece |
+| 13 | `#55` Roland Banks | needs `#54` + `#52` |
+| 14 | `#56` Study | needs location-state design; defer or build alongside Phase 4 |
+| 15 | `#64` after-resolution trigger window | distinct from `#112`; reactive trigger window for OnEvent-style "after this test succeeds, …" cards |
 
 ## Decisions made
 
@@ -95,14 +97,11 @@ Cards rather than infra-first. Build the minimal infra each card needs, ship the
 - **Event ordering: action-specific follow-up fires BEFORE `SkillTestEnded` (`#63`, PR #110).** `SkillTestSucceeded → follow-up events → CardDiscarded* → SkillTestEnded`. Matches the `SkillTestEnded` event-doc text ("Cleanup events … precede this"); load-bearing for `#64`'s after-resolution trigger window and any future listener keying off the end marker as "all sub-effects already applied." Pinned by `investigate_canonical_event_sequence_pins_followup_before_test_ended`.
 - **"Max 1 committed per skill test" not enforced (`#63`, PR #110).** Perception, Overpower, and Unexpected Courage all carry the constraint in their printed text but the engine accepts duplicate commits today. The general "card-level commit-limit constraint" needs the DSL to grow a primitive — wait until the second card with a non-trivial commit restriction lands before designing it. No separate tracking issue; resurfaces naturally when needed.
 - **Upkeep hand-size limit tracked as `#111` (`#63`, PR #110).** `InputResponse::CommitCards` carries `u32` indices for wire-format symmetry with `PickIndex`. The engine assumes hand size stays below 256 (a `u8::try_from(...).expect(...)` justified by the preceding bound check); `#111` makes that structural by implementing the Arkham upkeep discard-to-max-hand-size step.
+- **`Trigger::OnSkillTestResolution` is resolution-machinery, not a reaction window (`#112`).** Deduction-shaped text ("if this skill test is successful while investigating, discover 1 additional clue at that location") doesn't fit `OnCommit` (outcome unknown at commit) and doesn't fit `#64`'s reactive window (no player decision). New variant fires inside `finish_skill_test` for committed cards, gated on actual outcome. Settles `#39` Deduction's routing question; keeps `#64` strictly for player-window-driven "after a test succeeds, you may …" cards. Event order pinned by `investigate_canonical_event_order_with_on_resolution`: action follow-up before OnResolution before discards, load-bearing for `#64` listeners that key off `SkillTestEnded` as "all sub-effects applied."
 
 ## Open questions
 
 - **`#56` Study (location).** Locations have a state shape (shroud, clues, connections), but printed locations also have abilities — Reveal effects, on-enter triggers. The shape for location abilities isn't yet decided. Could land alongside Phase-4 scenario plumbing (`#74` scenario module skeleton) where the location-handling shape gets settled.
-- **`#39` Deduction routing.** The card text is "if your skill test is successful while investigating, discover 1 additional clue at that location" — fires after a successful Investigate, off a card committed from hand. Two viable paths:
-  - Via `#63` commits from hand → `Trigger::OnCommit` + `Condition::SkillTest { outcome: Success }`.
-  - Via `#64` after-resolution trigger window → reactive consumer of a `SkillTestSucceeded` event.
-  Pick when implementing.
 ## Dependencies
 
 Phases 0–2.


### PR DESCRIPTION
## Summary

- New `Trigger::OnSkillTestResolution { outcome: TestOutcome }`, the right semantic home for "if this skill test is successful while investigating, …" style card text (canonical motivating card: Deduction #39).
- New `InFlightSkillTest.tested_location: Option<LocationId>` + `LocationTarget::TestedLocation`, so "at that location" stays stable even if cards later move the investigator mid-resolution.
- Mock-registry integration test pinning the new event order: `SkillTestSucceeded → action follow-up → OnResolution → CardDiscarded → SkillTestEnded`.

Closes #112.

## Design decisions

- **Resolution-machinery, not a reaction window.** `OnCommit` is wrong (outcome unknown at commit). `#64`'s after-resolution reactive window is also wrong (no player decision, no \"may\"). The new trigger runs synchronously inside `finish_skill_test` for cards currently committed, gated on the actual outcome. Settles #39 Deduction's open routing question; keeps `#64` strictly for player-window-driven \"after a test succeeds, you may …\" cards.
- **No kind narrowing on the trigger.** Deduction's \"while investigating\" qualifier is expressed by the consumer card via `Effect::If` over a kind condition once #39 lands — the trigger surface stays minimal until a second card with non-trivial kind narrowing demands it.
- **Rejected effects panic (`unreachable!`).** Cards reaching the firing loop are deck-gate-validated; a reject is a card-impl bug, not a recoverable case. Mirrors `apply_skill_test_follow_up`'s existing `unreachable!`.
- **CLAUDE.md tightened.** PR-procedure step 7 now spells out that Decisions-made entries should be load-bearing for future PRs only — not a changelog. Surfaced when the initial draft of this PR added four Decisions entries where only one captured the load-bearing call.

## Test plan

- [ ] CI green on all five jobs (fmt, clippy, test, doc, wasm).
- [ ] `cargo test -p game-core --test on_skill_test_resolution` exercises the new trigger end-to-end (success/failure gates, uncommitted no-fire, multi-commit, canonical event order).
- [ ] Phase doc updated: #112 in Open table (will move to Closed when this merges via the follow-up PR), inserted into Arc 2 ordering as item 9 (pushing #39 to item 10), Decisions entry added, Deduction-routing Open question removed.
- [ ] Follow-up PR for #39 Deduction lands on top of this.