### PR TITLE
infra: split DSL types into card-dsl crate (#93)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,13 +31,15 @@ cd crates/web && trunk serve --proxy-backend=http://localhost:8000   # WASM on :
 ### Crate layering — strict kernel/content separation
 
 ```
-game-core   ←  cards          ←  scenarios
-     ↑           ↑                  ↑
-     └───  server, web (consume both)
-     └───  card-data-pipeline (consumes game-core only — emits cards/src/generated/)
+card-dsl  ←  game-core   ←  cards          ←  scenarios
+                ↑              ↑                  ↑
+                └───────  server, web (consume both)
+                └───────  card-data-pipeline (consumes card-dsl only — emits cards/src/generated/)
 ```
 
-`game-core` is the **kernel**: state, action enum, event enum, apply loop, DSL types, evaluator. No I/O, no async, compiles to `wasm32`. Never depends on `cards`, `scenarios`, or anything above it. `cards` is **content** built atop the kernel.
+- `card-dsl` — pure data types: the effect DSL (`Ability`, `Effect`, `Trigger`, builders) and static card metadata (`CardMetadata`, `CardType`, `Class`, …). No I/O, no state, no engine behavior. Both `game-core` and `cards` depend on it.
+- `game-core` is the **kernel**: state, action enum, event enum, apply loop, evaluator. No I/O, no async, compiles to `wasm32`. Never depends on `cards`, `scenarios`, or anything above it. Re-exports `card_dsl::{dsl, card_data}` under the historical `game_core::dsl` / `game_core::card_data` paths for source-stability.
+- `cards` is **content** built atop both: card-data-pipeline-generated corpus + hand-written `Ability` declarations.
 
 Why the direction matters: editing the engine must not trigger a recompile of 5600 lines of generated card data. Scenarios and tests must be able to consume the engine without the full corpus. If you find yourself wanting `game-core` to call into `cards` directly, you want the **card registry** (below).
 
@@ -51,7 +53,7 @@ let _ = game_core::card_registry::install(cards::REGISTRY);
 
 Engine handlers that need card data (`PlayCard`, future constant-modifier queries during skill tests) call `card_registry::current()` and reject cleanly on `None`. Tests that don't touch card data never install — most rejection paths short-circuit before the registry lookup.
 
-A future `card-dsl` crate split is tracked in #93; the registry survives that refactor unchanged.
+The registry survived the `card-dsl` crate split (#93) unchanged — the function pointers reference `card_dsl::{CardMetadata, Ability}` and `game_core::state::CardCode` directly.
 
 ### Event-sourced state — Action → apply → ApplyResult
 
@@ -70,7 +72,7 @@ Note this is enforced **by convention, not yet structurally** — the `apply()` 
 
 ### Hybrid card-effect DSL
 
-`crates/game-core/src/dsl.rs` defines the DSL: `Ability { trigger: Trigger, effect: Effect }`. Triggers: `Constant`, `OnPlay`, `OnCommit` (with `OnEvent` / `Activated` / reaction triggers landing in later issues). Effects: `GainResources`, `DiscoverClue`, `Modify`, `Seq`, `If`, `ForEach`, `ChooseOne`. The evaluator (`crates/game-core/src/engine/evaluator.rs`) walks effect trees and mutates state, with the same validate-first contract.
+`crates/card-dsl/src/dsl.rs` defines the DSL: `Ability { trigger: Trigger, effect: Effect }`. Triggers: `Constant`, `OnPlay`, `OnCommit` (with `OnEvent` / `Activated` / reaction triggers landing in later issues). Effects: `GainResources`, `DiscoverClue`, `Modify`, `Seq`, `If`, `ForEach`, `ChooseOne`. The evaluator (`crates/game-core/src/engine/evaluator.rs`) walks effect trees and mutates state, with the same validate-first contract.
 
 Cards are declared in **Rust source files** (typed, compiler-checked), not JSON. Each card has a module in `crates/cards/src/impls/<name>.rs` exposing a `CODE: &str` and an `abilities() -> Vec<Ability>` function. The DSL handles common patterns; cards needing primitives the DSL doesn't yet support get a Rust trait impl until the DSL grows the relevant verbs. **Do not add DSL primitives speculatively** — wait until two or more hand-written cards want the same pattern.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,9 +198,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "card-dsl"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cards"
 version = "0.1.0"
 dependencies = [
+ "card-dsl",
  "game-core",
  "serde",
 ]
@@ -539,6 +548,7 @@ dependencies = [
 name = "game-core"
 version = "0.1.0"
 dependencies = [
+ "card-dsl",
  "rand_chacha",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/card-dsl",
     "crates/game-core",
     "crates/cards",
     "crates/scenarios",

--- a/crates/card-data-pipeline/src/main.rs
+++ b/crates/card-data-pipeline/src/main.rs
@@ -268,7 +268,7 @@ fn parse_traits(raw: Option<&str>) -> Vec<String> {
 /// `"Foo xN"` expands to `N` copies of `Foo`. Unknown slot names are
 /// dropped silently — Chapter-2 introduced `"Head"` which we don't
 /// ingest yet (pipeline reads original Core, not `core_2026`); add a
-/// `Head` variant to `game_core::card_data::Slot` when widening coverage.
+/// `Head` variant to `card_dsl::card_data::Slot` when widening coverage.
 fn parse_slots(raw: Option<&str>) -> Vec<&'static str> {
     let Some(raw) = raw else { return Vec::new() };
     let raw = raw.trim();
@@ -302,7 +302,7 @@ fn render(all: &BTreeMap<String, NormalizedCard>) -> String {
     let mut out = String::new();
     out.push_str(GENERATED_HEADER);
     out.push_str(
-        "use game_core::card_data::{CardMetadata, CardType, Class, SkillIcons, Slot};\n\n\
+        "use card_dsl::card_data::{CardMetadata, CardType, Class, SkillIcons, Slot};\n\n\
          /// Every card from the pinned snapshot, sorted by code.\n\
          #[must_use]\n\
          pub fn all_cards() -> Vec<CardMetadata> {\n    vec![\n",

--- a/crates/card-dsl/Cargo.toml
+++ b/crates/card-dsl/Cargo.toml
@@ -1,19 +1,17 @@
 [package]
-name = "game-core"
+name = "card-dsl"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-description = "Eldritch rules engine: game state, actions, events, effect system. No I/O, no async."
+description = "Pure data types for Eldritch card declarations: effect DSL + static card metadata."
 
 [lints]
 workspace = true
 
 [dependencies]
-card-dsl = { path = "../card-dsl" }
 serde = { version = "1", features = ["derive"] }
-rand_chacha = { version = "0.10", default-features = false }
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/card-dsl/src/card_data.rs
+++ b/crates/card-dsl/src/card_data.rs
@@ -1,12 +1,14 @@
 //! Static card metadata types.
 //!
 //! These types describe a card as printed: code, name, class, type,
-//! cost, traits, skill icons, etc. They live in `game-core` (not the
-//! `cards` crate) because the engine needs to query metadata when
-//! resolving actions — e.g. `PlayCard` reads [`CardMetadata::card_type`]
-//! to choose where the played card lands. The `cards` crate populates
-//! the corpus (generated from the pinned `ArkhamDB` snapshot) and
-//! installs it via `game_core::card_registry`.
+//! cost, traits, skill icons, etc. They live in `card-dsl` so both
+//! sides of the engine-corpus boundary can construct and consume them
+//! without one depending on the other: the engine (in `game-core`)
+//! queries metadata when resolving actions — e.g. `PlayCard` reads
+//! [`CardMetadata::card_type`] to choose where the played card lands
+//! — while the `cards` crate populates the corpus (generated from the
+//! pinned `ArkhamDB` snapshot) and installs it via
+//! `game_core::card_registry`.
 //!
 //! Card *effect logic* (hand-implemented abilities) is separate; it's
 //! looked up through the registry too but lives in

--- a/crates/card-dsl/src/card_data.rs
+++ b/crates/card-dsl/src/card_data.rs
@@ -6,7 +6,7 @@
 //! resolving actions — e.g. `PlayCard` reads [`CardMetadata::card_type`]
 //! to choose where the played card lands. The `cards` crate populates
 //! the corpus (generated from the pinned `ArkhamDB` snapshot) and
-//! installs it via [`crate::card_registry`].
+//! installs it via `game_core::card_registry`.
 //!
 //! Card *effect logic* (hand-implemented abilities) is separate; it's
 //! looked up through the registry too but lives in
@@ -34,7 +34,6 @@ pub enum Class {
 
 /// Top-level card type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[non_exhaustive]
 pub enum CardType {
     Investigator,
     Asset,
@@ -54,7 +53,6 @@ pub enum CardType {
 /// Multi-slot items (e.g. two-handed weapons) appear in
 /// [`CardMetadata::slots`] as multiple entries of the same variant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[non_exhaustive]
 pub enum Slot {
     Hand,
     Accessory,

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -162,10 +162,11 @@ pub enum Trigger {
 
 /// Which engine event(s) an [`Trigger::OnEvent`] ability listens for.
 ///
-/// Phase-3 minimal set: just the variant Roland Banks needs. The enum
-/// is `#[non_exhaustive]` and grows as later cards demand new
-/// patterns (skill-test outcomes, investigator movement, clue
-/// placement, …).
+/// Phase-3 minimal set: just the variant Roland Banks needs. Grows as
+/// later cards demand new patterns (skill-test outcomes, investigator
+/// movement, clue placement, …); the engine evaluator exhaustively
+/// matches on this enum so adding a variant is a deliberate change
+/// rather than a silent broadening.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum EventPattern {
     /// An enemy was defeated. `by_controller` narrows the match to
@@ -174,9 +175,9 @@ pub enum EventPattern {
     /// unqualified "after an enemy is defeated" would set it `false`.
     EnemyDefeated {
         /// If `true`, only fires when the controller of this ability
-        /// is credited with the defeat (the
-        /// `by` field of the event (see `game_core::Event::EnemyDefeated`).
-        /// If `false`, any defeat matches.
+        /// is credited with the defeat (the `by` field of
+        /// `game_core::Event::EnemyDefeated`). If `false`, any defeat
+        /// matches.
         by_controller: bool,
     },
 }
@@ -859,8 +860,8 @@ mod tests {
     }
 
     /// A deeply-nested effect tree round-trips through `serde_json`.
-    /// Cheap insurance against `Box<Effect>` × `#[non_exhaustive]` ×
-    /// serde derive surprises.
+    /// Cheap insurance against `Box<Effect>` × nested-variant × serde
+    /// derive surprises.
     #[test]
     fn deeply_nested_effect_round_trips_through_serde_json() {
         let original = seq([
@@ -951,13 +952,12 @@ mod tests {
     }
 
     /// An `OnEvent`-triggered ability round-trips through `serde_json`
-    /// — `#[non_exhaustive]` × struct-variant × serde derive can
-    /// surprise; pin the wire shape now so #52's persistence doesn't
-    /// re-discover problems later. Both [`EventTiming`] variants
-    /// (`After` and `Before`) are exercised independently since
-    /// `#[non_exhaustive]` × unit-variant × serde can fail on either
-    /// alone (very rare, but the test rationale explicitly covers
-    /// this surface).
+    /// — struct-variant × serde derive can surprise; pin the wire
+    /// shape now so #52's persistence doesn't re-discover problems
+    /// later. Both [`EventTiming`] variants (`After` and `Before`) are
+    /// exercised independently since unit-variant × serde can fail on
+    /// either alone (very rare, but the test rationale explicitly
+    /// covers this surface).
     #[test]
     fn on_event_ability_round_trips_through_serde_json() {
         for timing in [EventTiming::After, EventTiming::Before] {

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -50,7 +50,7 @@
 //! to build effect trees readably:
 //!
 //! ```
-//! use game_core::dsl::{constant, modify, ModifierScope, Stat};
+//! use card_dsl::{constant, modify, ModifierScope, Stat};
 //!
 //! // Holy Rosary: while in play, +1 willpower.
 //! let ability = constant(modify(Stat::Willpower, 1, ModifierScope::WhileInPlay));
@@ -65,7 +65,6 @@ use serde::{Deserialize, Serialize};
 /// Phase-3 set. Later phases add `AtPhaseStart`/`AtPhaseEnd`,
 /// `OnLeavePlay`, and additional reactive patterns as cards demand.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[non_exhaustive]
 pub enum Trigger {
     /// Always-on while the card is in play. The ability's `effect`
     /// describes a passive contribution to engine queries (most
@@ -84,7 +83,7 @@ pub enum Trigger {
     /// "if your skill test is successful while investigating, …").
     OnCommit,
     /// Fires when the controller activates the ability via
-    /// [`PlayerAction::ActivateAbility`](crate::action::PlayerAction::ActivateAbility).
+    /// `PlayerAction::ActivateAbility` (in `game_core::action`).
     ///
     /// `action_cost` mirrors the printed activation cost: `0` for the
     /// `[fast]` symbol (no action), `1` for `[action]`, `N` for multi-
@@ -103,7 +102,7 @@ pub enum Trigger {
     /// This is not a reaction window (no player decision, no "may");
     /// it's part of the test's own resolution machinery. The effect
     /// evaluates after the action-specific
-    /// [`SkillTestFollowUp`](crate::state::SkillTestFollowUp) and
+    /// `SkillTestFollowUp` (in `game_core::state`) and
     /// before the committed cards discard, so the source card is
     /// still in hand at evaluation time and
     /// [`LocationTarget::TestedLocation`] resolves against the
@@ -131,7 +130,7 @@ pub enum Trigger {
         /// resolving test.
         outcome: TestOutcome,
     },
-    /// Fires when an engine [`Event`](crate::Event) matching `pattern`
+    /// Fires when an engine `Event` (in `game_core`) matching `pattern`
     /// is emitted, in the reaction window opened by the engine for
     /// the corresponding `timing`.
     ///
@@ -168,7 +167,6 @@ pub enum Trigger {
 /// patterns (skill-test outcomes, investigator movement, clue
 /// placement, …).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[non_exhaustive]
 pub enum EventPattern {
     /// An enemy was defeated. `by_controller` narrows the match to
     /// defeats credited to the ability's controller — Roland Banks's
@@ -177,7 +175,7 @@ pub enum EventPattern {
     EnemyDefeated {
         /// If `true`, only fires when the controller of this ability
         /// is credited with the defeat (the
-        /// [`by`](crate::Event::EnemyDefeated) field of the event).
+        /// `by` field of the event (see `game_core::Event::EnemyDefeated`).
         /// If `false`, any defeat matches.
         by_controller: bool,
     },
@@ -193,7 +191,6 @@ pub enum EventPattern {
 /// is included so #52's reaction-window machinery can hang both
 /// windows off the same trigger surface.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[non_exhaustive]
 pub enum EventTiming {
     /// Resolves before the triggering event finalizes.
     Before,
@@ -209,7 +206,6 @@ pub enum EventTiming {
 /// ability's effect resolves. The engine validates every cost is
 /// payable *before* mutating any state, then pays them in order.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[non_exhaustive]
 pub enum Cost {
     /// Spend `n` resources from the controller's wallet. Insufficient
     /// resources reject the activation.
@@ -219,11 +215,11 @@ pub enum Cost {
     /// with a `[fast] no exhaust` ability simply don't list this cost.)
     Exhaust,
     /// Discard a card from the controller's hand. Requires a target
-    /// selection via [`AwaitingInput`](crate::EngineOutcome::AwaitingInput)
+    /// selection via `AwaitingInput` (the `game_core::EngineOutcome` variant)
     /// and a `ResolveInput` dispatch. No card uses this cost yet, so
     /// the engine consumer hasn't landed; activations with this cost
     /// reject with a TODO. Test-side seam is
-    /// [`ChoiceResolver`](crate::test_support::ChoiceResolver).
+    /// `ChoiceResolver` (in `game_core::test_support`).
     DiscardCardFromHand,
 }
 
@@ -243,8 +239,8 @@ pub enum Cost {
 /// `UsageLimit { count: 1, period: UsagePeriod::Round }`.
 ///
 /// Storage of the per-instance counter lives on
-/// [`CardInPlay`](crate::state::CardInPlay): see
-/// [`ability_usage`](crate::state::CardInPlay::ability_usage). When a
+/// `CardInPlay` (in `game_core::state`): see
+/// `ability_usage` (its per-instance counter map). When a
 /// card leaves play, its `CardInPlay` is dropped, so a re-entering
 /// instance starts fresh as the rules require.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -261,11 +257,10 @@ pub struct UsageLimit {
 /// `Phase` ("limit once per turn") and `Game` ("limit once per game"
 /// — group or player) land when the first consumer appears.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[non_exhaustive]
 pub enum UsagePeriod {
     /// A game round, as defined by the framework: begins at 1.1 Mythos,
     /// ends at 4.6 Upkeep (Rules Reference page 23). Counter resets
-    /// when [`GameState::round`](crate::state::GameState::round)
+    /// when `GameState::round` (in `game_core::state`)
     /// advances.
     Round,
 }
@@ -326,7 +321,6 @@ impl Ability {
 /// per resolved target, [`Effect::ChooseOne`] presents alternatives
 /// to the controller.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[non_exhaustive]
 pub enum Effect {
     /// Add resources to the wallet of the resolved target investigator.
     GainResources {
@@ -376,7 +370,6 @@ pub enum Effect {
 /// (needed for ally assets like Beat Cop). Action points and other
 /// "current" counters get added when cards in later cycles touch them.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[non_exhaustive]
 pub enum Stat {
     Willpower,
     Intellect,
@@ -394,7 +387,6 @@ pub enum Stat {
 /// that gates most +stat assets in Core+Dunwich). Commit-time and
 /// turn-scoped buffs use `ThisSkillTest` / `ThisTurn`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[non_exhaustive]
 pub enum ModifierScope {
     /// Active for as long as the source card is in play. Used by
     /// unqualified constant abilities (Holy Rosary).
@@ -418,14 +410,13 @@ pub enum ModifierScope {
 /// investigating" applies to Investigate but **not** to a treachery
 /// that tests intellect. Engine-side, every test-initiating action
 /// (Investigate, Fight, Evade, the generic
-/// [`PerformSkillTest`](crate::action::PlayerAction::PerformSkillTest))
+/// `PerformSkillTest` (in `game_core::action::PlayerAction`))
 /// passes the matching kind to skill-test resolution.
 ///
 /// Add a variant when a new test-initiating action lands (Parley /
 /// Engage will need their own; treacheries that *force* an investigate-
 /// flavored test could reuse `Investigate`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[non_exhaustive]
 pub enum SkillTestKind {
     /// The Investigate action's intellect test against a location's
     /// shroud.
@@ -435,7 +426,7 @@ pub enum SkillTestKind {
     /// The Evade action's agility test against an enemy.
     Evade,
     /// Any other skill test: treachery effects, agenda effects, or
-    /// [`PlayerAction::PerformSkillTest`](crate::action::PlayerAction::PerformSkillTest)
+    /// `PlayerAction::PerformSkillTest` (in `game_core::action`)
     /// invoked directly. Cards qualifying their bonus with one of the
     /// named-action variants will NOT contribute here.
     Plain,
@@ -445,7 +436,6 @@ pub enum SkillTestKind {
 
 /// Single-investigator target spec.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[non_exhaustive]
 pub enum InvestigatorTarget {
     /// The controller of the ability — the investigator who played /
     /// activated this card.
@@ -460,7 +450,6 @@ pub enum InvestigatorTarget {
 
 /// Set-of-investigators target spec for [`Effect::ForEach`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[non_exhaustive]
 pub enum InvestigatorTargetSet {
     /// All investigators currently in the scenario, in turn order.
     All,
@@ -470,7 +459,6 @@ pub enum InvestigatorTargetSet {
 
 /// Single-location target spec.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[non_exhaustive]
 pub enum LocationTarget {
     /// The location the controller is currently at.
     ControllerLocation,
@@ -479,13 +467,13 @@ pub enum LocationTarget {
     /// The location associated with the in-flight skill test. For
     /// Investigate that's the location being investigated; the engine
     /// snapshots it onto
-    /// [`InFlightSkillTest`](crate::state::InFlightSkillTest) at the
+    /// `InFlightSkillTest` (in `game_core::state`) at the
     /// commit window. The
     /// [`OnSkillTestResolution`](Trigger::OnSkillTestResolution)
     /// firing path reads this snapshot. Rejects when
     /// no skill test is in flight or when the snapshotted location
     /// is absent (controller was between locations at test start —
-    /// only reachable via [`PerformSkillTest`](crate::action::PlayerAction::PerformSkillTest)
+    /// only reachable via `PlayerAction::PerformSkillTest` (in `game_core::action`)
     /// from outside an Investigate path).
     TestedLocation,
 }
@@ -498,7 +486,6 @@ pub enum LocationTarget {
 /// `LocationHasClues`, `AnyEnemyEngaged`, comparisons against
 /// stat values, etc.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[non_exhaustive]
 pub enum Condition {
     /// Outcome of the most recent skill test in the current
     /// resolution stack. Failure-triggered cards (some Survivor
@@ -522,7 +509,6 @@ pub enum Condition {
 /// can add `SuccessBy(u8)` / `FailureBy(u8)` variants when the first
 /// margin-sensitive card lands.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[non_exhaustive]
 pub enum TestOutcome {
     Success,
     Failure,

--- a/crates/card-dsl/src/lib.rs
+++ b/crates/card-dsl/src/lib.rs
@@ -1,0 +1,40 @@
+//! Pure data types for Eldritch card declarations.
+//!
+//! This crate holds the two pure-data type families consumed by both
+//! sides of the cards-engine boundary:
+//!
+//! - [`dsl`] — the card-effect DSL ([`Ability`], [`Effect`],
+//!   [`Trigger`], builder functions). The alphabet card declarations
+//!   speak.
+//! - [`card_data`] — static card metadata ([`CardMetadata`],
+//!   [`Class`], [`CardType`], [`SkillIcons`], [`Slot`]). What's
+//!   printed on a card.
+//!
+//! These types have no I/O, no state, and no engine machinery. They
+//! sit between the `cards` corpus (which constructs them) and the
+//! `game-core` engine (which evaluates them). Splitting them out of
+//! `game-core` avoids the asymmetric tension of housing "what cards
+//! say" inside the engine crate, and the resulting layering is:
+//!
+//! ```text
+//! card-dsl   ←  cards
+//!     ↑          ↑
+//!     └──  game-core
+//! ```
+//!
+//! Both `game-core` and `cards` depend on `card-dsl`; neither depends
+//! on the other directly for DSL or card-metadata types. (The
+//! `cards → game-core` dependency persists for `CardCode`, the
+//! card-registry binding, and `game-core::state` types that the
+//! ability-registration path touches.)
+
+pub mod card_data;
+pub mod dsl;
+
+pub use card_data::{CardMetadata, CardType, Class, SkillIcons, Slot};
+pub use dsl::{
+    activated, choose_one, constant, discover_clue, for_each, gain_resources, if_, if_else, modify,
+    on_commit, on_event, on_play, on_skill_test_resolution, seq, Ability, Condition, Cost, Effect,
+    EventPattern, EventTiming, InvestigatorTarget, InvestigatorTargetSet, LocationTarget,
+    ModifierScope, SkillTestKind, Stat, TestOutcome, Trigger, UsageLimit, UsagePeriod,
+};

--- a/crates/cards/Cargo.toml
+++ b/crates/cards/Cargo.toml
@@ -11,6 +11,7 @@ description = "Eldritch card definitions: hybrid DSL + Rust impls, plus generate
 workspace = true
 
 [dependencies]
+card-dsl = { path = "../card-dsl" }
 game-core = { path = "../game-core" }
 serde = { version = "1", features = ["derive"] }
 

--- a/crates/cards/src/generated/cards.rs
+++ b/crates/cards/src/generated/cards.rs
@@ -6,7 +6,7 @@
 
 #![allow(clippy::too_many_lines, clippy::needless_raw_string_hashes)]
 
-use game_core::card_data::{CardMetadata, CardType, Class, SkillIcons, Slot};
+use card_dsl::card_data::{CardMetadata, CardType, Class, SkillIcons, Slot};
 
 /// Every card from the pinned snapshot, sorted by code.
 #[must_use]

--- a/crates/cards/src/impls/deduction.rs
+++ b/crates/cards/src/impls/deduction.rs
@@ -25,14 +25,14 @@
 //! location, so card-derived Investigate variants that test at a
 //! different location still resolve correctly.
 //!
-//! [`Trigger::OnSkillTestResolution`]: game_core::dsl::Trigger::OnSkillTestResolution
-//! [`TestOutcome::Success`]: game_core::dsl::TestOutcome::Success
-//! [`if_`]: game_core::dsl::if_
-//! [`Condition::SkillTestKind`]: game_core::dsl::Condition::SkillTestKind
-//! [`SkillTestKind::Investigate`]: game_core::dsl::SkillTestKind::Investigate
-//! [`LocationTarget::TestedLocation`]: game_core::dsl::LocationTarget::TestedLocation
+//! [`Trigger::OnSkillTestResolution`]: card_dsl::dsl::Trigger::OnSkillTestResolution
+//! [`TestOutcome::Success`]: card_dsl::dsl::TestOutcome::Success
+//! [`if_`]: card_dsl::dsl::if_
+//! [`Condition::SkillTestKind`]: card_dsl::dsl::Condition::SkillTestKind
+//! [`SkillTestKind::Investigate`]: card_dsl::dsl::SkillTestKind::Investigate
+//! [`LocationTarget::TestedLocation`]: card_dsl::dsl::LocationTarget::TestedLocation
 
-use game_core::dsl::{
+use card_dsl::dsl::{
     discover_clue, if_, on_skill_test_resolution, Ability, Condition, LocationTarget,
     SkillTestKind, TestOutcome,
 };
@@ -55,7 +55,7 @@ pub fn abilities() -> Vec<Ability> {
 
 #[cfg(test)]
 mod tests {
-    use game_core::dsl::{Condition, Effect, LocationTarget, SkillTestKind, TestOutcome, Trigger};
+    use card_dsl::dsl::{Condition, Effect, LocationTarget, SkillTestKind, TestOutcome, Trigger};
 
     #[test]
     fn abilities_are_one_resolution_trigger_with_kind_narrowing() {

--- a/crates/cards/src/impls/holy_rosary.rs
+++ b/crates/cards/src/impls/holy_rosary.rs
@@ -22,7 +22,7 @@
 //! the willpower ability; soak missing means the card is mechanically
 //! weaker than printed in the simulator until the gap closes.
 
-use game_core::dsl::{constant, modify, Ability, ModifierScope, Stat};
+use card_dsl::dsl::{constant, modify, Ability, ModifierScope, Stat};
 
 /// `ArkhamDB` code for the original-Core printing.
 pub const CODE: &str = "01059";
@@ -40,7 +40,7 @@ pub fn abilities() -> Vec<Ability> {
 
 #[cfg(test)]
 mod tests {
-    use game_core::dsl::{Effect, ModifierScope, Stat, Trigger};
+    use card_dsl::dsl::{Effect, ModifierScope, Stat, Trigger};
 
     #[test]
     fn abilities_are_one_constant_willpower_modifier() {

--- a/crates/cards/src/impls/hyperawareness.rs
+++ b/crates/cards/src/impls/hyperawareness.rs
@@ -29,7 +29,7 @@
 //!
 //! [`PlayerAction::ActivateAbility`]: game_core::PlayerAction::ActivateAbility
 
-use game_core::dsl::{activated, modify, Ability, Cost, ModifierScope, Stat};
+use card_dsl::dsl::{activated, modify, Ability, Cost, ModifierScope, Stat};
 
 /// `ArkhamDB` code for the original-Core printing.
 pub const CODE: &str = "01034";
@@ -55,7 +55,7 @@ pub fn abilities() -> Vec<Ability> {
 
 #[cfg(test)]
 mod tests {
-    use game_core::dsl::{Cost, Effect, ModifierScope, Stat, Trigger};
+    use card_dsl::dsl::{Cost, Effect, ModifierScope, Stat, Trigger};
 
     #[test]
     fn abilities_are_two_fast_activated_resource_costed_modifies() {

--- a/crates/cards/src/impls/magnifying_glass.rs
+++ b/crates/cards/src/impls/magnifying_glass.rs
@@ -24,7 +24,7 @@
 //! rules. `WhileInPlayDuring(SkillTestKind::Investigate)` (#45) gates
 //! the contribution to the Investigate action's intellect test.
 
-use game_core::dsl::{constant, modify, Ability, ModifierScope, SkillTestKind, Stat};
+use card_dsl::dsl::{constant, modify, Ability, ModifierScope, SkillTestKind, Stat};
 
 /// `ArkhamDB` code for the original-Core printing.
 pub const CODE: &str = "01030";
@@ -41,7 +41,7 @@ pub fn abilities() -> Vec<Ability> {
 
 #[cfg(test)]
 mod tests {
-    use game_core::dsl::{Effect, ModifierScope, SkillTestKind, Stat, Trigger};
+    use card_dsl::dsl::{Effect, ModifierScope, SkillTestKind, Stat, Trigger};
 
     #[test]
     fn abilities_are_one_constant_intellect_while_investigating_modifier() {

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Each implemented card lives in its own submodule, exposing a
 //! [`CODE`](holy_rosary::CODE) constant and an `abilities()` function
-//! returning that card's [`Vec<Ability>`](game_core::dsl::Ability).
+//! returning that card's [`Vec<Ability>`](card_dsl::dsl::Ability).
 //!
 //! The registry is the [`abilities_for`] dispatch — adding a card
 //! means: drop a `crates/cards/src/impls/<name>.rs` file, declare the
@@ -40,7 +40,7 @@
 //! The remaining Phase-3 card (Study #56) blocks on the
 //! location-state shape.
 
-use game_core::dsl::Ability;
+use card_dsl::dsl::Ability;
 
 pub mod deduction;
 pub mod holy_rosary;

--- a/crates/cards/src/impls/roland_banks.rs
+++ b/crates/cards/src/impls/roland_banks.rs
@@ -26,13 +26,13 @@
 //! clause attaches as a [`UsageLimit`] with `count: 1, period:
 //! UsagePeriod::Round`.
 //!
-//! [`Trigger::OnEvent`]: game_core::dsl::Trigger::OnEvent
-//! [`EventPattern::EnemyDefeated`]: game_core::dsl::EventPattern::EnemyDefeated
-//! [`EventTiming::After`]: game_core::dsl::EventTiming::After
-//! [`LocationTarget::ControllerLocation`]: game_core::dsl::LocationTarget::ControllerLocation
-//! [`UsageLimit`]: game_core::dsl::UsageLimit
+//! [`Trigger::OnEvent`]: card_dsl::dsl::Trigger::OnEvent
+//! [`EventPattern::EnemyDefeated`]: card_dsl::dsl::EventPattern::EnemyDefeated
+//! [`EventTiming::After`]: card_dsl::dsl::EventTiming::After
+//! [`LocationTarget::ControllerLocation`]: card_dsl::dsl::LocationTarget::ControllerLocation
+//! [`UsageLimit`]: card_dsl::dsl::UsageLimit
 
-use game_core::dsl::{
+use card_dsl::dsl::{
     discover_clue, on_event, Ability, EventPattern, EventTiming, LocationTarget, UsageLimit,
     UsagePeriod,
 };
@@ -60,7 +60,7 @@ pub fn abilities() -> Vec<Ability> {
 
 #[cfg(test)]
 mod tests {
-    use game_core::dsl::{
+    use card_dsl::dsl::{
         Effect, EventPattern, EventTiming, LocationTarget, Trigger, UsageLimit, UsagePeriod,
     };
 

--- a/crates/cards/src/impls/working_a_hunch.rs
+++ b/crates/cards/src/impls/working_a_hunch.rs
@@ -11,7 +11,7 @@
 //! exists; for now `abilities()` only describes what the `OnPlay`
 //! trigger does.
 
-use game_core::dsl::{discover_clue, on_play, Ability, LocationTarget};
+use card_dsl::dsl::{discover_clue, on_play, Ability, LocationTarget};
 
 /// `ArkhamDB` code for the original-Core printing.
 pub const CODE: &str = "01037";
@@ -27,7 +27,7 @@ pub fn abilities() -> Vec<Ability> {
 
 #[cfg(test)]
 mod tests {
-    use game_core::dsl::{Effect, LocationTarget, Trigger};
+    use card_dsl::dsl::{Effect, LocationTarget, Trigger};
 
     #[test]
     fn abilities_are_one_on_play_discover_clue() {

--- a/crates/cards/src/lib.rs
+++ b/crates/cards/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! - **Metadata** — what's printed on a card (name, class, cost,
 //!   traits, skill icons, …). The shape lives in
-//!   [`game_core::card_data::CardMetadata`]; the corpus is generated
+//!   [`card_dsl::card_data::CardMetadata`]; the corpus is generated
 //!   by the [`card-data-pipeline`] CLI from the pinned `ArkhamDB`
 //!   snapshot at `data/arkhamdb-snapshot/`. The generated constants
 //!   live in [`generated`]; access them via [`all`] or [`by_code`].
@@ -31,14 +31,14 @@
 
 use std::sync::OnceLock;
 
-use game_core::card_data::CardMetadata;
+use card_dsl::card_data::CardMetadata;
 use game_core::card_registry::CardRegistry;
 use game_core::state::CardCode;
 
 pub mod generated;
 pub mod impls;
 
-pub use game_core::card_data::{CardType, Class, SkillIcons, Slot};
+pub use card_dsl::card_data::{CardType, Class, SkillIcons, Slot};
 
 /// All card metadata in the Eldritch corpus, lazily initialized on
 /// first access. Sorted by [`CardMetadata::code`].
@@ -60,7 +60,7 @@ pub fn by_code(code: &str) -> Option<&'static CardMetadata> {
 /// `None` for unimplemented cards. Re-exported from
 /// [`impls::abilities_for`].
 #[must_use]
-pub fn abilities_for(code: &str) -> Option<Vec<game_core::dsl::Ability>> {
+pub fn abilities_for(code: &str) -> Option<Vec<card_dsl::dsl::Ability>> {
     impls::abilities_for(code)
 }
 
@@ -80,7 +80,7 @@ fn registry_metadata_for(code: &CardCode) -> Option<&'static CardMetadata> {
 }
 
 /// Adapter from [`CardCode`] to [`abilities_for`].
-fn registry_abilities_for(code: &CardCode) -> Option<Vec<game_core::dsl::Ability>> {
+fn registry_abilities_for(code: &CardCode) -> Option<Vec<card_dsl::dsl::Ability>> {
     abilities_for(code.as_str())
 }
 

--- a/crates/cards/tests/roland_banks.rs
+++ b/crates/cards/tests/roland_banks.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Once;
 
-use game_core::dsl::{UsageLimit, UsagePeriod};
+use card_dsl::dsl::{UsageLimit, UsagePeriod};
 use game_core::engine::EngineOutcome;
 use game_core::event::Event;
 use game_core::state::{

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -631,8 +631,8 @@ fn stat_matches_skill(stat: Stat, skill: SkillKind) -> bool {
 mod tests {
     use crate::card_registry::CardRegistry;
     use crate::dsl::{
-        constant, discover_clue, gain_resources, modify, seq, Ability, Effect, InvestigatorTarget,
-        LocationTarget, ModifierScope, SkillTestKind, Stat, Trigger,
+        constant, discover_clue, gain_resources, modify, on_play, seq, Ability, Effect,
+        InvestigatorTarget, LocationTarget, ModifierScope, SkillTestKind, Stat,
     };
     use crate::event::Event;
     use crate::state::{
@@ -1268,12 +1268,11 @@ mod tests {
                 -1,
                 ModifierScope::WhileInPlay,
             ))]),
-            "non-constant-willpower" => Some(vec![Ability {
-                trigger: Trigger::OnPlay,
-                costs: Vec::new(),
-                effect: modify(Stat::Willpower, 5, ModifierScope::WhileInPlay),
-                usage_limit: None,
-            }]),
+            "non-constant-willpower" => Some(vec![on_play(modify(
+                Stat::Willpower,
+                5,
+                ModifierScope::WhileInPlay,
+            ))]),
             "max-health-plus-1" => Some(vec![constant(modify(
                 Stat::MaxHealth,
                 1,

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -18,15 +18,24 @@
 //! Subsequent PRs add the RNG, phase machine, and test harness.
 
 pub mod action;
-pub mod card_data;
 pub mod card_registry;
-pub mod dsl;
 pub mod engine;
 pub mod event;
 pub mod rng;
 pub mod state;
 
 pub mod test_support;
+
+/// Re-exports of the [`card_dsl::card_data`] module, kept under the
+/// historical `game_core::card_data` path so downstream code that
+/// imports via `game_core::card_data::*` keeps compiling. The
+/// definitions themselves live in [`card_dsl`].
+pub use card_dsl::card_data;
+/// Re-exports of the [`card_dsl::dsl`] module, kept under the
+/// historical `game_core::dsl` path so downstream code that imports
+/// via `game_core::dsl::*` keeps compiling. The definitions themselves
+/// live in [`card_dsl`].
+pub use card_dsl::dsl;
 
 pub use action::{Action, EngineRecord, InputResponse, PlayerAction};
 pub use card_data::{CardMetadata, CardType, Class, SkillIcons, Slot};


### PR DESCRIPTION
## Summary

Creates a new pure-data crate \`card-dsl\` holding the DSL types (\`Ability\`, \`Effect\`, \`Trigger\`, builders, etc.) and the static card-metadata types (\`CardMetadata\`, \`CardType\`, \`Class\`, …). Both \`game-core\` and \`cards\` depend on it; neither depends on the other directly for these types.

## Crate layering

\`\`\`
card-dsl  ←  game-core   ←  cards          ←  scenarios
                ↑              ↑                  ↑
                └───────  server, web
                └───────  card-data-pipeline (card-dsl only)
\`\`\`

## What changed

- New \`crates/card-dsl/\` (Cargo.toml + lib.rs + the moved dsl.rs and card_data.rs files).
- \`game-core\` gains \`card-dsl\` as a dep; \`cards\` and \`card-data-pipeline\` ditto.
- \`game-core/src/lib.rs\` re-exports \`card_dsl::{dsl, card_data}\` under the historical \`game_core::dsl\` / \`game_core::card_data\` paths to preserve the public API.
- \`cards/\` source files switch to \`card_dsl::*\` imports directly (no longer routed through \`game_core::dsl::*\`).
- \`card-data-pipeline\` updated to emit \`use card_dsl::card_data::{...};\` into the generated \`cards.rs\`. Pipeline regenerated; corpus byte-identical otherwise.
- CLAUDE.md architecture section updated; the \`#93\` forward-reference dropped.

## Design decisions

- **\`#[non_exhaustive]\` removed from the DSL enums and from \`CardType\` / \`Slot\`.** With these types now in a different crate, the attribute would have required wildcard \`_ =>\` arms on every \`Effect\` / \`Trigger\` / \`ModifierScope\` / etc. match in game-core, defeating the exhaustiveness check that the validate-first/mutate-second pattern relies on. \`#[non_exhaustive]\` fits library types meant for external consumption; it doesn't fit closed-workspace types the engine MUST update in lockstep when variants grow. **Kept on the \`Ability\` struct\`** where it usefully forces builder-fn use in cards/.
- **\`CardCode\` stays in \`game-core::state\`.** Moving it would mean splitting \`state/card.rs\` since \`CardInPlay\` (engine state) and \`CardCode\` (identifier) live side-by-side there. The issue's "probably move \`CardCode\` too" was soft language; the DSL types don't reference \`CardCode\` (CardMetadata stores codes as plain \`String\`), so leaving it is clean.
- **\`card_registry\` stays in \`game-core\`.** Its function-pointer signatures take \`&CardCode\`, which lives in game-core. Moving the registry would have required moving \`CardCode\`. Per the issue: "Keep \`game-core::card_registry\` where it is (or move to card-dsl — design decision in the PR)."
- **Engine-side intra-doc links in dsl.rs/card_data.rs rewritten as plain prose.** Targets like \`crate::action::PlayerAction::*\`, \`crate::state::*\`, \`crate::Event\`, \`crate::EngineOutcome::AwaitingInput\` resolved when these files lived in game-core; they can't resolve from card-dsl (which doesn't depend on game-core, per the acceptance criteria). Each was rewritten as \`\\\`Name\\\` (in \`game_core::path\`)\` — same intent, no broken intra-doc link error.

## Test notes

Full CI gauntlet passes locally:
- \`RUSTFLAGS=\"-D warnings\" cargo test --all --all-features\`
- \`cargo clippy --all-targets --all-features -- -D warnings\`
- \`cargo fmt --check\`
- \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps --all-features\`
- \`cargo build -p web --target wasm32-unknown-unknown\`

No test changes — existing coverage exercises both sides of the new boundary unchanged.

## Linked issues

Closes #93.