### PR TITLE
engine: DSL Trigger::OnEvent + EventPattern + EventTiming

### DIFF
--- a/crates/game-core/src/dsl.rs
+++ b/crates/game-core/src/dsl.rs
@@ -30,8 +30,12 @@
 //!   ability-specific effect machinery.
 //! - **Reaction abilities** (Roland Banks's `[reaction] After you
 //!   defeat an enemy: Discover 1 clue at your location. (Limit once
-//!   per round.)`). Need `Trigger::Reaction(EventPattern)` with the
-//!   engine's event-window plumbing plus per-round limit tracking.
+//!   per round.)`). The DSL surface ([`Trigger::OnEvent`]) lands;
+//!   the engine event-window plumbing — registering active triggers
+//!   from cards in play and firing them against emitted events —
+//!   lands in
+//!   [issue #52](https://github.com/talelburg/eldritch/issues/52),
+//!   and per-round limit tracking still needs a primitive.
 //! - **Stat-comparison / location-state conditions** (`LocationHasClues`,
 //!   `AnyEnemyEngaged`, `SkillSucceededByAtLeast(N)`). Phase-2 only
 //!   has [`Condition::SkillTest`] with success/failure granularity.
@@ -58,8 +62,8 @@ use serde::{Deserialize, Serialize};
 
 /// When an [`Ability`] is active.
 ///
-/// Phase-3 set. Later phases add `OnEvent(EventPattern)`,
-/// `AtPhaseStart`/`AtPhaseEnd`, `OnLeavePlay`, and reaction triggers.
+/// Phase-3 set. Later phases add `AtPhaseStart`/`AtPhaseEnd`,
+/// `OnLeavePlay`, and additional reactive patterns as cards demand.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Trigger {
@@ -127,6 +131,74 @@ pub enum Trigger {
         /// resolving test.
         outcome: TestOutcome,
     },
+    /// Fires when an engine [`Event`](crate::Event) matching `pattern`
+    /// is emitted, in the reaction window opened by the engine for
+    /// the corresponding `timing`.
+    ///
+    /// Canonical motivating card: Roland Banks (01001) —
+    /// `[reaction] After you defeat an enemy: Discover 1 clue at your
+    /// location.` compiles to `OnEvent { pattern: EnemyDefeated {
+    /// by_controller: true }, timing: After }`.
+    ///
+    /// Distinct from [`OnSkillTestResolution`](Self::OnSkillTestResolution),
+    /// which fires inside a skill test's own resolution machinery
+    /// (no player decision, no `may`). `OnEvent` triggers fire in
+    /// reaction windows where the controller may choose to use them.
+    ///
+    /// The DSL surface lands here; the engine machinery that
+    /// registers these triggers from cards in play and fires them
+    /// during reaction windows lands in
+    /// [issue #52](https://github.com/talelburg/eldritch/issues/52).
+    /// Until then the engine ignores `OnEvent` abilities; cards
+    /// declaring one compile and round-trip through serde but
+    /// otherwise do nothing at runtime.
+    OnEvent {
+        /// Which engine event(s) trigger this ability.
+        pattern: EventPattern,
+        /// Whether the trigger fires before or after the matching
+        /// event finalizes.
+        timing: EventTiming,
+    },
+}
+
+/// Which engine event(s) an [`Trigger::OnEvent`] ability listens for.
+///
+/// Phase-3 minimal set: just the variant Roland Banks needs. The enum
+/// is `#[non_exhaustive]` and grows as later cards demand new
+/// patterns (skill-test outcomes, investigator movement, clue
+/// placement, …).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum EventPattern {
+    /// An enemy was defeated. `by_controller` narrows the match to
+    /// defeats credited to the ability's controller — Roland Banks's
+    /// "after **you** defeat an enemy" sets this `true`; an
+    /// unqualified "after an enemy is defeated" would set it `false`.
+    EnemyDefeated {
+        /// If `true`, only fires when the controller of this ability
+        /// is credited with the defeat (the
+        /// [`by`](crate::Event::EnemyDefeated) field of the event).
+        /// If `false`, any defeat matches.
+        by_controller: bool,
+    },
+}
+
+/// When an [`Trigger::OnEvent`] ability fires relative to the
+/// triggering event finalizing.
+///
+/// Most reaction cards use [`After`](Self::After) ("After you defeat
+/// an enemy …"). [`Before`](Self::Before) is the "Forced — when …
+/// would …" timing that lets an effect interpose on an in-progress
+/// event; no card uses it in the Phase-3 scope yet, but the variant
+/// is included so #52's reaction-window machinery can hang both
+/// windows off the same trigger surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum EventTiming {
+    /// Resolves before the triggering event finalizes.
+    Before,
+    /// Resolves after the triggering event has finalized.
+    After,
 }
 
 // ---- costs -----------------------------------------------------
