### PR TITLE
card: Roland Banks reaction (01001) + UsageLimit DSL primitive

### DIFF
--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -32,10 +32,13 @@
 //!   `Modify`.
 //! - Deduction (01039) — `Trigger::OnSkillTestResolution` (Success-
 //!   gated) + `If(SkillTestKind(Investigate), DiscoverClue@TestedLocation)`.
+//! - Roland Banks (01001) — investigator. `Trigger::OnEvent`
+//!   reaction (`EnemyDefeated { by_controller: true }`, `After`) +
+//!   `UsageLimit { count: 1, period: Round }` for "Limit once per
+//!   round." Elder-sign half stubbed pending #118.
 //!
-//! Remaining Phase-3 cards (Roland Banks #55, Study #56) each block
-//! on a DSL primitive the cards crate doesn't yet emit — `OnEvent`
-//! reactions, location-state shape.
+//! The remaining Phase-3 card (Study #56) blocks on the
+//! location-state shape.
 
 use game_core::dsl::Ability;
 
@@ -43,6 +46,7 @@ pub mod deduction;
 pub mod holy_rosary;
 pub mod hyperawareness;
 pub mod magnifying_glass;
+pub mod roland_banks;
 pub mod working_a_hunch;
 
 /// Look up a card's hand-implemented abilities by code. Returns
@@ -54,6 +58,7 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
         holy_rosary::CODE => Some(holy_rosary::abilities()),
         hyperawareness::CODE => Some(hyperawareness::abilities()),
         magnifying_glass::CODE => Some(magnifying_glass::abilities()),
+        roland_banks::CODE => Some(roland_banks::abilities()),
         working_a_hunch::CODE => Some(working_a_hunch::abilities()),
         _ => None,
     }

--- a/crates/cards/src/impls/roland_banks.rs
+++ b/crates/cards/src/impls/roland_banks.rs
@@ -1,0 +1,103 @@
+//! Roland Banks (Guardian investigator, 01001).
+//!
+//! ```text
+//! Roland Banks. The Fed.
+//! Agency. Detective.
+//! Willpower 3. Intellect 3. Combat 4. Agility 2.
+//! Health 9. Sanity 5.
+//!
+//! [reaction] After you defeat an enemy: Discover 1 clue at your
+//! location. (Limit once per round.)
+//! [elder_sign] effect: +1 for each clue on your location.
+//! ```
+//!
+//! # Scope
+//!
+//! `abilities()` ships only the `[reaction]` half. The `[elder_sign]`
+//! half stays as the engine-wide `+0` placeholder until the dynamic
+//! skill-test modifier DSL primitive lands; tracked in
+//! [issue #118](https://github.com/talelburg/eldritch/issues/118).
+//!
+//! The reaction compiles to a [`Trigger::OnEvent`] with the
+//! [`EventPattern::EnemyDefeated`] pattern narrowed by
+//! `by_controller: true` (Roland's "After **you** defeat an enemy")
+//! at [`EventTiming::After`], discovering 1 clue at
+//! [`LocationTarget::ControllerLocation`]. The "Limit once per round"
+//! clause attaches as a [`UsageLimit`] with `count: 1, period:
+//! UsagePeriod::Round`.
+//!
+//! [`Trigger::OnEvent`]: game_core::dsl::Trigger::OnEvent
+//! [`EventPattern::EnemyDefeated`]: game_core::dsl::EventPattern::EnemyDefeated
+//! [`EventTiming::After`]: game_core::dsl::EventTiming::After
+//! [`LocationTarget::ControllerLocation`]: game_core::dsl::LocationTarget::ControllerLocation
+//! [`UsageLimit`]: game_core::dsl::UsageLimit
+
+use game_core::dsl::{
+    discover_clue, on_event, Ability, EventPattern, EventTiming, LocationTarget, UsageLimit,
+    UsagePeriod,
+};
+
+/// `ArkhamDB` code for the original-Core printing.
+pub const CODE: &str = "01001";
+
+/// Roland's `[reaction]` "After you defeat an enemy: Discover 1 clue
+/// at your location. (Limit once per round.)" The `[elder_sign]` half
+/// is tracked separately (#118).
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![on_event(
+        EventPattern::EnemyDefeated {
+            by_controller: true,
+        },
+        EventTiming::After,
+        discover_clue(LocationTarget::ControllerLocation, 1),
+    )
+    .with_usage_limit(UsageLimit {
+        count: 1,
+        period: UsagePeriod::Round,
+    })]
+}
+
+#[cfg(test)]
+mod tests {
+    use game_core::dsl::{
+        Effect, EventPattern, EventTiming, LocationTarget, Trigger, UsageLimit, UsagePeriod,
+    };
+
+    #[test]
+    fn abilities_are_one_reaction_with_once_per_round_limit() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(
+            abilities[0].trigger,
+            Trigger::OnEvent {
+                pattern: EventPattern::EnemyDefeated {
+                    by_controller: true,
+                },
+                timing: EventTiming::After,
+            },
+        );
+        assert!(matches!(
+            abilities[0].effect,
+            Effect::DiscoverClue {
+                from: LocationTarget::ControllerLocation,
+                count: 1,
+            },
+        ));
+        assert_eq!(
+            abilities[0].usage_limit,
+            Some(UsageLimit {
+                count: 1,
+                period: UsagePeriod::Round,
+            }),
+        );
+    }
+
+    /// Catches a `pub mod` rename or a fat-fingered match arm in
+    /// `impls::abilities_for` — the registry must dispatch CODE to
+    /// this module's `abilities()`.
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(super::CODE), Some(super::abilities()));
+    }
+}

