### PR TITLE
infra: Axum websocket endpoint + per-game broadcast hub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -138,8 +139,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -431,6 +434,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +723,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
@@ -721,7 +742,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -1402,7 +1423,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1690,6 +1711,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1706,6 +1733,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,6 +1750,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1732,6 +1779,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2034,12 +2090,15 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "cards",
+ "futures-util",
  "game-core",
  "scenarios",
+ "serde",
  "serde_json",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "tower",
  "tracing",
  "tracing-subscriber",
@@ -2317,7 +2376,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -2355,7 +2414,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -2607,6 +2666,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2728,6 +2811,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "typed-builder"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2803,6 +2920,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8-width"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -14,13 +14,16 @@ workspace = true
 game-core = { path = "../game-core" }
 cards = { path = "../cards" }
 scenarios = { path = "../scenarios" }
-axum = "0.8"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+axum = { version = "0.8", features = ["ws"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+futures-util = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "migrate"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
+tokio-tungstenite = "0.24"

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -8,6 +8,8 @@
 pub mod db;
 pub mod session;
 mod store;
+pub mod wire;
+mod ws;
 
 pub use session::{GameSession, SessionError};
 
@@ -22,6 +24,20 @@ use sqlx::SqlitePool;
 pub struct AppState {
     /// Connection pool for the `SQLite` action-log database.
     pub db: SqlitePool,
+    /// Live games keyed by `game_id`, each with its broadcast group.
+    rooms: ws::Rooms,
+}
+
+impl AppState {
+    /// Build application state over a database pool, with an empty live
+    /// rooms map.
+    #[must_use]
+    pub fn new(db: SqlitePool) -> Self {
+        Self {
+            db,
+            rooms: ws::rooms(),
+        }
+    }
 }
 
 /// Build the application router with all routes and shared state.
@@ -29,6 +45,7 @@ pub fn app(state: AppState) -> Router {
     Router::new()
         .route("/", get(index))
         .route("/health", get(health))
+        .route("/games/{game_id}/ws", get(ws::game_ws))
         .with_state(state)
 }
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -23,6 +23,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let listener = tokio::net::TcpListener::bind(addr).await?;
     tracing::info!("eldritch server listening on http://{addr}");
 
-    axum::serve(listener, app(AppState { db: pool })).await?;
+    axum::serve(listener, app(AppState::new(pool))).await?;
     Ok(())
 }

--- a/crates/server/src/wire.rs
+++ b/crates/server/src/wire.rs
@@ -1,0 +1,55 @@
+//! Websocket wire protocol: the JSON messages exchanged between a
+//! client and the server. The server is authoritative; clients submit
+//! [`PlayerAction`]s and render the event stream the server broadcasts.
+
+use game_core::state::GameState;
+use game_core::{EngineOutcome, Event, PlayerAction};
+use serde::{Deserialize, Serialize};
+
+/// A message sent from a client to the server.
+///
+/// Externally tagged (`{"submit": {...}}`) rather than internally
+/// tagged: the `Hello` baseline carries a [`GameState`] whose
+/// integer-keyed maps round-trip through `serde_json` only when the
+/// value is deserialized directly, not buffered through an
+/// internally-tagged `Content`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClientMessage {
+    /// Submit a player action for validation and application.
+    Submit {
+        /// The action to apply.
+        action: PlayerAction,
+    },
+}
+
+/// A message sent from the server to a client. Externally tagged for
+/// the same reason as [`ClientMessage`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServerMessage {
+    /// The full render baseline, sent on connect/reconnect. Carries the
+    /// current state and the outcome of the most recent apply (including
+    /// any pending [`AwaitingInput`](EngineOutcome::AwaitingInput)).
+    Hello {
+        /// Current derived game state. Boxed to keep the enum (and the
+        /// per-game broadcast ring buffer) small — `GameState` dwarfs
+        /// the other variants.
+        state: Box<GameState>,
+        /// Outcome of the most recent apply.
+        outcome: EngineOutcome,
+    },
+    /// Broadcast to every connection of a game after an accepted action.
+    Applied {
+        /// Events emitted by the action's resolution.
+        events: Vec<Event>,
+        /// Outcome of the apply.
+        outcome: EngineOutcome,
+    },
+    /// Sent only to the submitting client when its action is refused
+    /// (engine rejection, a malformed frame, or a persistence error).
+    Rejected {
+        /// Human-readable reason.
+        reason: String,
+    },
+}

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -1,0 +1,167 @@
+//! Websocket hub: one broadcast group per game, fanning accepted-action
+//! events out to every connection while serializing applies through a
+//! per-game [`GameSession`] mutex.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{Path, State};
+use axum::response::Response;
+use futures_util::stream::SplitSink;
+use futures_util::{SinkExt, StreamExt};
+use game_core::EngineOutcome;
+use tokio::sync::{broadcast, Mutex};
+
+use crate::session::GameSession;
+use crate::wire::{ClientMessage, ServerMessage};
+use crate::AppState;
+
+/// Per-game broadcast buffer depth. Generous for the low message rate
+/// of a single scenario; a slow client that overruns it gets a
+/// `Lagged` and resyncs from subsequent frames rather than blocking
+/// the game.
+const BROADCAST_CAPACITY: usize = 256;
+
+/// A live game: its session (behind a mutex so applies serialize across
+/// connections) and the broadcast channel its connections subscribe to.
+pub(crate) struct GameRoom {
+    session: Mutex<GameSession>,
+    tx: broadcast::Sender<ServerMessage>,
+}
+
+/// The server's map of live games, keyed by `game_id`.
+pub(crate) type Rooms = Arc<Mutex<HashMap<String, Arc<GameRoom>>>>;
+
+/// Build an empty rooms map for [`AppState`].
+pub(crate) fn rooms() -> Rooms {
+    Arc::new(Mutex::new(HashMap::new()))
+}
+
+/// Get the room for `game_id`, lazily loading it from the action log on
+/// a cache miss (e.g. first access, or after a server restart). Returns
+/// `None` if no such game exists.
+async fn get_or_load_room(state: &AppState, game_id: &str) -> Option<Arc<GameRoom>> {
+    let mut rooms = state.rooms.lock().await;
+    if let Some(room) = rooms.get(game_id) {
+        return Some(room.clone());
+    }
+    let session = GameSession::load(state.db.clone(), game_id).await.ok()??;
+    let (tx, _rx) = broadcast::channel(BROADCAST_CAPACITY);
+    let room = Arc::new(GameRoom {
+        session: Mutex::new(session),
+        tx,
+    });
+    rooms.insert(game_id.to_string(), room.clone());
+    Some(room)
+}
+
+/// Axum handler: upgrade a `GET /games/{game_id}/ws` request to a
+/// websocket attached to that game's broadcast group.
+pub(crate) async fn game_ws(
+    State(state): State<AppState>,
+    Path(game_id): Path<String>,
+    ws: WebSocketUpgrade,
+) -> Response {
+    ws.on_upgrade(move |socket| handle_socket(socket, state, game_id))
+}
+
+async fn handle_socket(socket: WebSocket, state: AppState, game_id: String) {
+    let Some(room) = get_or_load_room(&state, &game_id).await else {
+        // No such game — nothing to attach to. Drop the socket.
+        return;
+    };
+    let mut rx = room.tx.subscribe();
+    let (mut sink, mut stream) = socket.split();
+
+    // Send the render baseline before streaming events.
+    let hello = {
+        let session = room.session.lock().await;
+        ServerMessage::Hello {
+            state: Box::new(session.state.clone()),
+            outcome: session.outcome.clone(),
+        }
+    };
+    if send_msg(&mut sink, &hello).await.is_err() {
+        return;
+    }
+
+    loop {
+        tokio::select! {
+            broadcasted = rx.recv() => match broadcasted {
+                Ok(msg) => {
+                    if send_msg(&mut sink, &msg).await.is_err() {
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => {}
+                Err(broadcast::error::RecvError::Closed) => break,
+            },
+            incoming = stream.next() => {
+                let Some(Ok(message)) = incoming else { break };
+                if let Some(direct) = handle_client_message(&room, message).await {
+                    let close = matches!(direct, Disposition::Close);
+                    if let Disposition::Reply(msg) = direct {
+                        if send_msg(&mut sink, &msg).await.is_err() {
+                            break;
+                        }
+                    }
+                    if close {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// What to do with `sink` after handling one inbound frame.
+enum Disposition {
+    /// Send this message directly to the submitting client only.
+    Reply(ServerMessage),
+    /// Close the connection.
+    Close,
+}
+
+/// Apply one inbound frame. Accepted actions broadcast `Applied` to the
+/// whole room (returning `None` here — the sender receives it via its
+/// own subscription); rejections and malformed frames reply to the
+/// sender only.
+async fn handle_client_message(room: &GameRoom, message: Message) -> Option<Disposition> {
+    match message {
+        Message::Text(text) => match serde_json::from_str::<ClientMessage>(text.as_str()) {
+            Ok(ClientMessage::Submit { action }) => {
+                let mut session = room.session.lock().await;
+                match session.apply(action).await {
+                    Ok((events, EngineOutcome::Rejected { reason })) => {
+                        debug_assert!(events.is_empty());
+                        Some(Disposition::Reply(ServerMessage::Rejected {
+                            reason: reason.into_owned(),
+                        }))
+                    }
+                    Ok((events, outcome)) => {
+                        let _ = room.tx.send(ServerMessage::Applied { events, outcome });
+                        None
+                    }
+                    Err(e) => Some(Disposition::Reply(ServerMessage::Rejected {
+                        reason: e.to_string(),
+                    })),
+                }
+            }
+            Err(_) => Some(Disposition::Reply(ServerMessage::Rejected {
+                reason: "malformed message".to_string(),
+            })),
+        },
+        Message::Close(_) => Some(Disposition::Close),
+        // Ping/Pong/Binary are not part of the protocol; ignore them.
+        _ => None,
+    }
+}
+
+async fn send_msg(
+    sink: &mut SplitSink<WebSocket, Message>,
+    msg: &ServerMessage,
+) -> Result<(), axum::Error> {
+    let json = serde_json::to_string(msg).expect("ServerMessage always serializes");
+    sink.send(Message::Text(json.into())).await
+}

--- a/crates/server/tests/common/mod.rs
+++ b/crates/server/tests/common/mod.rs
@@ -1,0 +1,97 @@
+//! Shared helpers for server integration tests: a mock scenario
+//! registry, an in-memory pool, a spawned server, and a websocket
+//! client. Not every test binary uses every helper.
+#![allow(dead_code)]
+
+use std::net::SocketAddr;
+
+use futures_util::{SinkExt, StreamExt};
+use game_core::scenario::{ScenarioId, ScenarioModule, ScenarioRegistry};
+use game_core::state::{GameState, InvestigatorId};
+use game_core::test_support::builder::TestGame;
+use game_core::test_support::fixtures::test_investigator;
+use game_core::{Event, Resolution};
+use server::wire::{ClientMessage, ServerMessage};
+use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::SqlitePool;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+
+pub const TEST_SCENARIO_ID: &str = "test-scenario";
+
+fn test_setup() -> GameState {
+    TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_turn_order([InvestigatorId(1)])
+        .with_scenario_id(ScenarioId::new(TEST_SCENARIO_ID))
+        .with_rng_seed(42)
+        .build()
+}
+
+fn noop_resolution(_: &Resolution, _: &mut GameState, _: &mut Vec<Event>) {}
+
+static TEST_MODULE: ScenarioModule = ScenarioModule {
+    setup: test_setup,
+    apply_resolution: noop_resolution,
+};
+
+fn module_for(id: &ScenarioId) -> Option<&'static ScenarioModule> {
+    (id.as_str() == TEST_SCENARIO_ID).then_some(&TEST_MODULE)
+}
+
+/// Install the mock scenario registry (idempotent within a process).
+pub fn install_registry() {
+    let _ = game_core::scenario_registry::install(ScenarioRegistry { module_for });
+}
+
+/// A migrated single-connection in-memory pool.
+pub async fn memory_pool() -> SqlitePool {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("open in-memory sqlite");
+    server::db::MIGRATOR.run(&pool).await.expect("migrate");
+    pool
+}
+
+/// Spawn the server on an ephemeral port; return its bound address.
+pub async fn spawn_server(pool: SqlitePool) -> SocketAddr {
+    let app = server::app(server::AppState::new(pool));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve");
+    });
+    addr
+}
+
+pub type Client = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+
+/// Open a websocket to a game.
+pub async fn connect(addr: SocketAddr, game_id: &str) -> Client {
+    let url = format!("ws://{addr}/games/{game_id}/ws");
+    let (ws, _response) = connect_async(url).await.expect("ws connect");
+    ws
+}
+
+/// Send a client message as JSON text.
+pub async fn send(ws: &mut Client, msg: &ClientMessage) {
+    let json = serde_json::to_string(msg).expect("serialize ClientMessage");
+    ws.send(Message::Text(json)).await.expect("ws send");
+}
+
+/// Receive the next [`ServerMessage`], skipping ping/pong frames.
+pub async fn recv(ws: &mut Client) -> ServerMessage {
+    loop {
+        match ws.next().await.expect("stream open").expect("no ws error") {
+            Message::Text(text) => {
+                return serde_json::from_str(&text).expect("valid ServerMessage");
+            }
+            Message::Close(_) => panic!("server closed the connection unexpectedly"),
+            _ => {}
+        }
+    }
+}

--- a/crates/server/tests/health.rs
+++ b/crates/server/tests/health.rs
@@ -18,7 +18,7 @@ async fn health_returns_ok_when_database_reachable() {
         .await
         .expect("run migrations");
 
-    let app = server::app(server::AppState { db: pool });
+    let app = server::app(server::AppState::new(pool));
 
     let response = app
         .oneshot(

--- a/crates/server/tests/ws.rs
+++ b/crates/server/tests/ws.rs
@@ -1,0 +1,103 @@
+//! Websocket hub: connect → `Hello`, accepted submits broadcast
+//! `Applied` to every connection, rejected submits return `Rejected`
+//! to the sender only.
+
+mod common;
+
+use common::{connect, install_registry, memory_pool, recv, send, spawn_server, TEST_SCENARIO_ID};
+use game_core::scenario::ScenarioId;
+use game_core::{EngineOutcome, PlayerAction};
+use server::wire::{ClientMessage, ServerMessage};
+
+async fn seed_game(pool: &sqlx::SqlitePool, game_id: &str) {
+    server::GameSession::create(pool.clone(), game_id, ScenarioId::new(TEST_SCENARIO_ID))
+        .await
+        .expect("seed game");
+}
+
+#[tokio::test]
+async fn connect_receives_hello_with_current_state() {
+    install_registry();
+    let pool = memory_pool().await;
+    seed_game(&pool, "g-hello").await;
+    let addr = spawn_server(pool).await;
+
+    let mut ws = connect(addr, "g-hello").await;
+
+    match recv(&mut ws).await {
+        ServerMessage::Hello { state, outcome } => {
+            assert_eq!(state.round, 0);
+            assert!(matches!(outcome, EngineOutcome::Done));
+        }
+        other => panic!("expected Hello, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn accepted_action_broadcasts_applied_to_all_clients() {
+    install_registry();
+    let pool = memory_pool().await;
+    seed_game(&pool, "g-bcast").await;
+    let addr = spawn_server(pool).await;
+
+    let mut a = connect(addr, "g-bcast").await;
+    let mut b = connect(addr, "g-bcast").await;
+    // Draining each Hello guarantees both connections have subscribed
+    // before the submit, so neither misses the broadcast.
+    let _ = recv(&mut a).await;
+    let _ = recv(&mut b).await;
+
+    send(
+        &mut a,
+        &ClientMessage::Submit {
+            action: PlayerAction::StartScenario,
+        },
+    )
+    .await;
+
+    for ws in [&mut a, &mut b] {
+        match recv(ws).await {
+            ServerMessage::Applied { events, outcome } => {
+                assert!(!matches!(outcome, EngineOutcome::Rejected { .. }));
+                assert!(!events.is_empty(), "StartScenario emits events");
+            }
+            other => panic!("expected Applied, got {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn rejected_action_returns_rejected_to_sender_only() {
+    install_registry();
+    let pool = memory_pool().await;
+    seed_game(&pool, "g-reject").await;
+    let addr = spawn_server(pool).await;
+
+    let mut a = connect(addr, "g-reject").await;
+    let mut b = connect(addr, "g-reject").await;
+    let _ = recv(&mut a).await;
+    let _ = recv(&mut b).await;
+
+    // EndTurn is invalid from the round-0 Mythos setup state.
+    send(
+        &mut a,
+        &ClientMessage::Submit {
+            action: PlayerAction::EndTurn,
+        },
+    )
+    .await;
+
+    match recv(&mut a).await {
+        ServerMessage::Rejected { reason } => {
+            assert!(reason.contains("Investigation"), "reason was: {reason}");
+        }
+        other => panic!("expected Rejected, got {other:?}"),
+    }
+
+    // B sees nothing: rejections are not broadcast.
+    let quiet = tokio::time::timeout(std::time::Duration::from_millis(200), recv(&mut b)).await;
+    assert!(
+        quiet.is_err(),
+        "B must receive nothing for a rejected action"
+    );
+}

--- a/docs/phases/phase-5-server-and-persistence.md
+++ b/docs/phases/phase-5-server-and-persistence.md
@@ -19,7 +19,7 @@ client is Phase 6; auth + per-seat enforcement are Phase 8.
 | — | [#167](https://github.com/talelburg/eldritch/issues/167) — kickoff: design spec + issue breakdown | 🟡 open (this docs PR) |
 | P5.1 | [#168](https://github.com/talelburg/eldritch/issues/168) — sqlx + SQLite wiring: pool, migrations, action-log schema | 🟢 [PR #176](https://github.com/talelburg/eldritch/pull/176) |
 | P5.2 | [#169](https://github.com/talelburg/eldritch/issues/169) — GameSession host: create / apply-and-persist / load-by-replay | 🟢 [PR #177](https://github.com/talelburg/eldritch/pull/177) |
-| P5.3 | [#170](https://github.com/talelburg/eldritch/issues/170) — Axum WS endpoint + per-game broadcast hub | ⏳ open |
+| P5.3 | [#170](https://github.com/talelburg/eldritch/issues/170) — Axum WS endpoint + per-game broadcast hub | 🟢 [PR #178](https://github.com/talelburg/eldritch/pull/178) |
 | P5.4 | [#171](https://github.com/talelburg/eldritch/issues/171) — Game lifecycle HTTP: POST /games + lazy rehydrate | ⏳ open |
 | P5.5 | [#172](https://github.com/talelburg/eldritch/issues/172) — Reconnect + restart resume: deliver in-flight AwaitingInput | ⏳ open |
 | P5.6 | [#173](https://github.com/talelburg/eldritch/issues/173) — closing demo: two WS clients, restart+reconnect replay | ⏳ open |


### PR DESCRIPTION
## Summary

P5.3 — the server-authoritative websocket hub. Each game gets a broadcast group; clients submit `PlayerAction`s and the server validates, applies, persists, and fans the resulting events out to every connection. Lazily loads a game from the action log on first connect (also covers post-restart rehydrate).

## What changed

- **`wire.rs`** — `ClientMessage::Submit { action }` and `ServerMessage::{Hello, Applied, Rejected}`.
- **`ws.rs`** — `GameRoom` per game: a `Mutex<GameSession>` serializing applies + a `broadcast::Sender`. `GET /games/{game_id}/ws` upgrades, sends `Hello` (current state + outcome), then a `select!` loop fans broadcast `Applied` frames out and applies inbound submits.
- **`AppState`** gains a live-rooms map; construct via `AppState::new(db)` (main + health test updated).

## Design decisions

- **Externally tagged wire enums, not internally tagged.** `Hello` carries a `GameState` whose integer-keyed maps only round-trip through `serde_json` when deserialized directly; an internally-tagged `#[serde(tag="type")]` buffers into a `Content` that stringifies those keys and then fails to parse them back (`invalid type: string "1", expected u32`). Caught by the connect test.
- **Accepted → broadcast to all; rejected/malformed → reply to sender only.** The submitting client receives its own `Applied` via its subscription, so everyone sees one consistent event stream; rejections never broadcast.
- **`Hello.state` is boxed** — keeps `ServerMessage` (and the per-game broadcast ring buffer) small instead of sized to a full `GameState`.
- **Per-game `Mutex<GameSession>`** serializes concurrent applies; lazy room load on cache miss is the hook P5.4/P5.5 build on for `POST /games` and restart-resume.

## Test notes

Real end-to-end: a server spawned on an ephemeral port + `tokio-tungstenite` clients (shared harness in `tests/common`):
- connect → `Hello` with current state;
- accepted submit → `Applied` to **all** connected clients;
- rejected submit → `Rejected` to the sender only, nothing to others.

Full local gauntlet green: `fmt`, `clippy -D warnings`, `test --all`, `doc -D warnings`, `wasm-build`.

## Linked issues

Closes #170.