@@ -441,6 +513,18 @@ pub fn on_skill_test_resolution(outcome: TestOutcome, effect: Effect) -> Ability
     }
 }
 
+/// Construct a [`Trigger::OnEvent`] ability for the given pattern
+/// and timing. Costs are empty — reactive triggers fire from the
+/// engine's reaction-window plumbing, not via player activation.
+#[must_use]
+pub fn on_event(pattern: EventPattern, timing: EventTiming, effect: Effect) -> Ability {
+    Ability {
+        trigger: Trigger::OnEvent { pattern, timing },
+        costs: Vec::new(),
+        effect,
+    }
+}
+
 /// Construct a [`Trigger::Activated`] ability with the given action
 /// cost, payment costs, and effect.
 ///
@@ -739,6 +823,88 @@ mod tests {
         ]);
         let json = serde_json::to_string(&original).expect("serialize");
         let recovered: Effect = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(original, recovered);
+    }
+
+    /// Roland-Banks-shaped reaction: "after you defeat an enemy,
+    /// discover 1 clue at your location" — the canonical motivating
+    /// card for [`Trigger::OnEvent`]. The DSL doesn't fire it yet
+    /// (engine reaction windows land in #52), but construction must
+    /// work today so #55 has somewhere to land.
+    #[test]
+    fn on_event_builder_constructs_roland_banks_reaction() {
+        let ability = on_event(
+            EventPattern::EnemyDefeated {
+                by_controller: true,
+            },
+            EventTiming::After,
+            discover_clue(LocationTarget::ControllerLocation, 1),
+        );
+        assert_eq!(
+            ability.trigger,
+            Trigger::OnEvent {
+                pattern: EventPattern::EnemyDefeated {
+                    by_controller: true,
+                },
+                timing: EventTiming::After,
+            },
+        );
+        assert!(matches!(
+            ability.effect,
+            Effect::DiscoverClue {
+                from: LocationTarget::ControllerLocation,
+                count: 1,
+            },
+        ));
+        assert!(ability.costs.is_empty());
+    }
+
+    /// `OnEvent` is a distinct enum variant from existing trigger
+    /// shapes — the compiler enforces the distinction at every match
+    /// site, and the pattern/timing fields differentiate sub-cases
+    /// from each other.
+    #[test]
+    fn on_event_distinct_from_other_triggers_and_internally() {
+        let after_any = Trigger::OnEvent {
+            pattern: EventPattern::EnemyDefeated {
+                by_controller: false,
+            },
+            timing: EventTiming::After,
+        };
+        let after_controller = Trigger::OnEvent {
+            pattern: EventPattern::EnemyDefeated {
+                by_controller: true,
+            },
+            timing: EventTiming::After,
+        };
+        let before_controller = Trigger::OnEvent {
+            pattern: EventPattern::EnemyDefeated {
+                by_controller: true,
+            },
+            timing: EventTiming::Before,
+        };
+        assert_ne!(after_any, Trigger::Constant);
+        assert_ne!(after_any, Trigger::OnPlay);
+        assert_ne!(after_any, Trigger::OnCommit);
+        assert_ne!(after_any, after_controller);
+        assert_ne!(after_controller, before_controller);
+    }
+
+    /// An `OnEvent`-triggered ability round-trips through `serde_json`
+    /// — `#[non_exhaustive]` × struct-variant × serde derive can
+    /// surprise; pin the wire shape now so #52's persistence doesn't
+    /// re-discover problems later.
+    #[test]
+    fn on_event_ability_round_trips_through_serde_json() {
+        let original = on_event(
+            EventPattern::EnemyDefeated {
+                by_controller: true,
+            },
+            EventTiming::After,
+            discover_clue(LocationTarget::ControllerLocation, 1),
+        );
+        let json = serde_json::to_string(&original).expect("serialize");
+        let recovered: Ability = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(original, recovered);
     }
 

--- a/crates/game-core/src/dsl.rs
+++ b/crates/game-core/src/dsl.rs
@@ -6,42 +6,42 @@
 //! tests do, in Phase 3+) walks an [`Effect`] tree to actually mutate
 //! game state.
 //!