--- a/crates/cards/src/lib.rs
+++ b/crates/cards/src/lib.rs
@@ -132,24 +132,26 @@ mod tests {
         // Phase-2 PR-I: Holy Rosary (01059), Working a Hunch (01037).
         // Phase-3 #37: Magnifying Glass (01030).
         // Phase-3 #38: Hyperawareness (01034).
+        // Phase-3 #39: Deduction (01039).
+        // Phase-3 #55: Roland Banks (01001).
         assert!(is_playable("01037"));
         assert!(is_playable("01059"));
         assert!(is_playable("01030"));
         assert!(is_playable("01034"));
         assert!(is_playable("01039"));
+        assert!(is_playable("01001"));
     }
 
     #[test]
     fn unimplemented_cards_are_not_playable() {
         // Phase-3 doesn't touch most of the corpus.
-        assert!(!is_playable("01001")); // Roland Banks
         assert!(!is_playable("01017")); // Physical Training
         assert!(!is_playable("99999")); // unknown code
     }
 
     #[test]
     fn abilities_for_returns_some_for_implemented() {
-        for code in ["01030", "01034", "01037", "01039", "01059"] {
+        for code in ["01001", "01030", "01034", "01037", "01039", "01059"] {
             let abilities = super::abilities_for(code)
                 .unwrap_or_else(|| panic!("expected abilities for {code}"));
             assert!(

--- a/crates/cards/tests/roland_banks.rs
+++ b/crates/cards/tests/roland_banks.rs
@@ -1,0 +1,289 @@
+//! End-to-end test for Roland Banks (01001)'s `[reaction]` ability
+//! against the real `cards::REGISTRY`.
+//!
+//! Card text (from `data/arkhamdb-snapshot/pack/core/core.json`):
+//!
+//! > [reaction] After you defeat an enemy: Discover 1 clue at your
+//! > location. (Limit once per round.)
+//!
+//! Closes the Phase-3 acceptance for #55's reaction half. The
+//! `[elder_sign]` half stays on its `+0` placeholder; #118 picks it
+//! up alongside the dynamic skill-test modifier DSL primitive.
+//!
+//! Lives at `crates/cards/tests/` so it can install [`cards::REGISTRY`]
+//! in its own integration-test process without colliding with the
+//! mock-registry tests in `crates/game-core/tests/reaction_windows.rs`.
+
+use std::sync::Once;
+
+use game_core::dsl::{UsageLimit, UsagePeriod};
+use game_core::engine::EngineOutcome;
+use game_core::event::Event;
+use game_core::state::{
+    AbilityUsageRecord, CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, EnemyId,
+    InvestigatorId, LocationId, Phase, TokenModifiers, WindowKind,
+};
+use game_core::test_support::{
+    apply_no_commits, drive, test_enemy, test_investigator, test_location, ScriptedResolver,
+    TestGame,
+};
+use game_core::{assert_event, assert_no_event, Action, PlayerAction};
+
+/// `ArkhamDB` code for original-Core Roland Banks.
+const ROLAND: &str = "01001";
+
+/// `instance_id` we assign to Roland's investigator card in
+/// `cards_in_play`. Arbitrary; tests just need it stable to compare
+/// against `PendingTrigger.instance_id`.
+const ROLAND_INSTANCE: u32 = 1;
+
+fn install_real_registry() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// Build a Fight-ready scenario with Roland engaged with an enemy at
+/// 1 HP and Combat 1 so a successful Combat test defeats. Roland's
+/// investigator card is placed in `cards_in_play` so the existing
+/// reaction-window scan finds his `[reaction]` ability via the real
+/// registry.
+fn roland_at_location_with_enemy(
+    location_clues: u8,
+    round: u32,
+) -> (InvestigatorId, EnemyId, LocationId, game_core::GameState) {
+    install_real_registry();
+    let inv_id = InvestigatorId(1);
+    let enemy_id = EnemyId(100);
+    let loc_id = LocationId(10);
+
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(loc_id);
+    inv.skills.combat = 4; // Roland's printed combat.
+    inv.cards_in_play.push(CardInPlay::enter_play(
+        CardCode::new(ROLAND),
+        CardInstanceId(ROLAND_INSTANCE),
+    ));
+
+    let mut enemy = test_enemy(100, "Mock Ghoul");
+    enemy.fight = 1;
+    enemy.max_health = 1;
+    enemy.damage = 0;
+    enemy.engaged_with = Some(inv_id);
+
+    let mut loc = test_location(10, "Study");
+    loc.clues = location_clues;
+
+    let state = TestGame::new()
+        .with_phase(Phase::Investigation)
+        .with_round(round)
+        .with_active_investigator(inv_id)
+        .with_turn_order([inv_id])
+        .with_investigator(inv)
+        .with_enemy(enemy)
+        .with_location(loc)
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default())
+        .build();
+    (inv_id, enemy_id, loc_id, state)
+}
+
+fn fight_action(inv: InvestigatorId, enemy: EnemyId) -> Action {
+    Action::Player(PlayerAction::Fight {
+        investigator: inv,
+        enemy,
+    })
+}
+
+#[test]
+fn reaction_fires_after_roland_defeats_enemy_and_discovers_clue() {
+    let (inv_id, enemy_id, loc_id, state) = roland_at_location_with_enemy(2, 0);
+
+    // Empty commit, then PickIndex(0) for the reaction window.
+    let mut resolver = ScriptedResolver::new();
+    resolver.commit_cards(&[]).pick(0);
+    let result = drive(state, fight_action(inv_id, enemy_id), resolver);
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::EnemyDefeated { enemy: e, by: Some(by) } if *e == enemy_id && *by == inv_id
+    );
+    assert_event!(
+        result.events,
+        Event::WindowOpened {
+            kind: WindowKind::AfterEnemyDefeated { enemy: e, .. },
+        } if *e == enemy_id
+    );
+    assert_event!(
+        result.events,
+        Event::CluePlaced { investigator, count: 1 } if *investigator == inv_id
+    );
+    assert_event!(
+        result.events,
+        Event::WindowClosed {
+            kind: WindowKind::AfterEnemyDefeated { enemy: e, .. },
+        } if *e == enemy_id
+    );
+
+    // 1 of 2 clues stayed at the location; Roland is carrying 1.
+    assert_eq!(result.state.locations[&loc_id].clues, 1);
+    assert_eq!(result.state.investigators[&inv_id].clues, 1);
+
+    // Counter bumped on Roland's investigator card: 1 fire this round.
+    let inv = &result.state.investigators[&inv_id];
+    let roland_card = inv
+        .cards_in_play
+        .iter()
+        .find(|c| c.code.as_str() == ROLAND)
+        .expect("Roland's investigator card stayed in cards_in_play");
+    assert_eq!(
+        roland_card.ability_usage.get(&0),
+        Some(&AbilityUsageRecord { round: 0, count: 1 }),
+        "Roland's reaction (ability index 0) should have recorded one fire \
+         in round 0",
+    );
+}
+
+#[test]
+fn once_per_round_limit_blocks_second_reaction_in_same_round() {
+    // Pre-populate the counter as if Roland already fired his reaction
+    // earlier this round. The scan must see the limit as exhausted and
+    // NOT queue the trigger — so no reaction window opens after a
+    // second defeat in the same round.
+    let (inv_id, enemy_id, loc_id, mut state) = roland_at_location_with_enemy(2, 0);
+    {
+        let inv = state.investigators.get_mut(&inv_id).unwrap();
+        let roland_card = inv
+            .cards_in_play
+            .iter_mut()
+            .find(|c| c.code.as_str() == ROLAND)
+            .unwrap();
+        roland_card.bump_ability_usage(0, 0);
+    }
+
+    let result = apply_no_commits(state, fight_action(inv_id, enemy_id));
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    // Defeat still happened.
+    assert_event!(
+        result.events,
+        Event::EnemyDefeated { enemy: e, by: Some(by) } if *e == enemy_id && *by == inv_id
+    );
+    // But the reaction window does NOT open — no triggers were pending
+    // after the limit check filtered Roland's ability out.
+    assert_no_event!(result.events, Event::WindowOpened { .. });
+    assert_no_event!(result.events, Event::WindowClosed { .. });
+    assert_no_event!(result.events, Event::CluePlaced { .. });
+    // Clue counts unchanged at the location and on Roland.
+    assert_eq!(result.state.locations[&loc_id].clues, 2);
+    assert_eq!(result.state.investigators[&inv_id].clues, 0);
+}
+
+#[test]
+fn lazy_round_reset_re_enables_reaction_in_a_later_round() {
+    // Counter sits at "fired in round 0" but the state is now in
+    // round 1. The lazy reset (`is_usage_exhausted` returns false when
+    // the stored round differs from current) lets the reaction fire
+    // again. No explicit round-end hook is invoked — the round counter
+    // just advanced.
+    let (inv_id, enemy_id, _loc_id, mut state) = roland_at_location_with_enemy(2, 1);
+    {
+        let inv = state.investigators.get_mut(&inv_id).unwrap();
+        let roland_card = inv
+            .cards_in_play
+            .iter_mut()
+            .find(|c| c.code.as_str() == ROLAND)
+            .unwrap();
+        // Pretend Roland fired in the previous round.
+        roland_card.bump_ability_usage(0, 0);
+    }
+
+    let mut resolver = ScriptedResolver::new();
+    resolver.commit_cards(&[]).pick(0);
+    let result = drive(state, fight_action(inv_id, enemy_id), resolver);
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::WindowOpened {
+            kind: WindowKind::AfterEnemyDefeated { enemy: e, .. },
+        } if *e == enemy_id
+    );
+    assert_event!(
+        result.events,
+        Event::CluePlaced { investigator, count: 1 } if *investigator == inv_id
+    );
+
+    // Counter now records "fired once in round 1" — the round-0 entry
+    // was overwritten in place by the lazy reset.
+    let inv = &result.state.investigators[&inv_id];
+    let roland_card = inv
+        .cards_in_play
+        .iter()
+        .find(|c| c.code.as_str() == ROLAND)
+        .unwrap();
+    assert_eq!(
+        roland_card.ability_usage.get(&0),
+        Some(&AbilityUsageRecord { round: 1, count: 1 }),
+    );
+}
+
+#[test]
+fn skipping_the_reaction_window_does_not_bump_the_counter() {
+    // Roland's reaction is optional ("[reaction]" not "Forced —"). If
+    // the controller chooses Skip, no firing happened, so the counter
+    // must stay at 0 — Roland can still react to a later defeat this
+    // round.
+    let (inv_id, enemy_id, loc_id, state) = roland_at_location_with_enemy(2, 0);
+
+    let mut resolver = ScriptedResolver::new();
+    resolver.commit_cards(&[]).skip();
+    let result = drive(state, fight_action(inv_id, enemy_id), resolver);
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::WindowOpened {
+            kind: WindowKind::AfterEnemyDefeated { enemy: e, .. },
+        } if *e == enemy_id
+    );
+    // Window closed without firing → no clue moved.
+    assert_no_event!(result.events, Event::CluePlaced { .. });
+    assert_eq!(result.state.locations[&loc_id].clues, 2);
+    assert_eq!(result.state.investigators[&inv_id].clues, 0);
+
+    // Counter is untouched.
+    let inv = &result.state.investigators[&inv_id];
+    let roland_card = inv
+        .cards_in_play
+        .iter()
+        .find(|c| c.code.as_str() == ROLAND)
+        .unwrap();
+    assert!(
+        roland_card.ability_usage.is_empty(),
+        "Skip must not record a use; ability_usage = {:?}",
+        roland_card.ability_usage,
+    );
+}
+
+/// Belt-and-suspenders sanity check: the real registry returns
+/// Roland's abilities with the once-per-round usage limit set.
+/// Card-level unit tests verify this against `super::abilities()`;
+/// this verifies the dispatch through `cards::REGISTRY` (which
+/// downstream code goes through) sees the same shape.
+#[test]
+fn registry_returns_reaction_with_once_per_round_limit() {
+    install_real_registry();
+    let abilities =
+        (cards::REGISTRY.abilities_for)(&CardCode::new(ROLAND)).expect("Roland is registered");
+    assert_eq!(abilities.len(), 1);
+    assert_eq!(
+        abilities[0].usage_limit,
+        Some(UsageLimit {
+            count: 1,
+            period: UsagePeriod::Round,
+        }),
+    );
+}

