### PR TITLE
engine: consolidate (state, events) threading into a Cx context (#160)

### DIFF
--- a/crates/game-core/src/engine/cx.rs
+++ b/crates/game-core/src/engine/cx.rs
@@ -5,8 +5,8 @@
 //! by hand through every signature — the [`GameState`] being mutated and
 //! the [`Event`] buffer being emitted into. It is *not* a semantic
 //! context: the "you"/"source" of card text lives in
-//! [`EvalContext`](super::EvalContext), which will travel alongside `Cx`
-//! as a separate `eval_ctx` parameter once the evaluator is migrated.
+//! [`EvalContext`](super::EvalContext), which travels alongside `Cx`
+//! as a separate `eval_ctx` parameter in the evaluator.
 //!
 //! Bare field bundle by design — no helper methods. Read-only callees
 //! keep taking `&GameState`; a holder of `cx` calls them as

--- a/crates/game-core/src/engine/cx.rs
+++ b/crates/game-core/src/engine/cx.rs
@@ -1,0 +1,27 @@
+//! The engine's mutation context: the mutable working set threaded
+//! through every dispatch handler and effect evaluation.
+//!
+//! `Cx` bundles the two `&mut` references that previously rode together
+//! by hand through every signature — the [`GameState`] being mutated and
+//! the [`Event`] buffer being emitted into. It is *not* a semantic
+//! context: the "you"/"source" of card text lives in
+//! [`EvalContext`](super::EvalContext), which will travel alongside `Cx`
+//! as a separate `eval_ctx` parameter once the evaluator is migrated.
+//!
+//! Bare field bundle by design — no helper methods. Read-only callees
+//! keep taking `&GameState`; a holder of `cx` calls them as
+//! `read_fn(cx.state, …)`, which borrows only `cx.state` and leaves
+//! `cx.events` independently usable (disjoint-field borrowing).
+
+use crate::event::Event;
+use crate::state::GameState;
+
+/// Mutable engine working set: the state being mutated plus the event
+/// buffer being emitted into. Threaded as `cx: &mut Cx` through dispatch
+/// handlers and the effect evaluator.
+pub(crate) struct Cx<'a> {
+    /// The game state being mutated.
+    pub state: &'a mut GameState,
+    /// The events emitted by the current `apply` call.
+    pub events: &'a mut Vec<Event>,
+}

--- a/crates/game-core/src/engine/dispatch/abilities.rs
+++ b/crates/game-core/src/engine/dispatch/abilities.rs
@@ -3,10 +3,11 @@
 use crate::card_registry;
 use crate::dsl::{Cost, Trigger};
 use crate::event::Event;
-use crate::state::{CardCode, CardInstanceId, GameState, Investigator, InvestigatorId};
+use crate::state::{CardCode, CardInstanceId, Investigator, InvestigatorId};
 
 use super::super::evaluator::{apply_effect, EvalContext};
 use super::super::outcome::EngineOutcome;
+use super::Cx;
 
 /// Handler for [`PlayerAction::ActivateAbility`].
 ///
