### PR TITLE
test: headless wasm-bindgen-test harness + 6th CI job (P6.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,14 @@ jobs:
       - name: Build web crate
         working-directory: crates/web
         run: trunk build --release
+
+  wasm-test:
+    name: wasm-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
+      - uses: jetli/wasm-pack-action@v0.4.0
+      - name: Headless wasm tests
+        run: wasm-pack test --headless --firefox crates/web

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Likewise, **invoke** the `karpathy-guidelines` skill (don't just recall it) when
 
 ## Commands
 
-CI runs five jobs (`fmt`, `clippy`, `test`, `doc`, `wasm-build`), all warnings-as-errors. Match the strict flags locally before pushing — `cargo test` alone misses broken intra-doc links and clippy lints CI fails on.
+CI runs six jobs (`fmt`, `clippy`, `test`, `doc`, `wasm-build`, `wasm-test`), all warnings-as-errors. Match the strict flags locally before pushing — `cargo test` alone misses broken intra-doc links and clippy lints CI fails on.
 
 ```sh
 # Match CI's strict flags
@@ -25,6 +25,7 @@ RUSTFLAGS="-D warnings"     cargo test --all --all-features
                             cargo fmt --check
 RUSTDOCFLAGS="-D warnings"  cargo doc --workspace --no-deps --all-features
                             cargo build -p web --target wasm32-unknown-unknown
+                            wasm-pack test --headless --firefox crates/web   # headless browser tests (6th CI job)
 
 # Single test (binary name from `cargo test` output)
 cargo test -p game-core <test_fn_name>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,6 +1409,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,6 +1505,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "or_poisoned"
@@ -3136,6 +3158,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-test"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29826f9d9ecaa314c480d376b276d1c790e6cb6a4681fab8532da69cbabf977d"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c610311887f9e6599a546d278d12d69dfd3a3e92639b2129e4b11ad6cf1961d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60238e5b4b1b295701d6f9a66d2a126fe19990348f5fb9dae3b623a370119d94"
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3211,6 +3272,7 @@ dependencies = [
  "console_error_panic_hook",
  "game-core",
  "leptos",
+ "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -14,3 +14,6 @@ workspace = true
 game-core = { path = "../game-core" }
 leptos = { version = "0.8", features = ["csr"] }
 console_error_panic_hook = "0.1"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -1,0 +1,13 @@
+//! The root Leptos component for the Eldritch web client.
+
+use leptos::prelude::*;
+
+#[component]
+pub fn App() -> impl IntoView {
+    view! {
+        <main>
+            <h1>"Eldritch"</h1>
+            <p>"Coming soon — a digital simulator for the Arkham Horror LCG."</p>
+        </main>
+    }
+}

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -1,0 +1,7 @@
+//! Eldritch web client library: Leptos CSR components, compiled to WASM.
+//!
+//! The binary (`main.rs`) is a thin entrypoint that mounts [`app::App`].
+//! Components live here so integration tests in `tests/` — and later Phase-6
+//! components — can import them.
+
+pub mod app;

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -1,18 +1,6 @@
-//! Eldritch web client. Phase 0 placeholder — renders a single greeting.
-
-use leptos::prelude::*;
+//! Eldritch web client entrypoint: install the panic hook and mount the app.
 
 fn main() {
     console_error_panic_hook::set_once();
-    leptos::mount::mount_to_body(App);
-}
-
-#[component]
-fn App() -> impl IntoView {
-    view! {
-        <main>
-            <h1>"Eldritch"</h1>
-            <p>"Coming soon — a digital simulator for the Arkham Horror LCG."</p>
-        </main>
-    }
+    leptos::mount::mount_to_body(web::app::App);
 }

--- a/crates/web/tests/smoke.rs
+++ b/crates/web/tests/smoke.rs
@@ -1,0 +1,26 @@
+//! Headless smoke test proving the wasm-bindgen-test harness drives a real
+//! browser against the Leptos `App`. Compiled only for wasm32 (crate-level
+//! cfg below): the native `test`/`clippy`/`doc` jobs skip it entirely, so the
+//! five pre-existing CI jobs are unaffected.
+#![cfg(target_arch = "wasm32")]
+
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn app_renders_greeting() {
+    // mount_to_body returns an unmount handle; bind it (not `_`) so the view
+    // stays mounted through the assertion.
+    let _handle = leptos::mount::mount_to_body(web::app::App);
+
+    let body = leptos::prelude::document()
+        .body()
+        .expect("document should have a <body>");
+
+    assert!(
+        body.inner_html().contains("Eldritch"),
+        "rendered DOM should contain the greeting, got: {}",
+        body.inner_html()
+    );
+}

--- a/docs/phases/phase-6-web-client-v0.md
+++ b/docs/phases/phase-6-web-client-v0.md
@@ -19,7 +19,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | — | [#191](https://github.com/talelburg/eldritch/issues/191) — kickoff: design spec + issue breakdown | 🟡 open (this docs PR) |
 | P6.1 | [#182](https://github.com/talelburg/eldritch/issues/182) — `protocol` crate extraction + `state` on `Applied` | ✅ PR #193 |
 | P6.2 | [#183](https://github.com/talelburg/eldritch/issues/183) — server production-playable: synthetic registries + static WASM serving | ✅ PR #194 |
-| P6.3 | [#184](https://github.com/talelburg/eldritch/issues/184) — headless browser test harness + 6th CI job | ⏳ open |
+| P6.3 | [#184](https://github.com/talelburg/eldritch/issues/184) — headless browser test harness + 6th CI job | ✅ PR #195 |
 | P6.4 | [#185](https://github.com/talelburg/eldritch/issues/185) — WS client + reactive state store | ⏳ open |
 | P6.5 | [#186](https://github.com/talelburg/eldritch/issues/186) — board rendering (read-only) | ⏳ open |
 | P6.6 | [#187](https://github.com/talelburg/eldritch/issues/187) — AwaitingInput resolution UI + legality gating | ⏳ open |
@@ -33,7 +33,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 |---|---|---|---|
 | P6.1 | #182 protocol crate + `state` on `Applied` ✅ PR #193 | Foundational; unblocks the client speaking the protocol with shared types | kickoff |
 | P6.2 | #183 server registries + static WASM ✅ PR #194 | The thing the client connects to | — (parallel w/ P6.1) |
-| P6.3 | #184 headless harness + 6th CI job | Testing foundation before TDD-ing components; de-risks browser-in-CI early | — |
+| P6.3 | #184 headless harness + 6th CI job ✅ PR #195 | Testing foundation before TDD-ing components; de-risks browser-in-CI early | — |
 | P6.4 | #185 WS client + reactive store | The client's engine room; debug-dump render proves the round-trip | P6.1, P6.3 |
 | P6.5 | #186 board rendering | See the state | P6.4 |
 | P6.6 | #187 AwaitingInput UI + legality | Core-loop: `Investigate` opens a skill-test commit window (`AwaitingInput`), so this precedes the action controls | P6.5 |
@@ -102,6 +102,19 @@ Settled implementing P6.2 (PR #194):
 - **`ServeDir` uses `.fallback()`, not `.not_found_service()`.** The
   SPA fallback to `index.html` must return `200 OK` (the browser's JS
   resolves the route); `not_found_service` would force `404`.
+
+Settled implementing P6.3 (PR #195):
+
+- **Headless component tests live in `crates/web/tests/`, importing
+  `web::app::*`.** The `web` crate is now lib + bin (`lib.rs`/`app.rs` +
+  a thin `main.rs` shim) so `tests/` can reach the components — this is
+  the pattern every later P6 component test follows. Each such test file
+  **must** carry a crate-level `#![cfg(target_arch = "wasm32")]`: a
+  `wasm-bindgen-test` mounts into a DOM that doesn't exist off-wasm, so
+  without the gate the native `test`/`clippy` jobs would compile (and
+  `test` would *run*) a browser-only test and break. Only the
+  `wasm-test` job (wasm32 via `wasm-pack test --headless --firefox`)
+  runs them.
 
 ## Open questions
 

--- a/docs/phases/phase-6-web-client-v0.md
+++ b/docs/phases/phase-6-web-client-v0.md
@@ -16,7 +16,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 
 | Order | Issue | State |
 |---|---|---|
-| — | [#191](https://github.com/talelburg/eldritch/issues/191) — kickoff: design spec + issue breakdown | 🟡 open (this docs PR) |
+| — | [#191](https://github.com/talelburg/eldritch/issues/191) — kickoff: design spec + issue breakdown | ✅ PR #192 |
 | P6.1 | [#182](https://github.com/talelburg/eldritch/issues/182) — `protocol` crate extraction + `state` on `Applied` | ✅ PR #193 |
 | P6.2 | [#183](https://github.com/talelburg/eldritch/issues/183) — server production-playable: synthetic registries + static WASM serving | ✅ PR #194 |
 | P6.3 | [#184](https://github.com/talelburg/eldritch/issues/184) — headless browser test harness + 6th CI job | ✅ PR #195 |

--- a/docs/superpowers/plans/2026-06-08-p6.3-wasm-test-harness.md
+++ b/docs/superpowers/plans/2026-06-08-p6.3-wasm-test-harness.md
@@ -1,0 +1,275 @@
+# P6.3 — Headless wasm test harness + 6th CI job: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up a `wasm-bindgen-test` headless-browser harness and a sixth CI job (`wasm-test`), proven by one smoke test that mounts the existing `App` and asserts the greeting renders.
+
+**Architecture:** Split the binary-only `web` crate into a library (`lib.rs` + `app.rs`, holding the components) plus a thin binary shim (`main.rs`), so `tests/` can import `web::app::App`. A wasm-only integration test (`tests/smoke.rs`, crate-level `#![cfg(target_arch = "wasm32")]`) drives a headless browser via `wasm-pack test`; the cfg gate keeps the five existing native jobs unaffected. A sixth CI job runs the headless suite.
+
+**Tech Stack:** Rust, Leptos 0.8 (CSR), `wasm-bindgen-test` 0.3, `wasm-pack`, headless Firefox, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-phase-6-p6.3-wasm-test-harness-design.md`
+
+---
+
+## File structure
+
+- **Create** `crates/web/src/app.rs` — the `App` component (moved from `main.rs`, made `pub`).
+- **Create** `crates/web/src/lib.rs` — library root: `pub mod app;`. Importable surface for tests + future P6 components.
+- **Modify** `crates/web/src/main.rs` — shrink to a panic-hook + `mount_to_body(web::app::App)` shim.
+- **Modify** `crates/web/Cargo.toml` — add `[dev-dependencies] wasm-bindgen-test`.
+- **Create** `crates/web/tests/smoke.rs` — the wasm-only smoke test.
+- **Modify** `.github/workflows/ci.yml` — add the `wasm-test` job.
+- **Modify** `CLAUDE.md` — bump "five jobs" → six, add the local headless command.
+
+## Prerequisites (one-time, local)
+
+The executor needs `wasm-pack` and a headless-capable Firefox installed to run the suite locally.
+
+- [ ] **Verify / install `wasm-pack`**
+
+Run: `wasm-pack --version || cargo install wasm-pack`
+Expected: prints a version (e.g. `wasm-pack 0.13.x`).
+
+- [ ] **Verify Firefox is present** (geckodriver is auto-downloaded by `wasm-pack`)
+
+Run: `firefox --version`
+Expected: prints a Firefox version. If absent, install it (e.g. `sudo apt-get install -y firefox` / `firefox-esr`).
+
+---
+
+## Task 1: Crate restructure + headless smoke test (full TDD cycle)
+
+**Files:**
+- Modify: `crates/web/Cargo.toml`
+- Test: `crates/web/tests/smoke.rs` (create)
+- Create: `crates/web/src/app.rs`
+- Create: `crates/web/src/lib.rs`
+- Modify: `crates/web/src/main.rs`
+
+- [ ] **Step 1: Add the dev-dependency**
+
+In `crates/web/Cargo.toml`, after the `[dependencies]` block, add:
+
+```toml
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+```
+
+- [ ] **Step 2: Write the failing smoke test**
+
+Create `crates/web/tests/smoke.rs`:
+
+```rust
+//! Headless smoke test proving the wasm-bindgen-test harness drives a real
+//! browser against the Leptos `App`. Compiled only for wasm32 (crate-level
+//! cfg below): the native `test`/`clippy`/`doc` jobs skip it entirely, so the
+//! five pre-existing CI jobs are unaffected.
+#![cfg(target_arch = "wasm32")]
+
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn app_renders_greeting() {
+    // mount_to_body returns an unmount handle; bind it (not `_`) so the view
+    // stays mounted through the assertion.
+    let _handle = leptos::mount::mount_to_body(web::app::App);
+
+    let body = leptos::prelude::document()
+        .body()
+        .expect("document should have a <body>");
+
+    assert!(
+        body.inner_html().contains("Eldritch"),
+        "rendered DOM should contain the greeting, got: {}",
+        body.inner_html()
+    );
+}
+```
+
+Note for Step 4 fallback: if `leptos::prelude::document` does not resolve in Leptos 0.8.19, add `web-sys = { version = "0.3", features = ["Document", "HtmlElement"] }` to `[dev-dependencies]` and replace the `body` binding with:
+`let body = web_sys::window().unwrap().document().unwrap().body().expect("…");`
+
+- [ ] **Step 3: Run the test to verify it fails (for the right reason)**
+
+Run: `wasm-pack test --headless --firefox crates/web`
+Expected: **compile FAIL** — `unresolved import` / `could not find 'app' in 'web'` (the `web` crate has no library target yet, so `web::app::App` does not exist).
+
+- [ ] **Step 4: Create the component module**
+
+Create `crates/web/src/app.rs` (move the component out of `main.rs`, make it `pub`):
+
+```rust
+//! The root Leptos component for the Eldritch web client.
+
+use leptos::prelude::*;
+
+#[component]
+pub fn App() -> impl IntoView {
+    view! {
+        <main>
+            <h1>"Eldritch"</h1>
+            <p>"Coming soon — a digital simulator for the Arkham Horror LCG."</p>
+        </main>
+    }
+}
+```
+
+- [ ] **Step 5: Create the library root**
+
+Create `crates/web/src/lib.rs`:
+
+```rust
+//! Eldritch web client library: Leptos CSR components, compiled to WASM.
+//!
+//! The binary (`main.rs`) is a thin entrypoint that mounts [`app::App`].
+//! Components live here so integration tests in `tests/` — and later Phase-6
+//! components — can import them.
+
+pub mod app;
+```
+
+- [ ] **Step 6: Shrink the binary to a shim**
+
+Replace the entire contents of `crates/web/src/main.rs` with:
+
+```rust
+//! Eldritch web client entrypoint: install the panic hook and mount the app.
+
+fn main() {
+    console_error_panic_hook::set_once();
+    leptos::mount::mount_to_body(web::app::App);
+}
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `wasm-pack test --headless --firefox crates/web`
+Expected: **PASS** — `test app_renders_greeting ... ok`, `1 passed; 0 failed`.
+
+If `wasm-pack` resolution bumped `wasm-bindgen` away from the locked `0.2.120` (a version-mismatch error from `wasm-bindgen-test`), pin the matching patch and retry:
+`cargo update -p wasm-bindgen-test --precise 0.3.70` then re-run Step 7.
+
+- [ ] **Step 8: Verify the five existing jobs are unaffected**
+
+Run each and confirm the smoke test is invisible to native targets (cfg-gated out) and nothing else broke:
+
+```sh
+RUSTFLAGS="-D warnings" cargo test --all --all-features        # smoke.rs compiles to nothing; existing tests pass
+cargo clippy --all-targets --all-features -- -D warnings        # clean, incl. the new lib/bin
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown              # bin still builds for wasm
+(cd crates/web && trunk build)                                  # bundle still builds via the shim
+```
+
+Expected: all succeed.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/web/Cargo.toml crates/web/src/app.rs crates/web/src/lib.rs crates/web/src/main.rs crates/web/tests/smoke.rs Cargo.lock
+git commit -m "test: headless wasm-bindgen-test harness + web lib/bin split
+
+Split the binary-only web crate into a library (lib.rs + app.rs) plus a
+thin main.rs shim so integration tests can import web::app::App. Add a
+wasm-only smoke test (crate-level cfg(target_arch = wasm32)) that mounts
+App in a headless browser and asserts the greeting renders.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Sixth CI job (`wasm-test`)
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add the job**
+
+Append to `.github/workflows/ci.yml`, after the `wasm-build` job (same indentation level, inheriting the file-level `RUSTFLAGS: -D warnings`):
+
+```yaml
+  wasm-test:
+    name: wasm-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
+      - uses: jetli/wasm-pack-action@v0.4.0
+      - name: Headless wasm tests
+        run: wasm-pack test --headless --firefox crates/web
+```
+
+- [ ] **Step 2: Validate the YAML locally**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml')); print('ok')"`
+Expected: `ok` (well-formed YAML).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: add wasm-test job (headless wasm-bindgen-test)
+
+Sixth CI job runs the headless browser suite via wasm-pack + Firefox,
+inheriting warnings-as-errors. Firefox over Chrome to avoid chromedriver's
+version coupling to the runner's auto-updating Chrome.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+> Full verification of this job happens at PR time (`gh pr checks --watch`); the local equivalent (`wasm-pack test`) was verified green in Task 1, Step 7.
+
+---
+
+## Task 3: Docs (CLAUDE.md)
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Update the job count**
+
+In `CLAUDE.md`, find the line beginning `CI runs five jobs (` and change it to:
+
+```
+CI runs six jobs (`fmt`, `clippy`, `test`, `doc`, `wasm-build`, `wasm-test`), all warnings-as-errors. Match the strict flags locally before pushing — `cargo test` alone misses broken intra-doc links and clippy lints CI fails on.
+```
+
+- [ ] **Step 2: Add the local headless command**
+
+In the "Match CI's strict flags" code block in `CLAUDE.md`, immediately after the line `cargo build -p web --target wasm32-unknown-unknown`, add:
+
+```
+wasm-pack test --headless --firefox crates/web              # headless browser tests (6th CI job)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: note the wasm-test job + local headless command
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## After all tasks
+
+1. **Run the full local gauntlet** (the six commands from Task 1 Step 8 plus the `wasm-pack test` from Step 7) — all green.
+2. **Push** branch `test/wasm-test-harness`, **open the PR** (`gh pr create`, repo template, `Closes #184`), **watch CI** (`gh pr checks <PR#> --watch`) — confirm all six jobs, including the new `wasm-test`, go green.
+3. **Phase-doc update, as the final commit only after CI is green** (per `docs/phases/README.md`): in `docs/phases/phase-6-web-client-v0.md`, flip the P6.3 rows (Issues table + Ordering table) to `✅ PR #N`. Add a **Decisions made** entry only if it passes the future-PR-author test (likely: "Headless wasm tests = lib/bin split + `tests/smoke.rs` gated `#![cfg(target_arch = \"wasm32\")]`; CI uses `wasm-pack test --headless --firefox`"). Drop nothing from Open questions (none were P6.3-specific).
+4. **Merge only after explicit user approval.**
+
+---
+
+## Self-review
+
+- **Spec coverage:** restructure (§Design 1 → Task 1 S4–6); harness/dev-dep/test (§2 → Task 1 S1–2,7); native-job gotcha via crate-level cfg (§3 → Task 1 S2,8); 6th CI job (§4 → Task 2); CLAUDE.md command (§5 → Task 3); verification/"done" (§Verification → After-all-tasks + Task 1 S7–8). All covered.
+- **Placeholder scan:** none — every code/command step is concrete; the one conditional (`web-sys` fallback, version `--precise` pin) gives exact code/commands.
+- **Type consistency:** `web::app::App` used identically in `main.rs` and `tests/smoke.rs`; `mount_to_body` / `leptos::prelude::document()` consistent throughout; job name `wasm-test` and command `wasm-pack test --headless --firefox crates/web` identical across plan, CI, and docs.

--- a/docs/superpowers/specs/2026-06-08-phase-6-p6.3-wasm-test-harness-design.md
+++ b/docs/superpowers/specs/2026-06-08-phase-6-p6.3-wasm-test-harness-design.md
@@ -1,0 +1,139 @@
+# Phase 6 / P6.3 — Headless wasm test harness + 6th CI job: design spec
+
+**Date:** 2026-06-08
+**Status:** Design approved.
+**Milestone:** `phase-6-web-client-v0`
+**Issue:** [#184](https://github.com/talelburg/eldritch/issues/184)
+**Parent spec:** [`2026-06-08-phase-6-web-client-v0-design.md`](2026-06-08-phase-6-web-client-v0-design.md) (decision D4)
+
+## Goal
+
+Stand up a `wasm-bindgen-test` headless-browser harness and a sixth CI
+job (`wasm-test`), so every later Phase-6 client component (P6.4–P6.8)
+is TDD'd against a real browser. Prove the harness with a single smoke
+test that mounts the existing `App` and asserts the greeting renders.
+
+This is the testing foundation; it lands before any real component
+exists, deliberately de-risking browser-in-CI early.
+
+## Non-goals
+
+- No test-utility helpers, shared fixtures, or DOM-assertion library —
+  just the one smoke test proving the harness. P6.4 builds real
+  component tests on top.
+- No second browser. Firefox only (rationale below); Chrome is a
+  one-flag swap if it ever flakes.
+- No change to the five existing CI jobs' behavior.
+
+## Context: what exists
+
+- `crates/web` is a **binary-only** crate: `src/main.rs` holds the
+  Phase-0 `App` component (renders an `<h1>"Eldritch"</h1>` greeting)
+  and the `mount_to_body` entrypoint. Leptos 0.8 CSR; `game-core` is
+  already a wasm dependency.
+- CI (`.github/workflows/ci.yml`) runs five jobs (`fmt`, `clippy`,
+  `test`, `doc`, `wasm-build`), all under a global
+  `RUSTFLAGS: -D warnings`. `wasm-build` already uses `jetli/trunk-action`.
+
+## Why a binary-only crate forces a restructure
+
+Integration tests in `tests/` can only reach a crate's **library**
+target. `web` has no `lib.rs`, so its `App` is unreachable from
+`tests/`. Since the parent spec mandates browser TDD for *every* later
+component, the test surface set up here becomes the phase-wide pattern —
+so we introduce a library target now rather than locking components
+inside the binary.
+
+## Design
+
+### 1. Crate restructure: `web` becomes lib + bin
+
+- **`crates/web/src/app.rs`** (new) — the `App` component moves here,
+  made `pub`.
+- **`crates/web/src/lib.rs`** (new) — `pub mod app;`. Crate name `web`;
+  this is the importable surface for tests and future components.
+- **`crates/web/src/main.rs`** (shrinks) — panic-hook + 
+  `leptos::mount::mount_to_body(web::app::App)` shim, nothing else.
+
+Cargo auto-detects both targets from the presence of `lib.rs` +
+`main.rs`; no explicit `[lib]` / `[[bin]]` stanza needed. Trunk
+continues to build the bin target unchanged.
+
+### 2. Test harness
+
+- **`crates/web/Cargo.toml`** — add a `[dev-dependencies]` section with
+  `wasm-bindgen-test = "0.3"`. Add `wasm-bindgen` and/or `web-sys`
+  (with only the features the assertion needs, e.g. `Document`,
+  `Element`) **only if** naming those types in the assertion requires
+  them; prefer Leptos-provided accessors (e.g. `document()`) to keep the
+  dependency set minimal.
+- **`crates/web/tests/smoke.rs`** (new):
+  - `#![cfg(target_arch = "wasm32")]` at crate level (load-bearing —
+    see below).
+  - `wasm_bindgen_test_configure!(run_in_browser);`
+  - One `#[wasm_bindgen_test]`: mount `web::app::App` into the document,
+    assert the rendered DOM contains the `"Eldritch"` heading text.
+
+### 3. The native-job gotcha (load-bearing)
+
+A `wasm-bindgen-test` mounts into a DOM that does not exist off-wasm.
+Without guarding, the existing native `test` job (`cargo test --all`)
+and `clippy --all-targets` would compile — and `test` would attempt to
+*run* — a browser-only test with no document, breaking CI.
+
+The crate-level `#![cfg(target_arch = "wasm32")]` makes `tests/smoke.rs`
+compile to nothing on the host target. Therefore:
+
+- The five existing jobs (all host-target) see an empty test file →
+  behavior unchanged.
+- Only the new `wasm-test` job (wasm32 target via `wasm-pack`) compiles
+  and runs the smoke test.
+
+### 4. CI: 6th job `wasm-test`
+
+Added to `.github/workflows/ci.yml`, mirroring the existing jobs and
+inheriting the global `RUSTFLAGS: -D warnings`:
+
+```yaml
+wasm-test:
+  name: wasm-test
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v6
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - uses: Swatinem/rust-cache@v2
+    - uses: jetli/wasm-pack-action@v0.4.0
+    - run: wasm-pack test --headless --firefox crates/web
+```
+
+- **Runner — `wasm-pack test`:** conventional, builds the wasm test
+  bundle and drives a headless browser, auto-downloading the matching
+  driver. Consistent with the existing `jetli/trunk-action` usage.
+  (Raw `wasm-bindgen-test-runner` rejected — more manual driver/runner
+  wiring for no benefit.)
+- **Browser — Firefox:** chosen to avoid chromedriver's hard version
+  coupling to the runner's auto-updating Chrome (a known headless-CI
+  flakiness source); geckodriver is version-tolerant. Preinstalled on
+  `ubuntu-latest`. Reversible to `--chrome` by a single flag.
+
+### 5. Docs
+
+- **`CLAUDE.md` "Commands":** add the local headless command alongside
+  the existing strict-flag commands:
+  `wasm-pack test --headless --firefox crates/web`.
+
+## Verification / "done"
+
+- `wasm-pack test --headless --firefox crates/web` passes locally
+  (headless Firefox).
+- All six CI jobs green on the PR; the five existing jobs unchanged in
+  behavior.
+- `trunk build` still succeeds (the lib/bin shim didn't break the
+  bundle).
+
+## Open questions
+
+None blocking. Resolved during implementation: whether the DOM
+assertion needs a direct `web-sys`/`wasm-bindgen` dev-dependency or can
+rely on Leptos accessors (§2); exact `wasm-bindgen-test` patch version
+that aligns with the Leptos-pinned `wasm-bindgen`.


### PR DESCRIPTION
## Summary

Stands up the `wasm-bindgen-test` headless-browser harness and a sixth CI job (`wasm-test`), so every later Phase-6 client component (P6.4–P6.8) is TDD'd against a real browser. Proven by a smoke test that mounts the existing `App` and asserts the greeting renders.

## What changed

- **`web` crate split into lib + bin.** `App` moves to `crates/web/src/app.rs` (now `pub`); `crates/web/src/lib.rs` exposes `pub mod app;`; `main.rs` shrinks to a panic-hook + `mount_to_body(web::app::App)` shim. A binary-only crate can't be reached by `tests/`, so the library target is the importable surface every later component + test uses.
- **Headless smoke test** at `crates/web/tests/smoke.rs`: mounts `App`, asserts the rendered DOM contains the greeting.
- **6th CI job `wasm-test`**: runs `wasm-pack test --headless --firefox crates/web`, inheriting the global `RUSTFLAGS: -D warnings`.
- **Docs**: CLAUDE.md bumped to six jobs + the local headless command.

## Design decisions

- **State delivery N/A** — pure test/infra PR (spec decision D4).
- **The native jobs gotcha (load-bearing):** `tests/smoke.rs` carries a crate-level `#![cfg(target_arch = "wasm32")]`. A `wasm-bindgen-test` mounts into a DOM that doesn't exist off-wasm, so without the gate the existing native `test` job would try to *run* a browser-only test with no document. The gate makes the file compile to nothing on the host target — the five pre-existing jobs are behavior-unchanged; only `wasm-test` (wasm32 via `wasm-pack`) runs it.
- **Firefox over Chrome:** chromedriver hard-pins to the runner's auto-updating Chrome major version (a known headless-CI flakiness source); geckodriver is version-tolerant. One-flag swap if it ever regresses.
- **`wasm-pack` over raw `wasm-bindgen-test-runner`:** conventional, auto-downloads the matching driver, consistent with the existing `jetli/trunk-action` usage.
- `wasm-bindgen-test` resolved to `0.3.70`, matching the locked `wasm-bindgen 0.2.120` — no dependency bump.

## Test notes

Verified locally (headless Firefox 151 via the Mozilla APT `.deb`):

- `wasm-pack test --headless --firefox crates/web` → `app_renders_greeting ... ok` (1 passed).
- All five existing jobs green: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `RUSTFLAGS="-D warnings" cargo test --all --all-features`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`, `cargo build -p web --target wasm32-unknown-unknown`.
- `trunk build` still produces the bundle via the new shim.

## Linked issues

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)