### PR TITLE
engine: collapse marker WindowKind variants into PlayerWindow (#140)

### DIFF
--- a/crates/cards/tests/fast_play.rs
+++ b/crates/cards/tests/fast_play.rs
@@ -35,7 +35,7 @@ use game_core::action::{Action, PlayerAction};
 use game_core::engine::{apply, EngineOutcome};
 use game_core::state::{
     CardCode, CardInPlay, CardInstanceId, FastActorScope, InvestigatorId, LocationId, Phase,
-    WindowKind,
+    PhaseStep, WindowKind,
 };
 use game_core::test_support::{test_investigator, test_location, TestGame};
 
@@ -63,10 +63,7 @@ fn fast_asset_playable_by_owner_during_permissive_window() {
         .with_phase(Phase::Mythos)
         .with_active_investigator(InvestigatorId(1))
         .with_open_window(
-            WindowKind::BetweenPhases {
-                from: Phase::Mythos,
-                to: Phase::Investigation,
-            },
+            WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins),
             FastActorScope::Any,
         )
         .build();
@@ -105,10 +102,7 @@ fn fast_asset_rejected_by_non_owner_even_with_permissive_window() {
         .with_phase(Phase::Investigation)
         .with_active_investigator(InvestigatorId(1))
         .with_open_window(
-            WindowKind::BetweenPhases {
-                from: Phase::Mythos,
-                to: Phase::Investigation,
-            },
+            WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins),
             FastActorScope::Any,
         )
         .build();
@@ -148,10 +142,7 @@ fn non_fast_asset_still_rejected_when_not_active_investigator() {
         .with_phase(Phase::Investigation)
         .with_active_investigator(InvestigatorId(1))
         .with_open_window(
-            WindowKind::BetweenPhases {
-                from: Phase::Mythos,
-                to: Phase::Investigation,
-            },
+            WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins),
             FastActorScope::Any,
         )
         .build();
@@ -221,10 +212,7 @@ fn fast_activated_ability_usable_by_non_active_investigator_when_window_permits(
         .with_phase(Phase::Investigation)
         .with_active_investigator(InvestigatorId(1))
         .with_open_window(
-            WindowKind::BetweenPhases {
-                from: Phase::Mythos,
-                to: Phase::Investigation,
-            },
+            WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins),
             FastActorScope::Any,
         )
         .build();
@@ -306,10 +294,7 @@ fn fast_event_playable_by_active_investigator_outside_investigation_in_permissiv
         .with_phase(Phase::Mythos)
         .with_active_investigator(InvestigatorId(1))
         .with_open_window(
-            WindowKind::BetweenPhases {
-                from: Phase::Mythos,
-                to: Phase::Investigation,
-            },
+            WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins),
             FastActorScope::Any,
         )
         .build();
@@ -372,10 +357,7 @@ fn fast_event_playable_by_non_owner_when_window_permits() {
         .with_phase(Phase::Investigation)
         .with_active_investigator(InvestigatorId(1))
         .with_open_window(
-            WindowKind::BetweenPhases {
-                from: Phase::Mythos,
-                to: Phase::Investigation,
-            },
+            WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins),
             FastActorScope::Any,
         )
         .build();

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -5,7 +5,7 @@ use crate::card_registry;
 use crate::dsl::Trigger;
 use crate::event::Event;
 use crate::state::{
-    CardCode, Enemy, EnemyId, InvestigatorId, Phase, SpawnEngagePending, WindowKind,
+    CardCode, Enemy, EnemyId, InvestigatorId, Phase, PhaseStep, SpawnEngagePending, WindowKind,
 };
 
 use super::super::evaluator::{apply_effect, EvalContext};
@@ -602,7 +602,10 @@ pub(super) fn advance_mythos_draw_pending(cx: &mut Cx) {
     let next = super::cursor::next_active_investigator_after(cx.state, current);
     cx.state.mythos_draw_pending = next;
     if next.is_none() {
-        let outcome = super::reaction_windows::open_fast_window(cx, WindowKind::MythosAfterDraws);
+        let outcome = super::reaction_windows::open_fast_window(
+            cx,
+            WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws),
+        );
         debug_assert_eq!(
             outcome,
             EngineOutcome::Done,

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -5,7 +5,8 @@ use crate::action::InputResponse;
 use crate::engine::outcome::{EngineOutcome, InputRequest, ResumeToken};
 use crate::event::Event;
 use crate::state::{
-    CardCode, EnemyId, GameState, HandSizeDiscard, InvestigatorId, Phase, WindowKind, Zone,
+    CardCode, EnemyId, GameState, HandSizeDiscard, InvestigatorId, Phase, PhaseStep, WindowKind,
+    Zone,
 };
 
 use super::Cx;
@@ -120,7 +121,7 @@ pub(super) fn end_turn(cx: &mut Cx) -> EngineOutcome {
 /// Owns the `PhaseStarted(Investigation)` emit (Rules Reference p.24
 /// step 2.1) and opens the post-2.1 player window. Rotation to the
 /// first active investigator (step 2.2) runs in the
-/// [`WindowKind::InvestigationBegins`] continuation via
+/// [`PhaseStep::InvestigationBegins`] continuation via
 /// [`begin_investigator_turn`], lead-first by default; explicit
 /// player-pick within this window is deferred to #146.
 ///
@@ -140,7 +141,10 @@ pub(super) fn investigation_phase(cx: &mut Cx) {
     // order 2.1 → window → 2.2 holds. Auto-skips inline when nothing is
     // Fast-eligible, so single-investigator entry still lands the lead
     // active within the same apply() call.
-    let outcome = super::reaction_windows::open_fast_window(cx, WindowKind::InvestigationBegins);
+    let outcome = super::reaction_windows::open_fast_window(
+        cx,
+        WindowKind::PlayerWindow(PhaseStep::InvestigationBegins),
+    );
     debug_assert_eq!(
         outcome,
         EngineOutcome::Done,
@@ -160,7 +164,10 @@ pub(super) fn investigation_phase(cx: &mut Cx) {
 /// resolve it via `first_active_investigator` / `next_active_investigator_after`.
 pub(super) fn begin_investigator_turn(cx: &mut Cx, who: InvestigatorId) {
     rotate_to_active(cx, who);
-    let outcome = super::reaction_windows::open_fast_window(cx, WindowKind::InvestigatorTurnBegins);
+    let outcome = super::reaction_windows::open_fast_window(
+        cx,
+        WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins),
+    );
     debug_assert_eq!(
         outcome,
         EngineOutcome::Done,
@@ -220,7 +227,10 @@ fn mythos_phase(cx: &mut Cx) {
         // because nothing is eligible, runs the MythosAfterDraws
         // continuation (mythos_phase_end), which transitions to
         // Investigation. All in this same apply.
-        let outcome = super::reaction_windows::open_fast_window(cx, WindowKind::MythosAfterDraws);
+        let outcome = super::reaction_windows::open_fast_window(
+            cx,
+            WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws),
+        );
         debug_assert_eq!(
             outcome,
             EngineOutcome::Done,
@@ -323,12 +333,18 @@ pub(super) fn enemy_attack_kickoff(cx: &mut Cx) -> EngineOutcome {
     cx.state.enemy_attack_pending = super::cursor::first_active_investigator(cx.state);
 
     if cx.state.enemy_attack_pending.is_some() {
-        super::reaction_windows::open_fast_window(cx, WindowKind::BeforeInvestigatorAttacked)
+        super::reaction_windows::open_fast_window(
+            cx,
+            WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked),
+        )
     } else {
         // No Active investigators (turn_order empty or all eliminated).
         // Skip straight to the final window — mirror of mythos_phase's
         // no-drawer path.
-        super::reaction_windows::open_fast_window(cx, WindowKind::AfterAllInvestigatorsAttacked)
+        super::reaction_windows::open_fast_window(
+            cx,
+            WindowKind::PlayerWindow(PhaseStep::AfterAllInvestigatorsAttacked),
+        )
     }
 }
 
@@ -367,7 +383,7 @@ fn enemy_phase(cx: &mut Cx) -> EngineOutcome {
 }
 
 /// Called from [`run_window_continuation`]'s
-/// [`WindowKind::AfterAllInvestigatorsAttacked`] arm. Emits step
+/// [`PhaseStep::AfterAllInvestigatorsAttacked`] arm. Emits step
 /// 3.4's `PhaseEnded(Enemy)` marker, then transitions to Upkeep.
 /// Exact analog of [`mythos_phase_end`] / [`upkeep_phase_end`].
 pub(super) fn enemy_phase_end(cx: &mut Cx) -> EngineOutcome {
@@ -422,7 +438,7 @@ fn upkeep_phase(cx: &mut Cx) -> EngineOutcome {
     });
     // PLAYER WINDOW (post-4.1). Auto-skips inline (running upkeep_resume
     // via run_window_continuation) when nothing is Fast-eligible.
-    super::reaction_windows::open_fast_window(cx, WindowKind::UpkeepBegins)
+    super::reaction_windows::open_fast_window(cx, WindowKind::PlayerWindow(PhaseStep::UpkeepBegins))
 }
 
 /// The post-4.1 window continuation. Steps 4.2–4.4 run inline as named
@@ -759,7 +775,7 @@ mod investigation_phase_tests {
             matches!(
                 e,
                 Event::WindowOpened {
-                    kind: WindowKind::InvestigationBegins
+                    kind: WindowKind::PlayerWindow(PhaseStep::InvestigationBegins)
                 }
             )
         });
@@ -817,7 +833,7 @@ mod investigation_phase_tests {
             events.iter().any(|e| matches!(
                 e,
                 Event::WindowOpened {
-                    kind: WindowKind::InvestigationBegins
+                    kind: WindowKind::PlayerWindow(PhaseStep::InvestigationBegins)
                 }
             )),
             "investigation_phase opens the post-2.1 InvestigationBegins window"
@@ -1041,13 +1057,13 @@ mod investigation_phase_tests {
         assert!(events.iter().any(|e| matches!(
             e,
             Event::WindowOpened {
-                kind: WindowKind::InvestigationBegins
+                kind: WindowKind::PlayerWindow(PhaseStep::InvestigationBegins)
             }
         )));
         assert!(events.iter().any(|e| matches!(
             e,
             Event::WindowOpened {
-                kind: WindowKind::InvestigatorTurnBegins
+                kind: WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins)
             }
         )));
         assert!(!events.iter().any(|e| matches!(
@@ -1114,7 +1130,7 @@ mod mythos_phase_tests {
             events.iter().any(|e| matches!(
                 e,
                 Event::WindowOpened {
-                    kind: WindowKind::MythosAfterDraws
+                    kind: WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws)
                 }
             )),
             "must emit WindowOpened(MythosAfterDraws); events = {events:?}"
@@ -1123,7 +1139,7 @@ mod mythos_phase_tests {
             events.iter().any(|e| matches!(
                 e,
                 Event::WindowClosed {
-                    kind: WindowKind::MythosAfterDraws
+                    kind: WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws)
                 }
             )),
             "must emit WindowClosed(MythosAfterDraws); events = {events:?}"
@@ -1456,7 +1472,7 @@ mod upkeep_phase_tests {
             matches!(
                 e,
                 Event::WindowOpened {
-                    kind: WindowKind::UpkeepBegins
+                    kind: WindowKind::PlayerWindow(PhaseStep::UpkeepBegins)
                 }
             )
         })
@@ -1465,7 +1481,7 @@ mod upkeep_phase_tests {
             matches!(
                 e,
                 Event::WindowClosed {
-                    kind: WindowKind::UpkeepBegins
+                    kind: WindowKind::PlayerWindow(PhaseStep::UpkeepBegins)
                 }
             )
         })
@@ -1920,7 +1936,7 @@ mod enemy_phase_tests {
             Some(LocationId(2))
         );
         assert_event!(events, Event::EnemyEngaged { enemy, .. } if *enemy == EnemyId(1));
-        assert_event!(events, Event::WindowOpened { kind } if *kind == WindowKind::BeforeInvestigatorAttacked);
+        assert_event!(events, Event::WindowOpened { kind } if *kind == WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked));
     }
 
     #[test]
@@ -1965,7 +1981,7 @@ mod enemy_phase_tests {
             &InputResponse::PickLocation(LocationId(2)),
         );
         assert_eq!(resumed, EngineOutcome::Done);
-        assert_event!(ev2, Event::WindowOpened { kind } if *kind == WindowKind::BeforeInvestigatorAttacked);
+        assert_event!(ev2, Event::WindowOpened { kind } if *kind == WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked));
         // With no registry the attack window auto-skips and the cascade runs
         // Enemy->Upkeep->Mythos within the same resume call (same as the no-tie test).
         assert_eq!(state.phase, Phase::Mythos);
@@ -2253,7 +2269,7 @@ mod enemy_phase_tests {
             matches!(
                 e,
                 Event::WindowOpened {
-                    kind: WindowKind::BeforeInvestigatorAttacked
+                    kind: WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked)
                 }
             )
         })
@@ -2262,7 +2278,7 @@ mod enemy_phase_tests {
             matches!(
                 e,
                 Event::WindowClosed {
-                    kind: WindowKind::BeforeInvestigatorAttacked
+                    kind: WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked)
                 }
             )
         })
