### PR TITLE
engine: enemy_attack applies damage and horror simultaneously (#83)

### DIFF
--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -2128,15 +2128,18 @@ fn check_all_defeated(state: &GameState, events: &mut Vec<Event>) {
 /// values to land. Only one [`Event::InvestigatorDefeated`] fires per
 /// attack regardless of how many stats crossed.
 ///
-/// Tie-break when both stats cross simultaneously: the cause is
-/// [`DefeatCause::Damage`]. The Rules Reference does not disambiguate
-/// the simultaneous-lethal case; a deterministic choice is the
-/// requirement here, and damage-first matches the most common
-/// implementation convention. Revisit if a FAQ ruling surfaces or if
-/// campaign trauma needs to charge both physical and mental at once
-/// (Rules Reference page 8 frames the trauma rules around the singular
-/// "defeated by taking damage" / "by taking horror" cases, but doesn't
-/// rule out both).
+/// Tie-break when both stats cross simultaneously: [`DefeatCause::Damage`].
+/// Per Rules Reference page 6, an investigator simultaneously defeated
+/// by damage and horror *"chooses which type of trauma to suffer"* —
+/// physical vs. mental in the campaign log, and the corresponding
+/// in-scenario status flip follows. The engine doesn't model campaign
+/// trauma yet and has no [`AwaitingInput`] prompt for "pick trauma
+/// type," so `DefeatCause::Damage` is a deterministic placeholder for
+/// the status flip. Route the choice through `AwaitingInput` (and pick
+/// the corresponding [`Status`] variant) when trauma lands; out of
+/// scope for `#83`.
+///
+/// [`AwaitingInput`]: crate::engine::EngineOutcome::AwaitingInput
 fn enemy_attack(
     state: &mut GameState,
     events: &mut Vec<Event>,

--- a/crates/game-core/src/engine/dispatch.rs
+++ b/crates/game-core/src/engine/dispatch.rs
@@ -1927,62 +1927,143 @@ fn damage_enemy(
     }
 }
 
-/// Apply `amount` damage to an investigator. If their accumulated
-/// damage reaches `max_health`, flip status to [`Status::Killed`],
-/// emit [`Event::InvestigatorDefeated`], and (if no `Active`
-/// investigators remain) emit [`Event::AllInvestigatorsDefeated`].
+/// Add `amount` to the investigator's `damage` and emit
+/// [`Event::DamageTaken`]. Returns `true` iff the new total reaches
+/// `max_health` (i.e. the investigator now qualifies for defeat under
+/// [`DefeatCause::Damage`]).
+///
+/// Does NOT flip [`Status`] or emit [`Event::InvestigatorDefeated`] —
+/// the caller composes the defeat step via [`apply_investigator_defeat`]
+/// when the return is `true`. This split exists so [`enemy_attack`]
+/// can place damage AND horror on the investigator before either
+/// triggers defeat detection, matching the Rules Reference page 7
+/// "Apply Damage/Horror" clause: *"Any assigned damage/horror that
+/// has not been prevented is now placed on each card to which it has
+/// been assigned, simultaneously."*
 ///
 /// No-ops when `amount == 0` or the investigator is already defeated
 /// (status `!= Active`): defeated investigators are out of play and
 /// don't accumulate more damage.
 ///
-/// All damage-application paths should funnel through this helper so
-/// defeat detection stays consistent. The first caller is
-/// [`enemy_attack`]; future damage-dealing card effects plug in here
-/// too.
-///
-/// [`Status::Killed`]: crate::state::Status::Killed
-fn take_damage(
+/// [`Status`]: crate::state::Status
+fn apply_damage_numeric(
     state: &mut GameState,
     events: &mut Vec<Event>,
     investigator: InvestigatorId,
     amount: u8,
-) {
+) -> bool {
     if amount == 0 {
-        return;
+        return false;
     }
     let inv = state
         .investigators
         .get_mut(&investigator)
         .unwrap_or_else(|| {
             unreachable!(
-                "take_damage: investigator {investigator:?} is not in the investigators map; \
+                "apply_damage_numeric: investigator {investigator:?} is not in the investigators map; \
+             this is a state-corruption invariant violation"
+            )
+        });
+    if inv.status != Status::Active {
+        return false;
+    }
+    inv.damage = inv.damage.saturating_add(amount);
+    let lethal = inv.damage >= inv.max_health;
+    events.push(Event::DamageTaken {
+        investigator,
+        amount,
+    });
+    lethal
+}
+
+/// Symmetric to [`apply_damage_numeric`] but against `horror` /
+/// `max_sanity`. Returns `true` iff the new total reaches the
+/// max-sanity threshold; defeat application is the caller's
+/// responsibility (see [`apply_investigator_defeat`]).
+fn apply_horror_numeric(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+    amount: u8,
+) -> bool {
+    if amount == 0 {
+        return false;
+    }
+    let inv = state
+        .investigators
+        .get_mut(&investigator)
+        .unwrap_or_else(|| {
+            unreachable!(
+                "apply_horror_numeric: investigator {investigator:?} is not in the investigators map; \
+             this is a state-corruption invariant violation"
+            )
+        });
+    if inv.status != Status::Active {
+        return false;
+    }
+    inv.horror = inv.horror.saturating_add(amount);
+    let lethal = inv.horror >= inv.max_sanity;
+    events.push(Event::HorrorTaken {
+        investigator,
+        amount,
+    });
+    lethal
+}
+
+/// Flip an Active investigator's status to the appropriate defeated
+/// variant for `cause`, emit [`Event::InvestigatorDefeated`], and run
+/// [`check_all_defeated`]. No-op if the investigator is already
+/// non-Active (an investigator can only be defeated once per attack).
+///
+/// [`Status::Killed`]: crate::state::Status::Killed
+/// [`Status::Insane`]: crate::state::Status::Insane
+fn apply_investigator_defeat(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+    cause: DefeatCause,
+) {
+    let inv = state
+        .investigators
+        .get_mut(&investigator)
+        .unwrap_or_else(|| {
+            unreachable!(
+                "apply_investigator_defeat: investigator {investigator:?} is not in the investigators map; \
              this is a state-corruption invariant violation"
             )
         });
     if inv.status != Status::Active {
         return;
     }
-    inv.damage = inv.damage.saturating_add(amount);
-    let max_health = inv.max_health;
-    let now_defeated = inv.damage >= max_health;
-    events.push(Event::DamageTaken {
+    inv.status = match cause {
+        DefeatCause::Damage => Status::Killed,
+        DefeatCause::Horror => Status::Insane,
+        DefeatCause::Resigned => Status::Resigned,
+    };
+    events.push(Event::InvestigatorDefeated {
         investigator,
-        amount,
+        cause,
     });
-    if now_defeated {
-        inv.status = Status::Killed;
-        events.push(Event::InvestigatorDefeated {
-            investigator,
-            cause: DefeatCause::Damage,
-        });
-        check_all_defeated(state, events);
-    }
+    check_all_defeated(state, events);
 }
 
-/// Apply `amount` horror to an investigator. Symmetric to
-/// [`take_damage`] but against `horror` / `max_sanity`, defeating
-/// with [`Status::Insane`] and [`DefeatCause::Horror`].
+/// Apply `amount` horror to an investigator. If their accumulated
+/// horror reaches `max_sanity`, flip status to [`Status::Insane`],
+/// emit [`Event::InvestigatorDefeated`], and (if no `Active`
+/// investigators remain) emit [`Event::AllInvestigatorsDefeated`].
+///
+/// No-ops when `amount == 0` or the investigator is already defeated.
+///
+/// Single-source horror application (currently the Draw-from-empty-
+/// deck penalty) funnels through this convenience wrapper. Callers
+/// that need to apply both damage AND horror from the SAME source
+/// with simultaneous-placement semantics (i.e. [`enemy_attack`] and
+/// any future card effect that deals both) compose the lower-level
+/// [`apply_damage_numeric`] + [`apply_horror_numeric`] +
+/// [`apply_investigator_defeat`] triple instead. A `take_damage`
+/// twin is not provided because no single-source-damage caller exists
+/// yet; the recipe (numeric helper + defeat application on `true`
+/// return) is one line per call site.
 ///
 /// [`Status::Insane`]: crate::state::Status::Insane
 fn take_horror(
@@ -1991,35 +2072,8 @@ fn take_horror(
     investigator: InvestigatorId,
     amount: u8,
 ) {
-    if amount == 0 {
-        return;
-    }
-    let inv = state
-        .investigators
-        .get_mut(&investigator)
-        .unwrap_or_else(|| {
-            unreachable!(
-                "take_horror: investigator {investigator:?} is not in the investigators map; \
-             this is a state-corruption invariant violation"
-            )
-        });
-    if inv.status != Status::Active {
-        return;
-    }
-    inv.horror = inv.horror.saturating_add(amount);
-    let max_sanity = inv.max_sanity;
-    let now_defeated = inv.horror >= max_sanity;
-    events.push(Event::HorrorTaken {
-        investigator,
-        amount,
-    });
-    if now_defeated {
-        inv.status = Status::Insane;
-        events.push(Event::InvestigatorDefeated {
-            investigator,
-            cause: DefeatCause::Horror,
-        });
-        check_all_defeated(state, events);
+    if apply_horror_numeric(state, events, investigator, amount) {
+        apply_investigator_defeat(state, events, investigator, DefeatCause::Horror);
     }
 }
 
@@ -2028,12 +2082,13 @@ fn take_horror(
 ///
 /// **Contract for callers:** *any* code path that flips a
 /// `Status::Active` investigator to a non-`Active` status (Killed,
-/// Insane, Resigned) must call this helper afterwards. Currently
-/// only [`take_damage`] / [`take_horror`] flip status, so they're
-/// the only callers; future paths (the Resign action, scenario
-/// effects that defeat directly) need to add a call too — otherwise
-/// the event silently fails to fire when those paths cause the last
-/// `Active` to fall.
+/// Insane, Resigned) must call this helper afterwards. Currently the
+/// only status-flipping path is [`apply_investigator_defeat`], so
+/// that one helper is the only caller; future paths that flip status
+/// outside this helper (a scenario effect that bypasses the standard
+/// defeat-cause routing) need to add a call too — otherwise the event
+/// silently fails to fire when those paths cause the last `Active`
+/// to fall.
 ///
 /// Idempotent on subsequent defeats: the predicate becomes true once
 /// and stays true. Callers only invoke it after a status flip, so it
@@ -2061,12 +2116,27 @@ fn check_all_defeated(state: &GameState, events: &mut Vec<Event>) {
 /// flag — callers that need exhaustion (i.e. the enemy phase) apply
 /// it separately.
 ///
-/// Defeat handling flows through [`take_damage`] / [`take_horror`].
-/// If damage defeats first, horror is a no-op (already defeated);
-/// per rules damage and horror from an attack are simultaneous, so
-/// the practical loss of information is minor (the cause field on
-/// [`Event::InvestigatorDefeated`] still identifies the lethal
-/// stat).
+/// Damage and horror are placed on the investigator **simultaneously**
+/// per Rules Reference page 7 ("Apply Damage/Horror"): *"Any assigned
+/// damage/horror that has not been prevented is now placed on each
+/// card to which it has been assigned, simultaneously. … After
+/// applying damage/horror, if an investigator has damage equal to or
+/// higher than his or her health or horror equal to or higher than
+/// his or her sanity, he or she is defeated."* So `inv.damage` and
+/// `inv.horror` BOTH update before any defeat check, even when one
+/// alone would be lethal — campaign-log accounting needs both numeric
+/// values to land. Only one [`Event::InvestigatorDefeated`] fires per
+/// attack regardless of how many stats crossed.
+///
+/// Tie-break when both stats cross simultaneously: the cause is
+/// [`DefeatCause::Damage`]. The Rules Reference does not disambiguate
+/// the simultaneous-lethal case; a deterministic choice is the
+/// requirement here, and damage-first matches the most common
+/// implementation convention. Revisit if a FAQ ruling surfaces or if
+/// campaign trauma needs to charge both physical and mental at once
+/// (Rules Reference page 8 frames the trauma rules around the singular
+/// "defeated by taking damage" / "by taking horror" cases, but doesn't
+/// rule out both).
 fn enemy_attack(
     state: &mut GameState,
     events: &mut Vec<Event>,
@@ -2082,8 +2152,16 @@ fn enemy_attack(
     let damage = enemy.attack_damage;
     let horror = enemy.attack_horror;
 
-    take_damage(state, events, investigator, damage);
-    take_horror(state, events, investigator, horror);
+    let damage_lethal = apply_damage_numeric(state, events, investigator, damage);
+    let horror_lethal = apply_horror_numeric(state, events, investigator, horror);
+    if damage_lethal || horror_lethal {
+        let cause = if damage_lethal {
+            DefeatCause::Damage
+        } else {
+            DefeatCause::Horror
+        };
+        apply_investigator_defeat(state, events, investigator, cause);
+    }
 }
 
 /// Fire attacks of opportunity from every ready enemy engaged with

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -2130,7 +2130,7 @@ mod tests {
     fn defeated_investigator_does_not_take_further_damage() {
         // Two engaged ready enemies, both with attack_damage = 5.
         // Investigator has max_health = 1. The first AoO defeats;
-        // the second is a no-op (take_damage skips defeated).
+        // the second is a no-op (apply_damage_numeric skips defeated).
         let (inv_id, _, b, _, mut state) = move_scenario_with_engaged_enemy();
         state.investigators.get_mut(&inv_id).unwrap().max_health = 1;
         state.enemies.get_mut(&EnemyId(200)).unwrap().attack_damage = 5;

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -2157,6 +2157,121 @@ mod tests {
     }
 
     #[test]
+    fn aoo_with_lethal_damage_and_sublethal_horror_applies_both_numerically() {
+        // Rules Reference page 7: damage and horror from a single
+        // attack are applied simultaneously. Lethal damage MUST NOT
+        // short-circuit the horror application.
+        let (inv_id, _, b, enemy_id, mut state) = move_scenario_with_engaged_enemy();
+        state.investigators.get_mut(&inv_id).unwrap().max_health = 5;
+        // Plenty of sanity headroom so the horror is sub-lethal.
+        state.investigators.get_mut(&inv_id).unwrap().max_sanity = 8;
+        let enemy = state.enemies.get_mut(&enemy_id).unwrap();
+        enemy.attack_damage = 5;
+        enemy.attack_horror = 1;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: inv_id,
+                destination: b,
+            }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        // Both events fire and both numeric fields land.
+        assert_event!(
+            result.events,
+            Event::DamageTaken { investigator, amount: 5 } if *investigator == inv_id
+        );
+        assert_event!(
+            result.events,
+            Event::HorrorTaken { investigator, amount: 1 } if *investigator == inv_id
+        );
+        assert_eq!(result.state.investigators[&inv_id].damage, 5);
+        assert_eq!(result.state.investigators[&inv_id].horror, 1);
+        // Exactly one InvestigatorDefeated, caused by Damage.
+        assert_event_count!(result.events, 1, Event::InvestigatorDefeated { .. });
+        assert_event!(
+            result.events,
+            Event::InvestigatorDefeated {
+                investigator,
+                cause: DefeatCause::Damage,
+            } if *investigator == inv_id
+        );
+        assert_eq!(result.state.investigators[&inv_id].status, Status::Killed);
+    }
+
+    #[test]
+    fn aoo_with_sublethal_damage_and_lethal_horror_applies_both_numerically() {
+        // Symmetric to the lethal-damage case: lethal horror MUST NOT
+        // short-circuit the damage application.
+        let (inv_id, _, b, enemy_id, mut state) = move_scenario_with_engaged_enemy();
+        state.investigators.get_mut(&inv_id).unwrap().max_health = 8;
+        state.investigators.get_mut(&inv_id).unwrap().max_sanity = 1;
+        let enemy = state.enemies.get_mut(&enemy_id).unwrap();
+        enemy.attack_damage = 1;
+        enemy.attack_horror = 5;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: inv_id,
+                destination: b,
+            }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::DamageTaken { investigator, amount: 1 } if *investigator == inv_id
+        );
+        assert_event!(
+            result.events,
+            Event::HorrorTaken { investigator, amount: 5 } if *investigator == inv_id
+        );
+        assert_eq!(result.state.investigators[&inv_id].damage, 1);
+        assert_eq!(result.state.investigators[&inv_id].horror, 5);
+        assert_event_count!(result.events, 1, Event::InvestigatorDefeated { .. });
+        assert_event!(
+            result.events,
+            Event::InvestigatorDefeated {
+                investigator,
+                cause: DefeatCause::Horror,
+            } if *investigator == inv_id
+        );
+        assert_eq!(result.state.investigators[&inv_id].status, Status::Insane);
+    }
+
+    #[test]
+    fn aoo_with_both_lethal_defeats_once_with_damage_cause() {
+        // Both stats cross their threshold from the same attack. Per
+        // the enemy_attack doc comment, the tie-break is
+        // DefeatCause::Damage (Rules Reference is silent on the
+        // simultaneous-lethal case; damage-first is the convention).
+        let (inv_id, _, b, enemy_id, mut state) = move_scenario_with_engaged_enemy();
+        state.investigators.get_mut(&inv_id).unwrap().max_health = 1;
+        state.investigators.get_mut(&inv_id).unwrap().max_sanity = 1;
+        let enemy = state.enemies.get_mut(&enemy_id).unwrap();
+        enemy.attack_damage = 1;
+        enemy.attack_horror = 1;
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: inv_id,
+                destination: b,
+            }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_eq!(result.state.investigators[&inv_id].damage, 1);
+        assert_eq!(result.state.investigators[&inv_id].horror, 1);
+        assert_event_count!(result.events, 1, Event::InvestigatorDefeated { .. });
+        assert_event!(
+            result.events,
+            Event::InvestigatorDefeated {
+                investigator,
+                cause: DefeatCause::Damage,
+            } if *investigator == inv_id
+        );
+        assert_eq!(result.state.investigators[&inv_id].status, Status::Killed);
+    }
+
+    #[test]
     fn all_investigators_defeated_fires_only_when_last_active_falls() {
         // Two investigators, one defeated, then the second defeated.
         // AllInvestigatorsDefeated should fire only on the second.

--- a/docs/phases/README.md
+++ b/docs/phases/README.md
@@ -15,7 +15,7 @@ When starting work on a new issue, read the relevant phase doc first. It's faste
 | 0 | Foundations | ✅ closed | [phase-0-foundations.md](phase-0-foundations.md) |
 | 1 | Engine bones | ✅ closed | [phase-1-engine-bones.md](phase-1-engine-bones.md) |
 | 2 | Card data + DSL | ✅ closed | [phase-2-card-data-and-dsl.md](phase-2-card-data-and-dsl.md) |
-| 3 | Skill-test end-to-end | 🟡 in progress | [phase-3-skill-test-end-to-end.md](phase-3-skill-test-end-to-end.md) |
+| 3 | Skill-test end-to-end | ✅ closed | [phase-3-skill-test-end-to-end.md](phase-3-skill-test-end-to-end.md) |
 | 4 | Scenario plumbing | ⏳ planned | [phase-4-scenario-plumbing.md](phase-4-scenario-plumbing.md) |
 | 5 | Server + persistence | 📐 architecture only | [phase-5-server-and-persistence.md](phase-5-server-and-persistence.md) |
 | 6 | Web client v0 | 📐 architecture only | [phase-6-web-client-v0.md](phase-6-web-client-v0.md) |

--- a/docs/phases/phase-3-skill-test-end-to-end.md
+++ b/docs/phases/phase-3-skill-test-end-to-end.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-🟡 In progress. 21 closed / 2 open as of 2026-05-20.
+✅ Closed 2026-05-21. 21 issues shipped; 2 deferred (see Decisions).
 
 ## Goal
 
@@ -36,12 +36,14 @@ Full skill test sequence runs through the engine in tests — with real-card met
 | `#112` | DSL `Trigger::OnSkillTestResolution` + tested-location plumbing | Split out of `#39` so the trigger variant lands on its own; `#39` consumes it. |
 | `#54` | DSL `OnEvent` trigger | DSL surface only — `Trigger::OnEvent` + `EventPattern::EnemyDefeated` + `EventTiming::{Before, After}` + `on_event` builder. Firing (engine reaction-window machinery) lands in `#52`. |
 
-### Open (2)
+### Deferred (2)
 
-| # | Title | Notes |
+Moved out of the Phase-3 milestone at close (see Decisions, "Phase-3 closure deferred #56 and #64").
+
+| # | Title | New home |
 |---|---|---|
-| `#56` | Study location (01111) | Needs a location-state shape decision; thinnest issue body. |
-| `#64` | skill-test after-resolution trigger window | Needs `#54` (OnEvent) + `#19`. Distinct semantic from `#112` — `#64` is a player-window-driven reactive trigger after the test ends; `#112` is a resolution-machinery trigger on committed cards. The `FinishContinuation::PostOnResolution` seat (added in `#52`) is the natural step boundary. |
+| `#56` | Study location (01111) | Phase 4, alongside `#74` (location-state + scenario-module shape). |
+| `#64` | skill-test after-resolution trigger window | Held unmilestoned until a concrete card needs the player-window-driven reactive trigger. The `FinishContinuation::PostOnResolution` seat (added in `#52`) is preserved as the hookup point. |
 
 ## Ordering (Shape B)
 
@@ -57,7 +59,7 @@ Three PRs to demonstrate "skill test runs through the engine on real cards":
 
 End state: Holy Rosary's `+1 willpower` applies during a real willpower skill test; Working a Hunch resolves on-play end-to-end.
 
-### Arc 2: completing the milestone (in progress)
+### Arc 2: completing the milestone (closed 2026-05-15 to 2026-05-21)
 
 Cards rather than infra-first. Build the minimal infra each card needs, ship the card, repeat. Gives steady "new card works" wins instead of ~8 infra PRs before any new card lands.
 
@@ -76,8 +78,8 @@ Cards rather than infra-first. Build the minimal infra each card needs, ship the
 | 11 | `#54` OnEvent trigger | ✅ PR #115 |
 | 12 | `#52` reaction windows | ✅ PR #116 |
 | 13 | `#55` Roland Banks reaction | ✅ PR #120 |
-| 14 | `#56` Study | needs location-state design; defer or build alongside Phase 4 |
-| 15 | `#64` after-resolution trigger window | distinct from `#112`; reactive trigger window for OnEvent-style "after this test succeeds, …" cards |
+| 14 | `#56` Study | ⏭️ deferred to Phase 4 (waits on `#74` location shape) |
+| 15 | `#64` after-resolution trigger window | ⏭️ deferred to first card consumer (unmilestoned) |
 
 ## Decisions made
 
@@ -107,10 +109,7 @@ Cards rather than infra-first. Build the minimal infra each card needs, ship the
 - **`#55` split into reaction (Phase 3) + elder-sign (Phase 7, `#118`) (PR #120).** Roland's `[reaction]` is the load-bearing Phase-3 piece (first real-card consumer of `#52` reaction windows). His `[elder_sign]` needs a `Trigger::ElderSign` variant plus a dynamic skill-test modifier DSL surface (numeric expressions over state — clues at controller's location), whose shape benefits from a second consumer (likely `.45 Automatic` / Cover Up in Phase 7). Single-PR Roland would have lumped two unrelated DSL additions; the split keeps each PR focused and avoids locking the dynamic-modifier shape on one consumer. The broader unification of damage/horror/clues onto `CardInPlay` is `#119` (unmilestoned cross-cutting).
 - **Investigator card is a `CardInPlay` placed at scenario setup (`#55`, PR #120).** Per Rules Reference pages 4 ("Attach To") and 6 ("Clues"), the investigator card is a card in play under its owner's control. Putting it in `cards_in_play` lets the existing reaction-window scan, constant-modifier query, and any future ability walk pick up investigator abilities uniformly with assets — no bespoke "investigator-abilities" path. An earlier draft added `Investigator.card_code` as a back-pointer; removed during review because nothing reads it (the `CardInPlay.code` is the canonical identifier). When `#119` lands and the investigator's damage/horror/clues migrate to that `CardInPlay`, a `CardInstanceId` pointer may be wanted then — concrete consumer first.
 - **`UsageLimit` primitive lives on `Ability`, counter lives on `CardInPlay` (`#55`, PR #120).** `Ability.usage_limit: Option<UsageLimit { count, period }>` with `UsagePeriod::Round` for "Limit once per round" (Rules Reference page 14). Per-instance storage on `CardInPlay::ability_usage` (keyed by ability index) matches the page-14 rule that a card leaving and re-entering play brings a new ability instance — the counter drops with the `CardInPlay` automatically. Lazy round-keyed reset (mismatched-round records read as 0) avoids needing a round-end hook, which matters because Phase 3 doesn't cycle rounds yet. `Skip` doesn't bump the counter — page 14 ties the count to *initiation*. Cancellation-counts-against-limit (also page 14) is flagged with a TODO near `bump_usage_counter` for when a cancellation primitive lands.
-
-## Open questions
-
-- **`#56` Study (location).** Locations have a state shape (shroud, clues, connections), but printed locations also have abilities — Reveal effects, on-enter triggers. The shape for location abilities isn't yet decided. Could land alongside Phase-4 scenario plumbing (`#74` scenario module skeleton) where the location-handling shape gets settled.
+- **Phase-3 closure deferred `#56` and `#64`.** With the Roland-Banks reaction shipped (PR #120), the Phase-3 demo goal is satisfied: Magnifying Glass, Hyperawareness, Deduction, and Roland's reaction all run end-to-end against real card metadata + abilities. The remaining two issues each lack a concrete near-term consumer — `#56` Study needs a location-abilities shape that Phase 4's `#74` is the natural home for; `#64` is scaffolding for a player-window-driven reactive trigger with no card-in-scope wanting it. Holding both follows the codebase's "concrete consumer first" pattern (cf. the `#52` trigger-indexing deferral, the `#63` max-1-commit deferral, and the `#55` elder-sign split to Phase 7). The `FinishContinuation::PostOnResolution` seat already exists from `#52`, so `#64`'s hookup point survives untouched.
 
 ## Dependencies
 
@@ -118,14 +117,12 @@ Phases 0–2.
 
 ## What "done" looks like
 
-Skill test runs through the engine in tests against real-card metadata + abilities, with the full Phase-3-tagged card set implemented:
+Skill tests run through the engine against real-card metadata + abilities, demonstrated by integration tests in `crates/cards/tests/`:
 - Magnifying Glass `+1 intellect while investigating` ✓
 - Hyperawareness `[fast] Spend 1 resource: +1 stat for this skill test` ✓
-- Deduction commit-from-hand triggered effect
-- Roland Banks investigator with his reaction ability
-- Study location with whatever its printed abilities require
-
-End-to-end integration tests in `crates/cards/tests/` cover each card.
+- Deduction commit-from-hand triggered effect ✓
+- Roland Banks investigator with his reaction ability ✓
+- ~~Study location~~ → deferred to Phase 4 (`#74`)
 
 ## Side work shipped during the Phase-3 timeline
 


### PR DESCRIPTION
## Summary

Refactor `enemy_attack` so both numeric values land on the investigator
before defeat detection runs, matching the Rules Reference page 7
"Apply Damage/Horror" clause. Bundles the Phase-3 doc retrospective
since this is the last engine cleanup adjacent to Phase 3.

## What changed

**Engine**
- Split `take_damage` / `take_horror` into numeric primitives
  (`apply_damage_numeric`, `apply_horror_numeric`, both return whether
  the new total reached the defeat threshold) plus a shared defeat
  helper (`apply_investigator_defeat`, which handles status flip +
  `InvestigatorDefeated` event + `check_all_defeated`).
- `enemy_attack` now composes the trio: apply damage numerically,
  apply horror numerically, then a single defeat call if either
  crossed. Both `inv.damage` and `inv.horror` are updated regardless
  of which (if any) crossed first.
- `take_damage` removed — no live caller. `take_horror` kept as the
  convenience wrapper for single-source horror (Draw-from-empty-deck
  penalty). Future single-source-damage callers can re-add the twin
  or inline the recipe in one line.

**Tie-break**: when both stats reach their threshold from the same
attack, the cause is `DefeatCause::Damage`. The Rules Reference is
silent on the simultaneous-lethal case; damage-first is the
implementation convention. Documented in the `enemy_attack` doc-comment.

**Phase-3 retrospective** (`docs/phases/`)
- Status flipped to ✅ closed (2026-05-21) in both the README index and
  the phase-3 doc.
- `#56` Study and `#64` after-resolution trigger window moved to a new
  "Deferred" subsection — concrete-consumer-first pattern, cf. the
  `#52` trigger-indexing deferral and the `#55` elder-sign split to
  Phase 7. New Decisions entry captures the rationale.
- Open Questions section dropped (its only entry resolved as part of
  the deferral).

## Test notes

Three new tests in `crates/game-core/src/engine/mod.rs`:
- `aoo_with_lethal_damage_and_sublethal_horror_applies_both_numerically`
- `aoo_with_sublethal_damage_and_lethal_horror_applies_both_numerically`
- `aoo_with_both_lethal_defeats_once_with_damage_cause`

Each pins both numeric fields (`inv.damage`, `inv.horror`), the count
of `InvestigatorDefeated` events (exactly one), and the cause variant.

Full CI gauntlet passes locally:
- `RUSTFLAGS="-D warnings" cargo test --all --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- `cargo build -p web --target wasm32-unknown-unknown`

## Linked issues

Closes #83.