### PR TITLE
engine: enforce maximum hand size at upkeep (#111)

### DIFF
--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -333,6 +333,19 @@ pub enum InputResponse {
         /// Hand indices to commit.
         indices: Vec<u32>,
     },
+    /// Discard cards from hand to satisfy the upkeep maximum-hand-size
+    /// step (Rules Reference 4.5). Each entry is a zero-based index into
+    /// the prompted investigator's hand at the moment of the prompt. The
+    /// engine discards exactly the overflow (`hand.len() - 8`); any other
+    /// count, a duplicate, or an out-of-bounds index is rejected.
+    ///
+    /// `u32` rather than `u8` for wire-format symmetry with
+    /// [`CommitCards`](Self::CommitCards) / [`PickIndex`](Self::PickIndex);
+    /// downcast at validation time.
+    DiscardCards {
+        /// Hand indices to discard.
+        indices: Vec<u32>,
+    },
 }
 
 #[cfg(test)]
@@ -347,5 +360,15 @@ mod encounter_card_revealed_action_tests {
         let json = serde_json::to_string(&rec).expect("serialize");
         let back: EngineRecord = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, rec);
+    }
+
+    #[test]
+    fn discard_cards_input_serde_roundtrip() {
+        let original = InputResponse::DiscardCards {
+            indices: vec![0, 3, 7],
+        };
+        let json = serde_json::to_string(&original).expect("serialize");
+        let back: InputResponse = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, original);
     }
 }

--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -334,7 +334,7 @@ pub enum InputResponse {
         indices: Vec<u32>,
     },
     /// Discard cards from hand to satisfy the upkeep maximum-hand-size
-    /// step (Rules Reference 4.5). Each entry is a zero-based index into
+    /// step (Rules Reference p.25 step 4.5). Each entry is a zero-based index into
     /// the prompted investigator's hand at the moment of the prompt. The
     /// engine discards exactly the overflow (`hand.len() - 8`); any other
     /// count, a duplicate, or an out-of-bounds index is rejected.
@@ -361,6 +361,11 @@ mod encounter_card_revealed_action_tests {
         let back: EngineRecord = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, rec);
     }
+}
+
+#[cfg(test)]
+mod input_response_tests {
+    use super::*;
 
     #[test]
     fn discard_cards_input_serde_roundtrip() {

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -602,7 +602,12 @@ pub(super) fn advance_mythos_draw_pending(cx: &mut Cx) {
     let next = super::cursor::next_active_investigator_after(cx.state, current);
     cx.state.mythos_draw_pending = next;
     if next.is_none() {
-        super::reaction_windows::open_fast_window(cx, WindowKind::MythosAfterDraws);
+        let outcome = super::reaction_windows::open_fast_window(cx, WindowKind::MythosAfterDraws);
+        debug_assert_eq!(
+            outcome,
+            EngineOutcome::Done,
+            "open_fast_window(MythosAfterDraws) unexpectedly suspended; this window has no suspending continuation",
+        );
     }
 }
 

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -383,8 +383,7 @@ pub(super) fn resume_hunter_choice(
     // per-investigator attack loop (step 3.3). Reached only on the
     // no-further-suspension path; every suspension above early-returns
     // via `suspend_hunter_choice`.
-    super::phases::enemy_attack_kickoff(cx);
-    EngineOutcome::Done
+    super::phases::enemy_attack_kickoff(cx)
 }
 
 /// Resume a suspended engagement-on-spawn choice (#128, option A) with

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -310,9 +310,9 @@ pub(super) struct ActivateCheckResult {
 /// index. This covers the `MythosAfterDraws` window after all Fast
 /// plays have been made and the player is done.
 pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
-    // Hunter-movement suspension is its own mode; route it before the
-    // reaction-window and skill-test checks, which are independent
-    // suspension modes. (#128)
+    // Hunter movement, spawn engagement, and hand-size discard are three
+    // mutually exclusive suspension modes (different phases). Route to the
+    // right resume handler before the reaction-window and skill-test checks.
     debug_assert!(
         [
             cx.state.hunter_move_pending.is_some(),

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -120,6 +120,19 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
         };
     }
 
+    // A pending upkeep hand-size discard (#111) blocks every action but
+    // `ResolveInput`. Upkeep-phase only; never coexists with the other
+    // suspension modes, so guard order is immaterial.
+    if cx.state.hand_size_discard_pending.is_some()
+        && !matches!(action, PlayerAction::ResolveInput { .. })
+    {
+        return EngineOutcome::Rejected {
+            reason: "a hand-size discard choice is pending; submit a PlayerAction::ResolveInput \
+                     with InputResponse::DiscardCards before any other action"
+                .into(),
+        };
+    }
+
     let outcome = match action {
         PlayerAction::StartScenario => phases::start_scenario(cx),
         PlayerAction::EndTurn => phases::end_turn(cx),
@@ -301,9 +314,17 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
     // reaction-window and skill-test checks, which are independent
     // suspension modes. (#128)
     debug_assert!(
-        !(cx.state.hunter_move_pending.is_some() && cx.state.spawn_engage_pending.is_some()),
-        "hunter movement and spawn engagement cannot both be pending: they arise in \
-         different phases (Enemy 3.2 vs Mythos 1.4) and each blocks all other actions",
+        [
+            cx.state.hunter_move_pending.is_some(),
+            cx.state.spawn_engage_pending.is_some(),
+            cx.state.hand_size_discard_pending.is_some(),
+        ]
+        .iter()
+        .filter(|b| **b)
+        .count()
+            <= 1,
+        "hunter movement, spawn engagement, and hand-size discard are mutually exclusive \
+         suspension modes (different phases)",
     );
     if cx.state.hunter_move_pending.is_some() {
         return hunters::resume_hunter_choice(cx, response);
@@ -313,6 +334,13 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
     // from hunter movement: its resume re-enters the Mythos draw chain.
     if cx.state.spawn_engage_pending.is_some() {
         return hunters::resume_spawn_engage(cx, response);
+    }
+
+    // Upkeep step-4.5 hand-size discard (#111) is its own suspension mode;
+    // route it before the reaction-window check (it arises in Upkeep, not
+    // mid-skill-test, so the two never coexist).
+    if cx.state.hand_size_discard_pending.is_some() {
+        return phases::resume_hand_size_discard(cx, response);
     }
 
     if cx.state.top_reaction_window().is_some() {

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -3,7 +3,7 @@
 
 use crate::engine::outcome::EngineOutcome;
 use crate::event::Event;
-use crate::state::{EnemyId, InvestigatorId, Phase, WindowKind};
+use crate::state::{EnemyId, GameState, InvestigatorId, Phase, WindowKind};
 
 use super::Cx;
 
@@ -483,6 +483,23 @@ fn ready_exhausted_cards(cx: &mut Cx) {
             super::hunters::reengage_at_location(cx, eid);
         }
     }
+}
+
+/// Maximum hand size (Rules Reference p.25 step 4.5: discard down to 8). A module
+/// constant rather than a per-investigator field — no card in the
+/// current scope modifies the cap. A future hand-size-modifying card
+/// introduces the field when it is actually needed (#111 spec).
+#[allow(dead_code)] // consumed by check_hand_size when #111 lands
+pub(super) const HAND_SIZE_LIMIT: u8 = 8;
+
+/// Active investigators, in player order, whose hand exceeds
+/// [`HAND_SIZE_LIMIT`]. Empty when nobody is over the cap.
+#[allow(dead_code)] // consumed by check_hand_size when #111 lands
+pub(super) fn over_cap_investigators(state: &GameState) -> Vec<InvestigatorId> {
+    super::cursor::active_investigators_in_turn_order(state)
+        .into_iter()
+        .filter(|id| state.investigators[id].hand.len() > HAND_SIZE_LIMIT as usize)
+        .collect()
 }
 
 /// 4.5 Each investigator checks hand size.
@@ -2454,4 +2471,31 @@ mod enemy_phase_tests {
     // pause shape is exercised indirectly via the existing
     // any_fast_play_eligible-driven open_fast_window tests at
     // dispatch.rs's open_fast_window_tests block.
+}
+
+#[cfg(test)]
+mod hand_size_tests {
+    use super::*;
+    use crate::state::{CardCode, InvestigatorId};
+    use crate::test_support::{test_investigator, TestGame};
+
+    #[test]
+    fn over_cap_investigators_lists_only_over_eight_in_player_order() {
+        let inv1 = InvestigatorId(1);
+        let inv2 = InvestigatorId(2);
+        let mut state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_investigator(test_investigator(2))
+            .with_turn_order([inv2, inv1]) // player order: inv2 first
+            .build();
+        // inv1: 9 cards (over), inv2: 8 cards (at cap, not over).
+        state.investigators.get_mut(&inv1).unwrap().hand = vec![CardCode("x".into()); 9];
+        state.investigators.get_mut(&inv2).unwrap().hand = vec![CardCode("x".into()); 8];
+
+        assert_eq!(over_cap_investigators(&state), vec![inv1]);
+
+        // Push inv2 over too: order must follow turn_order (inv2 then inv1).
+        state.investigators.get_mut(&inv2).unwrap().hand = vec![CardCode("x".into()); 10];
+        assert_eq!(over_cap_investigators(&state), vec![inv2, inv1]);
+    }
 }

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -1,9 +1,12 @@
 //! Phase-driver functions: start/end scenario, per-phase entrypoints,
 //! and the round-cycle stepping logic.
 
+use crate::action::InputResponse;
 use crate::engine::outcome::{EngineOutcome, InputRequest, ResumeToken};
 use crate::event::Event;
-use crate::state::{EnemyId, GameState, HandSizeDiscard, InvestigatorId, Phase, WindowKind};
+use crate::state::{
+    CardCode, EnemyId, GameState, HandSizeDiscard, InvestigatorId, Phase, WindowKind, Zone,
+};
 
 use super::Cx;
 
@@ -529,6 +532,114 @@ fn check_hand_size(cx: &mut Cx) -> EngineOutcome {
             ),
         },
         resume_token: ResumeToken(0),
+    }
+}
+
+/// Resume a parked upkeep hand-size discard (#111). Validates the
+/// `DiscardCards` response against the currently-prompted investigator
+/// (`remaining[0]`): the indices must be unique, in-bounds, and exactly
+/// `hand.len() - HAND_SIZE_LIMIT` in count. On success, discards the
+/// chosen cards (emitting [`Event::CardDiscarded`] per card), pops the
+/// queue front, and either re-prompts the next over-cap investigator or
+/// — when the queue drains — runs [`upkeep_phase_end`] (4.6 + transition
+/// to Mythos). Rejections leave state and events untouched.
+pub(super) fn resume_hand_size_discard(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
+    let pending = cx
+        .state
+        .hand_size_discard_pending
+        .clone()
+        .unwrap_or_else(|| unreachable!("resume_hand_size_discard: no pending discard"));
+    let current = pending.remaining[0];
+
+    let InputResponse::DiscardCards { indices } = response else {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "ResolveInput: hand-size discard expects InputResponse::DiscardCards, got {response:?}",
+            )
+            .into(),
+        };
+    };
+
+    // ---- validate (state untouched on any failure) ----
+    let inv = cx.state.investigators.get(&current).unwrap_or_else(|| {
+        unreachable!("resume_hand_size_discard: prompted investigator {current:?} vanished")
+    });
+    let hand_len = inv.hand.len();
+    let target = hand_len.saturating_sub(HAND_SIZE_LIMIT as usize);
+    if indices.len() != target {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "ResolveInput::DiscardCards: {current:?} must discard exactly {target} card(s) \
+                 (hand {hand_len}, cap {HAND_SIZE_LIMIT}), got {}",
+                indices.len(),
+            )
+            .into(),
+        };
+    }
+    let mut seen = std::collections::BTreeSet::new();
+    for &i in indices {
+        if !seen.insert(i) {
+            return EngineOutcome::Rejected {
+                reason: format!("ResolveInput::DiscardCards: duplicate hand index {i}").into(),
+            };
+        }
+        if i as usize >= hand_len {
+            return EngineOutcome::Rejected {
+                reason: format!(
+                    "ResolveInput::DiscardCards: hand index {i} out of bounds (hand size {hand_len})",
+                )
+                .into(),
+            };
+        }
+    }
+
+    // ---- mutate ----
+    let discarded: Vec<CardCode> = {
+        let inv = cx
+            .state
+            .investigators
+            .get_mut(&current)
+            .expect("validated above");
+        let mut sorted: Vec<u32> = indices.clone();
+        sorted.sort_unstable();
+        let codes: Vec<CardCode> = sorted
+            .iter()
+            .map(|&i| inv.hand[i as usize].clone())
+            .collect();
+        for &i in sorted.iter().rev() {
+            inv.hand.remove(i as usize);
+        }
+        inv.discard.extend(codes.iter().cloned());
+        codes
+    };
+    for code in discarded {
+        cx.events.push(Event::CardDiscarded {
+            investigator: current,
+            code,
+            from: Zone::Hand,
+        });
+    }
+
+    // ---- advance the queue ----
+    let mut remaining = pending.remaining;
+    remaining.remove(0);
+    if remaining.is_empty() {
+        cx.state.hand_size_discard_pending = None;
+        upkeep_phase_end(cx); // 4.6 + transition to Mythos
+        EngineOutcome::Done
+    } else {
+        let next = remaining[0];
+        cx.state.hand_size_discard_pending = Some(HandSizeDiscard { remaining });
+        EngineOutcome::AwaitingInput {
+            request: InputRequest {
+                prompt: format!(
+                    "Upkeep step 4.5: {next:?} has more than {HAND_SIZE_LIMIT} cards in hand; \
+                     submit InputResponse::DiscardCards with the hand indices to discard down to \
+                     {HAND_SIZE_LIMIT}.",
+                ),
+            },
+            resume_token: ResumeToken(0),
+        }
     }
 }
 
@@ -2607,5 +2718,179 @@ mod hand_size_tests {
                 phase: Phase::Upkeep
             }
         );