@@ -2271,7 +2287,7 @@ mod enemy_phase_tests {
             matches!(
                 e,
                 Event::WindowOpened {
-                    kind: WindowKind::AfterAllInvestigatorsAttacked
+                    kind: WindowKind::PlayerWindow(PhaseStep::AfterAllInvestigatorsAttacked)
                 }
             )
         })
@@ -2280,7 +2296,7 @@ mod enemy_phase_tests {
             matches!(
                 e,
                 Event::WindowClosed {
-                    kind: WindowKind::AfterAllInvestigatorsAttacked
+                    kind: WindowKind::PlayerWindow(PhaseStep::AfterAllInvestigatorsAttacked)
                 }
             )
         })
@@ -2343,7 +2359,7 @@ mod enemy_phase_tests {
                 matches!(
                     e,
                     Event::WindowOpened {
-                        kind: WindowKind::BeforeInvestigatorAttacked
+                        kind: WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked)
                     }
                 )
                 .then_some(i)
@@ -2356,7 +2372,7 @@ mod enemy_phase_tests {
                 matches!(
                     e,
                     Event::WindowOpened {
-                        kind: WindowKind::AfterAllInvestigatorsAttacked
+                        kind: WindowKind::PlayerWindow(PhaseStep::AfterAllInvestigatorsAttacked)
                     }
                 )
                 .then_some(i)
@@ -2395,7 +2411,7 @@ mod enemy_phase_tests {
                 matches!(
                     e,
                     Event::WindowOpened {
-                        kind: WindowKind::BeforeInvestigatorAttacked
+                        kind: WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked)
                     }
                 )
             })
@@ -2425,7 +2441,7 @@ mod enemy_phase_tests {
             events.iter().all(|e| !matches!(
                 e,
                 Event::WindowOpened {
-                    kind: WindowKind::BeforeInvestigatorAttacked
+                    kind: WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked)
                 }
             )),
             "no per-investigator window when all are eliminated; events = {events:?}"
