### PR TITLE
docs: Phase 5 server + persistence design + issue breakdown

### DIFF
--- a/docs/phases/README.md
+++ b/docs/phases/README.md
@@ -17,7 +17,7 @@ When starting work on a new issue, read the relevant phase doc first. It's faste
 | 2 | Card data + DSL | ✅ closed | [phase-2-card-data-and-dsl.md](phase-2-card-data-and-dsl.md) |
 | 3 | Skill-test end-to-end | ✅ closed | [phase-3-skill-test-end-to-end.md](phase-3-skill-test-end-to-end.md) |
 | 4 | Scenario plumbing | ✅ closed | [phase-4-scenario-plumbing.md](phase-4-scenario-plumbing.md) |
-| 5 | Server + persistence | 📐 architecture only | [phase-5-server-and-persistence.md](phase-5-server-and-persistence.md) |
+| 5 | Server + persistence | 🟡 in progress | [phase-5-server-and-persistence.md](phase-5-server-and-persistence.md) |
 | 6 | Web client v0 | 📐 architecture only | [phase-6-web-client-v0.md](phase-6-web-client-v0.md) |
 | 7 | The Gathering | 📐 architecture only | [phase-7-the-gathering.md](phase-7-the-gathering.md) |
 | 8 | Multiplayer + auth | 📐 architecture only | [phase-8-multiplayer-and-auth.md](phase-8-multiplayer-and-auth.md) |
@@ -38,6 +38,7 @@ Some issues don't belong to a single phase. They live unmilestoned with `p2-late
 - `#31` — turn-order management cleanup (empty `turn_order` / `EndTurn` gracefully).
 - `#42` — card-data-pipeline test coverage expansion.
 - `#44` — DSL horror-soak / damage-redirect primitive (needed when soak-bearing cards land; tracked from PR-I).
+- `#174` — periodic state snapshots for replay perf (deferred from Phase 5; build only when profiling demands it).
 - `#83` — `enemy_attack` cleanup (apply both damage and horror when one defeats).
 - `#93` — split DSL types into a shared `card-dsl` crate (architectural improvement; not phase-gated).
 

--- a/docs/phases/phase-5-server-and-persistence.md
+++ b/docs/phases/phase-5-server-and-persistence.md
@@ -2,44 +2,69 @@
 
 ## Status
 
-📐 Architecture only. No issues filed.
+🟡 In progress (since 2026-06-07). Design spec landed; issues filed.
+
+Design spec: [`docs/superpowers/specs/2026-06-07-phase-5-server-and-persistence-design.md`](../superpowers/specs/2026-06-07-phase-5-server-and-persistence-design.md).
 
 ## Goal
 