+    }
+
+    #[test]
+    fn resume_hand_size_discard_discards_overflow_and_advances_to_mythos() {
+        use crate::action::InputResponse;
+        use crate::state::CardCode;
+        let id = InvestigatorId(1);
+        let mut state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_turn_order([id])
+            .with_phase(Phase::Upkeep)
+            .with_hand_size_discard_pending([id])
+            .build();
+        // 10-card hand: discard exactly 2 (indices 0 and 1) → land at 8.
+        state.investigators.get_mut(&id).unwrap().hand =
+            (0..10).map(|i| CardCode(format!("c{i}"))).collect();
+
+        let mut events = Vec::new();
+        let outcome = resume_hand_size_discard(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            &InputResponse::DiscardCards {
+                indices: vec![0, 1],
+            },
+        );
+
+        assert_eq!(outcome, EngineOutcome::Done);
+        assert!(state.hand_size_discard_pending.is_none());
+        assert_eq!(state.investigators[&id].hand.len(), 8);
+        assert_eq!(state.investigators[&id].discard.len(), 2);
+        assert_eq!(
+            state.phase,
+            Phase::Mythos,
+            "queue drained → 4.6 runs → next round Mythos"
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(
+                    e,
+                    Event::CardDiscarded {
+                        from: crate::state::Zone::Hand,
+                        ..
+                    }
+                ))
+                .count(),
+            2,
+        );
+    }
+
+    #[test]
+    fn resume_hand_size_discard_rejects_wrong_count() {
+        use crate::action::InputResponse;
+        use crate::state::CardCode;
+        let id = InvestigatorId(1);
+        let mut state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_turn_order([id])
+            .with_phase(Phase::Upkeep)
+            .with_hand_size_discard_pending([id])
+            .build();
+        state.investigators.get_mut(&id).unwrap().hand =
+            (0..10).map(|i| CardCode(format!("c{i}"))).collect();
+
+        let mut events = Vec::new();
+        // Need to discard 2; submitting 1 must reject with state untouched.
+        let outcome = resume_hand_size_discard(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            &InputResponse::DiscardCards { indices: vec![0] },
+        );
+
+        assert!(matches!(outcome, EngineOutcome::Rejected { .. }));
+        assert_eq!(
+            state.investigators[&id].hand.len(),
+            10,
+            "rejected: hand untouched"
+        );
+        assert!(
+            state.hand_size_discard_pending.is_some(),
+            "rejected: still pending"
+        );
+        assert!(events.is_empty(), "rejected: no events");
+    }
+
+    #[test]
+    fn resume_hand_size_discard_rejects_duplicate_and_oob_indices() {
+        use crate::action::InputResponse;
+        use crate::state::CardCode;
+        let id = InvestigatorId(1);
+        let build = || {
+            let mut s = TestGame::new()
+                .with_investigator(test_investigator(1))
+                .with_turn_order([id])
+                .with_phase(Phase::Upkeep)
+                .with_hand_size_discard_pending([id])
+                .build();
+            s.investigators.get_mut(&id).unwrap().hand =
+                (0..10).map(|i| CardCode(format!("c{i}"))).collect();
+            s
+        };
+
+        // Duplicate index (count is 2 but both point at slot 0).
+        let mut s1 = build();
+        let mut e1 = Vec::new();
+        let o1 = resume_hand_size_discard(
+            &mut Cx {
+                state: &mut s1,
+                events: &mut e1,
+            },
+            &InputResponse::DiscardCards {
+                indices: vec![0, 0],
+            },
+        );
+        assert!(matches!(o1, EngineOutcome::Rejected { .. }));
+        assert_eq!(s1.investigators[&id].hand.len(), 10);
+
+        // Out-of-bounds index.
+        let mut s2 = build();
+        let mut e2 = Vec::new();
+        let o2 = resume_hand_size_discard(
+            &mut Cx {
+                state: &mut s2,
+                events: &mut e2,
+            },
+            &InputResponse::DiscardCards {
+                indices: vec![0, 99],
+            },
+        );
+        assert!(matches!(o2, EngineOutcome::Rejected { .. }));
+        assert_eq!(s2.investigators[&id].hand.len(), 10);
+    }
+
+    #[test]
+    fn resume_hand_size_discard_sequences_investigators_in_player_order() {
+        use crate::action::InputResponse;
+        use crate::state::CardCode;
+        let inv1 = InvestigatorId(1);
+        let inv2 = InvestigatorId(2);
+        let mut state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_investigator(test_investigator(2))
+            .with_turn_order([inv1, inv2])
+            .with_phase(Phase::Upkeep)
+            .with_hand_size_discard_pending([inv1, inv2])
+            .build();
+        state.investigators.get_mut(&inv1).unwrap().hand =
+            (0..9).map(|i| CardCode(format!("a{i}"))).collect(); // discard 1
+        state.investigators.get_mut(&inv2).unwrap().hand =
+            (0..9).map(|i| CardCode(format!("b{i}"))).collect(); // discard 1
+
+        // inv1 resolves first → still pending for inv2, phase still Upkeep.
+        let mut events = Vec::new();
+        let o1 = resume_hand_size_discard(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            &InputResponse::DiscardCards { indices: vec![0] },
+        );
+        assert!(matches!(o1, EngineOutcome::AwaitingInput { .. }));
+        assert_eq!(
+            state
+                .hand_size_discard_pending
+                .as_ref()
+                .map(|p| p.remaining.clone()),
+            Some(vec![inv2]),
+        );
+        assert_eq!(state.phase, Phase::Upkeep);
+        assert_eq!(state.investigators[&inv1].hand.len(), 8);
     }
 }

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -229,13 +229,15 @@ fn mythos_phase(cx: &mut Cx) {
 /// `mythos_phase` step 1.1 — the rules' "round begins" point —
 /// rather than here. `step_phase` no longer touches `state.round`.
 ///
-/// Returns the transition's [`EngineOutcome`]. Only the
-/// Investigation→Enemy arm can return [`EngineOutcome::AwaitingInput`]
-/// (a hunter-movement tie in [`enemy_phase`]); every other arm runs its
-/// driver to completion and returns [`EngineOutcome::Done`]. The
-/// Investigation→Enemy suspension is owned by
-/// [`investigation_phase_end`], which propagates it up through
-/// [`end_turn`].
+/// Returns the transition's [`EngineOutcome`]. Two arms can return
+/// [`EngineOutcome::AwaitingInput`]:
+/// - **Investigation→Enemy**: a hunter-movement tie in [`enemy_phase`],
+///   owned by [`investigation_phase_end`] and propagated through [`end_turn`].
+/// - **Enemy→Upkeep**: the step-4.5 hand-size discard in [`upkeep_phase`]
+///   (#111), owned by [`upkeep_resume`] once that task lands.
+///
+/// Every other arm runs its driver to completion and returns
+/// [`EngineOutcome::Done`].
 fn step_phase(cx: &mut Cx) -> EngineOutcome {
     let from = cx.state.phase;
     let to = from.next();

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -511,6 +511,27 @@ pub(super) fn over_cap_investigators(state: &GameState) -> Vec<InvestigatorId> {
         .collect()
 }
 
+/// Stores `remaining` as `hand_size_discard_pending` and returns the
+/// [`EngineOutcome::AwaitingInput`] that prompts `remaining[0]` to discard.
+/// Used by both [`check_hand_size`] (first suspension) and
+/// [`resume_hand_size_discard`] (re-prompt after a queue pop).
+///
+/// `remaining` must be non-empty; callers ensure this before calling.
+fn park_hand_size_discard(cx: &mut Cx, remaining: Vec<InvestigatorId>) -> EngineOutcome {
+    let next = remaining[0];
+    cx.state.hand_size_discard_pending = Some(HandSizeDiscard { remaining });
+    EngineOutcome::AwaitingInput {
+        request: InputRequest {
+            prompt: format!(
+                "Upkeep step 4.5: {next:?} has more than {HAND_SIZE_LIMIT} cards in hand; \
+                 submit InputResponse::DiscardCards with the hand indices to discard down to \
+                 {HAND_SIZE_LIMIT}.",
+            ),
+        },
+        resume_token: ResumeToken(0),
+    }
+}
+
 /// 4.5 Each investigator checks hand size. In player order, each
 /// investigator over [`HAND_SIZE_LIMIT`] is prompted to discard down to
 /// the cap. Returns [`EngineOutcome::AwaitingInput`] (parking on the
@@ -519,20 +540,10 @@ pub(super) fn over_cap_investigators(state: &GameState) -> Vec<InvestigatorId> {
 /// proceeds straight to 4.6.
 fn check_hand_size(cx: &mut Cx) -> EngineOutcome {
     let remaining = over_cap_investigators(cx.state);
-    let Some(&first) = remaining.first() else {
+    if remaining.is_empty() {
         return EngineOutcome::Done;
-    };
-    cx.state.hand_size_discard_pending = Some(HandSizeDiscard { remaining });
-    EngineOutcome::AwaitingInput {
-        request: InputRequest {
-            prompt: format!(
-                "Upkeep step 4.5: {first:?} has more than {HAND_SIZE_LIMIT} cards in hand; \
-                 submit InputResponse::DiscardCards with the hand indices to discard down to \
-                 {HAND_SIZE_LIMIT}.",
-            ),
-        },
-        resume_token: ResumeToken(0),
     }
+    park_hand_size_discard(cx, remaining)
 }
 
 /// Resume a parked upkeep hand-size discard (#111). Validates the
@@ -628,18 +639,7 @@ pub(super) fn resume_hand_size_discard(cx: &mut Cx, response: &InputResponse) ->
         upkeep_phase_end(cx); // 4.6 + transition to Mythos
         EngineOutcome::Done
     } else {
-        let next = remaining[0];
-        cx.state.hand_size_discard_pending = Some(HandSizeDiscard { remaining });
-        EngineOutcome::AwaitingInput {
-            request: InputRequest {
-                prompt: format!(
-                    "Upkeep step 4.5: {next:?} has more than {HAND_SIZE_LIMIT} cards in hand; \
-                     submit InputResponse::DiscardCards with the hand indices to discard down to \
-                     {HAND_SIZE_LIMIT}.",
-                ),
-            },
-            resume_token: ResumeToken(0),
-        }
+        park_hand_size_discard(cx, remaining)
     }
 }
 
@@ -2768,6 +2768,11 @@ mod hand_size_tests {
                 .count(),
             2,
         );
+        assert_eq!(
+            state.investigators[&id].discard,
+            vec![CardCode("c0".into()), CardCode("c1".into())],
+            "the cards at the submitted indices (0,1) must be the ones discarded",
+        );
     }
 
     #[test]
@@ -2892,5 +2897,41 @@ mod hand_size_tests {
         );
         assert_eq!(state.phase, Phase::Upkeep);
         assert_eq!(state.investigators[&inv1].hand.len(), 8);
+    }
+
+    #[test]
+    fn resume_hand_size_discard_rejects_wrong_response_kind() {
+        use crate::action::InputResponse;
+        use crate::state::CardCode;
+        let id = InvestigatorId(1);
+        let mut state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_turn_order([id])
+            .with_phase(Phase::Upkeep)
+            .with_hand_size_discard_pending([id])
+            .build();
+        state.investigators.get_mut(&id).unwrap().hand =
+            (0..10).map(|i| CardCode(format!("c{i}"))).collect();
+
+        let mut events = Vec::new();
+        let outcome = resume_hand_size_discard(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            &InputResponse::Skip,
+        );
+
+        assert!(matches!(outcome, EngineOutcome::Rejected { .. }));
+        assert_eq!(
+            state.investigators[&id].hand.len(),
+            10,
+            "rejected: hand untouched"
+        );
+        assert!(
+            state.hand_size_discard_pending.is_some(),
+            "rejected: still pending"
+        );
+        assert!(events.is_empty(), "rejected: no events");
     }
 }

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -140,7 +140,12 @@ pub(super) fn investigation_phase(cx: &mut Cx) {
     // order 2.1 → window → 2.2 holds. Auto-skips inline when nothing is
     // Fast-eligible, so single-investigator entry still lands the lead
     // active within the same apply() call.
-    super::reaction_windows::open_fast_window(cx, WindowKind::InvestigationBegins);
+    let outcome = super::reaction_windows::open_fast_window(cx, WindowKind::InvestigationBegins);
+    debug_assert_eq!(
+        outcome,
+        EngineOutcome::Done,
+        "open_fast_window(InvestigationBegins) unexpectedly suspended; this window has no suspending continuation",
+    );
 }
 
 /// 2.2 Next investigator's turn begins. Rotates the active cursor to
@@ -155,7 +160,12 @@ pub(super) fn investigation_phase(cx: &mut Cx) {
 /// resolve it via `first_active_investigator` / `next_active_investigator_after`.
 pub(super) fn begin_investigator_turn(cx: &mut Cx, who: InvestigatorId) {
     rotate_to_active(cx, who);
-    super::reaction_windows::open_fast_window(cx, WindowKind::InvestigatorTurnBegins);
+    let outcome = super::reaction_windows::open_fast_window(cx, WindowKind::InvestigatorTurnBegins);
+    debug_assert_eq!(
+        outcome,
+        EngineOutcome::Done,
+        "open_fast_window(InvestigatorTurnBegins) unexpectedly suspended; this window has no suspending continuation",
+    );
 }
 
 /// 2.3 Investigation phase ends. Owns the `PhaseEnded(Investigation)`
@@ -210,7 +220,12 @@ fn mythos_phase(cx: &mut Cx) {
         // because nothing is eligible, runs the MythosAfterDraws
         // continuation (mythos_phase_end), which transitions to
         // Investigation. All in this same apply.
-        super::reaction_windows::open_fast_window(cx, WindowKind::MythosAfterDraws);
+        let outcome = super::reaction_windows::open_fast_window(cx, WindowKind::MythosAfterDraws);
+        debug_assert_eq!(
+            outcome,
+            EngineOutcome::Done,
+            "open_fast_window(MythosAfterDraws) unexpectedly suspended; this window has no suspending continuation",
+        );
     }
 }
 

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -1,9 +1,9 @@
 //! Phase-driver functions: start/end scenario, per-phase entrypoints,
 //! and the round-cycle stepping logic.
 
-use crate::engine::outcome::EngineOutcome;
+use crate::engine::outcome::{EngineOutcome, InputRequest, ResumeToken};
 use crate::event::Event;
-use crate::state::{EnemyId, GameState, InvestigatorId, Phase, WindowKind};
+use crate::state::{EnemyId, GameState, HandSizeDiscard, InvestigatorId, Phase, WindowKind};
 
 use super::Cx;
 