@@ -2433,7 +2449,7 @@ mod enemy_phase_tests {
         assert!(events.iter().any(|e| matches!(
             e,
             Event::WindowOpened {
-                kind: WindowKind::AfterAllInvestigatorsAttacked
+                kind: WindowKind::PlayerWindow(PhaseStep::AfterAllInvestigatorsAttacked)
             }
         )));
         // With all investigators eliminated, the cascade keeps going:
@@ -2563,7 +2579,7 @@ mod enemy_phase_tests {
         state.active_investigator = None;
         state.enemy_attack_pending = Some(inv_id);
         state.open_windows.push(OpenWindow {
-            kind: WindowKind::BeforeInvestigatorAttacked,
+            kind: WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked),
             pending_triggers: Vec::new(),
             fast_actors: FastActorScope::Any,
         });

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -427,8 +427,8 @@ fn bump_usage_counter(state: &mut GameState, trigger: &PendingTrigger) {
 /// `top_reaction_window_mut` skips empty-`pending_triggers` windows
 /// when finding the active reaction window. The close path must
 /// remove the same window the driver operated on, not the absolute
-/// top of the stack — once `BetweenPhases` (or any other
-/// non-reaction) window can sit above an active reaction window
+/// top of the stack — once a `PlayerWindow` gate (or any other
+/// non-reaction window) can sit above an active reaction window
 /// (#69/#70/#71), a naive `open_windows.pop()` would remove the wrong
 /// entry. Callers compute the index via
 /// [`GameState::top_reaction_window_index`].
@@ -460,9 +460,10 @@ pub(super) fn close_reaction_window_at(cx: &mut Cx, idx: usize) -> EngineOutcome
     cx.events.push(Event::WindowClosed { kind });
 
     // Run any kind-specific continuation (e.g. MythosAfterDraws →
-    // mythos_phase_end). For reaction windows that have no continuation
-    // (AfterEnemyDefeated, BetweenPhases) this has no side effects and
-    // returns Done. The continuation may suspend (upkeep step 4.5
+    // mythos_phase_end). For windows that have no continuation
+    // (AfterEnemyDefeated, or PlayerWindow steps like
+    // InvestigatorTurnBegins) this has no side effects and returns
+    // Done. The continuation may suspend (upkeep step 4.5
     // hand-size discard, #111), so propagate AwaitingInput rather than
     // dropping it.
     let continuation = run_window_continuation(cx, kind);

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -18,7 +18,7 @@ use crate::dsl::{EventPattern, EventTiming, Trigger};
 use crate::event::Event;
 use crate::state::{
     CardCode, CardInstanceId, FastActorScope, FinishContinuation, GameState, InvestigatorId,
-    OpenWindow, PendingTrigger, Phase, Status, WindowKind,
+    OpenWindow, PendingTrigger, Phase, PhaseStep, Status, WindowKind,
 };
 
 use super::super::evaluator::{apply_effect, EvalContext};
@@ -159,28 +159,18 @@ fn trigger_matches(
                 true
             }
         }
-        // BetweenPhases, MythosAfterDraws, UpkeepBegins,
-        // BeforeInvestigatorAttacked, AfterAllInvestigatorsAttacked,
-        // InvestigationBegins, and InvestigatorTurnBegins windows open
-        // for timing reasons; no Trigger::OnEvent pattern
-        // matches them — those windows gate Fast actions, not
-        // after-event reactions. AfterEnemyDefeated windows only match
-        // EnemyDefeated patterns (handled above); encounter-reveal
-        // patterns return false.
+        // PlayerWindow steps open for timing reasons; no
+        // Trigger::OnEvent pattern matches them — those windows gate
+        // Fast actions, not after-event reactions. AfterEnemyDefeated
+        // windows only match EnemyDefeated patterns (handled above);
+        // encounter-reveal patterns return false.
         //
         // EnemySpawned: no WindowKind opens specifically for "enemy
         // spawned" in Phase 4. A future PR (likely Phase-7+) that wants
         // to react to spawns will add the corresponding WindowKind
         // variant and update this arm.
         (
-            WindowKind::BetweenPhases { .. }
-            | WindowKind::AfterEnemyDefeated { .. }
-            | WindowKind::MythosAfterDraws
-            | WindowKind::UpkeepBegins
-            | WindowKind::BeforeInvestigatorAttacked
-            | WindowKind::AfterAllInvestigatorsAttacked
-            | WindowKind::InvestigationBegins
-            | WindowKind::InvestigatorTurnBegins,
+            WindowKind::PlayerWindow(_) | WindowKind::AfterEnemyDefeated { .. },
             EventPattern::EnemyDefeated { .. }
             | EventPattern::CardRevealed { .. }
             | EventPattern::EnemySpawned,
@@ -503,22 +493,22 @@ pub(super) fn close_reaction_window_at(cx: &mut Cx, idx: usize) -> EngineOutcome
 /// Kind-aware continuation called when a window closes (whether
 /// inline via [`open_fast_window`]'s auto-skip path or via the
 /// [`close_reaction_window_at`] pop path). For
-/// [`WindowKind::MythosAfterDraws`], runs
+/// [`PhaseStep::MythosAfterDraws`], runs
 /// [`mythos_phase_end`](super::phases::mythos_phase_end); for
-/// [`WindowKind::UpkeepBegins`], runs [`upkeep_resume`](super::phases::upkeep_resume). For
-/// [`WindowKind::BeforeInvestigatorAttacked`], resolves the cursor
+/// [`PhaseStep::UpkeepBegins`], runs [`upkeep_resume`](super::phases::upkeep_resume). For
+/// [`PhaseStep::BeforeInvestigatorAttacked`], resolves the cursor
 /// investigator's engaged-enemy attacks via
 /// [`resolve_attacks_for_investigator`](super::combat::resolve_attacks_for_investigator), advances
 /// [`GameState::enemy_attack_pending`] to the next Active investigator
 /// via [`cursor::next_active_investigator_after`](super::cursor::next_active_investigator_after),
 /// and opens the next window
-/// ([`WindowKind::BeforeInvestigatorAttacked`] again if the cursor
-/// advanced to `Some`, otherwise [`WindowKind::AfterAllInvestigatorsAttacked`]).
-/// For [`WindowKind::AfterAllInvestigatorsAttacked`], runs
-/// [`enemy_phase_end`](super::phases::enemy_phase_end). For [`WindowKind::InvestigationBegins`], starts
+/// ([`PhaseStep::BeforeInvestigatorAttacked`] again if the cursor
+/// advanced to `Some`, otherwise [`PhaseStep::AfterAllInvestigatorsAttacked`]).
+/// For [`PhaseStep::AfterAllInvestigatorsAttacked`], runs
+/// [`enemy_phase_end`](super::phases::enemy_phase_end). For [`PhaseStep::InvestigationBegins`], starts
 /// the first turn via [`begin_investigator_turn`](super::phases::begin_investigator_turn) for the first Active
-/// investigator (or parks if none). `AfterEnemyDefeated`, `BetweenPhases`,
-/// and [`WindowKind::InvestigatorTurnBegins`] windows have no
+/// investigator (or parks if none). [`WindowKind::AfterEnemyDefeated`] and
+/// [`PhaseStep::InvestigatorTurnBegins`] windows have no
 /// continuation — for them this returns [`EngineOutcome::Done`],
 /// preserving the existing [`close_reaction_window_at`] behavior.
 ///
@@ -528,138 +518,145 @@ pub(super) fn close_reaction_window_at(cx: &mut Cx, idx: usize) -> EngineOutcome
 /// [`EngineOutcome::AwaitingInput`] producer (#111).
 pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) -> EngineOutcome {
     match kind {
-        WindowKind::MythosAfterDraws => {
-            // Phase-transitioning continuation: cannot run while a skill
-            // test is in flight (would strand the test in the wrong
-            // phase). Phase 4 has no Mythos-phase skill-test sources, so
-            // this branch is structurally unreachable today. A future PR
-            // adding a Mythos-phase Revelation that initiates a skill
-            // test must redesign the close-window + phase-transition
-            // ordering before this assertion fires.
-            if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
-                unreachable!(
-                    "MythosAfterDraws window closed while a skill test is in flight \
+        WindowKind::PlayerWindow(step) => match step {
+            PhaseStep::MythosAfterDraws => {
+                // Phase-transitioning continuation: cannot run while a skill
+                // test is in flight (would strand the test in the wrong
+                // phase). Phase 4 has no Mythos-phase skill-test sources, so
+                // this branch is structurally unreachable today. A future PR
+                // adding a Mythos-phase Revelation that initiates a skill
+                // test must redesign the close-window + phase-transition
+                // ordering before this assertion fires.
+                if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
+                    unreachable!(
+                        "MythosAfterDraws window closed while a skill test is in flight \
                      (continuation={:?}). Phase transition would strand the skill test \
                      in the wrong phase. Phase 4 has no Mythos-phase skill test sources; \
                      if a future PR adds one (e.g. a treachery whose Revelation initiates \
                      a skill test), the window-close + phase-transition ordering needs \
                      redesign before this assertion can be relaxed.",
-                    in_flight.continuation,
-                );
+                        in_flight.continuation,
+                    );
+                }
+                super::phases::mythos_phase_end(cx);
+                EngineOutcome::Done
             }
-            super::phases::mythos_phase_end(cx);
-            EngineOutcome::Done
-        }
-        WindowKind::UpkeepBegins => {
-            // Phase-transitioning continuation (4.2–4.6 then Upkeep→Mythos):
-            // cannot run while a skill test is in flight. Phase 4 has no
-            // Upkeep-phase skill-test source, so structurally unreachable.
-            if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
-                unreachable!(
-                    "UpkeepBegins window closed while a skill test is in flight \
+            PhaseStep::UpkeepBegins => {
+                // Phase-transitioning continuation (4.2–4.6 then Upkeep→Mythos):
+                // cannot run while a skill test is in flight. Phase 4 has no
+                // Upkeep-phase skill-test source, so structurally unreachable.
+                if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
+                    unreachable!(
+                        "UpkeepBegins window closed while a skill test is in flight \
                      (continuation={:?}). Phase 4 has no Upkeep-phase skill-test \
                      sources; a future PR adding one needs the window-close + \
                      phase-transition ordering redesigned before this fires.",
-                    in_flight.continuation,
-                );
+                        in_flight.continuation,
+                    );
+                }
+                super::phases::upkeep_resume(cx)
             }
-            super::phases::upkeep_resume(cx)
-        }
-        WindowKind::BeforeInvestigatorAttacked => {
-            // Phase-transitioning continuation (advances to the next
-            // window and ultimately to Upkeep) — cannot run while a
-            // skill test is in flight (would strand it). Phase 4 has
-            // no Enemy-phase skill-test source, so this branch is
-            // structurally unreachable today. A future PR adding one
-            // (e.g. a treachery-style "make an Agility test or take
-            // damage" attack ability) must redesign the window-close
-            // + phase-transition ordering before this assertion fires.
-            if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
-                unreachable!(
-                    "BeforeInvestigatorAttacked window closed while a \
+            PhaseStep::BeforeInvestigatorAttacked => {
+                // Phase-transitioning continuation (advances to the next
+                // window and ultimately to Upkeep) — cannot run while a
+                // skill test is in flight (would strand it). Phase 4 has
+                // no Enemy-phase skill-test source, so this branch is
+                // structurally unreachable today. A future PR adding one
+                // (e.g. a treachery-style "make an Agility test or take
+                // damage" attack ability) must redesign the window-close
+                // + phase-transition ordering before this assertion fires.
+                if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
+                    unreachable!(
+                        "BeforeInvestigatorAttacked window closed while a \
                      skill test is in flight (continuation={:?}). Phase \
                      transition would strand the skill test in the \
                      wrong phase. Phase 4 has no Enemy-phase skill test \
                      sources; if a future PR adds one, the window-close \
                      + phase-transition ordering needs redesign before \
                      this assertion can be relaxed.",
-                    in_flight.continuation,
-                );
-            }
+                        in_flight.continuation,
+                    );
+                }
 
-            // Cursor expect-Some: BeforeInvestigatorAttacked is only
-            // ever opened after enemy_attack_pending is set to Some(_)
-            // in enemy_phase or in the advance below. A None cursor
-            // here is a state-corruption invariant violation, not a
-            // normal rejection path.
-            let investigator = cx.state.enemy_attack_pending.unwrap_or_else(|| {
-                unreachable!(
-                    "BeforeInvestigatorAttacked closed with \
+                // Cursor expect-Some: BeforeInvestigatorAttacked is only
+                // ever opened after enemy_attack_pending is set to Some(_)
+                // in enemy_phase or in the advance below. A None cursor
+                // here is a state-corruption invariant violation, not a
+                // normal rejection path.
+                let investigator = cx.state.enemy_attack_pending.unwrap_or_else(|| {
+                    unreachable!(
+                        "BeforeInvestigatorAttacked closed with \
                      enemy_attack_pending == None; this is a \
                      state-corruption invariant violation"
-                )
-            });
+                    )
+                });
 
-            super::combat::resolve_attacks_for_investigator(cx, investigator);
+                super::combat::resolve_attacks_for_investigator(cx, investigator);
 
-            // Advance the cursor: next Active investigator AFTER
-            // `investigator` in turn_order. The shared helper uses
-            // turn_order (not the filtered-Active list) as the index
-            // basis, so `investigator` itself can have been defeated
-            // mid-loop and we still find the right successor.
-            cx.state.enemy_attack_pending =
-                super::cursor::next_active_investigator_after(cx.state, investigator);
+                // Advance the cursor: next Active investigator AFTER
+                // `investigator` in turn_order. The shared helper uses
+                // turn_order (not the filtered-Active list) as the index
+                // basis, so `investigator` itself can have been defeated
+                // mid-loop and we still find the right successor.
+                cx.state.enemy_attack_pending =
+                    super::cursor::next_active_investigator_after(cx.state, investigator);
 
