### PR TITLE
test: reconnect + restart resume acceptance tests (P5.5)

### DIFF
--- a/crates/server/tests/common/mod.rs
+++ b/crates/server/tests/common/mod.rs
@@ -7,7 +7,7 @@ use std::net::SocketAddr;
 
 use futures_util::{SinkExt, StreamExt};
 use game_core::scenario::{ScenarioId, ScenarioModule, ScenarioRegistry};
-use game_core::state::{GameState, InvestigatorId};
+use game_core::state::{ChaosBag, ChaosToken, GameState, InvestigatorId};
 use game_core::test_support::builder::TestGame;
 use game_core::test_support::fixtures::test_investigator;
 use game_core::{Event, Resolution};
@@ -20,9 +20,14 @@ use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 pub const TEST_SCENARIO_ID: &str = "test-scenario";
 
 fn test_setup() -> GameState {
+    // Round-0 Mythos state: `StartScenario` is accepted, `EndTurn` is
+    // rejected. The single-token chaos bag also makes the investigator
+    // eligible for a `PerformSkillTest` (which pauses at a commit window
+    // → `AwaitingInput`), exercised by the resume tests.
     TestGame::new()
         .with_investigator(test_investigator(1))
         .with_turn_order([InvestigatorId(1)])
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
         .with_scenario_id(ScenarioId::new(TEST_SCENARIO_ID))
         .with_rng_seed(42)
         .build()

--- a/crates/server/tests/resume.rs
+++ b/crates/server/tests/resume.rs
@@ -1,0 +1,156 @@
+//! Reconnect + restart resume: a game paused at an in-flight
+//! `AwaitingInput` is delivered to a reconnecting client (and rebuilt
+//! from the log after a restart), and can be resolved over the wire.
+//!
+//! These are acceptance tests: the mechanics already fall out of the
+//! generic outcome handling built in P5.2 (`load` reconstructs the
+//! outcome by replay) and P5.3 (`Hello`/`Applied` carry the outcome,
+//! `ResolveInput` is just another `Submit`). No new server code is
+//! needed — these prove the pieces compose.
+
+mod common;
+
+use common::{connect, install_registry, memory_pool, recv, send, spawn_server, TEST_SCENARIO_ID};
+use game_core::scenario::ScenarioId;
+use game_core::state::{InvestigatorId, SkillKind};
+use game_core::{EngineOutcome, InputResponse, PlayerAction};
+use server::wire::{ClientMessage, ServerMessage};
+use server::GameSession;
+
+/// A skill test pauses at its commit window → `AwaitingInput`.
+fn skill_test() -> ClientMessage {
+    ClientMessage::Submit {
+        action: PlayerAction::PerformSkillTest {
+            investigator: InvestigatorId(1),
+            skill: SkillKind::Intellect,
+            difficulty: 2,
+        },
+    }
+}
+
+async fn seed(pool: &sqlx::SqlitePool, game_id: &str) {
+    GameSession::create(pool.clone(), game_id, ScenarioId::new(TEST_SCENARIO_ID))
+        .await
+        .expect("seed game");
+}
+
+#[tokio::test]
+async fn reconnect_delivers_in_flight_awaiting_input() {
+    install_registry();
+    let pool = memory_pool().await;
+    seed(&pool, "g-resume").await;
+    let addr = spawn_server(pool).await;
+
+    // Drive the game to AwaitingInput on connection A.
+    let mut a = connect(addr, "g-resume").await;
+    let _ = recv(&mut a).await; // Hello
+    send(&mut a, &skill_test()).await;
+    match recv(&mut a).await {
+        ServerMessage::Applied { outcome, .. } => {
+            assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
+        }
+        other => panic!("expected Applied(AwaitingInput), got {other:?}"),
+    }
+
+    // A fresh connection sees the in-flight prompt in its Hello.
+    let mut b = connect(addr, "g-resume").await;
+    match recv(&mut b).await {
+        ServerMessage::Hello { outcome, .. } => {
+            assert!(
+                matches!(outcome, EngineOutcome::AwaitingInput { .. }),
+                "reconnect must surface the in-flight AwaitingInput, got {outcome:?}"
+            );
+        }
+        other => panic!("expected Hello(AwaitingInput), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn restart_rebuilds_awaiting_input_via_replay() {
+    install_registry();
+    let pool = memory_pool().await;
+    seed(&pool, "g-restart").await;
+
+    // First server: drive to AwaitingInput.
+    let addr1 = spawn_server(pool.clone()).await;
+    let mut a = connect(addr1, "g-restart").await;
+    let _ = recv(&mut a).await; // Hello
+    send(&mut a, &skill_test()).await;
+    let _ = recv(&mut a).await; // Applied(AwaitingInput)
+
+    // "Restart": a fresh server with empty rooms over the same database.
+    // The game is gone from memory and must be rebuilt by replay.
+    let addr2 = spawn_server(pool).await;
+    let mut c = connect(addr2, "g-restart").await;
+    match recv(&mut c).await {
+        ServerMessage::Hello { outcome, .. } => {
+            assert!(
+                matches!(outcome, EngineOutcome::AwaitingInput { .. }),
+                "restart must rebuild AwaitingInput from the log, got {outcome:?}"
+            );
+        }
+        other => panic!("expected Hello(AwaitingInput), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn resolve_input_resumes_and_completes() {
+    install_registry();
+    let pool = memory_pool().await;
+    seed(&pool, "g-do-resolve").await;
+    let addr = spawn_server(pool).await;
+
+    let mut a = connect(addr, "g-do-resolve").await;
+    let _ = recv(&mut a).await; // Hello
+    send(&mut a, &skill_test()).await;
+    let _ = recv(&mut a).await; // Applied(AwaitingInput)
+
+    // Resolve: commit nothing. The engine finishes the test.
+    send(
+        &mut a,
+        &ClientMessage::Submit {
+            action: PlayerAction::ResolveInput {
+                response: InputResponse::CommitCards { indices: vec![] },
+            },
+        },
+    )
+    .await;
+    match recv(&mut a).await {
+        ServerMessage::Applied { outcome, .. } => {
+            assert!(
+                !matches!(
+                    outcome,
+                    EngineOutcome::AwaitingInput { .. } | EngineOutcome::Rejected { .. }
+                ),
+                "resolving the commit window completes the test, got {outcome:?}"
+            );
+        }
+        other => panic!("expected Applied(completed), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn non_resolve_action_while_awaiting_input_is_rejected() {
+    install_registry();
+    let pool = memory_pool().await;
+    seed(&pool, "g-busy").await;
+    let addr = spawn_server(pool).await;
+
+    let mut a = connect(addr, "g-busy").await;
+    let _ = recv(&mut a).await; // Hello
+    send(&mut a, &skill_test()).await;
+    let _ = recv(&mut a).await; // Applied(AwaitingInput)
+
+    // A non-ResolveInput submit while paused is rejected by the engine.
+    send(
+        &mut a,
+        &ClientMessage::Submit {
+            action: PlayerAction::EndTurn,
+        },
+    )
+    .await;
+    match recv(&mut a).await {
+        ServerMessage::Rejected { .. } => {}
+        other => panic!("expected Rejected while awaiting input, got {other:?}"),
+    }
+}

--- a/docs/phases/phase-5-server-and-persistence.md
+++ b/docs/phases/phase-5-server-and-persistence.md
@@ -21,7 +21,7 @@ client is Phase 6; auth + per-seat enforcement are Phase 8.
 | P5.2 | [#169](https://github.com/talelburg/eldritch/issues/169) — GameSession host: create / apply-and-persist / load-by-replay | 🟢 [PR #177](https://github.com/talelburg/eldritch/pull/177) |
 | P5.3 | [#170](https://github.com/talelburg/eldritch/issues/170) — Axum WS endpoint + per-game broadcast hub | 🟢 [PR #178](https://github.com/talelburg/eldritch/pull/178) |
 | P5.4 | [#171](https://github.com/talelburg/eldritch/issues/171) — Game lifecycle HTTP: POST /games + lazy rehydrate | 🟢 [PR #179](https://github.com/talelburg/eldritch/pull/179) |
-| P5.5 | [#172](https://github.com/talelburg/eldritch/issues/172) — Reconnect + restart resume: deliver in-flight AwaitingInput | ⏳ open |
+| P5.5 | [#172](https://github.com/talelburg/eldritch/issues/172) — Reconnect + restart resume: deliver in-flight AwaitingInput | 🟢 [PR #180](https://github.com/talelburg/eldritch/pull/180) |
 | P5.6 | [#173](https://github.com/talelburg/eldritch/issues/173) — closing demo: two WS clients, restart+reconnect replay | ⏳ open |
 
 Deferred out of the phase: [#174](https://github.com/talelburg/eldritch/issues/174) — periodic state snapshots for replay perf (p2-later, build only when profiling demands it).
@@ -53,6 +53,7 @@ Settled in the Phase 5 brainstorm (2026-06-07):
 - **Anonymous hub, no enforcement.** Any connected client may submit; the server applies + broadcasts to the game's connections. Identity/seats/turn-ownership are Phase 8.
 - **Single-port static WASM serving lands in Phase 6**, not Phase 5 — the WASM bundle doesn't exist until then. Phase 5 ships the API/WS server only. (Corrects the original browser-first "done" wording below.)
 - **Snapshots deferred** to #174; build only when replay is measurably slow.
+- **Resume needed zero new code (P5.5).** Reconnect / restart-rebuild / in-flight `AwaitingInput` delivery / `ResolveInput`-over-the-wire all fell out of the generic `EngineOutcome` threading from P5.2 (`load` reconstructs the outcome by replay) and P5.3 (`Hello`/`Applied` carry the outcome; `ResolveInput` is just another `Submit`). P5.5 is acceptance tests only. **Implication for P5.6:** reconnect/restart/resume is already covered by `tests/resume.rs`, so the closing demo's net-new surface is the **two-client identical-event-stream** property; don't re-litigate resume there.
 
 ## Open questions
 


### PR DESCRIPTION
## Summary

P5.5 — proves the in-flight `AwaitingInput` resume path end to end over the wire. **No new server code:** the mechanics already fall out of the generic outcome handling built earlier — `load()` reconstructs the outcome by replay (P5.2), and `Hello`/`Applied` carry the outcome while `ResolveInput` is just another `Submit` (P5.3). This issue is satisfied by acceptance tests confirming the pieces compose.

## What changed

- **`tests/resume.rs`** — four acceptance tests.
- **`tests/common`** — `test_setup` now seeds a single-token chaos bag so the investigator is eligible for a `PerformSkillTest` (which pauses at a commit window → `AwaitingInput`). Backward compatible: `StartScenario`/`EndTurn` behaviour is unchanged, so the ws/lifecycle/session suites are unaffected.

## Test notes (spawned server + tokio-tungstenite clients)

- **reconnect** — drive a game to `AwaitingInput`, then a *fresh* connection receives the in-flight prompt in its `Hello`.
- **restart** — after `AwaitingInput`, a second server with empty rooms over the same DB rebuilds the prompt by replaying the log.
- **resolve** — `ResolveInput { CommitCards [] }` resumes and completes the test.
- **guard** — a non-`ResolveInput` submit while paused is rejected.

## Design note

The "server restart rebuilds via replay" half of this issue was effectively already done by P5.3's lazy room-load on cache miss (and exercised by P5.4's `POST`-then-connect). What this issue adds is the `AwaitingInput`-specific coverage and the resolve-over-the-wire path. That the whole thing needed zero new production code is the intended payoff of P5.2/P5.3 threading `EngineOutcome` through generically.

Full local gauntlet green: `fmt`, `clippy -D warnings`, `test --all`, `doc -D warnings`, `wasm-build`.

## Linked issues

Closes #172.