### PR TITLE
infra: server production-playable — synthetic registries + single-port static serving (P6.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,6 +1391,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "mio"
@@ -2110,6 +2126,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.24.0",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -2701,6 +2718,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2745,6 +2775,31 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -2880,6 +2935,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -14,6 +14,8 @@ workspace = true
 game-core = { path = "../game-core" }
 protocol = { path = "../protocol" }
 cards = { path = "../cards" }
+# Explicit: synthetic fixtures power the toy scenario at runtime this phase;
+# keep them even if `test_fixtures` leaves `scenarios`' default set (phase-7).
 scenarios = { path = "../scenarios", features = ["test_fixtures"] }
 axum = { version = "0.8", features = ["ws"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -26,6 +26,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "migrate"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+tower-http = { version = "0.6", features = ["fs"] }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 game-core = { path = "../game-core" }
 protocol = { path = "../protocol" }
 cards = { path = "../cards" }
-scenarios = { path = "../scenarios" }
+scenarios = { path = "../scenarios", features = ["test_fixtures"] }
 axum = { version = "0.8", features = ["ws"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
 futures-util = "0.3"

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -15,11 +15,14 @@ mod ws;
 pub use id::GameId;
 pub use session::{GameSession, SessionError};
 
+use std::path::PathBuf;
+
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::routing::{get, post};
 use axum::Router;
 use sqlx::SqlitePool;
+use tower_http::services::{ServeDir, ServeFile};
 
 /// Shared application state handed to every Axum handler.
 #[derive(Clone)]
@@ -28,16 +31,27 @@ pub struct AppState {
     pub db: SqlitePool,
     /// Live games keyed by `game_id`, each with its broadcast group.
     rooms: ws::Rooms,
+    /// Directory holding the built client bundle (`index.html`, JS, wasm),
+    /// served as the router fallback.
+    dist_dir: PathBuf,
 }
 
 impl AppState {
-    /// Build application state over a database pool, with an empty live
-    /// rooms map.
+    /// Build application state over a database pool, serving the client
+    /// bundle from the default dev location (`crates/web/dist`, relative
+    /// to the workspace root).
     #[must_use]
     pub fn new(db: SqlitePool) -> Self {
+        Self::new_with_dist(db, PathBuf::from("crates/web/dist"))
+    }
+
+    /// Build application state with an explicit client-bundle directory.
+    #[must_use]
+    pub fn new_with_dist(db: SqlitePool, dist_dir: PathBuf) -> Self {
         Self {
             db,
             rooms: ws::rooms(),
+            dist_dir,
         }
     }
 }
@@ -57,18 +71,19 @@ pub fn install_registries() {
     let _ = game_core::card_registry::install(scenarios::test_fixtures::synth_cards::TEST_REGISTRY);
 }
 
-/// Build the application router with all routes and shared state.
+/// Build the application router with all routes and shared state. The
+/// JSON API and WebSocket take precedence; everything else falls back
+/// to the client bundle, with `index.html` as the SPA fallback.
 pub fn app(state: AppState) -> Router {
+    let index_html = state.dist_dir.join("index.html");
+    let static_files = ServeDir::new(&state.dist_dir).fallback(ServeFile::new(index_html));
+
     Router::new()
-        .route("/", get(index))
         .route("/health", get(health))
         .route("/games", post(lifecycle::create_game))
         .route("/games/{game_id}/ws", get(ws::game_ws))
+        .fallback_service(static_files)
         .with_state(state)
-}
-
-async fn index() -> &'static str {
-    "Eldritch — coming soon"
 }
 
 /// Readiness probe: `200 OK` if the database answers a trivial query,

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -42,6 +42,21 @@ impl AppState {
     }
 }
 
+/// Install the process-global scenario + card registries the server
+/// needs to create and play games. Call once at startup.
+///
+/// Phase 6 installs the **synthetic** fixtures (the toy scenario and
+/// its `_synth_*` cards) knowingly — the only playable content this
+/// phase. Idempotent: a second call is a no-op (the underlying
+/// `OnceLock`s reject re-installation).
+///
+/// TODO(phase-7): swap to the real `scenarios`/`cards` registries when
+/// The Gathering lands.
+pub fn install_registries() {
+    let _ = game_core::scenario_registry::install(scenarios::REGISTRY);
+    let _ = game_core::card_registry::install(scenarios::test_fixtures::synth_cards::TEST_REGISTRY);
+}
+
 /// Build the application router with all routes and shared state.
 pub fn app(state: AppState) -> Router {
     Router::new()

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -76,6 +76,10 @@ pub fn install_registries() {
 /// to the client bundle, with `index.html` as the SPA fallback.
 pub fn app(state: AppState) -> Router {
     let index_html = state.dist_dir.join("index.html");
+    // `.fallback()` (not `.not_found_service()`) keeps the response at
+    // 200 OK — correct for SPA routing, where the browser loads
+    // index.html and its JS resolves the path. `not_found_service`
+    // would force a 404, which an SPA shouldn't return for its routes.
     let static_files = ServeDir::new(&state.dist_dir).fallback(ServeFile::new(index_html));
 
     Router::new()

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -3,7 +3,7 @@
 
 use std::net::SocketAddr;
 
-use server::{app, db, AppState};
+use server::{app, db, install_registries, AppState};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -12,6 +12,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
         )
         .init();
+
+    install_registries();
 
     let database_url =
         std::env::var("DATABASE_URL").unwrap_or_else(|_| "sqlite:eldritch.db".to_string());

--- a/crates/server/tests/fixtures/dist/index.html
+++ b/crates/server/tests/fixtures/dist/index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>eldritch-test-bundle</title></head>
+  <body>eldritch-test-bundle</body>
+</html>

--- a/crates/server/tests/registries.rs
+++ b/crates/server/tests/registries.rs
@@ -1,0 +1,55 @@
+//! The production server installs the synthetic scenario + card
+//! registries (D5), so the real `POST /games` for the toy scenario
+//! succeeds and synthetic card codes resolve. Process-isolated: this
+//! test binary installs the *real* synthetic registries, distinct from
+//! the mock registry other test binaries install via `common`.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use common::memory_pool;
+use game_core::scenario::ScenarioId;
+use game_core::state::CardCode;
+use scenarios::test_fixtures::synth_cards::SYNTH_TREACHERY_CODE;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn install_registries_resolves_synthetic_scenario_and_cards() {
+    server::install_registries();
+
+    let scenario = game_core::scenario_registry::current().expect("scenario registry installed");
+    let id = ScenarioId::new("synthetic");
+    assert!(
+        (scenario.module_for)(&id).is_some(),
+        "synthetic scenario module must resolve"
+    );
+
+    let cards = game_core::card_registry::current().expect("card registry installed");
+    let code = CardCode(SYNTH_TREACHERY_CODE.into());
+    assert!(
+        (cards.metadata_for)(&code).is_some(),
+        "synthetic card metadata must resolve"
+    );
+    assert!(
+        (cards.abilities_for)(&code).is_some(),
+        "synthetic card abilities must resolve"
+    );
+}
+
+#[tokio::test]
+async fn post_games_creates_synthetic_game_against_installed_registries() {
+    server::install_registries();
+    let pool = memory_pool().await;
+    let app = server::app(server::AppState::new(pool));
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/games")
+        .header("content-type", "application/json")
+        .body(Body::from(r#"{"scenario_id":"synthetic"}"#))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+}

--- a/crates/server/tests/registries.rs
+++ b/crates/server/tests/registries.rs
@@ -12,14 +12,15 @@ use common::memory_pool;
 use game_core::scenario::ScenarioId;
 use game_core::state::CardCode;
 use scenarios::test_fixtures::synth_cards::SYNTH_TREACHERY_CODE;
+use scenarios::test_fixtures::synthetic::ID as SYNTHETIC_SCENARIO_ID;
 use tower::ServiceExt;
 
-#[tokio::test]
-async fn install_registries_resolves_synthetic_scenario_and_cards() {
+#[test]
+fn install_registries_resolves_synthetic_scenario_and_cards() {
     server::install_registries();
 
     let scenario = game_core::scenario_registry::current().expect("scenario registry installed");
-    let id = ScenarioId::new("synthetic");
+    let id = ScenarioId::new(SYNTHETIC_SCENARIO_ID);
     assert!(
         (scenario.module_for)(&id).is_some(),
         "synthetic scenario module must resolve"
@@ -47,7 +48,9 @@ async fn post_games_creates_synthetic_game_against_installed_registries() {
         .method("POST")
         .uri("/games")
         .header("content-type", "application/json")
-        .body(Body::from(r#"{"scenario_id":"synthetic"}"#))
+        .body(Body::from(format!(
+            r#"{{"scenario_id":"{SYNTHETIC_SCENARIO_ID}"}}"#
+        )))
         .unwrap();
     let response = app.oneshot(request).await.unwrap();
 

--- a/crates/server/tests/static_files.rs
+++ b/crates/server/tests/static_files.rs
@@ -1,0 +1,63 @@
+//! The server serves the client bundle from its dist dir as a router
+//! fallback, with `index.html` as the SPA fallback (D3). Uses a
+//! committed fixture dir because the real `crates/web/dist/` is
+//! gitignored (Trunk output) and absent in CI/fresh checkouts.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use sqlx::sqlite::SqlitePoolOptions;
+use tower::ServiceExt;
+
+const FIXTURE_DIST: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/dist");
+
+async fn app_with_fixture_dist() -> axum::Router {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("open in-memory sqlite");
+    server::db::MIGRATOR.run(&pool).await.expect("migrate");
+    server::app(server::AppState::new_with_dist(pool, FIXTURE_DIST.into()))
+}
+
+async fn body_string(response: axum::response::Response) -> String {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+async fn root_serves_index_html() {
+    let app = app_with_fixture_dist().await;
+    let response = app
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        body_string(response).await.contains("eldritch-test-bundle"),
+        "GET / serves the bundle's index.html"
+    );
+}
+
+#[tokio::test]
+async fn unknown_route_falls_back_to_index_html() {
+    let app = app_with_fixture_dist().await;
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/game/abc/some-spa-route")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        body_string(response).await.contains("eldritch-test-bundle"),
+        "an unmatched route falls back to index.html (SPA routing)"
+    );
+}

--- a/docs/phases/phase-6-web-client-v0.md
+++ b/docs/phases/phase-6-web-client-v0.md
@@ -18,7 +18,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 |---|---|---|
 | — | [#191](https://github.com/talelburg/eldritch/issues/191) — kickoff: design spec + issue breakdown | 🟡 open (this docs PR) |
 | P6.1 | [#182](https://github.com/talelburg/eldritch/issues/182) — `protocol` crate extraction + `state` on `Applied` | ✅ PR #193 |
-| P6.2 | [#183](https://github.com/talelburg/eldritch/issues/183) — server production-playable: synthetic registries + static WASM serving | ⏳ open |
+| P6.2 | [#183](https://github.com/talelburg/eldritch/issues/183) — server production-playable: synthetic registries + static WASM serving | ✅ PR #194 |
 | P6.3 | [#184](https://github.com/talelburg/eldritch/issues/184) — headless browser test harness + 6th CI job | ⏳ open |
 | P6.4 | [#185](https://github.com/talelburg/eldritch/issues/185) — WS client + reactive state store | ⏳ open |
 | P6.5 | [#186](https://github.com/talelburg/eldritch/issues/186) — board rendering (read-only) | ⏳ open |
@@ -32,7 +32,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | # | Issue | Why this slot | Depends on |
 |---|---|---|---|
 | P6.1 | #182 protocol crate + `state` on `Applied` ✅ PR #193 | Foundational; unblocks the client speaking the protocol with shared types | kickoff |
-| P6.2 | #183 server registries + static WASM | The thing the client connects to | — (parallel w/ P6.1) |
+| P6.2 | #183 server registries + static WASM ✅ PR #194 | The thing the client connects to | — (parallel w/ P6.1) |
 | P6.3 | #184 headless harness + 6th CI job | Testing foundation before TDD-ing components; de-risks browser-in-CI early | — |
 | P6.4 | #185 WS client + reactive store | The client's engine room; debug-dump render proves the round-trip | P6.1, P6.3 |
 | P6.5 | #186 board rendering | See the state | P6.4 |
@@ -92,12 +92,21 @@ in the design spec):
   real registries when Phase 7 lands The Gathering. Same
   `test_fixtures`-on-in-server tension Phase 4 flagged.
 
+Settled implementing P6.2 (PR #194):
+
+- **Bundle ships alongside the binary, not embedded.** D3's static
+  serving is a `ServeDir` over `crates/web/dist` (default; overridable
+  via `AppState::new_with_dist`) — artifacts are read from disk at
+  runtime, not compiled in. Embedding stays deferred (no deploy story
+  needs it yet).
+- **`ServeDir` uses `.fallback()`, not `.not_found_service()`.** The
+  SPA fallback to `index.html` must return `200 OK` (the browser's JS
+  resolves the route); `not_found_service` would force `404`.
+
 ## Open questions
 
-None blocking. Per-PR details: exact `ServeDir`/SPA-fallback wiring and
-whether the wasm bundle is embedded or shipped alongside the binary
-(P6.2); the precise legality-gating surface (P6.6); CSS/layout
-specifics (P6.5).
+None blocking. Per-PR details: the precise legality-gating surface
+(P6.6); CSS/layout specifics (P6.5).
 
 ## Dependencies
 

--- a/docs/superpowers/plans/2026-06-08-p6.2-server-production-playable.md
+++ b/docs/superpowers/plans/2026-06-08-p6.2-server-production-playable.md
@@ -1,0 +1,425 @@
+# P6.2 — Server production-playable Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the production `server` binary able to create and play the synthetic toy scenario, and serve the client bundle from a single port.
+
+**Architecture:** Two independent changes in `crates/server`. (1) A `server::install_registries()` helper installs the process-global synthetic scenario + card registries (D5), called by `main.rs` at startup. (2) `AppState` gains a `dist_dir`, and the router serves it via a `ServeDir` fallback with `index.html` as the SPA fallback (D3). Both are covered by new integration tests.
+
+**Tech Stack:** Rust, Axum 0.8, `tower-http` 0.6 (`fs` feature), `scenarios` crate `test_fixtures` (synthetic fixtures), SQLite/sqlx.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-phase-6-web-client-v0-design.md` (D3, D5). **Issue:** #183.
+
+**Out of scope (do not do):** real `cards`/`scenarios` registries (Phase 7); removing the vestigial direct `cards` dep from `server` (flag only — pre-existing, transitive via `scenarios`); deploy-time dist override; click→PlayCard over WebSocket (P6.7a).
+
+---
+
+## File structure
+
+- `crates/server/Cargo.toml` — add `tower-http` dep; make the `scenarios` dep's `test_fixtures` feature explicit.
+- `crates/server/src/lib.rs` — add `install_registries()`; add `AppState.dist_dir` + `new_with_dist`; replace the `/` route + `index` handler with a `ServeDir` fallback.
+- `crates/server/src/main.rs` — call `server::install_registries()` at startup.
+- `crates/server/tests/registries.rs` — **new**; proves the real registries resolve and `POST /games {"scenario_id":"synthetic"}` → 201.
+- `crates/server/tests/static_files.rs` — **new**; proves `/` and SPA fallback serve `index.html`.
+- `crates/server/tests/fixtures/dist/index.html` — **new**; committed fixture bundle (the real `dist/` is gitignored, so tests cannot rely on it).
+
+---
+
+## Task 1: `install_registries()` + registries wired into the binary
+
+**Files:**
+- Modify: `crates/server/Cargo.toml`
+- Modify: `crates/server/src/lib.rs`
+- Modify: `crates/server/src/main.rs`
+- Test: `crates/server/tests/registries.rs` (create)
+
+- [ ] **Step 1: Make the `scenarios` `test_fixtures` feature explicit in `Cargo.toml`**
+
+The synthetic registries live behind `scenarios`' `test_fixtures` feature. It is on by default, but the binary now depends on it at *runtime* (not just tests), so make that explicit. In `crates/server/Cargo.toml`, under `[dependencies]`, change the `scenarios` line:
+
+```toml
+scenarios = { path = "../scenarios", features = ["test_fixtures"] }
+```
+
+(Leave the `cards` dep untouched — it is unused in `src/` but pulled in transitively; removing it is out of scope.)
+
+- [ ] **Step 2: Write the failing test**
+
+Create `crates/server/tests/registries.rs`:
+
+```rust
+//! The production server installs the synthetic scenario + card
+//! registries (D5), so the real `POST /games` for the toy scenario
+//! succeeds and synthetic card codes resolve. Process-isolated: this
+//! test binary installs the *real* synthetic registries, distinct from
+//! the mock registry other test binaries install via `common`.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use common::memory_pool;
+use game_core::scenario::ScenarioId;
+use game_core::state::CardCode;
+use scenarios::test_fixtures::synth_cards::SYNTH_TREACHERY_CODE;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn install_registries_resolves_synthetic_scenario_and_cards() {
+    server::install_registries();
+
+    let scenario = game_core::scenario_registry::current().expect("scenario registry installed");
+    let id = ScenarioId::new("synthetic");
+    assert!(
+        (scenario.module_for)(&id).is_some(),
+        "synthetic scenario module must resolve"
+    );
+
+    let cards = game_core::card_registry::current().expect("card registry installed");
+    let code = CardCode(SYNTH_TREACHERY_CODE.into());
+    assert!(
+        (cards.metadata_for)(&code).is_some(),
+        "synthetic card metadata must resolve"
+    );
+    assert!(
+        (cards.abilities_for)(&code).is_some(),
+        "synthetic card abilities must resolve"
+    );
+}
+
+#[tokio::test]
+async fn post_games_creates_synthetic_game_against_installed_registries() {
+    server::install_registries();
+    let pool = memory_pool().await;
+    let app = server::app(server::AppState::new(pool));
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/games")
+        .header("content-type", "application/json")
+        .body(Body::from(r#"{"scenario_id":"synthetic"}"#))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+}
+```
+
+Note: `mod common;` reuses `crates/server/tests/common/mod.rs` for `memory_pool`. This test does **not** call `common::install_registry` (that installs a *mock*); it installs the real registries via `server::install_registries()`.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cargo test -p server --test registries`
+Expected: FAIL to compile — `server::install_registries` does not exist yet.
+
+- [ ] **Step 4: Implement `install_registries()` in `lib.rs`**
+
+In `crates/server/src/lib.rs`, add after the `AppState` impl block (before `pub fn app`):
+
+```rust
+/// Install the process-global scenario + card registries the server
+/// needs to create and play games. Call once at startup.
+///
+/// Phase 6 installs the **synthetic** fixtures (the toy scenario and
+/// its `_synth_*` cards) knowingly — the only playable content this
+/// phase. Idempotent: a second call is a no-op (the underlying
+/// `OnceLock`s reject re-installation).
+///
+/// TODO(phase-7): swap to the real `scenarios`/`cards` registries when
+/// The Gathering lands.
+pub fn install_registries() {
+    let _ = game_core::scenario_registry::install(scenarios::REGISTRY);
+    let _ = game_core::card_registry::install(scenarios::test_fixtures::synth_cards::TEST_REGISTRY);
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cargo test -p server --test registries`
+Expected: PASS (both tests).
+
+- [ ] **Step 6: Wire `install_registries()` into the binary**
+
+In `crates/server/src/main.rs`, add `install_registries` to the import and call it after `tracing_subscriber` init. Change the import line:
+
+```rust
+use server::{app, db, install_registries, AppState};
+```
+
+And add this call immediately after the `tracing_subscriber::fmt()....init();` block (before reading `DATABASE_URL`):
+
+```rust
+    install_registries();
+```
+
+- [ ] **Step 7: Verify the binary still builds**
+
+Run: `cargo build -p server`
+Expected: builds clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/server/Cargo.toml crates/server/src/lib.rs crates/server/src/main.rs crates/server/tests/registries.rs
+git commit -m "infra: install synthetic registries in server binary (P6.2)"
+```
+
+---
+
+## Task 2: Single-port static serving (`ServeDir` fallback)
+
+**Files:**
+- Modify: `crates/server/Cargo.toml`
+- Modify: `crates/server/src/lib.rs`
+- Test: `crates/server/tests/static_files.rs` (create)
+- Fixture: `crates/server/tests/fixtures/dist/index.html` (create)
+
+- [ ] **Step 1: Add the `tower-http` dependency**
+
+In `crates/server/Cargo.toml`, under `[dependencies]`, add:
+
+```toml
+tower-http = { version = "0.6", features = ["fs"] }
+```
+
+- [ ] **Step 2: Create the committed fixture bundle**
+
+Create `crates/server/tests/fixtures/dist/index.html` (the real `crates/web/dist/` is gitignored, so the test needs its own committed dir):
+
+```html
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>eldritch-test-bundle</title></head>
+  <body>eldritch-test-bundle</body>
+</html>
+```
+
+- [ ] **Step 3: Write the failing test**
+
+Create `crates/server/tests/static_files.rs`:
+
+```rust
+//! The server serves the client bundle from its dist dir as a router
+//! fallback, with `index.html` as the SPA fallback (D3). Uses a
+//! committed fixture dir because the real `crates/web/dist/` is
+//! gitignored (Trunk output) and absent in CI/fresh checkouts.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use sqlx::sqlite::SqlitePoolOptions;
+use tower::ServiceExt;
+
+const FIXTURE_DIST: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/dist");
+
+async fn app_with_fixture_dist() -> axum::Router {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("open in-memory sqlite");
+    server::db::MIGRATOR.run(&pool).await.expect("migrate");
+    server::app(server::AppState::new_with_dist(pool, FIXTURE_DIST.into()))
+}
+
+async fn body_string(response: axum::response::Response) -> String {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+async fn root_serves_index_html() {
+    let app = app_with_fixture_dist().await;
+    let response = app
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        body_string(response).await.contains("eldritch-test-bundle"),
+        "GET / serves the bundle's index.html"
+    );
+}
+
+#[tokio::test]
+async fn unknown_route_falls_back_to_index_html() {
+    let app = app_with_fixture_dist().await;
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/game/abc/some-spa-route")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        body_string(response).await.contains("eldritch-test-bundle"),
+        "an unmatched route falls back to index.html (SPA routing)"
+    );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run: `cargo test -p server --test static_files`
+Expected: FAIL to compile — `server::AppState::new_with_dist` does not exist; `/` currently returns the `"coming soon"` string (not the bundle).
+
+- [ ] **Step 5: Implement the `dist_dir` field and the `ServeDir` fallback**
+
+In `crates/server/src/lib.rs`:
+
+Add imports near the top (with the other `use` statements):
+
+```rust
+use std::path::PathBuf;
+use tower_http::services::{ServeDir, ServeFile};
+```
+
+Add the `dist_dir` field to `AppState`:
+
+```rust
+/// Shared application state handed to every Axum handler.
+#[derive(Clone)]
+pub struct AppState {
+    /// Connection pool for the `SQLite` action-log database.
+    pub db: SqlitePool,
+    /// Live games keyed by `game_id`, each with its broadcast group.
+    rooms: ws::Rooms,
+    /// Directory holding the built client bundle (`index.html`, JS, wasm),
+    /// served as the router fallback.
+    dist_dir: PathBuf,
+}
+```
+
+Replace the `AppState` impl block with:
+
+```rust
+impl AppState {
+    /// Build application state over a database pool, serving the client
+    /// bundle from the default dev location (`crates/web/dist`, relative
+    /// to the workspace root).
+    #[must_use]
+    pub fn new(db: SqlitePool) -> Self {
+        Self::new_with_dist(db, PathBuf::from("crates/web/dist"))
+    }
+
+    /// Build application state with an explicit client-bundle directory.
+    #[must_use]
+    pub fn new_with_dist(db: SqlitePool, dist_dir: PathBuf) -> Self {
+        Self {
+            db,
+            rooms: ws::rooms(),
+            dist_dir,
+        }
+    }
+}
+```
+
+Replace the `app` function and delete the `index` handler. The new `app`:
+
+```rust
+/// Build the application router with all routes and shared state. The
+/// JSON API and WebSocket take precedence; everything else falls back
+/// to the client bundle, with `index.html` as the SPA fallback.
+pub fn app(state: AppState) -> Router {
+    let index_html = state.dist_dir.join("index.html");
+    let static_files = ServeDir::new(&state.dist_dir).fallback(ServeFile::new(index_html));
+
+    Router::new()
+        .route("/health", get(health))
+        .route("/games", post(lifecycle::create_game))
+        .route("/games/{game_id}/ws", get(ws::game_ws))
+        .fallback_service(static_files)
+        .with_state(state)
+}
+```
+
+Delete the now-unused `index` handler entirely:
+
+```rust
+async fn index() -> &'static str {
+    "Eldritch — coming soon"
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cargo test -p server --test static_files`
+Expected: PASS (both tests).
+
+- [ ] **Step 7: Verify the existing server tests still pass**
+
+The `/` route was removed; confirm nothing else relied on it.
+
+Run: `cargo test -p server`
+Expected: PASS (all server tests, including `registries`, `static_files`, `health`, `lifecycle`, `ws`, `resume`, `game_session`, `closing_demo`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/server/Cargo.toml crates/server/src/lib.rs crates/server/tests/static_files.rs crates/server/tests/fixtures/dist/index.html
+git commit -m "infra: single-port static client serving via ServeDir fallback (P6.2)"
+```
+
+---
+
+## Task 3: Full CI gauntlet + phase-doc update
+
+**Files:**
+- Modify: `docs/phases/phase-6-web-client-v0.md` (final commit only)
+
+- [ ] **Step 1: Run the full CI gauntlet locally**
+
+Run each, expecting a clean pass:
+
+```sh
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+```
+
+Expected: all five green. If `fmt --check` flags anything, run `cargo fmt` and amend the relevant commit.
+
+- [ ] **Step 2: Push the branch and open the PR**
+
+```bash
+git push -u origin infra/server-production-playable
+gh pr create --fill
+```
+
+Use the repo PR template; `Closes #183.` in the body; include a one-paragraph design-decisions note (synthetic registries via `scenarios` `test_fixtures` with a Phase-7 TODO; `AppState.dist_dir` + `ServeDir` SPA fallback; committed test-fixture dist because the real `dist/` is gitignored).
+
+- [ ] **Step 3: Watch CI to green**
+
+Run: `gh pr checks <PR#> --watch`
+Expected: all six jobs pass (the existing five; the headless browser job is P6.3, not this PR).
+
+- [ ] **Step 4: Update the phase doc as the final commit (only after CI is green)**
+
+In `docs/phases/phase-6-web-client-v0.md`: flip the P6.2 row in both the **Issues** and **Ordering** tables to `✅ PR #<PR#>`. Drop the P6.2 portion of the **Open questions** note ("whether the wasm bundle is embedded or shipped alongside the binary") only if the PR settles it — it does **not** fully settle it (we ship alongside via `ServeDir`; embedding stays deferred), so **reword** rather than delete: note that Phase 6 ships the bundle alongside the binary via `ServeDir`, embedding deferred. Add a **Decisions made** entry only if it passes the test "would a future PR-author choose differently without it?" — a candidate: "synthetic registries are installed in the binary via `server::install_registries()` (Phase-6-only; `TODO(phase-7)` to swap)". Per `docs/phases/README.md`, keep it lean.
+
+```bash
+git add docs/phases/phase-6-web-client-v0.md
+git commit -m "docs: mark P6.2 shipped (#183)"
+git push
+```
+
+- [ ] **Step 5: Stop — await user approval before merge**
+
+Do not merge. Per CLAUDE.md, merge only after explicit user approval via `gh pr merge <PR#> --squash --delete-branch`.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** D5 (synthetic registries in binary) → Task 1. D3 (single-port static serving + SPA fallback) → Task 2. Acceptance "POST /games synthetic succeeds against the real binary" → Task 1 Step 2 (`post_games_creates_synthetic_game...`) + Step 6 (binary wiring). Acceptance "GET / serves index.html; wasm bundle loads" → Task 2 (`root_serves_index_html`; the wasm/JS are siblings served by the same `ServeDir`). "CI gauntlet green" → Task 3.
+- **Type consistency:** `install_registries()` (no args, `()` return); `AppState::new(pool)` / `AppState::new_with_dist(pool, PathBuf)`; `app(AppState) -> Router`. `FIXTURE_DIST.into()` yields `PathBuf` from `&str`. Registry field accessors `(reg.module_for)(&id)`, `(reg.metadata_for)(&code)`, `(reg.abilities_for)(&code)` match `game-core`'s `ScenarioRegistry` / `CardRegistry`.
+- **No placeholders:** every code/command step is concrete.
+```


### PR DESCRIPTION
## Summary

Makes the production `server` binary able to create and play the synthetic toy scenario and serve the client bundle from a single port — the server-side foundation for the Phase-6 web client (decisions D3, D5).

## What changed

- **Synthetic registries in the binary (D5).** New `server::install_registries()` installs the process-global scenario + card registries (`scenarios::REGISTRY` and `scenarios::test_fixtures::synth_cards::TEST_REGISTRY`); `main.rs` calls it at startup. `POST /games {"scenario_id":"synthetic"}` now succeeds against the real binary and synthetic cards resolve. Carries a `TODO(phase-7)` to swap to the real `cards`/`scenarios` registries when The Gathering lands.
- **Single-port static serving (D3).** The router serves the client bundle via a `ServeDir` fallback with `index.html` as the SPA fallback; explicit routes (`/health`, `/games`, `/games/{id}/ws`) take precedence. The placeholder `/` → "coming soon" route is removed. `AppState` gains a private `dist_dir` (default `crates/web/dist`; `new_with_dist` for tests/deploy).
- Added `tower-http` (`fs` feature).

## Design decisions

- `.fallback()` (not `.not_found_service()`) on `ServeDir` keeps the SPA fallback at `200 OK` — correct for client-side routing, where the browser loads `index.html` and its JS resolves the path. (Commented in `app()` to forestall a "fix" that would break SPA routing.)
- `test_fixtures` is made explicit on the `scenarios` dep: it's the synthetic content the binary now relies on at *runtime* this phase (the acknowledged "test_fixtures-on-in-server" tension from D5/Phase 4), forward-proofed against the feature leaving `scenarios`' default set.
- Static tests use a **committed** fixture dir (`crates/server/tests/fixtures/dist/`) because the real `crates/web/dist/` is gitignored (Trunk output) and absent in CI.

## Test notes

- `crates/server/tests/registries.rs` — registry lookups resolve the synthetic scenario + cards; `POST /games {"scenario_id":"synthetic"}` → 201 against the real `app()`.
- `crates/server/tests/static_files.rs` — `GET /` and an unknown SPA route both serve `index.html` (200).
- Full CI gauntlet green locally (fmt, clippy `-D warnings`, test `RUSTFLAGS=-D warnings`, doc `RUSTDOCFLAGS=-D warnings`, wasm-build). The 6th headless-browser job arrives in P6.3.

## Linked issues

Closes #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)