-            if cx.state.enemy_attack_pending.is_some() {
-                open_fast_window(cx, WindowKind::BeforeInvestigatorAttacked)
-            } else {
-                open_fast_window(cx, WindowKind::AfterAllInvestigatorsAttacked)
+                if cx.state.enemy_attack_pending.is_some() {
+                    open_fast_window(
+                        cx,
+                        WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked),
+                    )
+                } else {
+                    open_fast_window(
+                        cx,
+                        WindowKind::PlayerWindow(PhaseStep::AfterAllInvestigatorsAttacked),
+                    )
+                }
             }
-        }
-        WindowKind::AfterAllInvestigatorsAttacked => {
-            if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
-                unreachable!(
-                    "AfterAllInvestigatorsAttacked window closed while a \
+            PhaseStep::AfterAllInvestigatorsAttacked => {
+                if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
+                    unreachable!(
+                        "AfterAllInvestigatorsAttacked window closed while a \
                      skill test is in flight (continuation={:?}). Phase \
                      4 has no Enemy-phase skill-test sources; a future \
                      PR adding one needs the window-close + \
                      phase-transition ordering redesigned before this \
                      fires.",
-                    in_flight.continuation,
-                );
+                        in_flight.continuation,
+                    );
+                }
+                super::phases::enemy_phase_end(cx)
             }
-            super::phases::enemy_phase_end(cx)
-        }
-        WindowKind::InvestigationBegins => {
-            // Post-2.1 window closed; start the first turn (step 2.2).
-            // No skill-test-in-flight guard: this runs at phase start
-            // (no test can be in flight) and does not transition phase.
-            if let Some(id) = super::cursor::first_active_investigator(cx.state) {
-                super::phases::begin_investigator_turn(cx, id);
+            PhaseStep::InvestigationBegins => {
+                // Post-2.1 window closed; start the first turn (step 2.2).
+                // No skill-test-in-flight guard: this runs at phase start
+                // (no test can be in flight) and does not transition phase.
+                if let Some(id) = super::cursor::first_active_investigator(cx.state) {
+                    super::phases::begin_investigator_turn(cx, id);
+                }
+                // None branch: no active investigator can take a turn. Per
+                // Rules Reference p.10 step 6 the scenario ends — that
+                // resolution now fires at the defeat site:
+                // `check_all_defeated` latches `Resolution::Lost` (and emits
+                // `AllInvestigatorsDefeated`), which the `apply` hook turns
+                // into `ScenarioResolved` + `apply_resolution`. So by the
+                // time the cascade would re-enter Investigation with no
+                // active investigator, the loss has already resolved; this
+                // park branch stays as the cascade-breaker (auto-advancing
+                // would loop the round forever — every other phase auto-skips
+                // with no active investigators, so Investigation is the
+                // cascade's only natural pause point).
+                EngineOutcome::Done
             }
-            // None branch: no active investigator can take a turn. Per
-            // Rules Reference p.10 step 6 the scenario ends — that
-            // resolution now fires at the defeat site:
-            // `check_all_defeated` latches `Resolution::Lost` (and emits
-            // `AllInvestigatorsDefeated`), which the `apply` hook turns
-            // into `ScenarioResolved` + `apply_resolution`. So by the
-            // time the cascade would re-enter Investigation with no
-            // active investigator, the loss has already resolved; this
-            // park branch stays as the cascade-breaker (auto-advancing
-            // would loop the round forever — every other phase auto-skips
-            // with no active investigators, so Investigation is the
-            // cascade's only natural pause point).
-            EngineOutcome::Done
-        }
-        // InvestigatorTurnBegins: 2.2.1 — the active investigator now
-        // takes actions (Investigate / Move / Fight / Evade / PlayCard /
-        // Draw / ActivateAbility) as player-driven inputs, then ends the
-        // turn via EndTurn (2.2.2). No continuation work — the engine
-        // waits. The per-action "return to the previous player window"
-        // re-open (Rules Reference p.24 2.2.1) is deferred to #146.
-        WindowKind::AfterEnemyDefeated { .. }
-        | WindowKind::BetweenPhases { .. }
-        | WindowKind::InvestigatorTurnBegins => EngineOutcome::Done,
+            // InvestigatorTurnBegins: 2.2.1 — the active investigator now
+            // takes actions (Investigate / Move / Fight / Evade / PlayCard /
+            // Draw / ActivateAbility) as player-driven inputs, then ends the
+            // turn via EndTurn (2.2.2). No continuation work — the engine
+            // waits. The per-action "return to the previous player window"
+            // re-open (Rules Reference p.24 2.2.1) is deferred to #146.
+            PhaseStep::InvestigatorTurnBegins => EngineOutcome::Done,
+        },
+        WindowKind::AfterEnemyDefeated { .. } => EngineOutcome::Done,
     }
 }
 
@@ -1100,7 +1097,7 @@ mod open_fast_window_tests {
                 state: &mut state,
                 events: &mut events,
             },