--- a/crates/cards/tests/roland_banks.rs
+++ b/crates/cards/tests/roland_banks.rs
@@ -140,7 +140,7 @@ fn reaction_fires_after_roland_defeats_enemy_and_discovers_clue() {
         .expect("Roland's investigator card stayed in cards_in_play");
     assert_eq!(
         roland_card.ability_usage.get(&0),
-        Some(&AbilityUsageRecord { round: 0, count: 1 }),
+        Some(&AbilityUsageRecord::new(0, 1)),
         "Roland's reaction (ability index 0) should have recorded one fire \
          in round 0",
     );
@@ -226,7 +226,7 @@ fn lazy_round_reset_re_enables_reaction_in_a_later_round() {
         .unwrap();
     assert_eq!(
         roland_card.ability_usage.get(&0),
-        Some(&AbilityUsageRecord { round: 1, count: 1 }),
+        Some(&AbilityUsageRecord::new(1, 1)),
     );
 }
 

--- a/crates/game-core/src/dsl.rs
+++ b/crates/game-core/src/dsl.rs
@@ -227,6 +227,49 @@ pub enum Cost {
     DiscardCardFromHand,
 }
 
+// ---- usage limits ----------------------------------------------
+
+/// A "Limit X per \[period\]" cap on how often an ability may fire.
+///
+/// Per the Rules Reference page 14: *"Each instance of an ability with
+/// such a limit may be initiated X times during the designated period.
+/// If a card leaves play and re-enters play during the same period,
+/// the card is considered to be bringing a new instance of the ability
+/// to the game."*
+///
+/// Canonical motivating card: Roland Banks (01001) —
+/// `[reaction] After you defeat an enemy: Discover 1 clue at your
+/// location. (Limit once per round.)` compiles to
+/// `UsageLimit { count: 1, period: UsagePeriod::Round }`.
+///
+/// Storage of the per-instance counter lives on
+/// [`CardInPlay`](crate::state::CardInPlay): see
+/// [`ability_usage`](crate::state::CardInPlay::ability_usage). When a
+/// card leaves play, its `CardInPlay` is dropped, so a re-entering
+/// instance starts fresh as the rules require.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct UsageLimit {
+    /// Maximum number of times the ability may fire during one period.
+    pub count: u8,
+    /// Which period the count is measured over.
+    pub period: UsagePeriod,
+}
+
+/// The period a [`UsageLimit`] is measured over.
+///
+/// Phase-3 minimal set: `Round` (Roland's "Limit once per round").
+/// `Phase` ("limit once per turn") and `Game` ("limit once per game"
+/// — group or player) land when the first consumer appears.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum UsagePeriod {
+    /// A game round, as defined by the framework: begins at 1.1 Mythos,
+    /// ends at 4.6 Upkeep (Rules Reference page 23). Counter resets
+    /// when [`GameState::round`](crate::state::GameState::round)
+    /// advances.
+    Round,
+}
+
 // ---- abilities -------------------------------------------------
 
 /// One ability on a card: a trigger paired with payment costs and