@@ -295,16 +295,22 @@ fn rotate_to_active(cx: &mut Cx, id: InvestigatorId) {
 /// Rules Reference p.10 (Elimination); [`cursor::first_active_investigator`] is
 /// the shared helper used by Mythos 1.4 (#69) for the same semantics.
 /// The loop body runs in [`run_window_continuation`]'s arms.
-pub(super) fn enemy_attack_kickoff(cx: &mut Cx) {
+///
+/// Returns the opened window's [`EngineOutcome`]. The no-active-investigator
+/// path opens `AfterAllInvestigatorsAttacked`, whose continuation cascades
+/// Enemy → Upkeep; that cascade can now suspend at Upkeep step 4.5
+/// (hand-size discard, #111), so the outcome propagates rather than being
+/// discarded.
+pub(super) fn enemy_attack_kickoff(cx: &mut Cx) -> EngineOutcome {
     cx.state.enemy_attack_pending = super::cursor::first_active_investigator(cx.state);
 
     if cx.state.enemy_attack_pending.is_some() {
-        super::reaction_windows::open_fast_window(cx, WindowKind::BeforeInvestigatorAttacked);
+        super::reaction_windows::open_fast_window(cx, WindowKind::BeforeInvestigatorAttacked)
     } else {
         // No Active investigators (turn_order empty or all eliminated).
         // Skip straight to the final window — mirror of mythos_phase's
         // no-drawer path.
-        super::reaction_windows::open_fast_window(cx, WindowKind::AfterAllInvestigatorsAttacked);
+        super::reaction_windows::open_fast_window(cx, WindowKind::AfterAllInvestigatorsAttacked)
     }
 }
 
@@ -318,7 +324,9 @@ pub(super) fn enemy_attack_kickoff(cx: &mut Cx) {
 /// the [`EngineOutcome::AwaitingInput`] unchanged — the attack-loop
 /// kickoff is deferred to [`resume_hunter_choice`], which runs it once
 /// the last hunter resolves. Otherwise the kickoff runs inline here and
-/// this returns [`EngineOutcome::Done`].
+/// this returns its outcome — usually [`EngineOutcome::Done`], but the
+/// Enemy → Upkeep cascade can suspend at step 4.5 (hand-size discard,
+/// #111), so that `AwaitingInput` now propagates rather than being dropped.
 fn enemy_phase(cx: &mut Cx) -> EngineOutcome {
     // 3.1 Enemy phase begins.
     cx.events.push(Event::PhaseStarted {
@@ -337,8 +345,7 @@ fn enemy_phase(cx: &mut Cx) -> EngineOutcome {
     }
 
     // 3.3 Kick off the per-investigator attack loop.
-    enemy_attack_kickoff(cx);
-    EngineOutcome::Done
+    enemy_attack_kickoff(cx)
 }
 
 /// Called from [`run_window_continuation`]'s
@@ -401,13 +408,18 @@ fn upkeep_phase(cx: &mut Cx) -> EngineOutcome {
 }
 
 /// The post-4.1 window continuation. Steps 4.2–4.4 run inline as named
-/// call sites; step 4.5 is the [`check_hand_size`] stub (TODO #111).
-/// Then hands to [`upkeep_phase_end`] for 4.6 + transition.
+/// call sites; step 4.5 ([`check_hand_size`]) may suspend with
+/// [`EngineOutcome::AwaitingInput`] when an investigator is over the hand
+/// cap — in which case `upkeep_resume` short-circuits and 4.6 runs only
+/// once the discard resolves. Otherwise it hands to [`upkeep_phase_end`]
+/// for 4.6 + transition.
 pub(super) fn upkeep_resume(cx: &mut Cx) -> EngineOutcome {
     reset_actions(cx); // 4.2
     ready_exhausted_cards(cx); // 4.3
     upkeep_draw_and_resource(cx); // 4.4
-    check_hand_size(cx); // 4.5 (returns () until Task 5)
+    if let outcome @ EngineOutcome::AwaitingInput { .. } = check_hand_size(cx) {
+        return outcome; // 4.5 parked for discard; 4.6 runs on resume
+    }
     upkeep_phase_end(cx); // 4.6 + transition
     EngineOutcome::Done
 }
@@ -485,12 +497,10 @@ fn ready_exhausted_cards(cx: &mut Cx) {
 /// constant rather than a per-investigator field — no card in the
 /// current scope modifies the cap. A future hand-size-modifying card
 /// introduces the field when it is actually needed (#111 spec).
-#[allow(dead_code)] // consumed by check_hand_size when #111 lands
 pub(super) const HAND_SIZE_LIMIT: u8 = 8;
 
 /// Active investigators, in player order, whose hand exceeds
 /// [`HAND_SIZE_LIMIT`]. Empty when nobody is over the cap.
-#[allow(dead_code)] // consumed by check_hand_size when #111 lands
 pub(super) fn over_cap_investigators(state: &GameState) -> Vec<InvestigatorId> {
     super::cursor::active_investigators_in_turn_order(state)
         .into_iter()
@@ -498,13 +508,28 @@ pub(super) fn over_cap_investigators(state: &GameState) -> Vec<InvestigatorId> {
         .collect()
 }
 
-/// 4.5 Each investigator checks hand size.
-fn check_hand_size(_cx: &mut Cx) {
-    // TODO(#111): in player order, each investigator with more than 8
-    //   cards in hand discards down to 8 (Rules Reference p.25 step 4.5).
-    //   Needs an AwaitingInput producer for the discard choice. The call
-    //   site exists so the rule step is grep-able and #111 plugs in here
-    //   without changing the driver shape.
+/// 4.5 Each investigator checks hand size. In player order, each
+/// investigator over [`HAND_SIZE_LIMIT`] is prompted to discard down to
+/// the cap. Returns [`EngineOutcome::AwaitingInput`] (parking on the
+/// first over-cap investigator) when anyone is over, or
+/// [`EngineOutcome::Done`] when nobody is — in which case the caller
+/// proceeds straight to 4.6.
+fn check_hand_size(cx: &mut Cx) -> EngineOutcome {
+    let remaining = over_cap_investigators(cx.state);
+    let Some(&first) = remaining.first() else {
+        return EngineOutcome::Done;
+    };
+    cx.state.hand_size_discard_pending = Some(HandSizeDiscard { remaining });
+    EngineOutcome::AwaitingInput {
+        request: InputRequest {
+            prompt: format!(
+                "Upkeep step 4.5: {first:?} has more than {HAND_SIZE_LIMIT} cards in hand; \
+                 submit InputResponse::DiscardCards with the hand indices to discard down to \
+                 {HAND_SIZE_LIMIT}.",
+            ),
+        },
+        resume_token: ResumeToken(0),
+    }
 }
 
 /// 4.2 Reset actions. Rules Reference p.25: "Flip each investigator's
@@ -2493,5 +2518,87 @@ mod hand_size_tests {
         // Push inv2 over too: order must follow turn_order (inv2 then inv1).
         state.investigators.get_mut(&inv2).unwrap().hand = vec![CardCode("x".into()); 10];
         assert_eq!(over_cap_investigators(&state), vec![inv2, inv1]);
+    }
+
+    #[test]
+    fn check_hand_size_suspends_for_over_cap_investigator() {
+        use crate::state::CardCode;
+        let id = InvestigatorId(1);
+        let mut state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_turn_order([id])
+            .with_phase(Phase::Upkeep)
+            .build();
+        state.investigators.get_mut(&id).unwrap().hand = vec![CardCode("x".into()); 10];
+
+        let mut events = Vec::new();
+        let outcome = check_hand_size(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
+
+        assert!(
+            matches!(outcome, EngineOutcome::AwaitingInput { .. }),
+            "over-cap investigator must suspend; got {outcome:?}"
+        );
+        assert_eq!(
+            state
+                .hand_size_discard_pending
+                .as_ref()
+                .map(|p| p.remaining.clone()),
+            Some(vec![id]),
+        );
+    }
+
+    #[test]
+    fn check_hand_size_is_noop_when_all_at_or_below_cap() {
+        use crate::state::CardCode;
+        let id = InvestigatorId(1);
+        let mut state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_turn_order([id])
+            .with_phase(Phase::Upkeep)
+            .build();
+        state.investigators.get_mut(&id).unwrap().hand = vec![CardCode("x".into()); 8];
+
+        let mut events = Vec::new();
+        let outcome = check_hand_size(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
+
+        assert_eq!(outcome, EngineOutcome::Done);
+        assert!(state.hand_size_discard_pending.is_none());
+    }
+
+    #[test]
+    fn upkeep_resume_parks_at_hand_size_discard() {
+        use crate::state::CardCode;
+        let id = InvestigatorId(1);
+        let mut state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_turn_order([id])
+            .with_phase(Phase::Upkeep)
+            .build();
+        // 12-card hand so even after the step-4.4 draw the investigator is
+        // over the cap; a small deck so the draw doesn't deck out.
+        state.investigators.get_mut(&id).unwrap().hand =
+            (0..12).map(|i| CardCode(format!("h{i}"))).collect();
+        state.investigators.get_mut(&id).unwrap().deck =
+            (0..3).map(|i| CardCode(format!("d{i}"))).collect();
+
+        let mut events = Vec::new();
+        let outcome = upkeep_resume(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
+
+        assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
+        assert!(state.hand_size_discard_pending.is_some());
+        assert_eq!(
+            state.phase,
+            Phase::Upkeep,
+            "4.6 must NOT have run while parked"
+        );
     }
 }

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -256,10 +256,7 @@ fn step_phase(cx: &mut Cx) -> EngineOutcome {
             EngineOutcome::Done
         }
         Phase::Enemy if from != Phase::Enemy => enemy_phase(cx),
-        Phase::Upkeep if from != Phase::Upkeep => {
-            upkeep_phase(cx);
-            EngineOutcome::Done
-        }
+        Phase::Upkeep if from != Phase::Upkeep => upkeep_phase(cx),
         _ => unreachable!(
             "step_phase: from == to (from={from:?}, to={to:?}); Phase::next \
              never returns the same phase, so this branch is structurally \
@@ -346,19 +343,15 @@ fn enemy_phase(cx: &mut Cx) -> EngineOutcome {
 /// [`WindowKind::AfterAllInvestigatorsAttacked`] arm. Emits step
 /// 3.4's `PhaseEnded(Enemy)` marker, then transitions to Upkeep.
 /// Exact analog of [`mythos_phase_end`] / [`upkeep_phase_end`].
-pub(super) fn enemy_phase_end(cx: &mut Cx) {
+pub(super) fn enemy_phase_end(cx: &mut Cx) -> EngineOutcome {
     // 3.4 Enemy phase ends.
     cx.events.push(Event::PhaseEnded {
         phase: Phase::Enemy,
     });
-    // Enemy → Upkeep; calls upkeep_phase. Only the Investigation→Enemy
-    // transition can suspend (hunter movement), so this never does.
-    let outcome = step_phase(cx);
-    debug_assert_eq!(
-        outcome,
-        EngineOutcome::Done,
-        "unexpected suspension in Enemy→Upkeep transition"
-    );
+    // Enemy → Upkeep; calls upkeep_phase. This may now suspend at step
+    // 4.5 (hand-size discard, #111), so the outcome propagates rather
+    // than being asserted Done.
+    step_phase(cx)
 }
 
 /// Called after the post-1.4 window closes. Emits 1.5's
@@ -395,25 +388,26 @@ pub(super) fn mythos_phase_end(cx: &mut Cx) {
 /// window sits at the END, so its driver runs content then opens;
 /// Upkeep's sits at the START, so the driver opens immediately and the
 /// content is the continuation.
-fn upkeep_phase(cx: &mut Cx) {
+fn upkeep_phase(cx: &mut Cx) -> EngineOutcome {
     // 4.1 Upkeep phase begins.
     cx.events.push(Event::PhaseStarted {
         phase: Phase::Upkeep,
     });
     // PLAYER WINDOW (post-4.1). Auto-skips inline (running upkeep_resume
     // via run_window_continuation) when nothing is Fast-eligible.
-    super::reaction_windows::open_fast_window(cx, WindowKind::UpkeepBegins);
+    super::reaction_windows::open_fast_window(cx, WindowKind::UpkeepBegins)
 }
 
 /// The post-4.1 window continuation. Steps 4.2–4.4 run inline as named
 /// call sites; step 4.5 is the [`check_hand_size`] stub (TODO #111).
 /// Then hands to [`upkeep_phase_end`] for 4.6 + transition.
-pub(super) fn upkeep_resume(cx: &mut Cx) {
+pub(super) fn upkeep_resume(cx: &mut Cx) -> EngineOutcome {
     reset_actions(cx); // 4.2
     ready_exhausted_cards(cx); // 4.3
     upkeep_draw_and_resource(cx); // 4.4
-    check_hand_size(cx); // 4.5 (TODO #111)
+    check_hand_size(cx); // 4.5 (returns () until Task 5)
     upkeep_phase_end(cx); // 4.6 + transition
+    EngineOutcome::Done
 }
 
 /// Owns step 4.6's `PhaseEnded(Upkeep)` emit, then transitions to

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -233,8 +233,8 @@ fn mythos_phase(cx: &mut Cx) {
 /// [`EngineOutcome::AwaitingInput`]:
 /// - **Investigation→Enemy**: a hunter-movement tie in [`enemy_phase`],
 ///   owned by [`investigation_phase_end`] and propagated through [`end_turn`].
-/// - **Enemy→Upkeep**: the step-4.5 hand-size discard in [`upkeep_phase`]
-///   (#111), owned by [`upkeep_resume`] once that task lands.
+/// - **Enemy→Upkeep**: the step-4.5 hand-size discard (#111), owned by
+///   [`upkeep_resume`].
 ///
 /// Every other arm runs its driver to completion and returns
 /// [`EngineOutcome::Done`].
@@ -2497,6 +2497,7 @@ mod enemy_phase_tests {
 #[cfg(test)]
 mod hand_size_tests {
     use super::*;
+    use crate::assert_no_event;
     use crate::state::{CardCode, InvestigatorId};
     use crate::test_support::{test_investigator, TestGame};
 
@@ -2580,8 +2581,8 @@ mod hand_size_tests {
             .with_turn_order([id])
             .with_phase(Phase::Upkeep)
             .build();
-        // 12-card hand so even after the step-4.4 draw the investigator is
-        // over the cap; a small deck so the draw doesn't deck out.
+        // 13 cards in hand after the step-4.4 draw, still above the 8-card cap;
+        // a small deck so the draw doesn't deck out.
         state.investigators.get_mut(&id).unwrap().hand =
             (0..12).map(|i| CardCode(format!("h{i}"))).collect();
         state.investigators.get_mut(&id).unwrap().deck =
@@ -2599,6 +2600,12 @@ mod hand_size_tests {
             state.phase,
             Phase::Upkeep,
             "4.6 must NOT have run while parked"
+        );
+        assert_no_event!(
+            events,
+            Event::PhaseEnded {
+                phase: Phase::Upkeep
+            }
         );
     }
 }

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -471,8 +471,13 @@ pub(super) fn close_reaction_window_at(cx: &mut Cx, idx: usize) -> EngineOutcome
 
     // Run any kind-specific continuation (e.g. MythosAfterDraws →
     // mythos_phase_end). For reaction windows that have no continuation
-    // (AfterEnemyDefeated, BetweenPhases) this is a no-op.
-    run_window_continuation(cx, kind);
+    // (AfterEnemyDefeated, BetweenPhases) this is a no-op. The
+    // continuation may now suspend (upkeep step 4.5 hand-size discard,
+    // #111), so propagate an AwaitingInput rather than dropping it.
+    let continuation = run_window_continuation(cx, kind);
+    if matches!(continuation, EngineOutcome::AwaitingInput { .. }) {
+        return continuation;
+    }
 
     // If a skill test was mid-resolution when this window opened,
     // hand control back to its driver to run the remaining steps.
@@ -508,9 +513,14 @@ pub(super) fn close_reaction_window_at(cx: &mut Cx, idx: usize) -> EngineOutcome
 /// the first turn via [`begin_investigator_turn`](super::phases::begin_investigator_turn) for the first Active
 /// investigator (or parks if none). `AfterEnemyDefeated`, `BetweenPhases`,
 /// and [`WindowKind::InvestigatorTurnBegins`] windows have no
-/// continuation — for them this is a no-op preserving the existing
-/// [`close_reaction_window_at`] behavior.
-pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) {
+/// continuation — for them this returns [`EngineOutcome::Done`],
+/// preserving the existing [`close_reaction_window_at`] behavior.
+///
+/// Returns the continuation's [`EngineOutcome`]. Today every path
+/// returns [`EngineOutcome::Done`]; the return type is widened ahead of
+/// upkeep step 4.5 (hand-size discard) gaining an
+/// [`EngineOutcome::AwaitingInput`] producer (#111).
+pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) -> EngineOutcome {
     match kind {
         WindowKind::MythosAfterDraws => {
             // Phase-transitioning continuation: cannot run while a skill
@@ -532,6 +542,7 @@ pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) {
                 );
             }
             super::phases::mythos_phase_end(cx);
+            EngineOutcome::Done
         }
         WindowKind::UpkeepBegins => {
             // Phase-transitioning continuation (4.2–4.6 then Upkeep→Mythos):
@@ -546,7 +557,7 @@ pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) {
                     in_flight.continuation,
                 );
             }
-            super::phases::upkeep_resume(cx);
+            super::phases::upkeep_resume(cx)
         }
         WindowKind::BeforeInvestigatorAttacked => {
             // Phase-transitioning continuation (advances to the next
@@ -594,9 +605,9 @@ pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) {
                 super::cursor::next_active_investigator_after(cx.state, investigator);
 
             if cx.state.enemy_attack_pending.is_some() {
-                open_fast_window(cx, WindowKind::BeforeInvestigatorAttacked);
+                open_fast_window(cx, WindowKind::BeforeInvestigatorAttacked)
             } else {
-                open_fast_window(cx, WindowKind::AfterAllInvestigatorsAttacked);
+                open_fast_window(cx, WindowKind::AfterAllInvestigatorsAttacked)
             }
         }
         WindowKind::AfterAllInvestigatorsAttacked => {
@@ -611,7 +622,7 @@ pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) {
                     in_flight.continuation,
                 );
             }
-            super::phases::enemy_phase_end(cx);
+            super::phases::enemy_phase_end(cx)
         }
         WindowKind::InvestigationBegins => {
             // Post-2.1 window closed; start the first turn (step 2.2).
@@ -632,6 +643,7 @@ pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) {
             // would loop the round forever — every other phase auto-skips
             // with no active investigators, so Investigation is the
             // cascade's only natural pause point).
+            EngineOutcome::Done
         }
         // InvestigatorTurnBegins: 2.2.1 — the active investigator now
         // takes actions (Investigate / Move / Fight / Evade / PlayCard /
@@ -641,7 +653,7 @@ pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) {
         // re-open (Rules Reference p.24 2.2.1) is deferred to #146.
         WindowKind::AfterEnemyDefeated { .. }
         | WindowKind::BetweenPhases { .. }
-        | WindowKind::InvestigatorTurnBegins => {}
+        | WindowKind::InvestigatorTurnBegins => EngineOutcome::Done,
     }
 }
 
@@ -671,7 +683,11 @@ pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) {
 /// On the auto-skip path the window is popped before returning so the
 /// net effect on `state.open_windows` is identical to the pre-fix
 /// behaviour (window never lands persistently on the stack).
-pub(super) fn open_fast_window(cx: &mut Cx, kind: WindowKind) {
+///
+/// Returns the auto-skip path's continuation outcome (today always
+/// [`EngineOutcome::Done`]) when the window auto-skips; otherwise
+/// returns [`EngineOutcome::Done`] with the window left on the stack.
+pub(super) fn open_fast_window(cx: &mut Cx, kind: WindowKind) -> EngineOutcome {
     cx.events.push(Event::WindowOpened { kind });
 
     // Push first so any_fast_play_eligible's check_play_card call sees
@@ -698,11 +714,12 @@ pub(super) fn open_fast_window(cx: &mut Cx, kind: WindowKind) {
         // net effect on state.open_windows is the same as before the fix.
         let _ = cx.state.open_windows.pop();
         cx.events.push(Event::WindowClosed { kind });
-        run_window_continuation(cx, kind);
+        return run_window_continuation(cx, kind);
     }
     // Otherwise the window stays on the stack. The guard at the top of
     // apply() and resume_reaction_window / resolve_input handle the
     // wait + close path.
+    EngineOutcome::Done
 }
 
 /// Pure-validation peer to [`play_card`]. Returns `Ok` if the named

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -471,13 +471,19 @@ pub(super) fn close_reaction_window_at(cx: &mut Cx, idx: usize) -> EngineOutcome
 
     // Run any kind-specific continuation (e.g. MythosAfterDraws →
     // mythos_phase_end). For reaction windows that have no continuation
-    // (AfterEnemyDefeated, BetweenPhases) this is a no-op. The
-    // continuation may now suspend (upkeep step 4.5 hand-size discard,
-    // #111), so propagate an AwaitingInput rather than dropping it.
+    // (AfterEnemyDefeated, BetweenPhases) this has no side effects and
+    // returns Done. The continuation may suspend (upkeep step 4.5
+    // hand-size discard, #111), so propagate AwaitingInput rather than
+    // dropping it.
     let continuation = run_window_continuation(cx, kind);
     if matches!(continuation, EngineOutcome::AwaitingInput { .. }) {
         return continuation;
     }
+    debug_assert!(
+        matches!(continuation, EngineOutcome::Done),
+        "close_reaction_window_at: window continuation returned unexpected {continuation:?} \
+         (expected Done or AwaitingInput)",
+    );
 
     // If a skill test was mid-resolution when this window opened,
     // hand control back to its driver to run the remaining steps.
@@ -684,9 +690,10 @@ pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) -> EngineOu
 /// net effect on `state.open_windows` is identical to the pre-fix
 /// behaviour (window never lands persistently on the stack).
 ///
-/// Returns the auto-skip path's continuation outcome (today always
-/// [`EngineOutcome::Done`]) when the window auto-skips; otherwise
-/// returns [`EngineOutcome::Done`] with the window left on the stack.
+/// Returns the continuation's outcome on the auto-skip path (today always
+/// [`EngineOutcome::Done`]; propagates [`EngineOutcome::AwaitingInput`] once
+/// #111 step 4.5 can suspend); returns [`EngineOutcome::Done`] immediately on
+/// the wait path (window left on the stack).
 pub(super) fn open_fast_window(cx: &mut Cx, kind: WindowKind) -> EngineOutcome {
     cx.events.push(Event::WindowOpened { kind });
 
@@ -1127,7 +1134,7 @@ mod open_fast_window_tests {
         // no-op (no events, no state change).
         let mut state = TestGame::default().build();
         let mut events = Vec::new();
-        run_window_continuation(
+        let result = run_window_continuation(
             &mut Cx {
                 state: &mut state,
                 events: &mut events,
@@ -1137,6 +1144,7 @@ mod open_fast_window_tests {
                 by: None,
             },
         );
+        assert_eq!(result, EngineOutcome::Done);
         assert!(
             events.is_empty(),
             "AfterEnemyDefeated continuation must be a no-op; events = {events:?}"

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -1068,6 +1068,11 @@ mod hunter_pending_tests {
         let back: SpawnEngagePending = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, original);
     }
+}
+
+#[cfg(test)]
+mod hand_size_discard_tests {
+    use super::*;
 
     #[test]
     fn hand_size_discard_serde_roundtrip() {

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -186,6 +186,8 @@ pub struct GameState {
     pub hunter_move_pending: Option<HunterChoice>,
     /// Suspended engagement-on-spawn choice (#128). See [`SpawnEngagePending`].
     pub spawn_engage_pending: Option<SpawnEngagePending>,
+    /// Suspended upkeep hand-size discard (#111). See [`HandSizeDiscard`].
+    pub hand_size_discard_pending: Option<HandSizeDiscard>,
     /// Shared encounter deck (top = front). Built at scenario setup
     /// from encounter-set codes; drawn from during Mythos. When the
     /// deck runs out, `draw_encounter_top` (in `engine::dispatch`)
@@ -691,6 +693,22 @@ pub struct SpawnEngagePending {
     pub chain_count: usize,
 }
 
+/// Suspended upkeep maximum-hand-size discard (#111). `Some` only while
+/// the upkeep phase is paused at step 4.5 waiting for an over-cap
+/// investigator to choose discards; cleared once the queue drains.
+///
+/// `remaining[0]` is the investigator currently prompted. The queue is
+/// the player-order list of over-cap investigators, precomputed once
+/// when step 4.5 fires — discarding only ever shrinks the discarding
+/// investigator's own hand, so no other investigator's over-cap status
+/// can change mid-resolution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct HandSizeDiscard {
+    /// Over-cap investigators in player order; front = currently prompted.
+    pub remaining: Vec<InvestigatorId>,
+}
+
 /// A single pending [`Trigger::OnEvent`](crate::dsl::Trigger::OnEvent)
 /// ability waiting to fire inside an `OpenWindow`.
 ///
@@ -1048,6 +1066,16 @@ mod hunter_pending_tests {
         };
         let json = serde_json::to_string(&original).expect("serialize");
         let back: SpawnEngagePending = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn hand_size_discard_serde_roundtrip() {
+        let original = HandSizeDiscard {
+            remaining: vec![InvestigatorId(1), InvestigatorId(2)],
+        };
+        let json = serde_json::to_string(&original).expect("serialize");
+        let back: HandSizeDiscard = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, original);
     }
 }

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -17,9 +17,9 @@ pub use card::{AbilityUsageRecord, CardCode, CardInPlay, CardInstanceId, UseKind
 pub use chaos_bag::{resolve_token, ChaosBag, ChaosToken, TokenModifiers, TokenResolution};
 pub use enemy::{Enemy, EnemyId};
 pub use game_state::{
-    Act, Agenda, FastActorScope, FinishContinuation, GameState, HunterChoice, InFlightSkillTest,
-    OpenWindow, PendingSkillModifier, PendingTrigger, SkillTestFollowUp, SpawnEngagePending,
-    WindowKind,
+    Act, Agenda, FastActorScope, FinishContinuation, GameState, HandSizeDiscard, HunterChoice,
+    InFlightSkillTest, OpenWindow, PendingSkillModifier, PendingTrigger, SkillTestFollowUp,
+    SpawnEngagePending, WindowKind,
 };
 pub use investigator::{DefeatCause, Investigator, InvestigatorId, SkillKind, Skills, Status};
 pub use location::{Location, LocationId};

--- a/crates/game-core/src/test_support/builder.rs
+++ b/crates/game-core/src/test_support/builder.rs
@@ -28,8 +28,8 @@ use std::collections::{BTreeMap, VecDeque};
 use crate::rng::RngState;
 use crate::scenario::ScenarioId;
 use crate::state::{
-    ChaosBag, Enemy, EnemyId, FastActorScope, GameState, Investigator, InvestigatorId, Location,
-    LocationId, OpenWindow, Phase, TokenModifiers, WindowKind,
+    ChaosBag, Enemy, EnemyId, FastActorScope, GameState, HandSizeDiscard, Investigator,
+    InvestigatorId, Location, LocationId, OpenWindow, Phase, TokenModifiers, WindowKind,
 };
 
 /// Fluent builder for a [`GameState`].
@@ -51,7 +51,7 @@ pub struct TestGame {
     turn_order: Vec<InvestigatorId>,
     rng: RngState,
     mulligan_pending: Option<InvestigatorId>,
-    hand_size_discard_pending: Option<crate::state::HandSizeDiscard>,
+    hand_size_discard_pending: Option<HandSizeDiscard>,
     open_windows: Vec<OpenWindow>,
     scenario_id: Option<ScenarioId>,
 }
@@ -215,7 +215,7 @@ impl TestGame {
         mut self,
         remaining: impl IntoIterator<Item = InvestigatorId>,
     ) -> Self {
-        self.hand_size_discard_pending = Some(crate::state::HandSizeDiscard {
+        self.hand_size_discard_pending = Some(HandSizeDiscard {
             remaining: remaining.into_iter().collect(),
         });
         self

--- a/crates/game-core/src/test_support/builder.rs
+++ b/crates/game-core/src/test_support/builder.rs
@@ -51,6 +51,7 @@ pub struct TestGame {
     turn_order: Vec<InvestigatorId>,
     rng: RngState,
     mulligan_pending: Option<InvestigatorId>,
+    hand_size_discard_pending: Option<crate::state::HandSizeDiscard>,
     open_windows: Vec<OpenWindow>,
     scenario_id: Option<ScenarioId>,
 }
@@ -73,6 +74,7 @@ impl TestGame {
             turn_order: Vec::new(),
             rng: RngState::new(0),
             mulligan_pending: None,
+            hand_size_discard_pending: None,
             open_windows: Vec::new(),
             scenario_id: None,
         }
@@ -207,6 +209,18 @@ impl TestGame {
         self
     }
 
+    /// Seed a pending upkeep hand-size discard for the given player-order
+    /// queue (front = currently prompted).
+    pub fn with_hand_size_discard_pending(
+        mut self,
+        remaining: impl IntoIterator<Item = InvestigatorId>,
+    ) -> Self {
+        self.hand_size_discard_pending = Some(crate::state::HandSizeDiscard {
+            remaining: remaining.into_iter().collect(),
+        });
+        self
+    }
+
     /// Push an [`OpenWindow`] onto the build's `open_windows` stack
     /// for tests that need a specific window-state shape.
     ///
@@ -271,6 +285,7 @@ impl TestGame {
             enemy_attack_pending: None,
             hunter_move_pending: None,
             spawn_engage_pending: None,
+            hand_size_discard_pending: self.hand_size_discard_pending,
             encounter_deck: VecDeque::new(),
             encounter_discard: Vec::new(),
             agenda_deck: Vec::new(),

--- a/crates/scenarios/tests/upkeep_hand_size.rs
+++ b/crates/scenarios/tests/upkeep_hand_size.rs
@@ -29,6 +29,7 @@ fn install_test_registry() {
 }
 
 /// The hand-size cap enforced at upkeep step 4.5.
+// mirrors the engine-private phases::HAND_SIZE_LIMIT; keep in sync if the cap changes.
 const HAND_SIZE_LIMIT: usize = 8;
 
 #[test]
@@ -61,11 +62,14 @@ fn upkeep_prompts_and_discards_down_to_eight() {
 
     // Pad the hand so we're over cap at 4.5. The step-4.4 draw adds one
     // card; padding to 11 here lands us at 12 cards at the 4.5 check,
-    // requiring a discard of 12 - 8 = 4.
+    // requiring a discard of (11 + 1 draw) - HAND_SIZE_LIMIT = 4.
     let mut state = r2.state;
     {
         let inv = state.investigators.get_mut(&inv1).unwrap();
         while inv.hand.len() < 11 {
+            // Arbitrary code unknown to the test registry — fine because the
+            // hand-size discard path only moves cards between hand and discard
+            // and never performs a registry lookup.
             inv.hand.push(CardCode::new("01999"));
         }
     }
@@ -141,5 +145,85 @@ fn upkeep_prompts_and_discards_down_to_eight() {
     assert!(
         r4.state.mythos_draw_pending.is_some(),
         "Mythos draw cursor must be seeded once the round proceeds"
+    );
+}
+
+// ------------------------------------------------------------------
+// Replay determinism
+// ------------------------------------------------------------------
+
+#[test]
+fn upkeep_hand_size_discard_replay_is_deterministic() {
+    install_test_registry();
+
+    let inv1 = InvestigatorId(1);
+
+    // Build an initial state whose hand already contains 6 padding cards
+    // (arbitrary codes unknown to the test registry — the discard path
+    // never does a registry lookup). With 6 deck cards, StartScenario
+    // draws 5 → hand reaches 11; upkeep step 4.4 draws the last deck
+    // card → 12 cards, triggering the hand-size prompt. The full action
+    // sequence is thus fixed and requires no mid-sequence state mutation.
+    let make_initial = || {
+        let mut base = synthetic::setup();
+        {
+            let inv = base.investigators.get_mut(&inv1).unwrap();
+            // 6 deck cards: StartScenario draws 5, leaving 1 for the upkeep draw.
+            for i in 0..6u32 {
+                inv.deck.push(CardCode::new(format!("01{i:03}")));
+            }
+            // 6 hand cards pre-seeded: combined with the 5 drawn by StartScenario,
+            // the hand reaches 11 before the upkeep draw.
+            for _ in 0..6u32 {
+                inv.hand.push(CardCode::new("01999"));
+            }
+        }
+        base
+    };
+
+    // discard_count = 12 - HAND_SIZE_LIMIT = 4; indices 0..4.
+    let discard_count = 12u32 - u32::try_from(HAND_SIZE_LIMIT).unwrap();
+    let indices: Vec<u32> = (0..discard_count).collect();
+
+    let actions = vec![
+        Action::Player(PlayerAction::StartScenario),
+        Action::Player(PlayerAction::Mulligan {
+            investigator: inv1,
+            indices_to_redraw: vec![],
+        }),
+        Action::Player(PlayerAction::EndTurn),
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::DiscardCards {
+                indices: indices.clone(),
+            },
+        }),
+    ];
+
+    // --- First pass: drive and collect final state. ---
+    let final_state = {
+        let mut state = make_initial();
+        for action in &actions {
+            let result = apply(state, action.clone());
+            state = result.state;
+        }
+        state
+    };
+
+    // --- Second pass: replay from the same initial state. ---
+    let replayed_state = {
+        let mut state = make_initial();
+        for action in &actions {
+            let result = apply(state, action.clone());
+            state = result.state;
+        }
+        state
+    };
+
+    // Replaying the same action sequence from the same initial state must
+    // reproduce identical state bit-for-bit — the DiscardCards path is
+    // deterministic and must not drift between runs.
+    assert_eq!(
+        final_state, replayed_state,
+        "replay must reproduce identical state"
     );
 }

--- a/crates/scenarios/tests/upkeep_hand_size.rs
+++ b/crates/scenarios/tests/upkeep_hand_size.rs
@@ -1,0 +1,145 @@
+//! #111 acceptance: upkeep step 4.5 discards down to the hand-size cap.
+//!
+//! Drives a full apply cycle through `StartScenario` → `Mulligan` →
+//! `EndTurn`, padding the sole investigator's hand so that — after the
+//! step-4.4 draw — they hold more than the cap at step 4.5. The
+//! round-ending `EndTurn` must cascade into upkeep and pause with
+//! `AwaitingInput`; resolving the prompt with `DiscardCards` must land
+//! the hand at exactly the cap and let the round proceed.
+//!
+//! Lives in `crates/scenarios/tests/` for the same process-isolation /
+//! crate-direction reasons as `upkeep_phase.rs` and `mythos_phase.rs`:
+//! we install [`TEST_REGISTRY`] without colliding with other test
+//! binaries, and `game-core` unit tests can't reach a real registry.
+
+use std::sync::Once;
+
+use game_core::engine::{apply, EngineOutcome};
+use game_core::state::{CardCode, InvestigatorId, Phase};
+use game_core::{Action, InputResponse, PlayerAction};
+use scenarios::test_fixtures::synth_cards::TEST_REGISTRY;
+use scenarios::test_fixtures::synthetic;
+
+static INSTALL: Once = Once::new();
+
+fn install_test_registry() {
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(TEST_REGISTRY);
+    });
+}
+
+/// The hand-size cap enforced at upkeep step 4.5.
+const HAND_SIZE_LIMIT: usize = 8;
+
+#[test]
+fn upkeep_prompts_and_discards_down_to_eight() {
+    install_test_registry();
+
+    let mut base = synthetic::setup();
+    let inv1 = InvestigatorId(1);
+    {
+        let inv = base.investigators.get_mut(&inv1).unwrap();
+        // Seed 6 cards into the deck: StartScenario draws 5 for the
+        // opening hand, leaving 1 for the step-4.4 upkeep draw.
+        for i in 0..6u32 {
+            inv.deck.push(CardCode::new(format!("01{i:03}")));
+        }
+    }
+
+    // StartScenario → mulligan (keep hand).
+    let r1 = apply(base, Action::Player(PlayerAction::StartScenario));
+    assert_eq!(r1.outcome, EngineOutcome::Done);
+
+    let r2 = apply(
+        r1.state,
+        Action::Player(PlayerAction::Mulligan {
+            investigator: inv1,
+            indices_to_redraw: vec![],
+        }),
+    );
+    assert_eq!(r2.outcome, EngineOutcome::Done);
+
+    // Pad the hand so we're over cap at 4.5. The step-4.4 draw adds one
+    // card; padding to 11 here lands us at 12 cards at the 4.5 check,
+    // requiring a discard of 12 - 8 = 4.
+    let mut state = r2.state;
+    {
+        let inv = state.investigators.get_mut(&inv1).unwrap();
+        while inv.hand.len() < 11 {
+            inv.hand.push(CardCode::new("01999"));
+        }
+    }
+    let hand_before_end = state.investigators[&inv1].hand.len();
+    let discard_pile_before = state.investigators[&inv1].discard.len();
+    assert!(
+        state.hand_size_discard_pending.is_none(),
+        "no discard should be pending before the round-ending EndTurn"
+    );
+
+    // Act 1: the round-ending EndTurn cascades Investigation → Enemy →
+    // Upkeep (4.2 reset, 4.3 ready, 4.4 draw +1, 4.5 hand-size check).
+    // The +1 draw pushes the hand to 12 (> cap), so 4.5 suspends.
+    let r3 = apply(state, Action::Player(PlayerAction::EndTurn));
+
+    assert!(
+        matches!(r3.outcome, EngineOutcome::AwaitingInput { .. }),
+        "upkeep 4.5 must prompt for a discard, got {:?}",
+        r3.outcome,
+    );
+    assert!(
+        r3.state.hand_size_discard_pending.is_some(),
+        "hand_size_discard_pending must be set while awaiting the discard"
+    );
+    let hand_at_check = r3.state.investigators[&inv1].hand.len();
+    assert_eq!(
+        hand_at_check,
+        hand_before_end + 1,
+        "step-4.4 draw added exactly one card before the 4.5 check"
+    );
+    assert!(
+        hand_at_check > HAND_SIZE_LIMIT,
+        "hand ({hand_at_check}) must be over the cap at 4.5"
+    );
+
+    // Act 2: submit DiscardCards with exactly (hand_len - cap) indices.
+    let discard_count = hand_at_check - HAND_SIZE_LIMIT;
+    let indices: Vec<u32> = (0..u32::try_from(discard_count).unwrap()).collect();
+    let r4 = apply(
+        r3.state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::DiscardCards { indices },
+        }),
+    );
+
+    assert_eq!(
+        r4.outcome,
+        EngineOutcome::Done,
+        "resolving the discard must complete the upkeep cascade"
+    );
+    assert_eq!(
+        r4.state.investigators[&inv1].hand.len(),
+        HAND_SIZE_LIMIT,
+        "investigator must land at exactly the hand-size cap"
+    );
+    assert_eq!(
+        r4.state.investigators[&inv1].discard.len(),
+        discard_pile_before + discard_count,
+        "discarded cards must move to the investigator's discard pile"
+    );
+    assert!(
+        r4.state.hand_size_discard_pending.is_none(),
+        "discard-pending must be cleared once the queue drains"
+    );
+
+    // The round proceeded: the upkeep cascade completed and advanced to
+    // the Mythos phase of the next round.
+    assert_eq!(
+        r4.state.phase,
+        Phase::Mythos,
+        "round must proceed into Mythos after the discard resolves"
+    );
+    assert!(
+        r4.state.mythos_draw_pending.is_some(),
+        "Mythos draw cursor must be seeded once the round proceeds"
+    );
+}

--- a/docs/superpowers/plans/2026-06-06-111-max-hand-size.md
+++ b/docs/superpowers/plans/2026-06-06-111-max-hand-size.md
@@ -1,0 +1,974 @@
+# Maximum Hand Size at Upkeep (#111) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** At upkeep step 4.5, each investigator with more than 8 cards in hand is prompted (in player order) to discard down to 8.
+
+**Architecture:** A new `hand_size_discard_pending` suspension on `GameState` (a player-order queue), surfaced as `AwaitingInput` and resumed via a new `InputResponse::DiscardCards { indices }`. The discard runs inside the `upkeep_resume` window continuation, so the window-continuation cascade is widened to return `EngineOutcome` (approach P2) — letting the `AwaitingInput` from step 4.5 propagate to the apply boundary. Cap is a module constant (`HAND_SIZE_LIMIT = 8`); no per-investigator field.
+
+**Tech Stack:** Rust, `game-core` kernel crate. Event-sourced `apply(state, action) -> ApplyResult`. Validate-first / mutate-second handler contract.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-111-max-hand-size-design.md`
+
+**Note:** #111 is unmilestoned — no `docs/phases/` update is required (that step applies to phase-milestone issues only).
+
+---
+
+## File map
+
+- `crates/game-core/src/action.rs` — add `InputResponse::DiscardCards { indices: Vec<u32> }`.
+- `crates/game-core/src/state/game_state.rs` — add `HandSizeDiscard` struct + `hand_size_discard_pending` field + serde test.
+- `crates/game-core/src/test_support/builder.rs` — init the new field; add `with_hand_size_discard_pending` helper.
+- `crates/game-core/src/engine/dispatch/phases.rs` — `HAND_SIZE_LIMIT` const, `over_cap_investigators`, `check_hand_size` (now produces `AwaitingInput`), `upkeep_resume` / `upkeep_phase` / `enemy_phase_end` signature changes, `resume_hand_size_discard`.
+- `crates/game-core/src/engine/dispatch/reaction_windows.rs` — `run_window_continuation` / `open_fast_window` return `EngineOutcome`; `close_reaction_window_at` propagation.
+- `crates/game-core/src/engine/dispatch/mod.rs` — `resolve_input` routing + apply-top guard.
+- `crates/scenarios/tests/` — integration acceptance test.
+
+---
+
+## Task 1: Add the `DiscardCards` input variant
+
+**Files:**
+- Modify: `crates/game-core/src/action.rs:308-336` (the `InputResponse` enum)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)]` module in `crates/game-core/src/action.rs`:
+
+```rust
+#[test]
+fn discard_cards_input_serde_roundtrip() {
+    let original = InputResponse::DiscardCards {
+        indices: vec![0, 3, 7],
+    };
+    let json = serde_json::to_string(&original).expect("serialize");
+    let back: InputResponse = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back, original);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p game-core discard_cards_input_serde_roundtrip`
+Expected: FAIL — `no variant named DiscardCards`.
+
+- [ ] **Step 3: Add the variant**
+
+In the `InputResponse` enum (after the `CommitCards` variant), add:
+
+```rust
+    /// Discard cards from hand to satisfy the upkeep maximum-hand-size
+    /// step (Rules Reference 4.5). Each entry is a zero-based index into
+    /// the prompted investigator's hand at the moment of the prompt. The
+    /// engine discards exactly the overflow (`hand.len() - 8`); any other
+    /// count, a duplicate, or an out-of-bounds index is rejected.
+    ///
+    /// `u32` rather than `u8` for wire-format symmetry with
+    /// [`CommitCards`](Self::CommitCards) / [`PickIndex`](Self::PickIndex);
+    /// downcast at validation time.
+    DiscardCards {
+        /// Hand indices to discard.
+        indices: Vec<u32>,
+    },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p game-core discard_cards_input_serde_roundtrip`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/game-core/src/action.rs
+git commit -m "engine: add InputResponse::DiscardCards variant (#111)"
+```
+
+---
+
+## Task 2: Add the `HandSizeDiscard` suspension state
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (add struct near `SpawnEngagePending` ~line 677; add field after `spawn_engage_pending` ~line 188; add serde test)
+- Modify: `crates/game-core/src/test_support/builder.rs:273` (field init) and after `with_mulligan_pending` (~line 205) for the helper
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)]` serde module in `crates/game-core/src/state/game_state.rs` (next to `spawn_engage_pending_serde_roundtrip`):
+
+```rust
+#[test]
+fn hand_size_discard_serde_roundtrip() {
+    let original = HandSizeDiscard {
+        remaining: vec![InvestigatorId(1), InvestigatorId(2)],
+    };
+    let json = serde_json::to_string(&original).expect("serialize");
+    let back: HandSizeDiscard = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back, original);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p game-core hand_size_discard_serde_roundtrip`
+Expected: FAIL — `cannot find type HandSizeDiscard`.
+
+- [ ] **Step 3: Add the struct and field**
+
+Add the struct near `SpawnEngagePending` (~line 670, before it or after it):
+
+```rust
+/// Suspended upkeep maximum-hand-size discard (#111). `Some` only while
+/// the upkeep phase is paused at step 4.5 waiting for an over-cap
+/// investigator to choose discards; cleared once the queue drains.
+///
+/// `remaining[0]` is the investigator currently prompted. The queue is
+/// the player-order list of over-cap investigators, precomputed once
+/// when step 4.5 fires — discarding only ever shrinks the discarding
+/// investigator's own hand, so no other investigator's over-cap status
+/// can change mid-resolution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct HandSizeDiscard {
+    /// Over-cap investigators in player order; front = currently prompted.
+    pub remaining: Vec<InvestigatorId>,
+}
+```
+
+Add the field on `GameState` immediately after `spawn_engage_pending` (~line 188):
+
+```rust
+    /// Suspended upkeep hand-size discard (#111). See [`HandSizeDiscard`].
+    pub hand_size_discard_pending: Option<HandSizeDiscard>,
+```
+
+- [ ] **Step 4: Init the field in the builder**
+
+In `crates/game-core/src/test_support/builder.rs`, in the `GameState { … }` literal (next to `spawn_engage_pending: None,` at line 273), add:
+
+```rust
+            hand_size_discard_pending: None,
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test -p game-core hand_size_discard_serde_roundtrip`
+Expected: PASS (and the crate compiles — the builder is the sole `GameState` constructor; if the compiler flags another construction site, add the field there too).
+
+- [ ] **Step 6: Add a builder helper**
+
+In `crates/game-core/src/test_support/builder.rs`, after `with_mulligan_pending` (~line 205), add:
+
+```rust
+    /// Seed a pending upkeep hand-size discard for the given player-order
+    /// queue (front = currently prompted).
+    #[must_use]
+    pub fn with_hand_size_discard_pending(
+        mut self,
+        remaining: impl IntoIterator<Item = InvestigatorId>,
+    ) -> Self {
+        self.state.hand_size_discard_pending = Some(crate::state::HandSizeDiscard {
+            remaining: remaining.into_iter().collect(),
+        });
+        self
+    }
+```
+
+If `HandSizeDiscard` is not already re-exported from `crate::state`, confirm `crates/game-core/src/state/mod.rs` exports it (add `HandSizeDiscard` to the `pub use game_state::{…}` list alongside `SpawnEngagePending`).
+
+- [ ] **Step 7: Verify build**
+
+Run: `cargo test -p game-core --no-run`
+Expected: compiles.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/game-core/src/state/ crates/game-core/src/test_support/builder.rs
+git commit -m "engine: add hand_size_discard_pending suspension state (#111)"
+```
+
+---
+
+## Task 3: Hand-size constant and over-cap detection
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/phases.rs` (add const + helper near `check_hand_size` ~line 489; add unit test in the file's test module)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to a `#[cfg(test)]` module in `phases.rs` (e.g. extend `upkeep_phase_tests` or add `hand_size_tests`):
+
+```rust
+#[test]
+fn over_cap_investigators_lists_only_over_eight_in_player_order() {
+    use crate::state::CardCode;
+    let inv1 = InvestigatorId(1);
+    let inv2 = InvestigatorId(2);
+    let mut state = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_investigator(test_investigator(2))
+        .with_turn_order([inv2, inv1]) // player order: inv2 first
+        .build();
+    // inv1: 9 cards (over), inv2: 8 cards (at cap, not over).
+    state.investigators.get_mut(&inv1).unwrap().hand =
+        vec![CardCode("x".into()); 9];
+    state.investigators.get_mut(&inv2).unwrap().hand =
+        vec![CardCode("x".into()); 8];
+
+    assert_eq!(over_cap_investigators(&state), vec![inv1]);
+
+    // Push inv2 over too: order must follow turn_order (inv2 then inv1).
+    state.investigators.get_mut(&inv2).unwrap().hand =
+        vec![CardCode("x".into()); 10];
+    assert_eq!(over_cap_investigators(&state), vec![inv2, inv1]);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p game-core over_cap_investigators_lists_only_over_eight_in_player_order`
+Expected: FAIL — `cannot find function over_cap_investigators`.
+
+- [ ] **Step 3: Add the const and helper**
+
+In `phases.rs`, near `check_hand_size` (~line 488), add:
+
+```rust
+/// Maximum hand size (Rules Reference 4.5: discard down to 8). A module
+/// constant rather than a per-investigator field — no card in the
+/// current scope modifies the cap. A future hand-size-modifying card
+/// introduces the field when it is actually needed (#111 spec).
+pub(super) const HAND_SIZE_LIMIT: u8 = 8;
+
+/// Active investigators, in player order, whose hand exceeds
+/// [`HAND_SIZE_LIMIT`]. Empty when nobody is over the cap.
+pub(super) fn over_cap_investigators(state: &GameState) -> Vec<InvestigatorId> {
+    super::cursor::active_investigators_in_turn_order(state)
+        .into_iter()
+        .filter(|id| state.investigators[id].hand.len() > HAND_SIZE_LIMIT as usize)
+        .collect()
+}
+```
+
+Add `GameState` to the `use crate::state::{…}` import at the top of `phases.rs` if not already present.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p game-core over_cap_investigators_lists_only_over_eight_in_player_order`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/phases.rs
+git commit -m "engine: HAND_SIZE_LIMIT const + over_cap_investigators helper (#111)"
+```
+
+---
+
+## Task 4: Thread `EngineOutcome` through the window-continuation cascade (pure refactor)
+
+This is a no-behavior-change refactor: every function below starts and stays returning `EngineOutcome::Done`. It is the prerequisite for step 4.5 surfacing `AwaitingInput`. Existing tests are the safety net.
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (`run_window_continuation`, `open_fast_window`, `close_reaction_window_at`)
+- Modify: `crates/game-core/src/engine/dispatch/phases.rs` (`upkeep_phase`, `upkeep_resume`, `enemy_phase_end`, `step_phase` Upkeep arm)
+
+- [ ] **Step 1: Make `run_window_continuation` return `EngineOutcome`**
+
+Change its signature to `pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) -> EngineOutcome` and make the `match` the tail expression. Each arm yields a value (the existing `unreachable!` in-flight guards stay — they diverge):
+
+```rust
+    match kind {
+        WindowKind::MythosAfterDraws => {
+            // ... existing in_flight unreachable! guard ...
+            super::phases::mythos_phase_end(cx);
+            EngineOutcome::Done
+        }
+        WindowKind::UpkeepBegins => {
+            // ... existing in_flight unreachable! guard ...
+            super::phases::upkeep_resume(cx)
+        }
+        WindowKind::BeforeInvestigatorAttacked => {
+            // ... existing in_flight unreachable! guard ...
+            // ... existing investigator/resolve_attacks/cursor-advance body ...
+            if cx.state.enemy_attack_pending.is_some() {
+                open_fast_window(cx, WindowKind::BeforeInvestigatorAttacked)
+            } else {
+                open_fast_window(cx, WindowKind::AfterAllInvestigatorsAttacked)
+            }
+        }
+        WindowKind::AfterAllInvestigatorsAttacked => {
+            // ... existing in_flight unreachable! guard ...
+            super::phases::enemy_phase_end(cx)
+        }
+        WindowKind::InvestigationBegins => {
+            if let Some(id) = super::cursor::first_active_investigator(cx.state) {
+                super::phases::begin_investigator_turn(cx, id);
+            }
+            EngineOutcome::Done
+        }
+        WindowKind::AfterEnemyDefeated { .. }
+        | WindowKind::BetweenPhases { .. }
+        | WindowKind::InvestigatorTurnBegins => EngineOutcome::Done,
+    }
+```
+
+- [ ] **Step 2: Make `open_fast_window` return `EngineOutcome`**
+
+Change its signature to `-> EngineOutcome`. In the auto-skip branch, return the continuation; otherwise return `Done`:
+
+```rust
+    if !has_pending && !has_fast_eligible {
+        let _ = cx.state.open_windows.pop();
+        cx.events.push(Event::WindowClosed { kind });
+        return run_window_continuation(cx, kind);
+    }
+    EngineOutcome::Done
+```
+
+- [ ] **Step 3: Propagate in `close_reaction_window_at`**
+
+After the `let window = cx.state.open_windows.remove(idx); … cx.events.push(WindowClosed)`, replace the bare `run_window_continuation(cx, kind);` call with capture-and-propagate:
+
+```rust
+    let continuation = run_window_continuation(cx, kind);
+    if matches!(continuation, EngineOutcome::AwaitingInput { .. }) {
+        return continuation;
+    }
+
+    // (existing skill-test resume / Done tail unchanged)
+    if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
+        if !matches!(in_flight.continuation, FinishContinuation::AwaitingCommit) {
+            return super::skill_test::drive_skill_test(cx);
+        }
+    }
+    EngineOutcome::Done
+```
+
+- [ ] **Step 4: Update `upkeep_phase`, `upkeep_resume`, `enemy_phase_end`, and `step_phase`**
+
+In `phases.rs`:
+
+```rust
+fn upkeep_phase(cx: &mut Cx) -> EngineOutcome {
+    cx.events.push(Event::PhaseStarted { phase: Phase::Upkeep });
+    super::reaction_windows::open_fast_window(cx, WindowKind::UpkeepBegins)
+}
+
+pub(super) fn upkeep_resume(cx: &mut Cx) -> EngineOutcome {
+    reset_actions(cx); // 4.2
+    ready_exhausted_cards(cx); // 4.3
+    upkeep_draw_and_resource(cx); // 4.4
+    check_hand_size(cx); // 4.5 (returns () until Task 5)
+    upkeep_phase_end(cx); // 4.6 + transition
+    EngineOutcome::Done
+}
+
+pub(super) fn enemy_phase_end(cx: &mut Cx) -> EngineOutcome {
+    cx.events.push(Event::PhaseEnded { phase: Phase::Enemy });
+    // Enemy → Upkeep; calls upkeep_phase. May now suspend at step 4.5
+    // (hand-size discard), so the outcome propagates rather than being
+    // asserted Done.
+    step_phase(cx)
+}
+```
+
+In `step_phase`, change the Upkeep arm to return `upkeep_phase`'s outcome:
+
+```rust
+        Phase::Upkeep if from != Phase::Upkeep => upkeep_phase(cx),
+```
+
+(The Mythos and Investigation arms keep their `{ driver(cx); EngineOutcome::Done }` shape — those transitions never suspend for a discard. `mythos_phase_end` / `upkeep_phase_end` keep their `debug_assert_eq!(outcome, Done)` since Mythos→Investigation and Upkeep→Mythos never suspend.)
+
+- [ ] **Step 5: Run the full game-core suite to confirm no behavior change**
+
+Run: `cargo test -p game-core`
+Expected: PASS (all existing tests green — this is a pure refactor; every path still returns `Done`).
+
+- [ ] **Step 6: Run clippy (the signature changes must be warning-clean)**
+
+Run: `cargo clippy -p game-core --all-targets --all-features -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/reaction_windows.rs crates/game-core/src/engine/dispatch/phases.rs
+git commit -m "engine: thread EngineOutcome through window-continuation cascade (#111)"
+```
+
+---
+
+## Task 5: `check_hand_size` surfaces the discard prompt
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/phases.rs` (`check_hand_size`, `upkeep_resume`, imports)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `phases.rs` test module:
+
+```rust
+#[test]
+fn check_hand_size_suspends_for_over_cap_investigator() {
+    use crate::state::CardCode;
+    let id = InvestigatorId(1);
+    let mut state = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_turn_order([id])
+        .with_phase(Phase::Upkeep)
+        .build();
+    state.investigators.get_mut(&id).unwrap().hand = vec![CardCode("x".into()); 10];
+
+    let mut events = Vec::new();
+    let outcome = check_hand_size(&mut Cx { state: &mut state, events: &mut events });
+
+    assert!(
+        matches!(outcome, EngineOutcome::AwaitingInput { .. }),
+        "over-cap investigator must suspend; got {outcome:?}"
+    );
+    assert_eq!(
+        state.hand_size_discard_pending.as_ref().map(|p| p.remaining.clone()),
+        Some(vec![id]),
+    );
+}
+
+#[test]
+fn check_hand_size_is_noop_when_all_at_or_below_cap() {
+    use crate::state::CardCode;
+    let id = InvestigatorId(1);
+    let mut state = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_turn_order([id])
+        .with_phase(Phase::Upkeep)
+        .build();
+    state.investigators.get_mut(&id).unwrap().hand = vec![CardCode("x".into()); 8];
+
+    let mut events = Vec::new();
+    let outcome = check_hand_size(&mut Cx { state: &mut state, events: &mut events });
+
+    assert_eq!(outcome, EngineOutcome::Done);
+    assert!(state.hand_size_discard_pending.is_none());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p game-core check_hand_size_`
+Expected: FAIL — `check_hand_size` returns `()`, mismatched types.
+
+- [ ] **Step 3: Implement**
+
+Replace the `check_hand_size` stub in `phases.rs`:
+
+```rust
+/// 4.5 Each investigator checks hand size. In player order, each
+/// investigator over [`HAND_SIZE_LIMIT`] is prompted to discard down to
+/// the cap. Returns [`EngineOutcome::AwaitingInput`] (parking on the
+/// first over-cap investigator) when anyone is over, or
+/// [`EngineOutcome::Done`] when nobody is — in which case the caller
+/// proceeds straight to 4.6.
+fn check_hand_size(cx: &mut Cx) -> EngineOutcome {
+    let remaining = over_cap_investigators(cx.state);
+    let Some(&first) = remaining.first() else {
+        return EngineOutcome::Done;
+    };
+    cx.state.hand_size_discard_pending = Some(HandSizeDiscard { remaining });
+    EngineOutcome::AwaitingInput {
+        request: InputRequest {
+            prompt: format!(
+                "Upkeep step 4.5: {first:?} has more than {HAND_SIZE_LIMIT} cards in hand; \
+                 submit InputResponse::DiscardCards with the hand indices to discard down to \
+                 {HAND_SIZE_LIMIT}.",
+            ),
+        },
+        resume_token: ResumeToken(0),
+    }
+}
+```
+
+Update `upkeep_resume` to short-circuit on suspension:
+
+```rust
+pub(super) fn upkeep_resume(cx: &mut Cx) -> EngineOutcome {
+    reset_actions(cx); // 4.2
+    ready_exhausted_cards(cx); // 4.3
+    upkeep_draw_and_resource(cx); // 4.4
+    if let outcome @ EngineOutcome::AwaitingInput { .. } = check_hand_size(cx) {
+        return outcome; // 4.5 parked for discard; 4.6 runs on resume
+    }
+    upkeep_phase_end(cx); // 4.6 + transition
+    EngineOutcome::Done
+}
+```
+
+Add imports at the top of `phases.rs`:
+
+```rust
+use crate::engine::outcome::{InputRequest, ResumeToken};
+use crate::state::HandSizeDiscard;
+```
+
+(`EngineOutcome` is already imported.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p game-core check_hand_size_`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full game-core suite**
+
+Run: `cargo test -p game-core`
+Expected: PASS (the no-op path keeps existing upkeep tests green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/phases.rs
+git commit -m "engine: upkeep 4.5 surfaces hand-size discard AwaitingInput (#111)"
+```
+
+---
+
+## Task 6: Resume handler, routing, and guard
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/phases.rs` (`resume_hand_size_discard` + tests)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (`resolve_input` routing ~line 308; apply-top guard ~line 117)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `phases.rs` test module:
+
+```rust
+#[test]
+fn resume_hand_size_discard_discards_overflow_and_advances_to_mythos() {
+    use crate::state::CardCode;
+    let id = InvestigatorId(1);
+    let mut state = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_turn_order([id])
+        .with_phase(Phase::Upkeep)
+        .with_hand_size_discard_pending([id])
+        .build();
+    // 10-card hand: discard exactly 2 (indices 0 and 1) → land at 8.
+    state.investigators.get_mut(&id).unwrap().hand = (0..10)
+        .map(|i| CardCode(format!("c{i}")))
+        .collect();
+
+    let mut events = Vec::new();
+    let outcome = resume_hand_size_discard(
+        &mut Cx { state: &mut state, events: &mut events },
+        &InputResponse::DiscardCards { indices: vec![0, 1] },
+    );
+
+    assert_eq!(outcome, EngineOutcome::Done);
+    assert!(state.hand_size_discard_pending.is_none());
+    assert_eq!(state.investigators[&id].hand.len(), 8);
+    assert_eq!(state.investigators[&id].discard.len(), 2);
+    assert_eq!(state.phase, Phase::Mythos, "queue drained → 4.6 runs → next round Mythos");
+    assert_eq!(
+        events.iter().filter(|e| matches!(e, Event::CardDiscarded { from: crate::state::Zone::Hand, .. })).count(),
+        2,
+    );
+}
+
+#[test]
+fn resume_hand_size_discard_rejects_wrong_count() {
+    use crate::state::CardCode;
+    let id = InvestigatorId(1);
+    let mut state = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_turn_order([id])
+        .with_phase(Phase::Upkeep)
+        .with_hand_size_discard_pending([id])
+        .build();
+    state.investigators.get_mut(&id).unwrap().hand =
+        (0..10).map(|i| CardCode(format!("c{i}"))).collect();
+
+    let mut events = Vec::new();
+    // Need to discard 2; submitting 1 must reject with state untouched.
+    let outcome = resume_hand_size_discard(
+        &mut Cx { state: &mut state, events: &mut events },
+        &InputResponse::DiscardCards { indices: vec![0] },
+    );
+
+    assert!(matches!(outcome, EngineOutcome::Rejected { .. }));
+    assert_eq!(state.investigators[&id].hand.len(), 10, "rejected: hand untouched");
+    assert!(state.hand_size_discard_pending.is_some(), "rejected: still pending");
+    assert!(events.is_empty(), "rejected: no events");
+}
+
+#[test]
+fn resume_hand_size_discard_rejects_duplicate_and_oob_indices() {
+    use crate::state::CardCode;
+    let id = InvestigatorId(1);
+    let build = || {
+        let mut s = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_turn_order([id])
+            .with_phase(Phase::Upkeep)
+            .with_hand_size_discard_pending([id])
+            .build();
+        s.investigators.get_mut(&id).unwrap().hand =
+            (0..10).map(|i| CardCode(format!("c{i}"))).collect();
+        s
+    };
+
+    // Duplicate index (count is 2 but both point at slot 0).
+    let mut s1 = build();
+    let mut e1 = Vec::new();
+    let o1 = resume_hand_size_discard(
+        &mut Cx { state: &mut s1, events: &mut e1 },
+        &InputResponse::DiscardCards { indices: vec![0, 0] },
+    );
+    assert!(matches!(o1, EngineOutcome::Rejected { .. }));
+    assert_eq!(s1.investigators[&id].hand.len(), 10);
+
+    // Out-of-bounds index.
+    let mut s2 = build();
+    let mut e2 = Vec::new();
+    let o2 = resume_hand_size_discard(
+        &mut Cx { state: &mut s2, events: &mut e2 },
+        &InputResponse::DiscardCards { indices: vec![0, 99] },
+    );
+    assert!(matches!(o2, EngineOutcome::Rejected { .. }));
+    assert_eq!(s2.investigators[&id].hand.len(), 10);
+}
+
+#[test]
+fn resume_hand_size_discard_sequences_investigators_in_player_order() {
+    use crate::state::CardCode;
+    let inv1 = InvestigatorId(1);
+    let inv2 = InvestigatorId(2);
+    let mut state = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_investigator(test_investigator(2))
+        .with_turn_order([inv1, inv2])
+        .with_phase(Phase::Upkeep)
+        .with_hand_size_discard_pending([inv1, inv2])
+        .build();
+    state.investigators.get_mut(&inv1).unwrap().hand =
+        (0..9).map(|i| CardCode(format!("a{i}"))).collect(); // discard 1
+    state.investigators.get_mut(&inv2).unwrap().hand =
+        (0..9).map(|i| CardCode(format!("b{i}"))).collect(); // discard 1
+
+    // inv1 resolves first → still pending for inv2, phase still Upkeep.
+    let mut events = Vec::new();
+    let o1 = resume_hand_size_discard(
+        &mut Cx { state: &mut state, events: &mut events },
+        &InputResponse::DiscardCards { indices: vec![0] },
+    );
+    assert!(matches!(o1, EngineOutcome::AwaitingInput { .. }));
+    assert_eq!(
+        state.hand_size_discard_pending.as_ref().map(|p| p.remaining.clone()),
+        Some(vec![inv2]),
+    );
+    assert_eq!(state.phase, Phase::Upkeep);
+    assert_eq!(state.investigators[&inv1].hand.len(), 8);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p game-core resume_hand_size_discard`
+Expected: FAIL — `cannot find function resume_hand_size_discard`.
+
+- [ ] **Step 3: Implement the resume handler**
+
+Add to `phases.rs` (near `check_hand_size`). Add `use crate::action::InputResponse;` and `use crate::state::{CardCode, Zone};` to the file's imports (merge `CardCode`/`Zone` into the existing `crate::state::{…}` line):
+
+```rust
+/// Resume a parked upkeep hand-size discard (#111). Validates the
+/// `DiscardCards` response against the currently-prompted investigator
+/// (`remaining[0]`): the indices must be unique, in-bounds, and exactly
+/// `hand.len() - HAND_SIZE_LIMIT` in count. On success, discards the
+/// chosen cards (emitting [`Event::CardDiscarded`] per card), pops the
+/// queue front, and either re-prompts the next over-cap investigator or
+/// — when the queue drains — runs [`upkeep_phase_end`] (4.6 + transition
+/// to Mythos). Rejections leave state and events untouched.
+pub(super) fn resume_hand_size_discard(
+    cx: &mut Cx,
+    response: &InputResponse,
+) -> EngineOutcome {
+    let pending = cx
+        .state
+        .hand_size_discard_pending
+        .clone()
+        .unwrap_or_else(|| unreachable!("resume_hand_size_discard: no pending discard"));
+    let current = pending.remaining[0];
+
+    let InputResponse::DiscardCards { indices } = response else {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "ResolveInput: hand-size discard expects InputResponse::DiscardCards, got {response:?}",
+            )
+            .into(),
+        };
+    };
+
+    // ---- validate (state untouched on any failure) ----
+    let inv = cx.state.investigators.get(&current).unwrap_or_else(|| {
+        unreachable!("resume_hand_size_discard: prompted investigator {current:?} vanished")
+    });
+    let hand_len = inv.hand.len();
+    let target = hand_len.saturating_sub(HAND_SIZE_LIMIT as usize);
+    if indices.len() != target {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "ResolveInput::DiscardCards: {current:?} must discard exactly {target} card(s) \
+                 (hand {hand_len}, cap {HAND_SIZE_LIMIT}), got {}",
+                indices.len(),
+            )
+            .into(),
+        };
+    }
+    let mut seen = std::collections::BTreeSet::new();
+    for &i in indices {
+        if !seen.insert(i) {
+            return EngineOutcome::Rejected {
+                reason: format!("ResolveInput::DiscardCards: duplicate hand index {i}").into(),
+            };
+        }
+        if i as usize >= hand_len {
+            return EngineOutcome::Rejected {
+                reason: format!(
+                    "ResolveInput::DiscardCards: hand index {i} out of bounds (hand size {hand_len})",
+                )
+                .into(),
+            };
+        }
+    }
+
+    // ---- mutate ----
+    let discarded: Vec<CardCode> = {
+        let inv = cx
+            .state
+            .investigators
+            .get_mut(&current)
+            .expect("validated above");
+        let mut sorted: Vec<u32> = indices.clone();
+        sorted.sort_unstable();
+        let codes: Vec<CardCode> = sorted.iter().map(|&i| inv.hand[i as usize].clone()).collect();
+        for &i in sorted.iter().rev() {
+            inv.hand.remove(i as usize);
+        }
+        inv.discard.extend(codes.iter().cloned());
+        codes
+    };
+    for code in discarded {
+        cx.events.push(Event::CardDiscarded {
+            investigator: current,
+            code,
+            from: Zone::Hand,
+        });
+    }
+
+    // ---- advance the queue ----
+    let mut remaining = pending.remaining;
+    remaining.remove(0);
+    if remaining.is_empty() {
+        cx.state.hand_size_discard_pending = None;
+        upkeep_phase_end(cx); // 4.6 + transition to Mythos
+        EngineOutcome::Done
+    } else {
+        let next = remaining[0];
+        cx.state.hand_size_discard_pending = Some(HandSizeDiscard { remaining });
+        EngineOutcome::AwaitingInput {
+            request: InputRequest {
+                prompt: format!(
+                    "Upkeep step 4.5: {next:?} has more than {HAND_SIZE_LIMIT} cards in hand; \
+                     submit InputResponse::DiscardCards with the hand indices to discard down to \
+                     {HAND_SIZE_LIMIT}.",
+                ),
+            },
+            resume_token: ResumeToken(0),
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Route `ResolveInput` to the handler**
+
+In `crates/game-core/src/engine/dispatch/mod.rs`, in `resolve_input` (~line 308), add a branch immediately after the `spawn_engage_pending` branch (and before the reaction-window check):
+
+```rust
+    if cx.state.hand_size_discard_pending.is_some() {
+        return phases::resume_hand_size_discard(cx, response);
+    }
+```
+
+Extend the existing mutual-exclusion `debug_assert!` (~line 303) — or add a new one — to include the discard mode, e.g.:
+
+```rust
+    debug_assert!(
+        [
+            cx.state.hunter_move_pending.is_some(),
+            cx.state.spawn_engage_pending.is_some(),
+            cx.state.hand_size_discard_pending.is_some(),
+        ]
+        .iter()
+        .filter(|b| **b)
+        .count()
+            <= 1,
+        "hunter movement, spawn engagement, and hand-size discard are mutually exclusive \
+         suspension modes (different phases)",
+    );
+```
+
+- [ ] **Step 5: Add the apply-top guard**
+
+In `mod.rs`, after the `spawn_engage_pending` guard (~line 117), add:
+
+```rust
+    // A pending upkeep hand-size discard (#111) blocks every action but
+    // `ResolveInput`. Upkeep-phase only; never coexists with the other
+    // suspension modes, so guard order is immaterial.
+    if cx.state.hand_size_discard_pending.is_some()
+        && !matches!(action, PlayerAction::ResolveInput { .. })
+    {
+        return EngineOutcome::Rejected {
+            reason: "a hand-size discard choice is pending; submit a PlayerAction::ResolveInput \
+                     with InputResponse::DiscardCards before any other action"
+                .into(),
+        };
+    }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test -p game-core resume_hand_size_discard`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full game-core suite**
+
+Run: `cargo test -p game-core`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/phases.rs crates/game-core/src/engine/dispatch/mod.rs
+git commit -m "engine: resume handler + routing for upkeep hand-size discard (#111)"
+```
+
+---
+
+## Task 7: Integration acceptance test
+
+**Files:**
+- Create or extend: `crates/scenarios/tests/upkeep_hand_size.rs` (its own cargo binary, can `install(cards::REGISTRY)`)
+
+Check `crates/scenarios/tests/mythos_phase.rs` for the established pattern (registry install, scenario setup, driving the round to upkeep). Reuse its setup helpers if present.
+
+- [ ] **Step 1: Write the failing acceptance test**
+
+Drive a scenario so that, at upkeep, an investigator holds 10 cards with the cap at 8, then assert the prompt → discard → land-at-8 flow. Skeleton (adapt setup to the helpers in `mythos_phase.rs`):
+
+```rust
+//! #111 acceptance: upkeep step 4.5 discards down to the hand-size cap.
+
+use game_core::action::{Action, InputResponse, PlayerAction};
+use game_core::engine::apply;
+use game_core::state::InvestigatorId;
+use game_core::EngineOutcome;
+
+#[test]
+fn upkeep_prompts_and_discards_down_to_eight() {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+
+    // Arrange: a scenario advanced to the point where the round-end
+    // cascade reaches upkeep with `id` holding 10 cards (use the same
+    // setup utilities as crates/scenarios/tests/mythos_phase.rs).
+    let id = InvestigatorId(1);
+    let (mut state, end_turn_action) = setup_at_upkeep_with_hand(id, 10);
+
+    // Act 1: the EndTurn that ends the round cascades to upkeep and parks
+    // at the hand-size prompt.
+    let result = apply(state, end_turn_action);
+    assert!(
+        matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),
+        "upkeep 4.5 with 10 cards must prompt; got {:?}",
+        result.outcome,
+    );
+    state = result.state;
+    assert_eq!(state.investigators[&id].hand.len(), 10);
+
+    // Act 2: submit a 2-card discard.
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::DiscardCards { indices: vec![0, 1] },
+        }),
+    );
+
+    // Assert: hand at the cap, discard grew by 2, round proceeded.
+    state = result.state;
+    assert_eq!(state.investigators[&id].hand.len(), 8);
+    assert_eq!(state.investigators[&id].discard.len(), 2);
+}
+```
+
+If `mythos_phase.rs` lacks a reusable "advance to upkeep with a given hand" helper, write a small local `setup_at_upkeep_with_hand` in this test file following its construction pattern (build the scenario, run `StartScenario`, mulligan, then drive actions/`EndTurn` to the last turn of the round; pad the investigator's hand to the requested size before the final `EndTurn`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p scenarios --test upkeep_hand_size`
+Expected: FAIL initially while wiring the setup helper; iterate until it compiles and then fails only on the assertions, then passes once the flow is correct.
+
+- [ ] **Step 3: Make it pass**
+
+Adjust the setup helper until the flow drives correctly. No production code changes should be needed — Tasks 1–6 implement the behavior.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p scenarios --test upkeep_hand_size`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/scenarios/tests/upkeep_hand_size.rs
+git commit -m "test: integration acceptance for upkeep hand-size discard (#111)"
+```
+
+---
+
+## Task 8: Full CI gauntlet and PR
+
+- [ ] **Step 1: Run the full strict CI gauntlet locally**
+
+```bash
+RUSTFLAGS="-D warnings"     cargo test --all --all-features
+                            cargo clippy --all-targets --all-features -- -D warnings
+                            cargo fmt --check
+RUSTDOCFLAGS="-D warnings"  cargo doc --workspace --no-deps --all-features
+                            cargo build -p web --target wasm32-unknown-unknown
+```
+Expected: all five green. Fix any failures (fmt, intra-doc links the `doc` job catches, clippy).
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+git push -u origin engine/max-hand-size
+gh pr create --fill
+```
+PR body: brief design-decisions paragraph (const cap not a field; new `DiscardCards` variant; P2 — `EngineOutcome` threaded through the window-continuation cascade so step 4.5 surfaces `AwaitingInput`). End with `Closes #111.` and the Claude Code attribution footer.
+
+- [ ] **Step 3: Watch CI**
+
+```bash
+gh pr checks <PR#> --watch
+```
+Fix failures with follow-up commits to the same branch.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** const cap (T3), `DiscardCards` variant (T1), `hand_size_discard_pending` + cursor (T2), P2 plumbing (T4), step-4.5 suspend (T5), resume + routing + guard + exact-count validation (T6), acceptance test (T7). No-op-when-≤8 path covered (T5). Player-order sequencing covered (T6). All spec sections map to a task.
+- **Out of scope honored:** no `Investigator.max_hand_size` field, no constant-modifier wiring.
+- **Type consistency:** `HandSizeDiscard { remaining: Vec<InvestigatorId> }`, `HAND_SIZE_LIMIT: u8`, `over_cap_investigators`, `check_hand_size -> EngineOutcome`, `resume_hand_size_discard` used consistently across T2–T7. `InputResponse::DiscardCards { indices: Vec<u32> }` consistent. `Event::CardDiscarded { investigator, code, from: Zone::Hand }` matches `event.rs`.

--- a/docs/superpowers/specs/2026-06-06-111-max-hand-size-design.md
+++ b/docs/superpowers/specs/2026-06-06-111-max-hand-size-design.md
@@ -1,0 +1,175 @@
+# #111 — Enforce maximum hand size at upkeep (step 4.5)
+
+**Issue:** [#111](https://github.com/talelburg/eldritch/issues/111) (`engine`, `p1-next`)
+**Date:** 2026-06-06
+
+## Goal
+
+Enforce the standard maximum hand size: at upkeep step 4.5, each
+investigator with more than 8 cards in hand discards down to 8. The
+engine does not model this today, so hands grow unbounded.
+
+## Verified rule
+
+Rules Reference, step 4.5 (verified against
+`data/rules-reference/ahc01_rules_reference_web.pdf`):
+
+> In player order, each investigator with more than 8 cards in hand
+> chooses and discards cards from his or her hand until he or she has 8
+> cards remaining in hand.
+
+Load-bearing facts:
+
+- Cap is **8**.
+- Fires at **upkeep 4.5** — after the 4.4 draw (which can push a hand
+  over the cap), before 4.6 (round end / transition to Mythos).
+- The investigator **chooses** which cards (hence an interactive
+  prompt — `AwaitingInput`).
+- Processed **in player order**.
+
+## Scope decisions
+
+These were settled during brainstorming and deliberately narrow the
+issue's stated scope under YAGNI:
+
+- **`const HAND_SIZE_LIMIT: u8 = 8`** — no per-investigator
+  `max_hand_size` field, no constant-modifier-query wiring. No card in
+  the Core/Dunwich scope modifies hand size, so the field and query
+  integration the issue asks for would be unexercised. A future
+  hand-size-modifying card introduces the field when it is actually
+  needed.
+- **New `InputResponse::DiscardCards { indices: Vec<u32> }`** — a
+  single multi-pick response discards exactly the overflow in one
+  round-trip (matches the issue's acceptance: "accepts a 2-card
+  discard"). `u32` indices for wire-format symmetry with
+  `CommitCards` / `PickIndex`; downcast at validation. A dedicated
+  variant rather than reusing `CommitCards` because "commit" is the
+  wrong verb for a discard and conflating them risks routing
+  confusion.
+
+## State
+
+One new suspension field on `GameState`, mirroring the existing
+`hunter_move_pending` / `spawn_engage_pending` / `mythos_draw_pending`
+suspension fields:
+
+```rust
+hand_size_discard_pending: Option<HandSizeDiscard>
+```
+
+```rust
+struct HandSizeDiscard {
+    /// Over-cap investigators in player order, front = currently
+    /// prompted. Precomputed once at step 4.5.
+    remaining: Vec<InvestigatorId>,
+}
+```
+
+The queue is precomputed once when step 4.5 fires: discarding only ever
+shrinks the discarding investigator's own hand, so no other
+investigator's over-cap status can change mid-resolution and no
+recomputation is needed.
+
+## Control flow
+
+`check_hand_size(cx)` — today a stub at `phases.rs:489` carrying
+`TODO(#111)`, called from `upkeep_resume` between 4.4
+(`upkeep_draw_and_resource`) and 4.6 (`upkeep_phase_end`) — becomes:
+
+1. Scan active investigators in turn order
+   (`active_investigators_in_turn_order`) for `hand.len() > 8`.
+2. **No over-cap investigators:** fall through to `upkeep_phase_end`
+   exactly as today. Fully synchronous — no behavior change for the
+   common case.
+3. **Some over-cap investigators:** set `hand_size_discard_pending`
+   with the player-order queue and surface `AwaitingInput` with a
+   discard prompt for `remaining[0]`. Do **not** run
+   `upkeep_phase_end` yet — that runs when the queue drains.
+
+### Suspension plumbing (approach P2)
+
+The discard runs inside the `upkeep_resume` window continuation, which
+is currently `-> ()`, and no window continuation suspends today. To
+surface the pause as `AwaitingInput` (consistent with every other
+`ResolveInput` suspension — hunter / spawn / skill-test commit all
+return `AwaitingInput`):
+
+- Change `run_window_continuation` and `open_fast_window` to return
+  `EngineOutcome`.
+- The upkeep path (`upkeep_phase` → `open_fast_window(UpkeepBegins)`
+  auto-skip inline, and `close_reaction_window_at` → continuation when
+  the window was held open for a Fast play) propagates the
+  `AwaitingInput` out to the apply boundary.
+- The other `open_fast_window` / `run_window_continuation` callers
+  (Mythos `MythosAfterDraws`, Enemy `BeforeInvestigatorAttacked` /
+  `AfterAllInvestigatorsAttacked`, Investigation `InvestigationBegins`)
+  do not have a suspending continuation; they `debug_assert_eq!` the
+  returned outcome is `Done`, matching the existing
+  `upkeep_phase_end → step_phase` assertion style.
+
+Keeping the prompt where it is created (rather than converting
+`Done → AwaitingInput` at the apply boundary) is why P2 is preferred
+over the lower-plumbing "Done + pending flag" alternative used by the
+round-end Mythos pause: a boundary conversion would have to synthesize
+the `InputRequest` prompt far from the logic that knows what is being
+asked.
+
+## Input routing and resume
+
+- **`resolve_input`** (`mod.rs:299`) gains a new early branch, routed
+  before the reaction-window / skill-test checks like the other
+  distinct suspension modes:
+  ```rust
+  if cx.state.hand_size_discard_pending.is_some() {
+      return resume_hand_size_discard(cx, response);
+  }
+  ```
+  plus a `debug_assert!` that it is mutually exclusive with the other
+  `*_pending` modes (they arise in different phases).
+- **Apply-top guard** (`mod.rs:64–117`) gains a matching arm so any
+  non-`ResolveInput` action is rejected while a discard is pending,
+  mirroring the hunter / skill-test guards.
+- **`resume_hand_size_discard(cx, response)`**:
+  1. Validate the response is `DiscardCards { indices }` against
+     `remaining[0]`'s hand. Reject (state untouched, no events) unless
+     indices are unique, in-bounds, and the count is **exactly**
+     `hand.len() - HAND_SIZE_LIMIT`. Rejecting an inexact count keeps
+     the rule's "until 8 remaining" invariant structural.
+  2. On success: remove the chosen cards, emitting
+     `CardDiscarded { from: Zone::Hand, .. }` per card (reusing the
+     existing event), and pop the queue front.
+  3. If the queue is now empty → run `upkeep_phase_end` (4.6 +
+     transition to Mythos, which itself seeds `mythos_draw_pending`).
+     Otherwise re-emit `AwaitingInput` for the new `remaining[0]`.
+
+## Events
+
+No new event types. Each discarded card emits the existing
+`CardDiscarded { from: Zone::Hand, .. }`. Window open/close and phase
+boundary events are unchanged.
+
+## Testing
+
+Engine unit tests (`crates/game-core`, `TestGame` builder +
+event-assertion macros):
+
+- Over-cap detection: an investigator with `hand.len() > 8` at 4.5
+  produces `AwaitingInput`; `<= 8` runs the step fully synchronously
+  (no `hand_size_discard_pending`, proceeds to 4.6 unchanged).
+- Validation rejections leave state untouched: too few, too many,
+  duplicate, and out-of-bounds indices.
+- Player-order sequencing: two over-cap investigators are prompted in
+  turn order; each resolved by one `DiscardCards`; only after both
+  drain does 4.6 run.
+
+Integration test (`crates/cards/tests/` or
+`crates/scenarios/tests/`, where a registry can be installed) covering
+the issue's acceptance: end turn with 10 cards in hand and cap 8 fires
+`AwaitingInput`, accepts a 2-card `DiscardCards`, lands at hand size 8,
+and proceeds toward Mythos.
+
+## Out of scope
+
+- Per-investigator `max_hand_size` field and constant-modifier-query
+  integration (deferred until a card modifies the cap).
+- Any non-8 base cap.


### PR DESCRIPTION
## Summary

Enforces the standard maximum hand size at upkeep step 4.5: in player order, each active investigator holding more than 8 cards is prompted to discard down to 8. Previously hands grew unbounded.

Verified rule (Rules Reference 4.5): *"In player order, each investigator with more than 8 cards in hand chooses and discards cards from his or her hand until he or she has 8 cards remaining in hand."*

## What changed

- **`InputResponse::DiscardCards { indices }`** — a multi-pick response; the engine discards exactly the overflow (`hand.len() - 8`), rejecting wrong counts, duplicates, and out-of-bounds indices.
- **`GameState.hand_size_discard_pending`** — a new suspension (player-order queue) + `resume_hand_size_discard` handler, routed in `resolve_input` with an apply-top guard, mirroring the existing `hunter_move_pending` / `spawn_engage_pending` patterns.
- **`check_hand_size`** (the existing upkeep-4.5 stub) now surfaces an `AwaitingInput` discard prompt and parks the queue; nobody-over-cap stays fully synchronous (no behavior change for the common case).

## Design decisions

- **`const HAND_SIZE_LIMIT = 8`, not a per-investigator field.** No card in the Core/Dunwich scope modifies the cap, so the field + constant-modifier wiring the issue suggested would be unexercised. A future hand-size-modifying card introduces the field when it's actually needed (YAGNI).
- **P2 plumbing — `EngineOutcome` threaded through the window-continuation cascade.** The discard runs inside the `upkeep_resume` window continuation, which was synchronous. Rather than a "Done + pending flag" pause (the round-end Mythos pattern), the continuation cascade (`run_window_continuation`, `open_fast_window`, `enemy_attack_kickoff`, `enemy_phase`, `upkeep_phase`, `step_phase` Upkeep arm, `close_reaction_window_at`, `resume_hunter_choice` tail) was widened to return/propagate `EngineOutcome`, so step 4.5 surfaces `AwaitingInput` honestly — consistent with every other `ResolveInput` suspension. Non-suspending continuations assert their outcome stays `Done` (loud-on-future-regression).

## Testing

- Engine unit tests: over-cap detection (strict `> 8`, player order), suspend vs no-op paths, exact-count / duplicate / OOB / wrong-response-kind rejections (each leaves state + events untouched), multi-investigator player-order sequencing, and the `enemy_attack_kickoff` seam.
- Integration (`crates/scenarios/tests/upkeep_hand_size.rs`): full `StartScenario → Mulligan → EndTurn → DiscardCards` cycle through `apply()` with the registry installed — lands at exactly 8 and proceeds to the next round's Mythos. Plus a replay-determinism test.
- Full CI gauntlet (fmt, clippy, strict test, doc, wasm-build) green locally.

Closes #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