@@ -52,8 +53,7 @@ use super::super::outcome::EngineOutcome;
 /// `DiscoverClue`, `Seq` of those, future `Modify`/`ThisSkillTest`
 /// push) can't reject mid-flight once the standard prefix passes.
 pub(super) fn activate_ability(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
+    cx: &mut Cx,
     investigator: InvestigatorId,
     instance_id: CardInstanceId,
     ability_index: u8,
@@ -66,7 +66,7 @@ pub(super) fn activate_ability(
         effect,
         source_exhausted: _,
     } = match super::reaction_windows::check_activate_ability(
-        state,
+        cx.state,
         investigator,
         instance_id,
         ability_index,
@@ -77,8 +77,7 @@ pub(super) fn activate_ability(
 
     // Mutate.
     pay_activation_costs(
-        state,
-        events,
+        cx,
         investigator,
         instance_id,
         in_play_pos,
@@ -86,24 +85,22 @@ pub(super) fn activate_ability(
         action_cost,
         &costs,
     );
-    events.push(Event::AbilityActivated {
+    cx.events.push(Event::AbilityActivated {
         investigator,
         instance_id,
         code: source_code,
         ability_index,
     });
 
-    let ctx = EvalContext::for_controller_with_source(investigator, instance_id);
-    apply_effect(state, events, &effect, ctx)
+    let eval_ctx = EvalContext::for_controller_with_source(investigator, instance_id);
+    apply_effect(cx.state, cx.events, &effect, eval_ctx)
 }
 
 /// Pay the action cost and every payment cost of an activated
 /// ability. Mutates state in place and pushes the matching events.
 /// Caller has already validated that every cost is payable.
-#[allow(clippy::too_many_arguments)]
 fn pay_activation_costs(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
+    cx: &mut Cx,
     investigator: InvestigatorId,
     instance_id: CardInstanceId,
     in_play_pos: usize,
@@ -111,29 +108,41 @@ fn pay_activation_costs(
     action_cost: u8,
     costs: &[Cost],
 ) {
-    let inv_mut = state
-        .investigators
-        .get_mut(&investigator)
-        .expect("validated above");
     if action_cost > 0 {
+        let inv_mut = cx
+            .state
+            .investigators
+            .get_mut(&investigator)
+            .expect("validated above");
         inv_mut.actions_remaining = inv_mut.actions_remaining.saturating_sub(action_cost);
-        events.push(Event::ActionsRemainingChanged {
+        let new_count = inv_mut.actions_remaining;
+        cx.events.push(Event::ActionsRemainingChanged {
             investigator,
-            new_count: inv_mut.actions_remaining,
+            new_count,
         });
     }
     for cost in costs {
         match cost {
             Cost::Resources(n) => {
+                let inv_mut = cx
+                    .state
+                    .investigators
+                    .get_mut(&investigator)
+                    .expect("validated above");
                 inv_mut.resources = inv_mut.resources.saturating_sub(*n);
-                events.push(Event::ResourcesPaid {
+                cx.events.push(Event::ResourcesPaid {
                     investigator,
                     amount: *n,
                 });
             }
             Cost::Exhaust => {
-                inv_mut.cards_in_play[in_play_pos].exhausted = true;
-                events.push(Event::CardExhausted {
+                cx.state
+                    .investigators
+                    .get_mut(&investigator)
+                    .expect("validated above")
+                    .cards_in_play[in_play_pos]
+                    .exhausted = true;
+                cx.events.push(Event::CardExhausted {
                     investigator,
                     instance_id,
                     code: source_code.clone(),

--- a/crates/game-core/src/engine/dispatch/abilities.rs
+++ b/crates/game-core/src/engine/dispatch/abilities.rs
@@ -93,7 +93,7 @@ pub(super) fn activate_ability(
     });
 
     let eval_ctx = EvalContext::for_controller_with_source(investigator, instance_id);
-    apply_effect(cx.state, cx.events, &effect, eval_ctx)
+    apply_effect(cx, &effect, eval_ctx)
 }
 
 /// Pay the action cost and every payment cost of an activated

--- a/crates/game-core/src/engine/dispatch/act_agenda.rs
+++ b/crates/game-core/src/engine/dispatch/act_agenda.rs
@@ -1,19 +1,19 @@
 //! Act and agenda handlers: doom placement, threshold checking, agenda
 //! advancement, clue spending, and act advancement.
 
-use crate::event::Event;
 use crate::state::{GameState, InvestigatorId, Phase};
 
 use super::super::outcome::EngineOutcome;
+use super::Cx;
 
 /// Mythos step 1.2 (Rules Reference p.24): "Take 1 doom from the token
 /// pool, and place it on the current agenda card." No-op when no agenda
 /// deck is modeled (tests/fixtures without an agenda).
-pub(super) fn place_doom_on_agenda(state: &mut GameState, _events: &mut Vec<Event>) {
-    if state.agenda_deck.is_empty() {
+pub(super) fn place_doom_on_agenda(cx: &mut Cx) {
+    if cx.state.agenda_deck.is_empty() {
         return;
     }
-    state.agenda_doom = state.agenda_doom.saturating_add(1);
+    cx.state.agenda_doom = cx.state.agenda_doom.saturating_add(1);
 }
 
 /// Mythos step 1.3 (Rules Reference p.24): compare doom in play with the
@@ -28,17 +28,17 @@ pub(super) fn place_doom_on_agenda(state: &mut GameState, _events: &mut Vec<Even
 /// it ends the scenario: set the resolution latch instead of moving the
 /// cursor. Otherwise emit [`Event::AgendaAdvanced`], reset doom, and make
 /// the next agenda current.
-pub(super) fn check_doom_threshold(state: &mut GameState, events: &mut Vec<Event>) {
-    if state.agenda_deck.is_empty() {
+pub(super) fn check_doom_threshold(cx: &mut Cx) {
+    if cx.state.agenda_deck.is_empty() {
         return;
     }
-    let agenda = &state.agenda_deck[state.agenda_index];
-    if state.agenda_doom < agenda.doom_threshold {
+    let agenda = &cx.state.agenda_deck[cx.state.agenda_index];
+    if cx.state.agenda_doom < agenda.doom_threshold {
         return;
     }
     match agenda.resolution.clone() {
-        Some(resolution) => request_resolution(state, resolution),
-        None => advance_agenda(state, events),
+        Some(resolution) => request_resolution(cx.state, resolution),
+        None => advance_agenda(cx),
     }
 }
 
@@ -52,12 +52,12 @@ pub(super) fn check_doom_threshold(state: &mut GameState, events: &mut Vec<Event
 /// data (the final agenda must carry a `(→R#)` resolution point), so the
 /// missing-successor case is `unreachable!()` — mirrors the surge-chain
 /// malformation guards from #69.
-pub(super) fn advance_agenda(state: &mut GameState, events: &mut Vec<Event>) {
-    let from = state.agenda_index;
-    events.push(Event::AgendaAdvanced { from });
-    state.agenda_doom = 0;
-    state.agenda_index += 1;
-    if state.agenda_index >= state.agenda_deck.len() {
+pub(super) fn advance_agenda(cx: &mut Cx) {
+    let from = cx.state.agenda_index;
+    cx.events.push(crate::event::Event::AgendaAdvanced { from });
+    cx.state.agenda_doom = 0;
+    cx.state.agenda_index += 1;
+    if cx.state.agenda_index >= cx.state.agenda_deck.len() {
         unreachable!(
             "advance_agenda: agenda {from} advanced past the end of the deck without a \
              resolution firing — a terminal agenda must carry a resolution point; this is \
@@ -85,29 +85,25 @@ fn clue_contributors(state: &GameState, acting: InvestigatorId) -> Vec<Investiga
 /// (acting investigator first, then the rest in `turn_order`) and either
 /// set the resolution latch (terminal act) or emit [`Event::ActAdvanced`]
 /// and advance the cursor.
-pub(super) fn advance_act_action(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-) -> EngineOutcome {
-    if state.phase != Phase::Investigation {
+pub(super) fn advance_act_action(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
+    if cx.state.phase != Phase::Investigation {
         return EngineOutcome::Rejected {
             reason: format!(
                 "AdvanceAct is only valid during the Investigation phase (was {:?})",
-                state.phase
+                cx.state.phase
             )
             .into(),
         };
     }
-    if state.act_deck.is_empty() {
+    if cx.state.act_deck.is_empty() {
         return EngineOutcome::Rejected {
             reason: "AdvanceAct: no act deck is modeled for this scenario".into(),
         };
     }
-    let threshold = state.act_deck[state.act_index].clue_threshold;
-    let total_clues: u32 = clue_contributors(state, investigator)
+    let threshold = cx.state.act_deck[cx.state.act_index].clue_threshold;
+    let total_clues: u32 = clue_contributors(cx.state, investigator)
         .into_iter()
-        .filter_map(|id| state.investigators.get(&id))
+        .filter_map(|id| cx.state.investigators.get(&id))
         .map(|i| u32::from(i.clues))
         .sum();
     if total_clues < u32::from(threshold) {
@@ -120,10 +116,10 @@ pub(super) fn advance_act_action(
     }
 
     // All validations passed — mutate.
-    spend_clues(state, investigator, threshold);
-    match state.act_deck[state.act_index].resolution.clone() {
-        Some(resolution) => request_resolution(state, resolution),
-        None => advance_act(state, events),
+    spend_clues(cx.state, investigator, threshold);
+    match cx.state.act_deck[cx.state.act_index].resolution.clone() {
+        Some(resolution) => request_resolution(cx.state, resolution),
+        None => advance_act(cx),
     }
     EngineOutcome::Done
 }
@@ -158,11 +154,11 @@ fn spend_clues(state: &mut GameState, acting: InvestigatorId, amount: u8) {
 /// cursor. Only called for a non-terminal act; the missing-successor case
 /// is `unreachable!()` (a terminal act must carry a resolution point —
 /// malformed scenario data otherwise). Mirrors [`advance_agenda`].
-fn advance_act(state: &mut GameState, events: &mut Vec<Event>) {
-    let from = state.act_index;
-    events.push(Event::ActAdvanced { from });
-    state.act_index += 1;
-    if state.act_index >= state.act_deck.len() {
+fn advance_act(cx: &mut Cx) {
+    let from = cx.state.act_index;
+    cx.events.push(crate::event::Event::ActAdvanced { from });
+    cx.state.act_index += 1;
+    if cx.state.act_index >= cx.state.act_deck.len() {
         unreachable!(
             "advance_act: act {from} advanced past the end of the deck without a resolution \
              firing — a terminal act must carry a resolution point; this is malformed \
@@ -203,9 +199,15 @@ mod doom_agenda_tests {
             resolution: None,
         }];
         let mut events = Vec::new();
-        place_doom_on_agenda(&mut state, &mut events);
+        place_doom_on_agenda(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         assert_eq!(state.agenda_doom, 1);
-        place_doom_on_agenda(&mut state, &mut events);
+        place_doom_on_agenda(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         assert_eq!(state.agenda_doom, 2);
     }
 
@@ -228,7 +230,10 @@ mod doom_agenda_tests {
         ];
         state.agenda_doom = 2;
         let mut events = Vec::new();
-        check_doom_threshold(&mut state, &mut events);
+        check_doom_threshold(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         assert_eq!(state.agenda_index, 1);
         assert_eq!(state.agenda_doom, 0, "doom resets on advance");
         assert!(
@@ -251,7 +256,10 @@ mod doom_agenda_tests {
         }];
         state.agenda_doom = 2;
         let mut events = Vec::new();
-        check_doom_threshold(&mut state, &mut events);
+        check_doom_threshold(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         assert_eq!(
             state.agenda_index, 0,
             "cursor does not move on a terminal agenda"
@@ -270,7 +278,10 @@ mod doom_agenda_tests {
         }];
         state.agenda_doom = 2;
         let mut events = Vec::new();
-        check_doom_threshold(&mut state, &mut events);
+        check_doom_threshold(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         assert_eq!(state.agenda_index, 0);
         assert_eq!(state.agenda_doom, 2);
         assert!(events.is_empty());

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -118,8 +118,7 @@ pub(super) fn investigate(cx: &mut Cx, investigator: InvestigatorId) -> EngineOu
     }
 
     super::skill_test::start_skill_test(
-        cx.state,
-        cx.events,
+        cx,
         investigator,
         SkillKind::Intellect,
         SkillTestKind::Investigate,
@@ -399,8 +398,7 @@ pub(super) fn fight(cx: &mut Cx, investigator: InvestigatorId, enemy_id: EnemyId
     };
     spend_one_action(cx, investigator);
     super::skill_test::start_skill_test(
-        cx.state,
-        cx.events,
+        cx,
         investigator,
         SkillKind::Combat,
         SkillTestKind::Fight,
@@ -432,8 +430,7 @@ pub(super) fn evade(cx: &mut Cx, investigator: InvestigatorId, enemy_id: EnemyId
     };
     spend_one_action(cx, investigator);
     super::skill_test::start_skill_test(
-        cx.state,
-        cx.events,
+        cx,
         investigator,
         SkillKind::Agility,
         SkillTestKind::Evade,

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -97,7 +97,7 @@ pub(super) fn investigate(cx: &mut Cx, investigator: InvestigatorId) -> EngineOu
     // Evade, Parley, Engage, Resign are), so each ready engaged
     // enemy attacks before the test resolves.
     spend_one_action(cx, investigator);
-    super::combat::fire_attacks_of_opportunity(cx.state, cx.events, investigator);
+    super::combat::fire_attacks_of_opportunity(cx, investigator);
 
     // If AoO defeated the investigator, the action's primary effect
     // (the skill test) is suppressed. The action point and AoO events
@@ -228,7 +228,7 @@ pub(super) fn move_action(
     // Move triggers attacks of opportunity from each ready engaged
     // enemy. Per the Rules Reference, this happens BEFORE the move
     // resolves.
-    super::combat::fire_attacks_of_opportunity(cx.state, cx.events, investigator);
+    super::combat::fire_attacks_of_opportunity(cx, investigator);
 
     // If AoO defeated the investigator, the move is cancelled. The
     // action point and AoO events stay; the investigator (and any

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -9,6 +9,7 @@ use crate::state::{
 };
 
 use super::super::outcome::EngineOutcome;
+use super::Cx;
 
 /// Handler for [`PlayerAction::Investigate`].
 ///
@@ -25,38 +26,38 @@ use super::super::outcome::EngineOutcome;
 /// handler is the bare turn-action.
 ///
 /// [`Effect::DiscoverClue`]: crate::dsl::Effect::DiscoverClue
-pub(super) fn investigate(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-) -> EngineOutcome {
+pub(super) fn investigate(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
     // Validate-first.
-    if state.phase != Phase::Investigation {
+    if cx.state.phase != Phase::Investigation {
         return EngineOutcome::Rejected {
             reason: format!(
                 "Investigate is only valid during the Investigation phase (was {:?})",
-                state.phase
+                cx.state.phase
             )
             .into(),
         };
     }
-    if state.active_investigator != Some(investigator) {
+    if cx.state.active_investigator != Some(investigator) {
         return EngineOutcome::Rejected {
             reason: format!(
                 "Investigate: {investigator:?} is not the active investigator ({:?})",
-                state.active_investigator,
+                cx.state.active_investigator,
             )
             .into(),
         };
     }
     // Active-investigator + missing-from-map is a state-corruption
     // invariant violation; panic rather than silently rejecting.
-    let inv = state.investigators.get(&investigator).unwrap_or_else(|| {
-        unreachable!(
-            "Investigate: active_investigator {investigator:?} is not in the investigators \
+    let inv = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .unwrap_or_else(|| {
+            unreachable!(
+                "Investigate: active_investigator {investigator:?} is not in the investigators \
              map; this is a state-corruption invariant violation"
-        )
-    });
+            )
+        });
     if inv.status != Status::Active {
         return EngineOutcome::Rejected {
             reason: format!(
@@ -81,7 +82,7 @@ pub(super) fn investigate(
     // a state-corruption invariant violation, not a user-facing
     // rejection — match `end_turn` and `rotate_to_active` and surface
     // it loudly.
-    let location = state.locations.get(&location_id).unwrap_or_else(|| {
+    let location = cx.state.locations.get(&location_id).unwrap_or_else(|| {
         unreachable!(
             "Investigate: location {location_id:?} (investigator's current_location) \
              is not in the locations map; this is a state-corruption invariant violation"
@@ -95,26 +96,30 @@ pub(super) fn investigate(
     // test. Investigate is NOT on the AoO-exempt list (only Fight,
     // Evade, Parley, Engage, Resign are), so each ready engaged
     // enemy attacks before the test resolves.
-    spend_one_action(state, events, investigator);
-    super::combat::fire_attacks_of_opportunity(state, events, investigator);
+    spend_one_action(cx, investigator);
+    super::combat::fire_attacks_of_opportunity(cx.state, cx.events, investigator);
 
     // If AoO defeated the investigator, the action's primary effect
     // (the skill test) is suppressed. The action point and AoO events
     // already fired — they stay. The action declaration was legal;
     // the investigator just can't complete it.
-    let inv_after_aoo = state.investigators.get(&investigator).unwrap_or_else(|| {
-        unreachable!(
+    let inv_after_aoo = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .unwrap_or_else(|| {
+            unreachable!(
             "Investigate: investigator {investigator:?} disappeared between AoO and skill test; \
              this is a state-corruption invariant violation"
         )
-    });
+        });
     if inv_after_aoo.status != Status::Active {
         return EngineOutcome::Done;
     }
 
     super::skill_test::start_skill_test(
-        state,
-        events,
+        cx.state,
+        cx.events,
         investigator,
         SkillKind::Intellect,
         SkillTestKind::Investigate,
@@ -131,27 +136,29 @@ pub(super) fn investigate(
 /// opportunity before the move resolves, and engaged enemies move
 /// with the investigator. Both behaviors land alongside enemy state
 /// in #67; this handler covers only the bare movement.
+// Pre-existing bulk (99/100 lines before the Cx migration); the longer
+// `cx.state.` qualifier nudged it past the limit without adding logic.
+#[allow(clippy::too_many_lines)]
 pub(super) fn move_action(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
+    cx: &mut Cx,
     investigator: InvestigatorId,
     destination: LocationId,
 ) -> EngineOutcome {
     // Validate-first.
-    if state.phase != Phase::Investigation {
+    if cx.state.phase != Phase::Investigation {
         return EngineOutcome::Rejected {
             reason: format!(
                 "Move is only valid during the Investigation phase (was {:?})",
-                state.phase
+                cx.state.phase
             )
             .into(),
         };
     }
-    if state.active_investigator != Some(investigator) {
+    if cx.state.active_investigator != Some(investigator) {
         return EngineOutcome::Rejected {
             reason: format!(
                 "Move: {investigator:?} is not the active investigator ({:?})",
-                state.active_investigator,
+                cx.state.active_investigator,
             )
             .into(),
         };
@@ -159,12 +166,16 @@ pub(super) fn move_action(
     // Active-investigator + missing-from-map is a state-corruption
     // invariant violation (active_investigator is engine-set; the
     // pairing with the map entry is an invariant), so surface loudly.
-    let inv = state.investigators.get(&investigator).unwrap_or_else(|| {
-        unreachable!(
-            "Move: active_investigator {investigator:?} is not in the investigators map; \
+    let inv = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .unwrap_or_else(|| {
+            unreachable!(
+                "Move: active_investigator {investigator:?} is not in the investigators map; \
              this is a state-corruption invariant violation"
-        )
-    });
+            )
+        });
     if inv.status != Status::Active {
         return EngineOutcome::Rejected {
             reason: format!(
@@ -195,13 +206,13 @@ pub(super) fn move_action(
     // location is malformed input, not engine corruption, so we
     // reject. Check destination-in-state BEFORE connections so the
     // error message is informative when both fail.
-    let from_loc = state.locations.get(&from).unwrap_or_else(|| {
+    let from_loc = cx.state.locations.get(&from).unwrap_or_else(|| {
         unreachable!(
             "Move: location {from:?} (investigator's current_location) is not in the \
              locations map; this is a state-corruption invariant violation"
         )
     });
-    if !state.locations.contains_key(&destination) {
+    if !cx.state.locations.contains_key(&destination) {
         return EngineOutcome::Rejected {
             reason: format!("Move: destination {destination:?} is not in state").into(),
         };
@@ -213,22 +224,26 @@ pub(super) fn move_action(
     }
 
     // Mutate-second.
-    spend_one_action(state, events, investigator);
+    spend_one_action(cx, investigator);
 
     // Move triggers attacks of opportunity from each ready engaged
     // enemy. Per the Rules Reference, this happens BEFORE the move
     // resolves.
-    super::combat::fire_attacks_of_opportunity(state, events, investigator);
+    super::combat::fire_attacks_of_opportunity(cx.state, cx.events, investigator);
 
     // If AoO defeated the investigator, the move is cancelled. The
     // action point and AoO events stay; the investigator (and any
     // engaged enemies) don't change location.
-    let inv_after_aoo = state.investigators.get(&investigator).unwrap_or_else(|| {
-        unreachable!(
-            "Move: investigator {investigator:?} disappeared between AoO and move resolution; \
+    let inv_after_aoo = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .unwrap_or_else(|| {
+            unreachable!(
+                "Move: investigator {investigator:?} disappeared between AoO and move resolution; \
              this is a state-corruption invariant violation"
-        )
-    });
+            )
+        });
     if inv_after_aoo.status != Status::Active {
         return EngineOutcome::Done;
     }
@@ -237,23 +252,24 @@ pub(super) fn move_action(
     // engagement set before mutating any locations, then update each
     // engaged enemy's `current_location` to the destination
     // alongside the investigator's own move.
-    let engaged: Vec<EnemyId> = state
+    let engaged: Vec<EnemyId> = cx
+        .state
         .enemies
         .iter()
         .filter(|(_, e)| e.engaged_with == Some(investigator))
         .map(|(id, _)| *id)
         .collect();
-    state
+    cx.state
         .investigators
         .get_mut(&investigator)
         .expect("investigator existence checked above")
         .current_location = Some(destination);
     for enemy_id in engaged {
-        if let Some(enemy) = state.enemies.get_mut(&enemy_id) {
+        if let Some(enemy) = cx.state.enemies.get_mut(&enemy_id) {
             enemy.current_location = Some(destination);
         }
     }
-    events.push(Event::InvestigatorMoved {
+    cx.events.push(Event::InvestigatorMoved {
         investigator,
         from,
         to: destination,
@@ -340,18 +356,15 @@ fn validate_engaged_action<'a>(
 /// Spend 1 action point from the active investigator and emit
 /// `ActionsRemainingChanged`. Caller has already validated that
 /// `actions_remaining >= 1`.
-pub(super) fn spend_one_action(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-) {
-    let inv = state
+pub(super) fn spend_one_action(cx: &mut Cx, investigator: InvestigatorId) {
+    let inv = cx
+        .state
         .investigators
         .get_mut(&investigator)
         .expect("investigator existence checked before spend_one_action");
     let new_count = inv.actions_remaining - 1;
     inv.actions_remaining = new_count;
-    events.push(Event::ActionsRemainingChanged {
+    cx.events.push(Event::ActionsRemainingChanged {
         investigator,
         new_count,
     });
@@ -367,13 +380,9 @@ pub(super) fn spend_one_action(
 /// triggers (#64), and `AoO` from *other* engaged enemies (#78) are all
 /// downstream. `AoO` does NOT fire on Fight itself per the Rules
 /// Reference's `AoO`-exempt list.
-pub(super) fn fight(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-    enemy_id: EnemyId,
-) -> EngineOutcome {
-    let fight_difficulty = match validate_engaged_action(state, "Fight", investigator, enemy_id) {
+pub(super) fn fight(cx: &mut Cx, investigator: InvestigatorId, enemy_id: EnemyId) -> EngineOutcome {
+    let fight_difficulty = match validate_engaged_action(cx.state, "Fight", investigator, enemy_id)
+    {
         Ok(enemy) => {
             if enemy.fight < 0 {
                 return EngineOutcome::Rejected {
@@ -388,10 +397,10 @@ pub(super) fn fight(
         }
         Err(rejected) => return rejected,
     };
-    spend_one_action(state, events, investigator);
+    spend_one_action(cx, investigator);
     super::skill_test::start_skill_test(
-        state,
-        events,
+        cx.state,
+        cx.events,
         investigator,
         SkillKind::Combat,
         SkillTestKind::Fight,
@@ -404,13 +413,9 @@ pub(super) fn fight(
 ///
 /// Spends 1 action, runs an Agility skill test against the enemy's
 /// evade value, and on success disengages and exhausts the enemy.
-pub(super) fn evade(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-    enemy_id: EnemyId,
-) -> EngineOutcome {
-    let evade_difficulty = match validate_engaged_action(state, "Evade", investigator, enemy_id) {
+pub(super) fn evade(cx: &mut Cx, investigator: InvestigatorId, enemy_id: EnemyId) -> EngineOutcome {
+    let evade_difficulty = match validate_engaged_action(cx.state, "Evade", investigator, enemy_id)
+    {
         Ok(enemy) => {
             if enemy.evade < 0 {
                 return EngineOutcome::Rejected {
@@ -425,10 +430,10 @@ pub(super) fn evade(
         }
         Err(rejected) => return rejected,
     };
-    spend_one_action(state, events, investigator);
+    spend_one_action(cx, investigator);
     super::skill_test::start_skill_test(
-        state,
-        events,
+        cx.state,
+        cx.events,
         investigator,
         SkillKind::Agility,
         SkillTestKind::Evade,

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -497,7 +497,7 @@ pub(super) fn play_card(
     });
     let eval_ctx = EvalContext::for_controller(investigator);
     for ability in abilities.iter().filter(|a| a.trigger == Trigger::OnPlay) {
-        let outcome = apply_effect(cx.state, cx.events, &ability.effect, eval_ctx);
+        let outcome = apply_effect(cx, &ability.effect, eval_ctx);
         if !matches!(outcome, EngineOutcome::Done) {
             return outcome;
         }

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -268,7 +268,7 @@ pub(super) fn draw(
     }
 
     // Mutate.
-    super::actions::spend_one_action(state, events, investigator);
+    super::actions::spend_one_action(&mut super::Cx { state, events }, investigator);
     draw_one_with_deckout(state, events, investigator);
     EngineOutcome::Done
 }

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -5,12 +5,11 @@ use crate::card_data::CardType;
 use crate::card_registry;
 use crate::dsl::Trigger;
 use crate::event::Event;
-use crate::state::{
-    CardCode, CardInPlay, CardInstanceId, GameState, InvestigatorId, Phase, Status, Zone,
-};
+use crate::state::{CardCode, CardInPlay, CardInstanceId, InvestigatorId, Phase, Status, Zone};
 
 use super::super::evaluator::{apply_effect, EvalContext};
 use super::super::outcome::EngineOutcome;
+use super::Cx;
 
 /// Starting hand size at scenario setup. Per the Rules Reference,
 /// each investigator draws 5 cards before mulligan.
@@ -21,17 +20,13 @@ pub(super) const INITIAL_HAND_SIZE: u8 = 5;
 /// Permutes the named investigator's player deck via the deterministic
 /// RNG and emits [`Event::DeckShuffled`]. Empty decks are a silent
 /// no-op (no event emitted) — there's nothing to shuffle.
-pub(super) fn deck_shuffled(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-) -> EngineOutcome {
-    if !state.investigators.contains_key(&investigator) {
+pub(super) fn deck_shuffled(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
+    if !cx.state.investigators.contains_key(&investigator) {
         return EngineOutcome::Rejected {
             reason: format!("DeckShuffled: investigator {investigator:?} is not in state").into(),
         };
     }
-    shuffle_player_deck(state, events, investigator);
+    shuffle_player_deck(cx, investigator);
     EngineOutcome::Done
 }
 
@@ -41,12 +36,9 @@ pub(super) fn deck_shuffled(
 ///
 /// Emits [`Event::DeckShuffled`] iff the deck had at least 2 cards
 /// (a 0- or 1-card deck has nothing to permute).
-pub(super) fn shuffle_player_deck(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-) {
-    let inv = state
+pub(super) fn shuffle_player_deck(cx: &mut Cx, investigator: InvestigatorId) {
+    let inv = cx
+        .state
         .investigators
         .get_mut(&investigator)
         .unwrap_or_else(|| {
@@ -68,15 +60,19 @@ pub(super) fn shuffle_player_deck(
     let mut swaps: Vec<(usize, usize)> = Vec::with_capacity(deck_len - 1);
     let mut i = deck_len - 1;
     while i >= 1 {
-        let j = state.rng.next_index(i + 1);
+        let j = cx.state.rng.next_index(i + 1);
         swaps.push((i, j));
         i -= 1;
     }
-    let inv = state.investigators.get_mut(&investigator).expect("checked");
+    let inv = cx
+        .state
+        .investigators
+        .get_mut(&investigator)
+        .expect("checked");
     for (a, b) in swaps {
         inv.deck.swap(a, b);
     }
-    events.push(Event::DeckShuffled { investigator });
+    cx.events.push(Event::DeckShuffled { investigator });
 }
 
 /// Draw up to `count` cards from the named investigator's deck top
@@ -87,13 +83,9 @@ pub(super) fn shuffle_player_deck(
 /// Emits a single [`Event::CardsDrawn`] with the actually-drawn
 /// count, even if that's zero. A zero-count draw is informative for
 /// consumers tracking the attempt.
-pub(super) fn draw_cards(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-    count: u8,
-) {
-    let inv = state
+pub(super) fn draw_cards(cx: &mut Cx, investigator: InvestigatorId, count: u8) {
+    let inv = cx
+        .state
         .investigators
         .get_mut(&investigator)
         .unwrap_or_else(|| {
@@ -109,7 +101,7 @@ pub(super) fn draw_cards(
     inv.hand.extend(drawn_cards);
     // `drawn` ≤ `count: u8`, so the cast can't overflow.
     let drawn_u8 = u8::try_from(drawn).expect("drawn <= count <= u8::MAX");
-    events.push(Event::CardsDrawn {
+    cx.events.push(Event::CardsDrawn {
         investigator,
         count: drawn_u8,
     });
@@ -122,21 +114,17 @@ pub(super) fn draw_cards(
 /// the existing `gain_resources` zero-amount behavior.
 ///
 /// Caller guarantees `investigator` exists in `state.investigators`.
-pub(crate) fn grant_resources(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-    amount: u8,
-) {
+pub(crate) fn grant_resources(cx: &mut Cx, investigator: InvestigatorId, amount: u8) {
     if amount == 0 {
         return;
     }
-    let inv = state
+    let inv = cx
+        .state
         .investigators
         .get_mut(&investigator)
         .expect("grant_resources: caller guarantees investigator exists");
     inv.resources = inv.resources.saturating_add(amount);
-    events.push(Event::ResourcesGained {
+    cx.events.push(Event::ResourcesGained {
         investigator,
         amount,
     });
@@ -146,12 +134,9 @@ pub(crate) fn grant_resources(
 /// investigator. Used by [`draw`] when the deck runs empty. Drains
 /// `discard` into `deck`, then calls [`shuffle_player_deck`] (which
 /// emits [`Event::DeckShuffled`] when ≥ 2 cards land in the deck).
-fn reshuffle_discard_into_deck(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-) {
-    let inv = state
+fn reshuffle_discard_into_deck(cx: &mut Cx, investigator: InvestigatorId) {
+    let inv = cx
+        .state
         .investigators
         .get_mut(&investigator)
         .unwrap_or_else(|| {
@@ -162,7 +147,7 @@ fn reshuffle_discard_into_deck(
         });
     let cards: Vec<_> = inv.discard.drain(..).collect();
     inv.deck.extend(cards);
-    shuffle_player_deck(state, events, investigator);
+    shuffle_player_deck(cx, investigator);
 }
 
 /// Draw one card for `investigator`, applying the empty-deck rule:
@@ -174,12 +159,9 @@ fn reshuffle_discard_into_deck(
 /// inherited unchanged.
 ///
 /// Caller guarantees `investigator` exists in `state.investigators`.
-pub(super) fn draw_one_with_deckout(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-) {
-    let inv = state
+pub(super) fn draw_one_with_deckout(cx: &mut Cx, investigator: InvestigatorId) {
+    let inv = cx
+        .state
         .investigators
         .get(&investigator)
         .expect("draw_one_with_deckout: caller guarantees investigator exists");
@@ -187,19 +169,19 @@ pub(super) fn draw_one_with_deckout(
     let discard_empty = inv.discard.is_empty();
     if deck_empty {
         if !discard_empty {
-            reshuffle_discard_into_deck(state, events, investigator);
+            reshuffle_discard_into_deck(cx, investigator);
         }
         // After the (possibly no-op) reshuffle, attempt the draw.
         // draw_cards handles a still-empty deck by emitting
         // CardsDrawn { count: 0 } without moving cards.
-        draw_cards(state, events, investigator, 1);
+        draw_cards(cx, investigator, 1);
         // Horror penalty fires on any "would-draw-from-empty-deck"
         // (the reshuffle did happen if discard was non-empty; if it
         // was also empty, the rules don't strictly require horror
         // but we apply it as the safer reading).
-        super::elimination::take_horror(state, events, investigator, 1);
+        super::elimination::take_horror(cx.state, cx.events, investigator, 1);
     } else {
-        draw_cards(state, events, investigator, 1);
+        draw_cards(cx, investigator, 1);
     }
 }
 
@@ -223,35 +205,35 @@ pub(super) fn draw_one_with_deckout(
 ///   both zones) that the difference is mostly theoretical.
 ///
 /// The draw logic itself is delegated to [`draw_one_with_deckout`].
-pub(super) fn draw(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-) -> EngineOutcome {
-    if state.phase != Phase::Investigation {
+pub(super) fn draw(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
+    if cx.state.phase != Phase::Investigation {
         return EngineOutcome::Rejected {
             reason: format!(
                 "Draw is only valid during the Investigation phase (was {:?})",
-                state.phase
+                cx.state.phase
             )
             .into(),
         };
     }
-    if state.active_investigator != Some(investigator) {
+    if cx.state.active_investigator != Some(investigator) {
         return EngineOutcome::Rejected {
             reason: format!(
                 "Draw: {investigator:?} is not the active investigator ({:?})",
-                state.active_investigator,
+                cx.state.active_investigator,
             )
             .into(),
         };
     }
-    let inv = state.investigators.get(&investigator).unwrap_or_else(|| {
-        unreachable!(
-            "Draw: active_investigator {investigator:?} is not in the investigators map; \
+    let inv = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .unwrap_or_else(|| {
+            unreachable!(
+                "Draw: active_investigator {investigator:?} is not in the investigators map; \
              this is a state-corruption invariant violation"
-        )
-    });
+            )
+        });
     if inv.status != Status::Active {
         return EngineOutcome::Rejected {
             reason: format!(
@@ -268,8 +250,8 @@ pub(super) fn draw(
     }
 
     // Mutate.
-    super::actions::spend_one_action(&mut super::Cx { state, events }, investigator);
-    draw_one_with_deckout(state, events, investigator);
+    super::actions::spend_one_action(cx, investigator);
+    draw_one_with_deckout(cx, investigator);
     EngineOutcome::Done
 }
 
@@ -287,30 +269,33 @@ pub(super) fn draw(
 /// is a legal "keep my hand" mulligan that consumes the turn without
 /// touching the deck.
 pub(super) fn mulligan(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
+    cx: &mut Cx,
     investigator: InvestigatorId,
     indices_to_redraw: &[u8],
 ) -> EngineOutcome {
     // One check subsumes the three old ones: the cursor only ever holds
     // an Active `turn_order` id, so a mismatch covers setup-over (`None`),
     // wrong-player / too-early, and already-went (cursor moved past you).
-    if state.mulligan_pending != Some(investigator) {
+    if cx.state.mulligan_pending != Some(investigator) {
         return EngineOutcome::Rejected {
             reason: format!(
                 "Mulligan: it is not {investigator:?}'s turn to mulligan \
                  (pending: {:?})",
-                state.mulligan_pending,
+                cx.state.mulligan_pending,
             )
             .into(),
         };
     }
-    let inv = state.investigators.get(&investigator).unwrap_or_else(|| {
-        unreachable!(
-            "mulligan_pending {investigator:?} is not in the investigators map; \
+    let inv = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .unwrap_or_else(|| {
+            unreachable!(
+                "mulligan_pending {investigator:?} is not in the investigators map; \
              this is a state-corruption invariant violation"
-        )
-    });
+            )
+        });
     // Validate indices: each must be in bounds and unique.
     let hand_len = inv.hand.len();
     for &idx in indices_to_redraw {
@@ -332,7 +317,11 @@ pub(super) fn mulligan(
     // Mutate.
     let redrawn_count = u8::try_from(indices_to_redraw.len())
         .expect("indices_to_redraw.len() <= hand.len() <= u8::MAX in practice");
-    let inv_mut = state.investigators.get_mut(&investigator).expect("checked");
+    let inv_mut = cx
+        .state
+        .investigators
+        .get_mut(&investigator)
+        .expect("checked");
     // Walk indices high-to-low so smaller positions remain valid as
     // we remove. Move named cards directly into the deck — they
     // shuffle back in per the rules, not through the discard pile.
@@ -345,17 +334,18 @@ pub(super) fn mulligan(
     // For an empty "keep my hand" mulligan, skip both — there's
     // nothing to put back, so no shuffle and no draw.
     if redrawn_count > 0 {
-        shuffle_player_deck(state, events, investigator);
-        draw_cards(state, events, investigator, redrawn_count);
+        shuffle_player_deck(cx, investigator);
+        draw_cards(cx, investigator, redrawn_count);
     }
-    events.push(Event::MulliganPerformed {
+    cx.events.push(Event::MulliganPerformed {
         investigator,
         redrawn_count,
     });
     // Advance to the next Active investigator in player order (or `None`
     // when this was the last). The completion check in
     // `apply_player_action` keys off `None` to end setup.
-    state.mulligan_pending = super::cursor::next_active_investigator_after(state, investigator);
+    cx.state.mulligan_pending =
+        super::cursor::next_active_investigator_after(cx.state, investigator);
     EngineOutcome::Done
 }
 
@@ -475,8 +465,7 @@ pub(super) fn resolve_play_target(
 /// `events.clear()` still clears the event stream on a rejected
 /// outcome; the state-rollback hardening is out of scope here.
 pub(super) fn play_card(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
+    cx: &mut Cx,
     investigator: InvestigatorId,
     hand_index: u8,
 ) -> EngineOutcome {
@@ -485,7 +474,7 @@ pub(super) fn play_card(
         abilities,
         is_fast: _,
         card_type: _,
-    } = match super::reaction_windows::check_play_card(state, investigator, hand_index) {
+    } = match super::reaction_windows::check_play_card(cx.state, investigator, hand_index) {
         Ok(r) => r,
         Err(reason) => return EngineOutcome::Rejected { reason },
     };
@@ -493,7 +482,8 @@ pub(super) fn play_card(
     // the result (avoiding the lifetime question). The validator already
     // confirmed the hand_index is in bounds and the investigator exists.
     let idx = usize::from(hand_index);
-    let code: CardCode = state
+    let code: CardCode = cx
+        .state
         .investigators
         .get(&investigator)
         .expect("checked in validator")
@@ -501,32 +491,40 @@ pub(super) fn play_card(
         .clone();
 
     // Mutate.
-    events.push(Event::CardPlayed {
+    cx.events.push(Event::CardPlayed {
         investigator,
         code: code.clone(),
     });
-    let ctx = EvalContext::for_controller(investigator);
+    let eval_ctx = EvalContext::for_controller(investigator);
     for ability in abilities.iter().filter(|a| a.trigger == Trigger::OnPlay) {
-        let outcome = apply_effect(state, events, &ability.effect, ctx);
+        let outcome = apply_effect(cx.state, cx.events, &ability.effect, eval_ctx);
         if !matches!(outcome, EngineOutcome::Done) {
             return outcome;
         }
     }
     match destination {
         super::PlayDestination::InPlay => {
-            let instance_id = CardInstanceId(state.next_card_instance_id);
-            state.next_card_instance_id = state.next_card_instance_id.saturating_add(1);
-            let inv_mut = state.investigators.get_mut(&investigator).expect("checked");
+            let instance_id = CardInstanceId(cx.state.next_card_instance_id);
+            cx.state.next_card_instance_id = cx.state.next_card_instance_id.saturating_add(1);
+            let inv_mut = cx
+                .state
+                .investigators
+                .get_mut(&investigator)
+                .expect("checked");
             let card = inv_mut.hand.remove(idx);
             inv_mut
                 .cards_in_play
                 .push(CardInPlay::enter_play(card, instance_id));
         }
         super::PlayDestination::Discard => {
-            let inv_mut = state.investigators.get_mut(&investigator).expect("checked");
+            let inv_mut = cx
+                .state
+                .investigators
+                .get_mut(&investigator)
+                .expect("checked");
             let card = inv_mut.hand.remove(idx);
             inv_mut.discard.push(card.clone());
-            events.push(Event::CardDiscarded {
+            cx.events.push(Event::CardDiscarded {
                 investigator,
                 code: card,
                 from: Zone::Hand,
@@ -551,7 +549,14 @@ mod grant_resources_tests {
         let before = state.investigators[&id].resources;
         let mut events = Vec::new();
 
-        grant_resources(&mut state, &mut events, id, 2);
+        grant_resources(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            id,
+            2,
+        );
 
         assert_eq!(state.investigators[&id].resources, before + 2);
         assert!(events.iter().any(|e| matches!(
@@ -569,7 +574,14 @@ mod grant_resources_tests {
         let before = state.investigators[&id].resources;
         let mut events = Vec::new();
 
-        grant_resources(&mut state, &mut events, id, 0);
+        grant_resources(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            id,
+            0,
+        );
 
         assert_eq!(state.investigators[&id].resources, before);
         assert!(events.is_empty());
@@ -593,7 +605,13 @@ mod draw_one_with_deckout_tests {
         let mut state = TestGame::default().with_investigator(inv).build();
         let mut events = Vec::new();
 
-        draw_one_with_deckout(&mut state, &mut events, id);
+        draw_one_with_deckout(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            id,
+        );
 
         assert_eq!(
             state.investigators[&id].hand.len(),

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -179,7 +179,7 @@ pub(super) fn draw_one_with_deckout(cx: &mut Cx, investigator: InvestigatorId) {
         // (the reshuffle did happen if discard was non-empty; if it
         // was also empty, the rules don't strictly require horror
         // but we apply it as the safer reading).
-        super::elimination::take_horror(cx.state, cx.events, investigator, 1);
+        super::elimination::take_horror(cx, investigator, 1);
     } else {
         draw_cards(cx, investigator, 1);
     }

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -173,7 +173,7 @@ pub(super) fn enemy_attack(cx: &mut Cx, enemy_id: EnemyId, investigator: Investi
         } else {
             DefeatCause::Horror
         };
-        super::elimination::apply_investigator_defeat(cx.state, cx.events, investigator, cause);
+        super::elimination::apply_investigator_defeat(cx, investigator, cause);
     }
 }
 

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -37,8 +37,7 @@ pub(super) fn damage_enemy(cx: &mut Cx, enemy_id: EnemyId, amount: u8, by: Optio
         // `fire_on_skill_test_resolution`) returning AwaitingInput so the
         // player can fire their reaction triggers; see `drive_skill_test`.
         super::reaction_windows::queue_reaction_window(
-            cx.state,
-            cx.events,
+            cx,
             WindowKind::AfterEnemyDefeated {
                 enemy: enemy_id,
                 by,

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -1,21 +1,17 @@
 //! Combat helpers: enemy damage, investigator damage/horror, attacks.
 
 use crate::event::Event;
-use crate::state::{DefeatCause, EnemyId, GameState, InvestigatorId, Status, WindowKind};
+use crate::state::{DefeatCause, EnemyId, InvestigatorId, Status, WindowKind};
+
+use super::Cx;
 
 /// Apply `amount` damage to an enemy. If the new damage reaches or
 /// exceeds `max_health`, emit `EnemyDefeated` and remove the enemy
 /// from `state.enemies`. `by` attributes the defeat for
 /// trigger-window consumers (e.g. Roland's reaction). Used by Fight
 /// today; will be reused by future damage-dealing card effects.
-pub(super) fn damage_enemy(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    enemy_id: EnemyId,
-    amount: u8,
-    by: Option<InvestigatorId>,
-) {
-    let enemy = state.enemies.get_mut(&enemy_id).unwrap_or_else(|| {
+pub(super) fn damage_enemy(cx: &mut Cx, enemy_id: EnemyId, amount: u8, by: Option<InvestigatorId>) {
+    let enemy = cx.state.enemies.get_mut(&enemy_id).unwrap_or_else(|| {
         unreachable!(
             "damage_enemy: enemy {enemy_id:?} is not in state.enemies; \
              this is a state-corruption invariant violation"
@@ -23,17 +19,17 @@ pub(super) fn damage_enemy(
     });
     let new_damage = enemy.damage.saturating_add(amount).min(enemy.max_health);
     enemy.damage = new_damage;
-    events.push(Event::EnemyDamaged {
+    cx.events.push(Event::EnemyDamaged {
         enemy: enemy_id,
         amount,
         new_damage,
     });
     if new_damage >= enemy.max_health {
-        events.push(Event::EnemyDefeated {
+        cx.events.push(Event::EnemyDefeated {
             enemy: enemy_id,
             by,
         });
-        state.enemies.remove(&enemy_id);
+        cx.state.enemies.remove(&enemy_id);
         // Queue the post-defeat reaction window. Emits
         // `Event::WindowOpened` immediately (inside queue_reaction_window);
         // the skill-test driver then suspends at the next step boundary
@@ -41,8 +37,8 @@ pub(super) fn damage_enemy(
         // `fire_on_skill_test_resolution`) returning AwaitingInput so the
         // player can fire their reaction triggers; see `drive_skill_test`.
         super::reaction_windows::queue_reaction_window(
-            state,
-            events,
+            cx.state,
+            cx.events,
             WindowKind::AfterEnemyDefeated {
                 enemy: enemy_id,
                 by,
@@ -70,16 +66,12 @@ pub(super) fn damage_enemy(
 /// don't accumulate more damage.
 ///
 /// [`Status`]: crate::state::Status
-pub(super) fn apply_damage_numeric(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-    amount: u8,
-) -> bool {
+pub(super) fn apply_damage_numeric(cx: &mut Cx, investigator: InvestigatorId, amount: u8) -> bool {
     if amount == 0 {
         return false;
     }
-    let inv = state
+    let inv = cx
+        .state
         .investigators
         .get_mut(&investigator)
         .unwrap_or_else(|| {
@@ -93,7 +85,7 @@ pub(super) fn apply_damage_numeric(
     }
     inv.damage = inv.damage.saturating_add(amount);
     let lethal = inv.damage >= inv.max_health;
-    events.push(Event::DamageTaken {
+    cx.events.push(Event::DamageTaken {
         investigator,
         amount,
     });
@@ -104,16 +96,12 @@ pub(super) fn apply_damage_numeric(
 /// `max_sanity`. Returns `true` iff the new total reaches the
 /// max-sanity threshold; defeat application is the caller's
 /// responsibility (see [`super::elimination::apply_investigator_defeat`]).
-pub(super) fn apply_horror_numeric(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-    amount: u8,
-) -> bool {
+pub(super) fn apply_horror_numeric(cx: &mut Cx, investigator: InvestigatorId, amount: u8) -> bool {
     if amount == 0 {
         return false;
     }
-    let inv = state
+    let inv = cx
+        .state
         .investigators
         .get_mut(&investigator)
         .unwrap_or_else(|| {
@@ -127,7 +115,7 @@ pub(super) fn apply_horror_numeric(
     }
     inv.horror = inv.horror.saturating_add(amount);
     let lethal = inv.horror >= inv.max_sanity;
-    events.push(Event::HorrorTaken {
+    cx.events.push(Event::HorrorTaken {
         investigator,
         amount,
     });
@@ -168,13 +156,8 @@ pub(super) fn apply_horror_numeric(
 /// scope for `#83`.
 ///
 /// [`AwaitingInput`]: crate::engine::EngineOutcome::AwaitingInput
-pub(super) fn enemy_attack(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    enemy_id: EnemyId,
-    investigator: InvestigatorId,
-) {
-    let enemy = state.enemies.get(&enemy_id).unwrap_or_else(|| {
+pub(super) fn enemy_attack(cx: &mut Cx, enemy_id: EnemyId, investigator: InvestigatorId) {
+    let enemy = cx.state.enemies.get(&enemy_id).unwrap_or_else(|| {
         unreachable!(
             "enemy_attack: enemy {enemy_id:?} is not in state.enemies; \
              this is a state-corruption invariant violation"
@@ -183,15 +166,15 @@ pub(super) fn enemy_attack(
     let damage = enemy.attack_damage;
     let horror = enemy.attack_horror;
 
-    let damage_lethal = apply_damage_numeric(state, events, investigator, damage);
-    let horror_lethal = apply_horror_numeric(state, events, investigator, horror);
+    let damage_lethal = apply_damage_numeric(cx, investigator, damage);
+    let horror_lethal = apply_horror_numeric(cx, investigator, horror);
     if damage_lethal || horror_lethal {
         let cause = if damage_lethal {
             DefeatCause::Damage
         } else {
             DefeatCause::Horror
         };
-        super::elimination::apply_investigator_defeat(state, events, investigator, cause);
+        super::elimination::apply_investigator_defeat(cx.state, cx.events, investigator, cause);
     }
 }
 
@@ -205,19 +188,16 @@ pub(super) fn enemy_attack(
 /// (unmilestoned) covers this site alongside
 /// [`resolve_attacks_for_investigator`] — both sites share the same
 /// deterministic-order TODO.
-pub(super) fn fire_attacks_of_opportunity(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-) {
-    let attackers: Vec<EnemyId> = state
+pub(super) fn fire_attacks_of_opportunity(cx: &mut Cx, investigator: InvestigatorId) {
+    let attackers: Vec<EnemyId> = cx
+        .state
         .enemies
         .iter()
         .filter(|(_, e)| e.engaged_with == Some(investigator) && !e.exhausted)
         .map(|(id, _)| *id)
         .collect();
     for enemy_id in attackers {
-        enemy_attack(state, events, enemy_id, investigator);
+        enemy_attack(cx, enemy_id, investigator);
     }
 }
 
@@ -271,14 +251,11 @@ pub(super) fn fire_attacks_of_opportunity(
 /// `TODO(#143)`: player-pick attack order, unmilestoned, covers both
 /// this site and [`fire_attacks_of_opportunity`] (which has the same
 /// TODO).
-pub(super) fn resolve_attacks_for_investigator(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-) {
+pub(super) fn resolve_attacks_for_investigator(cx: &mut Cx, investigator: InvestigatorId) {
     // Snapshot ready engaged attackers in deterministic EnemyId order.
     // BTreeMap iteration is already key-sorted.
-    let attackers: Vec<EnemyId> = state
+    let attackers: Vec<EnemyId> = cx
+        .state
         .enemies
         .iter()
         .filter(|(_, e)| e.engaged_with == Some(investigator) && !e.exhausted)
@@ -287,7 +264,8 @@ pub(super) fn resolve_attacks_for_investigator(
 
     for enemy_id in attackers {
         // Early-break on defeat. See fn doc.
-        let active = state
+        let active = cx
+            .state
             .investigators
             .get(&investigator)
             .is_some_and(|inv| inv.status == Status::Active);
@@ -296,10 +274,10 @@ pub(super) fn resolve_attacks_for_investigator(
         }
 
         // Damage + horror placement (simultaneous per p.7) + defeat.
-        enemy_attack(state, events, enemy_id, investigator);
+        enemy_attack(cx, enemy_id, investigator);
 
         // Exhaust the attacker post-resolution.
-        let enemy = state.enemies.get_mut(&enemy_id).unwrap_or_else(|| {
+        let enemy = cx.state.enemies.get_mut(&enemy_id).unwrap_or_else(|| {
             unreachable!(
                 "resolve_attacks_for_investigator: snapshotted enemy \
                  {enemy_id:?} is gone from state.enemies; this is a \
@@ -307,6 +285,6 @@ pub(super) fn resolve_attacks_for_investigator(
             )
         });
         enemy.exhausted = true;
-        events.push(Event::EnemyExhausted { enemy: enemy_id });
+        cx.events.push(Event::EnemyExhausted { enemy: enemy_id });
     }
 }

--- a/crates/game-core/src/engine/dispatch/elimination.rs
+++ b/crates/game-core/src/engine/dispatch/elimination.rs
@@ -130,7 +130,7 @@ fn run_elimination_steps(
         });
     }
     for &eid in &affected {
-        super::hunters::reengage_at_location(state, events, eid);
+        super::hunters::reengage_at_location(&mut super::Cx { state, events }, eid);
     }
 
     // Step 4: place other (non-enemy) threat-area cards in the

--- a/crates/game-core/src/engine/dispatch/elimination.rs
+++ b/crates/game-core/src/engine/dispatch/elimination.rs
@@ -1,8 +1,9 @@
 //! Investigator elimination helpers: defeat application, elimination
 //! steps, horror application, and all-defeated detection.
 
+use super::Cx;
 use crate::event::Event;
-use crate::state::{DefeatCause, EnemyId, GameState, InvestigatorId, Status};
+use crate::state::{DefeatCause, EnemyId, InvestigatorId, Status};
 
 #[cfg(test)]
 use crate::state::{CardCode, CardInPlay, CardInstanceId, LocationId, Phase};
@@ -15,12 +16,11 @@ use crate::state::{CardCode, CardInPlay, CardInstanceId, LocationId, Phase};
 /// [`Status::Killed`]: crate::state::Status::Killed
 /// [`Status::Insane`]: crate::state::Status::Insane
 pub(super) fn apply_investigator_defeat(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
+    cx: &mut Cx,
     investigator: InvestigatorId,
     cause: DefeatCause,
 ) {
-    let inv = state
+    let inv = cx.state
         .investigators
         .get_mut(&investigator)
         .unwrap_or_else(|| {
@@ -37,7 +37,7 @@ pub(super) fn apply_investigator_defeat(
         DefeatCause::Horror => Status::Insane,
         DefeatCause::Resigned => Status::Resigned,
     };
-    events.push(Event::InvestigatorDefeated {
+    cx.events.push(Event::InvestigatorDefeated {
         investigator,
         cause,
     });
@@ -45,30 +45,28 @@ pub(super) fn apply_investigator_defeat(
     // Rules Reference p.10 Elimination steps 1–5 run here, between the
     // defeat event and the all-defeated check (step 6 signal). See the
     // design doc 2026-05-31-144 for the full breakdown.
-    run_elimination_steps(state, events, investigator);
+    run_elimination_steps(cx, investigator);
 
-    check_all_defeated(state, events);
+    check_all_defeated(cx);
 }
 
 /// Execute Rules Reference p.10 Elimination steps 1–5 for an
 /// investigator whose `status` has just been flipped to a defeated
 /// variant. Synchronous: the step-3 re-engagement tie auto-picks the
 /// lead rather than suspending (see `reengage_at_location`).
-fn run_elimination_steps(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-) {
+fn run_elimination_steps(cx: &mut Cx, investigator: InvestigatorId) {
     // The location the investigator was at "when eliminated" — read once
     // before any mutations; step 2 deposits clues here.
-    let last_location = state
+    let last_location = cx
+        .state
         .investigators
         .get(&investigator)
         .and_then(|inv| inv.current_location);
 
     // Step 1: remove every card this investigator controls in play and
     // owns in out-of-play areas (hand/deck/discard) from the game.
-    let inv = state
+    let inv = cx
+        .state
         .investigators
         .get_mut(&investigator)
         .unwrap_or_else(|| {
@@ -94,10 +92,10 @@ fn run_elimination_steps(
     inv.resources = 0;
     if clues > 0 {
         if let Some(loc_id) = last_location {
-            if let Some(loc) = state.locations.get_mut(&loc_id) {
+            if let Some(loc) = cx.state.locations.get_mut(&loc_id) {
                 loc.clues = loc.clues.saturating_add(clues);
                 let new_count = loc.clues;
-                events.push(Event::LocationCluesChanged {
+                cx.events.push(Event::LocationCluesChanged {
                     location: loc_id,
                     new_count,
                 });
@@ -113,24 +111,25 @@ fn run_elimination_steps(
     // them along), so no location update is needed — just clear
     // `engaged_with`. Disengage all first (simultaneous), then let the
     // ready ones re-engage a surviving co-located investigator per prey.
-    let affected: Vec<EnemyId> = state
+    let affected: Vec<EnemyId> = cx
+        .state
         .enemies
         .iter()
         .filter(|(_, e)| e.engaged_with == Some(investigator))
         .map(|(id, _)| *id)
         .collect();
     for &eid in &affected {
-        let enemy = state.enemies.get_mut(&eid).unwrap_or_else(|| {
+        let enemy = cx.state.enemies.get_mut(&eid).unwrap_or_else(|| {
             unreachable!("run_elimination_steps: enemy {eid:?} vanished; state corruption")
         });
         enemy.engaged_with = None;
-        events.push(Event::EnemyDisengaged {
+        cx.events.push(Event::EnemyDisengaged {
             enemy: eid,
             investigator,
         });
     }
     for &eid in &affected {
-        super::hunters::reengage_at_location(&mut super::Cx { state, events }, eid);
+        super::hunters::reengage_at_location(cx, eid);
     }
 
     // Step 4: place other (non-enemy) threat-area cards in the
@@ -153,7 +152,8 @@ fn run_elimination_steps(
     // step 2 deposited clues using `last_location` (step 3 reads
     // `enemy.current_location` directly, relying on the same value via
     // the engagement invariant).
-    let inv = state
+    let inv = cx
+        .state
         .investigators
         .get_mut(&investigator)
         .unwrap_or_else(|| {
@@ -183,14 +183,9 @@ fn run_elimination_steps(
 /// return) is one line per call site.
 ///
 /// [`Status::Insane`]: crate::state::Status::Insane
-pub(super) fn take_horror(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-    amount: u8,
-) {
-    if super::combat::apply_horror_numeric(&mut super::Cx { state, events }, investigator, amount) {
-        apply_investigator_defeat(state, events, investigator, DefeatCause::Horror);
+pub(super) fn take_horror(cx: &mut Cx, investigator: InvestigatorId, amount: u8) {
+    if super::combat::apply_horror_numeric(cx, investigator, amount) {
+        apply_investigator_defeat(cx, investigator, DefeatCause::Horror);
     }
 }
 
@@ -217,23 +212,24 @@ pub(super) fn take_horror(
 /// investigator transition it requests [`crate::scenario::Resolution::Lost`]
 /// per Rules Reference p.10 step 6. The `apply` hook turns that latch into
 /// [`Event::ScenarioResolved`] + `apply_resolution`.
-pub(super) fn check_all_defeated(state: &mut GameState, events: &mut Vec<Event>) {
-    let any_active = state
+pub(super) fn check_all_defeated(cx: &mut Cx) {
+    let any_active = cx
+        .state
         .investigators
         .values()
         .any(|inv| inv.status == Status::Active);
     // Empty-investigators is nonsense scenario state; suppress the
     // event so we don't emit a meaningless "all defeated" when there
     // was nobody to defeat in the first place.
-    if !any_active && !state.investigators.is_empty() {
-        events.push(Event::AllInvestigatorsDefeated);
+    if !any_active && !cx.state.investigators.is_empty() {
+        cx.events.push(Event::AllInvestigatorsDefeated);
         // Rules Reference p.10 step 6: "If there are no remaining players,
         // the scenario ends. Refer to 'no resolution was reached' entry
         // for that scenario in the campaign guide." Latch the loss
         // (first-writer-wins, so an already-fired act/agenda resolution
         // stays authoritative).
         super::act_agenda::request_resolution(
-            state,
+            cx.state,
             crate::scenario::Resolution::Lost {
                 reason: "no resolution was reached".into(),
             },
@@ -264,7 +260,14 @@ mod elimination_tests {
         let mut state = TestGame::default().with_investigator(inv).build();
         let mut events = Vec::new();
 
-        apply_investigator_defeat(&mut state, &mut events, id, DefeatCause::Damage);
+        apply_investigator_defeat(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            id,
+            DefeatCause::Damage,
+        );
 
         let after = &state.investigators[&id];
         assert!(after.hand.is_empty(), "hand drained");
@@ -303,7 +306,14 @@ mod elimination_tests {
             .build();
         let mut events = Vec::new();
 
-        apply_investigator_defeat(&mut state, &mut events, id, DefeatCause::Damage);
+        apply_investigator_defeat(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            id,
+            DefeatCause::Damage,
+        );
 
         assert_eq!(
             state.locations[&loc_id].clues, 3,
@@ -349,7 +359,14 @@ mod elimination_tests {
             .build();
         let mut events = Vec::new();
 
-        apply_investigator_defeat(&mut state, &mut events, dead, DefeatCause::Damage);
+        apply_investigator_defeat(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            dead,
+            DefeatCause::Damage,
+        );
 
         assert_event!(events, Event::EnemyDisengaged { enemy, investigator }
             if *enemy == EnemyId(1) && *investigator == dead);
@@ -391,7 +408,14 @@ mod elimination_tests {
             .build();
         let mut events = Vec::new();
 
-        apply_investigator_defeat(&mut state, &mut events, dead, DefeatCause::Damage);
+        apply_investigator_defeat(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            dead,
+            DefeatCause::Damage,
+        );
 
         assert_event!(events, Event::EnemyDisengaged { enemy, investigator }
             if *enemy == EnemyId(1) && *investigator == dead);
@@ -419,7 +443,14 @@ mod elimination_tests {
         let mut events = Vec::new();
 
         // Apply lethal horror through the standard defeat path.
-        take_horror(&mut state, &mut events, inv, 1);
+        take_horror(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            inv,
+            1,
+        );
 
         assert_event!(events, Event::AllInvestigatorsDefeated);
         assert!(
@@ -461,7 +492,14 @@ mod elimination_tests {
             .build();
         let mut events = Vec::new();
 
-        apply_investigator_defeat(&mut state, &mut events, dead, DefeatCause::Horror);
+        apply_investigator_defeat(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            dead,
+            DefeatCause::Horror,
+        );
 
         assert_eq!(state.investigators[&dead].status, Status::Insane);
         assert_eq!(state.locations[&loc].clues, 1, "clue placed at location");
@@ -503,7 +541,14 @@ mod elimination_tests {
             .build();
         let mut events = Vec::new();
 
-        apply_investigator_defeat(&mut state, &mut events, dead, DefeatCause::Damage);
+        apply_investigator_defeat(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            dead,
+            DefeatCause::Damage,
+        );
 
         assert_event!(events, Event::EnemyDisengaged { enemy, investigator }
             if *enemy == EnemyId(1) && *investigator == dead);
@@ -526,7 +571,14 @@ mod elimination_tests {
         let mut state = TestGame::default().with_investigator(inv).build();
         let mut events = Vec::new();
 
-        apply_investigator_defeat(&mut state, &mut events, id, DefeatCause::Damage);
+        apply_investigator_defeat(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            id,
+            DefeatCause::Damage,
+        );
 
         assert_eq!(
             state.investigators[&id].clues, 0,

--- a/crates/game-core/src/engine/dispatch/elimination.rs
+++ b/crates/game-core/src/engine/dispatch/elimination.rs
@@ -189,7 +189,7 @@ pub(super) fn take_horror(
     investigator: InvestigatorId,
     amount: u8,
 ) {
-    if super::combat::apply_horror_numeric(state, events, investigator, amount) {
+    if super::combat::apply_horror_numeric(&mut super::Cx { state, events }, investigator, amount) {
         apply_investigator_defeat(state, events, investigator, DefeatCause::Horror);
     }
 }

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -333,7 +333,7 @@ fn spawn_enemy(
                 location: location_id,
                 engaged_with: Some(target),
             });
-            super::hunters::engage_enemy_with(cx.state, cx.events, enemy_id, target);
+            super::hunters::engage_enemy_with(cx, enemy_id, target);
             EngineOutcome::Done
         }
         super::hunters::PreyResolution::Tie(tied) => {
@@ -1246,8 +1246,10 @@ mod spawn_enemy_tests {
 
         // Investigator 3 is not among the co-located candidates.
         let outcome = super::super::hunters::resume_spawn_engage(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &InputResponse::PickInvestigator(InvestigatorId(3)),
         );
         assert!(

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -602,11 +602,7 @@ pub(super) fn advance_mythos_draw_pending(cx: &mut Cx) {
     let next = super::cursor::next_active_investigator_after(cx.state, current);
     cx.state.mythos_draw_pending = next;
     if next.is_none() {
-        super::reaction_windows::open_fast_window(
-            cx.state,
-            cx.events,
-            WindowKind::MythosAfterDraws,
-        );
+        super::reaction_windows::open_fast_window(cx, WindowKind::MythosAfterDraws);
     }
 }
 

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -581,7 +581,12 @@ pub(super) fn run_mythos_draw_chain(
         };
 
         // Step 2: Check for the peril keyword on the drawn card.
-        super::skill_test::peril_check(state, events, &code, investigator, metadata.peril);
+        super::skill_test::peril_check(
+            &mut super::Cx { state, events },
+            &code,
+            investigator,
+            metadata.peril,
+        );
 
         // Step 3 + 4: Resolve revelation, then enemy-spawn if applicable.
         let outcome = resolve_encounter_card(state, events, investigator, code.clone(), metadata);

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -129,7 +129,7 @@ fn resolve_encounter_card(
                 .iter()
                 .filter(|a| a.trigger == Trigger::Revelation)
             {
-                let outcome = apply_effect(cx.state, cx.events, &ability.effect, eval_ctx);
+                let outcome = apply_effect(cx, &ability.effect, eval_ctx);
                 if !matches!(outcome, EngineOutcome::Done) {
                     return outcome;
                 }
@@ -160,7 +160,7 @@ fn resolve_encounter_card(
                 .iter()
                 .filter(|a| a.trigger == Trigger::Revelation)
             {
-                let outcome = apply_effect(cx.state, cx.events, &ability.effect, eval_ctx);
+                let outcome = apply_effect(cx, &ability.effect, eval_ctx);
                 if !matches!(outcome, EngineOutcome::Done) {
                     return outcome;
                 }

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -5,11 +5,12 @@ use crate::card_registry;
 use crate::dsl::Trigger;
 use crate::event::Event;
 use crate::state::{
-    CardCode, Enemy, EnemyId, GameState, InvestigatorId, Phase, SpawnEngagePending, WindowKind,
+    CardCode, Enemy, EnemyId, InvestigatorId, Phase, SpawnEngagePending, WindowKind,
 };
 
 use super::super::evaluator::{apply_effect, EvalContext};
 use super::super::outcome::{EngineOutcome, InputRequest, ResumeToken};
+use super::Cx;
 
 /// Hard cap on a single Mythos draw chain. Real scenarios surge ≤2
 /// in a chain; the cap exists purely to guarantee termination on
@@ -25,11 +26,8 @@ const MAX_SURGE_CHAIN: usize = 64;
 /// emits [`Event::EncounterDeckShuffled`] (when ≥ 2 cards). No
 /// validation — the encounter deck is shared, so there's no
 /// per-investigator existence check.
-pub(super) fn encounter_deck_shuffled(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-) -> EngineOutcome {
-    shuffle_encounter_deck(state, events);
+pub(super) fn encounter_deck_shuffled(cx: &mut Cx) -> EngineOutcome {
+    shuffle_encounter_deck(cx);
     EngineOutcome::Done
 }
 
@@ -66,18 +64,14 @@ pub(super) fn encounter_deck_shuffled(
 ///
 /// Compare to `play_card`'s documented mid-resolution caveat in
 /// CLAUDE.md: same shape, same rationale.
-pub(super) fn encounter_card_revealed(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-) -> EngineOutcome {
+pub(super) fn encounter_card_revealed(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
     let Some(registry) = card_registry::current() else {
         return EngineOutcome::Rejected {
             reason: "EncounterCardRevealed: no card registry installed".into(),
         };
     };
 
-    let Some(code) = draw_encounter_top(state, events) else {
+    let Some(code) = draw_encounter_top(cx) else {
         return EngineOutcome::Rejected {
             reason: "EncounterCardRevealed: encounter deck and discard both empty".into(),
         };
@@ -88,7 +82,7 @@ pub(super) fn encounter_card_revealed(
             reason: format!("EncounterCardRevealed: unknown card code: {code:?}").into(),
         };
     };
-    resolve_encounter_card(state, events, investigator, code, metadata)
+    resolve_encounter_card(cx, investigator, code, metadata)
 }
 
 /// Shared post-draw resolution helper. Resolves the per-card 5-step
@@ -108,8 +102,7 @@ pub(super) fn encounter_card_revealed(
 /// per #126's design decision). The apply loop's `events.clear()`
 /// on Rejected still wipes the event stream on rejection.
 fn resolve_encounter_card(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
+    cx: &mut Cx,
     investigator: InvestigatorId,
     code: CardCode,
     metadata: &CardMetadata,
@@ -117,7 +110,7 @@ fn resolve_encounter_card(
     let card_type = metadata.card_type;
 
     // Emit BEFORE Revelation resolves — see caveat in encounter_card_revealed.
-    events.push(Event::CardRevealed {
+    cx.events.push(Event::CardRevealed {
         investigator,
         code: code.clone(),
         card_type,
@@ -131,17 +124,17 @@ fn resolve_encounter_card(
                 };
             };
             let abilities = (registry.abilities_for)(&code).unwrap_or_default();
-            let ctx = EvalContext::for_controller(investigator);
+            let eval_ctx = EvalContext::for_controller(investigator);
             for ability in abilities
                 .iter()
                 .filter(|a| a.trigger == Trigger::Revelation)
             {
-                let outcome = apply_effect(state, events, &ability.effect, ctx);
+                let outcome = apply_effect(cx.state, cx.events, &ability.effect, eval_ctx);
                 if !matches!(outcome, EngineOutcome::Done) {
                     return outcome;
                 }
             }
-            state.encounter_discard.push(code);
+            cx.state.encounter_discard.push(code);
             EngineOutcome::Done
         }
         CardType::Enemy => {
@@ -162,17 +155,17 @@ fn resolve_encounter_card(
                 };
             };
             let abilities = (registry.abilities_for)(&code).unwrap_or_default();
-            let ctx = EvalContext::for_controller(investigator);
+            let eval_ctx = EvalContext::for_controller(investigator);
             for ability in abilities
                 .iter()
                 .filter(|a| a.trigger == Trigger::Revelation)
             {
-                let outcome = apply_effect(state, events, &ability.effect, ctx);
+                let outcome = apply_effect(cx.state, cx.events, &ability.effect, eval_ctx);
                 if !matches!(outcome, EngineOutcome::Done) {
                     return outcome;
                 }
             }
-            spawn_enemy(state, events, investigator, code, metadata)
+            spawn_enemy(cx, investigator, code, metadata)
         }
         other => EngineOutcome::Rejected {
             reason: format!(
@@ -250,8 +243,7 @@ fn resolve_encounter_card(
 /// pending choice carries the rest of the work to [`resume_spawn_engage`]).
 #[allow(clippy::too_many_lines)]
 fn spawn_enemy(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
+    cx: &mut Cx,
     investigator: InvestigatorId,
     code: CardCode,
     metadata: &CardMetadata,
@@ -260,7 +252,8 @@ fn spawn_enemy(
     let location_id = match &metadata.spawn {
         Some(Spawn {
             location: SpawnLocation::Specific(loc_code),
-        }) => match state
+        }) => match cx
+            .state
             .locations
             .iter()
             .find(|(_, loc)| loc.code.as_str() == loc_code.as_str())
@@ -273,7 +266,8 @@ fn spawn_enemy(
                 };
             }
         },
-        None => match state
+        None => match cx
+            .state
             .investigators
             .get(&investigator)
             .and_then(|inv| inv.current_location)
@@ -295,14 +289,14 @@ fn spawn_enemy(
     //    set is narrowed by the enemy's prey — every spawn uses
     //    `Prey::Default` (Task 2), so a 2+ set always ties and suspends
     //    for the lead investigator's `PickInvestigator` (option A).
-    let candidates = super::cursor::active_investigators_at(state, location_id);
+    let candidates = super::cursor::active_investigators_at(cx.state, location_id);
 
     // 3. Mint and place (mutate-second). The enemy is inserted unengaged;
     //    the `One` and (post-resume) `Tie` cases set `engaged_with` via
     //    `engage_enemy_with` so the `EnemyEngaged` event always pairs with
     //    the mutation.
-    let enemy_id = EnemyId(state.next_enemy_id);
-    state.next_enemy_id = state.next_enemy_id.saturating_add(1);
+    let enemy_id = EnemyId(cx.state.next_enemy_id);
+    cx.state.next_enemy_id = cx.state.next_enemy_id.saturating_add(1);
 
     let enemy = Enemy {
         id: enemy_id,
@@ -320,11 +314,11 @@ fn spawn_enemy(
         hunter: false,
         prey: crate::card_data::Prey::Default,
     };
-    state.enemies.insert(enemy_id, enemy);
+    cx.state.enemies.insert(enemy_id, enemy);
 
-    match super::hunters::resolve_prey(state, crate::card_data::Prey::Default, &candidates) {
+    match super::hunters::resolve_prey(cx.state, crate::card_data::Prey::Default, &candidates) {
         super::hunters::PreyResolution::None => {
-            events.push(Event::EnemySpawned {
+            cx.events.push(Event::EnemySpawned {
                 enemy: enemy_id,
                 code,
                 location: location_id,
@@ -333,17 +327,17 @@ fn spawn_enemy(
             EngineOutcome::Done
         }
         super::hunters::PreyResolution::One(target) => {
-            events.push(Event::EnemySpawned {
+            cx.events.push(Event::EnemySpawned {
                 enemy: enemy_id,
                 code,
                 location: location_id,
                 engaged_with: Some(target),
             });
-            super::hunters::engage_enemy_with(state, events, enemy_id, target);
+            super::hunters::engage_enemy_with(cx.state, cx.events, enemy_id, target);
             EngineOutcome::Done
         }
         super::hunters::PreyResolution::Tie(tied) => {
-            events.push(Event::EnemySpawned {
+            cx.events.push(Event::EnemySpawned {
                 enemy: enemy_id,
                 code,
                 location: location_id,
@@ -354,7 +348,7 @@ fn spawn_enemy(
             // stored value to the live chain position before returning the
             // `AwaitingInput` (the single-draw `EncounterCardRevealed` path
             // has no chain, so 0 is correct there).
-            state.spawn_engage_pending = Some(SpawnEngagePending {
+            cx.state.spawn_engage_pending = Some(SpawnEngagePending {
                 enemy: enemy_id,
                 investigator_to_draw: investigator,
                 candidates: tied.clone(),
@@ -380,8 +374,8 @@ fn spawn_enemy(
 ///
 /// Emits [`Event::EncounterDeckShuffled`] iff the deck had at least
 /// 2 cards (a 0- or 1-card deck has nothing to permute).
-pub(super) fn shuffle_encounter_deck(state: &mut GameState, events: &mut Vec<Event>) {
-    let deck_len = state.encounter_deck.len();
+pub(super) fn shuffle_encounter_deck(cx: &mut Cx) {
+    let deck_len = cx.state.encounter_deck.len();
     if deck_len < 2 {
         return;
     }
@@ -391,14 +385,14 @@ pub(super) fn shuffle_encounter_deck(state: &mut GameState, events: &mut Vec<Eve
     let mut swaps: Vec<(usize, usize)> = Vec::with_capacity(deck_len - 1);
     let mut i = deck_len - 1;
     while i >= 1 {
-        let j = state.rng.next_index(i + 1);
+        let j = cx.state.rng.next_index(i + 1);
         swaps.push((i, j));
         i -= 1;
     }
     for (a, b) in swaps {
-        state.encounter_deck.swap(a, b);
+        cx.state.encounter_deck.swap(a, b);
     }
-    events.push(Event::EncounterDeckShuffled);
+    cx.events.push(Event::EncounterDeckShuffled);
 }
 
 /// Drain `state.encounter_discard` into `state.encounter_deck` and
@@ -411,11 +405,11 @@ pub(super) fn shuffle_encounter_deck(state: &mut GameState, events: &mut Vec<Eve
 /// player-deck pattern. The `EngineRecord` variant is reserved for
 /// explicit shuffle actions (future "shuffle X into the encounter
 /// deck" effects).
-pub(super) fn reshuffle_encounter_discard(state: &mut GameState, events: &mut Vec<Event>) {
-    state
+pub(super) fn reshuffle_encounter_discard(cx: &mut Cx) {
+    cx.state
         .encounter_deck
-        .extend(state.encounter_discard.drain(..));
-    shuffle_encounter_deck(state, events);
+        .extend(cx.state.encounter_discard.drain(..));
+    shuffle_encounter_deck(cx);
 }
 
 /// Draw the top card of the encounter deck, transparently reshuffling
@@ -426,36 +420,29 @@ pub(super) fn reshuffle_encounter_discard(state: &mut GameState, events: &mut Ve
 /// the deck and the discard are empty — callers decide how to
 /// interpret this (#69's Mythos loop treats it as a scenario
 /// condition rather than an engine error).
-pub(super) fn draw_encounter_top(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-) -> Option<CardCode> {
-    if state.encounter_deck.is_empty() {
-        if state.encounter_discard.is_empty() {
+pub(super) fn draw_encounter_top(cx: &mut Cx) -> Option<CardCode> {
+    if cx.state.encounter_deck.is_empty() {
+        if cx.state.encounter_discard.is_empty() {
             return None;
         }
-        reshuffle_encounter_discard(state, events);
+        reshuffle_encounter_discard(cx);
     }
-    state.encounter_deck.pop_front()
+    cx.state.encounter_deck.pop_front()
 }
 
 /// Handler for [`PlayerAction::DrawEncounterCard`]. Validates phase
 /// + cursor; delegates to [`mythos_draw_for`] on success.
-pub(super) fn draw_encounter_card(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-) -> EngineOutcome {
-    if state.phase != Phase::Mythos {
+pub(super) fn draw_encounter_card(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
+    if cx.state.phase != Phase::Mythos {
         return EngineOutcome::Rejected {
             reason: format!(
                 "DrawEncounterCard: only valid during Mythos phase, got {:?}",
-                state.phase,
+                cx.state.phase,
             )
             .into(),
         };
     }
-    match state.mythos_draw_pending {
+    match cx.state.mythos_draw_pending {
         None => EngineOutcome::Rejected {
             reason: "DrawEncounterCard: no draw pending (all investigators have drawn)".into(),
         },
@@ -465,7 +452,7 @@ pub(super) fn draw_encounter_card(
             )
             .into(),
         },
-        Some(_) => mythos_draw_for(state, events, investigator),
+        Some(_) => mythos_draw_for(cx, investigator),
     }
 }
 
@@ -489,14 +476,10 @@ pub(super) fn draw_encounter_card(
 /// scope this can't happen because the synthetic fixture ensures every
 /// investigator has a location at scenario start; revisit if a future
 /// scenario lets investigators reach a location-less state during play.
-fn mythos_draw_for(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-) -> EngineOutcome {
+fn mythos_draw_for(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
     // Fresh chain: count starts at 0 and the loop draws at least one
     // card (`draw_more = true`).
-    run_mythos_draw_chain(state, events, investigator, 0, true)
+    run_mythos_draw_chain(cx, investigator, 0, true)
 }
 
 /// The Mythos surge-draw loop, shared by the initial draw
@@ -526,8 +509,7 @@ fn mythos_draw_for(
 /// mutation. Out of Phase-4 scope (the synthetic fixture gives every
 /// investigator a location at setup).
 pub(super) fn run_mythos_draw_chain(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
+    cx: &mut Cx,
     investigator: InvestigatorId,
     mut chain_count: usize,
     mut draw_more: bool,
@@ -553,7 +535,7 @@ pub(super) fn run_mythos_draw_chain(
         }
 
         // Step 1: Draw the card from the encounter deck.
-        let Some(code) = draw_encounter_top(state, events) else {
+        let Some(code) = draw_encounter_top(cx) else {
             if chain_count == 1 {
                 return EngineOutcome::Rejected {
                     reason: "DrawEncounterCard: encounter deck and discard both empty".into(),
@@ -581,22 +563,17 @@ pub(super) fn run_mythos_draw_chain(
         };
 
         // Step 2: Check for the peril keyword on the drawn card.
-        super::skill_test::peril_check(
-            &mut super::Cx { state, events },
-            &code,
-            investigator,
-            metadata.peril,
-        );
+        super::skill_test::peril_check(cx, &code, investigator, metadata.peril);
 
         // Step 3 + 4: Resolve revelation, then enemy-spawn if applicable.
-        let outcome = resolve_encounter_card(state, events, investigator, code.clone(), metadata);
+        let outcome = resolve_encounter_card(cx, investigator, code.clone(), metadata);
         match outcome {
             EngineOutcome::Done => {}
             EngineOutcome::AwaitingInput { .. } => {
                 // A mid-chain spawn engagement tie suspended. Record the
                 // live chain position so the resume keeps counting toward
                 // the cap rather than restarting its budget.
-                if let Some(pending) = state.spawn_engage_pending.as_mut() {
+                if let Some(pending) = cx.state.spawn_engage_pending.as_mut() {
                     pending.chain_count = chain_count;
                 }
                 return outcome;
@@ -609,22 +586,27 @@ pub(super) fn run_mythos_draw_chain(
     }
 
     // Chain complete — advance the cursor.
-    advance_mythos_draw_pending(state, events);
+    advance_mythos_draw_pending(cx);
     EngineOutcome::Done
 }
 
 /// Advance `state.mythos_draw_pending` after a completed chain. If
 /// a next investigator exists in turn order, set to that id.
 /// Otherwise set to None and open the post-1.4 window.
-pub(super) fn advance_mythos_draw_pending(state: &mut GameState, events: &mut Vec<Event>) {
-    let current = state
+pub(super) fn advance_mythos_draw_pending(cx: &mut Cx) {
+    let current = cx
+        .state
         .mythos_draw_pending
         .expect("advance_mythos_draw_pending called only after a successful chain");
     // Eliminated-skip semantics live in `next_active_investigator_after`.
-    let next = super::cursor::next_active_investigator_after(state, current);
-    state.mythos_draw_pending = next;
+    let next = super::cursor::next_active_investigator_after(cx.state, current);
+    cx.state.mythos_draw_pending = next;
     if next.is_none() {
-        super::reaction_windows::open_fast_window(state, events, WindowKind::MythosAfterDraws);
+        super::reaction_windows::open_fast_window(
+            cx.state,
+            cx.events,
+            WindowKind::MythosAfterDraws,
+        );
     }
 }
 
@@ -727,7 +709,10 @@ mod encounter_deck_helper_tests {
         state.encounter_deck.push_back(CardCode("c".into()));
 
         let mut events = Vec::new();
-        shuffle_encounter_deck(&mut state, &mut events);
+        shuffle_encounter_deck(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert!(matches!(events.as_slice(), [Event::EncounterDeckShuffled]));
         assert_eq!(state.encounter_deck.len(), 3);
@@ -751,7 +736,10 @@ mod encounter_deck_helper_tests {
                 state.encounter_deck.push_back(CardCode(format!("c{i}")));
             }
             let mut events = Vec::new();
-            shuffle_encounter_deck(&mut state, &mut events);
+            shuffle_encounter_deck(&mut Cx {
+                state: &mut state,
+                events: &mut events,
+            });
             assert!(events.is_empty(), "expected no event for n={n} deck");
         }
     }
@@ -765,7 +753,10 @@ mod encounter_deck_helper_tests {
         }
 
         let mut events = Vec::new();
-        reshuffle_encounter_discard(&mut state, &mut events);
+        reshuffle_encounter_discard(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert!(
             state.encounter_discard.is_empty(),
@@ -784,7 +775,10 @@ mod encounter_deck_helper_tests {
         state.encounter_discard.push(CardCode("solo".into()));
 
         let mut events = Vec::new();
-        reshuffle_encounter_discard(&mut state, &mut events);
+        reshuffle_encounter_discard(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert!(state.encounter_discard.is_empty());
         assert_eq!(state.encounter_deck.len(), 1);
@@ -801,18 +795,33 @@ mod encounter_deck_helper_tests {
         let mut events = Vec::new();
 
         assert_eq!(
-            draw_encounter_top(&mut state, &mut events),
+            draw_encounter_top(&mut Cx {
+                state: &mut state,
+                events: &mut events,
+            }),
             Some(CardCode("a".into()))
         );
         assert_eq!(
-            draw_encounter_top(&mut state, &mut events),
+            draw_encounter_top(&mut Cx {
+                state: &mut state,
+                events: &mut events,
+            }),
             Some(CardCode("b".into()))
         );
         assert_eq!(
-            draw_encounter_top(&mut state, &mut events),
+            draw_encounter_top(&mut Cx {
+                state: &mut state,
+                events: &mut events,
+            }),
             Some(CardCode("c".into()))
         );
-        assert_eq!(draw_encounter_top(&mut state, &mut events), None);
+        assert_eq!(
+            draw_encounter_top(&mut Cx {
+                state: &mut state,
+                events: &mut events,
+            }),
+            None
+        );
         assert!(
             events.is_empty(),
             "no events for any draw — discard is always empty, no reshuffle is triggered"
@@ -828,7 +837,10 @@ mod encounter_deck_helper_tests {
         state.encounter_discard.push(CardCode("z".into()));
 
         let mut events = Vec::new();
-        let drawn = draw_encounter_top(&mut state, &mut events);
+        let drawn = draw_encounter_top(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         let drawn_code = drawn.expect("should reshuffle and draw");
         assert!(
@@ -856,7 +868,13 @@ mod encounter_deck_helper_tests {
     fn draw_encounter_top_returns_none_when_deck_and_discard_both_empty() {
         let mut state = TestGame::new().build();
         let mut events = Vec::new();
-        assert_eq!(draw_encounter_top(&mut state, &mut events), None);
+        assert_eq!(
+            draw_encounter_top(&mut Cx {
+                state: &mut state,
+                events: &mut events,
+            }),
+            None
+        );
         assert!(events.is_empty(), "no events on empty-on-both");
     }
 
@@ -899,7 +917,10 @@ mod encounter_deck_helper_tests {
                 state.encounter_deck.push_back(CardCode(format!("c{i:02}")));
             }
             let mut events = Vec::new();
-            shuffle_encounter_deck(&mut state, &mut events);
+            shuffle_encounter_deck(&mut Cx {
+                state: &mut state,
+                events: &mut events,
+            });
             state.encounter_deck.iter().cloned().collect()
         }
 
@@ -972,8 +993,10 @@ mod spawn_enemy_tests {
         let mut events = Vec::new();
 
         let outcome = spawn_enemy(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             InvestigatorId(1),
             CardCode("_synth_enemy".into()),
             &metadata,
@@ -1012,8 +1035,10 @@ mod spawn_enemy_tests {
         let mut events = Vec::new();
 
         let outcome = spawn_enemy(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             InvestigatorId(1),
             CardCode("_synth_enemy".into()),
             &metadata,
@@ -1036,8 +1061,10 @@ mod spawn_enemy_tests {
         }));
         let mut events = Vec::new();
         let outcome = spawn_enemy(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             InvestigatorId(1),
             CardCode("_synth_enemy".into()),
             &metadata,
@@ -1072,8 +1099,10 @@ mod spawn_enemy_tests {
         let mut events = Vec::new();
 
         let outcome = spawn_enemy(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             InvestigatorId(1),
             CardCode("_synth_enemy".into()),
             &metadata,
@@ -1100,8 +1129,10 @@ mod spawn_enemy_tests {
         let metadata = synth_enemy_metadata(None);
         let mut events = Vec::new();
         let outcome = spawn_enemy(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             InvestigatorId(1),
             CardCode("_synth_enemy".into()),
             &metadata,
@@ -1134,8 +1165,10 @@ mod spawn_enemy_tests {
         let metadata = synth_enemy_metadata(None);
         let mut events = Vec::new();
         let outcome = spawn_enemy(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             InvestigatorId(1),
             CardCode("_synth_enemy".into()),
             &metadata,
@@ -1164,8 +1197,10 @@ mod spawn_enemy_tests {
         let metadata = synth_enemy_metadata(None);
         let mut events = Vec::new();
         let outcome = spawn_enemy(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             InvestigatorId(1),
             CardCode("_synth_enemy".into()),
             &metadata,
@@ -1199,8 +1234,10 @@ mod spawn_enemy_tests {
         let metadata = synth_enemy_metadata(None);
         let mut events = Vec::new();
         let _ = spawn_enemy(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             InvestigatorId(1),
             CardCode("_synth_enemy".into()),
             &metadata,
@@ -1244,15 +1281,19 @@ mod spawn_enemy_tests {
         let mut events = Vec::new();
 
         let _ = spawn_enemy(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             InvestigatorId(1),
             CardCode("_synth_enemy".into()),
             &metadata,
         );
         let _ = spawn_enemy(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             InvestigatorId(1),
             CardCode("_synth_enemy".into()),
             &metadata,
@@ -1300,7 +1341,13 @@ mod mythos_draw_for_tests {
             .push_back(CardCode("__no_such_card".into()));
         let pre_deck_len = state.encounter_deck.len();
         let mut events = Vec::new();
-        let outcome = mythos_draw_for(&mut state, &mut events, InvestigatorId(1));
+        let outcome = mythos_draw_for(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            InvestigatorId(1),
+        );
         match outcome {
             EngineOutcome::Rejected { reason } => {
                 assert!(
@@ -1336,7 +1383,13 @@ mod draw_encounter_card_tests {
             .build();
         state.mythos_draw_pending = Some(InvestigatorId(1));
         let mut events = Vec::new();
-        let outcome = draw_encounter_card(&mut state, &mut events, InvestigatorId(1));
+        let outcome = draw_encounter_card(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            InvestigatorId(1),
+        );
         assert!(matches!(
             outcome,
             EngineOutcome::Rejected { reason } if reason.contains("only valid during Mythos")
@@ -1351,7 +1404,13 @@ mod draw_encounter_card_tests {
             .build();
         state.mythos_draw_pending = None;
         let mut events = Vec::new();
-        let outcome = draw_encounter_card(&mut state, &mut events, InvestigatorId(1));
+        let outcome = draw_encounter_card(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            InvestigatorId(1),
+        );
         assert!(matches!(
             outcome,
             EngineOutcome::Rejected { reason } if reason.contains("no draw pending")
@@ -1368,7 +1427,13 @@ mod draw_encounter_card_tests {
         state.mythos_draw_pending = Some(InvestigatorId(1));
         let mut events = Vec::new();
         // Inv2 attempts to draw when inv1 is expected.
-        let outcome = draw_encounter_card(&mut state, &mut events, InvestigatorId(2));
+        let outcome = draw_encounter_card(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            InvestigatorId(2),
+        );
         assert!(matches!(
             outcome,
             EngineOutcome::Rejected { reason } if reason.contains("out of order")

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -667,8 +667,10 @@ mod encounter_card_revealed_tests {
         let mut events = Vec::new();
 
         let outcome = super::super::apply_engine_record(
-            &mut state,
-            &mut events,
+            &mut crate::engine::Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &EngineRecord::EncounterCardRevealed {
                 investigator: InvestigatorId(1),
             },

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -787,8 +787,10 @@ mod hunter_resume_tests {
         // Resume by picking C.
         let mut ev2 = Vec::new();
         let resumed = super::super::resolve_input(
-            &mut state,
-            &mut ev2,
+            &mut crate::engine::Cx {
+                state: &mut state,
+                events: &mut ev2,
+            },
             &crate::action::InputResponse::PickLocation(LocationId(3)),
         );
         assert_eq!(resumed, EngineOutcome::Done);
@@ -831,8 +833,10 @@ mod hunter_resume_tests {
         let mut ev2 = Vec::new();
         // LocationId(4) is the destination, not a first-step candidate.
         let result = super::super::resolve_input(
-            &mut state,
-            &mut ev2,
+            &mut crate::engine::Cx {
+                state: &mut state,
+                events: &mut ev2,
+            },
             &crate::action::InputResponse::PickLocation(LocationId(4)),
         );
         assert!(matches!(result, EngineOutcome::Rejected { .. }));
@@ -876,8 +880,10 @@ mod hunter_resume_tests {
         assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
         let mut ev2 = Vec::new();
         let resumed = super::super::resolve_input(
-            &mut state,
-            &mut ev2,
+            &mut crate::engine::Cx {
+                state: &mut state,
+                events: &mut ev2,
+            },
             &crate::action::InputResponse::PickInvestigator(InvestigatorId(2)),
         );
         assert_eq!(resumed, EngineOutcome::Done);
@@ -972,8 +978,10 @@ mod hunter_resume_tests {
         // Resolve hunter 1's tie -> hunter 2 then moves B->D and engages.
         let mut ev2 = Vec::new();
         let resumed = super::super::resolve_input(
-            &mut state,
-            &mut ev2,
+            &mut crate::engine::Cx {
+                state: &mut state,
+                events: &mut ev2,
+            },
             &crate::action::InputResponse::PickLocation(LocationId(2)),
         );
         assert_eq!(resumed, EngineOutcome::Done);
@@ -1023,8 +1031,10 @@ mod hunter_resume_tests {
         // Submit PickInvestigator when PickLocation is expected.
         let mut ev2 = Vec::new();
         let result = super::super::resolve_input(
-            &mut state,
-            &mut ev2,
+            &mut crate::engine::Cx {
+                state: &mut state,
+                events: &mut ev2,
+            },
             &crate::action::InputResponse::PickInvestigator(InvestigatorId(1)),
         );
         assert!(
@@ -1075,8 +1085,10 @@ mod hunter_resume_tests {
         // Submit PickLocation when PickInvestigator is expected.
         let mut ev2 = Vec::new();
         let result = super::super::resolve_input(
-            &mut state,
-            &mut ev2,
+            &mut crate::engine::Cx {
+                state: &mut state,
+                events: &mut ev2,
+            },
             &crate::action::InputResponse::PickLocation(LocationId(1)),
         );
         assert!(

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -405,7 +405,7 @@ pub(super) fn resume_hunter_choice(
     // per-investigator attack loop (step 3.3). Reached only on the
     // no-further-suspension path; every suspension above early-returns
     // via `suspend_hunter_choice`.
-    super::phases::enemy_attack_kickoff(state, events);
+    super::phases::enemy_attack_kickoff(&mut super::Cx { state, events });
     EngineOutcome::Done
 }
 

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -462,8 +462,7 @@ pub(super) fn resume_spawn_engage(
     // "we suspended mid-chain for this investigator."
     if state.mythos_draw_pending == Some(pending.investigator_to_draw) {
         super::encounter::run_mythos_draw_chain(
-            state,
-            events,
+            &mut super::Cx { state, events },
             pending.investigator_to_draw,
             pending.chain_count,
             pending.surge,

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -6,6 +6,7 @@ use crate::event::Event;
 use crate::state::{Enemy, EnemyId, GameState, HunterChoice, InvestigatorId, LocationId};
 
 use super::cursor;
+use super::Cx;
 use crate::engine::outcome::{EngineOutcome, InputRequest, ResumeToken};
 
 /// Result of narrowing a candidate investigator set by a prey
@@ -143,17 +144,12 @@ fn hunter_destinations(state: &GameState, from: LocationId, prey: Prey) -> Vec<L
 
 /// Move `enemy` to `to`, emitting [`Event::EnemyMoved`]. Caller has
 /// already validated that `to` is a legal destination.
-fn move_hunter_to(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    enemy_id: EnemyId,
-    to: LocationId,
-) {
-    let enemy = state.enemies.get_mut(&enemy_id).unwrap_or_else(|| {
+fn move_hunter_to(cx: &mut Cx, enemy_id: EnemyId, to: LocationId) {
+    let enemy = cx.state.enemies.get_mut(&enemy_id).unwrap_or_else(|| {
         unreachable!("move_hunter_to: enemy {enemy_id:?} vanished mid-movement; state corruption")
     });
     enemy.current_location = Some(to);
-    events.push(Event::EnemyMoved {
+    cx.events.push(Event::EnemyMoved {
         enemy: enemy_id,
         to,
     });
@@ -161,17 +157,12 @@ fn move_hunter_to(
 
 /// Set engagement on `enemy_id` → `target` and emit
 /// [`Event::EnemyEngaged`]. Shared by movement and spawn.
-pub(super) fn engage_enemy_with(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    enemy_id: EnemyId,
-    target: InvestigatorId,
-) {
-    let enemy = state.enemies.get_mut(&enemy_id).unwrap_or_else(|| {
+pub(super) fn engage_enemy_with(cx: &mut Cx, enemy_id: EnemyId, target: InvestigatorId) {
+    let enemy = cx.state.enemies.get_mut(&enemy_id).unwrap_or_else(|| {
         unreachable!("engage_enemy_with: enemy {enemy_id:?} vanished; state corruption")
     });
     enemy.engaged_with = Some(target);
-    events.push(Event::EnemyEngaged {
+    cx.events.push(Event::EnemyEngaged {
         enemy: enemy_id,
         investigator: target,
     });
@@ -181,22 +172,18 @@ pub(super) fn engage_enemy_with(
 /// location. Returns `Some(HunterChoice::Engage{..})` if the co-located
 /// set ties under prey (caller suspends); otherwise engages the resolved
 /// investigator (or no-one) and returns `None`.
-fn engage_on_arrival(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    enemy_id: EnemyId,
-) -> Option<HunterChoice> {
-    let loc = state.enemies[&enemy_id]
+fn engage_on_arrival(cx: &mut Cx, enemy_id: EnemyId) -> Option<HunterChoice> {
+    let loc = cx.state.enemies[&enemy_id]
         .current_location
         .unwrap_or_else(|| {
             unreachable!("engage_on_arrival: enemy {enemy_id:?} has no location; state corruption")
         });
-    let prey = state.enemies[&enemy_id].prey;
-    let candidates = cursor::active_investigators_at(state, loc);
-    match resolve_prey(state, prey, &candidates) {
+    let prey = cx.state.enemies[&enemy_id].prey;
+    let candidates = cursor::active_investigators_at(cx.state, loc);
+    match resolve_prey(cx.state, prey, &candidates) {
         PreyResolution::None => None,
         PreyResolution::One(target) => {
-            engage_enemy_with(state, events, enemy_id, target);
+            engage_enemy_with(cx, enemy_id, target);
             None
         }
         PreyResolution::Tie(v) => Some(HunterChoice::Engage {
@@ -227,12 +214,8 @@ fn engage_on_arrival(
 /// not disengage a prior target or emit [`Event::EnemyDisengaged`];
 /// callers are responsible for clearing (and announcing) any existing
 /// engagement first.
-pub(super) fn reengage_at_location(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    enemy_id: EnemyId,
-) {
-    let enemy = &state.enemies[&enemy_id];
+pub(super) fn reengage_at_location(cx: &mut Cx, enemy_id: EnemyId) {
+    let enemy = &cx.state.enemies[&enemy_id];
     if enemy.exhausted {
         return;
     }
@@ -240,33 +223,29 @@ pub(super) fn reengage_at_location(
         return;
     };
     let prey = enemy.prey;
-    let candidates = cursor::active_investigators_at(state, loc);
-    match resolve_prey(state, prey, &candidates) {
+    let candidates = cursor::active_investigators_at(cx.state, loc);
+    match resolve_prey(cx.state, prey, &candidates) {
         PreyResolution::None => {}
-        PreyResolution::One(target) => engage_enemy_with(state, events, enemy_id, target),
-        PreyResolution::Tie(tied) => engage_enemy_with(state, events, enemy_id, tied[0]),
+        PreyResolution::One(target) => engage_enemy_with(cx, enemy_id, target),
+        PreyResolution::Tie(tied) => engage_enemy_with(cx, enemy_id, tied[0]),
     }
 }
 
 /// Process a single hunter (movement + engage-on-arrival). Returns
 /// `Some(HunterChoice)` if a tie suspends, else `None` (fully resolved).
-fn process_one_hunter(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    enemy_id: EnemyId,
-) -> Option<HunterChoice> {
-    let from = state.enemies[&enemy_id]
+fn process_one_hunter(cx: &mut Cx, enemy_id: EnemyId) -> Option<HunterChoice> {
+    let from = cx.state.enemies[&enemy_id]
         .current_location
         .unwrap_or_else(|| {
             unreachable!("process_one_hunter: enemy {enemy_id:?} has no location; state corruption")
         });
-    let here = cursor::active_investigators_at(state, from);
+    let here = cursor::active_investigators_at(cx.state, from);
     if here.is_empty() {
-        let prey = state.enemies[&enemy_id].prey;
-        let dests = hunter_destinations(state, from, prey);
+        let prey = cx.state.enemies[&enemy_id].prey;
+        let dests = hunter_destinations(cx.state, from, prey);
         match dests.as_slice() {
             [] => return None,
-            [one] => move_hunter_to(state, events, enemy_id, *one),
+            [one] => move_hunter_to(cx, enemy_id, *one),
             _ => {
                 return Some(HunterChoice::Move {
                     enemy: enemy_id,
@@ -275,7 +254,7 @@ fn process_one_hunter(
             }
         }
     }
-    engage_on_arrival(state, events, enemy_id)
+    engage_on_arrival(cx, enemy_id)
 }
 
 /// Find the next eligible hunter with id strictly greater than `after`
@@ -294,11 +273,11 @@ fn next_eligible_hunter(state: &GameState, after: Option<EnemyId>) -> Option<Ene
 /// `EnemyId` order until none remain ([`EngineOutcome::Done`]) or one
 /// suspends on a lead-investigator tie
 /// ([`EngineOutcome::AwaitingInput`]).
-pub(crate) fn drive_hunter_moves(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome {
+pub(crate) fn drive_hunter_moves(cx: &mut Cx) -> EngineOutcome {
     let mut cursor: Option<EnemyId> = None;
-    while let Some(id) = next_eligible_hunter(state, cursor) {
-        if let Some(choice) = process_one_hunter(state, events, id) {
-            return suspend_hunter_choice(state, choice);
+    while let Some(id) = next_eligible_hunter(cx.state, cursor) {
+        if let Some(choice) = process_one_hunter(cx, id) {
+            return suspend_hunter_choice(cx, choice);
         }
         cursor = Some(id);
     }
@@ -307,7 +286,7 @@ pub(crate) fn drive_hunter_moves(state: &mut GameState, events: &mut Vec<Event>)
 
 /// Store the pending hunter choice and return `AwaitingInput` for the
 /// lead investigator (#128, Task 7 wires the resume path).
-fn suspend_hunter_choice(state: &mut GameState, choice: HunterChoice) -> EngineOutcome {
+fn suspend_hunter_choice(cx: &mut Cx, choice: HunterChoice) -> EngineOutcome {
     let prompt = match &choice {
         HunterChoice::Move { enemy, candidates } => format!(
             "Hunter {enemy:?} movement: lead investigator picks a destination among \
@@ -318,7 +297,7 @@ fn suspend_hunter_choice(state: &mut GameState, choice: HunterChoice) -> EngineO
              {candidates:?} (submit InputResponse::PickInvestigator)"
         ),
     };
-    state.hunter_move_pending = Some(choice);
+    cx.state.hunter_move_pending = Some(choice);
     EngineOutcome::AwaitingInput {
         request: InputRequest { prompt },
         resume_token: ResumeToken(0),
@@ -331,11 +310,10 @@ fn suspend_hunter_choice(state: &mut GameState, choice: HunterChoice) -> EngineO
 /// invalid pick, rejects and leaves `hunter_move_pending` untouched so
 /// the client can retry. (#128)
 pub(super) fn resume_hunter_choice(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
+    cx: &mut Cx,
     response: &crate::action::InputResponse,
 ) -> EngineOutcome {
-    let pending = state.hunter_move_pending.clone().unwrap_or_else(|| {
+    let pending = cx.state.hunter_move_pending.clone().unwrap_or_else(|| {
         unreachable!("resume_hunter_choice: called with no pending hunter choice")
     });
     let current_enemy = match (&pending, response) {
@@ -351,12 +329,12 @@ pub(super) fn resume_hunter_choice(
                     .into(),
                 };
             }
-            state.hunter_move_pending = None;
-            move_hunter_to(state, events, *enemy, *loc);
+            cx.state.hunter_move_pending = None;
+            move_hunter_to(cx, *enemy, *loc);
             // After the move, attempt engage-on-arrival; that itself may
             // suspend on an engagement tie.
-            if let Some(choice) = engage_on_arrival(state, events, *enemy) {
-                return suspend_hunter_choice(state, choice);
+            if let Some(choice) = engage_on_arrival(cx, *enemy) {
+                return suspend_hunter_choice(cx, choice);
             }
             *enemy
         }
@@ -372,8 +350,8 @@ pub(super) fn resume_hunter_choice(
                     .into(),
                 };
             }
-            state.hunter_move_pending = None;
-            engage_enemy_with(state, events, *enemy, *who);
+            cx.state.hunter_move_pending = None;
+            engage_enemy_with(cx, *enemy, *who);
             *enemy
         }
         (HunterChoice::Move { .. }, other) => {
@@ -395,9 +373,9 @@ pub(super) fn resume_hunter_choice(
     };
     // Continue with the next eligible hunter after the one we finished.
     let mut cursor = Some(current_enemy);
-    while let Some(id) = next_eligible_hunter(state, cursor) {
-        if let Some(choice) = process_one_hunter(state, events, id) {
-            return suspend_hunter_choice(state, choice);
+    while let Some(id) = next_eligible_hunter(cx.state, cursor) {
+        if let Some(choice) = process_one_hunter(cx, id) {
+            return suspend_hunter_choice(cx, choice);
         }
         cursor = Some(id);
     }
@@ -405,7 +383,7 @@ pub(super) fn resume_hunter_choice(
     // per-investigator attack loop (step 3.3). Reached only on the
     // no-further-suspension path; every suspension above early-returns
     // via `suspend_hunter_choice`.
-    super::phases::enemy_attack_kickoff(&mut super::Cx { state, events });
+    super::phases::enemy_attack_kickoff(cx);
     EngineOutcome::Done
 }
 
@@ -423,11 +401,10 @@ pub(super) fn resume_hunter_choice(
 /// `None`, or points elsewhere) engages and stops at `Done` without
 /// touching the cursor.
 pub(super) fn resume_spawn_engage(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
+    cx: &mut Cx,
     response: &crate::action::InputResponse,
 ) -> EngineOutcome {
-    let pending = state.spawn_engage_pending.clone().unwrap_or_else(|| {
+    let pending = cx.state.spawn_engage_pending.clone().unwrap_or_else(|| {
         unreachable!("resume_spawn_engage: called with no pending spawn engagement")
     });
     let crate::action::InputResponse::PickInvestigator(who) = response else {
@@ -448,8 +425,8 @@ pub(super) fn resume_spawn_engage(
             .into(),
         };
     }
-    state.spawn_engage_pending = None;
-    engage_enemy_with(state, events, pending.enemy, *who);
+    cx.state.spawn_engage_pending = None;
+    engage_enemy_with(cx, pending.enemy, *who);
 
     // Only re-enter the Mythos surge chain if the suspend happened
     // mid-chain (the drawing investigator is still the pending cursor).
@@ -460,9 +437,9 @@ pub(super) fn resume_spawn_engage(
     // retarget the Mythos cursor between suspend and resume. Hence
     // `mythos_draw_pending == Some(investigator_to_draw)` reliably means
     // "we suspended mid-chain for this investigator."
-    if state.mythos_draw_pending == Some(pending.investigator_to_draw) {
+    if cx.state.mythos_draw_pending == Some(pending.investigator_to_draw) {
         super::encounter::run_mythos_draw_chain(
-            &mut super::Cx { state, events },
+            cx,
             pending.investigator_to_draw,
             pending.chain_count,
             pending.surge,
@@ -551,6 +528,7 @@ mod resolve_prey_tests {
 #[cfg(test)]
 mod hunter_movement_tests {
     use super::*;
+    use crate::engine::Cx;
     use crate::state::{EnemyId, InvestigatorId, LocationId, Phase};
     use crate::test_support::{test_enemy, test_investigator, test_location, TestGame};
     use crate::{assert_event, assert_no_event};
@@ -580,7 +558,10 @@ mod hunter_movement_tests {
             .with_enemy(ghoul)
             .build();
         let mut events = Vec::new();
-        let outcome = drive_hunter_moves(&mut state, &mut events);
+        let outcome = drive_hunter_moves(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         assert_eq!(outcome, EngineOutcome::Done);
         assert_eq!(
             state.enemies[&EnemyId(1)].current_location,
@@ -612,7 +593,10 @@ mod hunter_movement_tests {
             .with_enemy(h)
             .build();
         let mut events = Vec::new();
-        drive_hunter_moves(&mut state, &mut events);
+        drive_hunter_moves(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         assert_eq!(
             state.enemies[&EnemyId(1)].current_location,
             Some(LocationId(2))
@@ -643,7 +627,10 @@ mod hunter_movement_tests {
             .with_enemy(h)
             .build();
         let mut events = Vec::new();
-        drive_hunter_moves(&mut state, &mut events);
+        drive_hunter_moves(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         assert_eq!(
             state.enemies[&EnemyId(1)].current_location,
             Some(LocationId(9))
@@ -672,7 +659,10 @@ mod hunter_movement_tests {
             .with_enemy(h)
             .build();
         let mut events = Vec::new();
-        drive_hunter_moves(&mut state, &mut events);
+        drive_hunter_moves(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         assert_eq!(
             state.enemies[&EnemyId(1)].current_location,
             Some(LocationId(1))
@@ -700,7 +690,10 @@ mod hunter_movement_tests {
             .with_enemy(e)
             .build();
         let mut events = Vec::new();
-        drive_hunter_moves(&mut state, &mut events);
+        drive_hunter_moves(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         assert_eq!(
             state.enemies[&EnemyId(1)].current_location,
             Some(LocationId(1))
@@ -730,7 +723,10 @@ mod hunter_movement_tests {
             .with_enemy(h)
             .build();
         let mut events = Vec::new();
-        let outcome = drive_hunter_moves(&mut state, &mut events);
+        let outcome = drive_hunter_moves(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         assert_eq!(outcome, EngineOutcome::Done);
         assert_eq!(
             state.enemies[&EnemyId(1)].current_location,
@@ -749,6 +745,7 @@ mod hunter_movement_tests {
 mod hunter_resume_tests {
     use super::*;
     use crate::assert_event;
+    use crate::engine::Cx;
     use crate::state::{EnemyId, InvestigatorId, LocationId, Phase};
     use crate::test_support::{test_enemy, test_investigator, test_location, TestGame};
 
@@ -780,7 +777,10 @@ mod hunter_resume_tests {
             .with_enemy(hunter)
             .build();
         let mut events = Vec::new();
-        let outcome = drive_hunter_moves(&mut state, &mut events);
+        let outcome = drive_hunter_moves(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
         assert!(state.hunter_move_pending.is_some());
         // Resume by picking C.
@@ -828,7 +828,10 @@ mod hunter_resume_tests {
             .with_enemy(hunter)
             .build();
         let mut events = Vec::new();
-        drive_hunter_moves(&mut state, &mut events);
+        drive_hunter_moves(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         let mut ev2 = Vec::new();
         // LocationId(4) is the destination, not a first-step candidate.
         let result = super::super::resolve_input(
@@ -870,7 +873,10 @@ mod hunter_resume_tests {
             .with_enemy(h)
             .build();
         let mut events = Vec::new();
-        let outcome = drive_hunter_moves(&mut state, &mut events);
+        let outcome = drive_hunter_moves(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         // Moved to B already, suspended on engagement tie.
         assert_eq!(
             state.enemies[&EnemyId(1)].current_location,
@@ -925,7 +931,10 @@ mod hunter_resume_tests {
             .with_enemy(hunter)
             .build();
         let mut events = Vec::new();
-        let outcome = drive_hunter_moves(&mut state, &mut events);
+        let outcome = drive_hunter_moves(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         assert_eq!(outcome, EngineOutcome::Done);
         // Moves toward inv1 (B) and engages immediately (arrives at B).
         assert_eq!(
@@ -972,7 +981,10 @@ mod hunter_resume_tests {
             .with_enemy(clean_hunter)
             .build();
         let mut events = Vec::new();
-        let outcome = drive_hunter_moves(&mut state, &mut events);
+        let outcome = drive_hunter_moves(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
         // Resolve hunter 1's tie -> hunter 2 then moves B->D and engages.
         let mut ev2 = Vec::new();
@@ -1024,7 +1036,10 @@ mod hunter_resume_tests {
             .with_enemy(hunter)
             .build();
         let mut events = Vec::new();
-        let outcome = drive_hunter_moves(&mut state, &mut events);
+        let outcome = drive_hunter_moves(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
         assert!(state.hunter_move_pending.is_some());
         // Submit PickInvestigator when PickLocation is expected.
@@ -1073,7 +1088,10 @@ mod hunter_resume_tests {
             .with_enemy(hunter)
             .build();
         let mut events = Vec::new();
-        let outcome = drive_hunter_moves(&mut state, &mut events);
+        let outcome = drive_hunter_moves(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         // Moved to B already, suspended on engagement tie.
         assert_eq!(
             state.enemies[&EnemyId(1)].current_location,
@@ -1106,6 +1124,7 @@ mod reengage_tests {
     use super::*;
     use crate::assert_event;
     use crate::assert_no_event;
+    use crate::engine::Cx;
     use crate::test_support::{test_enemy, test_investigator, test_location, TestGame};
 
     #[test]
@@ -1131,7 +1150,13 @@ mod reengage_tests {
             .build();
         let mut events = Vec::new();
 
-        reengage_at_location(&mut state, &mut events, EnemyId(1));
+        reengage_at_location(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            EnemyId(1),
+        );
 
         assert_eq!(state.enemies[&EnemyId(1)].engaged_with, Some(surv));
         assert_event!(events, Event::EnemyEngaged { enemy, investigator }
@@ -1154,7 +1179,13 @@ mod reengage_tests {
             .build();
         let mut events = Vec::new();
 
-        reengage_at_location(&mut state, &mut events, EnemyId(1));
+        reengage_at_location(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            EnemyId(1),
+        );
 
         assert_eq!(state.enemies[&EnemyId(1)].engaged_with, None);
         assert_no_event!(events, Event::EnemyEngaged { .. });
@@ -1187,7 +1218,13 @@ mod reengage_tests {
             .build();
         let mut events = Vec::new();
 
-        reengage_at_location(&mut state, &mut events, EnemyId(1));
+        reengage_at_location(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            EnemyId(1),
+        );
 
         assert_eq!(
             state.enemies[&EnemyId(1)].engaged_with,
@@ -1222,7 +1259,13 @@ mod reengage_tests {
             .build();
         let mut events = Vec::new();
 
-        reengage_at_location(&mut state, &mut events, EnemyId(1));
+        reengage_at_location(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            EnemyId(1),
+        );
 
         assert_eq!(state.enemies[&EnemyId(1)].engaged_with, None);
         assert_no_event!(events, Event::EnemyEngaged { .. });
@@ -1238,7 +1281,13 @@ mod reengage_tests {
         };
         let mut state = TestGame::default().with_enemy(enemy).build();
         let mut events = Vec::new();
-        reengage_at_location(&mut state, &mut events, EnemyId(1));
+        reengage_at_location(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            EnemyId(1),
+        );
         assert_eq!(state.enemies[&EnemyId(1)].engaged_with, None);
         assert_no_event!(events, Event::EnemyEngaged { .. });
     }

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -322,7 +322,7 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
     }
 
     if cx.state.top_reaction_window().is_some() {
-        return reaction_windows::resume_reaction_window(cx.state, cx.events, response);
+        return reaction_windows::resume_reaction_window(cx, response);
     }
 
     // Pure-Fast window path (Option B): no reaction-driven window is
@@ -332,7 +332,7 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
     if !cx.state.open_windows.is_empty() {
         if matches!(response, InputResponse::Skip) {
             let idx = cx.state.open_windows.len() - 1;
-            return reaction_windows::close_reaction_window_at(cx.state, cx.events, idx);
+            return reaction_windows::close_reaction_window_at(cx, idx);
         }
         return EngineOutcome::Rejected {
             reason: format!(

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -171,7 +171,7 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
         },
         PlayerAction::ResolveInput { response } => resolve_input(cx, response),
         PlayerAction::AdvanceAct { investigator } => {
-            act_agenda::advance_act_action(cx.state, cx.events, *investigator)
+            act_agenda::advance_act_action(cx, *investigator)
         }
     };
 

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -130,13 +130,11 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
         } => {
             skill_test::perform_skill_test(cx.state, cx.events, *investigator, *skill, *difficulty)
         }
-        PlayerAction::Investigate { investigator } => {
-            actions::investigate(cx.state, cx.events, *investigator)
-        }
+        PlayerAction::Investigate { investigator } => actions::investigate(cx, *investigator),
         PlayerAction::Move {
             investigator,
             destination,
-        } => actions::move_action(cx.state, cx.events, *investigator, *destination),
+        } => actions::move_action(cx, *investigator, *destination),
         PlayerAction::Draw { investigator } => cards::draw(cx.state, cx.events, *investigator),
         PlayerAction::Mulligan {
             investigator,
@@ -145,11 +143,11 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
         PlayerAction::Fight {
             investigator,
             enemy,
-        } => actions::fight(cx.state, cx.events, *investigator, *enemy),
+        } => actions::fight(cx, *investigator, *enemy),
         PlayerAction::Evade {
             investigator,
             enemy,
-        } => actions::evade(cx.state, cx.events, *investigator, *enemy),
+        } => actions::evade(cx, *investigator, *enemy),
         PlayerAction::PlayCard {
             investigator,
             hand_index,

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -164,7 +164,7 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
         PlayerAction::DrawEncounterCard => match cx.state.mythos_draw_pending {
             // DrawEncounterCard carries no investigator payload — the
             // acting investigator IS the pending cursor.
-            Some(actor) => encounter::draw_encounter_card(cx.state, cx.events, actor),
+            Some(actor) => encounter::draw_encounter_card(cx, actor),
             None => EngineOutcome::Rejected {
                 reason: "DrawEncounterCard: no draw pending (all investigators have drawn)".into(),
             },
@@ -217,11 +217,9 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
 pub fn apply_engine_record(cx: &mut Cx, record: &EngineRecord) -> EngineOutcome {
     match record {
         EngineRecord::DeckShuffled { investigator } => cards::deck_shuffled(cx, *investigator),
-        EngineRecord::EncounterDeckShuffled => {
-            encounter::encounter_deck_shuffled(cx.state, cx.events)
-        }
+        EngineRecord::EncounterDeckShuffled => encounter::encounter_deck_shuffled(cx),
         EngineRecord::EncounterCardRevealed { investigator } => {
-            encounter::encounter_card_revealed(cx.state, cx.events, *investigator)
+            encounter::encounter_card_revealed(cx, *investigator)
         }
     }
 }

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -154,13 +154,7 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
             investigator,
             instance_id,
             ability_index,
-        } => abilities::activate_ability(
-            cx.state,
-            cx.events,
-            *investigator,
-            *instance_id,
-            *ability_index,
-        ),
+        } => abilities::activate_ability(cx, *investigator, *instance_id, *ability_index),
         PlayerAction::DrawEncounterCard => match cx.state.mythos_draw_pending {
             // DrawEncounterCard carries no investigator payload — the
             // acting investigator IS the pending cursor.

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -135,11 +135,11 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
             investigator,
             destination,
         } => actions::move_action(cx, *investigator, *destination),
-        PlayerAction::Draw { investigator } => cards::draw(cx.state, cx.events, *investigator),
+        PlayerAction::Draw { investigator } => cards::draw(cx, *investigator),
         PlayerAction::Mulligan {
             investigator,
             indices_to_redraw,
-        } => cards::mulligan(cx.state, cx.events, *investigator, indices_to_redraw),
+        } => cards::mulligan(cx, *investigator, indices_to_redraw),
         PlayerAction::Fight {
             investigator,
             enemy,
@@ -151,7 +151,7 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
         PlayerAction::PlayCard {
             investigator,
             hand_index,
-        } => cards::play_card(cx.state, cx.events, *investigator, *hand_index),
+        } => cards::play_card(cx, *investigator, *hand_index),
         PlayerAction::ActivateAbility {
             investigator,
             instance_id,
@@ -218,9 +218,7 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
 /// Apply an [`EngineRecord`] to the state, pushing events.
 pub fn apply_engine_record(cx: &mut Cx, record: &EngineRecord) -> EngineOutcome {
     match record {
-        EngineRecord::DeckShuffled { investigator } => {
-            cards::deck_shuffled(cx.state, cx.events, *investigator)
-        }
+        EngineRecord::DeckShuffled { investigator } => cards::deck_shuffled(cx, *investigator),
         EngineRecord::EncounterDeckShuffled => {
             encounter::encounter_deck_shuffled(cx.state, cx.events)
         }

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -127,9 +127,7 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
             investigator,
             skill,
             difficulty,
-        } => {
-            skill_test::perform_skill_test(cx.state, cx.events, *investigator, *skill, *difficulty)
-        }
+        } => skill_test::perform_skill_test(cx, *investigator, *skill, *difficulty),
         PlayerAction::Investigate { investigator } => actions::investigate(cx, *investigator),
         PlayerAction::Move {
             investigator,
@@ -353,9 +351,7 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
         };
     }
     match response {
-        InputResponse::CommitCards { indices } => {
-            skill_test::finish_skill_test(cx.state, cx.events, indices)
-        }
+        InputResponse::CommitCards { indices } => skill_test::finish_skill_test(cx, indices),
         other => EngineOutcome::Rejected {
             reason: format!(
                 "ResolveInput: skill-test commit window expects InputResponse::CommitCards, \

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -312,13 +312,13 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
          different phases (Enemy 3.2 vs Mythos 1.4) and each blocks all other actions",
     );
     if cx.state.hunter_move_pending.is_some() {
-        return hunters::resume_hunter_choice(cx.state, cx.events, response);
+        return hunters::resume_hunter_choice(cx, response);
     }
 
     // Engagement-on-spawn suspension (#128, option A) is a distinct mode
     // from hunter movement: its resume re-enters the Mythos draw chain.
     if cx.state.spawn_engage_pending.is_some() {
-        return hunters::resume_spawn_engage(cx.state, cx.events, response);
+        return hunters::resume_spawn_engage(cx, response);
     }
 
     if cx.state.top_reaction_window().is_some() {

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -121,8 +121,8 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
     }
 
     let outcome = match action {
-        PlayerAction::StartScenario => phases::start_scenario(cx.state, cx.events),
-        PlayerAction::EndTurn => phases::end_turn(cx.state, cx.events),
+        PlayerAction::StartScenario => phases::start_scenario(cx),
+        PlayerAction::EndTurn => phases::end_turn(cx),
         PlayerAction::PerformSkillTest {
             investigator,
             skill,
@@ -202,7 +202,7 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
         // — hosts check `open_windows` and present `ResolveInput::Skip`
         // to close it, exactly as for the phase-transition windows the
         // void `*_phase` drivers open.
-        phases::investigation_phase(cx.state, cx.events);
+        phases::investigation_phase(cx);
     }
 
     // Reaction windows open at the step boundary inside the handler

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -10,10 +10,10 @@
 
 use crate::action::{EngineRecord, InputResponse, PlayerAction};
 use crate::card_data::CardType;
-use crate::event::Event;
-use crate::state::{CardCode, GameState};
+use crate::state::CardCode;
 
 use super::outcome::EngineOutcome;
+use super::Cx;
 
 mod abilities;
 mod act_agenda;
@@ -37,18 +37,14 @@ mod skill_test;
 /// other variants return [`EngineOutcome::Rejected`] with a TODO message
 /// so callers and tests get a useful signal rather than a silent no-op.
 #[allow(clippy::too_many_lines)] // dispatcher: a guard ladder + one match arm per PlayerAction
-pub fn apply_player_action(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    action: &PlayerAction,
-) -> EngineOutcome {
+pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome {
     // While a mulligan is pending (the setup mulligan cursor is `Some`),
     // only Mulligan (and the already-rejected re-StartScenario) is valid.
     // Per the Rules Reference, "after all players have completed their
     // mulligans, the game begins" — the engine enforces that by gating
     // other actions until every investigator has signaled their mulligan
     // choice.
-    if state.mulligan_pending.is_some()
+    if cx.state.mulligan_pending.is_some()
         && !matches!(
             action,
             PlayerAction::Mulligan { .. } | PlayerAction::StartScenario
@@ -66,10 +62,11 @@ pub fn apply_player_action(
     // window opens mid-skill-test (e.g. Roland's "after you defeat an
     // enemy" firing during a Fight that defeats), both
     // `in_flight_skill_test` and the open reaction window on
-    // `state.open_windows` are populated — the test is mid-resolution,
+    // `cx.state.open_windows` are populated — the test is mid-resolution,
     // parked at the window boundary inside `drive_skill_test`. The
     // reaction-window message is the one the client needs.
-    if state.top_reaction_window().is_some() && !matches!(action, PlayerAction::ResolveInput { .. })
+    if cx.state.top_reaction_window().is_some()
+        && !matches!(action, PlayerAction::ResolveInput { .. })
     {
         return EngineOutcome::Rejected {
             reason: "a reaction window is open; submit a \
@@ -84,7 +81,8 @@ pub fn apply_player_action(
     // While a skill test is paused at its commit window (no reaction
     // window open yet), only `ResolveInput` can advance the engine.
     // Mirrors the `mulligan_pending` guard above.
-    if state.in_flight_skill_test.is_some() && !matches!(action, PlayerAction::ResolveInput { .. })
+    if cx.state.in_flight_skill_test.is_some()
+        && !matches!(action, PlayerAction::ResolveInput { .. })
     {
         return EngineOutcome::Rejected {
             reason: "a skill test is paused at its commit window; submit a \
@@ -97,7 +95,9 @@ pub fn apply_player_action(
     // Hunter movement is Enemy-phase only; it can't coexist with an open
     // reaction window or an in-flight skill test, so order among the guards
     // is immaterial — but a pending hunter choice still blocks other actions.
-    if state.hunter_move_pending.is_some() && !matches!(action, PlayerAction::ResolveInput { .. }) {
+    if cx.state.hunter_move_pending.is_some()
+        && !matches!(action, PlayerAction::ResolveInput { .. })
+    {
         return EngineOutcome::Rejected {
             reason: "a hunter-movement choice is pending; submit a PlayerAction::ResolveInput \
                      with InputResponse::PickLocation (movement) or \
@@ -109,7 +109,8 @@ pub fn apply_player_action(
     // A pending engagement-on-spawn choice (#128) likewise blocks every
     // action but `ResolveInput`. Mirrors the hunter guard above; the two
     // never coexist (different phases), so guard order is immaterial.
-    if state.spawn_engage_pending.is_some() && !matches!(action, PlayerAction::ResolveInput { .. })
+    if cx.state.spawn_engage_pending.is_some()
+        && !matches!(action, PlayerAction::ResolveInput { .. })
     {
         return EngineOutcome::Rejected {
             reason: "an engagement-on-spawn choice is pending; submit a \
@@ -120,55 +121,61 @@ pub fn apply_player_action(
     }
 
     let outcome = match action {
-        PlayerAction::StartScenario => phases::start_scenario(state, events),
-        PlayerAction::EndTurn => phases::end_turn(state, events),
+        PlayerAction::StartScenario => phases::start_scenario(cx.state, cx.events),
+        PlayerAction::EndTurn => phases::end_turn(cx.state, cx.events),
         PlayerAction::PerformSkillTest {
             investigator,
             skill,
             difficulty,
-        } => skill_test::perform_skill_test(state, events, *investigator, *skill, *difficulty),
+        } => {
+            skill_test::perform_skill_test(cx.state, cx.events, *investigator, *skill, *difficulty)
+        }
         PlayerAction::Investigate { investigator } => {
-            actions::investigate(state, events, *investigator)
+            actions::investigate(cx.state, cx.events, *investigator)
         }
         PlayerAction::Move {
             investigator,
             destination,
-        } => actions::move_action(state, events, *investigator, *destination),
-        PlayerAction::Draw { investigator } => cards::draw(state, events, *investigator),
+        } => actions::move_action(cx.state, cx.events, *investigator, *destination),
+        PlayerAction::Draw { investigator } => cards::draw(cx.state, cx.events, *investigator),
         PlayerAction::Mulligan {
             investigator,
             indices_to_redraw,
-        } => cards::mulligan(state, events, *investigator, indices_to_redraw),
+        } => cards::mulligan(cx.state, cx.events, *investigator, indices_to_redraw),
         PlayerAction::Fight {
             investigator,
             enemy,
-        } => actions::fight(state, events, *investigator, *enemy),
+        } => actions::fight(cx.state, cx.events, *investigator, *enemy),
         PlayerAction::Evade {
             investigator,
             enemy,
-        } => actions::evade(state, events, *investigator, *enemy),
+        } => actions::evade(cx.state, cx.events, *investigator, *enemy),
         PlayerAction::PlayCard {
             investigator,
             hand_index,
-        } => cards::play_card(state, events, *investigator, *hand_index),
+        } => cards::play_card(cx.state, cx.events, *investigator, *hand_index),
         PlayerAction::ActivateAbility {
             investigator,
             instance_id,
             ability_index,
-        } => {
-            abilities::activate_ability(state, events, *investigator, *instance_id, *ability_index)
-        }
-        PlayerAction::DrawEncounterCard => match state.mythos_draw_pending {
+        } => abilities::activate_ability(
+            cx.state,
+            cx.events,
+            *investigator,
+            *instance_id,
+            *ability_index,
+        ),
+        PlayerAction::DrawEncounterCard => match cx.state.mythos_draw_pending {
             // DrawEncounterCard carries no investigator payload — the
             // acting investigator IS the pending cursor.
-            Some(actor) => encounter::draw_encounter_card(state, events, actor),
+            Some(actor) => encounter::draw_encounter_card(cx.state, cx.events, actor),
             None => EngineOutcome::Rejected {
                 reason: "DrawEncounterCard: no draw pending (all investigators have drawn)".into(),
             },
         },
-        PlayerAction::ResolveInput { response } => resolve_input(state, events, response),
+        PlayerAction::ResolveInput { response } => resolve_input(cx, response),
         PlayerAction::AdvanceAct { investigator } => {
-            act_agenda::advance_act_action(state, events, *investigator)
+            act_agenda::advance_act_action(cx.state, cx.events, *investigator)
         }
     };
 
@@ -180,7 +187,7 @@ pub fn apply_player_action(
     // doesn't silently stay set across a partial mulligan.
     if matches!(outcome, EngineOutcome::Done)
         && matches!(action, PlayerAction::Mulligan { .. })
-        && state.mulligan_pending.is_none()
+        && cx.state.mulligan_pending.is_none()
     {
         // Setup complete — "the game begins" (Rules Reference p.27).
         // Round 1 skips the Mythos phase (p.24), so the first phase to
@@ -191,11 +198,11 @@ pub fn apply_player_action(
         // NOTE: investigation_phase may leave an InvestigationBegins
         // window open (when a Fast-eligible play exists); this function
         // still returns the Mulligan's `Done`. So this is one of the few
-        // paths where `Done` can accompany a non-empty `state.open_windows`
+        // paths where `Done` can accompany a non-empty `cx.state.open_windows`
         // — hosts check `open_windows` and present `ResolveInput::Skip`
         // to close it, exactly as for the phase-transition windows the
         // void `*_phase` drivers open.
-        phases::investigation_phase(state, events);
+        phases::investigation_phase(cx.state, cx.events);
     }
 
     // Reaction windows open at the step boundary inside the handler
@@ -211,18 +218,16 @@ pub fn apply_player_action(
 }
 
 /// Apply an [`EngineRecord`] to the state, pushing events.
-pub fn apply_engine_record(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    record: &EngineRecord,
-) -> EngineOutcome {
+pub fn apply_engine_record(cx: &mut Cx, record: &EngineRecord) -> EngineOutcome {
     match record {
         EngineRecord::DeckShuffled { investigator } => {
-            cards::deck_shuffled(state, events, *investigator)
+            cards::deck_shuffled(cx.state, cx.events, *investigator)
         }
-        EngineRecord::EncounterDeckShuffled => encounter::encounter_deck_shuffled(state, events),
+        EngineRecord::EncounterDeckShuffled => {
+            encounter::encounter_deck_shuffled(cx.state, cx.events)
+        }
         EngineRecord::EncounterCardRevealed { investigator } => {
-            encounter::encounter_card_revealed(state, events, *investigator)
+            encounter::encounter_card_revealed(cx.state, cx.events, *investigator)
         }
     }
 }
@@ -305,41 +310,37 @@ pub(super) struct ActivateCheckResult {
 /// directly via [`close_reaction_window_at`] on the literal top-of-stack
 /// index. This covers the `MythosAfterDraws` window after all Fast
 /// plays have been made and the player is done.
-pub(crate) fn resolve_input(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    response: &InputResponse,
-) -> EngineOutcome {
+pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
     // Hunter-movement suspension is its own mode; route it before the
     // reaction-window and skill-test checks, which are independent
     // suspension modes. (#128)
     debug_assert!(
-        !(state.hunter_move_pending.is_some() && state.spawn_engage_pending.is_some()),
+        !(cx.state.hunter_move_pending.is_some() && cx.state.spawn_engage_pending.is_some()),
         "hunter movement and spawn engagement cannot both be pending: they arise in \
          different phases (Enemy 3.2 vs Mythos 1.4) and each blocks all other actions",
     );
-    if state.hunter_move_pending.is_some() {
-        return hunters::resume_hunter_choice(state, events, response);
+    if cx.state.hunter_move_pending.is_some() {
+        return hunters::resume_hunter_choice(cx.state, cx.events, response);
     }
 
     // Engagement-on-spawn suspension (#128, option A) is a distinct mode
     // from hunter movement: its resume re-enters the Mythos draw chain.
-    if state.spawn_engage_pending.is_some() {
-        return hunters::resume_spawn_engage(state, events, response);
+    if cx.state.spawn_engage_pending.is_some() {
+        return hunters::resume_spawn_engage(cx.state, cx.events, response);
     }
 
-    if state.top_reaction_window().is_some() {
-        return reaction_windows::resume_reaction_window(state, events, response);
+    if cx.state.top_reaction_window().is_some() {
+        return reaction_windows::resume_reaction_window(cx.state, cx.events, response);
     }
 
     // Pure-Fast window path (Option B): no reaction-driven window is
     // pending, but a window (e.g. MythosAfterDraws) may still be on the
     // stack with empty pending_triggers. Skip is the only valid response
     // here — PickIndex / CommitCards reject below.
-    if !state.open_windows.is_empty() {
+    if !cx.state.open_windows.is_empty() {
         if matches!(response, InputResponse::Skip) {
-            let idx = state.open_windows.len() - 1;
-            return reaction_windows::close_reaction_window_at(state, events, idx);
+            let idx = cx.state.open_windows.len() - 1;
+            return reaction_windows::close_reaction_window_at(cx.state, cx.events, idx);
         }
         return EngineOutcome::Rejected {
             reason: format!(
@@ -350,14 +351,14 @@ pub(crate) fn resolve_input(
         };
     }
 
-    if state.in_flight_skill_test.is_none() {
+    if cx.state.in_flight_skill_test.is_none() {
         return EngineOutcome::Rejected {
             reason: "ResolveInput: no AwaitingInput prompt is currently outstanding".into(),
         };
     }
     match response {
         InputResponse::CommitCards { indices } => {
-            skill_test::finish_skill_test(state, events, indices)
+            skill_test::finish_skill_test(cx.state, cx.events, indices)
         }
         other => EngineOutcome::Rejected {
             reason: format!(

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -187,10 +187,10 @@ fn mythos_phase(cx: &mut Cx) {
     });
 
     // 1.2 Place 1 doom on the current agenda.
-    super::act_agenda::place_doom_on_agenda(cx.state, cx.events);
+    super::act_agenda::place_doom_on_agenda(cx);
 
     // 1.3 Check doom threshold.
-    super::act_agenda::check_doom_threshold(cx.state, cx.events);
+    super::act_agenda::check_doom_threshold(cx);
 
     // 1.4 Each investigator draws 1 encounter card.
     //     Seed the cursor; the actual draws are player-driven via

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -1124,7 +1124,10 @@ mod mythos_phase_tests {
         state.mythos_draw_pending = Some(InvestigatorId(1));
         let mut events = Vec::new();
 
-        super::super::encounter::advance_mythos_draw_pending(&mut state, &mut events);
+        super::super::encounter::advance_mythos_draw_pending(&mut super::super::Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert_eq!(
             state.mythos_draw_pending,

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -565,8 +565,10 @@ mod investigation_phase_tests {
 
         let mut events = Vec::new();
         let outcome = apply_player_action(
-            &mut state,
-            &mut events,
+            &mut crate::engine::Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &PlayerAction::Mulligan {
                 investigator: InvestigatorId(1),
                 indices_to_redraw: vec![],
@@ -1713,8 +1715,10 @@ mod enemy_phase_tests {
         assert_eq!(state.phase, Phase::Enemy);
         let mut ev2 = Vec::new();
         let resumed = resolve_input(
-            &mut state,
-            &mut ev2,
+            &mut crate::engine::Cx {
+                state: &mut state,
+                events: &mut ev2,
+            },
             &InputResponse::PickLocation(LocationId(2)),
         );
         assert_eq!(resumed, EngineOutcome::Done);

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -137,7 +137,7 @@ pub(super) fn investigation_phase(cx: &mut Cx) {
     // order 2.1 → window → 2.2 holds. Auto-skips inline when nothing is
     // Fast-eligible, so single-investigator entry still lands the lead
     // active within the same apply() call.
-    super::reaction_windows::open_fast_window(cx.state, cx.events, WindowKind::InvestigationBegins);
+    super::reaction_windows::open_fast_window(cx, WindowKind::InvestigationBegins);
 }
 
 /// 2.2 Next investigator's turn begins. Rotates the active cursor to
@@ -152,11 +152,7 @@ pub(super) fn investigation_phase(cx: &mut Cx) {
 /// resolve it via `first_active_investigator` / `next_active_investigator_after`.
 pub(super) fn begin_investigator_turn(cx: &mut Cx, who: InvestigatorId) {
     rotate_to_active(cx, who);
-    super::reaction_windows::open_fast_window(
-        cx.state,
-        cx.events,
-        WindowKind::InvestigatorTurnBegins,
-    );
+    super::reaction_windows::open_fast_window(cx, WindowKind::InvestigatorTurnBegins);
 }
 
 /// 2.3 Investigation phase ends. Owns the `PhaseEnded(Investigation)`
@@ -211,11 +207,7 @@ fn mythos_phase(cx: &mut Cx) {
         // because nothing is eligible, runs the MythosAfterDraws
         // continuation (mythos_phase_end), which transitions to
         // Investigation. All in this same apply.
-        super::reaction_windows::open_fast_window(
-            cx.state,
-            cx.events,
-            WindowKind::MythosAfterDraws,
-        );
+        super::reaction_windows::open_fast_window(cx, WindowKind::MythosAfterDraws);
     }
 }
 
@@ -308,20 +300,12 @@ pub(super) fn enemy_attack_kickoff(cx: &mut Cx) {
     cx.state.enemy_attack_pending = super::cursor::first_active_investigator(cx.state);
 
     if cx.state.enemy_attack_pending.is_some() {
-        super::reaction_windows::open_fast_window(
-            cx.state,
-            cx.events,
-            WindowKind::BeforeInvestigatorAttacked,
-        );
+        super::reaction_windows::open_fast_window(cx, WindowKind::BeforeInvestigatorAttacked);
     } else {
         // No Active investigators (turn_order empty or all eliminated).
         // Skip straight to the final window — mirror of mythos_phase's
         // no-drawer path.
-        super::reaction_windows::open_fast_window(
-            cx.state,
-            cx.events,
-            WindowKind::AfterAllInvestigatorsAttacked,
-        );
+        super::reaction_windows::open_fast_window(cx, WindowKind::AfterAllInvestigatorsAttacked);
     }
 }
 
@@ -418,7 +402,7 @@ fn upkeep_phase(cx: &mut Cx) {
     });
     // PLAYER WINDOW (post-4.1). Auto-skips inline (running upkeep_resume
     // via run_window_continuation) when nothing is Fast-eligible.
-    super::reaction_windows::open_fast_window(cx.state, cx.events, WindowKind::UpkeepBegins);
+    super::reaction_windows::open_fast_window(cx, WindowKind::UpkeepBegins);
 }
 
 /// The post-4.1 window continuation. Steps 4.2–4.4 run inline as named

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -344,7 +344,7 @@ fn enemy_phase(cx: &mut Cx) -> EngineOutcome {
 
     // 3.2 Hunter enemies move. Park on a lead-investigator tie; the
     //     attack-loop kickoff then happens on resume.
-    match super::hunters::drive_hunter_moves(cx.state, cx.events) {
+    match super::hunters::drive_hunter_moves(cx) {
         outcome @ EngineOutcome::AwaitingInput { .. } => return outcome,
         // drive_hunter_moves only ever returns Done or AwaitingInput, never Rejected.
         EngineOutcome::Rejected { reason } => {
@@ -496,7 +496,7 @@ fn ready_exhausted_cards(cx: &mut Cx) {
     // newly_readied is in ascending EnemyId order (BTreeMap key order).
     for eid in newly_readied {
         if cx.state.enemies[&eid].engaged_with.is_none() {
-            super::hunters::reengage_at_location(cx.state, cx.events, eid);
+            super::hunters::reengage_at_location(cx, eid);
         }
     }
 }

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -3,20 +3,22 @@
 
 use crate::engine::outcome::EngineOutcome;
 use crate::event::Event;
-use crate::state::{EnemyId, GameState, InvestigatorId, Phase, WindowKind};
+use crate::state::{EnemyId, InvestigatorId, Phase, WindowKind};
+
+use super::Cx;
 
 /// Action points granted to an investigator at the start of their
 /// turn during the Investigation phase. Per the Arkham Horror LCG
 /// rulebook.
 pub(super) const ACTIONS_PER_TURN: u8 = 3;
 
-pub(super) fn start_scenario(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome {
+pub(super) fn start_scenario(cx: &mut Cx) -> EngineOutcome {
     // The GameState constructor places the world in its initial shape;
     // this action is the explicit "session has begun" marker that lands
     // in the action log. Replaying it on an already-started state is a
     // bug, not a no-op — reject so callers notice rather than silently
     // double-emitting `ScenarioStarted`.
-    if state.round != 0 {
+    if cx.state.round != 0 {
         return EngineOutcome::Rejected {
             reason: "StartScenario applied to a state that is already in progress".into(),
         };
@@ -26,16 +28,16 @@ pub(super) fn start_scenario(state: &mut GameState, events: &mut Vec<Event>) -> 
     // the first round of the game, skip the mythos phase." No
     // PhaseStarted(Mythos) / PhaseEnded(Mythos) fire — the phase
     // doesn't happen.
-    state.round = 1;
-    state.phase = Phase::Investigation;
-    events.push(Event::ScenarioStarted);
+    cx.state.round = 1;
+    cx.state.phase = Phase::Investigation;
+    cx.events.push(Event::ScenarioStarted);
 
     // For each investigator (sorted by id for determinism), shuffle
     // their deck and deal an initial hand of up to 5.
-    let inv_ids: Vec<InvestigatorId> = state.investigators.keys().copied().collect();
+    let inv_ids: Vec<InvestigatorId> = cx.state.investigators.keys().copied().collect();
     for inv_id in inv_ids {
-        super::cards::shuffle_player_deck(state, events, inv_id);
-        super::cards::draw_cards(state, events, inv_id, super::cards::INITIAL_HAND_SIZE);
+        super::cards::shuffle_player_deck(cx.state, cx.events, inv_id);
+        super::cards::draw_cards(cx.state, cx.events, inv_id, super::cards::INITIAL_HAND_SIZE);
     }
 
     // Seed the mulligan cursor to the first Active investigator in
@@ -45,11 +47,11 @@ pub(super) fn start_scenario(state: &mut GameState, events: &mut Vec<Event>) -> 
     // at which point setup ends. Other player actions are rejected while
     // the cursor is `Some`. An empty/all-eliminated `turn_order` seeds
     // `None` — the same degenerate no-op as the Mythos draw cursor.
-    state.mulligan_pending = super::cursor::first_active_investigator(state);
+    cx.state.mulligan_pending = super::cursor::first_active_investigator(cx.state);
 
     // Round-1 action seed: round 1 skips Mythos, so there's no Upkeep 4.2
     // to grant the first round's actions. Every Active investigator → ACTIONS_PER_TURN.
-    reset_actions(state, events);
+    reset_actions(cx);
 
     // NOTE: the Investigation phase is NOT begun here. Setup has no
     // action windows (Rules Reference p.27); the phase begins after the
@@ -57,13 +59,13 @@ pub(super) fn start_scenario(state: &mut GameState, events: &mut Vec<Event>) -> 
     EngineOutcome::Done
 }
 
-pub(super) fn end_turn(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome {
-    if state.phase != Phase::Investigation {
+pub(super) fn end_turn(cx: &mut Cx) -> EngineOutcome {
+    if cx.state.phase != Phase::Investigation {
         return EngineOutcome::Rejected {
             reason: "EndTurn is only valid during the Investigation phase".into(),
         };
     }
-    let Some(active_id) = state.active_investigator else {
+    let Some(active_id) = cx.state.active_investigator else {
         return EngineOutcome::Rejected {
             reason: "EndTurn requires an active investigator".into(),
         };
@@ -72,22 +74,26 @@ pub(super) fn end_turn(state: &mut GameState, events: &mut Vec<Event>) -> Engine
     // existing in the investigators map; a missing entry would be state
     // corruption, not a normal rejection. Surface it loudly rather than
     // hiding behind Rejected.
-    let active = state.investigators.get_mut(&active_id).unwrap_or_else(|| {
-        unreachable!(
-            "active_investigator {active_id:?} is not in the investigators map; \
+    let active = cx
+        .state
+        .investigators
+        .get_mut(&active_id)
+        .unwrap_or_else(|| {
+            unreachable!(
+                "active_investigator {active_id:?} is not in the investigators map; \
                  this is a state-corruption invariant violation"
-        )
-    });
+            )
+        });
 
     // Drain remaining actions and announce the turn ended.
     if active.actions_remaining != 0 {
         active.actions_remaining = 0;
-        events.push(Event::ActionsRemainingChanged {
+        cx.events.push(Event::ActionsRemainingChanged {
             investigator: active_id,
             new_count: 0,
         });
     }
-    events.push(Event::TurnEnded {
+    cx.events.push(Event::TurnEnded {
         investigator: active_id,
     });
 
@@ -95,14 +101,14 @@ pub(super) fn end_turn(state: &mut GameState, events: &mut Vec<Event>) -> Engine
     // proceed to 2.3. next_active_investigator_after skips eliminated
     // investigators (Rules Reference p.10) — the same shared helper the
     // Enemy phase uses.
-    if let Some(next_id) = super::cursor::next_active_investigator_after(state, active_id) {
-        begin_investigator_turn(state, events, next_id);
+    if let Some(next_id) = super::cursor::next_active_investigator_after(cx.state, active_id) {
+        begin_investigator_turn(cx, next_id);
         EngineOutcome::Done
     } else {
-        state.active_investigator = None;
+        cx.state.active_investigator = None;
         // 2.3 → Enemy. The cascade may suspend on a hunter-movement tie
         // (Enemy 3.2); propagate its outcome rather than swallowing it.
-        investigation_phase_end(state, events)
+        investigation_phase_end(cx)
     }
 }
 
@@ -120,9 +126,9 @@ pub(super) fn end_turn(state: &mut GameState, events: &mut Vec<Event>) -> Engine
 /// hand, which is always the case in unit tests with no card registry
 /// installed), so single-investigator entry still lands the lead active
 /// within the same `apply()` call.
-pub(super) fn investigation_phase(state: &mut GameState, events: &mut Vec<Event>) {
+pub(super) fn investigation_phase(cx: &mut Cx) {
     // 2.1 Investigation phase begins.
-    events.push(Event::PhaseStarted {
+    cx.events.push(Event::PhaseStarted {
         phase: Phase::Investigation,
     });
     // PLAYER WINDOW (post-2.1). Rotation to the first investigator
@@ -131,7 +137,7 @@ pub(super) fn investigation_phase(state: &mut GameState, events: &mut Vec<Event>
     // order 2.1 → window → 2.2 holds. Auto-skips inline when nothing is
     // Fast-eligible, so single-investigator entry still lands the lead
     // active within the same apply() call.
-    super::reaction_windows::open_fast_window(state, events, WindowKind::InvestigationBegins);
+    super::reaction_windows::open_fast_window(cx.state, cx.events, WindowKind::InvestigationBegins);
 }
 
 /// 2.2 Next investigator's turn begins. Rotates the active cursor to
@@ -144,13 +150,13 @@ pub(super) fn investigation_phase(state: &mut GameState, events: &mut Vec<Event>
 ///
 /// `who` must be an `Active` investigator in `turn_order`; callers
 /// resolve it via `first_active_investigator` / `next_active_investigator_after`.
-pub(super) fn begin_investigator_turn(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    who: InvestigatorId,
-) {
-    rotate_to_active(state, events, who);
-    super::reaction_windows::open_fast_window(state, events, WindowKind::InvestigatorTurnBegins);
+pub(super) fn begin_investigator_turn(cx: &mut Cx, who: InvestigatorId) {
+    rotate_to_active(cx, who);
+    super::reaction_windows::open_fast_window(
+        cx.state,
+        cx.events,
+        WindowKind::InvestigatorTurnBegins,
+    );
 }
 
 /// 2.3 Investigation phase ends. Owns the `PhaseEnded(Investigation)`
@@ -158,18 +164,18 @@ pub(super) fn begin_investigator_turn(
 /// `enemy_phase_end` / `upkeep_phase_end` — then transitions to the
 /// Enemy phase. Called only from `end_turn`'s terminal branch (the last
 /// investigator has taken a turn this round).
-fn investigation_phase_end(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome {
-    events.push(Event::PhaseEnded {
+fn investigation_phase_end(cx: &mut Cx) -> EngineOutcome {
+    cx.events.push(Event::PhaseEnded {
         phase: Phase::Investigation,
     });
-    step_phase(state, events) // Investigation → Enemy; calls enemy_phase
+    step_phase(cx) // Investigation → Enemy; calls enemy_phase
 }
 
 /// Entered by [`step_phase`] on the Upkeep→Mythos transition. Lays
 /// out the Rules Reference p.24 sub-steps as discrete named call
 /// sites so the rule structure is grep-able and #73 / future-peril-PR
 /// fills in TODO bodies without changing the driver shape.
-fn mythos_phase(state: &mut GameState, events: &mut Vec<Event>) {
+fn mythos_phase(cx: &mut Cx) {
     // 1.1 Round begins. Mythos phase begins.
     //     Rules Reference p.24: "As this is the first framework event
     //     of the round, it [1.1] also formalizes the beginning of a new
@@ -179,16 +185,16 @@ fn mythos_phase(state: &mut GameState, events: &mut Vec<Event>) {
     //     bypassed: start_scenario sets round = 1 directly (Mythos
     //     skipped). This is also the future home for a RoundStarted
     //     event when a consumer lands.
-    state.round = state.round.saturating_add(1);
-    events.push(Event::PhaseStarted {
+    cx.state.round = cx.state.round.saturating_add(1);
+    cx.events.push(Event::PhaseStarted {
         phase: Phase::Mythos,
     });
 
     // 1.2 Place 1 doom on the current agenda.
-    super::act_agenda::place_doom_on_agenda(state, events);
+    super::act_agenda::place_doom_on_agenda(cx.state, cx.events);
 
     // 1.3 Check doom threshold.
-    super::act_agenda::check_doom_threshold(state, events);
+    super::act_agenda::check_doom_threshold(cx.state, cx.events);
 
     // 1.4 Each investigator draws 1 encounter card.
     //     Seed the cursor; the actual draws are player-driven via
@@ -197,15 +203,19 @@ fn mythos_phase(state: &mut GameState, events: &mut Vec<Event>) {
     //     Per Rules Reference p.10 (Elimination), eliminated
     //     investigators (Killed, Insane, Resigned) do not draw
     //     encounter cards — skip to the first Active investigator.
-    state.mythos_draw_pending = super::cursor::first_active_investigator(state);
-    if state.mythos_draw_pending.is_none() {
+    cx.state.mythos_draw_pending = super::cursor::first_active_investigator(cx.state);
+    if cx.state.mythos_draw_pending.is_none() {
         // No Active investigators to draw (turn_order is empty or all
         // investigators are eliminated). Open the post-1.4 window
         // immediately; open_fast_window's auto-skip path triggers
         // because nothing is eligible, runs the MythosAfterDraws
         // continuation (mythos_phase_end), which transitions to
         // Investigation. All in this same apply.
-        super::reaction_windows::open_fast_window(state, events, WindowKind::MythosAfterDraws);
+        super::reaction_windows::open_fast_window(
+            cx.state,
+            cx.events,
+            WindowKind::MythosAfterDraws,
+        );
     }
 }
 
@@ -234,11 +244,11 @@ fn mythos_phase(state: &mut GameState, events: &mut Vec<Event>) {
 /// Investigation→Enemy suspension is owned by
 /// [`investigation_phase_end`], which propagates it up through
 /// [`end_turn`].
-fn step_phase(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome {
-    let from = state.phase;
+fn step_phase(cx: &mut Cx) -> EngineOutcome {
+    let from = cx.state.phase;
     let to = from.next();
 
-    state.phase = to;
+    cx.state.phase = to;
     // The round-counter bump moves into mythos_phase (step 1.1).
     // step_phase no longer touches state.round.
 
@@ -246,16 +256,16 @@ fn step_phase(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome {
     // PhaseStarted directly (for phases without a driver yet).
     match to {
         Phase::Mythos if from != Phase::Mythos => {
-            mythos_phase(state, events);
+            mythos_phase(cx);
             EngineOutcome::Done
         }
         Phase::Investigation if from != Phase::Investigation => {
-            investigation_phase(state, events);
+            investigation_phase(cx);
             EngineOutcome::Done
         }
-        Phase::Enemy if from != Phase::Enemy => enemy_phase(state, events),
+        Phase::Enemy if from != Phase::Enemy => enemy_phase(cx),
         Phase::Upkeep if from != Phase::Upkeep => {
-            upkeep_phase(state, events);
+            upkeep_phase(cx);
             EngineOutcome::Done
         }
         _ => unreachable!(
@@ -275,12 +285,12 @@ fn step_phase(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome {
 ///
 /// `id` must refer to an investigator in `state.investigators` (a
 /// whole-program invariant for ids drawn from `turn_order`).
-fn rotate_to_active(state: &mut GameState, _events: &mut Vec<Event>, id: InvestigatorId) {
+fn rotate_to_active(cx: &mut Cx, id: InvestigatorId) {
     debug_assert!(
-        state.investigators.contains_key(&id),
+        cx.state.investigators.contains_key(&id),
         "rotate_to_active: investigator {id:?} not in investigators (state corruption)"
     );
-    state.active_investigator = Some(id);
+    cx.state.active_investigator = Some(id);
 }
 
 /// 3.3 Seed the per-investigator attack cursor and open the first
@@ -294,13 +304,13 @@ fn rotate_to_active(state: &mut GameState, _events: &mut Vec<Event>, id: Investi
 /// Rules Reference p.10 (Elimination); [`cursor::first_active_investigator`] is
 /// the shared helper used by Mythos 1.4 (#69) for the same semantics.
 /// The loop body runs in [`run_window_continuation`]'s arms.
-pub(super) fn enemy_attack_kickoff(state: &mut GameState, events: &mut Vec<Event>) {
-    state.enemy_attack_pending = super::cursor::first_active_investigator(state);
+pub(super) fn enemy_attack_kickoff(cx: &mut Cx) {
+    cx.state.enemy_attack_pending = super::cursor::first_active_investigator(cx.state);
 
-    if state.enemy_attack_pending.is_some() {
+    if cx.state.enemy_attack_pending.is_some() {
         super::reaction_windows::open_fast_window(
-            state,
-            events,
+            cx.state,
+            cx.events,
             WindowKind::BeforeInvestigatorAttacked,
         );
     } else {
@@ -308,8 +318,8 @@ pub(super) fn enemy_attack_kickoff(state: &mut GameState, events: &mut Vec<Event
         // Skip straight to the final window — mirror of mythos_phase's
         // no-drawer path.
         super::reaction_windows::open_fast_window(
-            state,
-            events,
+            cx.state,
+            cx.events,
             WindowKind::AfterAllInvestigatorsAttacked,
         );
     }
@@ -326,15 +336,15 @@ pub(super) fn enemy_attack_kickoff(state: &mut GameState, events: &mut Vec<Event
 /// kickoff is deferred to [`resume_hunter_choice`], which runs it once
 /// the last hunter resolves. Otherwise the kickoff runs inline here and
 /// this returns [`EngineOutcome::Done`].
-fn enemy_phase(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome {
+fn enemy_phase(cx: &mut Cx) -> EngineOutcome {
     // 3.1 Enemy phase begins.
-    events.push(Event::PhaseStarted {
+    cx.events.push(Event::PhaseStarted {
         phase: Phase::Enemy,
     });
 
     // 3.2 Hunter enemies move. Park on a lead-investigator tie; the
     //     attack-loop kickoff then happens on resume.
-    match super::hunters::drive_hunter_moves(state, events) {
+    match super::hunters::drive_hunter_moves(cx.state, cx.events) {
         outcome @ EngineOutcome::AwaitingInput { .. } => return outcome,
         // drive_hunter_moves only ever returns Done or AwaitingInput, never Rejected.
         EngineOutcome::Rejected { reason } => {
@@ -344,7 +354,7 @@ fn enemy_phase(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome 
     }
 
     // 3.3 Kick off the per-investigator attack loop.
-    enemy_attack_kickoff(state, events);
+    enemy_attack_kickoff(cx);
     EngineOutcome::Done
 }
 
@@ -352,14 +362,14 @@ fn enemy_phase(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome 
 /// [`WindowKind::AfterAllInvestigatorsAttacked`] arm. Emits step
 /// 3.4's `PhaseEnded(Enemy)` marker, then transitions to Upkeep.
 /// Exact analog of [`mythos_phase_end`] / [`upkeep_phase_end`].
-pub(super) fn enemy_phase_end(state: &mut GameState, events: &mut Vec<Event>) {
+pub(super) fn enemy_phase_end(cx: &mut Cx) {
     // 3.4 Enemy phase ends.
-    events.push(Event::PhaseEnded {
+    cx.events.push(Event::PhaseEnded {
         phase: Phase::Enemy,
     });
     // Enemy → Upkeep; calls upkeep_phase. Only the Investigation→Enemy
     // transition can suspend (hunter movement), so this never does.
-    let outcome = step_phase(state, events);
+    let outcome = step_phase(cx);
     debug_assert_eq!(
         outcome,
         EngineOutcome::Done,
@@ -373,20 +383,20 @@ pub(super) fn enemy_phase_end(state: &mut GameState, events: &mut Vec<Event>) {
 /// `mythos_phase_end`. Invoked from `close_reaction_window_at`'s
 /// kind-aware tail when a `MythosAfterDraws` window pops, and from
 /// `open_fast_window`'s auto-skip path inline.
-pub(super) fn mythos_phase_end(state: &mut GameState, events: &mut Vec<Event>) {
+pub(super) fn mythos_phase_end(cx: &mut Cx) {
     // 1.5 Mythos phase ends.
     //     The PhaseEnded(Mythos) emit lives HERE rather than in
     //     step_phase so step 1.5 has explicit ownership in the
     //     driver — mirror of step 1.1's PhaseStarted ownership in
     //     mythos_phase. Rules Reference p.24: "This step formalizes
     //     the end of the mythos phase."
-    events.push(Event::PhaseEnded {
+    cx.events.push(Event::PhaseEnded {
         phase: Phase::Mythos,
     });
     // Mythos → Investigation; calls investigation_phase. Only the
     // Investigation→Enemy transition can suspend (hunter movement), so
     // this cascade always completes.
-    let outcome = step_phase(state, events);
+    let outcome = step_phase(cx);
     debug_assert_eq!(
         outcome,
         EngineOutcome::Done,
@@ -401,38 +411,38 @@ pub(super) fn mythos_phase_end(state: &mut GameState, events: &mut Vec<Event>) {
 /// window sits at the END, so its driver runs content then opens;
 /// Upkeep's sits at the START, so the driver opens immediately and the
 /// content is the continuation.
-fn upkeep_phase(state: &mut GameState, events: &mut Vec<Event>) {
+fn upkeep_phase(cx: &mut Cx) {
     // 4.1 Upkeep phase begins.
-    events.push(Event::PhaseStarted {
+    cx.events.push(Event::PhaseStarted {
         phase: Phase::Upkeep,
     });
     // PLAYER WINDOW (post-4.1). Auto-skips inline (running upkeep_resume
     // via run_window_continuation) when nothing is Fast-eligible.
-    super::reaction_windows::open_fast_window(state, events, WindowKind::UpkeepBegins);
+    super::reaction_windows::open_fast_window(cx.state, cx.events, WindowKind::UpkeepBegins);
 }
 
 /// The post-4.1 window continuation. Steps 4.2–4.4 run inline as named
 /// call sites; step 4.5 is the [`check_hand_size`] stub (TODO #111).
 /// Then hands to [`upkeep_phase_end`] for 4.6 + transition.
-pub(super) fn upkeep_resume(state: &mut GameState, events: &mut Vec<Event>) {
-    reset_actions(state, events); // 4.2
-    ready_exhausted_cards(state, events); // 4.3
-    upkeep_draw_and_resource(state, events); // 4.4
-    check_hand_size(state, events); // 4.5 (TODO #111)
-    upkeep_phase_end(state, events); // 4.6 + transition
+pub(super) fn upkeep_resume(cx: &mut Cx) {
+    reset_actions(cx); // 4.2
+    ready_exhausted_cards(cx); // 4.3
+    upkeep_draw_and_resource(cx); // 4.4
+    check_hand_size(cx); // 4.5 (TODO #111)
+    upkeep_phase_end(cx); // 4.6 + transition
 }
 
 /// Owns step 4.6's `PhaseEnded(Upkeep)` emit, then transitions to
 /// Mythos. Exact analog of [`mythos_phase_end`]. `step_phase` emits no
 /// `PhaseEnded` itself — every phase's `*_end` helper owns its own.
-fn upkeep_phase_end(state: &mut GameState, events: &mut Vec<Event>) {
+fn upkeep_phase_end(cx: &mut Cx) {
     // 4.6 Upkeep phase ends. Round ends.
-    events.push(Event::PhaseEnded {
+    cx.events.push(Event::PhaseEnded {
         phase: Phase::Upkeep,
     });
     // Upkeep → Mythos; calls mythos_phase. Only the Investigation→Enemy
     // transition can suspend (hunter movement), so this never does.
-    let outcome = step_phase(state, events);
+    let outcome = step_phase(cx);
     debug_assert_eq!(
         outcome,
         EngineOutcome::Done,
@@ -452,14 +462,14 @@ fn upkeep_phase_end(state: &mut GameState, events: &mut Vec<Event>) {
 /// co-located with an investigator engages it via [`reengage_at_location`]
 /// (Rules Reference p.10: "if an exhausted enemy at the same location as an
 /// investigator becomes ready, it engages as soon as it is readied").
-fn ready_exhausted_cards(state: &mut GameState, events: &mut Vec<Event>) {
-    let inv_ids: Vec<InvestigatorId> = state.investigators.keys().copied().collect();
+fn ready_exhausted_cards(cx: &mut Cx) {
+    let inv_ids: Vec<InvestigatorId> = cx.state.investigators.keys().copied().collect();
     for id in inv_ids {
-        let inv = state.investigators.get_mut(&id).expect("id from keys");
+        let inv = cx.state.investigators.get_mut(&id).expect("id from keys");
         for card in &mut inv.cards_in_play {
             if card.exhausted {
                 card.exhausted = false;
-                events.push(Event::CardReadied {
+                cx.events.push(Event::CardReadied {
                     investigator: id,
                     instance_id: card.instance_id,
                     code: card.code.clone(),
@@ -467,13 +477,13 @@ fn ready_exhausted_cards(state: &mut GameState, events: &mut Vec<Event>) {
             }
         }
     }
-    let enemy_ids: Vec<EnemyId> = state.enemies.keys().copied().collect();
+    let enemy_ids: Vec<EnemyId> = cx.state.enemies.keys().copied().collect();
     let mut newly_readied: Vec<EnemyId> = Vec::new();
     for eid in enemy_ids {
-        let enemy = state.enemies.get_mut(&eid).expect("id from keys");
+        let enemy = cx.state.enemies.get_mut(&eid).expect("id from keys");
         if enemy.exhausted {
             enemy.exhausted = false;
-            events.push(Event::EnemyReadied { enemy: eid });
+            cx.events.push(Event::EnemyReadied { enemy: eid });
             newly_readied.push(eid);
         }
     }
@@ -485,14 +495,14 @@ fn ready_exhausted_cards(state: &mut GameState, events: &mut Vec<Event>) {
     // that readied while still engaged keeps its existing engagement.
     // newly_readied is in ascending EnemyId order (BTreeMap key order).
     for eid in newly_readied {
-        if state.enemies[&eid].engaged_with.is_none() {
-            super::hunters::reengage_at_location(state, events, eid);
+        if cx.state.enemies[&eid].engaged_with.is_none() {
+            super::hunters::reengage_at_location(cx.state, cx.events, eid);
         }
     }
 }
 
 /// 4.5 Each investigator checks hand size.
-fn check_hand_size(_state: &mut GameState, _events: &mut Vec<Event>) {
+fn check_hand_size(_cx: &mut Cx) {
     // TODO(#111): in player order, each investigator with more than 8
     //   cards in hand discards down to 8 (Rules Reference p.25 step 4.5).
     //   Needs an AwaitingInput producer for the discard choice. The call
@@ -510,15 +520,16 @@ fn check_hand_size(_state: &mut GameState, _events: &mut Vec<Event>) {
 /// no longer refreshes (step 2.2 is just "the turn begins");
 /// `start_scenario` seeds round 1. Eliminated investigators are skipped
 /// (Rules Reference p.10).
-fn reset_actions(state: &mut GameState, events: &mut Vec<Event>) {
-    for id in super::cursor::active_investigators_in_turn_order(state) {
-        let inv = state
+fn reset_actions(cx: &mut Cx) {
+    for id in super::cursor::active_investigators_in_turn_order(cx.state) {
+        let inv = cx
+            .state
             .investigators
             .get_mut(&id)
             .expect("id from active_investigators_in_turn_order");
         if inv.actions_remaining != ACTIONS_PER_TURN {
             inv.actions_remaining = ACTIONS_PER_TURN;
-            events.push(Event::ActionsRemainingChanged {
+            cx.events.push(Event::ActionsRemainingChanged {
                 investigator: id,
                 new_count: ACTIONS_PER_TURN,
             });
@@ -531,13 +542,13 @@ fn reset_actions(state: &mut GameState, events: &mut Vec<Event>) {
 /// Once those cards have been drawn, each investigator gains 1
 /// resource." Two passes to honor that ordering: all draws first, then
 /// all resource gains.
-fn upkeep_draw_and_resource(state: &mut GameState, events: &mut Vec<Event>) {
-    let ids = super::cursor::active_investigators_in_turn_order(state);
+fn upkeep_draw_and_resource(cx: &mut Cx) {
+    let ids = super::cursor::active_investigators_in_turn_order(cx.state);
     for &id in &ids {
-        super::cards::draw_one_with_deckout(state, events, id);
+        super::cards::draw_one_with_deckout(cx.state, cx.events, id);
     }
     for &id in &ids {
-        super::cards::grant_resources(state, events, id, 1);
+        super::cards::grant_resources(cx.state, cx.events, id, 1);
     }
 }
 
@@ -629,7 +640,10 @@ mod investigation_phase_tests {
         state.active_investigator = None;
 
         let mut events = Vec::new();
-        investigation_phase(&mut state, &mut events);
+        investigation_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert_eq!(
             state.active_investigator,
@@ -678,7 +692,10 @@ mod investigation_phase_tests {
         state.active_investigator = None;
 
         let mut events = Vec::new();
-        investigation_phase(&mut state, &mut events);
+        investigation_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert_eq!(
             state.active_investigator, None,
@@ -714,7 +731,10 @@ mod investigation_phase_tests {
         state.active_investigator = None;
 
         let mut events = Vec::new();
-        investigation_phase(&mut state, &mut events);
+        investigation_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert_eq!(
             state.active_investigator,
@@ -736,7 +756,10 @@ mod investigation_phase_tests {
         state.turn_order = vec![InvestigatorId(1)];
 
         let mut events = Vec::new();
-        let outcome = end_turn(&mut state, &mut events);
+        let outcome = end_turn(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert!(matches!(outcome, EngineOutcome::Done));
         assert!(
@@ -785,7 +808,10 @@ mod investigation_phase_tests {
         state.turn_order = vec![InvestigatorId(1), InvestigatorId(2)];
 
         let mut events = Vec::new();
-        let outcome = end_turn(&mut state, &mut events);
+        let outcome = end_turn(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert!(matches!(outcome, EngineOutcome::Done));
         assert_eq!(
@@ -823,7 +849,10 @@ mod investigation_phase_tests {
         state.turn_order = vec![InvestigatorId(1)];
 
         let mut events = Vec::new();
-        step_phase(&mut state, &mut events);
+        step_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert_eq!(
             events
@@ -848,7 +877,10 @@ mod investigation_phase_tests {
         state.active_investigator = None;
 
         let mut events = Vec::new();
-        step_phase(&mut state, &mut events); // Mythos→Investigation
+        step_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        }); // Mythos→Investigation
 
         assert_eq!(state.phase, Phase::Investigation);
         assert_eq!(state.active_investigator, Some(InvestigatorId(1)));
@@ -896,7 +928,10 @@ mod mythos_phase_tests {
         state.mythos_draw_pending = None;
         let mut events = Vec::new();
 
-        mythos_phase(&mut state, &mut events);
+        mythos_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert_eq!(state.mythos_draw_pending, Some(InvestigatorId(1)));
         assert!(
@@ -917,7 +952,10 @@ mod mythos_phase_tests {
         state.mythos_draw_pending = None;
         let mut events = Vec::new();
 
-        mythos_phase(&mut state, &mut events);
+        mythos_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         // No drawers → open_fast_window runs for MythosAfterDraws,
         // which auto-skips (no Fast eligibility), runs continuation
@@ -971,7 +1009,10 @@ mod mythos_phase_tests {
         state.turn_order = vec![InvestigatorId(1)];
         let mut events = Vec::new();
 
-        mythos_phase_end(&mut state, &mut events);
+        mythos_phase_end(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert_eq!(state.phase, Phase::Investigation);
         assert!(
@@ -1014,7 +1055,10 @@ mod mythos_phase_tests {
         state.mythos_draw_pending = None;
         let mut events = Vec::new();
 
-        mythos_phase(&mut state, &mut events);
+        mythos_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert_eq!(
             state.mythos_draw_pending,
@@ -1045,7 +1089,10 @@ mod mythos_phase_tests {
         state.mythos_draw_pending = None;
         let mut events = Vec::new();
 
-        mythos_phase(&mut state, &mut events);
+        mythos_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert_eq!(state.mythos_draw_pending, None);
         assert_eq!(
@@ -1239,7 +1286,10 @@ mod upkeep_phase_tests {
         state.active_investigator = None;
 
         let mut events = Vec::new();
-        step_phase(&mut state, &mut events); // Enemy → Upkeep, cascades to Mythos
+        step_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        }); // Enemy → Upkeep, cascades to Mythos
 
         let pos = |pred: &dyn Fn(&Event) -> bool| events.iter().position(pred);
         let started = pos(&|e| {
@@ -1315,7 +1365,10 @@ mod upkeep_phase_tests {
             .build();
         let mut events = Vec::new();
 
-        ready_exhausted_cards(&mut state, &mut events);
+        ready_exhausted_cards(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert!(
             !state.investigators[&inv_id].cards_in_play[0].exhausted,
@@ -1345,7 +1398,10 @@ mod upkeep_phase_tests {
             .build();
         let mut events = Vec::new();
 
-        ready_exhausted_cards(&mut state, &mut events);
+        ready_exhausted_cards(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert!(!state.enemies[&enemy_id].exhausted, "enemy readied");
         assert_eq!(
@@ -1372,7 +1428,10 @@ mod upkeep_phase_tests {
             .build();
         let mut events = Vec::new();
 
-        ready_exhausted_cards(&mut state, &mut events);
+        ready_exhausted_cards(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert!(
             events.is_empty(),
@@ -1396,7 +1455,10 @@ mod upkeep_phase_tests {
             .build();
         let mut events = Vec::new();
 
-        ready_exhausted_cards(&mut state, &mut events);
+        ready_exhausted_cards(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert!(!state.enemies[&enemy_id].exhausted, "enemy readied");
         assert_eq!(
@@ -1419,7 +1481,10 @@ mod upkeep_phase_tests {
             .build();
         let mut events = Vec::new();
 
-        ready_exhausted_cards(&mut state, &mut events);
+        ready_exhausted_cards(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert!(!state.enemies[&enemy_id].exhausted, "enemy readied");
         assert_eq!(
@@ -1452,7 +1517,10 @@ mod upkeep_phase_tests {
         state.turn_order = vec![a, b, c];
         let mut events = Vec::new();
 
-        upkeep_draw_and_resource(&mut state, &mut events);
+        upkeep_draw_and_resource(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert_eq!(state.investigators[&a].resources, res_a + 1);
         assert_eq!(state.investigators[&b].resources, res_b + 1);
@@ -1483,7 +1551,10 @@ mod upkeep_phase_tests {
         state.turn_order = vec![a, b];
         let mut events = Vec::new();
 
-        upkeep_draw_and_resource(&mut state, &mut events);
+        upkeep_draw_and_resource(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         let last_draw = events
             .iter()
@@ -1514,7 +1585,10 @@ mod upkeep_phase_tests {
         state.turn_order = vec![a, b];
         let mut events = Vec::new();
 
-        reset_actions(&mut state, &mut events);
+        reset_actions(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert_eq!(state.investigators[&a].actions_remaining, ACTIONS_PER_TURN);
         assert_eq!(
@@ -1540,7 +1614,10 @@ mod upkeep_phase_tests {
         state.turn_order = vec![id];
         let mut events = Vec::new();
 
-        reset_actions(&mut state, &mut events);
+        reset_actions(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
 
         assert_eq!(state.investigators[&id].actions_remaining, ACTIONS_PER_TURN);
         assert!(events.is_empty(), "no event when value is unchanged");
@@ -1554,7 +1631,13 @@ mod upkeep_phase_tests {
         let mut state = TestGame::default().with_investigator(inv).build();
         let mut events = Vec::new();
 
-        rotate_to_active(&mut state, &mut events, id);
+        rotate_to_active(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            id,
+        );
 
         assert_eq!(state.active_investigator, Some(id));
         assert_eq!(
@@ -1582,7 +1665,10 @@ mod upkeep_phase_tests {
         state.round = 4;
 
         let mut events = Vec::new();
-        step_phase(&mut state, &mut events); // Upkeep → ... → Mythos via the cascade
+        step_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        }); // Upkeep → ... → Mythos via the cascade
 
         assert_eq!(state.round, 5, "round bumps on Mythos entry");
         assert_eq!(state.phase, Phase::Mythos);
@@ -1667,7 +1753,10 @@ mod enemy_phase_tests {
             .with_enemy(hunter)
             .build();
         let mut events = Vec::new();
-        let outcome = end_turn(&mut state, &mut events);
+        let outcome = end_turn(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         assert_eq!(outcome, EngineOutcome::Done);
         // No registry installed → the attack window auto-skips inline and
         // the cascade runs Enemy→Upkeep→Mythos within this same call (same
@@ -1710,7 +1799,10 @@ mod enemy_phase_tests {
             .with_enemy(hunter)
             .build();
         let mut events = Vec::new();
-        let outcome = end_turn(&mut state, &mut events);
+        let outcome = end_turn(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
         assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
         assert_eq!(state.phase, Phase::Enemy);
         let mut ev2 = Vec::new();
@@ -1966,7 +2058,10 @@ mod enemy_phase_tests {
         state.active_investigator = None;
         let mut events = Vec::new();
 
-        step_phase(&mut state, &mut events); // Investigation → Enemy
+        step_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        }); // Investigation → Enemy
 
         // Positional ordering of the major events.
         let pos = |pred: &dyn Fn(&Event) -> bool| events.iter().position(pred);
@@ -2060,7 +2155,10 @@ mod enemy_phase_tests {
         state.active_investigator = None;
         let mut events = Vec::new();
 
-        step_phase(&mut state, &mut events); // Investigation → Enemy
+        step_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        }); // Investigation → Enemy
 
         // Two BeforeInvestigatorAttacked windows + one AfterAll.
         let before_opens: Vec<usize> = events
@@ -2110,7 +2208,10 @@ mod enemy_phase_tests {
         state.investigators.get_mut(&id2).unwrap().status = Status::Insane;
         let mut events = Vec::new();
 
-        step_phase(&mut state, &mut events); // Investigation → Enemy
+        step_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        }); // Investigation → Enemy
 
         // Only 2 BeforeInvestigatorAttacked windows (id1 + id3).
         let before_count = events
@@ -2139,7 +2240,10 @@ mod enemy_phase_tests {
         state.investigators.get_mut(&id1).unwrap().status = Status::Killed;
         let mut events = Vec::new();
 
-        step_phase(&mut state, &mut events); // Investigation → Enemy
+        step_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        }); // Investigation → Enemy
 
         // No BeforeInvestigatorAttacked windows — straight to AfterAll.
         assert!(
@@ -2184,7 +2288,10 @@ mod enemy_phase_tests {
         state.active_investigator = None;
         let mut events = Vec::new();
 
-        step_phase(&mut state, &mut events); // Investigation → Enemy
+        step_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        }); // Investigation → Enemy
 
         // The attack landed. Event-stream evidence — state.enemies's
         // `exhausted` flag is reset by Upkeep step 4.3 later in the
@@ -2220,7 +2327,10 @@ mod enemy_phase_tests {
         // Use a state where Upkeep's cascade can complete (Active investigator exists).
         let mut events = Vec::new();
 
-        step_phase(&mut state, &mut events); // Enemy → Upkeep
+        step_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        }); // Enemy → Upkeep
 
         // step_phase itself MUST NOT emit PhaseEnded(Enemy); only
         // enemy_phase_end is allowed to (which doesn't run here — we

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -1834,7 +1834,13 @@ mod enemy_phase_tests {
             .build();
         let mut events = Vec::new();
 
-        super::super::combat::resolve_attacks_for_investigator(&mut state, &mut events, inv_id);
+        super::super::combat::resolve_attacks_for_investigator(
+            &mut super::super::Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            inv_id,
+        );
 
         // Damage placed.
         assert!(
@@ -1901,7 +1907,13 @@ mod enemy_phase_tests {
             .build();
         let mut events = Vec::new();
 
-        super::super::combat::resolve_attacks_for_investigator(&mut state, &mut events, inv_id);
+        super::super::combat::resolve_attacks_for_investigator(
+            &mut super::super::Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            inv_id,
+        );
 
         // Exactly one DamageTaken (from e3, amount 1).
         let damages: Vec<&Event> = events
@@ -1964,7 +1976,13 @@ mod enemy_phase_tests {
             .build();
         let mut events = Vec::new();
 
-        super::super::combat::resolve_attacks_for_investigator(&mut state, &mut events, inv_id);
+        super::super::combat::resolve_attacks_for_investigator(
+            &mut super::super::Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            inv_id,
+        );
 
         // The two DamageTaken events must appear in EnemyId(2) → EnemyId(10) order
         // (verifiable via their amounts: 1 then 2).
@@ -2007,7 +2025,13 @@ mod enemy_phase_tests {
             .build();
         let mut events = Vec::new();
 
-        super::super::combat::resolve_attacks_for_investigator(&mut state, &mut events, inv_id);
+        super::super::combat::resolve_attacks_for_investigator(
+            &mut super::super::Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            inv_id,
+        );
 
         // e1 attacked + exhausted.
         assert!(

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -36,8 +36,8 @@ pub(super) fn start_scenario(cx: &mut Cx) -> EngineOutcome {
     // their deck and deal an initial hand of up to 5.
     let inv_ids: Vec<InvestigatorId> = cx.state.investigators.keys().copied().collect();
     for inv_id in inv_ids {
-        super::cards::shuffle_player_deck(cx.state, cx.events, inv_id);
-        super::cards::draw_cards(cx.state, cx.events, inv_id, super::cards::INITIAL_HAND_SIZE);
+        super::cards::shuffle_player_deck(cx, inv_id);
+        super::cards::draw_cards(cx, inv_id, super::cards::INITIAL_HAND_SIZE);
     }
 
     // Seed the mulligan cursor to the first Active investigator in
@@ -545,10 +545,10 @@ fn reset_actions(cx: &mut Cx) {
 fn upkeep_draw_and_resource(cx: &mut Cx) {
     let ids = super::cursor::active_investigators_in_turn_order(cx.state);
     for &id in &ids {
-        super::cards::draw_one_with_deckout(cx.state, cx.events, id);
+        super::cards::draw_one_with_deckout(cx, id);
     }
     for &id in &ids {
-        super::cards::grant_resources(cx.state, cx.events, id, 1);
+        super::cards::grant_resources(cx, id, 1);
     }
 }
 

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -347,7 +347,7 @@ fn fire_pending_trigger(cx: &mut Cx, i: u32) -> EngineOutcome {
     // information is already on the trigger record.
     let eval_ctx = EvalContext::for_controller_with_source(trigger.controller, trigger.instance_id);
     let usage_limit = ability.usage_limit;
-    let result = apply_effect(cx.state, cx.events, &ability.effect, eval_ctx);
+    let result = apply_effect(cx, &ability.effect, eval_ctx);
     if let EngineOutcome::Rejected { reason } = result {
         // Card-impl bugs surface loudly — same policy as
         // `fire_on_skill_test_resolution`.

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -491,7 +491,7 @@ pub(super) fn close_reaction_window_at(
     // terminal outcome.
     if let Some(in_flight) = state.in_flight_skill_test.as_ref() {
         if !matches!(in_flight.continuation, FinishContinuation::AwaitingCommit) {
-            return super::skill_test::drive_skill_test(state, events);
+            return super::skill_test::drive_skill_test(&mut super::Cx { state, events });
         }
     }
 

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -596,7 +596,10 @@ pub(super) fn run_window_continuation(
                 )
             });
 
-            super::combat::resolve_attacks_for_investigator(state, events, investigator);
+            super::combat::resolve_attacks_for_investigator(
+                &mut super::Cx { state, events },
+                investigator,
+            );
 
             // Advance the cursor: next Active investigator AFTER
             // `investigator` in turn_order. The shared helper uses

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -23,6 +23,7 @@ use crate::state::{
 
 use super::super::evaluator::{apply_effect, EvalContext};
 use super::super::outcome::{EngineOutcome, InputRequest, ResumeToken};
+use super::Cx;
 
 /// Queue a reaction window of the given `kind` if any in-play card
 /// has a matching `Trigger::OnEvent` ability. No-op when the registry
@@ -45,20 +46,16 @@ use super::super::outcome::{EngineOutcome, InputRequest, ResumeToken};
 /// doesn't arise; the overwrite is a loud-on-debug placeholder
 /// rather than silent stacking — multi-window queueing lands when a
 /// multi-defeat effect arrives.
-pub(super) fn queue_reaction_window(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    kind: WindowKind,
-) {
-    let pending_triggers = scan_pending_triggers(state, kind);
+pub(super) fn queue_reaction_window(cx: &mut Cx, kind: WindowKind) {
+    let pending_triggers = scan_pending_triggers(cx.state, kind);
     if pending_triggers.is_empty() {
         return;
     }
-    events.push(Event::WindowOpened { kind });
+    cx.events.push(Event::WindowOpened { kind });
     // Reaction windows admit any investigator's Fast actions
     // (Rules Reference: Fast may be played at any player window).
     // Multi-window nesting is now structural — push twice is valid.
-    state.open_windows.push(OpenWindow {
+    cx.state.open_windows.push(OpenWindow {
         kind,
         pending_triggers,
         fast_actors: FastActorScope::Any,
@@ -199,11 +196,9 @@ fn trigger_matches(
 /// [`Event::WindowOpened`] is emitted by [`queue_reaction_window`]
 /// (not here) so the event appears at queue time and is symmetric with
 /// the [`open_fast_window`] path.
-pub(super) fn open_queued_reaction_window(
-    state: &GameState,
-    _events: &mut Vec<Event>,
-) -> EngineOutcome {
-    let window = state
+pub(super) fn open_queued_reaction_window(cx: &mut Cx) -> EngineOutcome {
+    let window = cx
+        .state
         .top_reaction_window()
         .expect("open_queued_reaction_window: caller checked is_some");
     EngineOutcome::AwaitingInput {
@@ -236,23 +231,20 @@ pub(super) fn open_queued_reaction_window(
 /// Closing the window emits [`Event::WindowClosed`] with the same
 /// kind, pops the top entry from [`GameState::open_windows`], and
 /// returns [`Done`].
-pub(super) fn resume_reaction_window(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    response: &InputResponse,
-) -> EngineOutcome {
+pub(super) fn resume_reaction_window(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
     match response {
-        InputResponse::PickIndex(i) => fire_pending_trigger(state, events, *i),
+        InputResponse::PickIndex(i) => fire_pending_trigger(cx, *i),
         InputResponse::Skip => {
             // Resolve the active reaction-window index up-front so the
             // close path operates on the same window the driver had
             // been driving (not the absolute top of `open_windows`,
             // which may be an empty-pending_triggers window sitting
             // above it).
-            let idx = state
+            let idx = cx
+                .state
                 .top_reaction_window_index()
                 .expect("resume_reaction_window: caller checked is_some");
-            close_reaction_window_at(state, events, idx)
+            close_reaction_window_at(cx, idx)
         }
         other => EngineOutcome::Rejected {
             reason: format!(
@@ -267,17 +259,18 @@ pub(super) fn resume_reaction_window(
 /// Fire the pending trigger at index `i` in the open reaction window.
 /// Rejects out-of-bounds; the window stays open so the client can
 /// retry with a corrected index.
-fn fire_pending_trigger(state: &mut GameState, events: &mut Vec<Event>, i: u32) -> EngineOutcome {
+fn fire_pending_trigger(cx: &mut Cx, i: u32) -> EngineOutcome {
     // Capture the index of the reaction window we're driving up-front
     // so the close path removes the same entry (not the absolute top of
     // the stack, which may be a different, empty-pending_triggers
     // window once non-reaction windows can sit above one).
-    let window_idx = state
+    let window_idx = cx
+        .state
         .top_reaction_window_index()
         .expect("fire_pending_trigger: caller checked is_some");
     // Snapshot to avoid borrowing state across the apply_effect call.
     let (trigger, pending_idx) = {
-        let window = &state.open_windows[window_idx];
+        let window = &cx.state.open_windows[window_idx];
         let idx = match usize::try_from(i) {
             Ok(idx) if idx < window.pending_triggers.len() => idx,
             _ => {
@@ -303,7 +296,8 @@ fn fire_pending_trigger(state: &mut GameState, events: &mut Vec<Event>, i: u32) 
              missing; the OnceLock contract guarantees once-set-stays-set"
         );
     };
-    let inv = state
+    let inv = cx
+        .state
         .investigators
         .get(&trigger.controller)
         .unwrap_or_else(|| {
@@ -351,9 +345,9 @@ fn fire_pending_trigger(state: &mut GameState, events: &mut Vec<Event>, i: u32) 
     // effects (`discover_clue`, `gain_resources`) don't read this,
     // but the first source-attributing reaction effect will, and the
     // information is already on the trigger record.
-    let ctx = EvalContext::for_controller_with_source(trigger.controller, trigger.instance_id);
+    let eval_ctx = EvalContext::for_controller_with_source(trigger.controller, trigger.instance_id);
     let usage_limit = ability.usage_limit;
-    let result = apply_effect(state, events, &ability.effect, ctx);
+    let result = apply_effect(cx.state, cx.events, &ability.effect, eval_ctx);
     if let EngineOutcome::Rejected { reason } = result {
         // Card-impl bugs surface loudly — same policy as
         // `fire_on_skill_test_resolution`.
@@ -361,20 +355,20 @@ fn fire_pending_trigger(state: &mut GameState, events: &mut Vec<Event>, i: u32) 
     }
 
     if usage_limit.is_some() {
-        bump_usage_counter(state, &trigger);
+        bump_usage_counter(cx.state, &trigger);
     }
 
     // Drop the fired entry now that resolution succeeded. The window
     // we drove sits at `window_idx` — apply_effect does not push or
     // pop `open_windows` entries, so the index remains valid.
-    let window = &mut state.open_windows[window_idx];
+    let window = &mut cx.state.open_windows[window_idx];
     window.pending_triggers.remove(pending_idx);
 
     // If more triggers remain pending, re-emit AwaitingInput so the
     // player can pick the next one. Otherwise the window closes
     // automatically.
     if window.pending_triggers.is_empty() {
-        return close_reaction_window_at(state, events, window_idx);
+        return close_reaction_window_at(cx, window_idx);
     }
     let kind = window.kind;
     let pending_len = window.pending_triggers.len();
@@ -448,15 +442,12 @@ fn bump_usage_counter(state: &mut GameState, trigger: &PendingTrigger) {
 /// (#69/#70/#71), a naive `open_windows.pop()` would remove the wrong
 /// entry. Callers compute the index via
 /// [`GameState::top_reaction_window_index`].
-pub(super) fn close_reaction_window_at(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    idx: usize,
-) -> EngineOutcome {
+pub(super) fn close_reaction_window_at(cx: &mut Cx, idx: usize) -> EngineOutcome {
     // Borrow the window at `idx` to check for forced triggers remaining
     // before removing — Rejected must leave state untouched.
     {
-        let window = state
+        let window = cx
+            .state
             .open_windows
             .get(idx)
             .expect("close_reaction_window_at: caller-supplied index must be in bounds");
@@ -474,14 +465,14 @@ pub(super) fn close_reaction_window_at(
             };
         }
     }
-    let window = state.open_windows.remove(idx);
+    let window = cx.state.open_windows.remove(idx);
     let kind = window.kind;
-    events.push(Event::WindowClosed { kind });
+    cx.events.push(Event::WindowClosed { kind });
 
     // Run any kind-specific continuation (e.g. MythosAfterDraws →
     // mythos_phase_end). For reaction windows that have no continuation
     // (AfterEnemyDefeated, BetweenPhases) this is a no-op.
-    run_window_continuation(state, events, kind);
+    run_window_continuation(cx, kind);
 
     // If a skill test was mid-resolution when this window opened,
     // hand control back to its driver to run the remaining steps.
@@ -489,9 +480,9 @@ pub(super) fn close_reaction_window_at(
     // window (no driver state to resume); this happens when a future
     // non-skill-test action queues a window — `Done` is the right
     // terminal outcome.
-    if let Some(in_flight) = state.in_flight_skill_test.as_ref() {
+    if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
         if !matches!(in_flight.continuation, FinishContinuation::AwaitingCommit) {
-            return super::skill_test::drive_skill_test(&mut super::Cx { state, events });
+            return super::skill_test::drive_skill_test(cx);
         }
     }
 
@@ -519,11 +510,7 @@ pub(super) fn close_reaction_window_at(
 /// and [`WindowKind::InvestigatorTurnBegins`] windows have no
 /// continuation — for them this is a no-op preserving the existing
 /// [`close_reaction_window_at`] behavior.
-pub(super) fn run_window_continuation(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    kind: WindowKind,
-) {
+pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) {
     match kind {
         WindowKind::MythosAfterDraws => {
             // Phase-transitioning continuation: cannot run while a skill
@@ -533,7 +520,7 @@ pub(super) fn run_window_continuation(
             // adding a Mythos-phase Revelation that initiates a skill
             // test must redesign the close-window + phase-transition
             // ordering before this assertion fires.
-            if let Some(in_flight) = state.in_flight_skill_test.as_ref() {
+            if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
                 unreachable!(
                     "MythosAfterDraws window closed while a skill test is in flight \
                      (continuation={:?}). Phase transition would strand the skill test \
@@ -544,13 +531,13 @@ pub(super) fn run_window_continuation(
                     in_flight.continuation,
                 );
             }
-            super::phases::mythos_phase_end(&mut super::Cx { state, events });
+            super::phases::mythos_phase_end(cx);
         }
         WindowKind::UpkeepBegins => {
             // Phase-transitioning continuation (4.2–4.6 then Upkeep→Mythos):
             // cannot run while a skill test is in flight. Phase 4 has no
             // Upkeep-phase skill-test source, so structurally unreachable.
-            if let Some(in_flight) = state.in_flight_skill_test.as_ref() {
+            if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
                 unreachable!(
                     "UpkeepBegins window closed while a skill test is in flight \
                      (continuation={:?}). Phase 4 has no Upkeep-phase skill-test \
@@ -559,7 +546,7 @@ pub(super) fn run_window_continuation(
                     in_flight.continuation,
                 );
             }
-            super::phases::upkeep_resume(&mut super::Cx { state, events });
+            super::phases::upkeep_resume(cx);
         }
         WindowKind::BeforeInvestigatorAttacked => {
             // Phase-transitioning continuation (advances to the next
@@ -570,7 +557,7 @@ pub(super) fn run_window_continuation(
             // (e.g. a treachery-style "make an Agility test or take
             // damage" attack ability) must redesign the window-close
             // + phase-transition ordering before this assertion fires.
-            if let Some(in_flight) = state.in_flight_skill_test.as_ref() {
+            if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
                 unreachable!(
                     "BeforeInvestigatorAttacked window closed while a \
                      skill test is in flight (continuation={:?}). Phase \
@@ -588,7 +575,7 @@ pub(super) fn run_window_continuation(
             // in enemy_phase or in the advance below. A None cursor
             // here is a state-corruption invariant violation, not a
             // normal rejection path.
-            let investigator = state.enemy_attack_pending.unwrap_or_else(|| {
+            let investigator = cx.state.enemy_attack_pending.unwrap_or_else(|| {
                 unreachable!(
                     "BeforeInvestigatorAttacked closed with \
                      enemy_attack_pending == None; this is a \
@@ -596,27 +583,24 @@ pub(super) fn run_window_continuation(
                 )
             });
 
-            super::combat::resolve_attacks_for_investigator(
-                &mut super::Cx { state, events },
-                investigator,
-            );
+            super::combat::resolve_attacks_for_investigator(cx, investigator);
 
             // Advance the cursor: next Active investigator AFTER
             // `investigator` in turn_order. The shared helper uses
             // turn_order (not the filtered-Active list) as the index
             // basis, so `investigator` itself can have been defeated
             // mid-loop and we still find the right successor.
-            state.enemy_attack_pending =
-                super::cursor::next_active_investigator_after(state, investigator);
+            cx.state.enemy_attack_pending =
+                super::cursor::next_active_investigator_after(cx.state, investigator);
 
-            if state.enemy_attack_pending.is_some() {
-                open_fast_window(state, events, WindowKind::BeforeInvestigatorAttacked);
+            if cx.state.enemy_attack_pending.is_some() {
+                open_fast_window(cx, WindowKind::BeforeInvestigatorAttacked);
             } else {
-                open_fast_window(state, events, WindowKind::AfterAllInvestigatorsAttacked);
+                open_fast_window(cx, WindowKind::AfterAllInvestigatorsAttacked);
             }
         }
         WindowKind::AfterAllInvestigatorsAttacked => {
-            if let Some(in_flight) = state.in_flight_skill_test.as_ref() {
+            if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
                 unreachable!(
                     "AfterAllInvestigatorsAttacked window closed while a \
                      skill test is in flight (continuation={:?}). Phase \
@@ -627,14 +611,14 @@ pub(super) fn run_window_continuation(
                     in_flight.continuation,
                 );
             }
-            super::phases::enemy_phase_end(&mut super::Cx { state, events });
+            super::phases::enemy_phase_end(cx);
         }
         WindowKind::InvestigationBegins => {
             // Post-2.1 window closed; start the first turn (step 2.2).
             // No skill-test-in-flight guard: this runs at phase start
             // (no test can be in flight) and does not transition phase.
-            if let Some(id) = super::cursor::first_active_investigator(state) {
-                super::phases::begin_investigator_turn(&mut super::Cx { state, events }, id);
+            if let Some(id) = super::cursor::first_active_investigator(cx.state) {
+                super::phases::begin_investigator_turn(cx, id);
             }
             // None branch: no active investigator can take a turn. Per
             // Rules Reference p.10 step 6 the scenario ends — that
@@ -687,33 +671,34 @@ pub(super) fn run_window_continuation(
 /// On the auto-skip path the window is popped before returning so the
 /// net effect on `state.open_windows` is identical to the pre-fix
 /// behaviour (window never lands persistently on the stack).
-pub(super) fn open_fast_window(state: &mut GameState, events: &mut Vec<Event>, kind: WindowKind) {
-    events.push(Event::WindowOpened { kind });
+pub(super) fn open_fast_window(cx: &mut Cx, kind: WindowKind) {
+    cx.events.push(Event::WindowOpened { kind });
 
     // Push first so any_fast_play_eligible's check_play_card call sees
     // this window in state.open_windows when evaluating permissive_window.
-    let pending_triggers = scan_pending_triggers(state, kind);
-    state.open_windows.push(OpenWindow {
+    let pending_triggers = scan_pending_triggers(cx.state, kind);
+    cx.state.open_windows.push(OpenWindow {
         kind,
         pending_triggers,
         fast_actors: FastActorScope::Any,
     });
 
-    let has_pending = !state
+    let has_pending = !cx
+        .state
         .open_windows
         .last()
         .expect("just pushed; cannot be empty")
         .pending_triggers
         .is_empty();
-    let has_fast_eligible = any_fast_play_eligible(state);
+    let has_fast_eligible = any_fast_play_eligible(cx.state);
 
     if !has_pending && !has_fast_eligible {
         // Auto-skip: nothing to do. Pop the window we just pushed,
         // emit WindowClosed, and run the continuation inline, so the
         // net effect on state.open_windows is the same as before the fix.
-        let _ = state.open_windows.pop();
-        events.push(Event::WindowClosed { kind });
-        run_window_continuation(state, events, kind);
+        let _ = cx.state.open_windows.pop();
+        cx.events.push(Event::WindowClosed { kind });
+        run_window_continuation(cx, kind);
     }
     // Otherwise the window stays on the stack. The guard at the top of
     // apply() and resume_reaction_window / resolve_input handle the
@@ -1086,7 +1071,13 @@ mod open_fast_window_tests {
             .with_investigator(test_investigator(1))
             .build();
         let mut events = Vec::new();
-        open_fast_window(&mut state, &mut events, WindowKind::MythosAfterDraws);
+        open_fast_window(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            WindowKind::MythosAfterDraws,
+        );
 
         assert!(
             state.open_windows.is_empty(),
@@ -1120,8 +1111,10 @@ mod open_fast_window_tests {
         let mut state = TestGame::default().build();
         let mut events = Vec::new();
         run_window_continuation(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             WindowKind::AfterEnemyDefeated {
                 enemy: EnemyId(1),
                 by: None,

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -544,7 +544,7 @@ pub(super) fn run_window_continuation(
                     in_flight.continuation,
                 );
             }
-            super::phases::mythos_phase_end(state, events);
+            super::phases::mythos_phase_end(&mut super::Cx { state, events });
         }
         WindowKind::UpkeepBegins => {
             // Phase-transitioning continuation (4.2–4.6 then Upkeep→Mythos):
@@ -559,7 +559,7 @@ pub(super) fn run_window_continuation(
                     in_flight.continuation,
                 );
             }
-            super::phases::upkeep_resume(state, events);
+            super::phases::upkeep_resume(&mut super::Cx { state, events });
         }
         WindowKind::BeforeInvestigatorAttacked => {
             // Phase-transitioning continuation (advances to the next
@@ -624,14 +624,14 @@ pub(super) fn run_window_continuation(
                     in_flight.continuation,
                 );
             }
-            super::phases::enemy_phase_end(state, events);
+            super::phases::enemy_phase_end(&mut super::Cx { state, events });
         }
         WindowKind::InvestigationBegins => {
             // Post-2.1 window closed; start the first turn (step 2.2).
             // No skill-test-in-flight guard: this runs at phase start
             // (no test can be in flight) and does not transition phase.
             if let Some(id) = super::cursor::first_active_investigator(state) {
-                super::phases::begin_investigator_turn(state, events, id);
+                super::phases::begin_investigator_turn(&mut super::Cx { state, events }, id);
             }
             // None branch: no active investigator can take a turn. Per
             // Rules Reference p.10 step 6 the scenario ends — that

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -220,7 +220,7 @@ pub(super) fn finish_skill_test(cx: &mut Cx, indices: &[u32]) -> EngineOutcome {
 pub(super) fn drive_skill_test(cx: &mut Cx) -> EngineOutcome {
     loop {
         if cx.state.top_reaction_window().is_some() {
-            return super::reaction_windows::open_queued_reaction_window(cx.state, cx.events);
+            return super::reaction_windows::open_queued_reaction_window(cx);
         }
 
         let (continuation, investigator, indices_u8) = {

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -490,7 +490,7 @@ fn apply_skill_test_follow_up(
             // Mid-test enemy disappearance isn't possible in Phase 3
             // (no commit-window effects mutate enemies), so
             // damage_enemy's enemy-missing panic stays loud.
-            super::combat::damage_enemy(cx.state, cx.events, enemy, 1, Some(investigator));
+            super::combat::damage_enemy(cx, enemy, 1, Some(investigator));
         }
         SkillTestFollowUp::Evade { enemy } => {
             let e = cx.state.enemies.get_mut(&enemy).unwrap_or_else(|| {

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -478,7 +478,7 @@ fn apply_skill_test_follow_up(
             // action validates before starting the test. Empty-
             // location is a silent no-op by design. Any rejection
             // here is a state-corruption invariant violation.
-            let outcome = apply_effect(cx.state, cx.events, &effect, eval_ctx);
+            let outcome = apply_effect(cx, &effect, eval_ctx);
             if let EngineOutcome::Rejected { reason } = outcome {
                 unreachable!(
                     "Investigate follow-up: discover_clue rejected unexpectedly after \
@@ -579,7 +579,7 @@ fn fire_on_skill_test_resolution(
                 continue;
             }
             let eval_ctx = EvalContext::for_controller(investigator);
-            let result = apply_effect(cx.state, cx.events, &ability.effect, eval_ctx);
+            let result = apply_effect(cx, &ability.effect, eval_ctx);
             if let EngineOutcome::Rejected { reason } = result {
                 unreachable!(
                     "OnSkillTestResolution: effect for card {code:?} rejected unexpectedly: \

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -19,10 +19,10 @@ use super::super::evaluator::{
     apply_effect, constant_skill_modifier, pending_skill_modifier, EvalContext,
 };
 use super::super::outcome::{EngineOutcome, InputRequest, ResumeToken};
+use super::Cx;
 
 pub(super) fn start_skill_test(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
+    cx: &mut Cx,
     investigator: InvestigatorId,
     skill: SkillKind,
     kind: SkillTestKind,
@@ -34,7 +34,7 @@ pub(super) fn start_skill_test(
     // negative (FFG difficulties are always ≥ 0). Defeated
     // investigators can't take skill tests — they're out of play.
     // A second test cannot overlap an in-flight one.
-    let Some(inv) = state.investigators.get(&investigator) else {
+    let Some(inv) = cx.state.investigators.get(&investigator) else {
         return EngineOutcome::Rejected {
             reason: format!("skill test: investigator {investigator:?} not in state").into(),
         };
@@ -48,7 +48,7 @@ pub(super) fn start_skill_test(
             .into(),
         };
     }
-    if state.chaos_bag.tokens.is_empty() {
+    if cx.state.chaos_bag.tokens.is_empty() {
         return EngineOutcome::Rejected {
             reason: "skill test requires a non-empty chaos bag".into(),
         };
@@ -58,7 +58,7 @@ pub(super) fn start_skill_test(
             reason: format!("skill test: difficulty {difficulty} must be >= 0").into(),
         };
     }
-    if state.in_flight_skill_test.is_some() {
+    if cx.state.in_flight_skill_test.is_some() {
         return EngineOutcome::Rejected {
             reason: "skill test: another skill test is already in flight; only one test \
                      may pause at a commit window at a time"
@@ -73,7 +73,7 @@ pub(super) fn start_skill_test(
     // borrow from the validation block above is still live; reading
     // `current_location` here doesn't extend it past this line.
     let tested_location = inv.current_location;
-    state.in_flight_skill_test = Some(InFlightSkillTest {
+    cx.state.in_flight_skill_test = Some(InFlightSkillTest {
         investigator,
         skill,
         kind,
@@ -83,7 +83,7 @@ pub(super) fn start_skill_test(
         follow_up,
         continuation: FinishContinuation::AwaitingCommit,
     });
-    events.push(Event::SkillTestStarted {
+    cx.events.push(Event::SkillTestStarted {
         investigator,
         skill,
         difficulty,
@@ -129,14 +129,10 @@ pub(super) fn start_skill_test(
 /// paused so the caller can submit a fixed-up response.
 ///
 /// [`close_reaction_window_at`]: super::reaction_windows::close_reaction_window_at
-pub(super) fn finish_skill_test(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    indices: &[u32],
-) -> EngineOutcome {
+pub(super) fn finish_skill_test(cx: &mut Cx, indices: &[u32]) -> EngineOutcome {
     // Snapshot the in-flight record (Copy-able primitives only) so
     // later mutation paths can re-borrow state freely.
-    let Some(in_flight) = state.in_flight_skill_test.as_ref() else {
+    let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() else {
         return EngineOutcome::Rejected {
             reason: "ResolveInput::CommitCards: no in-flight skill test to resume".into(),
         };
@@ -160,41 +156,40 @@ pub(super) fn finish_skill_test(
     // Validate the commit indices against the resolving
     // investigator's hand. On Err, state is untouched and the engine
     // stays paused so the client can retry.
-    let indices_u8 = match validate_commit_indices(state, investigator, indices) {
+    let indices_u8 = match validate_commit_indices(cx.state, investigator, indices) {
         Ok(v) => v,
         Err(rejected) => return rejected,
     };
 
-    let skill_value = sum_skill_value(state, investigator, skill, kind, &indices_u8);
+    let skill_value = sum_skill_value(cx.state, investigator, skill, kind, &indices_u8);
 
     // Persist the committed indices into the in-flight record for
     // replay clarity. Safe to expect: we read `in_flight_skill_test`
     // immediately above and nothing has cleared it since.
-    state
+    cx.state
         .in_flight_skill_test
         .as_mut()
         .expect("in_flight_skill_test was Some immediately above")
         .committed_by_active
         .clone_from(&indices_u8);
 
-    let succeeded =
-        resolve_chaos_token_and_emit(state, events, investigator, skill, difficulty, skill_value);
+    let succeeded = resolve_chaos_token_and_emit(cx, investigator, skill, difficulty, skill_value);
 
     if succeeded {
-        apply_skill_test_follow_up(state, events, investigator, follow_up);
+        apply_skill_test_follow_up(cx, investigator, follow_up);
     }
 
     // Step 2 is complete. Advance the continuation (carrying the
     // outcome forward) and let the driver handle the remaining
     // steps (including the possibly-queued reaction window from
     // inside the follow-up).
-    state
+    cx.state
         .in_flight_skill_test
         .as_mut()
         .expect("in_flight_skill_test was Some immediately above")
         .continuation = FinishContinuation::PostFollowUp { succeeded };
 
-    drive_skill_test(state, events)
+    drive_skill_test(cx)
 }
 
 /// Walk the skill-test resolution sequence from the current
@@ -222,14 +217,14 @@ pub(super) fn finish_skill_test(
 ///   modifiers, clear in-flight, return `Done`.
 ///
 /// [`close_reaction_window_at`]: super::reaction_windows::close_reaction_window_at
-pub(super) fn drive_skill_test(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome {
+pub(super) fn drive_skill_test(cx: &mut Cx) -> EngineOutcome {
     loop {
-        if state.top_reaction_window().is_some() {
-            return super::reaction_windows::open_queued_reaction_window(state, events);
+        if cx.state.top_reaction_window().is_some() {
+            return super::reaction_windows::open_queued_reaction_window(cx.state, cx.events);
         }
 
         let (continuation, investigator, indices_u8) = {
-            let in_flight = state.in_flight_skill_test.as_ref().unwrap_or_else(|| {
+            let in_flight = cx.state.in_flight_skill_test.as_ref().unwrap_or_else(|| {
                 unreachable!(
                     "drive_skill_test: in_flight_skill_test must exist while driver is active; \
                      state-corruption invariant violation"
@@ -250,24 +245,24 @@ pub(super) fn drive_skill_test(state: &mut GameState, events: &mut Vec<Event>) -
                 );
             }
             FinishContinuation::PostFollowUp { succeeded } => {
-                fire_on_skill_test_resolution(state, events, investigator, &indices_u8, succeeded);
-                state
+                fire_on_skill_test_resolution(cx, investigator, &indices_u8, succeeded);
+                cx.state
                     .in_flight_skill_test
                     .as_mut()
                     .expect("in_flight_skill_test must persist across driver steps")
                     .continuation = FinishContinuation::PostOnResolution { succeeded };
             }
             FinishContinuation::PostOnResolution { succeeded: _ } => {
-                discard_committed_cards(state, events, investigator, &indices_u8);
-                events.push(Event::SkillTestEnded { investigator });
+                discard_committed_cards(cx, investigator, &indices_u8);
+                cx.events.push(Event::SkillTestEnded { investigator });
                 // ModifierScope::ThisSkillTest contributions expire when
                 // the test ends. Drain pending entries for *this*
                 // investigator only — entries queued for other
                 // investigators' future tests stay.
-                state
+                cx.state
                     .pending_skill_modifiers
                     .retain(|m| m.investigator != investigator);
-                state.in_flight_skill_test = None;
+                cx.state.in_flight_skill_test = None;
                 return EngineOutcome::Done;
             }
         }
@@ -386,17 +381,17 @@ fn sum_committed_icons(hand: &[CardCode], indices: &[u8], skill: SkillKind) -> i
 /// inside `i8`, but saturation defends against absurd state
 /// configurations without needing a wider integer type.
 fn resolve_chaos_token_and_emit(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
+    cx: &mut Cx,
     investigator: InvestigatorId,
     skill: SkillKind,
     difficulty: i8,
     skill_value: i8,
 ) -> bool {
-    let token_idx = state.rng.next_index(state.chaos_bag.tokens.len());
-    let token = state.chaos_bag.tokens[token_idx];
-    let resolution = resolve_token(token, &state.token_modifiers);
-    events.push(Event::ChaosTokenRevealed { token, resolution });
+    let token_idx = cx.state.rng.next_index(cx.state.chaos_bag.tokens.len());
+    let token = cx.state.chaos_bag.tokens[token_idx];
+    let resolution = resolve_token(token, &cx.state.token_modifiers);
+    cx.events
+        .push(Event::ChaosTokenRevealed { token, resolution });
 
     let (total, fail_reason) = match resolution {
         TokenResolution::Modifier(n) => (skill_value.saturating_add(n).max(0), None),
@@ -406,7 +401,7 @@ fn resolve_chaos_token_and_emit(
     let margin = total.saturating_sub(difficulty);
     let succeeded = margin >= 0 && fail_reason.is_none();
     if succeeded {
-        events.push(Event::SkillTestSucceeded {
+        cx.events.push(Event::SkillTestSucceeded {
             investigator,
             skill,
             margin,
@@ -414,7 +409,7 @@ fn resolve_chaos_token_and_emit(
     } else {
         let reason = fail_reason.unwrap_or(FailureReason::Total);
         let by = difficulty.saturating_sub(total);
-        events.push(Event::SkillTestFailed {
+        cx.events.push(Event::SkillTestFailed {
             investigator,
             skill,
             reason,
@@ -429,27 +424,34 @@ fn resolve_chaos_token_and_emit(
 /// [`Event::SkillTestEnded`] docs, these discards precede the
 /// `SkillTestEnded` cleanup marker. Walk indices in descending order
 /// so each `remove` keeps the still-pending indices stable.
-fn discard_committed_cards(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    investigator: InvestigatorId,
-    indices_u8: &[u8],
-) {
+fn discard_committed_cards(cx: &mut Cx, investigator: InvestigatorId, indices_u8: &[u8]) {
     let mut sorted: Vec<u8> = indices_u8.to_vec();
     sorted.sort_by(|a, b| b.cmp(a));
-    let inv = state
-        .investigators
-        .get_mut(&investigator)
-        .unwrap_or_else(|| {
-            unreachable!(
-                "discard_committed_cards: investigator {investigator:?} vanished after \
-                 follow-up; this is a state-corruption invariant violation"
-            )
-        });
-    for idx in sorted {
-        let code = inv.hand.remove(usize::from(idx));
-        inv.discard.push(code.clone());
-        events.push(Event::CardDiscarded {
+    // Collect discarded codes first (releasing the mutable borrow on
+    // cx.state) so we can push to cx.events afterwards without a
+    // simultaneous borrow through cx.
+    let discarded: Vec<CardCode> = {
+        let inv = cx
+            .state
+            .investigators
+            .get_mut(&investigator)
+            .unwrap_or_else(|| {
+                unreachable!(
+                    "discard_committed_cards: investigator {investigator:?} vanished after \
+                     follow-up; this is a state-corruption invariant violation"
+                )
+            });
+        sorted
+            .iter()
+            .map(|&idx| {
+                let code = inv.hand.remove(usize::from(idx));
+                inv.discard.push(code.clone());
+                code
+            })
+            .collect()
+    };
+    for code in discarded {
+        cx.events.push(Event::CardDiscarded {
             investigator,
             code,
             from: Zone::Hand,
@@ -461,8 +463,7 @@ fn discard_committed_cards(
 /// skill test. Failure-path follow-ups (none today) would route here
 /// too if we grow them.
 fn apply_skill_test_follow_up(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
+    cx: &mut Cx,
     investigator: InvestigatorId,
     follow_up: SkillTestFollowUp,
 ) {
@@ -470,14 +471,14 @@ fn apply_skill_test_follow_up(
         SkillTestFollowUp::None => {}
         SkillTestFollowUp::Investigate => {
             let effect = discover_clue(LocationTarget::ControllerLocation, 1);
-            let ctx = EvalContext::for_controller(investigator);
+            let eval_ctx = EvalContext::for_controller(investigator);
             // Same caveat as the pre-refactor `investigate`: the only
             // remaining rejection path inside `discover_clue` is
             // "controller is between locations", which the Investigate
             // action validates before starting the test. Empty-
             // location is a silent no-op by design. Any rejection
             // here is a state-corruption invariant violation.
-            let outcome = apply_effect(state, events, &effect, ctx);
+            let outcome = apply_effect(cx.state, cx.events, &effect, eval_ctx);
             if let EngineOutcome::Rejected { reason } = outcome {
                 unreachable!(
                     "Investigate follow-up: discover_clue rejected unexpectedly after \
@@ -489,10 +490,10 @@ fn apply_skill_test_follow_up(
             // Mid-test enemy disappearance isn't possible in Phase 3
             // (no commit-window effects mutate enemies), so
             // damage_enemy's enemy-missing panic stays loud.
-            super::combat::damage_enemy(state, events, enemy, 1, Some(investigator));
+            super::combat::damage_enemy(cx.state, cx.events, enemy, 1, Some(investigator));
         }
         SkillTestFollowUp::Evade { enemy } => {
-            let e = state.enemies.get_mut(&enemy).unwrap_or_else(|| {
+            let e = cx.state.enemies.get_mut(&enemy).unwrap_or_else(|| {
                 unreachable!(
                     "Evade follow-up: enemy {enemy:?} vanished while test was in flight; \
                      this is a state-corruption invariant violation"
@@ -500,11 +501,11 @@ fn apply_skill_test_follow_up(
             });
             e.engaged_with = None;
             e.exhausted = true;
-            events.push(Event::EnemyDisengaged {
+            cx.events.push(Event::EnemyDisengaged {
                 enemy,
                 investigator,
             });
-            events.push(Event::EnemyExhausted { enemy });
+            cx.events.push(Event::EnemyExhausted { enemy });
         }
     }
 }
@@ -528,8 +529,7 @@ fn apply_skill_test_follow_up(
 /// triggered effect. Mirrors `apply_skill_test_follow_up`'s
 /// `unreachable!` on a follow-up rejection.
 fn fire_on_skill_test_resolution(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
+    cx: &mut Cx,
     investigator: InvestigatorId,
     indices_u8: &[u8],
     succeeded: bool,
@@ -551,12 +551,16 @@ fn fire_on_skill_test_resolution(
     // Each committed index resolves to a hand-position CardCode; the
     // cards are still in hand at this point (discard happens next).
     let codes: Vec<CardCode> = {
-        let inv = state.investigators.get(&investigator).unwrap_or_else(|| {
-            unreachable!(
-                "fire_on_skill_test_resolution: investigator {investigator:?} vanished while \
+        let inv = cx
+            .state
+            .investigators
+            .get(&investigator)
+            .unwrap_or_else(|| {
+                unreachable!(
+                    "fire_on_skill_test_resolution: investigator {investigator:?} vanished while \
                  test was in flight; this is a state-corruption invariant violation"
-            )
-        });
+                )
+            });
         indices_u8
             .iter()
             .map(|&i| inv.hand[usize::from(i)].clone())
@@ -574,8 +578,8 @@ fn fire_on_skill_test_resolution(
             if outcome != outcome_now {
                 continue;
             }
-            let ctx = EvalContext::for_controller(investigator);
-            let result = apply_effect(state, events, &ability.effect, ctx);
+            let eval_ctx = EvalContext::for_controller(investigator);
+            let result = apply_effect(cx.state, cx.events, &ability.effect, eval_ctx);
             if let EngineOutcome::Rejected { reason } = result {
                 unreachable!(
                     "OnSkillTestResolution: effect for card {code:?} rejected unexpectedly: \
@@ -591,15 +595,13 @@ fn fire_on_skill_test_resolution(
 /// Opens the commit window with no action-specific follow-up. The
 /// after-resolution trigger window (#64) is downstream.
 pub(super) fn perform_skill_test(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
+    cx: &mut Cx,
     investigator: InvestigatorId,
     skill: SkillKind,
     difficulty: i8,
 ) -> EngineOutcome {
     start_skill_test(
-        state,
-        events,
+        cx,
         investigator,
         skill,
         SkillTestKind::Plain,
@@ -609,14 +611,13 @@ pub(super) fn perform_skill_test(
 }
 
 pub(super) fn peril_check(
-    _state: &mut GameState,
-    _events: &mut Vec<Event>,
+    _cx: &mut Cx,
     _code: &CardCode,
     _investigator: InvestigatorId,
     _is_peril: bool,
 ) {
     // TODO(future-peril-PR): if `is_peril`, install a temporary
-    //   restriction on `state` such that other investigators cannot
+    //   restriction on `_cx.state` such that other investigators cannot
     //   (a) play cards, (b) trigger abilities, or (c) commit to the
     //   drawing investigator's skill tests until this card's
     //   resolution completes.

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -316,7 +316,11 @@ fn gain_resources(
             reason: format!("GainResources: investigator {target_id:?} is not in the state").into(),
         };
     }
-    crate::engine::dispatch::cards::grant_resources(state, events, target_id, amount);
+    crate::engine::dispatch::cards::grant_resources(
+        &mut crate::engine::Cx { state, events },
+        target_id,
+        amount,
+    );
     EngineOutcome::Done
 }
 

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -59,6 +59,7 @@ use crate::event::Event;
 use crate::state::{GameState, InvestigatorId, SkillKind};
 
 use super::outcome::EngineOutcome;
+use super::Cx;
 
 /// Per-evaluation context the effect needs to resolve targets and
 /// reference in-flight game state (current skill test, etc.).
@@ -127,24 +128,17 @@ impl EvalContext {
 /// authors expect the whole sequence or nothing — but it means
 /// gluing implemented + stubbed effects together still blocks on
 /// the stubs.
-pub fn apply_effect(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    effect: &Effect,
-    ctx: EvalContext,
-) -> EngineOutcome {
+pub(crate) fn apply_effect(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) -> EngineOutcome {
     match effect {
-        Effect::GainResources { target, amount } => {
-            gain_resources(state, events, ctx, *target, *amount)
-        }
-        Effect::DiscoverClue { from, count } => discover_clue(state, events, ctx, *from, *count),
-        Effect::Seq(effects) => apply_seq(state, events, effects, ctx),
-        Effect::Modify { stat, delta, scope } => modify(state, ctx, *stat, *delta, *scope),
+        Effect::GainResources { target, amount } => gain_resources(cx, eval_ctx, *target, *amount),
+        Effect::DiscoverClue { from, count } => discover_clue(cx, eval_ctx, *from, *count),
+        Effect::Seq(effects) => apply_seq(cx, effects, eval_ctx),
+        Effect::Modify { stat, delta, scope } => modify(cx, eval_ctx, *stat, *delta, *scope),
         Effect::If {
             condition,
             then,
             else_,
-        } => apply_if(state, events, ctx, condition, then, else_.as_deref()),
+        } => apply_if(cx, eval_ctx, condition, then, else_.as_deref()),
         Effect::ForEach { .. } => awaiting_input_stub("ForEach"),
         Effect::ChooseOne(_) => awaiting_input_stub("ChooseOne"),
     }
@@ -163,14 +157,13 @@ pub fn apply_effect(
 /// events the branch already pushed. The structural fix lives at
 /// the outer `apply` loop (TODO in `engine/mod.rs::apply`).
 fn apply_if(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    ctx: EvalContext,
+    cx: &mut Cx,
+    eval_ctx: EvalContext,
     condition: &Condition,
     then: &Effect,
     else_: Option<&Effect>,
 ) -> EngineOutcome {
-    let holds = match eval_condition(state, condition) {
+    let holds = match eval_condition(cx.state, condition) {
         Ok(b) => b,
         Err(reason) => {
             return EngineOutcome::Rejected {
@@ -179,9 +172,9 @@ fn apply_if(
         }
     };
     if holds {
-        apply_effect(state, events, then, ctx)
+        apply_effect(cx, then, eval_ctx)
     } else if let Some(else_branch) = else_ {
-        apply_effect(state, events, else_branch, ctx)
+        apply_effect(cx, else_branch, eval_ctx)
     } else {
         EngineOutcome::Done
     }
@@ -234,21 +227,21 @@ fn eval_condition(state: &GameState, condition: &Condition) -> Result<bool, Stri
 /// - [`ModifierScope::ThisTurn`]: not yet wired; rejects with TODO
 ///   until a card or test demands it.
 fn modify(
-    state: &mut GameState,
-    ctx: EvalContext,
+    cx: &mut Cx,
+    eval_ctx: EvalContext,
     stat: crate::dsl::Stat,
     delta: i8,
     scope: ModifierScope,
 ) -> EngineOutcome {
     match scope {
         ModifierScope::ThisSkillTest => {
-            state
+            cx.state
                 .pending_skill_modifiers
                 .push(crate::state::PendingSkillModifier {
-                    investigator: ctx.controller,
+                    investigator: eval_ctx.controller,
                     stat,
                     delta,
-                    source: ctx.source,
+                    source: eval_ctx.source,
                 });
             EngineOutcome::Done
         }
@@ -287,9 +280,8 @@ fn awaiting_input_stub(name: &'static str) -> EngineOutcome {
 // ---- leaf-effect implementations ------------------------------
 
 fn gain_resources(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    ctx: EvalContext,
+    cx: &mut Cx,
+    eval_ctx: EvalContext,
     target: InvestigatorTarget,
     amount: u8,
 ) -> EngineOutcome {
@@ -300,7 +292,7 @@ fn gain_resources(
         // isn't a state change worth narrating.
         return EngineOutcome::Done;
     }
-    let target_id = match resolve_investigator_target(state, ctx, target) {
+    let target_id = match resolve_investigator_target(cx.state, eval_ctx, target) {
         Ok(id) => id,
         Err(reason) => {
             return EngineOutcome::Rejected {
@@ -311,23 +303,18 @@ fn gain_resources(
     // Validate-first: confirm the investigator exists in state before
     // we touch anything. The "active" target may resolve to None if
     // outside the Investigation phase; that's a reject, not a panic.
-    if !state.investigators.contains_key(&target_id) {
+    if !cx.state.investigators.contains_key(&target_id) {
         return EngineOutcome::Rejected {
             reason: format!("GainResources: investigator {target_id:?} is not in the state").into(),
         };
     }
-    crate::engine::dispatch::cards::grant_resources(
-        &mut crate::engine::Cx { state, events },
-        target_id,
-        amount,
-    );
+    crate::engine::dispatch::cards::grant_resources(cx, target_id, amount);
     EngineOutcome::Done
 }
 
 fn discover_clue(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    ctx: EvalContext,
+    cx: &mut Cx,
+    eval_ctx: EvalContext,
     from: LocationTarget,
     count: u8,
 ) -> EngineOutcome {
@@ -340,7 +327,7 @@ fn discover_clue(
     }
 
     // Resolve the source location.
-    let location_id = match resolve_location_target(state, ctx, from) {
+    let location_id = match resolve_location_target(cx.state, eval_ctx, from) {
         Ok(id) => id,
         Err(reason) => {
             return EngineOutcome::Rejected {
@@ -352,7 +339,7 @@ fn discover_clue(
     // Validate-first: collect the data we need to mutate without
     // mutating yet, so a missing-investigator or empty-location case
     // doesn't leave state half-modified.
-    let Some(location) = state.locations.get(&location_id) else {
+    let Some(location) = cx.state.locations.get(&location_id) else {
         return EngineOutcome::Rejected {
             reason: format!("DiscoverClue: location {location_id:?} is not in the state").into(),
         };
@@ -368,11 +355,11 @@ fn discover_clue(
     let actually_taken = count.min(location.clues);
     let new_location_count = location.clues - actually_taken;
 
-    if !state.investigators.contains_key(&ctx.controller) {
+    if !cx.state.investigators.contains_key(&eval_ctx.controller) {
         return EngineOutcome::Rejected {
             reason: format!(
                 "DiscoverClue: controller {:?} is not in the state",
-                ctx.controller
+                eval_ctx.controller
             )
             .into(),
         };
@@ -380,34 +367,30 @@ fn discover_clue(
 
     // Commit the mutations. From here both writes succeed
     // unconditionally.
-    state
+    cx.state
         .locations
         .get_mut(&location_id)
         .expect("checked above")
         .clues = new_location_count;
-    let investigator = state
+    let investigator = cx
+        .state
         .investigators
-        .get_mut(&ctx.controller)
+        .get_mut(&eval_ctx.controller)
         .expect("checked above");
     investigator.clues = investigator.clues.saturating_add(actually_taken);
 
-    events.push(Event::CluePlaced {
-        investigator: ctx.controller,
+    cx.events.push(Event::CluePlaced {
+        investigator: eval_ctx.controller,
         count: actually_taken,
     });
-    events.push(Event::LocationCluesChanged {
+    cx.events.push(Event::LocationCluesChanged {
         location: location_id,
         new_count: new_location_count,
     });
     EngineOutcome::Done
 }
 
-fn apply_seq(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    effects: &[Effect],
-    ctx: EvalContext,
-) -> EngineOutcome {
+fn apply_seq(cx: &mut Cx, effects: &[Effect], eval_ctx: EvalContext) -> EngineOutcome {
     // Stop at the first non-Done outcome. A Rejected mid-Seq leaves
     // earlier effects committed — not great as a rollback story, but
     // matches the existing handler contract (the validate-first
@@ -421,7 +404,7 @@ fn apply_seq(
     // AwaitingInput is unreachable here (no implemented variant
     // produces it), so the simple early-return is correct for v0.
     for effect in effects {
-        let outcome = apply_effect(state, events, effect, ctx);
+        let outcome = apply_effect(cx, effect, eval_ctx);
         if !matches!(outcome, EngineOutcome::Done) {
             return outcome;
         }
@@ -639,6 +622,7 @@ mod tests {
     use crate::{assert_event, assert_no_event};
 
     use super::{apply_effect, constant_skill_modifier, EngineOutcome, EvalContext};
+    use crate::engine::Cx;
 
     fn ctx(id: u32) -> EvalContext {
         EvalContext::for_controller(InvestigatorId(id))
@@ -654,8 +638,10 @@ mod tests {
         let mut events = Vec::new();
 
         let outcome = apply_effect(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &gain_resources(InvestigatorTarget::Controller, 3),
             ctx(1),
         );
@@ -682,8 +668,10 @@ mod tests {
         let mut events = Vec::new();
 
         let outcome = apply_effect(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &gain_resources(InvestigatorTarget::Active, 0),
             ctx(1),
         );
@@ -703,8 +691,10 @@ mod tests {
         let mut events = Vec::new();
 
         let outcome = apply_effect(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &gain_resources(InvestigatorTarget::Active, 1),
             ctx(1),
         );
@@ -728,8 +718,10 @@ mod tests {
         let mut events = Vec::new();
 
         let outcome = apply_effect(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &discover_clue(LocationTarget::ControllerLocation, 1),
             ctx(1),
         );
@@ -764,8 +756,10 @@ mod tests {
         let mut events = Vec::new();
 
         let outcome = apply_effect(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &discover_clue(LocationTarget::ControllerLocation, 3),
             ctx(1),
         );
@@ -798,8 +792,10 @@ mod tests {
         let mut events = Vec::new();
 
         let outcome = apply_effect(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &discover_clue(LocationTarget::ControllerLocation, 1),
             ctx(1),
         );
@@ -820,8 +816,10 @@ mod tests {
         let mut events = Vec::new();
 
         let outcome = apply_effect(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &discover_clue(LocationTarget::ControllerLocation, 1),
             ctx(1),
         );
@@ -863,8 +861,10 @@ mod tests {
         let mut events = Vec::new();
 
         let outcome = apply_effect(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &discover_clue(LocationTarget::TestedLocation, 1),
             ctx(1),
         );
@@ -891,8 +891,10 @@ mod tests {
         let mut events = Vec::new();
 
         let outcome = apply_effect(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &discover_clue(LocationTarget::TestedLocation, 1),
             ctx(1),
         );
@@ -939,7 +941,14 @@ mod tests {
             discover_clue(LocationTarget::TestedLocation, 1),
         );
 
-        let outcome = apply_effect(&mut state, &mut events, &effect, ctx(1));
+        let outcome = apply_effect(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            &effect,
+            ctx(1),
+        );
 
         assert_eq!(outcome, EngineOutcome::Done);
         assert_eq!(state.locations[&LocationId(10)].clues, 1);
@@ -956,7 +965,14 @@ mod tests {
             discover_clue(LocationTarget::TestedLocation, 1),
         );
 
-        let outcome = apply_effect(&mut state, &mut events, &effect, ctx(1));
+        let outcome = apply_effect(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            &effect,
+            ctx(1),
+        );
 
         assert_eq!(outcome, EngineOutcome::Done);
         // No-op: location clues unchanged, no events emitted.
@@ -977,7 +993,14 @@ mod tests {
         );
         let resources_before = state.investigators[&InvestigatorId(1)].resources;
 
-        let outcome = apply_effect(&mut state, &mut events, &effect, ctx(1));
+        let outcome = apply_effect(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            &effect,
+            ctx(1),
+        );
 
         assert_eq!(outcome, EngineOutcome::Done);
         // Else branch ran: location untouched, resources +2.
@@ -1000,7 +1023,14 @@ mod tests {
             discover_clue(LocationTarget::TestedLocation, 1),
         );
 
-        let outcome = apply_effect(&mut state, &mut events, &effect, ctx(1));
+        let outcome = apply_effect(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            &effect,
+            ctx(1),
+        );
 
         assert!(matches!(outcome, EngineOutcome::Rejected { .. }));
         assert!(events.is_empty());
@@ -1022,7 +1052,14 @@ mod tests {
             discover_clue(LocationTarget::TestedLocation, 1),
         );
 
-        let outcome = apply_effect(&mut state, &mut events, &effect, ctx(1));
+        let outcome = apply_effect(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            &effect,
+            ctx(1),
+        );
 
         match outcome {
             EngineOutcome::Rejected { reason } => {
@@ -1055,8 +1092,10 @@ mod tests {
         let mut events = Vec::new();
 
         let outcome = apply_effect(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &discover_clue(LocationTarget::TestedLocation, 1),
             ctx(1),
         );
@@ -1081,8 +1120,10 @@ mod tests {
         let mut events = Vec::new();
 
         let outcome = apply_effect(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &seq([
                 gain_resources(InvestigatorTarget::Controller, 2),
                 discover_clue(LocationTarget::ControllerLocation, 1),
@@ -1114,8 +1155,10 @@ mod tests {
         let mut events = Vec::new();
 
         let outcome = apply_effect(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &seq([
                 gain_resources(InvestigatorTarget::Active, 1), // rejects
                 discover_clue(LocationTarget::ControllerLocation, 1), // shouldn't run
@@ -1137,8 +1180,10 @@ mod tests {
         let mut state = TestGame::new().build();
         let mut events = Vec::new();
         let outcome = apply_effect(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &modify(Stat::Willpower, 1, ModifierScope::WhileInPlay),
             ctx(1),
         );
@@ -1153,8 +1198,10 @@ mod tests {
             .build();
         let mut events = Vec::new();
         let outcome = apply_effect(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &modify(Stat::Intellect, 1, ModifierScope::ThisSkillTest),
             ctx(1),
         );
@@ -1178,8 +1225,10 @@ mod tests {
         let mut events = Vec::new();
         let ctx_with_src = EvalContext::for_controller_with_source(id, src);
         let outcome = apply_effect(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &modify(Stat::Combat, 2, ModifierScope::ThisSkillTest),
             ctx_with_src,
         );
@@ -1192,8 +1241,10 @@ mod tests {
         let mut state = TestGame::new().build();
         let mut events = Vec::new();
         let outcome = apply_effect(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &modify(Stat::Willpower, 1, ModifierScope::ThisTurn),
             ctx(1),
         );
@@ -1213,8 +1264,10 @@ mod tests {
         let mut state = TestGame::new().build();
         let mut events = Vec::new();
         let outcome = apply_effect(
-            &mut state,
-            &mut events,
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             &Effect::ChooseOne(vec![gain_resources(InvestigatorTarget::Controller, 1)]),
             ctx(1),
         );

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -17,7 +17,7 @@ pub mod evaluator;
 mod outcome;
 pub(crate) mod pathfinding;
 
-pub use evaluator::{apply_effect, EvalContext};
+pub use evaluator::EvalContext;
 pub use outcome::{EngineOutcome, InputRequest, ResumeToken};
 
 use crate::action::Action;

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -10,6 +10,8 @@
 //! replaying it via [`apply`] from the initial state reproduces the
 //! current state bit-for-bit.
 
+mod cx;
+pub(crate) use cx::Cx;
 mod dispatch;
 pub mod evaluator;
 mod outcome;
@@ -91,24 +93,32 @@ pub fn apply_with_scenario_registry(
     let mut state = state;
     let mut events = Vec::new();
     let resolution_already_fired = state.resolution.is_some();
-    let outcome = match action {
-        Action::Player(p) => dispatch::apply_player_action(&mut state, &mut events, &p),
-        Action::Engine(e) => dispatch::apply_engine_record(&mut state, &mut events, &e),
+    let outcome = {
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+        let outcome = match action {
+            Action::Player(p) => dispatch::apply_player_action(&mut cx, &p),
+            Action::Engine(e) => dispatch::apply_engine_record(&mut cx, &e),
+        };
+        if matches!(outcome, EngineOutcome::Rejected { .. }) {
+            // Belt-and-suspenders: handlers are expected to validate before
+            // mutating, so events should already be empty here. Clear
+            // anyway in case a handler accidentally pushed before bailing.
+            cx.events.clear();
+        } else if !resolution_already_fired {
+            // A dispatch site may have latched a resolution this apply (act/
+            // agenda resolution point, or no-remaining-players elimination).
+            // Fire the module hook exactly once, on the None->Some transition.
+            // Runs on Done AND AwaitingInput — a resolution can latch during
+            // an apply that pauses (e.g. doom crosses the threshold in Mythos
+            // 1.3 before the 1.4 draw pause).
+            fire_scenario_resolution(&mut cx, registry);
+        }
+        outcome
+        // `cx` drops here, releasing borrows on `state` and `events`.
     };
-    if matches!(outcome, EngineOutcome::Rejected { .. }) {
-        // Belt-and-suspenders: handlers are expected to validate before
-        // mutating, so events should already be empty here. Clear
-        // anyway in case a handler accidentally pushed before bailing.
-        events.clear();
-    } else if !resolution_already_fired {
-        // A dispatch site may have latched a resolution this apply (act/
-        // agenda resolution point, or no-remaining-players elimination).
-        // Fire the module hook exactly once, on the None->Some transition.
-        // Runs on Done AND AwaitingInput — a resolution can latch during
-        // an apply that pauses (e.g. doom crosses the threshold in Mythos
-        // 1.3 before the 1.4 draw pause).
-        fire_scenario_resolution(&mut state, &mut events, registry);
-    }
     ApplyResult {
         state,
         events,
@@ -126,25 +136,21 @@ pub fn apply_with_scenario_registry(
 /// is a property of engine state, so it fires even when no module is
 /// registered (or `scenario_id` is `None`); only `apply_resolution` needs
 /// the registry/module.
-fn fire_scenario_resolution(
-    state: &mut GameState,
-    events: &mut Vec<Event>,
-    registry: Option<&ScenarioRegistry>,
-) {
-    let Some(resolution) = state.resolution.clone() else {
+fn fire_scenario_resolution(cx: &mut Cx, registry: Option<&ScenarioRegistry>) {
+    let Some(resolution) = cx.state.resolution.clone() else {
         return;
     };
-    events.push(Event::ScenarioResolved {
+    cx.events.push(Event::ScenarioResolved {
         resolution: resolution.clone(),
     });
-    let Some(id) = state.scenario_id.as_ref() else {
+    let Some(id) = cx.state.scenario_id.as_ref() else {
         return;
     };
     let Some(reg) = registry else { return };
     let Some(module) = (reg.module_for)(id) else {
         return;
     };
-    (module.apply_resolution)(&resolution, state, events);
+    (module.apply_resolution)(&resolution, cx.state, cx.events);
 }
 
 #[cfg(test)]

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -729,7 +729,7 @@ pub struct PendingTrigger {
 /// A queued [`ModifierScope::ThisSkillTest`] contribution waiting to
 /// apply to a skill test.
 ///
-/// Pushed by [`apply_effect`](crate::engine::apply_effect) when an
+/// Pushed by `apply_effect` when an
 /// activated or triggered ability resolves a `Modify { scope:
 /// ThisSkillTest, … }` effect. Consumed (and cleared) by the next
 /// skill-test resolution for the same investigator.

--- a/docs/superpowers/plans/2026-06-05-160-engine-mutation-context.md
+++ b/docs/superpowers/plans/2026-06-05-160-engine-mutation-context.md
@@ -1,0 +1,374 @@
+# `Cx` Mutation-Context Bundle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `(&mut GameState, &mut Vec<Event>)` parameter pair threaded through ~96 engine functions with a single `Cx<'a>` field bundle, with zero behavior change.
+
+**Architecture:** A `pub(crate) struct Cx<'a> { state, events }` bare field bundle, threaded as `cx: &mut Cx` into free functions (not methods, no helpers). Migration proceeds module-by-module; at the migration frontier, calls between migrated and not-yet-migrated functions are bridged with two mechanical shims so every intermediate step compiles and the test suite stays green.
+
+**Tech Stack:** Rust, `cargo` workspace (`game-core` kernel crate). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-160-engine-mutation-context-design.md`
+
+---
+
+## Background the implementer needs
+
+### This is a pure refactor — no new tests, no behavior change
+
+The existing test suite IS the correctness oracle. **Do not write new tests.** Each task's verification is "the suite still passes." A "Rejected leaves state untouched" structural test is explicitly *out of scope* (it belongs to issue #161).
+
+### The transformation rule (uniform across every function)
+
+A function that currently looks like:
+
+```rust
+pub(super) fn investigate(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    investigator: InvestigatorId,
+) -> EngineOutcome {
+    if state.phase != Phase::Investigation { /* ... */ }
+    events.push(Event::Investigated { /* ... */ });
+    // ...
+}
+```
+
+becomes:
+
+```rust
+pub(super) fn investigate(
+    cx: &mut Cx,
+    investigator: InvestigatorId,
+) -> EngineOutcome {
+    if cx.state.phase != Phase::Investigation { /* ... */ }
+    cx.events.push(Event::Investigated { /* ... */ });
+    // ...
+}
+```
+
+i.e. drop the two params, add `cx: &mut Cx` as the **first** param, and rewrite the body: `state.` → `cx.state.`, `events.` → `cx.events.`, bare `state` → `cx.state`, bare `events` → `cx.events`.
+
+Read-only functions that take `state: &GameState` (no `events`) are **left unchanged** — e.g. everything in `dispatch/cursor.rs`. A migrated caller calls them as `read_fn(cx.state, …)`.
+
+### The two frontier shims (both are temporary; all are gone by the final task)
+
+Because migration is incremental, a migrated function may call a not-yet-migrated one and vice-versa. Bridge each direction mechanically:
+
+**Shim A — migrated function calls a raw (not-yet-migrated) function** → *unbundle*:
+
+```rust
+// callee still takes (state, events, …):
+phases::start_scenario(cx.state, cx.events);
+```
+
+**Shim B — raw (not-yet-migrated) function calls a migrated function** → *re-bundle*:
+
+```rust
+// inside a fn that still has `state: &mut GameState, events: &mut Vec<Event>`:
+let mut cx = Cx { state, events };
+let outcome = cards::play_card(&mut cx, investigator, hand_index);
+// `cx` drops here; `state`/`events` are usable again afterward
+```
+
+`Cx { state, events }` moves the reborrowed `&mut` references in; after `cx` drops at end of scope, `state`/`events` are free again (non-lexical lifetimes). If the function needs `state`/`events` again *after* the call in the same statement sequence, that's fine — the borrow ends when `cx` is last used.
+
+### Migration order
+
+Top-down from the entry point minimizes shim churn (you mostly only need Shim A). Module order below follows the rough call hierarchy. If the borrow checker forces a Shim B somewhere, use it — it's mechanical and removed when the callee's module migrates.
+
+### The `eval_ctx` rename
+
+The evaluator's semantic context is `EvalContext`, conventionally bound to a variable named `ctx`. Once `Cx`/`cx` exists, `cx` and `ctx` read ambiguously side-by-side. So **wherever an `EvalContext` value named `ctx` co-occurs with `cx`**, rename it `ctx` → `eval_ctx`. This affects the evaluator module (Task 13) and these 5 dispatch modules: `abilities`, `cards`, `reaction_windows`, `encounter`, `skill_test` (Tasks for those modules). `apply_effect` takes `ctx: EvalContext` **by value** (it is `Copy`); keep it by value, just rename to `eval_ctx`.
+
+### Inner-loop verification commands
+
+Fast loop after each task:
+
+```sh
+cargo build -p game-core --all-features
+RUSTFLAGS="-D warnings" cargo test -p game-core --all-features
+```
+
+Full CI gauntlet (run on Task 1 to baseline, and on the final task):
+
+```sh
+RUSTFLAGS="-D warnings"     cargo test --all --all-features
+                            cargo clippy --all-targets --all-features -- -D warnings
+                            cargo fmt --check
+RUSTDOCFLAGS="-D warnings"  cargo doc --workspace --no-deps --all-features
+                            cargo build -p web --target wasm32-unknown-unknown
+```
+
+---
+
+## Task 1: Define `Cx` and migrate the entry point
+
+**Files:**
+- Create: `crates/game-core/src/engine/cx.rs`
+- Modify: `crates/game-core/src/engine/mod.rs` (add `mod cx;`, construct `cx`, migrate `fire_scenario_resolution`)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (`apply_player_action`, `apply_engine_record`, `resolve_input`)
+
+- [ ] **Step 1: Create the `Cx` type**
+
+`crates/game-core/src/engine/cx.rs`:
+
+```rust
+//! The engine's mutation context: the mutable working set threaded
+//! through every dispatch handler and effect evaluation.
+//!
+//! `Cx` bundles the two `&mut` references that previously rode together
+//! by hand through every signature — the [`GameState`] being mutated and
+//! the [`Event`] buffer being emitted into. It is *not* a semantic
+//! context: the "you"/"source" of card text lives in
+//! [`EvalContext`](super::EvalContext), which travels alongside `Cx` as a
+//! separate `eval_ctx` parameter in the evaluator.
+//!
+//! Bare field bundle by design — no helper methods. Read-only callees
+//! keep taking `&GameState`; a holder of `cx` calls them as
+//! `read_fn(cx.state, …)`, which borrows only `cx.state` and leaves
+//! `cx.events` independently usable (disjoint-field borrowing).
+
+use crate::event::Event;
+use crate::state::GameState;
+
+/// Mutable engine working set: the state being mutated plus the event
+/// buffer being emitted into. Threaded as `cx: &mut Cx` through dispatch
+/// handlers and the effect evaluator.
+pub(crate) struct Cx<'a> {
+    /// The game state being mutated.
+    pub state: &'a mut GameState,
+    /// The events emitted by the current `apply` call.
+    pub events: &'a mut Vec<Event>,
+}
+```
+
+- [ ] **Step 2: Declare the module and re-export `Cx` within the engine**
+
+In `crates/game-core/src/engine/mod.rs`, add the module declaration near the other `mod` lines and make `Cx` reachable from sibling modules:
+
+```rust
+mod cx;
+pub(crate) use cx::Cx;
+```
+
+- [ ] **Step 3: Migrate `fire_scenario_resolution` and the construction site**
+
+In `crates/game-core/src/engine/mod.rs`, change `fire_scenario_resolution`'s signature from `(state: &mut GameState, events: &mut Vec<Event>, registry: …)` to `(cx: &mut Cx, registry: …)` and rewrite its body (`state.` → `cx.state.`, `events.push` → `cx.events.push`).
+
+Then in `apply_with_scenario_registry`, build the `cx` and route through it:
+
+```rust
+let mut state = state;
+let mut events = Vec::new();
+let resolution_already_fired = state.resolution.is_some();
+let mut cx = Cx { state: &mut state, events: &mut events };
+let outcome = match action {
+    Action::Player(p) => dispatch::apply_player_action(&mut cx, &p),
+    Action::Engine(e) => dispatch::apply_engine_record(&mut cx, &e),
+};
+if matches!(outcome, EngineOutcome::Rejected { .. }) {
+    cx.events.clear();
+} else if !resolution_already_fired {
+    fire_scenario_resolution(&mut cx, registry);
+}
+drop(cx);
+ApplyResult { state, events, /* … unchanged … */ }
+```
+
+(The explicit `drop(cx)` makes the borrow release before `state`/`events` move into `ApplyResult`; NLL would also handle it, but the explicit drop is clearer.)
+
+- [ ] **Step 4: Migrate the three dispatchers in `dispatch/mod.rs`**
+
+Change `apply_player_action`, `apply_engine_record`, and `resolve_input` to take `cx: &mut Cx` instead of `(state, events)`. Rewrite their bodies with the transformation rule. Every call into a `dispatch::*` submodule stays raw for now — use **Shim A** at each:
+
+```rust
+PlayerAction::StartScenario => phases::start_scenario(cx.state, cx.events),
+PlayerAction::Investigate { investigator } => {
+    actions::investigate(cx.state, cx.events, *investigator)
+}
+// … etc for every arm; and the guard ladder's `state.` → `cx.state.`
+```
+
+Likewise `phases::investigation_phase(cx.state, cx.events)` in the post-mulligan block, and the `hunters::`/`reaction_windows::`/`skill_test::` calls in `resolve_input`.
+
+- [ ] **Step 5: Build and test**
+
+Run:
+```sh
+cargo build -p game-core --all-features
+RUSTFLAGS="-D warnings" cargo test -p game-core --all-features
+```
+Expected: builds clean, all tests PASS. (`Cx` may trigger a `dead_code` warning on the `state`/`events` fields if something is off — they're read via `cx.state`/`cx.events`, so a clean build means the wiring is right.)
+
+- [ ] **Step 6: Run the full CI gauntlet to baseline**
+
+Run the five-job gauntlet from the Background section. Expected: all green. This baselines the refactor.
+
+- [ ] **Step 7: Commit**
+
+```sh
+git add crates/game-core/src/engine/cx.rs crates/game-core/src/engine/mod.rs crates/game-core/src/engine/dispatch/mod.rs
+git commit -m "engine: introduce Cx bundle, migrate apply entry point (#160)"
+```
+
+---
+
+## Tasks 2–12: Migrate one dispatch submodule each
+
+Each task migrates every `(state, events)`-taking function in one module to `cx: &mut Cx`, fixes call sites at the module's boundaries, and (for the 5 flagged modules) renames `EvalContext` locals `ctx` → `eval_ctx`. The procedure is identical per module; only the file and function count differ.
+
+**Per-module procedure (apply to each module below):**
+
+- [ ] **Step 1: Migrate every function in the module** that takes `state: &mut GameState, events: &mut Vec<Event>`. Apply the transformation rule (drop the pair, add `cx: &mut Cx` first, rewrite body). Functions taking only `state: &GameState` (read-only) are left unchanged.
+
+- [ ] **Step 2: Fix intra-module call sites** — calls between functions now both taking `cx` pass `cx` directly: `helper(cx, …)`.
+
+- [ ] **Step 3: Fix outbound calls into not-yet-migrated modules** with **Shim A** (unbundle): `other_mod::raw_fn(cx.state, cx.events, …)`.
+
+- [ ] **Step 4: Fix inbound calls from already-migrated modules** — callers that previously used Shim A (`this_mod::fn(cx.state, cx.events, …)`) now pass `cx` directly: `this_mod::fn(cx, …)`. Search the whole `engine/` tree for callers of each migrated function and update them. If a *not-yet-migrated* module calls into this one, bridge with **Shim B** (re-bundle).
+
+- [ ] **Step 5 (flagged modules only): rename `EvalContext` locals** `ctx` → `eval_ctx` so they don't read ambiguously next to `cx`. Flagged: `abilities`, `cards`, `reaction_windows`, `encounter`, `skill_test`. The `apply_effect` call becomes `apply_effect(cx.state, cx.events, &effect, eval_ctx)` while `apply_effect` itself is still raw (it migrates in Task 13) — Shim A applies to it until then.
+
+- [ ] **Step 6: Build + test**
+```sh
+cargo build -p game-core --all-features
+RUSTFLAGS="-D warnings" cargo test -p game-core --all-features
+```
+Expected: clean build, all tests PASS.
+
+- [ ] **Step 7: Commit** with message `engine: thread Cx through dispatch::<module> (#160)`.
+
+**Module order and counts** (do these as separate tasks/commits, top-down):
+
+- [ ] **Task 2 — `dispatch/phases.rs`** (19 functions; the phase-driver hub, called by `mod.rs`)
+- [ ] **Task 3 — `dispatch/actions.rs`** (5 functions: `investigate`, `move_action`, `fight`, `evade`, +1)
+- [ ] **Task 4 — `dispatch/cards.rs`** (9 functions; **flagged** — `eval_ctx` rename; note `cards::grant_resources` is reached by the evaluator via its full path, keep it `pub(super)`)
+- [ ] **Task 5 — `dispatch/skill_test.rs`** (9 functions; **flagged**)
+- [ ] **Task 6 — `dispatch/combat.rs`** (6 functions)
+- [ ] **Task 7 — `dispatch/encounter.rs`** (11 functions; **flagged**)
+- [ ] **Task 8 — `dispatch/hunters.rs`** (9 functions)
+- [ ] **Task 9 — `dispatch/reaction_windows.rs`** (7 functions; **flagged**)
+- [ ] **Task 10 — `dispatch/act_agenda.rs`** (7 functions)
+- [ ] **Task 11 — `dispatch/abilities.rs`** (2 functions; **flagged**)
+- [ ] **Task 12 — `dispatch/elimination.rs`** (4 functions)
+
+(`dispatch/cursor.rs` has zero `&mut GameState` functions — nothing to migrate.)
+
+---
+
+## Task 13: Migrate the evaluator and remove the last shims
+
+**Files:**
+- Modify: `crates/game-core/src/engine/evaluator.rs` (`apply_effect` + 5 internal effect helpers + the `#[cfg(test)]` callers)
+- Modify: any dispatch module still using Shim A to call `apply_effect`
+
+- [ ] **Step 1: Migrate `apply_effect` and its effect helpers**
+
+Change `apply_effect`'s signature from:
+
+```rust
+pub fn apply_effect(
+    state: &mut GameState,
+    events: &mut Vec<Event>,
+    effect: &Effect,
+    ctx: EvalContext,
+) -> EngineOutcome
+```
+
+to:
+
+```rust
+pub fn apply_effect(
+    cx: &mut Cx,
+    effect: &Effect,
+    eval_ctx: EvalContext,
+) -> EngineOutcome
+```
+
+Do the same for the internal effect-application helpers that thread `(state, events, …, ctx)` (`apply_if`, `apply_seq`, and the per-effect appliers around lines 237/290/324, plus `gain_resources`/`discover_clue`): add `cx: &mut Cx` first, drop the pair, rename `ctx` → `eval_ctx`, rewrite bodies. Intra-evaluator calls pass `cx` and `eval_ctx` through.
+
+- [ ] **Step 2: Update the dispatch call sites to pass `cx`**
+
+The 7 `apply_effect(cx.state, cx.events, &effect, eval_ctx)` Shim-A sites (in `abilities.rs`, `encounter.rs` ×2, `cards.rs`, `skill_test.rs` ×2, `reaction_windows.rs`) become `apply_effect(cx, &effect, eval_ctx)`.
+
+- [ ] **Step 3: Update the evaluator's own `#[cfg(test)]` tests**
+
+The evaluator's in-file tests construct a state + events and call `apply_effect`. Update them to build a `Cx` and pass it:
+
+```rust
+let mut events = Vec::new();
+let mut cx = Cx { state: &mut state, events: &mut events };
+let outcome = apply_effect(&mut cx, &effect, eval_ctx(1));
+```
+
+(The test helper `fn ctx(id) -> EvalContext` may be renamed `eval_ctx` for consistency, but it's local to the test module and optional.)
+
+- [ ] **Step 4: Sweep for any remaining shims**
+
+Search the engine tree for leftover frontier bridges — there should be none in production code:
+```sh
+grep -rn "cx.state, cx.events" crates/game-core/src/engine/
+grep -rn "Cx { state, events }" crates/game-core/src/engine/
+```
+Expected: only `read_fn(cx.state, …)` style single-field uses remain (calls into genuinely read-only `&GameState` functions). No `(cx.state, cx.events)` pair passed to a migratable function; no Shim-B re-bundle left.
+
+- [ ] **Step 5: Build + test**
+```sh
+cargo build -p game-core --all-features
+RUSTFLAGS="-D warnings" cargo test -p game-core --all-features
+```
+Expected: clean, all PASS.
+
+- [ ] **Step 6: Full CI gauntlet**
+
+Run all five jobs. Pay attention to:
+- `doc` — the `pub use evaluator::{apply_effect, EvalContext}` re-export still resolves; the intra-doc link `[apply_effect]` in `state/game_state.rs:732` must still link. `RUSTDOCFLAGS="-D warnings" cargo doc` catches breakage.
+- `clippy` — watch for `needless_pass_by_ref_mut` on any function that ends up only reading `cx` (unlikely, but if flagged, that function should have stayed on `&GameState` — convert it).
+- `wasm-build` — `game-core` is `wasm32`-clean; confirm the bundle didn't pull anything non-portable (it won't — pure refactor).
+
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+```sh
+git add crates/game-core/src/engine/evaluator.rs crates/game-core/src/engine/dispatch/
+git commit -m "engine: thread Cx through evaluator; remove frontier shims (#160)"
+```
+
+---
+
+## Task 14: Final verification and phase doc
+
+**Files:**
+- Modify: `docs/phases/` — only if an open question or arc row references this issue (check `docs/phases/README.md` "Cross-cutting / unmilestoned work" — #160 is unmilestoned, so likely no phase-doc row to flip; if none, skip per the "lean toward skipping" rule).
+
+- [ ] **Step 1: Confirm the invariant holds across the suite**
+
+Run the full gauntlet once more from a clean tree:
+```sh
+RUSTFLAGS="-D warnings"     cargo test --all --all-features
+                            cargo clippy --all-targets --all-features -- -D warnings
+                            cargo fmt --check
+RUSTDOCFLAGS="-D warnings"  cargo doc --workspace --no-deps --all-features
+                            cargo build -p web --target wasm32-unknown-unknown
+```
+Expected: all green. This is the zero-behavior-change proof.
+
+- [ ] **Step 2: Sanity-check the diff is purely mechanical**
+
+```sh
+git diff main --stat
+```
+Expected: changes confined to `crates/game-core/src/engine/` (plus the new `cx.rs` and the two spec/plan docs). No card, scenario, server, or web source touched.
+
+- [ ] **Step 3: Push and open the PR**
+
+Per the repo PR procedure: push `engine/mutation-context-cx`, open the PR with `gh pr create` (template; design-decisions paragraph referencing the spec), `Closes #160.`, then `gh pr checks --watch`.
+
+---
+
+## Self-review notes (for the executor)
+
+- **Spec coverage:** Cx type (Task 1) ✔; dispatch migration (Tasks 2–12) ✔; evaluator + `eval_ctx` rename (Task 13) ✔; read-only fns stay `&GameState` (transformation rule) ✔; no helpers / no validate-split (by omission — nothing in the plan adds them) ✔; zero-behavior-change oracle = existing suite (every task's verify) ✔.
+- **No new tests** is intentional, per spec — do not add a "reject leaves state untouched" test here (that's #161).
+- **Counts** (19/5/9/9/6/11/9/7/7/2/4 = 88 dispatch functions + ~6 evaluator + 1 `fire_scenario_resolution` + 3 dispatchers ≈ 96 sites) are from `grep -c "state: &mut GameState"` per file at plan time; if a count is off by one in the actual file, migrate whatever's there — the rule is uniform.

--- a/docs/superpowers/specs/2026-06-05-160-engine-mutation-context-design.md
+++ b/docs/superpowers/specs/2026-06-05-160-engine-mutation-context-design.md
@@ -1,0 +1,139 @@
+# Consolidate `(&mut GameState, &mut Vec<Event>)` threading into a `Cx` context (#160)
+
+**Date:** 2026-06-05
+**Issue:** #160
+**Type:** Pure refactor — behavior-preserving signature change. No logic changes.
+
+## Problem
+
+Nearly every function in the engine threads the same two mutable references by
+hand: `state: &mut GameState` and `events: &mut Vec<Event>`. In the dispatch
+layer alone there are ~91 signature sites taking the pair; the evaluator adds 5
+more. It is the single most-repeated pattern in the engine — it bloats every
+signature and makes call sites noisy (`foo(state, events, a, b)`).
+
+This is debt worth clearing **before Phase 5** puts a server on top of the
+engine: refactoring the engine's core mutation-threading pattern is cheapest
+while the engine is the only consumer of these signatures.
+
+## Why this is a clean move
+
+- **Zero behavior change.** Only signatures and call sites change; bodies are a
+  mechanical `state.` → `cx.state.` / `events.push` → `cx.events.push` rewrite.
+  The full existing test suite plus the CI gauntlet is the correctness oracle.
+- **No new tests.** A "Rejected leaves state untouched" structural test belongs
+  to #161 (the two-phase `apply()` refactor), not here.
+- **Disjoint-field borrowing is preserved** (see below), so the migration does
+  not introduce borrow-checker friction.
+
+## Decisions settled in brainstorming
+
+1. **Bare field bundle, free functions** — not methods on the context, not an
+   engine struct. Methods read cleaner at call sites but are a much larger diff
+   and invite partial-borrow pain. Free functions taking `cx: &mut Cx` is the
+   smallest, most mechanical migration.
+2. **No helpers in v1** — no `cx.emit(e)`, no `cx.investigator_mut(id)`.
+   - Helpers are a *separable* concern: they can be added in a later 10-line
+     follow-up with zero churn to the ~95 migrated sites, because they don't
+     change `Cx`'s shape. "No helpers now" is cheaply reversible; "helpers now"
+     bakes a guess into the big diff.
+   - `*_mut`-style accessors are *actively harmful*: a method like
+     `cx.investigator_mut(id)` borrows all of `*cx`, so you couldn't touch
+     `cx.events` while holding the result. Raw field access
+     (`cx.state.investigators.get_mut(&id)`) borrows only `cx.state`, leaving
+     `cx.events` independently borrowable. Accessor methods would *remove* an
+     ergonomic property we want to keep.
+   - `cx.emit(e)` is the strongest helper candidate (59 `events.push` sites, no
+     borrow downside) but is pure sugar today. It gains a real job in #161 (an
+     emission chokepoint for the apply pass), so it's deferred to land there
+     with a purpose rather than guessed at now.
+3. **Include the evaluator** (5 sites) so the whole engine mutation path speaks
+   one language and there's no seam where dispatch speaks `Cx` but its callee
+   doesn't.
+4. **Naming: `Cx` / `cx`.** The evaluator already has a *semantic* context,
+   `EvalContext` (`controller`, `source` — the "you"/"source" of card text;
+   `Copy`, no mutable refs). `Cx` is a different animal: the *mutation-plumbing*
+   bundle. They will co-occur in evaluator signatures, so the existing
+   `EvalContext` parameter is renamed `ctx` → `eval_ctx` throughout the
+   evaluator module to keep the two visibly distinct:
+   `apply_effect(cx: &mut Cx, effect, eval_ctx: &EvalContext)`.
+
+## Design
+
+### The type
+
+A new `pub(crate)` type in a dedicated `crates/game-core/src/engine/cx.rs`:
+
+```rust
+pub(crate) struct Cx<'a> {
+    pub state:  &'a mut GameState,
+    pub events: &'a mut Vec<Event>,
+}
+```
+
+Pure field bundle. No `Clone`/`Copy` (it holds `&mut`), no helper methods, no
+constructor ceremony — built with a struct literal at the one place it
+originates. Fields are `pub(crate)` so handlers write `cx.state…` /
+`cx.events.push(…)` directly.
+
+### What changes
+
+- **Construction point** — `apply_with_scenario_registry` (`engine/mod.rs`)
+  builds `let mut cx = Cx { state: &mut state, events: &mut events }` and passes
+  `&mut cx` into `apply_player_action` / `apply_engine_record` /
+  `fire_scenario_resolution`. After the dispatch call `cx`'s borrows end (NLL),
+  so the owned `state` / `events` move into `ApplyResult` exactly as today. The
+  belt-and-suspenders backstop becomes `cx.events.clear()`.
+- **Dispatch handlers (~91 sites)** — `fn investigate(cx: &mut Cx, inv: …)`
+  instead of `(state, events, inv, …)`. Bodies rewrite `state.` → `cx.state.`,
+  `events.push` → `cx.events.push`.
+- **Evaluator (5 sites)** — same migration, plus the `ctx: &EvalContext` →
+  `eval_ctx: &EvalContext` rename throughout the evaluator module.
+- **Read-only functions stay on `&GameState`.** A handler holding `cx` calls
+  them as `read_fn(cx.state, …)` — disjoint-field borrowing keeps `cx.events`
+  independently usable. This is the ergonomic property the "no accessor helpers"
+  decision exists to preserve.
+
+### Explicit non-goals (deferred to #161)
+
+- **No validate/apply split.** `Cx` is a single mutating context. #161 owns
+  introducing a read-only validate pass and may add a read-only view then. The
+  existing `check_play_card` / `PlayCheckResult` plan-then-apply seam is left
+  exactly as-is.
+- **No `emit` or accessor helpers** (see Decision 2).
+
+## Migration shape (keeps it compiling + reviewable)
+
+The signatures are interdependent, but a migrated function can **unbundle at the
+frontier** — call a not-yet-migrated callee as `f(cx.state, cx.events, …)`. So
+the migration proceeds incrementally with the suite green between each step:
+
+1. **Define `Cx`; wire the entry point.** `apply_with_scenario_registry`
+   constructs `cx` and immediately unbundles into today's handlers
+   (`apply_player_action(&mut cx.state, &mut cx.events, …)` initially, or migrate
+   the two entry dispatchers in this step). Compiles, tests pass.
+2. **Migrate one dispatch submodule at a time** — `actions`, `cards`, `combat`,
+   `encounter`, `hunters`, `phases`, `reaction_windows`, `skill_test`,
+   `act_agenda`, `abilities`, `elimination`, `cursor` — unbundling at calls into
+   not-yet-migrated modules. Run the suite each step.
+3. **Migrate the evaluator** (+ `eval_ctx` rename) **and `fire_scenario_resolution`**;
+   remove the last unbundling sites. Full CI gauntlet.
+
+## What "done" looks like
+
+- `Cx<'a>` exists in `engine/cx.rs`; every dispatch handler and evaluator
+  function that previously took `(&mut GameState, &mut Vec<Event>)` now takes
+  `cx: &mut Cx`.
+- No remaining unbundling sites (`f(cx.state, cx.events, …)`) except where the
+  callee is a genuinely read-only `&GameState` function.
+- The `EvalContext` parameter is named `eval_ctx` wherever it co-occurs with
+  `cx`.
+- The full CI gauntlet (`fmt`, `clippy -D warnings`, `test`, `doc`,
+  `wasm-build`) is green with no behavior change.
+
+## Dependencies
+
+- #159 (dispatch split) — landed (`c961264`). Soft prerequisite: the migration
+  happens against navigable per-domain files rather than one 9.5k-line file.
+- Coordinates with #161 (two-phase `apply()`): `Cx` is the single mutating
+  context #161 builds on when it introduces the read-only validate pass.


### PR DESCRIPTION
## Summary

Replaces the `(state: &mut GameState, events: &mut Vec<Event>)` parameter pair — previously threaded by hand through ~96 engine functions — with a single bundle `Cx<'a> { state, events }` passed as `cx: &mut Cx`. Pure refactor, **zero behavior change**: the existing test suite is the correctness oracle (test counts unchanged throughout).

## What changed

- New `pub(crate) struct Cx<'a> { state, events }` in `engine/cx.rs` — a **bare field bundle**, no helper methods, constructed once at the `apply()` entry point.
- `cx: &mut Cx` threaded through **every dispatch submodule, the effect evaluator, and the apply entry point**. Read-only callees keep taking `&GameState` (called as `cx.state`), preserving disjoint-field borrowing — which is exactly why no accessor helpers were added.
- The evaluator's semantic `EvalContext` parameter renamed `ctx` → `eval_ctx` to disambiguate from the new `cx` where they co-occur.
- `apply_effect` reduced `pub` → `pub(crate)` (forced: it now takes the `pub(crate)` `Cx`; zero external callers, so no breakage); its re-export dropped, `EvalContext`'s kept.

## Design decisions

- **Bare bundle, free functions, no helpers.** Methods on `Cx` (or an `emit`/accessor surface) read cleaner but invite partial-borrow pain and bake a guess into the 96-site diff. An `emit` helper and the validate/apply split are deliberately **deferred to #161**, where they gain a real job.
- **Scope boundary:** the only raw `(state, events)` pair remaining is the cross-crate `ScenarioModule::apply_resolution` function-pointer interface (implemented by the `scenarios` crate) — migrating it would leak the internal `Cx` across the crate boundary, so it stays and is called as `(cx.state, cx.events)`.
- Two functions (`discard_committed_cards`, `pay_activation_costs`) required borrow-driven restructuring rather than pure substitution; both verified behavior-identical (same mutations, same event order).

Spec: `docs/superpowers/specs/2026-06-05-160-engine-mutation-context-design.md`
Plan: `docs/superpowers/plans/2026-06-05-160-engine-mutation-context.md`

## Test notes

No new tests (behavior-preserving). Full CI gauntlet green locally: `RUSTFLAGS="-D warnings" cargo test --all --all-features`, `clippy --all-targets --all-features -D warnings`, `fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc`, and `wasm32` build.

## Linked issues

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)