@@ -240,6 +283,11 @@ pub enum Cost {
 /// commit abilities use an empty `costs` vec. Activated abilities
 /// list their payment here in addition to the `action_cost` baked
 /// into [`Trigger::Activated`].
+///
+/// `usage_limit` carries the "Limit X per period" cap on firing — see
+/// [`UsageLimit`]. `None` means "unlimited within the rules' default
+/// once-per-occurrence cap on reaction abilities" (Rules Reference
+/// page 2). A `Some(...)` value applies the stronger printed cap.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct Ability {
@@ -249,6 +297,24 @@ pub struct Ability {
     #[serde(default)]
     pub costs: Vec<Cost>,
     pub effect: Effect,
+    /// "Limit X per \[period\]" cap. `None` for abilities with no
+    /// printed cap. Defaults to `None` on deserialize so older saved
+    /// logs still load cleanly.
+    #[serde(default)]
+    pub usage_limit: Option<UsageLimit>,
+}
+
+impl Ability {
+    /// Attach a [`UsageLimit`] to this ability. Builder-style sugar so
+    /// card impls can chain off the `on_event(...)` / `activated(...)`
+    /// constructors instead of mutating fields by name (which the
+    /// `cards` crate can't do anyway — [`Ability`] is
+    /// `#[non_exhaustive]`).
+    #[must_use]
+    pub fn with_usage_limit(mut self, limit: UsageLimit) -> Self {
+        self.usage_limit = Some(limit);
+        self
+    }
 }
 
 // ---- effects ---------------------------------------------------
@@ -473,6 +539,7 @@ pub fn constant(effect: Effect) -> Ability {
         trigger: Trigger::Constant,
         costs: Vec::new(),
         effect,
+        usage_limit: None,
     }
 }
 