-//! # Phase-2 scope
+//! # Scope
 //!
-//! Just enough primitives to express the simple Phase-2 cards (Holy
-//! Rosary's constant modifiers, Working a Hunch's `on_play` clue
-//! discovery). Costs, action abilities, reaction triggers, and
-//! complex conditions are deferred — cards needing them get a Rust
-//! trait impl until the DSL grows the relevant verbs.
+//! The primitive set grows as cards demand. Today the DSL covers
+//! constant modifiers, on-play and on-commit triggers, activated
+//! abilities with action / payment costs, and a skill-test-resolution
+//! trigger. Reaction-style abilities have a DSL surface
+//! ([`Trigger::OnEvent`]) but no engine machinery yet (see below).
+//! Cards needing primitives the DSL doesn't yet express get a Rust
+//! trait impl until the verb lands.
 //!
 //! # What's not yet expressible
 //!
 //! Common shapes the DSL cannot describe today, and where they'll
 //! land:
 //!
-//! - **Activated abilities** (`[action]` / `[fast]` symbols on
-//!   asset abilities — Hyperawareness's `[fast] Spend 1 resource:
-//!   You get +1 [intellect] for this skill test`, etc.). Need a
-//!   `Trigger::Activated { action_cost: u8, costs: Vec<Cost> }` plus
-//!   cost primitives.
 //! - **Forced / leave-play triggers** (Harold Walsted's `Forced — when
 //!   Harold Walsted leaves play: Remove him from the game and add...`
 //!   from the Dunwich cycle). Need `Trigger::OnLeavePlay` plus
 //!   ability-specific effect machinery.
+//! - **Stat-comparison / location-state conditions** (`LocationHasClues`,
+//!   `AnyEnemyEngaged`, `SkillSucceededByAtLeast(N)`). [`Condition`]
+//!   today only covers skill-test outcome and kind.
+//!
+//! # Has DSL surface but not yet engine support
+//!
 //! - **Reaction abilities** (Roland Banks's `[reaction] After you
 //!   defeat an enemy: Discover 1 clue at your location. (Limit once
-//!   per round.)`). The DSL surface ([`Trigger::OnEvent`]) lands;
-//!   the engine event-window plumbing — registering active triggers
-//!   from cards in play and firing them against emitted events —
-//!   lands in
+//!   per round.)`). [`Trigger::OnEvent`] compiles and round-trips
+//!   through serde, but the engine event-window plumbing —
+//!   registering active triggers from cards in play and firing them
+//!   against emitted events — lands in
 //!   [issue #52](https://github.com/talelburg/eldritch/issues/52),
 //!   and per-round limit tracking still needs a primitive.
-//! - **Stat-comparison / location-state conditions** (`LocationHasClues`,
-//!   `AnyEnemyEngaged`, `SkillSucceededByAtLeast(N)`). Phase-2 only
-//!   has [`Condition::SkillTest`] with success/failure granularity.
 //!
-//! Cards needing any of these go to a Rust impl until the DSL grows
-//! the relevant primitive.
+//! Cards needing primitives in either list go to a Rust impl until
+//! the relevant verb lands.
 //!
 //! # Free-function builders
 //!
