### PR TITLE
test: add TestGame::with_investigator_at convenience (#28)

### DIFF
--- a/crates/game-core/src/test_support/builder.rs
+++ b/crates/game-core/src/test_support/builder.rs
@@ -83,17 +83,18 @@ impl TestGame {
     /// Add an investigator placed at `location`. Sets the investigator's
     /// `current_location` to `Some(location)` then inserts; equivalent to
     /// the pre-existing two-step `let mut inv = …; inv.current_location =
-    /// Some(loc); .with_investigator(inv)` shape. The named location
-    /// itself must still be added separately via [`with_location`] (this
-    /// helper does not insert one — most tests already have a fixture
-    /// builder for the location with its specific shroud / connections /
-    /// clues).
+    /// Some(loc); .with_investigator(inv)` shape. Replaces any existing
+    /// investigator entry with the same id, like [`with_investigator`].
+    /// The named location itself must still be added separately via
+    /// [`with_location`] (this helper does not insert one — most tests
+    /// already have a fixture builder for the location with its specific
+    /// shroud / connections / clues).
     ///
     /// # Example
     ///
     /// ```
     /// use game_core::{
-    ///     state::LocationId,
+    ///     InvestigatorId, LocationId,
     ///     test_support::{test_investigator, test_location, TestGame},
     /// };
     ///
@@ -102,11 +103,12 @@ impl TestGame {
     ///     .with_location(test_location(10, "Study"))
     ///     .build();
     /// assert_eq!(
-    ///     state.investigators[&game_core::InvestigatorId(1)].current_location,
+    ///     state.investigators[&InvestigatorId(1)].current_location,
     ///     Some(LocationId(10)),
     /// );
     /// ```
     ///
+    /// [`with_investigator`]: Self::with_investigator
     /// [`with_location`]: Self::with_location
     pub fn with_investigator_at(
         mut self,

--- a/crates/game-core/src/test_support/builder.rs
+++ b/crates/game-core/src/test_support/builder.rs
@@ -27,7 +27,7 @@ use std::collections::BTreeMap;
 
 use crate::rng::RngState;
 use crate::state::{
-    ChaosBag, Enemy, EnemyId, GameState, Investigator, InvestigatorId, Location, Phase,
+    ChaosBag, Enemy, EnemyId, GameState, Investigator, InvestigatorId, Location, LocationId, Phase,
     TokenModifiers,
 };
 
@@ -76,6 +76,44 @@ impl TestGame {
     /// Add an investigator to the state. Replaces any existing entry
     /// with the same id.
     pub fn with_investigator(mut self, investigator: Investigator) -> Self {
+        self.investigators.insert(investigator.id, investigator);
+        self
+    }
+
+    /// Add an investigator placed at `location`. Sets the investigator's
+    /// `current_location` to `Some(location)` then inserts; equivalent to
+    /// the pre-existing two-step `let mut inv = …; inv.current_location =
+    /// Some(loc); .with_investigator(inv)` shape. The named location
+    /// itself must still be added separately via [`with_location`] (this
+    /// helper does not insert one — most tests already have a fixture
+    /// builder for the location with its specific shroud / connections /
+    /// clues).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use game_core::{
+    ///     state::LocationId,
+    ///     test_support::{test_investigator, test_location, TestGame},
+    /// };
+    ///
+    /// let state = TestGame::new()
+    ///     .with_investigator_at(test_investigator(1), LocationId(10))
+    ///     .with_location(test_location(10, "Study"))
+    ///     .build();
+    /// assert_eq!(
+    ///     state.investigators[&game_core::InvestigatorId(1)].current_location,
+    ///     Some(LocationId(10)),
+    /// );
+    /// ```
+    ///
+    /// [`with_location`]: Self::with_location
+    pub fn with_investigator_at(
+        mut self,
+        mut investigator: Investigator,
+        location: LocationId,
+    ) -> Self {
+        investigator.current_location = Some(location);
         self.investigators.insert(investigator.id, investigator);
         self
     }


### PR DESCRIPTION
## Summary

Adds a one-liner builder method for the recurring "investigator X at location Y" test setup — collapses the two-step \`let mut inv = …; inv.current_location = Some(loc); .with_investigator(inv)\` pattern.

## What changed

- New \`TestGame::with_investigator_at(investigator, location)\` in \`crates/game-core/src/test_support/builder.rs\`. Sets \`current_location\` then inserts; same shape as \`with_investigator\` with the placement.
- Doc-test in the method's doc-comment demonstrates the workflow and asserts the placement.

## Out of scope

Migrating existing call sites (~20 across cards/ tests and game-core/ tests). The issue scope is the helper + doc-test; new tests pick up the convenience, existing sites stay as-is to keep this PR small.

## Test notes

Doc-test exercised by \`cargo test\`. Full CI gauntlet passes locally (test/clippy/fmt/doc/wasm-build).

## Linked issues

Closes #28.