@@ -486,6 +553,7 @@ pub fn on_play(effect: Effect) -> Ability {
         trigger: Trigger::OnPlay,
         costs: Vec::new(),
         effect,
+        usage_limit: None,
     }
 }
 
@@ -497,6 +565,7 @@ pub fn on_commit(effect: Effect) -> Ability {
         trigger: Trigger::OnCommit,
         costs: Vec::new(),
         effect,
+        usage_limit: None,
     }
 }
 
@@ -510,6 +579,7 @@ pub fn on_skill_test_resolution(outcome: TestOutcome, effect: Effect) -> Ability
         trigger: Trigger::OnSkillTestResolution { outcome },
         costs: Vec::new(),
         effect,
+        usage_limit: None,
     }
 }
 
@@ -522,6 +592,7 @@ pub fn on_event(pattern: EventPattern, timing: EventTiming, effect: Effect) -> A
         trigger: Trigger::OnEvent { pattern, timing },
         costs: Vec::new(),
         effect,
+        usage_limit: None,
     }
 }
 
@@ -540,6 +611,7 @@ pub fn activated(action_cost: u8, costs: Vec<Cost>, effect: Effect) -> Ability {
         trigger: Trigger::Activated { action_cost },
         costs,
         effect,
+        usage_limit: None,
     }
 }
 

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -1358,6 +1358,15 @@ fn fire_pending_trigger(state: &mut GameState, events: &mut Vec<Event>, i: u32) 
 /// trigger. Called by [`fire_pending_trigger`] only for abilities
 /// whose `usage_limit` is `Some(_)`; for abilities with no limit
 /// nothing tracks them.
+///
+/// **TODO (cancellation-counts-against-limit).** Rules Reference
+/// page 14: *"If the effects of a card or ability with a limit or
+/// maximum are canceled, it is still counted against the
+/// limit/maximum, because the ability has been initiated."* Phase-3
+/// has no cancellation primitive, so today we only bump on successful
+/// resolution. When cancellation lands, the bump call must move
+/// before the effect resolves (or fork into both paths) so canceled
+/// fires still count.
 fn bump_usage_counter(state: &mut GameState, trigger: &PendingTrigger) {
     let current_round = state.round;
     let inv = state

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -1116,6 +1116,12 @@ fn scan_pending_triggers(state: &GameState, kind: WindowKind) -> Vec<PendingTrig
                 }
                 let ability_index = u8::try_from(idx)
                     .expect("abilities vec exceeds u8::MAX — card-impl bug, abilities are tiny");
+                // "Limit X per [period]" — skip triggers whose per-
+                // instance counter has already reached the cap this
+                // round. Rules Reference page 14.
+                if card.is_usage_exhausted(ability_index, ability.usage_limit, state.round) {
+                    continue;
+                }
                 // Phase-3 scope: every queued trigger is optional.
                 // The DSL has no forced primitive yet (#52 doc).
                 pending.push(PendingTrigger {
@@ -1309,11 +1315,16 @@ fn fire_pending_trigger(state: &mut GameState, events: &mut Vec<Event>, i: u32) 
     // but the first source-attributing reaction effect will, and the
     // information is already on the trigger record.
     let ctx = EvalContext::for_controller_with_source(trigger.controller, trigger.instance_id);
+    let usage_limit = ability.usage_limit;
     let result = apply_effect(state, events, &ability.effect, ctx);
     if let EngineOutcome::Rejected { reason } = result {
         // Card-impl bugs surface loudly — same policy as
         // `fire_on_skill_test_resolution`.
         unreachable!("OnEvent reaction: effect for card {code:?} rejected unexpectedly: {reason}");
+    }
+
+    if usage_limit.is_some() {
+        bump_usage_counter(state, &trigger);
     }
 
     // Drop the fired entry now that resolution succeeded.
@@ -1341,6 +1352,38 @@ fn fire_pending_trigger(state: &mut GameState, events: &mut Vec<Event>, i: u32) 
         },
         resume_token: ResumeToken(0),
     }