@@ -861,8 +861,10 @@ mod tests {
 
     /// `OnEvent` is a distinct enum variant from existing trigger
     /// shapes — the compiler enforces the distinction at every match
-    /// site, and the pattern/timing fields differentiate sub-cases
-    /// from each other.
+    /// site, and the `by_controller` / `timing` fields differentiate
+    /// the currently-expressible sub-cases. Pattern-vs-pattern
+    /// distinction lands as soon as a second [`EventPattern`] variant
+    /// arrives.
     #[test]
     fn on_event_distinct_from_other_triggers_and_internally() {
         let after_any = Trigger::OnEvent {
@@ -893,19 +895,25 @@ mod tests {
     /// An `OnEvent`-triggered ability round-trips through `serde_json`
     /// — `#[non_exhaustive]` × struct-variant × serde derive can
     /// surprise; pin the wire shape now so #52's persistence doesn't
-    /// re-discover problems later.
+    /// re-discover problems later. Both [`EventTiming`] variants
+    /// (`After` and `Before`) are exercised independently since
+    /// `#[non_exhaustive]` × unit-variant × serde can fail on either
+    /// alone (very rare, but the test rationale explicitly covers
+    /// this surface).
     #[test]
     fn on_event_ability_round_trips_through_serde_json() {
-        let original = on_event(
-            EventPattern::EnemyDefeated {
-                by_controller: true,
-            },
-            EventTiming::After,
-            discover_clue(LocationTarget::ControllerLocation, 1),
-        );
-        let json = serde_json::to_string(&original).expect("serialize");
-        let recovered: Ability = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(original, recovered);
+        for timing in [EventTiming::After, EventTiming::Before] {
+            let original = on_event(
+                EventPattern::EnemyDefeated {
+                    by_controller: true,
+                },
+                timing,
+                discover_clue(LocationTarget::ControllerLocation, 1),
+            );
+            let json = serde_json::to_string(&original).expect("serialize");
+            let recovered: Ability = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(original, recovered);
+        }
     }
 
     /// Effects clone deeply (the recursive Box doesn't break Clone).

--- a/docs/phases/phase-3-skill-test-end-to-end.md
+++ b/docs/phases/phase-3-skill-test-end-to-end.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-🟡 In progress. 18 closed / 5 open as of 2026-05-18.
+🟡 In progress. 19 closed / 4 open as of 2026-05-18.
 
 ## Goal
 
@@ -10,7 +10,7 @@ Full skill test sequence runs through the engine in tests — with real-card met
 
 ## Issues
 
-### Closed (18)
+### Closed (19)
 
 | # | Title | Notes |
 |---|---|---|
@@ -32,14 +32,14 @@ Full skill test sequence runs through the engine in tests — with real-card met
 | `#92` | constant-modifier query during skill-test resolution | Closes the Phase-3 demo: Holy Rosary `+1 willpower` actually applies. |
 | `#102` | `ThisSkillTest` modifier accumulator | Pushed + drained on `SkillTestEnded`. |
 | `#112` | DSL `Trigger::OnSkillTestResolution` + tested-location plumbing | Split out of `#39` so the trigger variant lands on its own; `#39` consumes it. |
+| `#54` | DSL `OnEvent` trigger | DSL surface only — `Trigger::OnEvent` + `EventPattern::EnemyDefeated` + `EventTiming::{Before, After}` + `on_event` builder. Firing (engine reaction-window machinery) lands in `#52`. |
 
-### Open (5)
+### Open (4)
 
 | # | Title | Notes |
 |---|---|---|
-| `#52` | reaction windows + trigger ordering | Needs `#54` + `#19`. The largest remaining engine piece. |
-| `#54` | DSL `OnEvent` trigger | Small extension; unblocks `#52` and `#55` Roland Banks. |
-| `#55` | Roland Banks investigator (01001) | Needs `#54` + `#52`. |
+| `#52` | reaction windows + trigger ordering | Needs `#19`; consumes `#54`. The largest remaining engine piece. |
+| `#55` | Roland Banks investigator (01001) | Needs `#52`; consumes `#54`. |
 | `#56` | Study location (01111) | Needs a location-state shape decision; thinnest issue body. |
 | `#64` | skill-test after-resolution trigger window | Needs `#54` (OnEvent) + `#19`. Distinct semantic from `#112` — `#64` is a player-window-driven reactive trigger after the test ends; `#112` is a resolution-machinery trigger on committed cards. |
 
@@ -73,7 +73,7 @@ Cards rather than infra-first. Build the minimal infra each card needs, ship the
 | 8 | `#63` skill-test commits | ✅ PR #110 |
 | 9 | `#112` `Trigger::OnSkillTestResolution` + tested-location plumbing | ✅ PR #113 |
 | 10 | `#39` Deduction | ✅ PR #114 |
-| 11 | `#54` OnEvent trigger | small |
+| 11 | `#54` OnEvent trigger | ✅ PR #115 |
 | 12 | `#52` reaction windows | needs `#54` + `#19`; largest remaining piece |
 | 13 | `#55` Roland Banks | needs `#54` + `#52` |
 | 14 | `#56` Study | needs location-state design; defer or build alongside Phase 4 |
@@ -97,6 +97,7 @@ Cards rather than infra-first. Build the minimal infra each card needs, ship the
 - **Event ordering: action-specific follow-up fires BEFORE `SkillTestEnded` (`#63`, PR #110).** `SkillTestSucceeded → follow-up events → CardDiscarded* → SkillTestEnded`. Matches the `SkillTestEnded` event-doc text ("Cleanup events … precede this"); load-bearing for `#64`'s after-resolution trigger window and any future listener keying off the end marker as "all sub-effects already applied." Pinned by `investigate_canonical_event_sequence_pins_followup_before_test_ended`.
 - **"Max 1 committed per skill test" not enforced (`#63`, PR #110).** Perception, Overpower, and Unexpected Courage all carry the constraint in their printed text but the engine accepts duplicate commits today. The general "card-level commit-limit constraint" needs the DSL to grow a primitive — wait until the second card with a non-trivial commit restriction lands before designing it. No separate tracking issue; resurfaces naturally when needed.
 - **Upkeep hand-size limit tracked as `#111` (`#63`, PR #110).** `InputResponse::CommitCards` carries `u32` indices for wire-format symmetry with `PickIndex`. The engine assumes hand size stays below 256 (a `u8::try_from(...).expect(...)` justified by the preceding bound check); `#111` makes that structural by implementing the Arkham upkeep discard-to-max-hand-size step.
+- **`Trigger::OnEvent` ships with both `Before` and `After` timings (`#54`, PR #115).** Reaction-window machinery in `#52` pre-committed to the natural "scan Before triggers, fire event, scan After triggers" shape. Shipping only `After` would force `#52` to grow the variant before it can do the canonical loop. `EventPattern` starts at one variant (`EnemyDefeated { by_controller: bool }`) since only Roland Banks (`#55`) consumes it in Phase 3; `by_controller: bool` instead of a `By` enum because a single-variant enum is noise — swap to enum the day a second "by" qualifier lands.
 - **`Trigger::OnSkillTestResolution` is resolution-machinery, not a reaction window (`#112`, PR #113).** Deduction-shaped text ("if this skill test is successful while investigating, discover 1 additional clue at that location") doesn't fit `OnCommit` (outcome unknown at commit) and doesn't fit `#64`'s reactive window (no player decision). New variant fires inside `finish_skill_test` for committed cards, gated on actual outcome. Settles `#39` Deduction's routing question; keeps `#64` strictly for player-window-driven "after a test succeeds, you may …" cards. Event order pinned by `investigate_canonical_event_order_with_on_resolution`: action follow-up before OnResolution before discards, load-bearing for `#64` listeners that key off `SkillTestEnded` as "all sub-effects applied."
 
 ## Open questions


### PR DESCRIPTION
## Summary

- Adds `Trigger::OnEvent { pattern: EventPattern, timing: EventTiming }` to the card-effect DSL, the reactive-trigger surface needed by Roland Banks (#55) and other `[reaction]` cards.
- `EventPattern` starts with just the variant Roland Banks needs (`EnemyDefeated { by_controller: bool }`); `EventTiming` carries `Before` and `After`.
- New `on_event(pattern, timing, effect)` builder; doc preamble + `Trigger` doc comment updated to remove "OnEvent lands later" forward references and point at #52 for the still-missing reaction-window plumbing.

## Design decisions

- **DSL surface only — no firing.** The trigger compiles, round-trips through serde, and reaches the registry, but the engine doesn't yet register it from cards in play or fire it during reaction windows. That work is #52 (the largest remaining Phase-3 engine piece). Mirrors the `#112` (trigger surface) → `#39` (consumer) split — keeps `#52`'s PR focused on the window machinery rather than the type design.
- **`EventPattern` starts at one variant.** Per CLAUDE.md's "don't add DSL primitives speculatively" rule. `SkillTestEnded` / `InvestigatorMovedTo` / etc. (suggested in the issue body) land when a card demands them. `#[non_exhaustive]` makes extension non-breaking.
- **`by_controller: bool` rather than a `TargetSpec` enum.** Single-variant enums are noise; the issue body's `TargetSpec` shape is over-spec for Phase-3 cards (only Roland Banks consumes this trigger). A bool is forward-compatible: we can swap to an enum the day a second "by" variant lands.
- **Both `Before` and `After` timings up front.** A timing field with one variant adds no discrimination; #52's reaction-window machinery will need to hang both windows off the same trigger anyway. Skipped `DuringForced` from the issue body — its semantics overlap `Before` once forced/may distinction is sorted, and no card needs it yet.

## Out of scope

- Engine reaction-window machinery (`#52`).
- Per-round limit tracking (Roland Banks's "Limit once per round.")
- Roland Banks card itself (`#55`).

## Test plan

- [x] `cargo test -p game-core dsl::tests::on_event` — 3 new tests (builder, distinct-from-other-triggers, serde round-trip).
- [x] Full CI gauntlet local: `cargo test --all --all-features` (RUSTFLAGS=-D warnings), clippy strict, fmt check, doc strict, wasm web build.

Closes #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)