-            WindowKind::MythosAfterDraws,
+            WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws),
         );
 
         assert!(
@@ -1111,7 +1108,7 @@ mod open_fast_window_tests {
             matches!(
                 events.first(),
                 Some(Event::WindowOpened {
-                    kind: WindowKind::MythosAfterDraws
+                    kind: WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws)
                 })
             ),
             "first event must be WindowOpened; got {:?}",
@@ -1121,7 +1118,7 @@ mod open_fast_window_tests {
             events.iter().any(|e| matches!(
                 e,
                 Event::WindowClosed {
-                    kind: WindowKind::MythosAfterDraws
+                    kind: WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws)
                 }
             )),
             "must emit WindowClosed for MythosAfterDraws; events = {events:?}"

--- a/crates/game-core/src/event.rs
+++ b/crates/game-core/src/event.rs
@@ -486,15 +486,12 @@ pub enum FailureReason {
 #[cfg(test)]
 mod window_opened_event_tests {
     use super::*;
-    use crate::state::{Phase, WindowKind};
+    use crate::state::{PhaseStep, WindowKind};
 
     #[test]
     fn window_opened_serde_roundtrip() {
         let ev = Event::WindowOpened {
-            kind: WindowKind::BetweenPhases {
-                from: Phase::Mythos,
-                to: Phase::Investigation,
-            },
+            kind: WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws),
         };
         let json = serde_json::to_string(&ev).expect("serialize");
         let back: Event = serde_json::from_str(&json).expect("deserialize");

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -129,8 +129,9 @@ pub struct GameState {
     /// Window kinds open at canonical timing points:
     /// - `AfterEnemyDefeated` — queued by `damage_enemy` when an
     ///   enemy reaches 0 health.
-    /// - `BetweenPhases` — opened by the phase machine at every
-    ///   phase transition (Phase-4 phase-content PRs wire this).
+    /// - `PlayerWindow` — a printed player window at a Rules-Reference
+    ///   timing step (e.g. `MythosAfterDraws`), opened by the phase
+    ///   machine; gates Fast actions and runs a per-step continuation.
     ///
     /// Multi-window queueing (one effect that queues two windows in
     /// the same apply) is now structural — push twice, drive resumes
@@ -805,7 +806,7 @@ impl GameState {
     /// Callers driving the reaction window pass this index to
     /// `close_reaction_window_at` so the close path removes the same
     /// entry the driver was operating on, rather than blindly popping
-    /// the top of the stack — a `BetweenPhases` window with empty
+    /// the top of the stack — a `PlayerWindow` gate with empty
     /// `pending_triggers` can sit above an active reaction window,
     /// which would corrupt the stack on naive `pop()`.
     ///

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -567,16 +567,19 @@ pub enum WindowKind {
         /// `by` field. `None` for non-investigator-attributed defeats.
         by: Option<InvestigatorId>,
     },
-    /// A window opened between two phases. Phase-4 phase-content PRs
-    /// open this at each canonical transition (e.g. before Mythos,
-    /// between Investigation and Enemy) so Fast cards + cross-phase
-    /// reactions fire correctly. `fast_actors` is typically `Any`.
-    BetweenPhases {
-        /// The phase we're leaving.
-        from: Phase,
-        /// The phase we're entering.
-        to: Phase,
-    },
+    /// A printed player window at a Rules-Reference timing step. Carries
+    /// no event payload — these windows gate Fast actions (and run a
+    /// per-step continuation when they close), they are not after-event
+    /// reaction windows. The specific timing point is the [`PhaseStep`].
+    PlayerWindow(PhaseStep),
+}
+
+/// The Rules-Reference timing step a [`WindowKind::PlayerWindow`] sits
+/// at. Each step uniquely determines its phase, so the phase is not
+/// carried separately (the engine reads [`GameState::phase`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum PhaseStep {
     /// The player window between Rules Reference p.24 step 1.4
     /// (each investigator draws an encounter card) and step 1.5
     /// (Mythos phase ends). Carries no payload — there is no
@@ -606,7 +609,7 @@ pub enum WindowKind {
     ///
     /// One window per Active investigator in `turn_order`.
     ///
-    /// [`MythosAfterDraws`]: WindowKind::MythosAfterDraws
+    /// [`MythosAfterDraws`]: PhaseStep::MythosAfterDraws
     /// [`turn_order`]: GameState::turn_order
     BeforeInvestigatorAttacked,
     /// The player window after all investigators have resolved their
@@ -615,7 +618,7 @@ pub enum WindowKind {
     /// Continuation runs `enemy_phase_end` (step 3.4 + transition).
     /// Mirror of [`MythosAfterDraws`]'s end-of-step shape.
     ///
-    /// [`MythosAfterDraws`]: WindowKind::MythosAfterDraws
+    /// [`MythosAfterDraws`]: PhaseStep::MythosAfterDraws
     AfterAllInvestigatorsAttacked,
     /// The player window between Rules Reference p.24 step 2.1
     /// (Investigation phase begins) and step 2.2 (the first
@@ -839,59 +842,8 @@ mod open_window_tests {
     }
 
     #[test]
-    fn between_phases_window_kind_serde_roundtrip() {
-        let kind = WindowKind::BetweenPhases {
-            from: Phase::Mythos,
-            to: Phase::Investigation,
-        };
-        let json = serde_json::to_string(&kind).expect("serialize");
-        let back: WindowKind = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(back, kind);
-    }
-
-    #[test]
-    fn mythos_after_draws_window_kind_serde_roundtrip() {
-        let kind = WindowKind::MythosAfterDraws;
-        let json = serde_json::to_string(&kind).expect("serialize");
-        let back: WindowKind = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(back, kind);
-    }
-
-    #[test]
-    fn upkeep_begins_window_kind_serde_roundtrip() {
-        let kind = WindowKind::UpkeepBegins;
-        let json = serde_json::to_string(&kind).expect("serialize");
-        let back: WindowKind = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(back, kind);
-    }
-
-    #[test]
-    fn before_investigator_attacked_window_kind_serde_roundtrip() {
-        let kind = WindowKind::BeforeInvestigatorAttacked;
-        let json = serde_json::to_string(&kind).expect("serialize");
-        let back: WindowKind = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(back, kind);
-    }
-
-    #[test]
-    fn after_all_investigators_attacked_window_kind_serde_roundtrip() {
-        let kind = WindowKind::AfterAllInvestigatorsAttacked;
-        let json = serde_json::to_string(&kind).expect("serialize");
-        let back: WindowKind = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(back, kind);
-    }
-
-    #[test]
-    fn investigation_begins_window_kind_serde_roundtrip() {
-        let kind = WindowKind::InvestigationBegins;
-        let json = serde_json::to_string(&kind).expect("serialize");
-        let back: WindowKind = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(back, kind);
-    }
-
-    #[test]
-    fn investigator_turn_begins_window_kind_serde_roundtrip() {
-        let kind = WindowKind::InvestigatorTurnBegins;
+    fn player_window_kind_serde_roundtrip() {
+        let kind = WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws);
         let json = serde_json::to_string(&kind).expect("serialize");
         let back: WindowKind = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, kind);

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -18,8 +18,8 @@ pub use chaos_bag::{resolve_token, ChaosBag, ChaosToken, TokenModifiers, TokenRe
 pub use enemy::{Enemy, EnemyId};
 pub use game_state::{
     Act, Agenda, FastActorScope, FinishContinuation, GameState, HandSizeDiscard, HunterChoice,
-    InFlightSkillTest, OpenWindow, PendingSkillModifier, PendingTrigger, SkillTestFollowUp,
-    SpawnEngagePending, WindowKind,
+    InFlightSkillTest, OpenWindow, PendingSkillModifier, PendingTrigger, PhaseStep,
+    SkillTestFollowUp, SpawnEngagePending, WindowKind,
 };
 pub use investigator::{DefeatCause, Investigator, InvestigatorId, SkillKind, Skills, Status};
 pub use location::{Location, LocationId};

--- a/crates/game-core/src/test_support/builder.rs
+++ b/crates/game-core/src/test_support/builder.rs
@@ -307,6 +307,7 @@ impl Default for TestGame {
 #[cfg(test)]
 mod with_open_window_tests {
     use super::*;
+    use crate::state::PhaseStep;
     use crate::test_support::test_investigator;
 
     #[test]
@@ -314,10 +315,7 @@ mod with_open_window_tests {
         let state = TestGame::new()
             .with_investigator(test_investigator(1))
             .with_open_window(
-                WindowKind::BetweenPhases {
-                    from: Phase::Mythos,
-                    to: Phase::Investigation,
-                },
+                WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins),
                 FastActorScope::Any,
             )
             .build();
@@ -331,27 +329,18 @@ mod with_open_window_tests {
         let state = TestGame::new()
             .with_investigator(test_investigator(1))
             .with_open_window(
-                WindowKind::BetweenPhases {
-                    from: Phase::Mythos,
-                    to: Phase::Investigation,
-                },
+                WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws),
                 FastActorScope::Any,
             )
             .with_open_window(
-                WindowKind::BetweenPhases {
-                    from: Phase::Investigation,
-                    to: Phase::Enemy,
-                },
+                WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins),
                 FastActorScope::ActiveInvestigator(InvestigatorId(1)),
             )
             .build();
         assert_eq!(state.open_windows.len(), 2);
         assert!(matches!(
             state.open_windows[1].kind,
-            WindowKind::BetweenPhases {
-                to: Phase::Enemy,
-                ..
-            }
+            WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins)
         ));
     }
 }

--- a/crates/game-core/tests/reaction_windows.rs
+++ b/crates/game-core/tests/reaction_windows.rs
@@ -24,7 +24,7 @@ use game_core::engine::EngineOutcome;
 use game_core::event::Event;
 use game_core::state::{
     CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, EnemyId, FastActorScope,
-    InvestigatorId, LocationId, OpenWindow, Phase, TokenModifiers, WindowKind,
+    InvestigatorId, LocationId, OpenWindow, Phase, PhaseStep, TokenModifiers, WindowKind,
 };
 use game_core::test_support::{
     apply_no_commits, test_enemy, test_investigator, test_location, TestGame,
@@ -882,15 +882,15 @@ fn skip_after_firing_one_drops_remaining_optionals() {
 #[test]
 fn close_reaction_window_at_removes_reaction_window_not_empty_phase_gate_on_top() {
     // Regression for the structural fix in a3958c6: when the stack is
-    //   [AfterEnemyDefeated R (with pending triggers), BetweenPhases B (empty)]
+    //   [AfterEnemyDefeated R (with pending triggers), PlayerWindow B (empty)]
     // a naive open_windows.pop() would remove B (the top), leaving R
     // unresolved and leaking. close_reaction_window_at takes an explicit
     // index so it removes R and leaves B intact.
     //
     // Setup: drive a Fight to the reaction-window AwaitingInput, then
-    // manually push an empty BetweenPhases window on top of the stack
-    // to replicate the stack shape Phase-4 phase-content PRs (#69/#70/#71)
-    // will produce in production paths.
+    // manually push an empty player-window gate on top of the stack to
+    // replicate the stack shape Phase-4 phase-content PRs (#69/#70/#71)
+    // produce in production paths.
     let (inv_id, enemy_id, _loc_id, state) = fight_to_defeat_scenario(&[(ROLAND_REACTION, 1)]);
     let mut paused = fight_through_commit_window(state, fight_action(inv_id, enemy_id));
     assert!(
@@ -903,13 +903,10 @@ fn close_reaction_window_at_removes_reaction_window_not_empty_phase_gate_on_top(
     assert_eq!(paused.state.open_windows.len(), 1);
     assert!(!paused.state.open_windows[0].pending_triggers.is_empty());
 
-    // Inject an empty BetweenPhases window on top to create the
+    // Inject an empty player-window gate on top to create the
     // [R (pending), B (empty)] shape.
     paused.state.open_windows.push(OpenWindow::new_empty(
-        WindowKind::BetweenPhases {
-            from: Phase::Investigation,
-            to: Phase::Mythos,
-        },
+        WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins),
         FastActorScope::Any,
     ));
     assert_eq!(
@@ -927,7 +924,7 @@ fn close_reaction_window_at_removes_reaction_window_not_empty_phase_gate_on_top(
         }),
     );
 
-    // The BetweenPhases window (B) must still be on the stack.
+    // The player-window gate (B) must still be on the stack.
     assert_eq!(
         resumed.state.open_windows.len(),
         1,
@@ -937,11 +934,8 @@ fn close_reaction_window_at_removes_reaction_window_not_empty_phase_gate_on_top(
     );
     assert_eq!(
         resumed.state.open_windows[0].kind,
-        WindowKind::BetweenPhases {
-            from: Phase::Investigation,
-            to: Phase::Mythos,
-        },
-        "the surviving window must be the BetweenPhases gate, not the reaction window",
+        WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins),
+        "the surviving window must be the player-window gate, not the reaction window",
     );
     // R must have emitted WindowClosed.
     assert_event!(

--- a/crates/scenarios/tests/mythos_phase.rs
+++ b/crates/scenarios/tests/mythos_phase.rs
@@ -24,7 +24,7 @@ use std::sync::Once;
 use game_core::card_data::CardType;
 use game_core::engine::{apply, EngineOutcome};
 use game_core::event::Event;
-use game_core::state::{CardCode, InvestigatorId, LocationId, Phase, WindowKind};
+use game_core::state::{CardCode, InvestigatorId, LocationId, Phase, PhaseStep, WindowKind};
 use game_core::{assert_event, assert_event_sequence, Action, InputResponse, PlayerAction};
 use scenarios::test_fixtures::synth_cards::{
     SYNTH_ENEMY_CODE, SYNTH_FAST_EVENT_CODE, SYNTH_SURGE_TREACHERY_CODE, SYNTH_TREACHERY_CODE,
@@ -648,7 +648,7 @@ fn mythos_after_draws_window_stays_open_when_fast_event_in_hand() {
     assert!(
         matches!(
             result.state.open_windows.last(),
-            Some(w) if w.kind == WindowKind::MythosAfterDraws
+            Some(w) if w.kind == WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws)
         ),
         "top open window must be MythosAfterDraws; got {:?}",
         result.state.open_windows.last()
@@ -666,7 +666,7 @@ fn mythos_after_draws_window_stays_open_when_fast_event_in_hand() {
     assert_event!(
         result.events,
         Event::WindowOpened {
-            kind: WindowKind::MythosAfterDraws
+            kind: WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws)
         }
     );
 
@@ -675,7 +675,7 @@ fn mythos_after_draws_window_stays_open_when_fast_event_in_hand() {
         !result.events.iter().any(|e| matches!(
             e,
             Event::WindowClosed {
-                kind: WindowKind::MythosAfterDraws
+                kind: WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws)
             }
         )),
         "WindowClosed(MythosAfterDraws) must not fire while window is open; \
@@ -745,7 +745,7 @@ fn mythos_after_draws_window_closed_by_skip_and_transitions_to_investigation() {
             .state
             .open_windows
             .last()
-            .is_some_and(|w| w.kind == WindowKind::InvestigationBegins),
+            .is_some_and(|w| w.kind == WindowKind::PlayerWindow(PhaseStep::InvestigationBegins)),
         "top window must be InvestigationBegins; got {:?}",
         skip_result.state.open_windows.last()
     );
@@ -771,14 +771,14 @@ fn mythos_after_draws_window_closed_by_skip_and_transitions_to_investigation() {
     assert_event!(
         skip_result.events,
         Event::WindowClosed {
-            kind: WindowKind::MythosAfterDraws
+            kind: WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws)
         }
     );
     // WindowOpened event for InvestigationBegins must also be present.
     assert_event!(
         skip_result.events,
         Event::WindowOpened {
-            kind: WindowKind::InvestigationBegins
+            kind: WindowKind::PlayerWindow(PhaseStep::InvestigationBegins)
         }
     );
 }

--- a/docs/superpowers/plans/2026-06-07-140-windowkind-playerwindow-collapse.md
+++ b/docs/superpowers/plans/2026-06-07-140-windowkind-playerwindow-collapse.md
@@ -1,0 +1,284 @@
+# WindowKind PlayerWindow Collapse Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Collapse the six payload-less marker `WindowKind` variants into `WindowKind::PlayerWindow(PhaseStep)`, keep the event-carrying `AfterEnemyDefeated` distinct, and delete the dead `BetweenPhases` variant.
+
+**Architecture:** Behavior-preserving refactor of one enum in `game-core`. `WindowKind` shrinks to two variants; a new sibling enum `PhaseStep` enumerates the six timing points. Continuation dispatch and `trigger_matches` re-key on `PhaseStep` instead of variant name. Dead `BetweenPhases` test fixtures migrate to `PhaseStep::InvestigatorTurnBegins` (same payload-less, `Done`-continuation shape).
+
+**Tech Stack:** Rust, `serde`. No new dependencies.
+
+**Refactor note — no new tests, existing suite is the contract.** This change adds zero behavior. The verification at every step is "the existing suite stays green under CI-strict flags." The enum change is atomic within `game-core` (removing variants breaks every match + construction site at once), so Task 1 covers all of `game-core` and is verified by `cargo test -p game-core`; Task 2 covers the `cards` crate fixtures; Task 3 runs the full CI gauntlet.
+
+Spec: `docs/superpowers/specs/2026-06-07-140-windowkind-playerwindow-collapse-design.md`.
+
+---
+
+### Task 1: Restructure `WindowKind` + migrate all of `game-core`
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (enum definition ~556–633, serde tests ~841–898)
+- Modify: `crates/game-core/src/state/mod.rs` (re-export, line ~19–22)
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (`trigger_matches` ~142–188, `run_window_continuation` ~529–663, construction sites ~614/616, in-mod tests ~1100–1145)
+- Modify: `crates/game-core/src/engine/dispatch/phases.rs` (construction sites ~143/163/223/326/331/425; in-mod test assertions ~762/820/1044/1050/1117/1126/1459)
+- Modify: `crates/game-core/src/engine/dispatch/encounter.rs` (construction site ~605)
+- Modify: `crates/game-core/src/engine/dispatch/combat.rs` (doc-link references only)
+- Modify: `crates/game-core/src/event.rs` (import ~21; serde test ~489–494)
+- Modify: `crates/game-core/src/test_support/builder.rs` (import ~32; `with_open_window` tests ~317–354)
+- Modify: `crates/game-core/tests/reaction_windows.rs` (import ~27; empty-window-on-stack test ~885–944)
+
+- [ ] **Step 1: Replace the enum definition.**
+
+In `crates/game-core/src/state/game_state.rs`, replace the entire `WindowKind` enum (the `#[non_exhaustive] pub enum WindowKind { ... }` block, currently variants `AfterEnemyDefeated`, `BetweenPhases`, `MythosAfterDraws`, `UpkeepBegins`, `BeforeInvestigatorAttacked`, `AfterAllInvestigatorsAttacked`, `InvestigationBegins`, `InvestigatorTurnBegins`) with the two enums below. Move each marker's existing Rules-Reference doc-comment verbatim onto the matching `PhaseStep` variant. Delete `BetweenPhases`'s doc-comment entirely. Keep the `AfterEnemyDefeated` doc-comment and the enum-level doc-comment on `WindowKind`.
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum WindowKind {
+    /// Fires after an enemy was defeated. Pairs with
+    /// [`EventPattern::EnemyDefeated`](crate::dsl::EventPattern::EnemyDefeated)
+    /// with [`EventTiming::After`](crate::dsl::EventTiming::After).
+    AfterEnemyDefeated {
+        /// The defeated enemy. Carried so trigger effects keying on
+        /// "the defeated enemy" can route against the right id even
+        /// after `state.enemies` has dropped the entry.
+        enemy: EnemyId,
+        /// Who defeated it, if attributable. Mirrors the
+        /// [`Event::EnemyDefeated`](crate::Event::EnemyDefeated)
+        /// `by` field. `None` for non-investigator-attributed defeats.
+        by: Option<InvestigatorId>,
+    },
+    /// A printed player window at a Rules-Reference timing step. Carries
+    /// no event payload — these windows gate Fast actions (and run a
+    /// per-step continuation when they close), they are not after-event
+    /// reaction windows. The specific timing point is the [`PhaseStep`].
+    PlayerWindow(PhaseStep),
+}
+
+/// The Rules-Reference timing step a [`WindowKind::PlayerWindow`] sits
+/// at. Each step uniquely determines its phase, so the phase is not
+/// carried separately (the engine reads [`GameState::phase`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum PhaseStep {
+    /// <MOVE the MythosAfterDraws doc-comment body here>
+    MythosAfterDraws,
+    /// <MOVE the UpkeepBegins doc-comment body here>
+    UpkeepBegins,
+    /// <MOVE the BeforeInvestigatorAttacked doc-comment body here>
+    BeforeInvestigatorAttacked,
+    /// <MOVE the AfterAllInvestigatorsAttacked doc-comment body here>
+    AfterAllInvestigatorsAttacked,
+    /// <MOVE the InvestigationBegins doc-comment body here>
+    InvestigationBegins,
+    /// <MOVE the InvestigatorTurnBegins doc-comment body here>
+    InvestigatorTurnBegins,
+}
+```
+
+When moving doc-comments, update intra-doc links *within them* that point at sibling markers: `[`MythosAfterDraws`]: WindowKind::MythosAfterDraws` becomes `[`MythosAfterDraws`]: PhaseStep::MythosAfterDraws` (e.g. the link definitions on the `BeforeInvestigatorAttacked` / `AfterAllInvestigatorsAttacked` doc-comments).
+
+- [ ] **Step 2: Re-export `PhaseStep`.**
+
+In `crates/game-core/src/state/mod.rs`, add `PhaseStep` to the `pub use game_state::{ ... }` list (alphabetical neighborhood near `Phase`).
+
+- [ ] **Step 3: Mechanical rename across all `game-core` markers.**
+
+Apply this rule everywhere in `crates/game-core/src/` (code *and* doc-comments), for the six markers `MythosAfterDraws`, `UpkeepBegins`, `BeforeInvestigatorAttacked`, `AfterAllInvestigatorsAttacked`, `InvestigationBegins`, `InvestigatorTurnBegins`:
+
+  - **Construction:** `WindowKind::<Marker>` → `WindowKind::PlayerWindow(PhaseStep::<Marker>)`.
+    - Sites: `encounter.rs` (`MythosAfterDraws`); `phases.rs` (`InvestigationBegins`, `InvestigatorTurnBegins`, `MythosAfterDraws`, `BeforeInvestigatorAttacked`, `AfterAllInvestigatorsAttacked`, `UpkeepBegins`); `reaction_windows.rs` lines ~614/616 (`BeforeInvestigatorAttacked`, `AfterAllInvestigatorsAttacked`).
+  - **Pattern match** `kind: WindowKind::<Marker>` (in `#[cfg(test)]` assertions in `phases.rs` and `reaction_windows.rs`) → `kind: WindowKind::PlayerWindow(PhaseStep::<Marker>)`.
+  - **Doc-link** `[`...`](WindowKind::<Marker>)` and `[\`WindowKind::<Marker>\`]` → point at `PhaseStep::<Marker>`.
+
+  Leave `WindowKind::AfterEnemyDefeated` and the new `WindowKind::PlayerWindow` untouched by this rule.
+
+- [ ] **Step 4: Rewrite `trigger_matches`.**
+
+In `reaction_windows.rs`, replace the six-name false-arm with a single `PlayerWindow` arm. The `match (kind, pattern)` becomes:
+
+```rust
+    match (kind, pattern) {
+        (
+            WindowKind::AfterEnemyDefeated { by, .. },
+            EventPattern::EnemyDefeated { by_controller },
+        ) => {
+            if by_controller {
+                by == Some(controller)
+            } else {
+                true
+            }
+        }
+        // PlayerWindow steps open for timing reasons; no
+        // Trigger::OnEvent pattern matches them — those windows gate
+        // Fast actions, not after-event reactions. AfterEnemyDefeated
+        // windows only match EnemyDefeated patterns (handled above);
+        // encounter-reveal / spawn patterns return false.
+        (
+            WindowKind::PlayerWindow(_) | WindowKind::AfterEnemyDefeated { .. },
+            EventPattern::EnemyDefeated { .. }
+            | EventPattern::CardRevealed { .. }
+            | EventPattern::EnemySpawned,
+        ) => false,
+    }
+```
+
+- [ ] **Step 5: Rewrite `run_window_continuation`.**
+
+In `reaction_windows.rs`, restructure the top-level `match kind` so the six step arms nest under `PlayerWindow(step)`. Keep every arm body verbatim (including the `unreachable!` skill-test-in-flight guards and the cursor/attack logic). The shape:
+
+```rust
+pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) -> EngineOutcome {
+    match kind {
+        WindowKind::PlayerWindow(step) => match step {
+            PhaseStep::MythosAfterDraws => { /* existing MythosAfterDraws body */ }
+            PhaseStep::UpkeepBegins => { /* existing UpkeepBegins body */ }
+            PhaseStep::BeforeInvestigatorAttacked => { /* existing body */ }
+            PhaseStep::AfterAllInvestigatorsAttacked => { /* existing body */ }
+            PhaseStep::InvestigationBegins => { /* existing body */ }
+            PhaseStep::InvestigatorTurnBegins => EngineOutcome::Done,
+        },
+        WindowKind::AfterEnemyDefeated { .. } => EngineOutcome::Done,
+    }
+}
+```
+
+The old combined `AfterEnemyDefeated | BetweenPhases | InvestigatorTurnBegins => Done` arm is gone: `InvestigatorTurnBegins` is now a `PlayerWindow` step returning `Done`, `AfterEnemyDefeated` keeps its own `Done` arm, and `BetweenPhases` no longer exists. Update the function's doc-comment to drop the `BetweenPhases` mention and refer to `PhaseStep::…` for the step names.
+
+- [ ] **Step 6: Migrate the `BetweenPhases` serde test in `game_state.rs`.**
+
+In the `open_window_tests` mod, delete the five separate per-marker round-trip tests (`mythos_after_draws_window_kind_serde_roundtrip`, `upkeep_begins_…`, `before_investigator_attacked_…`, `after_all_investigators_attacked_…`, `investigation_begins_…`, `investigator_turn_begins_…`) and the `between_phases_window_kind_serde_roundtrip` test, replacing them with one representative `PlayerWindow` round-trip. Keep `open_window_serde_roundtrip` (the `AfterEnemyDefeated` one) as-is.
+
+```rust
+    #[test]
+    fn player_window_kind_serde_roundtrip() {
+        let kind = WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws);
+        let json = serde_json::to_string(&kind).expect("serialize");
+        let back: WindowKind = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, kind);
+    }
+```
+
+- [ ] **Step 7: Migrate the `event.rs` serde test.**
+
+In `crates/game-core/src/event.rs`, the `#[cfg(test)]` test (~489–494) that builds a `WindowKind::BetweenPhases { from, to }`: change it to `WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws)`. Update the test's `use crate::state::{...}` line to import `PhaseStep` instead of `Phase` if `Phase` is now unused there.
+
+- [ ] **Step 8: Migrate the `builder.rs` dead fixtures.**
+
+In `crates/game-core/src/test_support/builder.rs`, the `with_open_window_tests` mod uses `WindowKind::BetweenPhases { from, to }` as a generic Fast-window stand-in. Replace both uses with `WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins)`. The `with_open_window_stacks_in_order` test's `matches!(... WindowKind::BetweenPhases { to: Phase::Enemy, .. })` assertion must change to distinguish the two pushed windows another way — push two *different* steps (e.g. `MythosAfterDraws` then `InvestigatorTurnBegins`) and assert the top is `WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins)`. Update the `use` import to add `PhaseStep` and drop `Phase` if it becomes unused in that test mod.
+
+```rust
+    #[test]
+    fn with_open_window_stacks_in_order() {
+        let state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_open_window(
+                WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws),
+                FastActorScope::Any,
+            )
+            .with_open_window(
+                WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins),
+                FastActorScope::ActiveInvestigator(InvestigatorId(1)),
+            )
+            .build();
+        assert_eq!(state.open_windows.len(), 2);
+        assert!(matches!(
+            state.open_windows[1].kind,
+            WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins)
+        ));
+    }
+```
+
+- [ ] **Step 9: Migrate `tests/reaction_windows.rs` dead fixture.**
+
+In `crates/game-core/tests/reaction_windows.rs`, the empty-window-on-stack test (~885–944) injects an empty `WindowKind::BetweenPhases { from, to }` on top of a reaction window to verify `close_reaction_window_at` pops the right index. Replace both the constructed window (~909) and the assertion `matches!` (~940) with `WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins)`. Update the comments that name "BetweenPhases" to name the new window (e.g. "an empty player-window gate"). Add `PhaseStep` to the `use game_core::state::{...}` import; drop `Phase` if it becomes unused.
+
+- [ ] **Step 10: Build and test game-core under CI-strict flags.**
+
+```bash
+RUSTFLAGS="-D warnings" cargo test -p game-core --all-features
+RUSTDOCFLAGS="-D warnings" cargo doc -p game-core --no-deps --all-features
+```
+Expected: both PASS. The `doc` run is the safety net for any missed `WindowKind::<Marker>` intra-doc link — a stale link fails it. If anything fails, fix the named site and re-run.
+
+- [ ] **Step 11: Commit.**
+
+```bash
+git add crates/game-core
+git commit -m "$(printf 'engine: collapse marker WindowKind variants into PlayerWindow\n\nReplace the six payload-less marker variants with\nWindowKind::PlayerWindow(PhaseStep) and remove the dead BetweenPhases\nvariant. Continuation dispatch and trigger_matches re-key on PhaseStep.\n\nRefs #140.\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 2: Migrate the `cards` crate Fast-play fixtures
+
+**Files:**
+- Modify: `crates/cards/tests/fast_play.rs` (import ~38; six `WindowKind::BetweenPhases` uses ~66/108/151/224/309/375)
+
+- [ ] **Step 1: Replace the six `BetweenPhases` uses.**
+
+In `crates/cards/tests/fast_play.rs`, each `WindowKind::BetweenPhases { from, to }` was a generic "Fast-allowed window whose continuation is a no-op". Replace each with `WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins)` (same payload-less, `Done`-continuation shape). Add `PhaseStep` to the `use ... { WindowKind }` import; drop now-unused `Phase` import only if nothing else in the file uses it (check — `Phase` may still be used for `.with_phase(...)`).
+
+- [ ] **Step 2: Test the cards crate under CI-strict flags.**
+
+```bash
+RUSTFLAGS="-D warnings" cargo test -p cards --all-features
+```
+Expected: PASS (all Fast-play tests green with the new window kind).
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add crates/cards
+git commit -m "$(printf 'test: migrate cards Fast-play fixtures off dead BetweenPhases\n\nUse WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins) as the\ngeneric Fast-allowed window stand-in, matching the removed\nBetweenPhases shape (payload-less, no-op continuation).\n\nRefs #140.\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 3: Full CI gauntlet + scenarios cross-check
+
+**Files:** none (verification only; fix-forward if a site was missed)
+
+- [ ] **Step 1: Confirm no stray references remain.**
+
+```bash
+grep -rn "BetweenPhases" crates/ ; echo "exit: $?"
+grep -rn "WindowKind::MythosAfterDraws\|WindowKind::UpkeepBegins\|WindowKind::BeforeInvestigatorAttacked\|WindowKind::AfterAllInvestigatorsAttacked\|WindowKind::InvestigationBegins\|WindowKind::InvestigatorTurnBegins" crates/
+```
+Expected: the first grep prints nothing (exit 1 from grep = no matches); the second prints nothing. Any hit is a missed site — fix it (note `crates/scenarios/tests/mythos_phase.rs` references `WindowKind::MythosAfterDraws` and `WindowKind::InvestigationBegins` and must be migrated the same way, with `PhaseStep` added to its import).
+
+- [ ] **Step 2: Run the full CI gauntlet.**
+
+```bash
+RUSTFLAGS="-D warnings"     cargo test --all --all-features
+                            cargo clippy --all-targets --all-features -- -D warnings
+                            cargo fmt --check
+RUSTDOCFLAGS="-D warnings"  cargo doc --workspace --no-deps --all-features
+                            cargo build -p web --target wasm32-unknown-unknown
+```
+Expected: all five PASS.
+
+- [ ] **Step 3: Commit any fixes from Step 1/2.**
+
+```bash
+git add -A
+git commit -m "$(printf 'test: migrate scenarios fixtures off marker WindowKind variants\n\nRefs #140.\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+(Skip if Steps 1–2 needed no edits.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Remove `BetweenPhases` + migrate test sites → Task 1 (builder, tests/reaction_windows, event serde), Task 2 (cards fast_play), Task 3 (scenarios). ✅
+- `PlayerWindow(PhaseStep)`, no redundant `phase` → Task 1 Step 1. ✅
+- `trigger_matches` collapse → Task 1 Step 4. ✅
+- `run_window_continuation` restructure, bodies verbatim → Task 1 Step 5. ✅
+- Serde test consolidation → Task 1 Step 6. ✅
+- Doc-link migration (doc -D warnings safety net) → Task 1 Step 3 + Step 10. ✅
+- Serde/replay safety → no code action needed (no `Action` carries `WindowKind`); covered by gauntlet. ✅
+
+**Placeholder scan:** The `<MOVE the … doc-comment body here>` markers in Step 1 are explicit instructions to relocate existing verbatim doc text (the source text is in `game_state.rs` today), not unwritten content. All code blocks are complete.
+
+**Type consistency:** `WindowKind::PlayerWindow(PhaseStep)` and the six `PhaseStep::*` names are used identically across Tasks 1–3. `InvestigatorTurnBegins` is the uniform dead-fixture replacement in builder.rs, tests/reaction_windows.rs, and fast_play.rs.

--- a/docs/superpowers/specs/2026-06-07-140-windowkind-playerwindow-collapse-design.md
+++ b/docs/superpowers/specs/2026-06-07-140-windowkind-playerwindow-collapse-design.md
@@ -1,0 +1,139 @@
+# Collapse marker `WindowKind` variants into `PlayerWindow(PhaseStep)` (#140)
+
+## Problem
+
+`WindowKind` (`crates/game-core/src/state/game_state.rs`) currently mixes
+three kinds of variant:
+
+| Variant | Payload | Read by `trigger_matches`? | Continuation | Opened in production? |
+|---|---|---|---|---|
+| `AfterEnemyDefeated { enemy, by }` | yes | **yes** — `by` → `EnemyDefeated.by_controller` | none (`Done`) | yes |
+| `BetweenPhases { from, to }` | yes | no | none (`Done`) | **no — dead** |
+| `MythosAfterDraws` | none | no | `mythos_phase_end` | yes |
+| `UpkeepBegins` | none | no | `upkeep_resume` | yes |
+| `BeforeInvestigatorAttacked` | none | no | cursor + resolve attacks | yes |
+| `AfterAllInvestigatorsAttacked` | none | no | `enemy_phase_end` | yes |
+| `InvestigationBegins` | none | no | `begin_investigator_turn` | yes |
+| `InvestigatorTurnBegins` | none | no | none (`Done`) | yes |
+
+Two problems:
+
+1. **`BetweenPhases` is dead.** It is never opened by any production path —
+   the "phase machine opens this at every transition" machinery described in
+   its doc-comment was never built; each phase got its own specific marker
+   instead. It survives only as a test fixture (a generic "Fast-allowed window"
+   stand-in) and exhaustiveness/serde boilerplate.
+2. **Six payload-less markers sit as siblings of the one genuinely
+   event-carrying variant**, obscuring that they are all the same shape: a
+   printed player window at a Rules-Reference timing step, distinguished only
+   by *which* step.
+
+The issue set a bar of "≥3 phase-content PRs landed before refactoring"; six
+markers now exist, so the data is in.
+
+## Decision
+
+Collapse the six markers into a single `WindowKind::PlayerWindow(PhaseStep)`,
+keep the event-carrying `AfterEnemyDefeated` distinct, and delete the dead
+`BetweenPhases`.
+
+`PlayerWindow` carries **only** `PhaseStep` — not the issue's originally
+suggested `{ phase, step }`. Each `PhaseStep` already uniquely determines its
+phase, nothing reads a window's phase (the engine reads `cx.state.phase`), so a
+`phase` field would be redundant state that can desync.
+
+## Type shape
+
+`crates/game-core/src/state/game_state.rs`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum WindowKind {
+    AfterEnemyDefeated { enemy: EnemyId, by: Option<InvestigatorId> },
+    PlayerWindow(PhaseStep),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum PhaseStep {
+    MythosAfterDraws,
+    UpkeepBegins,
+    BeforeInvestigatorAttacked,
+    AfterAllInvestigatorsAttacked,
+    InvestigationBegins,
+    InvestigatorTurnBegins,
+}
+```
+
+`PhaseStep` takes the same derives + `#[non_exhaustive]` as `WindowKind`. Each
+marker's existing Rules-Reference doc-comment (timing-step citation,
+continuation description) moves onto the corresponding `PhaseStep` variant.
+
+## Changes
+
+1. **Definition** — replace the six markers + `BetweenPhases` with the two
+   enums above; migrate doc-comments.
+
+2. **Construction sites** — rewrite each `WindowKind::Marker` to
+   `WindowKind::PlayerWindow(PhaseStep::Marker)`. Production sites:
+   `engine/dispatch/encounter.rs`, `engine/dispatch/phases.rs` (several),
+   `engine/dispatch/reaction_windows.rs`.
+
+3. **`trigger_matches`** (`reaction_windows.rs`) — the six-name false-arm
+   collapses to one `WindowKind::PlayerWindow(_)` arm (still `false` for all
+   patterns — none of these are event-reaction windows). The
+   `AfterEnemyDefeated` arm is unchanged.
+
+4. **`run_window_continuation`** (`reaction_windows.rs`) — restructure to:
+
+   ```rust
+   match kind {
+       WindowKind::PlayerWindow(step) => match step {
+           PhaseStep::MythosAfterDraws => { /* unchanged body */ }
+           PhaseStep::UpkeepBegins => { /* unchanged body */ }
+           PhaseStep::BeforeInvestigatorAttacked => { /* unchanged body */ }
+           PhaseStep::AfterAllInvestigatorsAttacked => { /* unchanged body */ }
+           PhaseStep::InvestigationBegins => { /* unchanged body */ }
+           PhaseStep::InvestigatorTurnBegins => EngineOutcome::Done,
+       },
+       WindowKind::AfterEnemyDefeated { .. } => EngineOutcome::Done,
+   }
+   ```
+
+   Bodies (including the skill-test-in-flight `unreachable!` guards) are
+   preserved verbatim. `BetweenPhases`'s old `Done` arm is dropped — its only
+   sibling in that arm, `InvestigatorTurnBegins`, keeps its existing `Done`.
+
+5. **Dead-fixture migration** — the test sites that injected `BetweenPhases` as
+   a generic "Fast-allowed window whose continuation is a no-op" migrate to
+   `PhaseStep::InvestigatorTurnBegins`: the payload-less marker with the same
+   `Done`-continuation shape, so behavior is preserved. Sites:
+   - `crates/game-core/src/test_support/builder.rs` — two `with_open_window` tests.
+   - `crates/game-core/tests/reaction_windows.rs` — the empty-window-on-stack test.
+   - `crates/cards/tests/fast_play.rs` — six uses.
+
+6. **Serde tests** — the six per-marker round-trip tests in `game_state.rs`
+   collapse to one representative `PlayerWindow(PhaseStep::…)` round-trip
+   (the `AfterEnemyDefeated` round-trip stays). The `event.rs` serde test that
+   used `BetweenPhases` migrates to a `PlayerWindow` shape.
+
+## Serde / replay safety
+
+`WindowKind` appears only in `Event` and `GameState.open_windows`, never in any
+`Action`. Replay is from the flat `Vec<Action>` log, so the changed JSON shape
+does not break determinism. `GameState` is serialized to the web client, but
+client and server ship together — there is no persisted save format to migrate.
+
+## Non-goals
+
+- No change to `AfterEnemyDefeated` or its `by_controller` routing.
+- No change to `OpenWindow`, `FastActorScope`, or Fast-eligibility logic.
+- No new timing points — the refactor only restructures the existing eight.
+
+## Success criteria
+
+Behavior-preserving refactor. Success = the full CI gauntlet stays green
+(`test` under `RUSTFLAGS="-D warnings"`, `clippy --all-targets --all-features
+-D warnings`, `fmt --check`, `doc -D warnings`, `wasm-build`), with the only
+intended behavior delta being that `WindowKind::BetweenPhases` no longer exists.


### PR DESCRIPTION
## Summary

Collapse the six payload-less marker `WindowKind` variants into a single `WindowKind::PlayerWindow(PhaseStep)`, keep the event-carrying `AfterEnemyDefeated` distinct, and remove the dead `BetweenPhases` variant. Behavior-preserving refactor.

## What changed

- **`WindowKind`** now has two variants: `AfterEnemyDefeated { enemy, by }` (unchanged) and `PlayerWindow(PhaseStep)`. The six timing-point markers move into a new sibling enum `PhaseStep` (`MythosAfterDraws`, `UpkeepBegins`, `BeforeInvestigatorAttacked`, `AfterAllInvestigatorsAttacked`, `InvestigationBegins`, `InvestigatorTurnBegins`), carrying their existing Rules-Reference doc-comments.
- **`BetweenPhases` removed** — it was never opened by any production path (the "phase machine opens it at every transition" machinery was never built; each phase got its own specific marker). It survived only as a test fixture and serde/exhaustiveness boilerplate.
- `PlayerWindow` carries **only** `PhaseStep`, not the originally-proposed `{ phase, step }`: each step uniquely determines its phase, nothing reads a window's phase (the engine reads `state.phase`), so a `phase` field would be redundant desyncable state.
- `trigger_matches` and `run_window_continuation` re-key on `PhaseStep` (continuation bodies preserved verbatim, including the skill-test-in-flight `unreachable!` guards).
- Dead `BetweenPhases` test fixtures (builder, `tests/reaction_windows.rs`, `cards/tests/fast_play.rs`, `scenarios/tests/mythos_phase.rs`) migrate to `PhaseStep::InvestigatorTurnBegins` — the payload-less marker with the same no-op (`Done`) continuation shape `BetweenPhases` had.
- Six per-marker serde round-trip tests consolidated into one `PlayerWindow` round-trip.

## Design decisions

- **No redundant `phase` field** (see above).
- **`InvestigatorTurnBegins` as the uniform dead-fixture replacement**: the test sites used `BetweenPhases` as a generic "Fast-allowed window whose continuation is a no-op"; `InvestigatorTurnBegins` is the surviving marker with exactly that shape, so behavior is preserved.
- **Serde/replay safety**: `WindowKind` appears only in `Event` and `GameState.open_windows`, never in an `Action`. Replay is from the flat `Vec<Action>` log, so the changed JSON shape doesn't affect determinism; client and server ship together, so there's no persisted save format to migrate.

Spec: `docs/superpowers/specs/2026-06-07-140-windowkind-playerwindow-collapse-design.md`.

## Test notes

Behavior-preserving — full CI gauntlet green locally (`RUSTFLAGS="-D warnings" cargo test --all --all-features`, `clippy --all-targets --all-features -D warnings`, `fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo build -p web --target wasm32-unknown-unknown`). The only intended behavior delta is that `WindowKind::BetweenPhases` no longer exists.

## Linked issues

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)