### PR TITLE
infra: POST /games lifecycle + GameId newtype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,6 +2102,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -23,6 +23,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "migrate"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/server/src/id.rs
+++ b/crates/server/src/id.rs
@@ -1,0 +1,70 @@
+//! `GameId`: the server-side identifier for a persisted game session.
+
+use serde::{Deserialize, Serialize};
+
+/// Stable identifier for a persisted game — it names a row in the
+/// `games` table. A server/persistence concept, distinct from
+/// game-core's domain ids (`ScenarioId`, `InvestigatorId`, …), so it
+/// lives in the host crate rather than the kernel.
+///
+/// Transparent over [`String`]: it serializes as a bare JSON string,
+/// binds directly to a `SQLite` TEXT column, and extracts straight from
+/// a URL path segment.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct GameId(String);
+
+impl GameId {
+    /// Wrap an existing id string.
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    /// Generate a fresh random id (UUID v4).
+    #[must_use]
+    pub fn random() -> Self {
+        Self(uuid::Uuid::new_v4().to_string())
+    }
+
+    /// Borrow the underlying string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for GameId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for GameId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl From<String> for GameId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GameId;
+
+    #[test]
+    fn random_ids_are_distinct() {
+        assert_ne!(GameId::random(), GameId::random());
+    }
+
+    #[test]
+    fn serializes_as_a_bare_string() {
+        let id = GameId::new("abc");
+        assert_eq!(serde_json::to_string(&id).unwrap(), "\"abc\"");
+        let back: GameId = serde_json::from_str("\"abc\"").unwrap();
+        assert_eq!(back, id);
+    }
+}

--- a/crates/server/src/id.rs
+++ b/crates/server/src/id.rs
@@ -33,21 +33,9 @@ impl GameId {
     }
 }
 
-impl std::fmt::Display for GameId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
 impl From<&str> for GameId {
     fn from(s: &str) -> Self {
         Self(s.to_string())
-    }
-}
-
-impl From<String> for GameId {
-    fn from(s: String) -> Self {
-        Self(s)
     }
 }
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -6,16 +6,19 @@
 //! it directly.
 
 pub mod db;
+mod id;
+pub mod lifecycle;
 pub mod session;
 mod store;
 pub mod wire;
 mod ws;
 
+pub use id::GameId;
 pub use session::{GameSession, SessionError};
 
 use axum::extract::State;
 use axum::http::StatusCode;
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::Router;
 use sqlx::SqlitePool;
 
@@ -45,6 +48,7 @@ pub fn app(state: AppState) -> Router {
     Router::new()
         .route("/", get(index))
         .route("/health", get(health))
+        .route("/games", post(lifecycle::create_game))
         .route("/games/{game_id}/ws", get(ws::game_ws))
         .with_state(state)
 }

--- a/crates/server/src/lifecycle.rs
+++ b/crates/server/src/lifecycle.rs
@@ -1,0 +1,46 @@
+//! Game lifecycle HTTP: create a game.
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use game_core::scenario::ScenarioId;
+use serde::{Deserialize, Serialize};
+
+use crate::id::GameId;
+use crate::session::{GameSession, SessionError};
+use crate::AppState;
+
+/// Body of `POST /games`.
+#[derive(Debug, Deserialize)]
+pub struct CreateGameRequest {
+    /// The scenario module to set up.
+    pub scenario_id: String,
+}
+
+/// Response to a successful `POST /games`.
+#[derive(Debug, Serialize)]
+pub struct CreateGameResponse {
+    /// The newly created game's id.
+    pub game_id: GameId,
+}
+
+/// `POST /games`: set up a new game from a scenario and return its id.
+///
+/// `201 Created` with the `game_id` on success; `400 Bad Request` for an
+/// unknown scenario; `500` on a persistence failure.
+pub(crate) async fn create_game(
+    State(state): State<AppState>,
+    Json(request): Json<CreateGameRequest>,
+) -> Result<(StatusCode, Json<CreateGameResponse>), StatusCode> {
+    let scenario_id = ScenarioId::new(request.scenario_id);
+    match GameSession::create(state.db.clone(), GameId::random(), scenario_id).await {
+        Ok(session) => Ok((
+            StatusCode::CREATED,
+            Json(CreateGameResponse {
+                game_id: session.game_id,
+            }),
+        )),
+        Err(SessionError::UnknownScenario(_)) => Err(StatusCode::BAD_REQUEST),
+        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+    }
+}

--- a/crates/server/src/session.rs
+++ b/crates/server/src/session.rs
@@ -12,6 +12,7 @@ use game_core::state::GameState;
 use game_core::{Action, EngineOutcome, Event, PlayerAction};
 use sqlx::SqlitePool;
 