+}
+
+/// Bump the per-instance ability-usage counter for the just-fired
+/// trigger. Called by [`fire_pending_trigger`] only for abilities
+/// whose `usage_limit` is `Some(_)`; for abilities with no limit
+/// nothing tracks them.
+fn bump_usage_counter(state: &mut GameState, trigger: &PendingTrigger) {
+    let current_round = state.round;
+    let inv = state
+        .investigators
+        .get_mut(&trigger.controller)
+        .unwrap_or_else(|| {
+            unreachable!(
+                "bump_usage_counter: controller {ctl:?} vanished while reaction window \
+                 was open; state-corruption invariant violation",
+                ctl = trigger.controller,
+            )
+        });
+    let card = inv
+        .cards_in_play
+        .iter_mut()
+        .find(|c| c.instance_id == trigger.instance_id)
+        .unwrap_or_else(|| {
+            unreachable!(
+                "bump_usage_counter: instance {inst:?} vanished from controller {ctl:?}'s \
+                 cards_in_play while reaction window was open; state-corruption invariant \
+                 violation",
+                inst = trigger.instance_id,
+                ctl = trigger.controller,
+            )
+        });
+    card.bump_ability_usage(trigger.ability_index, current_round);
 }
 
 /// Close the open reaction window. Rejects when any forced trigger

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -1272,6 +1272,7 @@ mod tests {
                 trigger: Trigger::OnPlay,
                 costs: Vec::new(),
                 effect: modify(Stat::Willpower, 5, ModifierScope::WhileInPlay),
+                usage_limit: None,
             }]),
             "max-health-plus-1" => Some(vec![constant(modify(
                 Stat::MaxHealth,

--- a/crates/game-core/src/state/card.rs
+++ b/crates/game-core/src/state/card.rs
@@ -171,10 +171,25 @@ pub struct CardInPlay {
 /// `count` is the number of fires during that round (compared against
 /// the ability's [`UsageLimit::count`](crate::dsl::UsageLimit::count)
 /// to gate further fires).
+///
+/// `#[non_exhaustive]` so future periods (`Phase`, `Game`) can add
+/// fields without breaking downstream construction. Use
+/// [`AbilityUsageRecord::new`] to construct from outside the crate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct AbilityUsageRecord {
     pub round: u32,
     pub count: u8,
+}
+
+impl AbilityUsageRecord {
+    /// Construct a usage record. The fields are `pub`, but the struct
+    /// is `#[non_exhaustive]` so downstream code (tests, future
+    /// scenario modules) must go through this constructor.
+    #[must_use]
+    pub fn new(round: u32, count: u8) -> Self {
+        Self { round, count }
+    }
 }
 
 impl CardInPlay {

--- a/crates/game-core/src/state/card.rs
+++ b/crates/game-core/src/state/card.rs
@@ -4,6 +4,8 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+use crate::dsl::{UsageLimit, UsagePeriod};
+
 /// `ArkhamDB` card code (e.g. `"01030"` for Magnifying Glass).
 ///
 /// Newtype over `String` so we can't accidentally pass arbitrary strings
@@ -143,6 +145,36 @@ pub struct CardInPlay {
     /// Horror accumulated on this asset (for horror-soak / ally
     /// sanity). Distinct from the controlling investigator's horror.
     pub accumulated_horror: u8,
+    /// Per-ability usage counter for "Limit X per \[period\]" caps. Key
+    /// is the ability index within the card's `abilities()`; value
+    /// records the last round the ability fired and how many times.
+    ///
+    /// Reset is **lazy** — when a query needs the count for the current
+    /// round, it reads the record; if the stored `round` doesn't match
+    /// [`GameState::round`](crate::state::GameState::round), the count
+    /// is treated as 0 (and overwritten on next fire). No explicit
+    /// round-end hook is required, which matters because Phase 3 has
+    /// no round-cycling framework yet — rounds tick by a test or future
+    /// scenario action mutating `state.round`.
+    ///
+    /// Empty for cards with no [`UsageLimit`] on any ability.
+    ///
+    /// [`UsageLimit`]: crate::dsl::UsageLimit
+    #[serde(default)]
+    pub ability_usage: BTreeMap<u8, AbilityUsageRecord>,
+}
+
+/// One ability's firing record for "Limit X per \[period\]" tracking.
+///
+/// `round` is the value of
+/// [`GameState::round`](crate::state::GameState::round) at last fire.
+/// `count` is the number of fires during that round (compared against
+/// the ability's [`UsageLimit::count`](crate::dsl::UsageLimit::count)
+/// to gate further fires).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AbilityUsageRecord {
+    pub round: u32,
+    pub count: u8,
 }
 
 impl CardInPlay {
@@ -158,6 +190,57 @@ impl CardInPlay {
             uses: BTreeMap::new(),
             accumulated_damage: 0,
             accumulated_horror: 0,
+            ability_usage: BTreeMap::new(),
         }
+    }
+
+    /// Returns `true` if the ability at `ability_index` has already
+    /// reached its [`UsageLimit::count`] for the current period.
+    ///
+    /// `None` for `limit` (the ability has no printed "Limit X per …"
+    /// clause) always returns `false` — that ability has no per-period
+    /// cap; the rules' default once-per-occurrence cap on reaction
+    /// abilities is enforced by the reaction-window dispatch itself,
+    /// not by this counter.
+    #[must_use]
+    pub fn is_usage_exhausted(
+        &self,
+        ability_index: u8,
+        limit: Option<UsageLimit>,
+        current_round: u32,
+    ) -> bool {
+        let Some(limit) = limit else {
+            return false;
+        };
+        match limit.period {
+            UsagePeriod::Round => {
+                let Some(record) = self.ability_usage.get(&ability_index) else {
+                    return false;
+                };
+                if record.round != current_round {
+                    return false;
+                }
+                record.count >= limit.count
+            }
+        }
+    }
+
+    /// Record one firing of the ability at `ability_index` against the
+    /// current period. Resets the counter if the stored record is for
+    /// a stale period (lazy reset — see the field-level docs on
+    /// [`ability_usage`](Self::ability_usage)).
+    pub fn bump_ability_usage(&mut self, ability_index: u8, current_round: u32) {
+        let record = self
+            .ability_usage
+            .entry(ability_index)
+            .or_insert(AbilityUsageRecord {
+                round: current_round,
+                count: 0,
+            });
+        if record.round != current_round {
+            record.round = current_round;
+            record.count = 0;
+        }
+        record.count = record.count.saturating_add(1);
     }
 }

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -13,7 +13,7 @@ pub mod investigator;
 pub mod location;
 pub mod phase;
 
-pub use card::{CardCode, CardInPlay, CardInstanceId, UseKind, Zone};
+pub use card::{AbilityUsageRecord, CardCode, CardInPlay, CardInstanceId, UseKind, Zone};
 pub use chaos_bag::{resolve_token, ChaosBag, ChaosToken, TokenModifiers, TokenResolution};
 pub use enemy::{Enemy, EnemyId};
 pub use game_state::{

--- a/crates/game-core/tests/reaction_windows.rs
+++ b/crates/game-core/tests/reaction_windows.rs
@@ -6,9 +6,11 @@
 //! a mock registry without colliding with game-core's in-crate tests or
 //! with other `tests/*.rs` files. Mirrors `on_skill_test_resolution.rs`.
 //!
-//! No real card carries [`Trigger::OnEvent`](game_core::dsl::Trigger::OnEvent)
-//! yet — the follow-up issue (#55 Roland Banks) is the first consumer.
-//! Until then, mock cards are the only way to exercise the full path.
+//! Roland Banks (01001, #55) is the first real-card `Trigger::OnEvent`
+//! consumer; that card's end-to-end test lives in
+//! `crates/cards/tests/roland_banks.rs`. This file keeps mock cards to
+//! exercise edge cases (multi-controller defeats, two abilities on one
+//! card, `by_controller: false`) that no real Phase-3 card hits.
 
 use std::sync::OnceLock;
 

--- a/docs/phases/phase-3-skill-test-end-to-end.md
+++ b/docs/phases/phase-3-skill-test-end-to-end.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-🟡 In progress. 20 closed / 3 open as of 2026-05-19.
+🟡 In progress. 21 closed / 2 open as of 2026-05-20.
 
 ## Goal
 
@@ -10,11 +10,12 @@ Full skill test sequence runs through the engine in tests — with real-card met
 
 ## Issues
 
-### Closed (20)
+### Closed (21)
 
 | # | Title | Notes |
 |---|---|---|
 | `#19` | deterministic `ChoiceResolver` | Test infra; ships ahead of first engine consumer (`#63`). `commit_cards` stubbed pending commit-window response shape. |
+| `#55` | Roland Banks reaction (01001) | Reaction half only. Elder-sign + dynamic skill-test modifier DSL spun off to `#118` (Phase 7). First real-card consumer of `#52` reaction-window machinery; introduced `Ability.usage_limit` primitive. |
 | `#63` | skill-test card commits from hand | First engine consumer of `#19`. Splits `resolve_skill_test` → `start_skill_test` + `finish_skill_test`; adds `state.in_flight_skill_test`, `SkillTestFollowUp`, `InputResponse::CommitCards`. |
 | `#37` | Magnifying Glass (01030) | First new card after the Phase-3 demo; composes `#87` + `#45`. |
 | `#38` | Hyperawareness (01034) | Exercises `Trigger::Activated` + `ThisSkillTest` push end-to-end. |
@@ -35,11 +36,10 @@ Full skill test sequence runs through the engine in tests — with real-card met
 | `#112` | DSL `Trigger::OnSkillTestResolution` + tested-location plumbing | Split out of `#39` so the trigger variant lands on its own; `#39` consumes it. |
 | `#54` | DSL `OnEvent` trigger | DSL surface only — `Trigger::OnEvent` + `EventPattern::EnemyDefeated` + `EventTiming::{Before, After}` + `on_event` builder. Firing (engine reaction-window machinery) lands in `#52`. |
 
-### Open (3)
+### Open (2)
 
 | # | Title | Notes |
 |---|---|---|
-| `#55` | Roland Banks investigator (01001) | Needs `#52` (✅) + `#54` (✅). First consumer of the reaction-window machinery. |
 | `#56` | Study location (01111) | Needs a location-state shape decision; thinnest issue body. |
 | `#64` | skill-test after-resolution trigger window | Needs `#54` (OnEvent) + `#19`. Distinct semantic from `#112` — `#64` is a player-window-driven reactive trigger after the test ends; `#112` is a resolution-machinery trigger on committed cards. The `FinishContinuation::PostOnResolution` seat (added in `#52`) is the natural step boundary. |
 
@@ -75,7 +75,7 @@ Cards rather than infra-first. Build the minimal infra each card needs, ship the
 | 10 | `#39` Deduction | ✅ PR #114 |
 | 11 | `#54` OnEvent trigger | ✅ PR #115 |
 | 12 | `#52` reaction windows | ✅ PR #116 |
-| 13 | `#55` Roland Banks | needs `#54` + `#52` |
+| 13 | `#55` Roland Banks reaction | ✅ PR #120 |
 | 14 | `#56` Study | needs location-state design; defer or build alongside Phase 4 |
 | 15 | `#64` after-resolution trigger window | distinct from `#112`; reactive trigger window for OnEvent-style "after this test succeeds, …" cards |
 
@@ -104,6 +104,9 @@ Cards rather than infra-first. Build the minimal infra each card needs, ship the
 - **All triggers route through the player; forced vs. optional is a flag, not auto-resolve (`#52`, PR #116).** Reaction-window resolution presents every pending trigger through `AwaitingInput`; `InputResponse::PickIndex(i)` fires the i-th, `Skip` closes the window. `PendingTrigger.forced` is enforced by `close_reaction_window` (Skip rejects while forced remain). Phase-3 has no Forced cards; the engine constructs `forced: false` everywhere and the DSL has no surface for setting it. The first Forced card adds the DSL primitive without engine churn — the scaffold is intentionally ready.
 - **Rules Reference vendored at `data/rules-reference/` (`#52`, PR #116).** The PDF is in-repo with a `SOURCE.md` naming the upstream URL — FFG's `filer_public` CDN has restructured several times so a stable local path beats a link. The CLAUDE.md directive on consulting it for procedural-rules claims points at the local path. Quote-handling clause says "load-bearing clause verbatim; elision OK on decorative surrounding clauses; never substitute words" — that's the standard for engine doc-comments citing the Rules Reference.
 - **Trigger indexing is a follow-up, not Phase 3 (`#52`, PR #116).** `scan_pending_triggers` walks every investigator's `cards_in_play` per window emission. For Phase-3 board sizes (a handful of cards per investigator) this is negligible. An index keyed by trigger kind becomes worth the invariant-maintenance cost when boards grow in Phase 4+. Tracked as a separate issue.
+- **`#55` split into reaction (Phase 3) + elder-sign (Phase 7, `#118`) (PR #120).** Roland's `[reaction]` is the load-bearing Phase-3 piece (first real-card consumer of `#52` reaction windows). His `[elder_sign]` needs a `Trigger::ElderSign` variant plus a dynamic skill-test modifier DSL surface (numeric expressions over state — clues at controller's location), whose shape benefits from a second consumer (likely `.45 Automatic` / Cover Up in Phase 7). Single-PR Roland would have lumped two unrelated DSL additions; the split keeps each PR focused and avoids locking the dynamic-modifier shape on one consumer. The broader unification of damage/horror/clues onto `CardInPlay` is `#119` (unmilestoned cross-cutting).
+- **Investigator card is a `CardInPlay` placed at scenario setup (`#55`, PR #120).** Per Rules Reference pages 4 ("Attach To") and 6 ("Clues"), the investigator card is a card in play under its owner's control. Putting it in `cards_in_play` lets the existing reaction-window scan, constant-modifier query, and any future ability walk pick up investigator abilities uniformly with assets — no bespoke "investigator-abilities" path. An earlier draft added `Investigator.card_code` as a back-pointer; removed during review because nothing reads it (the `CardInPlay.code` is the canonical identifier). When `#119` lands and the investigator's damage/horror/clues migrate to that `CardInPlay`, a `CardInstanceId` pointer may be wanted then — concrete consumer first.
+- **`UsageLimit` primitive lives on `Ability`, counter lives on `CardInPlay` (`#55`, PR #120).** `Ability.usage_limit: Option<UsageLimit { count, period }>` with `UsagePeriod::Round` for "Limit once per round" (Rules Reference page 14). Per-instance storage on `CardInPlay::ability_usage` (keyed by ability index) matches the page-14 rule that a card leaving and re-entering play brings a new ability instance — the counter drops with the `CardInPlay` automatically. Lazy round-keyed reset (mismatched-round records read as 0) avoids needing a round-end hook, which matters because Phase 3 doesn't cycle rounds yet. `Skip` doesn't bump the counter — page 14 ties the count to *initiation*. Cancellation-counts-against-limit (also page 14) is flagged with a TODO near `bump_usage_counter` for when a cancellation primitive lands.
 
 ## Open questions
 


### PR DESCRIPTION
## Summary

Ships Roland Banks's `[reaction]` half: "After you defeat an enemy: Discover 1 clue at your location. (Limit once per round.)" First real-card consumer of the reaction-window machinery from #52/PR #116. Closes #55 in the narrowed scope agreed in the design discussion (elder-sign spun off to #118, storage unification to #119).

## What changed

**DSL primitive (`UsageLimit`).** New `UsageLimit { count: u8, period: UsagePeriod }` + `UsagePeriod::Round` (`#[non_exhaustive]`). Hangs off `Ability.usage_limit: Option<UsageLimit>` (`#[serde(default)]`). Card-side builder sugar: `on_event(...).with_usage_limit(UsageLimit { count: 1, period: UsagePeriod::Round })`.

**Per-instance counter on `CardInPlay`.** New `ability_usage: BTreeMap<u8, AbilityUsageRecord { round, count }>`. Lazy round-keyed reset (no explicit round-end hook — Phase 3 doesn't cycle rounds yet; on read, mismatched-round records are treated as 0). Helpers `is_usage_exhausted` / `bump_ability_usage` on `CardInPlay`.

**Reaction-window plumbing.** `scan_pending_triggers` filters out triggers whose `usage_limit` is satisfied for `state.round`. `fire_pending_trigger` increments the counter after the effect resolves successfully (extracted to `bump_usage_counter` to keep the function under the clippy line-count cap). `Skip` does not bump — matches Rules Reference page 14: "Each instance of an ability with such a limit may be initiated X times" (the count is on initiations).

**Card impl.** `crates/cards/src/impls/roland_banks.rs` (code `01001`). Reaction compiles to `on_event(EnemyDefeated { by_controller: true }, After, discover_clue(ControllerLocation, 1))` with the once-per-round limit. Elder-sign stays on the engine's `+0` placeholder with a comment pointing at #118.

**Investigator card as a card in play.** The integration test seats Roland's investigator card in `cards_in_play` at setup (a `CardInPlay { code: "01001", ... }`). Per Rules Reference pages 4 ("Attach To") and 6 ("Clues"), the investigator card is a card in play under its owner's control — uniform handling lets the existing reaction-window scan find Roland's `[reaction]` ability without bespoke investigator-ability plumbing. No new field added to `Investigator`; storage unification (damage/horror/clues onto `CardInPlay`) is tracked separately as #119.

## Test notes

- **Card unit tests** (`crates/cards/src/impls/roland_banks.rs`): shape check on the returned `Ability`; registry-dispatch sanity.
- **Integration tests** (`crates/cards/tests/roland_banks.rs`, real registry):
  - Reaction fires after defeating an enemy → clue discovered at Roland's location → counter bumps.
  - Pre-populated counter for round N + fight in round N → no reaction window opens.
  - Pre-populated counter for round 0 + fight in round 1 → window opens (lazy reset).
  - Skip on the reaction window → counter untouched, no clue moved.
  - Belt-and-suspenders: `cards::REGISTRY.abilities_for("01001")` returns a `Some` with the once-per-round limit set.
- **Existing reaction-window mock tests** (`crates/game-core/tests/reaction_windows.rs`) still pass — stale doc-comment about "no real card carries `OnEvent` yet" updated.

CI gauntlet (all five jobs) run locally with the strict flags before push.

## Linked issues

Closes #55.

Spun off during scope:
- #118 — Roland's `[elder_sign]` + dynamic skill-test modifier DSL surface (Phase 7).
- #119 — Unify damage/horror/clues onto `CardInPlay` (unmilestoned cross-cutting).