-Engine on Axum + SQLite event log; reconnect works.
+Engine on Axum + SQLite event log; reconnect works. **Headless** this
+phase — proven with Rust WebSocket integration-test clients. The browser
+client is Phase 6; auth + per-seat enforcement are Phase 8.
+
+## Issues
+
+| Order | Issue | State |
+|---|---|---|
+| — | [#167](https://github.com/talelburg/eldritch/issues/167) — kickoff: design spec + issue breakdown | 🟡 open (this docs PR) |
+| P5.1 | [#168](https://github.com/talelburg/eldritch/issues/168) — sqlx + SQLite wiring: pool, migrations, action-log schema | ⏳ open |
+| P5.2 | [#169](https://github.com/talelburg/eldritch/issues/169) — GameSession host: create / apply-and-persist / load-by-replay | ⏳ open |
+| P5.3 | [#170](https://github.com/talelburg/eldritch/issues/170) — Axum WS endpoint + per-game broadcast hub | ⏳ open |
+| P5.4 | [#171](https://github.com/talelburg/eldritch/issues/171) — Game lifecycle HTTP: POST /games + lazy rehydrate | ⏳ open |
+| P5.5 | [#172](https://github.com/talelburg/eldritch/issues/172) — Reconnect + restart resume: deliver in-flight AwaitingInput | ⏳ open |
+| P5.6 | [#173](https://github.com/talelburg/eldritch/issues/173) — closing demo: two WS clients, restart+reconnect replay | ⏳ open |
+
+Deferred out of the phase: [#174](https://github.com/talelburg/eldritch/issues/174) — periodic state snapshots for replay perf (p2-later, build only when profiling demands it).
+
+## Ordering
+
+Strict dependency chain: P5.1 → P5.2 → P5.3 → P5.4 → P5.5 → P5.6.
+
+- **P5.1** is the foundation everything sits on (DB + schema).
+- **P5.2** is the pure-engine ↔ persistence seam (host-side `GameSession`); testable headless against in-memory SQLite before any networking exists.
+- **P5.3–P5.5** layer the network: the WS hub, then lifecycle + lazy rehydrate, then resume semantics.
+- **P5.6** is the closing demo that exercises the whole stack (mirrors Phase 4's #157).
 
 ## Decisions made
 
-From the 2026-05-01/02 strategy phase:
+From the 2026-05-01/02 strategy phase (still standing):
 
-- **Wire protocol:** server-authoritative event streaming. Browsers send `PlayerAction`s; server validates, applies, emits events, appends to the log, broadcasts events to all connected browsers. Browsers apply events to a local view for rendering only — never authoritative.
-- **Persistence model:** event-sourced. Game state is *derived* by replaying the action log; periodic snapshots are a perf optimization, not the source of truth.
-- **Action log granularity:** fine-grained. Every token reveal, skill-test modifier, commit is its own event. Per-player UI-only actions (browsing hand, hovering cards) do NOT go in the global log.
-- **Two log streams:**
-  - **Action log** (in DB) — the gameplay event sequence per scenario, load-bearing for resume / undo / replay / debug.
-  - **Operational logs** (`tracing` crate) — server-application logs (connections, errors, timing). Different purposes; different homes.
-- **Hosting (v1):** smallest thing that works — single small VM ($5–10/mo) or self-host on home hardware. No k8s, no autoscaling, no CDN. A single Dockerfile is cheap insurance for portability but not required for v1.
-- **Production form:** the server binary serves the API/websocket and the static WASM bundle on one port. (Two ports only in dev.)
+- **Server-authoritative event streaming.** Clients send `PlayerAction`s; the server validates via `apply()`, appends to the log, broadcasts events. Client views are non-authoritative.
+- **Event-sourced persistence.** State is derived by replaying the action log; snapshots are perf-only.
+- **Two log streams:** action log (DB, load-bearing) vs operational logs (`tracing`).
+- **Single-port production binary** (API + WS + static WASM); two ports only in dev.
+
+Settled in the Phase 5 brainstorm (2026-06-07):
+
+- **Headless demonstration.** Phase 5 proves itself with Rust WS integration-test clients, not a browser. Keeps the Phase 5 / Phase 6 boundary clean.
+- **`sqlx` + SQLite**, async, with the built-in migration runner. No `spawn_blocking` offload.
+- **Flat action-log rows** `(game_id, seq, action_json)`; replay folds `apply()` over rows ordered by `seq`. No schema churn when `Action` changes.
+- **Seed-state blob, not setup-replay.** The `setup()` output is stored once as `games.seed_state`; replay = seed-state + folded actions. Decouples replay correctness from `setup()` determinism. (`GameState.rng` is already serialized; in-play randomness is recorded as explicit `EngineRecord` actions.)
+- **Anonymous hub, no enforcement.** Any connected client may submit; the server applies + broadcasts to the game's connections. Identity/seats/turn-ownership are Phase 8.
+- **Single-port static WASM serving lands in Phase 6**, not Phase 5 — the WASM bundle doesn't exist until then. Phase 5 ships the API/WS server only. (Corrects the original browser-first "done" wording below.)
+- **Snapshots deferred** to #174; build only when replay is measurably slow.
 
 ## Open questions
 
-⏳ **Scoping TBD.** Issues for this phase haven't been filed. When Phase 4 closes, file:
-
-- **Database schema and migration tooling.** SQLite, likely with `sqlx` or `rusqlite`. Migration strategy.
-- **Event-log schema.** One table per scenario with `(scenario_id, sequence_number, action_json)` rows? Or normalized? Tradeoff between query convenience and replay simplicity (a flat blob is simpler).
-- **Periodic state snapshots** for resume performance. Every N actions? Every X minutes?
-- **Websocket session model.** One websocket per player per scenario? Reconnect-with-resume-token?
-- **Action validation flow.** `PlayerAction` parsing at the wire boundary, then `apply()`, then broadcast. Error paths for rejected actions.
-- **`game-core` ↔ server boundary.** `game-core` stays pure (no I/O); the server is the host that loads/saves state and applies actions. Define the trait or function surface server uses.
-- **Mid-scenario resume mechanics.** A scenario abandoned in progress reloads from log → state, players reconnect, engine continues.
+None blocking. Remaining choices are issue-local implementation detail (e.g. `GameId` representation, exact WS frame encoding) and will be settled in their respective PRs.
 
 ## Dependencies
 
-- Phase 4 (scenario plumbing) — server needs a complete-enough engine to actually persist meaningful state.
-- Phase 0 server hello-world (already shipped) gives us Axum + Tokio scaffolding to grow into.
+- Phase 4 (scenario plumbing) — closed; provides a complete-enough engine to persist meaningful state.
+- Phase 0 server hello-world (already shipped) — Axum + Tokio scaffolding to grow into.
 
 ## What "done" looks like
 
-- Two browsers can connect to a running server, both see the same scenario state.
-- Closing both browsers, restarting the server, and reconnecting reproduces the exact state via action-log replay.
-- Reconnecting a single browser mid-scenario picks up where it left off without losing in-flight choices.
+- Two Rust WS clients connect to one running game and receive identical event streams.
+- Closing both clients, restarting the server, and reconnecting reproduces the exact state via action-log replay.
+- A single client reconnecting mid-scenario receives the in-flight `AwaitingInput` and can resolve it.

--- a/docs/superpowers/specs/2026-06-07-phase-5-server-and-persistence-design.md
+++ b/docs/superpowers/specs/2026-06-07-phase-5-server-and-persistence-design.md
@@ -1,0 +1,199 @@
+# Phase 5 — Server + persistence: design spec
+
+**Date:** 2026-06-07
+**Status:** Approved design, pre-implementation
+**Milestone:** `phase-5-server-and-persistence`
+
+## Goal
+
+Run the pure `game-core` engine behind an Axum server with a SQLite,
+event-sourced action log, such that game state survives a server
+restart and clients can reconnect mid-scenario without losing in-flight
+choices.
+
+Phase 5 is **headless**: it ships the server, wire protocol, and
+persistence, exercised by Rust WebSocket integration-test clients. The
+real browser client is Phase 6; auth and per-seat turn enforcement are
+Phase 8.
+
+## Locked decisions (from the 2026-05-01/02 strategy phase)
+
+- Server-authoritative event streaming. Clients send `PlayerAction`s;
+  the server validates via `apply()`, appends to the log, and broadcasts
+  events. Client views are non-authoritative, render-only.
+- Event-sourced persistence: state is *derived* by replaying the action
+  log. Snapshots are a perf optimization, not the source of truth.
+- Fine-grained action log; UI-only actions (hovering, browsing hand) do
+  not enter the global log.
+- Two log streams: the action log (DB, load-bearing) vs operational logs
+  (`tracing` crate, server-application diagnostics).
+- Single-port production binary (API + WS + static WASM); two ports only
+  in dev.
+
+## Decisions settled in this brainstorm
+
+1. **Demonstration is headless.** Phase 5 proves itself with Rust WS
+   integration-test clients, not a browser. "Two browsers see the same
+   state" becomes "two WS clients receive identical event streams." Keeps
+   the Phase 5 / Phase 6 boundary clean.
+2. **Persistence library: `sqlx`** with SQLite. Async, integrates with
+   tokio/axum, built-in migration runner. No `spawn_blocking` offload.
+3. **Action log storage: flat blob rows** — `(game_id, seq, action_json)`.
+   Replay folds `apply()` over the rows ordered by `seq`. Matches the
+   engine's existing flat `Vec<Action>` model; no schema churn when the
+   `Action` enum changes.
+4. **Seeding: store the `setup()` output as a seed-state blob** in the
+   `games` row, rather than re-deriving from `scenario_id` at replay.
+   This is a *correctness* seed, not a perf snapshot. It decouples replay
+   from `setup()` ever needing to be deterministic or seed-parameterized.
+   `GameState.rng` (`RngState = (seed, draws)`) is already part of the
+   serialized state, and in-play randomness is recorded as explicit
+   `EngineRecord` actions, so seed-state + folded actions reproduce state
+   bit-for-bit.
+5. **Snapshots deferred.** Replaying a single scenario's log is trivially
+   fast at this scale. Filed as a p2-later perf issue; built only when
+   profiling demands it.
+6. **Anonymous hub, no enforcement.** Any connected client of a game may
+   submit actions; the server applies and broadcasts to all of the game's
+   connections. No identity, no seat/turn ownership. Auth and per-seat
+   enforcement are explicitly Phase 8.
+7. **Single-port static WASM serving deferred to Phase 6.** The strategy
+   decision stands, but the WASM bundle does not exist until Phase 6, so
+   the `ServeDir` + fallback wiring lands there. Phase 5 ships the API/WS
+   server only. (This is a correction to the Phase 5 phase-doc's "done"
+   wording, which was written browser-first.)
+
+## Architecture
+
+### Crate boundary — `game-core` stays pure, the server owns all I/O
+
+`game-core` continues to expose only the pure entry point
+`apply(state: GameState, action: Action) -> ApplyResult`. All I/O —
+database, websockets, connection state — lives in the `server` crate.
+
+A new `GameSession` type **in the `server` crate** is the host wrapper:
+
+```text
+GameSession {
+    game_id: GameId,
+    state:   GameState,        // current derived state
+    outcome: EngineOutcome,    // Done | AwaitingInput | (last) Rejected
+}
+```
+
+- `create(scenario_id)` → invokes the scenario registry's `setup()`,
+  persists the seed state, returns a fresh session.
+- `apply(PlayerAction)` → folds through `game_core::apply`, persists the
+  action on acceptance, returns `(events, outcome)`. On `Rejected`,
+  nothing is persisted (the engine guarantees state is unchanged).
+- `load(game_id)` → rehydrate by replay: read seed state + actions,
+  fold.
+
+`cards::REGISTRY` and `scenarios::REGISTRY` are installed once in
+`main()` at startup via the existing `install` functions.
+
+### Persistence — `sqlx` + SQLite, two tables
+
+```sql
+-- migrations/0001_init.sql
+CREATE TABLE games (
+    game_id      TEXT PRIMARY KEY,
+    scenario_id  TEXT NOT NULL,
+    seed_state   TEXT NOT NULL,   -- serde_json of the setup() GameState
+    created_at   TEXT NOT NULL
+);
+
+CREATE TABLE actions (
+    game_id  TEXT NOT NULL REFERENCES games(game_id),
+    seq      INTEGER NOT NULL,
+    action   TEXT NOT NULL,       -- serde_json of Action
+    PRIMARY KEY (game_id, seq)
+);
+```
+
+**Replay:** deserialize `games.seed_state` into a `GameState`, then fold
+`apply()` over `actions` ordered by `seq`. The result equals the live
+state bit-for-bit.
+
+**Write path:** an accepted `apply` appends one `actions` row at the next
+`seq`. The append and any session-cache update must agree on `seq`;
+`seq` is owned by the persistence layer (max existing `seq` + 1 per
+game).
+
+### Wire protocol (WebSocket, JSON)
+
+Client → Server:
+
+- `Submit(PlayerAction)` — includes `ResolveInput` for in-flight choices.
+
+Game creation/join is an HTTP path (below), not a WS message.
+
+Server → Client:
+
+- `Hello { state: GameState, outcome: EngineOutcome }` — sent on
+  connect/reconnect. The full render baseline, including any
+  `AwaitingInput`.
+- `Applied { events: Vec<Event>, outcome: EngineOutcome }` — broadcast to
+  every connection of the game after each accepted action.
+- `Rejected { reason }` — sent **only to the submitting client**.
+
+### Lifecycle + connection hub
+
+- `POST /games { scenario_id }` → runs `setup()`, writes the `games` row,
+  returns `game_id`.
+- `GET /games/:id/ws` → upgrades to a websocket, joins the game's
+  broadcast group (a tokio `broadcast` channel), receives `Hello`, then
+  streams `Applied` frames.
+- The server holds live `GameSession`s in an in-memory map keyed by
+  `game_id`. On a cache miss (e.g. after a restart, or first access to an
+  older game), it lazily `load`s the session by replay from the DB.
+
+### Error / rejection paths
+
+- A `PlayerAction` that the engine rejects produces `Rejected { reason }`
+  to the sender only; no DB write, no broadcast.
+- Malformed wire frames (undeserializable) are answered with a protocol
+  error to the sender; the connection stays open.
+- While a session is `AwaitingInput`, any non-`ResolveInput` `Submit`
+  rejects (the engine already enforces this); the server surfaces the
+  rejection to the sender.
+
+## Issues + ordering (Shape B)
+
+Filed against the `phase-5-server-and-persistence` milestone, plus one
+kickoff tracking issue for this design PR.
+
+| Order | Issue | Category | Summary |
+|---|---|---|---|
+| — | Phase 5 kickoff: design spec + issue breakdown | infra | Tracks this docs PR (spec + initial phase-doc update). |
+| P5.1 | sqlx + SQLite wiring | infra | Workspace deps, `SqlitePool`, migration harness, `0001_init.sql` (games + actions), startup smoke test. |
+| P5.2 | `GameSession` + store | engine/server | create-from-setup, apply-and-persist, load-by-replay; tested against in-memory SQLite. |
+| P5.3 | Axum WS endpoint + broadcast hub | server | `Hello` / `Applied` / `Rejected` protocol, per-game broadcast group, connection map. |
+| P5.4 | Game lifecycle HTTP | server | `POST /games`, lazy session rehydrate on cache miss. |
+| P5.5 | Reconnect + restart resume | server | Mid-scenario reconnect delivers current state incl. `AwaitingInput`; server restart rebuilds via replay. |
+| P5.6 | Closing demo (test) | test | Two Rust WS clients on one game receive identical event streams; restart + reconnect reproduces state; mid-scenario reconnect delivers the in-flight choice. |
+
+**Dependency order:** P5.1 → P5.2 → P5.3 → P5.4 → P5.5 → P5.6.
+
+### Out of scope / deferred
+
+- **Snapshots** for replay perf → p2-later issue (filed, not built).
+- **Single-port static WASM serving** (`ServeDir` + fallback) → Phase 6,
+  when the bundle exists.
+- **Auth / seat ownership / turn enforcement** → Phase 8.
+
+## What "done" looks like (headless)
+
+- Two Rust WS clients connect to one running game and receive identical
+  event streams.
+- Closing both clients, restarting the server, and reconnecting
+  reproduces the exact state via action-log replay.
+- A single client reconnecting mid-scenario receives the in-flight
+  `AwaitingInput` and can resolve it.
+
+## Dependencies
+
+- Phase 4 (scenario plumbing) — closed; provides a complete-enough engine
+  to persist meaningful state.
+- Phase 0 server hello-world — provides the Axum + Tokio scaffolding to
+  grow into.


### PR DESCRIPTION
## Summary

Kicks off Phase 5 (server + persistence). Adds the brainstormed design spec and opens the phase: files the implementation issues, flips the phase doc to in-progress, and records the settled decisions and ordering. No engine/server code — design + docs only.

## What changed

- **New design spec** `docs/superpowers/specs/2026-06-07-phase-5-server-and-persistence-design.md` — the full Phase 5 design and rationale.
- **Phase doc** `docs/phases/phase-5-server-and-persistence.md` — status → 🟡, Issues table (#168–#173), Shape-B ordering, Decisions, deferred #174.
- **README index** — Phase 5 row → in-progress; #174 added to cross-cutting work.

## Design decisions (why)

- **Headless this phase.** Phase 5's original 'done' was browser-worded, but the web client is Phase 6 and multiplayer/auth is Phase 8. Phase 5 proves itself with Rust WS integration-test clients, keeping the 5/6 seam clean.
- **`sqlx` + SQLite, flat action-log rows** `(game_id, seq, action_json)` — replay folds `apply()` over ordered rows; no schema churn when `Action` changes.
- **Seed-state blob, not setup-replay** — the `setup()` output is stored once in `games.seed_state`; replay = seed-state + folded actions. Decouples replay correctness from `setup()` determinism (`GameState.rng` is serialized; in-play randomness is already recorded as `EngineRecord` actions).
- **Anonymous hub, no enforcement** — identity/seats/turn-ownership deferred to Phase 8.
- **Single-port static WASM serving deferred to Phase 6** (bundle doesn't exist yet); **snapshots deferred** to #174.

## Test notes

Docs-only PR; no code paths touched. CI `fmt`/`clippy`/`test`/`doc`/`wasm-build` should be unaffected.

## Linked issues

Closes #167.