+use crate::id::GameId;
 use crate::store;
 
 /// Errors from [`GameSession`] persistence operations.
@@ -32,7 +33,7 @@ pub enum SessionError {
 /// A live game: derived state plus its connection to the action log.
 pub struct GameSession {
     /// Stable identifier for this game (primary key in `games`).
-    pub game_id: String,
+    pub game_id: GameId,
     /// Current derived state.
     pub state: GameState,
     /// Outcome of the most recent apply (`Done` for a freshly created
@@ -54,7 +55,7 @@ impl GameSession {
     /// [`SessionError::UnknownScenario`] if none is registered.
     pub async fn create(
         db: SqlitePool,
-        game_id: impl Into<String>,
+        game_id: impl Into<GameId>,
         scenario_id: ScenarioId,
     ) -> Result<Self, SessionError> {
         let module = game_core::scenario_registry::current()
@@ -67,7 +68,7 @@ impl GameSession {
         store::insert_game(
             &db,
             &game_id,
-            scenario_id.as_str(),
+            &scenario_id,
             &seed_state,
             &unix_millis_string(),
         )
@@ -108,7 +109,7 @@ impl GameSession {
 
     /// Reconstruct a session by replaying its action log over the seed
     /// state. Returns `None` if no game with `game_id` exists.
-    pub async fn load(db: SqlitePool, game_id: &str) -> Result<Option<Self>, SessionError> {
+    pub async fn load(db: SqlitePool, game_id: &GameId) -> Result<Option<Self>, SessionError> {
         let Some((_scenario_id, seed_state)) = store::load_game(&db, game_id).await? else {
             return Ok(None);
         };
@@ -125,7 +126,7 @@ impl GameSession {
         }
 
         Ok(Some(Self {
-            game_id: game_id.to_string(),
+            game_id: game_id.clone(),
             state,
             outcome,
             seq,

--- a/crates/server/src/store.rs
+++ b/crates/server/src/store.rs
@@ -2,21 +2,24 @@
 //! tables. JSON (de)serialization lives in [`crate::session`]; this
 //! layer only moves strings in and out of `SQLite`.
 
+use game_core::scenario::ScenarioId;
 use sqlx::SqlitePool;
+
+use crate::id::GameId;
 
 /// Insert a new game's seed row.
 pub(crate) async fn insert_game(
     db: &SqlitePool,
-    game_id: &str,
-    scenario_id: &str,
+    game_id: &GameId,
+    scenario_id: &ScenarioId,
     seed_state: &str,
     created_at: &str,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
         "INSERT INTO games (game_id, scenario_id, seed_state, created_at) VALUES (?, ?, ?, ?)",
     )
-    .bind(game_id)
-    .bind(scenario_id)
+    .bind(game_id.as_str())
+    .bind(scenario_id.as_str())
     .bind(seed_state)
     .bind(created_at)
     .execute(db)
@@ -27,12 +30,12 @@ pub(crate) async fn insert_game(
 /// Append one action row at `seq` for a game.
 pub(crate) async fn insert_action(
     db: &SqlitePool,
-    game_id: &str,
+    game_id: &GameId,
     seq: i64,
     action: &str,
 ) -> Result<(), sqlx::Error> {
     sqlx::query("INSERT INTO actions (game_id, seq, action) VALUES (?, ?, ?)")
-        .bind(game_id)
+        .bind(game_id.as_str())
         .bind(seq)
         .bind(action)
         .execute(db)
@@ -43,10 +46,10 @@ pub(crate) async fn insert_action(
 /// Fetch a game's `(scenario_id, seed_state)`, or `None` if no such game.
 pub(crate) async fn load_game(
     db: &SqlitePool,
-    game_id: &str,
+    game_id: &GameId,
 ) -> Result<Option<(String, String)>, sqlx::Error> {
     sqlx::query_as("SELECT scenario_id, seed_state FROM games WHERE game_id = ?")
-        .bind(game_id)
+        .bind(game_id.as_str())
         .fetch_optional(db)
         .await
 }
@@ -54,11 +57,11 @@ pub(crate) async fn load_game(
 /// Fetch a game's action JSON blobs in `seq` order.
 pub(crate) async fn load_actions(
     db: &SqlitePool,
-    game_id: &str,
+    game_id: &GameId,
 ) -> Result<Vec<String>, sqlx::Error> {
     let rows: Vec<(String,)> =
         sqlx::query_as("SELECT action FROM actions WHERE game_id = ? ORDER BY seq")
-            .bind(game_id)
+            .bind(game_id.as_str())
             .fetch_all(db)
             .await?;
     Ok(rows.into_iter().map(|(action,)| action).collect())

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -13,6 +13,7 @@ use futures_util::{SinkExt, StreamExt};
 use game_core::EngineOutcome;
 use tokio::sync::{broadcast, Mutex};
 
+use crate::id::GameId;
 use crate::session::GameSession;
 use crate::wire::{ClientMessage, ServerMessage};
 use crate::AppState;
@@ -30,8 +31,8 @@ pub(crate) struct GameRoom {
     tx: broadcast::Sender<ServerMessage>,
 }
 
-/// The server's map of live games, keyed by `game_id`.
-pub(crate) type Rooms = Arc<Mutex<HashMap<String, Arc<GameRoom>>>>;
+/// The server's map of live games, keyed by [`GameId`].
+pub(crate) type Rooms = Arc<Mutex<HashMap<GameId, Arc<GameRoom>>>>;
 
 /// Build an empty rooms map for [`AppState`].
 pub(crate) fn rooms() -> Rooms {
@@ -41,7 +42,7 @@ pub(crate) fn rooms() -> Rooms {
 /// Get the room for `game_id`, lazily loading it from the action log on
 /// a cache miss (e.g. first access, or after a server restart). Returns
 /// `None` if no such game exists.
-async fn get_or_load_room(state: &AppState, game_id: &str) -> Option<Arc<GameRoom>> {
+async fn get_or_load_room(state: &AppState, game_id: &GameId) -> Option<Arc<GameRoom>> {
     let mut rooms = state.rooms.lock().await;
     if let Some(room) = rooms.get(game_id) {
         return Some(room.clone());
@@ -52,7 +53,7 @@ async fn get_or_load_room(state: &AppState, game_id: &str) -> Option<Arc<GameRoo
         session: Mutex::new(session),
         tx,
     });
-    rooms.insert(game_id.to_string(), room.clone());
+    rooms.insert(game_id.clone(), room.clone());
     Some(room)
 }
 
@@ -60,13 +61,13 @@ async fn get_or_load_room(state: &AppState, game_id: &str) -> Option<Arc<GameRoo
 /// websocket attached to that game's broadcast group.
 pub(crate) async fn game_ws(
     State(state): State<AppState>,
-    Path(game_id): Path<String>,
+    Path(game_id): Path<GameId>,
     ws: WebSocketUpgrade,
 ) -> Response {
     ws.on_upgrade(move |socket| handle_socket(socket, state, game_id))
 }
 
-async fn handle_socket(socket: WebSocket, state: AppState, game_id: String) {
+async fn handle_socket(socket: WebSocket, state: AppState, game_id: GameId) {
     let Some(room) = get_or_load_room(&state, &game_id).await else {
         // No such game — nothing to attach to. Drop the socket.
         return;

--- a/crates/server/tests/game_session.rs
+++ b/crates/server/tests/game_session.rs
@@ -9,6 +9,7 @@ use game_core::test_support::builder::TestGame;
 use game_core::test_support::fixtures::test_investigator;
 use game_core::{EngineOutcome, Event, PlayerAction, Resolution};
 use server::session::GameSession;
+use server::GameId;
 use sqlx::sqlite::SqlitePoolOptions;
 use sqlx::SqlitePool;
 
@@ -61,7 +62,7 @@ async fn create_persists_seed_and_exposes_setup_state() {
 
     // The in-memory state equals the scenario's setup() output.
     assert_eq!(session.state, test_setup());
-    assert_eq!(session.game_id, "game-1");
+    assert_eq!(session.game_id.as_str(), "game-1");
 
     // A games row was persisted.
     let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM games WHERE game_id = ?")
@@ -142,7 +143,7 @@ async fn load_replays_log_to_reproduce_live_state() {
         .unwrap();
     session.apply(PlayerAction::StartScenario).await.unwrap();
 
-    let loaded = GameSession::load(pool.clone(), "g4")
+    let loaded = GameSession::load(pool.clone(), &GameId::new("g4"))
         .await
         .unwrap()
         .expect("game exists");
@@ -151,6 +152,6 @@ async fn load_replays_log_to_reproduce_live_state() {
     assert_eq!(loaded.game_id, session.game_id);
 
     // An unknown game id loads as None.
-    let missing = GameSession::load(pool, "nope").await.unwrap();
+    let missing = GameSession::load(pool, &GameId::new("nope")).await.unwrap();
     assert!(missing.is_none());
 }

--- a/crates/server/tests/lifecycle.rs
+++ b/crates/server/tests/lifecycle.rs
@@ -1,0 +1,61 @@
+//! Game lifecycle HTTP: `POST /games` creates a game and returns its id;
+//! the created game is persisted and loadable (proving the lazy-rehydrate
+//! path a later WS connect relies on).
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use common::{install_registry, memory_pool, TEST_SCENARIO_ID};
+use server::{GameId, GameSession};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn post_games_creates_game_and_returns_id() {
+    install_registry();
+    let pool = memory_pool().await;
+    let app = server::app(server::AppState::new(pool.clone()));
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/games")
+        .header("content-type", "application/json")
+        .body(Body::from(format!(
+            r#"{{"scenario_id":"{TEST_SCENARIO_ID}"}}"#
+        )))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let game_id = json["game_id"].as_str().expect("game_id is a string");
+
+    // The created game is persisted and loadable.
+    let loaded = GameSession::load(pool, &GameId::new(game_id))
+        .await
+        .unwrap();
+    assert!(
+        loaded.is_some(),
+        "POSTed game should be loadable from the log"
+    );
+}
+
+#[tokio::test]
+async fn post_games_unknown_scenario_is_bad_request() {
+    install_registry();
+    let pool = memory_pool().await;
+    let app = server::app(server::AppState::new(pool));
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/games")
+        .header("content-type", "application/json")
+        .body(Body::from(r#"{"scenario_id":"no-such-scenario"}"#))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}

--- a/docs/phases/phase-5-server-and-persistence.md
+++ b/docs/phases/phase-5-server-and-persistence.md
@@ -20,7 +20,7 @@ client is Phase 6; auth + per-seat enforcement are Phase 8.
 | P5.1 | [#168](https://github.com/talelburg/eldritch/issues/168) — sqlx + SQLite wiring: pool, migrations, action-log schema | 🟢 [PR #176](https://github.com/talelburg/eldritch/pull/176) |
 | P5.2 | [#169](https://github.com/talelburg/eldritch/issues/169) — GameSession host: create / apply-and-persist / load-by-replay | 🟢 [PR #177](https://github.com/talelburg/eldritch/pull/177) |
 | P5.3 | [#170](https://github.com/talelburg/eldritch/issues/170) — Axum WS endpoint + per-game broadcast hub | 🟢 [PR #178](https://github.com/talelburg/eldritch/pull/178) |
-| P5.4 | [#171](https://github.com/talelburg/eldritch/issues/171) — Game lifecycle HTTP: POST /games + lazy rehydrate | ⏳ open |
+| P5.4 | [#171](https://github.com/talelburg/eldritch/issues/171) — Game lifecycle HTTP: POST /games + lazy rehydrate | 🟢 [PR #179](https://github.com/talelburg/eldritch/pull/179) |
 | P5.5 | [#172](https://github.com/talelburg/eldritch/issues/172) — Reconnect + restart resume: deliver in-flight AwaitingInput | ⏳ open |
 | P5.6 | [#173](https://github.com/talelburg/eldritch/issues/173) — closing demo: two WS clients, restart+reconnect replay | ⏳ open |
 


### PR DESCRIPTION
## Summary

P5.4 — the game-creation HTTP endpoint plus a typed `GameId`. `POST /games` sets up a scenario, persists the seed, and returns the new id; a later WS connect reaches it via the lazy-rehydrate path already in place.

## What changed

- **`GameId(String)` newtype** (`#[serde(transparent)]`) — threaded through `session` / `store` / `ws` in place of bare `String` ids. `Path<GameId>` extracts it from the URL, it binds to a TEXT column, and serializes as a bare JSON string.
- **`POST /games { scenario_id }`** — generate a random `GameId`, run `GameSession::create`, persist the seed; `201 Created` + `game_id`, or `400` for an unknown scenario.
- **Lazy rehydrate** is already implemented (`ws::get_or_load_room` loads from the log on cache miss), so a POSTed game is reachable without pre-registration — proven by the create-then-load test.

## Design decisions

- **`GameId` lives in the `server` crate, not `game-core`.** It identifies a *persisted session* (a row in `games`), a host/persistence concept — unlike `ScenarioId`/`InvestigatorId`, which are game-rules entities in the kernel. (Per the P5.3 review discussion.)
- **Where it lands:** introduced here in P5.4 rather than retrofitting the merged P5.3 PR, because `POST /games` is where the id is generated and returned — its natural birthplace. It also hardens `store::insert_game`'s adjacent `&str` params (game_id vs scenario_id are now distinct types).
- **`create` keeps `impl Into<GameId>`** so `From<&str>`/`From<String>` keep call sites ergonomic; `load` takes `&GameId`.

## Test notes

- `tests/lifecycle.rs` (tower `oneshot`): `POST /games` → `201` + a `game_id` that `GameSession::load` then finds; unknown scenario → `400`.
- `GameId` unit tests: random ids are distinct; transparent serde round-trips as a bare string.
- Existing session/ws tests updated for the new signatures and stay green.

Full local gauntlet green: `fmt`, `clippy -D warnings`, `test --all`, `doc -D warnings`, `wasm-build`.

## Linked issues

Closes #171.