### PR TITLE
test: phase-5 closing demo (P5.6)

### DIFF
--- a/crates/server/tests/closing_demo.rs
+++ b/crates/server/tests/closing_demo.rs
@@ -1,0 +1,132 @@
+//! Phase-5 closing demo: the end-to-end demonstration that closes the
+//! milestone (mirrors Phase 4's #157). One narrative exercises every
+//! "done" criterion of the phase:
+//!
+//! 1. two clients connected to one game see the same initial state and
+//!    an identical event stream as actions are applied (the spectator
+//!    foundation for multiplayer);
+//! 2. a client reconnecting mid-scenario receives the in-flight
+//!    `AwaitingInput` and can resolve it;
+//! 3. restarting the server (fresh in-memory rooms, same database) and
+//!    reconnecting reproduces the exact state via action-log replay.
+
+mod common;
+
+use common::{connect, install_registry, memory_pool, recv, send, spawn_server, TEST_SCENARIO_ID};
+use game_core::scenario::ScenarioId;
+use game_core::state::{GameState, InvestigatorId, SkillKind};
+use game_core::{EngineOutcome, Event, InputResponse, PlayerAction};
+use server::wire::{ClientMessage, ServerMessage};
+use server::GameSession;
+
+fn submit(action: PlayerAction) -> ClientMessage {
+    ClientMessage::Submit { action }
+}
+
+fn hello_state(msg: ServerMessage) -> GameState {
+    match msg {
+        ServerMessage::Hello { state, .. } => *state,
+        other => panic!("expected Hello, got {other:?}"),
+    }
+}
+
+fn hello_outcome(msg: ServerMessage) -> EngineOutcome {
+    match msg {
+        ServerMessage::Hello { outcome, .. } => outcome,
+        other => panic!("expected Hello, got {other:?}"),
+    }
+}
+
+fn applied_events(msg: ServerMessage) -> Vec<Event> {
+    match msg {
+        ServerMessage::Applied { events, .. } => events,
+        other => panic!("expected Applied, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn phase_5_closing_demo() {
+    install_registry();
+    let pool = memory_pool().await;
+    GameSession::create(pool.clone(), "demo", ScenarioId::new(TEST_SCENARIO_ID))
+        .await
+        .expect("create the demo game");
+    let addr = spawn_server(pool.clone()).await;
+
+    // (1) Two clients connect and see the same initial state.
+    let mut actor = connect(addr, "demo").await;
+    let mut spectator = connect(addr, "demo").await;
+    let actor_initial = hello_state(recv(&mut actor).await);
+    let spectator_initial = hello_state(recv(&mut spectator).await);
+    assert_eq!(
+        actor_initial, spectator_initial,
+        "both connections see the same initial state"
+    );
+
+    // The actor performs a skill test, which pauses at its commit window.
+    // The spectator, who sends nothing, observes the identical stream.
+    send(
+        &mut actor,
+        &submit(PlayerAction::PerformSkillTest {
+            investigator: InvestigatorId(1),
+            skill: SkillKind::Intellect,
+            difficulty: 2,
+        }),
+    )
+    .await;
+    let actor_start = applied_events(recv(&mut actor).await);
+    let spectator_start = applied_events(recv(&mut spectator).await);
+    assert_eq!(
+        actor_start, spectator_start,
+        "spectator sees the identical event stream"
+    );
+    assert!(
+        actor_start.contains(&Event::SkillTestStarted {
+            investigator: InvestigatorId(1),
+            skill: SkillKind::Intellect,
+            difficulty: 2,
+        }),
+        "the skill test announced itself: {actor_start:?}"
+    );
+
+    // (2) A client reconnecting mid-scenario receives the in-flight
+    // AwaitingInput.
+    let mut latecomer = connect(addr, "demo").await;
+    assert!(
+        matches!(
+            hello_outcome(recv(&mut latecomer).await),
+            EngineOutcome::AwaitingInput { .. }
+        ),
+        "a mid-scenario reconnect surfaces the in-flight prompt"
+    );
+
+    // The actor resolves the commit window; both original clients see the
+    // identical resolution stream.
+    send(
+        &mut actor,
+        &submit(PlayerAction::ResolveInput {
+            response: InputResponse::CommitCards { indices: vec![] },
+        }),
+    )
+    .await;
+    let actor_resolve = applied_events(recv(&mut actor).await);
+    let spectator_resolve = applied_events(recv(&mut spectator).await);
+    assert_eq!(
+        actor_resolve, spectator_resolve,
+        "spectator sees the identical resolution stream"
+    );
+
+    // Capture the post-resolution live state from a fresh connection.
+    let mut probe = connect(addr, "demo").await;
+    let live_state = hello_state(recv(&mut probe).await);
+
+    // (3) Restart: a new server with empty rooms over the same database.
+    // The game must be rebuilt from the action log.
+    let restarted = spawn_server(pool).await;
+    let mut reconnect = connect(restarted, "demo").await;
+    let replayed_state = hello_state(recv(&mut reconnect).await);
+    assert_eq!(
+        live_state, replayed_state,
+        "restart reproduces the exact state via action-log replay"
+    );
+}

--- a/docs/phases/README.md
+++ b/docs/phases/README.md
@@ -17,7 +17,7 @@ When starting work on a new issue, read the relevant phase doc first. It's faste
 | 2 | Card data + DSL | ✅ closed | [phase-2-card-data-and-dsl.md](phase-2-card-data-and-dsl.md) |
 | 3 | Skill-test end-to-end | ✅ closed | [phase-3-skill-test-end-to-end.md](phase-3-skill-test-end-to-end.md) |
 | 4 | Scenario plumbing | ✅ closed | [phase-4-scenario-plumbing.md](phase-4-scenario-plumbing.md) |
-| 5 | Server + persistence | 🟡 in progress | [phase-5-server-and-persistence.md](phase-5-server-and-persistence.md) |
+| 5 | Server + persistence | ✅ closed | [phase-5-server-and-persistence.md](phase-5-server-and-persistence.md) |
 | 6 | Web client v0 | 📐 architecture only | [phase-6-web-client-v0.md](phase-6-web-client-v0.md) |
 | 7 | The Gathering | 📐 architecture only | [phase-7-the-gathering.md](phase-7-the-gathering.md) |
 | 8 | Multiplayer + auth | 📐 architecture only | [phase-8-multiplayer-and-auth.md](phase-8-multiplayer-and-auth.md) |

--- a/docs/phases/phase-5-server-and-persistence.md
+++ b/docs/phases/phase-5-server-and-persistence.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-🟡 In progress (since 2026-06-07). Design spec landed; issues filed.
+✅ Closed (2026-06-07). All six issues (P5.1–P5.6) shipped; the milestone demonstration is `crates/server/tests/closing_demo.rs`.
 
 Design spec: [`docs/superpowers/specs/2026-06-07-phase-5-server-and-persistence-design.md`](../superpowers/specs/2026-06-07-phase-5-server-and-persistence-design.md).
 
@@ -22,7 +22,7 @@ client is Phase 6; auth + per-seat enforcement are Phase 8.
 | P5.3 | [#170](https://github.com/talelburg/eldritch/issues/170) — Axum WS endpoint + per-game broadcast hub | 🟢 [PR #178](https://github.com/talelburg/eldritch/pull/178) |
 | P5.4 | [#171](https://github.com/talelburg/eldritch/issues/171) — Game lifecycle HTTP: POST /games + lazy rehydrate | 🟢 [PR #179](https://github.com/talelburg/eldritch/pull/179) |
 | P5.5 | [#172](https://github.com/talelburg/eldritch/issues/172) — Reconnect + restart resume: deliver in-flight AwaitingInput | 🟢 [PR #180](https://github.com/talelburg/eldritch/pull/180) |
-| P5.6 | [#173](https://github.com/talelburg/eldritch/issues/173) — closing demo: two WS clients, restart+reconnect replay | ⏳ open |
+| P5.6 | [#173](https://github.com/talelburg/eldritch/issues/173) — closing demo: two WS clients, restart+reconnect replay | ✅ [PR #181](https://github.com/talelburg/eldritch/pull/181) |
 
 Deferred out of the phase: [#174](https://github.com/talelburg/eldritch/issues/174) — periodic state snapshots for replay perf (p2-later, build only when profiling demands it).
 
@@ -57,7 +57,7 @@ Settled in the Phase 5 brainstorm (2026-06-07):
 
 ## Open questions
 
-None blocking. Remaining choices are issue-local implementation detail (e.g. `GameId` representation, exact WS frame encoding) and will be settled in their respective PRs.
+None — all settled. `GameId` landed as a server-crate transparent newtype (P5.4); the WS frame encoding is the externally-tagged `ClientMessage` / `ServerMessage` (P5.3). Snapshots remain deferred to #174 (build only when replay is measurably slow).
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

P5.6 — the end-to-end demonstration that closes Phase 5 (mirrors Phase 4's #157). One narrative test over a spawned server + `tokio-tungstenite` clients exercises every "done" criterion of the phase. **No new server code** — it closes out the milestone on the surface built across P5.1–P5.5.

## The demo

`tests/closing_demo.rs`, a single `phase_5_closing_demo`:

1. **Two-client identical stream** — an actor and a passive spectator connect to one game, see the same initial state, and receive the *identical* `Applied` event stream as the actor performs a skill test and resolves it. (The net-new property per P5.5's scope note — the multiplayer-spectator foundation.)
2. **Mid-scenario reconnect** — while the game is paused at the skill-test commit window, a latecomer connects and its `Hello` carries the in-flight `AwaitingInput`.
3. **Restart → replay** — a fresh server with empty rooms over the same database reproduces the exact post-resolution state by replaying the action log.

## Notes

- Verified non-flaky (5/5 runs) — the broadcast design means both clients receive the same `Applied` frame, and the per-action send/recv sequencing keeps the streams ordered.
- This is the last issue in the `phase-5-server-and-persistence` milestone; the phase doc is flipped to a retrospective in the final commit.

Full local gauntlet green: `fmt`, `clippy -D warnings`, `test --all`, `doc -D warnings`, `wasm-build`.

## Linked issues

Closes #173.