### PR TITLE
ui: WS client + reactive state store (P6.4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,15 @@ cargo test -p cards --test play_card <test_fn_name>     # integration tests in c
 # Regenerate the card corpus (only after bumping data/arkhamdb-snapshot)
 cargo run -p card-data-pipeline
 
-# Dev loop (two terminals)
-cargo run -p server                                       # Axum on :8000
-cd crates/web && trunk serve --proxy-backend=http://localhost:8000   # WASM on :3000
+# Dev loop — single port (serves the WASM bundle + API + WS together)
+cd crates/web && trunk build      # rebuild after client changes (no hot-reload)
+cargo run -p server               # serves crates/web/dist + API/WS on :8000
+# then open http://localhost:8000
+#
+# `trunk serve --proxy-backend=…` (hot-reload on :3000) does NOT work with
+# trunk 0.21.x: its proxy mounts as an axum `.nest()`, which panics at the
+# root `/`, and our REST (`POST /games`) + WS (`/games/{id}/ws`) share the
+# `/games` prefix so no two-entry proxy config works either. Use single-port.
 ```
 
 ## Architecture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gloo-utils"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3270,9 +3282,16 @@ name = "web"
 version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
+ "futures",
  "game-core",
+ "gloo-net",
+ "gloo-timers",
  "leptos",
+ "protocol",
+ "serde_json",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -60,6 +60,61 @@ pub enum ServerMessage {
     },
 }
 
+/// Stable identifier for a persisted game. Part of the client/server
+/// contract: returned by `POST /games` and used in the WebSocket path
+/// `/games/{game_id}/ws`. Transparent over `String` — serializes as a
+/// bare JSON string, binds to a `SQLite` TEXT column, and extracts from a
+/// URL path segment. Id *minting* (`random_game_id`) lives server-side
+/// to keep `uuid` out of this wasm-safe crate.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct GameId(String);
+
+impl GameId {
+    /// Wrap an existing id string.
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+    /// Borrow the underlying string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for GameId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+/// Body of `POST /games`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateGameRequest {
+    /// The scenario module to set up.
+    pub scenario_id: String,
+}
+
+/// Response to a successful `POST /games`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateGameResponse {
+    /// The newly created game's id.
+    pub game_id: GameId,
+}
+
+#[cfg(test)]
+mod id_tests {
+    use super::GameId;
+
+    #[test]
+    fn serializes_as_a_bare_string() {
+        let id = GameId::new("abc");
+        assert_eq!(serde_json::to_string(&id).unwrap(), "\"abc\"");
+        let back: GameId = serde_json::from_str("\"abc\"").unwrap();
+        assert_eq!(back, id);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -62,10 +62,12 @@ pub enum ServerMessage {
 
 /// Stable identifier for a persisted game. Part of the client/server
 /// contract: returned by `POST /games` and used in the WebSocket path
-/// `/games/{game_id}/ws`. Transparent over `String` — serializes as a
-/// bare JSON string, binds to a `SQLite` TEXT column, and extracts from a
-/// URL path segment. Id *minting* (`random_game_id`) lives server-side
-/// to keep `uuid` out of this wasm-safe crate.
+/// `/games/{game_id}/ws`. Lives here (not in `game-core`) because it is a
+/// host/transport concept, not a kernel domain id like `ScenarioId`.
+/// Transparent over `String` — serializes as a bare JSON string, binds to
+/// a `SQLite` TEXT column, and extracts from a URL path segment. Id
+/// *minting* (`random_game_id`) lives server-side to keep `uuid` out of
+/// this wasm-safe crate.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct GameId(String);

--- a/crates/server/src/id.rs
+++ b/crates/server/src/id.rs
@@ -1,58 +1,23 @@
-//! `GameId`: the server-side identifier for a persisted game session.
+//! `GameId` re-export + server-side id minting.
+//!
+//! The `GameId` type lives in `protocol` (it is part of the client/server
+//! contract). Generation uses `uuid`, a persistence concern, so it stays
+//! here rather than in the wasm-safe `protocol` crate.
 
-use serde::{Deserialize, Serialize};
+pub use protocol::GameId;
 
-/// Stable identifier for a persisted game — it names a row in the
-/// `games` table. A server/persistence concept, distinct from
-/// game-core's domain ids (`ScenarioId`, `InvestigatorId`, …), so it
-/// lives in the host crate rather than the kernel.
-///
-/// Transparent over [`String`]: it serializes as a bare JSON string,
-/// binds directly to a `SQLite` TEXT column, and extracts straight from
-/// a URL path segment.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct GameId(String);
-
-impl GameId {
-    /// Wrap an existing id string.
-    pub fn new(s: impl Into<String>) -> Self {
-        Self(s.into())
-    }
-
-    /// Generate a fresh random id (UUID v4).
-    #[must_use]
-    pub fn random() -> Self {
-        Self(uuid::Uuid::new_v4().to_string())
-    }
-
-    /// Borrow the underlying string.
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl From<&str> for GameId {
-    fn from(s: &str) -> Self {
-        Self(s.to_string())
-    }
+/// Generate a fresh random game id (UUID v4).
+#[must_use]
+pub fn random_game_id() -> GameId {
+    GameId::new(uuid::Uuid::new_v4().to_string())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::GameId;
+    use super::random_game_id;
 
     #[test]
     fn random_ids_are_distinct() {
-        assert_ne!(GameId::random(), GameId::random());
-    }
-
-    #[test]
-    fn serializes_as_a_bare_string() {
-        let id = GameId::new("abc");
-        assert_eq!(serde_json::to_string(&id).unwrap(), "\"abc\"");
-        let back: GameId = serde_json::from_str("\"abc\"").unwrap();
-        assert_eq!(back, id);
+        assert_ne!(random_game_id(), random_game_id());
     }
 }

--- a/crates/server/src/lifecycle.rs
+++ b/crates/server/src/lifecycle.rs
@@ -4,25 +4,11 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::Json;
 use game_core::scenario::ScenarioId;
-use serde::{Deserialize, Serialize};
+use protocol::{CreateGameRequest, CreateGameResponse};
 
-use crate::id::GameId;
+use crate::id::random_game_id;
 use crate::session::{GameSession, SessionError};
 use crate::AppState;
-
-/// Body of `POST /games`.
-#[derive(Debug, Deserialize)]
-pub struct CreateGameRequest {
-    /// The scenario module to set up.
-    pub scenario_id: String,
-}
-
-/// Response to a successful `POST /games`.
-#[derive(Debug, Serialize)]
-pub struct CreateGameResponse {
-    /// The newly created game's id.
-    pub game_id: GameId,
-}
 
 /// `POST /games`: set up a new game from a scenario and return its id.
 ///
@@ -33,7 +19,7 @@ pub(crate) async fn create_game(
     Json(request): Json<CreateGameRequest>,
 ) -> Result<(StatusCode, Json<CreateGameResponse>), StatusCode> {
     let scenario_id = ScenarioId::new(request.scenario_id);
-    match GameSession::create(state.db.clone(), GameId::random(), scenario_id).await {
+    match GameSession::create(state.db.clone(), random_game_id(), scenario_id).await {
         Ok(session) => Ok((
             StatusCode::CREATED,
             Json(CreateGameResponse {

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -12,8 +12,17 @@ workspace = true
 
 [dependencies]
 game-core = { path = "../game-core" }
+protocol = { path = "../protocol" }
 leptos = { version = "0.8", features = ["csr"] }
 console_error_panic_hook = "0.1"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+gloo-net = { version = "0.6", features = ["websocket", "http"] }
+gloo-timers = { version = "0.3", features = ["futures"] }
+futures = "0.3"
+wasm-bindgen-futures = "0.4"
+serde_json = "1"
+web-sys = { version = "0.3", features = ["Storage", "Location", "Window"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/web/Trunk.toml
+++ b/crates/web/Trunk.toml
@@ -4,3 +4,11 @@ target = "index.html"
 [serve]
 port = 3000
 addresses = ["127.0.0.1"]
+
+# NOTE: no `[[proxy]]` here. trunk 0.21's proxy mounts each entry as an
+# axum `.nest()`, which (a) panics at the root `/`, and (b) can't serve
+# our REST (`POST /games`) and WebSocket (`/games/{id}/ws`) — they share
+# the `/games` prefix, so two entries collide on one wildcard route while
+# a single entry serves only one of HTTP/WS. For local dev, use the
+# single-port path instead (it's what production runs): `trunk build`,
+# then `cargo run -p server`, and open http://localhost:8000.

--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -12,10 +12,8 @@ pub fn App() -> impl IntoView {
     // builds render from a signal that tests drive directly.
     #[cfg(target_arch = "wasm32")]
     {
-        // Transport is wired in Task 7; for now just ensure the store
-        // is in context (provide_store above already did that).
-        // TODO(Task 7): crate::transport::start(use_store());
-        let _ = use_store();
+        let store = use_store();
+        crate::transport::start(store);
     }
 
     view! {

--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -20,8 +20,30 @@ pub fn App() -> impl IntoView {
         <main>
             <h1>"Eldritch"</h1>
             <DebugDump/>
+            {
+                #[cfg(target_arch = "wasm32")]
+                { view! { <DebugSubmit/> }.into_any() }
+                #[cfg(not(target_arch = "wasm32"))]
+                { ().into_any() }
+            }
         </main>
     }
+}
+
+/// Wasm-only debug control: pushes a `ClientMessage::Submit { EndTurn }`
+/// onto the transport's outbound channel, exercising the send path
+/// end-to-end. P6.7 builds the real action controls on this seam.
+#[cfg(target_arch = "wasm32")]
+#[component]
+fn DebugSubmit() -> impl IntoView {
+    let tx = use_context::<crate::transport::OutboundTx>()
+        .expect("OutboundTx provided by transport::start");
+    let on_click = move |_| {
+        let _ = tx.unbounded_send(protocol::ClientMessage::Submit {
+            action: game_core::PlayerAction::EndTurn,
+        });
+    };
+    view! { <button on:click=on_click>"Submit EndTurn (debug)"</button> }
 }
 
 /// Read-only dump of the client store — proves the round-trip before

--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -2,12 +2,64 @@
 
 use leptos::prelude::*;
 
+use crate::store::{provide_store, use_store, ConnStatus};
+
 #[component]
 pub fn App() -> impl IntoView {
+    provide_store();
+
+    // Spawn the browser transport only on wasm; native/headless-reducer
+    // builds render from a signal that tests drive directly.
+    #[cfg(target_arch = "wasm32")]
+    {
+        // Transport is wired in Task 7; for now just ensure the store
+        // is in context (provide_store above already did that).
+        // TODO(Task 7): crate::transport::start(use_store());
+        let _ = use_store();
+    }
+
     view! {
         <main>
             <h1>"Eldritch"</h1>
-            <p>"Coming soon — a digital simulator for the Arkham Horror LCG."</p>
+            <DebugDump/>
         </main>
+    }
+}
+
+/// Read-only dump of the client store — proves the round-trip before
+/// P6.5's real board. Renders a stable presence label (for the headless
+/// test) plus a human-facing pretty-print of the state.
+#[component]
+pub fn DebugDump() -> impl IntoView {
+    let store = use_store();
+
+    let status = move || match store.get().status {
+        ConnStatus::Connecting => "connecting",
+        ConnStatus::Connected => "connected",
+        ConnStatus::Reconnecting => "reconnecting",
+        ConnStatus::Failed => "failed",
+    };
+    let presence = move || {
+        if store.get().game.is_some() {
+            "present"
+        } else {
+            "none"
+        }
+    };
+    let rejection = move || store.get().last_rejection.unwrap_or_default();
+    let dump = move || {
+        store
+            .get()
+            .game
+            .map_or_else(|| "<no state yet>".to_string(), |g| format!("{g:#?}"))
+    };
+
+    view! {
+        <section>
+            <p>"status: " {status}</p>
+            <p>"state: " {presence}</p>
+            <p>"rejection: " {rejection}</p>
+            <pre>{dump}</pre>
+        </section>
     }
 }

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -5,3 +5,8 @@
 //! components — can import them.
 
 pub mod app;
+pub mod store;
+pub mod url;
+
+#[cfg(target_arch = "wasm32")]
+pub mod transport;

--- a/crates/web/src/store.rs
+++ b/crates/web/src/store.rs
@@ -78,7 +78,12 @@ mod tests {
 
     #[test]
     fn applied_updates_game_and_outcome() {
-        let mut s = ClientState::default();
+        // Seed a pending rejection to prove Applied leaves it untouched
+        // (only Hello clears it).
+        let mut s = ClientState {
+            last_rejection: Some("stale".into()),
+            ..Default::default()
+        };
         reduce(
             &mut s,
             ServerMessage::Applied {
@@ -89,6 +94,7 @@ mod tests {
         );
         assert!(s.game.is_some());
         assert_eq!(s.outcome, Some(EngineOutcome::Done));
+        assert_eq!(s.last_rejection.as_deref(), Some("stale"));
     }
 
     #[test]

--- a/crates/web/src/store.rs
+++ b/crates/web/src/store.rs
@@ -2,6 +2,7 @@
 
 use game_core::state::GameState;
 use game_core::EngineOutcome;
+use leptos::prelude::*;
 use protocol::ServerMessage;
 
 /// Connection lifecycle, set by the transport (not by `reduce`).
@@ -44,6 +45,22 @@ pub fn reduce(state: &mut ClientState, msg: ServerMessage) {
             state.last_rejection = Some(reason);
         }
     }
+}
+
+/// The single reactive store handed through Leptos context.
+pub type StoreSignal = RwSignal<ClientState>;
+
+/// Provide a fresh store signal into context and return it.
+pub fn provide_store() -> StoreSignal {
+    let signal = RwSignal::new(ClientState::default());
+    provide_context(signal);
+    signal
+}
+
+/// Read the store signal from context. Panics if not provided — a
+/// programmer error (every view lives under `provide_store`).
+pub fn use_store() -> StoreSignal {
+    use_context::<StoreSignal>().expect("store signal provided at App root")
 }
 
 #[cfg(test)]

--- a/crates/web/src/store.rs
+++ b/crates/web/src/store.rs
@@ -1,0 +1,1 @@
+//! Reactive client store: `ClientState` + the pure `ServerMessage` reducer.

--- a/crates/web/src/store.rs
+++ b/crates/web/src/store.rs
@@ -1,1 +1,112 @@
 //! Reactive client store: `ClientState` + the pure `ServerMessage` reducer.
+
+use game_core::state::GameState;
+use game_core::EngineOutcome;
+use protocol::ServerMessage;
+
+/// Connection lifecycle, set by the transport (not by `reduce`).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum ConnStatus {
+    #[default]
+    Connecting,
+    Connected,
+    Reconnecting,
+    Failed,
+}
+
+/// Everything the UI renders. `game`/`outcome`/`last_rejection` come
+/// from `reduce`; `status` is driven by the transport.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct ClientState {
+    pub game: Option<GameState>,
+    pub outcome: Option<EngineOutcome>,
+    pub status: ConnStatus,
+    pub last_rejection: Option<String>,
+}
+
+/// Fold one server message into the client state. Data only — never
+/// touches `status`. Mirrors the server: a `Rejected` leaves
+/// `game`/`outcome` unchanged (the rejection was sender-only).
+pub fn reduce(state: &mut ClientState, msg: ServerMessage) {
+    match msg {
+        ServerMessage::Hello { state: s, outcome } => {
+            state.game = Some(*s);
+            state.outcome = Some(outcome);
+            state.last_rejection = None;
+        }
+        ServerMessage::Applied {
+            state: s, outcome, ..
+        } => {
+            state.game = Some(*s);
+            state.outcome = Some(outcome);
+        }
+        ServerMessage::Rejected { reason } => {
+            state.last_rejection = Some(reason);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use game_core::test_support::builder::TestGame;
+    use game_core::test_support::fixtures::test_investigator;
+
+    fn sample_state() -> GameState {
+        TestGame::new()
+            .with_investigator(test_investigator(1))
+            .build()
+    }
+
+    #[test]
+    fn hello_sets_game_and_clears_rejection() {
+        let mut s = ClientState {
+            last_rejection: Some("stale".into()),
+            ..Default::default()
+        };
+        reduce(
+            &mut s,
+            ServerMessage::Hello {
+                state: Box::new(sample_state()),
+                outcome: EngineOutcome::Done,
+            },
+        );
+        assert!(s.game.is_some());
+        assert_eq!(s.outcome, Some(EngineOutcome::Done));
+        assert_eq!(s.last_rejection, None);
+    }
+
+    #[test]
+    fn applied_updates_game_and_outcome() {
+        let mut s = ClientState::default();
+        reduce(
+            &mut s,
+            ServerMessage::Applied {
+                state: Box::new(sample_state()),
+                events: Vec::new(),
+                outcome: EngineOutcome::Done,
+            },
+        );
+        assert!(s.game.is_some());
+        assert_eq!(s.outcome, Some(EngineOutcome::Done));
+    }
+
+    #[test]
+    fn rejected_sets_reason_without_touching_game() {
+        let mut s = ClientState {
+            game: Some(sample_state()),
+            outcome: Some(EngineOutcome::Done),
+            ..Default::default()
+        };
+        let before = s.game.clone();
+        reduce(
+            &mut s,
+            ServerMessage::Rejected {
+                reason: "not your turn".into(),
+            },
+        );
+        assert_eq!(s.last_rejection.as_deref(), Some("not your turn"));
+        assert_eq!(s.game, before);
+        assert_eq!(s.outcome, Some(EngineOutcome::Done));
+    }
+}

--- a/crates/web/src/transport.rs
+++ b/crates/web/src/transport.rs
@@ -1,0 +1,1 @@
+//! Browser transport (wasm only): bootstrap, WebSocket connect/reconnect, send.

--- a/crates/web/src/transport.rs
+++ b/crates/web/src/transport.rs
@@ -1,1 +1,146 @@
-//! Browser transport (wasm only): bootstrap, WebSocket connect/reconnect, send.
+//! Browser transport (wasm only): bootstrap a game, connect its
+//! WebSocket, fold inbound frames into the store, forward outbound
+//! actions, and reconnect on close.
+
+use futures::channel::mpsc;
+use futures::{select, SinkExt, StreamExt};
+use gloo_net::http::Request;
+use gloo_net::websocket::{futures::WebSocket, Message};
+use gloo_timers::future::TimeoutFuture;
+use leptos::prelude::*;
+use wasm_bindgen_futures::spawn_local;
+
+use protocol::{ClientMessage, CreateGameRequest, CreateGameResponse, GameId, ServerMessage};
+
+use crate::store::{reduce, ConnStatus, StoreSignal};
+use crate::url::current_ws_url;
+
+/// localStorage key holding the active game id across reloads.
+const GAME_ID_KEY: &str = "eldritch_game_id";
+/// The only playable scenario this phase (D5: synthetic registries).
+// TODO(phase-7): swap to a real scenario id when The Gathering lands.
+const SCENARIO_ID: &str = "synthetic";
+/// Fixed reconnect backoff. Plenty for a solo v0; not exponential.
+const RECONNECT_MS: u32 = 1000;
+
+/// Sender used by views (the debug button, later P6.7 controls) to
+/// submit actions; cloneable, survives reconnects.
+pub type OutboundTx = mpsc::UnboundedSender<ClientMessage>;
+
+/// Start the transport: provide an `OutboundTx` into context, then spawn
+/// the bootstrap + connect loop. Call once from `App` (wasm only).
+pub fn start(store: StoreSignal) {
+    let (tx, rx) = mpsc::unbounded::<ClientMessage>();
+    provide_context(tx);
+    spawn_local(run(store, rx));
+}
+
+async fn run(store: StoreSignal, mut rx: mpsc::UnboundedReceiver<ClientMessage>) {
+    let mut game_id: GameId = match bootstrap(store).await {
+        Some(id) => id,
+        None => return, // bootstrap set ConnStatus::Failed already
+    };
+
+    loop {
+        let saw_hello = connect_once(&store, &game_id, &mut rx).await;
+
+        // A saved id whose game no longer exists: the server drops the
+        // socket before any Hello. Discard it and create a fresh game.
+        if !saw_hello {
+            clear_saved_id();
+            match create_game(store).await {
+                Some(id) => game_id = id,
+                None => return,
+            }
+        }
+
+        store.update(|s| s.status = ConnStatus::Reconnecting);
+        TimeoutFuture::new(RECONNECT_MS).await;
+    }
+}
+
+/// Resolve a game id: reuse a saved one, else create and save. Returns
+/// `None` (and sets `Failed`) if creation fails.
+async fn bootstrap(store: StoreSignal) -> Option<GameId> {
+    if let Some(id) = saved_id() {
+        return Some(id);
+    }
+    create_game(store).await
+}
+
+async fn create_game(store: StoreSignal) -> Option<GameId> {
+    let resp = Request::post("/games")
+        .json(&CreateGameRequest {
+            scenario_id: SCENARIO_ID.to_string(),
+        })
+        .ok()?
+        .send()
+        .await
+        .ok()?;
+    if let Ok(r) = resp.json::<CreateGameResponse>().await {
+        save_id(&r.game_id);
+        Some(r.game_id)
+    } else {
+        store.update(|s| s.status = ConnStatus::Failed);
+        None
+    }
+}
+
+/// One socket lifetime: open, mark Connected, pump inbound->reduce and
+/// outbound->sink until close. Returns whether a `Hello` was seen.
+async fn connect_once(
+    store: &StoreSignal,
+    game_id: &GameId,
+    rx: &mut mpsc::UnboundedReceiver<ClientMessage>,
+) -> bool {
+    store.update(|s| s.status = ConnStatus::Connecting);
+    let Ok(ws) = WebSocket::open(&current_ws_url(game_id.as_str())) else {
+        return false;
+    };
+    store.update(|s| s.status = ConnStatus::Connected);
+
+    let (mut write, read) = ws.split();
+    let mut read = read.fuse();
+    let mut saw_hello = false;
+
+    loop {
+        select! {
+            incoming = read.next() => match incoming {
+                Some(Ok(Message::Text(txt))) => {
+                    if let Ok(msg) = serde_json::from_str::<ServerMessage>(&txt) {
+                        saw_hello |= matches!(msg, ServerMessage::Hello { .. });
+                        store.update(|s| reduce(s, msg));
+                    }
+                }
+                Some(Ok(Message::Bytes(_))) => {}
+                Some(Err(_)) | None => break, // socket closed/errored
+            },
+            outbound = rx.next() => {
+                if let Some(action) = outbound {
+                    if let Ok(json) = serde_json::to_string(&action) {
+                        let _ = write.send(Message::Text(json)).await;
+                    }
+                }
+            }
+        }
+    }
+    saw_hello
+}
+
+fn local_storage() -> Option<web_sys::Storage> {
+    web_sys::window()?.local_storage().ok().flatten()
+}
+fn saved_id() -> Option<GameId> {
+    let raw = local_storage()?.get_item(GAME_ID_KEY).ok().flatten()?;
+    Some(GameId::new(raw))
+}
+fn save_id(id: &GameId) {
+    if let Some(ls) = local_storage() {
+        let _ = ls.set_item(GAME_ID_KEY, id.as_str());
+    }
+}
+fn clear_saved_id() {
+    if let Some(ls) = local_storage() {
+        let _ = ls.remove_item(GAME_ID_KEY);
+    }
+}

--- a/crates/web/src/transport.rs
+++ b/crates/web/src/transport.rs
@@ -42,25 +42,41 @@ async fn run(store: StoreSignal, mut rx: mpsc::UnboundedReceiver<ClientMessage>)
     };
 
     loop {
-        let saw_hello = connect_once(&store, &game_id, &mut rx).await;
-
-        // A saved id whose game no longer exists: the server drops the
-        // socket before any Hello. Discard it and create a fresh game.
-        // This relies on the server contract that a valid game *always*
-        // sends Hello immediately on connect, so "no Hello before close"
-        // means the id is stale (it also catches the rare open/handshake
-        // failure, which the same recovery handles harmlessly).
-        if !saw_hello {
-            clear_saved_id();
-            match create_game(store).await {
-                Some(id) => game_id = id,
-                None => return,
+        match connect_once(&store, &game_id, &mut rx).await {
+            // Opened, but the server closed before any Hello: a valid game
+            // always sends Hello immediately, so the id is unknown to the
+            // server (e.g. a DB reset). Discard it and create a fresh game.
+            ConnectOutcome::StaleId => {
+                clear_saved_id();
+                match create_game(store).await {
+                    Some(id) => game_id = id,
+                    None => return,
+                }
             }
+            // Couldn't reach the server, or a normal disconnect after a
+            // live session — keep the SAME id and just retry. The server
+            // may be restarting; recreating here would abandon the game
+            // (and wipe the saved id) on every transient outage.
+            ConnectOutcome::Unreachable | ConnectOutcome::Disconnected => {}
         }
 
         store.update(|s| s.status = ConnStatus::Reconnecting);
         TimeoutFuture::new(RECONNECT_MS).await;
     }
+}
+
+/// Outcome of one socket lifetime — the reconnect loop treats these three
+/// cases differently (only `StaleId` discards the saved game id).
+enum ConnectOutcome {
+    /// `WebSocket::open` failed: the server is unreachable (down or
+    /// restarting). Keep the id and retry.
+    Unreachable,
+    /// Opened, but the server closed before sending any `Hello` — the id
+    /// is stale (unknown to the server). Discard it and recreate.
+    StaleId,
+    /// Connected, saw `Hello`, then the socket closed: a normal
+    /// disconnect. Keep the id and reconnect.
+    Disconnected,
 }
 
 /// Resolve a game id: reuse a saved one, else create and save. Returns
@@ -91,15 +107,17 @@ async fn create_game(store: StoreSignal) -> Option<GameId> {
 }
 
 /// One socket lifetime: open, mark Connected, pump inbound->reduce and
-/// outbound->sink until close. Returns whether a `Hello` was seen.
+/// outbound->sink until close. The returned [`ConnectOutcome`] tells the
+/// reconnect loop whether the id is stale, the server is unreachable, or
+/// it was a normal disconnect.
 async fn connect_once(
     store: &StoreSignal,
     game_id: &GameId,
     rx: &mut mpsc::UnboundedReceiver<ClientMessage>,
-) -> bool {
+) -> ConnectOutcome {
     store.update(|s| s.status = ConnStatus::Connecting);
     let Ok(ws) = WebSocket::open(&current_ws_url(game_id.as_str())) else {
-        return false;
+        return ConnectOutcome::Unreachable;
     };
     store.update(|s| s.status = ConnStatus::Connected);
 
@@ -128,7 +146,11 @@ async fn connect_once(
             }
         }
     }
-    saw_hello
+    if saw_hello {
+        ConnectOutcome::Disconnected
+    } else {
+        ConnectOutcome::StaleId
+    }
 }
 
 fn local_storage() -> Option<web_sys::Storage> {

--- a/crates/web/src/transport.rs
+++ b/crates/web/src/transport.rs
@@ -46,6 +46,10 @@ async fn run(store: StoreSignal, mut rx: mpsc::UnboundedReceiver<ClientMessage>)
 
         // A saved id whose game no longer exists: the server drops the
         // socket before any Hello. Discard it and create a fresh game.
+        // This relies on the server contract that a valid game *always*
+        // sends Hello immediately on connect, so "no Hello before close"
+        // means the id is stale (it also catches the rare open/handshake
+        // failure, which the same recovery handles harmlessly).
         if !saw_hello {
             clear_saved_id();
             match create_game(store).await {

--- a/crates/web/src/url.rs
+++ b/crates/web/src/url.rs
@@ -12,6 +12,15 @@ pub fn ws_url(location_protocol: &str, host: &str, game_id: &str) -> String {
     format!("{scheme}://{host}/games/{game_id}/ws")
 }
 
+/// Read `window.location` and build this game's WebSocket URL.
+#[cfg(target_arch = "wasm32")]
+pub fn current_ws_url(game_id: &str) -> String {
+    let loc = web_sys::window().expect("a browser window").location();
+    let protocol = loc.protocol().unwrap_or_else(|_| "http:".to_string());
+    let host = loc.host().unwrap_or_default();
+    ws_url(&protocol, &host, game_id)
+}
+
 #[cfg(test)]
 mod tests {
     use super::ws_url;
@@ -31,13 +40,4 @@ mod tests {
             "wss://play.example.com/games/g1/ws"
         );
     }
-}
-
-/// Read `window.location` and build this game's WebSocket URL.
-#[cfg(target_arch = "wasm32")]
-pub fn current_ws_url(game_id: &str) -> String {
-    let loc = web_sys::window().expect("a browser window").location();
-    let protocol = loc.protocol().unwrap_or_else(|_| "http:".to_string());
-    let host = loc.host().unwrap_or_default();
-    ws_url(&protocol, &host, game_id)
 }

--- a/crates/web/src/url.rs
+++ b/crates/web/src/url.rs
@@ -1,1 +1,43 @@
 //! Same-origin WebSocket URL derivation (D3): never a hardcoded port.
+
+/// Build the same-origin WebSocket URL for a game. `location_protocol`
+/// is `window.location.protocol` (`"http:"` / `"https:"`); `host`
+/// includes the port. Upgrades to `wss` under TLS; otherwise `ws`.
+pub fn ws_url(location_protocol: &str, host: &str, game_id: &str) -> String {
+    let scheme = if location_protocol == "https:" {
+        "wss"
+    } else {
+        "ws"
+    };
+    format!("{scheme}://{host}/games/{game_id}/ws")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ws_url;
+
+    #[test]
+    fn plain_http_uses_ws_and_keeps_port() {
+        assert_eq!(
+            ws_url("http:", "localhost:3000", "abc"),
+            "ws://localhost:3000/games/abc/ws"
+        );
+    }
+
+    #[test]
+    fn https_upgrades_to_wss() {
+        assert_eq!(
+            ws_url("https:", "play.example.com", "g1"),
+            "wss://play.example.com/games/g1/ws"
+        );
+    }
+}
+
+/// Read `window.location` and build this game's WebSocket URL.
+#[cfg(target_arch = "wasm32")]
+pub fn current_ws_url(game_id: &str) -> String {
+    let loc = web_sys::window().expect("a browser window").location();
+    let protocol = loc.protocol().unwrap_or_else(|_| "http:".to_string());
+    let host = loc.host().unwrap_or_default();
+    ws_url(&protocol, &host, game_id)
+}

--- a/crates/web/src/url.rs
+++ b/crates/web/src/url.rs
@@ -1,0 +1,1 @@
+//! Same-origin WebSocket URL derivation (D3): never a hardcoded port.

--- a/crates/web/tests/store.rs
+++ b/crates/web/tests/store.rs
@@ -24,6 +24,8 @@ fn body_html() -> String {
 async fn hello_renders_state_present() {
     let store = leptos::prelude::RwSignal::new(ClientState::default());
     // Provide the same signal the component reads, then mount the dump.
+    // Bind the unmount handle (not `_`) so the view stays mounted through
+    // the assertions.
     let _handle = leptos::mount::mount_to_body(move || {
         leptos::prelude::provide_context(store);
         leptos::view! { <DebugDump/> }
@@ -45,7 +47,7 @@ async fn hello_renders_state_present() {
                 state: Box::new(game),
                 outcome: EngineOutcome::Done,
             },
-        )
+        );
     });
 
     // CSR render effects flush on the next executor tick, not synchronously

--- a/crates/web/tests/store.rs
+++ b/crates/web/tests/store.rs
@@ -1,0 +1,60 @@
+//! Headless acceptance: feeding `Hello`/`Applied` updates the signal and
+//! the DOM rendered from it. wasm32-only (browser DOM); native jobs skip.
+#![cfg(target_arch = "wasm32")]
+
+use game_core::test_support::builder::TestGame;
+use game_core::test_support::fixtures::test_investigator;
+use game_core::EngineOutcome;
+use leptos::prelude::Update;
+use protocol::ServerMessage;
+use wasm_bindgen_test::*;
+use web::app::DebugDump;
+use web::store::{reduce, ClientState};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn body_html() -> String {
+    leptos::prelude::document()
+        .body()
+        .expect("body")
+        .inner_html()
+}
+
+#[wasm_bindgen_test]
+async fn hello_renders_state_present() {
+    let store = leptos::prelude::RwSignal::new(ClientState::default());
+    // Provide the same signal the component reads, then mount the dump.
+    let _handle = leptos::mount::mount_to_body(move || {
+        leptos::prelude::provide_context(store);
+        leptos::view! { <DebugDump/> }
+    });
+
+    assert!(
+        body_html().contains("state: none"),
+        "before: {}",
+        body_html()
+    );
+
+    let game = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .build();
+    store.update(|s| {
+        reduce(
+            s,
+            ServerMessage::Hello {
+                state: Box::new(game),
+                outcome: EngineOutcome::Done,
+            },
+        )
+    });
+
+    // CSR render effects flush on the next executor tick, not synchronously
+    // with `update`. Yield so the DOM reflects the new signal value.
+    leptos::task::tick().await;
+
+    assert!(
+        body_html().contains("state: present"),
+        "after: {}",
+        body_html()
+    );
+}

--- a/docs/phases/README.md
+++ b/docs/phases/README.md
@@ -41,6 +41,7 @@ Some issues don't belong to a single phase. They live unmilestoned with `p2-late
 - `#174` — periodic state snapshots for replay perf (deferred from Phase 5; build only when profiling demands it).
 - `#83` — `enemy_attack` cleanup (apply both damage and horror when one defeats).
 - `#93` — split DSL types into a shared `card-dsl` crate (architectural improvement; not phase-gated).
+- `#196` — harden wasm CI against GitHub release-CDN 504s (cache/pin `wasm-bindgen`/`wasm-opt`/`wasm-pack`; flaked four reruns on `main` after #195).
 
 ## Template
 

--- a/docs/phases/phase-6-web-client-v0.md
+++ b/docs/phases/phase-6-web-client-v0.md
@@ -21,6 +21,8 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | P6.2 | [#183](https://github.com/talelburg/eldritch/issues/183) — server production-playable: synthetic registries + static WASM serving | ✅ PR #194 |
 | P6.3 | [#184](https://github.com/talelburg/eldritch/issues/184) — headless browser test harness + 6th CI job | ✅ PR #195 |
 | P6.4 | [#185](https://github.com/talelburg/eldritch/issues/185) — WS client + reactive state store | ✅ PR #197 |
+| P6.4a | [#199](https://github.com/talelburg/eldritch/issues/199) — restore trunk hot-reload dev loop | ⏳ open |
+| P6.4b | [#198](https://github.com/talelburg/eldritch/issues/198) — WebSocket liveness (heartbeat + graceful shutdown) | ⏳ open |
 | P6.5 | [#186](https://github.com/talelburg/eldritch/issues/186) — board rendering (read-only) | ⏳ open |
 | P6.6 | [#187](https://github.com/talelburg/eldritch/issues/187) — AwaitingInput resolution UI + legality gating | ⏳ open |
 | P6.7a | [#188](https://github.com/talelburg/eldritch/issues/188) — core-loop action controls | ⏳ open |
@@ -35,6 +37,8 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | P6.2 | #183 server registries + static WASM ✅ PR #194 | The thing the client connects to | — (parallel w/ P6.1) |
 | P6.3 | #184 headless harness + 6th CI job ✅ PR #195 | Testing foundation before TDD-ing components; de-risks browser-in-CI early | — |
 | P6.4 | #185 WS client + reactive store ✅ PR #197 | The client's engine room; debug-dump render proves the round-trip | P6.1, P6.3 |
+| P6.4a | #199 hot-reload dev loop | Restore hot-reload **before** the content-UI slots so P6.5+ iterate fast; likely moves the WS to a distinct `/ws/{id}` path | P6.4 |
+| P6.4b | #198 WS liveness | Heartbeat + graceful shutdown so the client detects silently-dropped connections — finishes the transport before content builds on it; revisit `leptos-use` here (P6.4 deferral trigger) | P6.4a |
 | P6.5 | #186 board rendering | See the state | P6.4 |
 | P6.6 | #187 AwaitingInput UI + legality | Core-loop: `Investigate` opens a skill-test commit window (`AwaitingInput`), so this precedes the action controls | P6.5 |
 | P6.7a | #188 core-loop action controls | Toy scenario clickable to a **Won** resolution | P6.6 |
@@ -42,7 +46,12 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | P6.8 | #190 resolution + closing demo | Milestone close | all |
 
 P6.1 and P6.2 both touch `server`; sequence to avoid churn. P6.3 is
-independent and can land any time before P6.4.
+independent and can land any time before P6.4. P6.4a and P6.4b are
+foundation follow-ups from P6.4 (surfaced during its manual testing,
+[#198](https://github.com/talelburg/eldritch/issues/198) /
+[#199](https://github.com/talelburg/eldritch/issues/199)) that land
+**before** the content UI; both touch the WS route/transport, so do the
+route move (P6.4a) first to avoid reworking it under P6.4b.
 
 ## Decisions made
 

--- a/docs/phases/phase-6-web-client-v0.md
+++ b/docs/phases/phase-6-web-client-v0.md
@@ -20,7 +20,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | P6.1 | [#182](https://github.com/talelburg/eldritch/issues/182) — `protocol` crate extraction + `state` on `Applied` | ✅ PR #193 |
 | P6.2 | [#183](https://github.com/talelburg/eldritch/issues/183) — server production-playable: synthetic registries + static WASM serving | ✅ PR #194 |
 | P6.3 | [#184](https://github.com/talelburg/eldritch/issues/184) — headless browser test harness + 6th CI job | ✅ PR #195 |
-| P6.4 | [#185](https://github.com/talelburg/eldritch/issues/185) — WS client + reactive state store | ⏳ open |
+| P6.4 | [#185](https://github.com/talelburg/eldritch/issues/185) — WS client + reactive state store | ✅ PR #197 |
 | P6.5 | [#186](https://github.com/talelburg/eldritch/issues/186) — board rendering (read-only) | ⏳ open |
 | P6.6 | [#187](https://github.com/talelburg/eldritch/issues/187) — AwaitingInput resolution UI + legality gating | ⏳ open |
 | P6.7a | [#188](https://github.com/talelburg/eldritch/issues/188) — core-loop action controls | ⏳ open |
@@ -34,7 +34,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | P6.1 | #182 protocol crate + `state` on `Applied` ✅ PR #193 | Foundational; unblocks the client speaking the protocol with shared types | kickoff |
 | P6.2 | #183 server registries + static WASM ✅ PR #194 | The thing the client connects to | — (parallel w/ P6.1) |
 | P6.3 | #184 headless harness + 6th CI job ✅ PR #195 | Testing foundation before TDD-ing components; de-risks browser-in-CI early | — |
-| P6.4 | #185 WS client + reactive store | The client's engine room; debug-dump render proves the round-trip | P6.1, P6.3 |
+| P6.4 | #185 WS client + reactive store ✅ PR #197 | The client's engine room; debug-dump render proves the round-trip | P6.1, P6.3 |
 | P6.5 | #186 board rendering | See the state | P6.4 |
 | P6.6 | #187 AwaitingInput UI + legality | Core-loop: `Investigate` opens a skill-test commit window (`AwaitingInput`), so this precedes the action controls | P6.5 |
 | P6.7a | #188 core-loop action controls | Toy scenario clickable to a **Won** resolution | P6.6 |
@@ -115,6 +115,28 @@ Settled implementing P6.3 (PR #195):
   `test` would *run*) a browser-only test and break. Only the
   `wasm-test` job (wasm32 via `wasm-pack test --headless --firefox`)
   runs them.
+
+Settled implementing P6.4 (PR #197):
+
+- **`protocol` owns the full client/server contract — HTTP DTOs and
+  identity, not just the WS messages.** `GameId` and the `POST /games`
+  DTOs (`CreateGameRequest`/`CreateGameResponse`) were hoisted out of
+  `server` into `protocol` so the wasm client reuses the real types
+  rather than redefining `String`/local copies. `GameId` carries no
+  `sqlx`/`axum` impls, so the move kept `protocol` dependency-free; id
+  *minting* (`uuid`) stays server-side as `id::random_game_id`, and
+  `server` re-exports `protocol::GameId`. **Convention for later slots:
+  a new client-facing endpoint's request/response types belong in
+  `protocol`.**
+- **`leptos-use` deferred — revisit on the *second* concrete need.**
+  P6.4 needed only a WebSocket + localStorage, both served by
+  already-present `gloo-net` + ~6 lines of `web-sys`, with a pure
+  `reduce` kept library-agnostic. `leptos-use` version-tracks Leptos (an
+  upgrade tax) and adopting it is purely additive, so it was **not**
+  taken. Adopt it when a second concrete cluster appears — e.g.
+  responsive board layout in **P6.5** (`use_media_query` /
+  `use_element_size`) or auth in **Phase 8** (`use_cookie`) — at which
+  point it is justified by real needs, not speculation.
 
 ## Open questions
 

--- a/docs/superpowers/plans/2026-06-08-p6.4-ws-client-store.md
+++ b/docs/superpowers/plans/2026-06-08-p6.4-ws-client-store.md
@@ -16,6 +16,9 @@
 
 | File | Responsibility |
 |---|---|
+| `crates/protocol/src/lib.rs` | **(Task 1)** add `GameId` (sans `random()`) + `CreateGameRequest`/`CreateGameResponse` DTOs |
+| `crates/server/src/id.rs` | **(Task 1)** `pub use protocol::GameId;` + server-side `random_game_id()` |
+| `crates/server/src/lifecycle.rs` | **(Task 1)** import DTOs from `protocol`; use `id::random_game_id()` |
 | `crates/web/Cargo.toml` | add `protocol` dep; wasm-only deps under a `[target.'cfg(target_arch = "wasm32")'.dependencies]` table |
 | `crates/web/src/lib.rs` | declare `store`, `url`, `app`; declare `transport` cfg-gated to wasm32 |
 | `crates/web/src/url.rs` | pure `ws_url(protocol, host, game_id)`; wasm reader of `window().location()` |
@@ -28,7 +31,171 @@
 
 ---
 
-## Task 1: Dependencies + module skeleton
+## Task 1: Hoist `GameId` + HTTP DTOs into `protocol`
+
+Make `game_id` and the `POST /games` request/response part of the shared
+`protocol` crate so the client reuses the real types. `GameId` has no
+`sqlx`/`axum` impls (it persists via `.bind(as_str())`, extracts via
+`Deserialize`), so the move is dependency-free for `protocol`. Id-minting
+(`random()`, uuid) stays server-side to keep `uuid` out of wasm-safe
+`protocol`.
+
+**Files:**
+- Modify: `crates/protocol/src/lib.rs` (add `GameId` + DTOs)
+- Modify: `crates/server/src/id.rs` (re-export + `random_game_id`)
+- Modify: `crates/server/src/lifecycle.rs` (import DTOs from `protocol`; use `random_game_id`)
+
+- [ ] **Step 1: Add `GameId` + DTOs to `protocol`**
+
+Append to `crates/protocol/src/lib.rs`:
+```rust
+/// Stable identifier for a persisted game. Part of the client/server
+/// contract: returned by `POST /games` and used in the WebSocket path
+/// `/games/{game_id}/ws`. Transparent over `String` — serializes as a
+/// bare JSON string, binds to a SQLite TEXT column, and extracts from a
+/// URL path segment. Id *minting* (`random_game_id`) lives server-side
+/// to keep `uuid` out of this wasm-safe crate.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct GameId(String);
+
+impl GameId {
+    /// Wrap an existing id string.
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+    /// Borrow the underlying string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for GameId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+/// Body of `POST /games`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateGameRequest {
+    /// The scenario module to set up.
+    pub scenario_id: String,
+}
+
+/// Response to a successful `POST /games`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateGameResponse {
+    /// The newly created game's id.
+    pub game_id: GameId,
+}
+
+#[cfg(test)]
+mod id_tests {
+    use super::GameId;
+
+    #[test]
+    fn serializes_as_a_bare_string() {
+        let id = GameId::new("abc");
+        assert_eq!(serde_json::to_string(&id).unwrap(), "\"abc\"");
+        let back: GameId = serde_json::from_str("\"abc\"").unwrap();
+        assert_eq!(back, id);
+    }
+}
+```
+
+(The `serializes_as_a_bare_string` test moves here from `server/src/id.rs`;
+`serde_json` is already a `protocol` dev-dependency.)
+
+- [ ] **Step 2: Reduce `server/src/id.rs` to a re-export + minting helper**
+
+Replace `crates/server/src/id.rs` with:
+```rust
+//! `GameId` re-export + server-side id minting.
+//!
+//! The `GameId` type lives in `protocol` (it is part of the client/server
+//! contract). Generation uses `uuid`, a persistence concern, so it stays
+//! here rather than in the wasm-safe `protocol` crate.
+
+pub use protocol::GameId;
+
+/// Generate a fresh random game id (UUID v4).
+#[must_use]
+pub fn random_game_id() -> GameId {
+    GameId::new(uuid::Uuid::new_v4().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::random_game_id;
+
+    #[test]
+    fn random_ids_are_distinct() {
+        assert_ne!(random_game_id(), random_game_id());
+    }
+}
+```
+
+- [ ] **Step 3: Update `lifecycle.rs` to use the hoisted types**
+
+In `crates/server/src/lifecycle.rs`:
+- Delete the local `CreateGameRequest` and `CreateGameResponse` struct
+  definitions.
+- Replace the imports so the DTOs and `GameId` come from `protocol`:
+  ```rust
+  use crate::id::random_game_id;
+  use crate::AppState;
+  use crate::session::{GameSession, SessionError};
+  use protocol::{CreateGameRequest, CreateGameResponse};
+  ```
+  (Remove the now-unused `use serde::{Deserialize, Serialize};` and the
+  `use crate::id::GameId;` line.)
+- Change the create call from `GameId::random()` to `random_game_id()`:
+  ```rust
+  match GameSession::create(state.db.clone(), random_game_id(), scenario_id).await {
+  ```
+
+Leave `crates/server/src/lib.rs`'s `pub use id::GameId;` as-is — it now
+re-exports the `protocol` type, so `server::GameId` and every
+`crate::id::GameId` reference across the server + its tests keep working.
+
+- [ ] **Step 4: Run the full test suite (refactor must be behavior-preserving)**
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: PASS — `protocol` gains the id test; `server` keeps
+`random_ids_are_distinct`; all server integration tests
+(`lifecycle`/`game_session`/`ws`/`resume`) compile against the re-exported
+`GameId` and pass unchanged.
+
+- [ ] **Step 5: Clippy + fmt (warnings are errors)**
+
+Run:
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+```
+Expected: clean (watch for an unused `serde`/`GameId` import left in
+`lifecycle.rs`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/protocol/src/lib.rs crates/server/src/id.rs crates/server/src/lifecycle.rs
+git commit -m "protocol: hoist GameId + POST /games DTOs from server
+
+GameId and the create-game request/response are client/server contract,
+not server-only. Move them to the shared protocol crate so the web client
+reuses the real types. Id minting (uuid) stays server-side as
+id::random_game_id; server re-exports protocol::GameId so existing paths
+and tests are untouched.
+
+Refs #185."
+```
+
+---
+
+## Task 2: Dependencies + module skeleton
 
 **Files:**
 - Modify: `crates/web/Cargo.toml`
@@ -51,7 +218,6 @@ gloo-net = { version = "0.6", features = ["websocket", "http"] }
 gloo-timers = { version = "0.3", features = ["futures"] }
 futures = "0.3"
 wasm-bindgen-futures = "0.4"
-serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 web-sys = { version = "0.3", features = ["Storage", "Location", "Window"] }
 
@@ -107,7 +273,7 @@ git commit -m "ui: P6.4 deps + module skeleton (wasm-gated transport)"
 
 ---
 
-## Task 2: Pure `ws_url`
+## Task 3: Pure `ws_url`
 
 **Files:**
 - Modify: `crates/web/src/url.rs`
@@ -183,7 +349,7 @@ git commit -m "ui: P6.4 same-origin ws_url derivation (D3)"
 
 ---
 
-## Task 3: `ClientState` + pure `reduce`
+## Task 4: `ClientState` + pure `reduce`
 
 **Files:**
 - Modify: `crates/web/src/store.rs`
@@ -321,7 +487,7 @@ git commit -m "ui: P6.4 ClientState + pure ServerMessage reducer"
 
 ---
 
-## Task 4: Store context helpers (signal + outbound channel)
+## Task 5: Store context helpers (signal + outbound channel)
 
 **Files:**
 - Modify: `crates/web/src/store.rs`
@@ -372,7 +538,7 @@ git commit -m "ui: P6.4 store context helpers (provide/use signal)"
 
 ---
 
-## Task 5: DebugDump view + headless acceptance test
+## Task 6: DebugDump view + headless acceptance test
 
 **Files:**
 - Modify: `crates/web/src/app.rs`
@@ -516,7 +682,7 @@ git commit -m "ui: P6.4 DebugDump view + headless signal-render test"
 
 ---
 
-## Task 6: Transport — bootstrap, connect loop, reconnect, send
+## Task 7: Transport — bootstrap, connect loop, reconnect, send
 
 **Files:**
 - Modify: `crates/web/src/transport.rs`
@@ -537,10 +703,9 @@ use gloo_net::http::Request;
 use gloo_net::websocket::{futures::WebSocket, Message};
 use gloo_timers::future::TimeoutFuture;
 use leptos::prelude::*;
-use serde::{Deserialize, Serialize};
 use wasm_bindgen_futures::spawn_local;
 
-use protocol::{ClientMessage, ServerMessage};
+use protocol::{ClientMessage, CreateGameRequest, CreateGameResponse, GameId, ServerMessage};
 
 use crate::store::{reduce, ConnStatus, StoreSignal};
 use crate::url::current_ws_url;
@@ -552,15 +717,6 @@ const GAME_ID_KEY: &str = "eldritch_game_id";
 const SCENARIO_ID: &str = "synthetic";
 /// Fixed reconnect backoff. Plenty for a solo v0; not exponential.
 const RECONNECT_MS: u32 = 1000;
-
-#[derive(Serialize)]
-struct CreateGameRequest {
-    scenario_id: String,
-}
-#[derive(Deserialize)]
-struct CreateGameResponse {
-    game_id: String,
-}
 
 /// Sender used by views (the debug button, later P6.7 controls) to
 /// submit actions; cloneable, survives reconnects.
@@ -575,7 +731,7 @@ pub fn start(store: StoreSignal) {
 }
 
 async fn run(store: StoreSignal, mut rx: mpsc::UnboundedReceiver<ClientMessage>) {
-    let mut game_id = match bootstrap(store).await {
+    let mut game_id: GameId = match bootstrap(store).await {
         Some(id) => id,
         None => return, // bootstrap set ConnStatus::Failed already
     };
@@ -600,14 +756,14 @@ async fn run(store: StoreSignal, mut rx: mpsc::UnboundedReceiver<ClientMessage>)
 
 /// Resolve a game id: reuse a saved one, else create and save. Returns
 /// `None` (and sets `Failed`) if creation fails.
-async fn bootstrap(store: StoreSignal) -> Option<String> {
+async fn bootstrap(store: StoreSignal) -> Option<GameId> {
     if let Some(id) = saved_id() {
         return Some(id);
     }
     create_game(store).await
 }
 
-async fn create_game(store: StoreSignal) -> Option<String> {
+async fn create_game(store: StoreSignal) -> Option<GameId> {
     let resp = Request::post("/games")
         .json(&CreateGameRequest {
             scenario_id: SCENARIO_ID.to_string(),
@@ -616,8 +772,7 @@ async fn create_game(store: StoreSignal) -> Option<String> {
         .send()
         .await
         .ok()?;
-    let parsed = resp.json::<CreateGameResponse>().await.ok();
-    match parsed {
+    match resp.json::<CreateGameResponse>().await.ok() {
         Some(r) => {
             save_id(&r.game_id);
             Some(r.game_id)
@@ -633,11 +788,11 @@ async fn create_game(store: StoreSignal) -> Option<String> {
 /// outbound→sink until close. Returns whether a `Hello` was seen.
 async fn connect_once(
     store: &StoreSignal,
-    game_id: &str,
+    game_id: &GameId,
     rx: &mut mpsc::UnboundedReceiver<ClientMessage>,
 ) -> bool {
     store.update(|s| s.status = ConnStatus::Connecting);
-    let Ok(ws) = WebSocket::open(&current_ws_url(game_id)) else {
+    let Ok(ws) = WebSocket::open(&current_ws_url(game_id.as_str())) else {
         return false;
     };
     store.update(|s| s.status = ConnStatus::Connected);
@@ -677,12 +832,13 @@ async fn connect_once(
 fn local_storage() -> Option<web_sys::Storage> {
     web_sys::window()?.local_storage().ok().flatten()
 }
-fn saved_id() -> Option<String> {
-    local_storage()?.get_item(GAME_ID_KEY).ok().flatten()
+fn saved_id() -> Option<GameId> {
+    let raw = local_storage()?.get_item(GAME_ID_KEY).ok().flatten()?;
+    Some(GameId::new(raw))
 }
-fn save_id(id: &str) {
+fn save_id(id: &GameId) {
     if let Some(ls) = local_storage() {
-        let _ = ls.set_item(GAME_ID_KEY, id);
+        let _ = ls.set_item(GAME_ID_KEY, id.as_str());
     }
 }
 fn clear_saved_id() {
@@ -711,7 +867,7 @@ git commit -m "ui: P6.4 transport — bootstrap, connect loop, reconnect, send"
 
 ---
 
-## Task 7: Wire the debug submit button + full verification
+## Task 8: Wire the debug submit button + full verification
 
 **Files:**
 - Modify: `crates/web/src/app.rs`
@@ -805,10 +961,10 @@ Closes #185."
 
 ## Self-review notes (author)
 
-- **Spec coverage:** same-origin URL (Task 2), reducer + state shape (Task 3), signal store (Task 4), debug dump + acceptance test (Task 5), bootstrap/localStorage/reconnect/stale-id/send (Task 6), submit + manual reconnect+restore (Task 7). leptos-use deferral is a phase-doc note, applied at PR finalize (not a code task).
+- **Spec coverage:** GameId + DTO hoist to `protocol` (Task 1), same-origin URL (Task 3), reducer + state shape (Task 4), signal store (Task 5), debug dump + acceptance test (Task 6), bootstrap/localStorage/reconnect/stale-id/send (Task 7), submit + manual reconnect+restore (Task 8). leptos-use deferral is a phase-doc note, applied at PR finalize (not a code task).
 - **Native/wasm split** is enforced structurally: wasm deps under the target table; `transport` + URL reader cfg-gated; `app` spawns transport under cfg. Every task runs both `cargo build -p web` and the wasm build.
 - **Stale-id recovery** is the `saw_hello` flag in `connect_once`/`run`.
-- **Open verification risk:** the exact `PlayerAction` path and a couple of Leptos-0.8 view/`into_any` ergonomics (Task 5/7) may need a small adjustment at implementation time — flagged inline at each site. The reviewing engineer should follow the path `protocol` already uses.
+- **Open verification risk:** the exact `PlayerAction` path and a couple of Leptos-0.8 view/`into_any` ergonomics (Task 6/8) may need a small adjustment at implementation time — flagged inline at each site. The reviewing engineer should follow the path `protocol` already uses.
 
 ## Phase-doc update (at PR finalize, after CI green — NOT a code commit)
 

--- a/docs/superpowers/plans/2026-06-08-p6.4-ws-client-store.md
+++ b/docs/superpowers/plans/2026-06-08-p6.4-ws-client-store.md
@@ -1,0 +1,822 @@
+# P6.4 — WS Client + Reactive State Store Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the Leptos web client a transport + reactive store: open a same-origin WebSocket to a running game, fold `Hello`/`Applied`/`Rejected` into signals, submit actions, reconnect on close, and render a debug dump that proves the round-trip.
+
+**Architecture:** A **pure core** (`reduce(&mut ClientState, ServerMessage)`, `ws_url(...)`) compiled on every target and unit-tested natively; a **wasm-only transport** (`gloo-net` WebSocket + reconnect loop, `gloo-net` HTTP for `POST /games`, `web-sys` localStorage) cfg-gated so the native `test`/`clippy`/`doc` jobs still compile the crate. The root component renders the debug dump from one `RwSignal<ClientState>`; an outbound `futures` mpsc channel carries `ClientMessage` to the current socket so reconnect swaps the sink invisibly.
+
+**Tech Stack:** Rust + Leptos 0.8 (CSR), `protocol` crate (`ClientMessage`/`ServerMessage`), `gloo-net` (websocket + http), `futures`, `wasm-bindgen-futures`, `gloo-timers` (async reconnect sleep), `web-sys` (Storage/Location), `serde_json`. Tests: native `#[cfg(test)]` + headless `wasm-bindgen-test`.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-p6.4-ws-client-store-design.md`
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `crates/web/Cargo.toml` | add `protocol` dep; wasm-only deps under a `[target.'cfg(target_arch = "wasm32")'.dependencies]` table |
+| `crates/web/src/lib.rs` | declare `store`, `url`, `app`; declare `transport` cfg-gated to wasm32 |
+| `crates/web/src/url.rs` | pure `ws_url(protocol, host, game_id)`; wasm reader of `window().location()` |
+| `crates/web/src/store.rs` | `ClientState`, `ConnStatus`, pure `reduce`; `provide`/`use` context helpers for the signal + outbound channel |
+| `crates/web/src/app.rs` | root `App` + `DebugDump` component (renders from the signal); spawns the transport (wasm only); one debug "Submit EndTurn" button |
+| `crates/web/src/transport.rs` | (wasm only) bootstrap (localStorage / `POST /games`), connect loop (inbound→reduce, outbound→sink), reconnect + stale-id recovery |
+| `crates/web/tests/store.rs` | headless: feed `Hello`/`Applied` → assert signal-driven DOM updates |
+
+**Native vs wasm rule (load-bearing):** `store.rs` and `url.rs`'s pure parts use only `protocol`/`game-core`/`leptos` (compile everywhere). Everything touching `gloo-net`/`web-sys`/`futures`/`serde_json`/timers lives in `transport.rs` (and the wasm reader in `url.rs`), gated `#[cfg(target_arch = "wasm32")]`, with deps under the wasm target table. `app.rs` renders from the signal on every target but spawns the transport only under `cfg(target_arch = "wasm32")`.
+
+---
+
+## Task 1: Dependencies + module skeleton
+
+**Files:**
+- Modify: `crates/web/Cargo.toml`
+- Modify: `crates/web/src/lib.rs`
+- Create: `crates/web/src/url.rs`, `crates/web/src/store.rs`, `crates/web/src/transport.rs`
+
+- [ ] **Step 1: Add dependencies**
+
+Replace the `[dependencies]`/`[dev-dependencies]` section of `crates/web/Cargo.toml` with:
+
+```toml
+[dependencies]
+game-core = { path = "../game-core" }
+protocol = { path = "../protocol" }
+leptos = { version = "0.8", features = ["csr"] }
+console_error_panic_hook = "0.1"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+gloo-net = { version = "0.6", features = ["websocket", "http"] }
+gloo-timers = { version = "0.3", features = ["futures"] }
+futures = "0.3"
+wasm-bindgen-futures = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+web-sys = { version = "0.3", features = ["Storage", "Location", "Window"] }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+```
+
+- [ ] **Step 2: Create empty module files**
+
+`crates/web/src/url.rs`:
+```rust
+//! Same-origin WebSocket URL derivation (D3): never a hardcoded port.
+```
+
+`crates/web/src/store.rs`:
+```rust
+//! Reactive client store: `ClientState` + the pure `ServerMessage` reducer.
+```
+
+`crates/web/src/transport.rs`:
+```rust
+//! Browser transport (wasm only): bootstrap, WebSocket connect/reconnect, send.
+```
+
+- [ ] **Step 3: Wire modules in `lib.rs`**
+
+Replace `crates/web/src/lib.rs` body (keep the existing crate doc-comment) so the module list reads:
+```rust
+pub mod app;
+pub mod store;
+pub mod url;
+
+#[cfg(target_arch = "wasm32")]
+pub mod transport;
+```
+
+- [ ] **Step 4: Verify native build (modules empty, crate still compiles)**
+
+Run: `cargo build -p web`
+Expected: success (the new modules are empty; no wasm deps pulled on the host target).
+
+- [ ] **Step 5: Verify wasm build pulls the new deps**
+
+Run: `cargo build -p web --target wasm32-unknown-unknown`
+Expected: success; `gloo-net`, `gloo-timers`, etc. compile.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/web/Cargo.toml crates/web/src/lib.rs crates/web/src/url.rs crates/web/src/store.rs crates/web/src/transport.rs
+git commit -m "ui: P6.4 deps + module skeleton (wasm-gated transport)"
+```
+
+---
+
+## Task 2: Pure `ws_url`
+
+**Files:**
+- Modify: `crates/web/src/url.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `crates/web/src/url.rs`:
+```rust
+/// Build the same-origin WebSocket URL for a game. `location_protocol`
+/// is `window.location.protocol` (`"http:"` / `"https:"`); `host`
+/// includes the port. Upgrades to `wss` under TLS; otherwise `ws`.
+pub fn ws_url(location_protocol: &str, host: &str, game_id: &str) -> String {
+    let scheme = if location_protocol == "https:" { "wss" } else { "ws" };
+    format!("{scheme}://{host}/games/{game_id}/ws")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ws_url;
+
+    #[test]
+    fn plain_http_uses_ws_and_keeps_port() {
+        assert_eq!(
+            ws_url("http:", "localhost:3000", "abc"),
+            "ws://localhost:3000/games/abc/ws"
+        );
+    }
+
+    #[test]
+    fn https_upgrades_to_wss() {
+        assert_eq!(
+            ws_url("https:", "play.example.com", "g1"),
+            "wss://play.example.com/games/g1/ws"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the test — expect PASS**
+
+(The implementation is written alongside the test because it is a pure one-liner; there is no separate red step worth faking a stub for.)
+
+Run: `cargo test -p web --lib url::`
+Expected: PASS (2 tests).
+
+- [ ] **Step 3: Add the wasm reader (gated, no native impact)**
+
+Append to `crates/web/src/url.rs`:
+```rust
+/// Read `window.location` and build this game's WebSocket URL.
+#[cfg(target_arch = "wasm32")]
+pub fn current_ws_url(game_id: &str) -> String {
+    let loc = web_sys::window()
+        .expect("a browser window")
+        .location();
+    let protocol = loc.protocol().unwrap_or_else(|_| "http:".to_string());
+    let host = loc.host().unwrap_or_default();
+    ws_url(&protocol, &host, game_id)
+}
+```
+
+- [ ] **Step 4: Verify both targets compile**
+
+Run: `cargo build -p web && cargo build -p web --target wasm32-unknown-unknown`
+Expected: both succeed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/web/src/url.rs
+git commit -m "ui: P6.4 same-origin ws_url derivation (D3)"
+```
+
+---
+
+## Task 3: `ClientState` + pure `reduce`
+
+**Files:**
+- Modify: `crates/web/src/store.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `crates/web/src/store.rs`:
+```rust
+use game_core::state::GameState;
+use game_core::EngineOutcome;
+use protocol::ServerMessage;
+
+/// Connection lifecycle, set by the transport (not by `reduce`).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum ConnStatus {
+    #[default]
+    Connecting,
+    Connected,
+    Reconnecting,
+    Failed,
+}
+
+/// Everything the UI renders. `game`/`outcome`/`last_rejection` come
+/// from `reduce`; `status` is driven by the transport.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct ClientState {
+    pub game: Option<GameState>,
+    pub outcome: Option<EngineOutcome>,
+    pub status: ConnStatus,
+    pub last_rejection: Option<String>,
+}
+
+/// Fold one server message into the client state. Data only — never
+/// touches `status`. Mirrors the server: a `Rejected` leaves
+/// `game`/`outcome` unchanged (the rejection was sender-only).
+pub fn reduce(state: &mut ClientState, msg: ServerMessage) {
+    match msg {
+        ServerMessage::Hello { state: s, outcome } => {
+            state.game = Some(*s);
+            state.outcome = Some(outcome);
+            state.last_rejection = None;
+        }
+        ServerMessage::Applied { state: s, outcome, .. } => {
+            state.game = Some(*s);
+            state.outcome = Some(outcome);
+        }
+        ServerMessage::Rejected { reason } => {
+            state.last_rejection = Some(reason);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use game_core::test_support::builder::TestGame;
+    use game_core::test_support::fixtures::test_investigator;
+
+    fn sample_state() -> GameState {
+        TestGame::new()
+            .with_investigator(test_investigator(1))
+            .build()
+    }
+
+    #[test]
+    fn hello_sets_game_and_clears_rejection() {
+        let mut s = ClientState {
+            last_rejection: Some("stale".into()),
+            ..Default::default()
+        };
+        reduce(
+            &mut s,
+            ServerMessage::Hello {
+                state: Box::new(sample_state()),
+                outcome: EngineOutcome::Done,
+            },
+        );
+        assert!(s.game.is_some());
+        assert_eq!(s.outcome, Some(EngineOutcome::Done));
+        assert_eq!(s.last_rejection, None);
+    }
+
+    #[test]
+    fn applied_updates_game_and_outcome() {
+        let mut s = ClientState::default();
+        reduce(
+            &mut s,
+            ServerMessage::Applied {
+                state: Box::new(sample_state()),
+                events: Vec::new(),
+                outcome: EngineOutcome::Done,
+            },
+        );
+        assert!(s.game.is_some());
+        assert_eq!(s.outcome, Some(EngineOutcome::Done));
+    }
+
+    #[test]
+    fn rejected_sets_reason_without_touching_game() {
+        let mut s = ClientState {
+            game: Some(sample_state()),
+            outcome: Some(EngineOutcome::Done),
+            ..Default::default()
+        };
+        let before = s.game.clone();
+        reduce(
+            &mut s,
+            ServerMessage::Rejected {
+                reason: "not your turn".into(),
+            },
+        );
+        assert_eq!(s.last_rejection.as_deref(), Some("not your turn"));
+        assert_eq!(s.game, before);
+        assert_eq!(s.outcome, Some(EngineOutcome::Done));
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests — expect PASS**
+
+Run: `cargo test -p web --lib store::`
+Expected: PASS (3 tests). (Types + reducer are written with the tests; the body is small enough that a separate stub step adds no value.)
+
+- [ ] **Step 3: Verify wasm target still builds**
+
+Run: `cargo build -p web --target wasm32-unknown-unknown`
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/web/src/store.rs
+git commit -m "ui: P6.4 ClientState + pure ServerMessage reducer"
+```
+
+---
+
+## Task 4: Store context helpers (signal + outbound channel)
+
+**Files:**
+- Modify: `crates/web/src/store.rs`
+
+- [ ] **Step 1: Add the context types and helpers**
+
+Add near the top of `crates/web/src/store.rs` (after the existing `use` lines):
+```rust
+use leptos::prelude::*;
+
+/// The single reactive store handed through Leptos context.
+pub type StoreSignal = RwSignal<ClientState>;
+
+/// Provide a fresh store signal into context and return it.
+pub fn provide_store() -> StoreSignal {
+    let signal = RwSignal::new(ClientState::default());
+    provide_context(signal);
+    signal
+}
+
+/// Read the store signal from context. Panics if not provided — a
+/// programmer error (every view lives under `provide_store`).
+pub fn use_store() -> StoreSignal {
+    use_context::<StoreSignal>().expect("store signal provided at App root")
+}
+```
+
+The outbound action channel is wasm-only and lives in `transport.rs`
+(Task 6), provided into context there — it needs no native-side type
+here.
+
+- [ ] **Step 2: Verify both targets compile**
+
+Run: `cargo build -p web && cargo build -p web --target wasm32-unknown-unknown`
+Expected: both succeed.
+
+- [ ] **Step 3: Run the existing reducer tests (no regression)**
+
+Run: `cargo test -p web --lib store::`
+Expected: PASS (3 tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/web/src/store.rs
+git commit -m "ui: P6.4 store context helpers (provide/use signal)"
+```
+
+---
+
+## Task 5: DebugDump view + headless acceptance test
+
+**Files:**
+- Modify: `crates/web/src/app.rs`
+- Create: `crates/web/tests/store.rs`
+
+- [ ] **Step 1: Write the `DebugDump` component and update `App`**
+
+Replace `crates/web/src/app.rs` with:
+```rust
+//! The root Leptos component for the Eldritch web client.
+
+use leptos::prelude::*;
+
+use crate::store::{provide_store, use_store, ConnStatus};
+
+#[component]
+pub fn App() -> impl IntoView {
+    provide_store();
+
+    // Spawn the browser transport only on wasm; native/headless-reducer
+    // builds render from a signal that tests drive directly.
+    #[cfg(target_arch = "wasm32")]
+    {
+        let store = use_store();
+        crate::transport::start(store);
+    }
+
+    view! {
+        <main>
+            <h1>"Eldritch"</h1>
+            <DebugDump/>
+        </main>
+    }
+}
+
+/// Read-only dump of the client store — proves the round-trip before
+/// P6.5's real board. Renders a stable presence label (for the headless
+/// test) plus a human-facing pretty-print of the state.
+#[component]
+pub fn DebugDump() -> impl IntoView {
+    let store = use_store();
+
+    let status = move || match store.get().status {
+        ConnStatus::Connecting => "connecting",
+        ConnStatus::Connected => "connected",
+        ConnStatus::Reconnecting => "reconnecting",
+        ConnStatus::Failed => "failed",
+    };
+    let presence = move || if store.get().game.is_some() { "present" } else { "none" };
+    let rejection = move || store.get().last_rejection.unwrap_or_default();
+    let dump = move || {
+        store
+            .get()
+            .game
+            .map(|g| format!("{g:#?}"))
+            .unwrap_or_else(|| "<no state yet>".to_string())
+    };
+
+    view! {
+        <section>
+            <p>"status: " {status}</p>
+            <p>"state: " {presence}</p>
+            <p>"rejection: " {rejection}</p>
+            <pre>{dump}</pre>
+        </section>
+    }
+}
+```
+
+- [ ] **Step 2: Write the headless test**
+
+Create `crates/web/tests/store.rs`:
+```rust
+//! Headless acceptance: feeding `Hello`/`Applied` updates the signal and
+//! the DOM rendered from it. wasm32-only (browser DOM); native jobs skip.
+#![cfg(target_arch = "wasm32")]
+
+use game_core::test_support::builder::TestGame;
+use game_core::test_support::fixtures::test_investigator;
+use game_core::EngineOutcome;
+use protocol::ServerMessage;
+use wasm_bindgen_test::*;
+use web::store::{provide_store, reduce, ClientState, DebugDump};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn body_html() -> String {
+    leptos::prelude::document()
+        .body()
+        .expect("body")
+        .inner_html()
+}
+
+#[wasm_bindgen_test]
+fn hello_renders_state_present() {
+    let store = leptos::prelude::RwSignal::new(ClientState::default());
+    // Provide the same signal the component reads, then mount the dump.
+    let _handle = leptos::mount::mount_to_body(move || {
+        leptos::prelude::provide_context(store);
+        leptos::view! { <DebugDump/> }
+    });
+
+    assert!(body_html().contains("state: none"), "before: {}", body_html());
+
+    let game = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .build();
+    store.update(|s| {
+        reduce(
+            s,
+            ServerMessage::Hello {
+                state: Box::new(game),
+                outcome: EngineOutcome::Done,
+            },
+        )
+    });
+
+    assert!(body_html().contains("state: present"), "after: {}", body_html());
+}
+```
+
+> If `provide_store` is unused by this test, drop it from the import.
+> The test provides its own signal so it can both feed and assert on it.
+
+- [ ] **Step 3: Verify native build + lib tests unaffected**
+
+Run: `cargo build -p web && cargo test -p web --lib`
+Expected: success; lib tests (url + store) pass. The wasm-only `tests/store.rs` is skipped on the host target.
+
+- [ ] **Step 4: Run the headless test**
+
+Run: `wasm-pack test --headless --firefox crates/web`
+Expected: both headless tests pass (`smoke.rs` greeting + `store.rs` hello renders present).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/web/src/app.rs crates/web/tests/store.rs
+git commit -m "ui: P6.4 DebugDump view + headless signal-render test"
+```
+
+---
+
+## Task 6: Transport — bootstrap, connect loop, reconnect, send
+
+**Files:**
+- Modify: `crates/web/src/transport.rs`
+
+This module is wasm-only and exercises live I/O, so it is verified by the manual check in Task 7 (no unit test for the socket loop). The pure pieces it relies on (`ws_url`, `reduce`) are already tested.
+
+- [ ] **Step 1: Implement the transport**
+
+Replace `crates/web/src/transport.rs` with:
+```rust
+//! Browser transport (wasm only): bootstrap a game, connect its
+//! WebSocket, fold inbound frames into the store, forward outbound
+//! actions, and reconnect on close.
+
+use futures::channel::mpsc;
+use futures::{select, SinkExt, StreamExt};
+use gloo_net::http::Request;
+use gloo_net::websocket::{futures::WebSocket, Message};
+use gloo_timers::future::TimeoutFuture;
+use leptos::prelude::*;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen_futures::spawn_local;
+
+use protocol::{ClientMessage, ServerMessage};
+
+use crate::store::{reduce, ConnStatus, StoreSignal};
+use crate::url::current_ws_url;
+
+/// localStorage key holding the active game id across reloads.
+const GAME_ID_KEY: &str = "eldritch_game_id";
+/// The only playable scenario this phase (D5: synthetic registries).
+// TODO(phase-7): swap to a real scenario id when The Gathering lands.
+const SCENARIO_ID: &str = "synthetic";
+/// Fixed reconnect backoff. Plenty for a solo v0; not exponential.
+const RECONNECT_MS: u32 = 1000;
+
+#[derive(Serialize)]
+struct CreateGameRequest {
+    scenario_id: String,
+}
+#[derive(Deserialize)]
+struct CreateGameResponse {
+    game_id: String,
+}
+
+/// Sender used by views (the debug button, later P6.7 controls) to
+/// submit actions; cloneable, survives reconnects.
+pub type OutboundTx = mpsc::UnboundedSender<ClientMessage>;
+
+/// Start the transport: provide an `OutboundTx` into context, then spawn
+/// the bootstrap + connect loop. Call once from `App` (wasm only).
+pub fn start(store: StoreSignal) {
+    let (tx, rx) = mpsc::unbounded::<ClientMessage>();
+    provide_context(tx);
+    spawn_local(run(store, rx));
+}
+
+async fn run(store: StoreSignal, mut rx: mpsc::UnboundedReceiver<ClientMessage>) {
+    let mut game_id = match bootstrap(store).await {
+        Some(id) => id,
+        None => return, // bootstrap set ConnStatus::Failed already
+    };
+
+    loop {
+        let saw_hello = connect_once(&store, &game_id, &mut rx).await;
+
+        // A saved id whose game no longer exists: the server drops the
+        // socket before any Hello. Discard it and create a fresh game.
+        if !saw_hello {
+            clear_saved_id();
+            match create_game(store).await {
+                Some(id) => game_id = id,
+                None => return,
+            }
+        }
+
+        store.update(|s| s.status = ConnStatus::Reconnecting);
+        TimeoutFuture::new(RECONNECT_MS).await;
+    }
+}
+
+/// Resolve a game id: reuse a saved one, else create and save. Returns
+/// `None` (and sets `Failed`) if creation fails.
+async fn bootstrap(store: StoreSignal) -> Option<String> {
+    if let Some(id) = saved_id() {
+        return Some(id);
+    }
+    create_game(store).await
+}
+
+async fn create_game(store: StoreSignal) -> Option<String> {
+    let resp = Request::post("/games")
+        .json(&CreateGameRequest {
+            scenario_id: SCENARIO_ID.to_string(),
+        })
+        .ok()?
+        .send()
+        .await
+        .ok()?;
+    let parsed = resp.json::<CreateGameResponse>().await.ok();
+    match parsed {
+        Some(r) => {
+            save_id(&r.game_id);
+            Some(r.game_id)
+        }
+        None => {
+            store.update(|s| s.status = ConnStatus::Failed);
+            None
+        }
+    }
+}
+
+/// One socket lifetime: open, mark Connected, pump inbound→reduce and
+/// outbound→sink until close. Returns whether a `Hello` was seen.
+async fn connect_once(
+    store: &StoreSignal,
+    game_id: &str,
+    rx: &mut mpsc::UnboundedReceiver<ClientMessage>,
+) -> bool {
+    store.update(|s| s.status = ConnStatus::Connecting);
+    let Ok(ws) = WebSocket::open(&current_ws_url(game_id)) else {
+        return false;
+    };
+    store.update(|s| s.status = ConnStatus::Connected);
+
+    let (mut write, read) = ws.split();
+    let mut read = read.fuse();
+    let mut saw_hello = false;
+
+    loop {
+        select! {
+            incoming = read.next() => match incoming {
+                Some(Ok(Message::Text(txt))) => {
+                    if let Ok(msg) = serde_json::from_str::<ServerMessage>(&txt) {
+                        saw_hello |= matches!(msg, ServerMessage::Hello { .. });
+                        store.update(|s| reduce(s, msg));
+                    }
+                }
+                Some(Ok(Message::Bytes(_))) => {}
+                Some(Err(_)) | None => break, // socket closed/errored
+            },
+            outbound = rx.next() => {
+                if let Some(action) = outbound {
+                    if let Ok(json) = serde_json::to_string(&action) {
+                        let _ = write.send(Message::Text(json)).await;
+                    }
+                }
+            }
+        }
+    }
+    saw_hello
+}
+
+// Note: this module imports only what it uses (`reduce`, `ConnStatus`,
+// `StoreSignal`). `ClientState` is constructed via `Default` inside the
+// store, not named here.
+
+fn local_storage() -> Option<web_sys::Storage> {
+    web_sys::window()?.local_storage().ok().flatten()
+}
+fn saved_id() -> Option<String> {
+    local_storage()?.get_item(GAME_ID_KEY).ok().flatten()
+}
+fn save_id(id: &str) {
+    if let Some(ls) = local_storage() {
+        let _ = ls.set_item(GAME_ID_KEY, id);
+    }
+}
+fn clear_saved_id() {
+    if let Some(ls) = local_storage() {
+        let _ = ls.remove_item(GAME_ID_KEY);
+    }
+}
+```
+
+- [ ] **Step 2: Verify wasm build (warnings-as-errors)**
+
+Run: `RUSTFLAGS="-D warnings" cargo build -p web --target wasm32-unknown-unknown`
+Expected: success, no warnings. Fix any unused import by removing it.
+
+- [ ] **Step 3: Verify native build unaffected**
+
+Run: `cargo build -p web`
+Expected: success (transport is cfg-gated out; no wasm deps on host).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/web/src/transport.rs
+git commit -m "ui: P6.4 transport — bootstrap, connect loop, reconnect, send"
+```
+
+---
+
+## Task 7: Wire the debug submit button + full verification
+
+**Files:**
+- Modify: `crates/web/src/app.rs`
+
+- [ ] **Step 1: Add the debug submit button (wasm only)**
+
+In `crates/web/src/app.rs`, add to the `App` view a button that pushes an
+`EndTurn` action onto the outbound channel. Inside the existing
+`#[cfg(target_arch = "wasm32")]` block in `App`, after `transport::start`,
+the `OutboundTx` is in context; render the button only on wasm. Add a
+helper component:
+
+```rust
+#[cfg(target_arch = "wasm32")]
+#[component]
+fn DebugSubmit() -> impl IntoView {
+    use leptos::prelude::*;
+    let tx = use_context::<crate::transport::OutboundTx>()
+        .expect("OutboundTx provided by transport::start");
+    let on_click = move |_| {
+        let mut tx = tx.clone();
+        let _ = tx.start_send(game_core::PlayerAction::EndTurn);
+    };
+    view! { <button on:click=on_click>"Submit EndTurn (debug)"</button> }
+}
+```
+
+And render it in `App`'s `view!` guarded by cfg — use a small wrapper so
+the native view omits it:
+```rust
+// in App(), replace the <DebugDump/> line with:
+<DebugDump/>
+{
+    #[cfg(target_arch = "wasm32")]
+    { view! { <DebugSubmit/> }.into_any() }
+    #[cfg(not(target_arch = "wasm32"))]
+    { ().into_any() }
+}
+```
+
+> Confirm `game_core::PlayerAction::EndTurn` is the correct variant path
+> (check `crates/game-core/src/lib.rs` re-exports); adjust if it is
+> `game_core::action::PlayerAction`. Use the path that the `protocol`
+> crate already uses for `ClientMessage::Submit { action }`.
+
+- [ ] **Step 2: Verify both targets build with warnings-as-errors**
+
+Run:
+```bash
+cargo build -p web
+RUSTFLAGS="-D warnings" cargo build -p web --target wasm32-unknown-unknown
+```
+Expected: both succeed, no warnings.
+
+- [ ] **Step 3: Run the full local CI gauntlet**
+
+Run:
+```bash
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+wasm-pack test --headless --firefox crates/web
+```
+Expected: all green.
+
+- [ ] **Step 4: Manual verification (records the acceptance criteria)**
+
+In two terminals:
+```bash
+cargo run -p server                                  # :8000, installs synthetic registries
+cd crates/web && trunk serve --proxy-backend=http://localhost:8000   # :3000
+```
+Open `http://localhost:3000`. Confirm:
+1. The debug dump shows `status: connected` and `state: present` with a pretty-printed toy-scenario `GameState`.
+2. Refresh the page → it rejoins the **same** game (same id in localStorage; state restored, not a new game).
+3. Click "Submit EndTurn (debug)" → the dump updates (turn advances / outcome changes), proving the outbound round-trip.
+4. Stop and restart the server → the client reconnects (status flips to `reconnecting` then `connected`) and the board restores.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/web/src/app.rs
+git commit -m "ui: P6.4 debug submit button + round-trip wiring
+
+Closes #185."
+```
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** same-origin URL (Task 2), reducer + state shape (Task 3), signal store (Task 4), debug dump + acceptance test (Task 5), bootstrap/localStorage/reconnect/stale-id/send (Task 6), submit + manual reconnect+restore (Task 7). leptos-use deferral is a phase-doc note, applied at PR finalize (not a code task).
+- **Native/wasm split** is enforced structurally: wasm deps under the target table; `transport` + URL reader cfg-gated; `app` spawns transport under cfg. Every task runs both `cargo build -p web` and the wasm build.
+- **Stale-id recovery** is the `saw_hello` flag in `connect_once`/`run`.
+- **Open verification risk:** the exact `PlayerAction` path and a couple of Leptos-0.8 view/`into_any` ergonomics (Task 5/7) may need a small adjustment at implementation time — flagged inline at each site. The reviewing engineer should follow the path `protocol` already uses.
+
+## Phase-doc update (at PR finalize, after CI green — NOT a code commit)
+
+Per `docs/phases/README.md` "Maintaining these docs", update
+`docs/phases/phase-6-web-client-v0.md`: flip P6.4's row to `✅ PR #N`,
+move #185 to Closed (bump counts), and add **one** *Decisions made*
+entry recording the **leptos-use deferral + revisit trigger** (second
+concrete need: P6.5 responsive layout / P8 auth) and the
+auto-create+localStorage bootstrap. Also fold in the pending
+`docs/phases/README.md` #196 tracking line.
+```

--- a/docs/superpowers/specs/2026-06-08-p6.4-ws-client-store-design.md
+++ b/docs/superpowers/specs/2026-06-08-p6.4-ws-client-store-design.md
@@ -34,6 +34,19 @@ rendering, action controls, or legality gating (those are P6.5–P6.7).
   in Phase 8 — `use_cookie`); adopting it is purely additive, so
   deferring costs ~nothing. **This deferral + its revisit trigger must
   be recorded in the phase-6 doc's *Decisions made* when this PR lands.**
+- **`GameId` + HTTP DTOs hoisted into `protocol`.** `game_id` is a
+  protocol-level concept (the client receives it from `POST /games` and
+  uses it in the WS path), so `GameId` moves from `crates/server/src/id.rs`
+  into `protocol` and the client reuses the real type rather than a bare
+  `String`. The move is dependency-free for `protocol` (already on
+  `serde`; `GameId` has no `sqlx`/`axum` impls — it persists via
+  `.bind(as_str())` and extracts via `Deserialize`). **`random()` (uuid
+  minting) stays server-side** as `id::random_game_id()` to keep `uuid`
+  out of the wasm-safe `protocol` crate; `server` re-exports
+  `pub use protocol::GameId;` so existing paths/tests are untouched. The
+  `POST /games` DTOs (`CreateGameRequest`/`CreateGameResponse`) move too
+  — they are the HTTP half of the same client/server contract, so the
+  client imports them instead of redefining local copies.
 - **Pure reducer core (D4).** A library-agnostic
   `reduce(&mut ClientState, ServerMessage)` plus a pure
   `ws_url(...)` and stale-id decision are the natively-testable core;

--- a/docs/superpowers/specs/2026-06-08-p6.4-ws-client-store-design.md
+++ b/docs/superpowers/specs/2026-06-08-p6.4-ws-client-store-design.md
@@ -1,0 +1,168 @@
+# P6.4 — WS client + reactive state store (design)
+
+**Issue:** [#185](https://github.com/talelburg/eldritch/issues/185) ·
+**Phase:** 6 (web client v0) ·
+**Parent spec:** [`2026-06-08-phase-6-web-client-v0-design.md`](2026-06-08-phase-6-web-client-v0-design.md)
+(client layer 1; D1 state-on-`Applied`, D3 same-origin URL, D4 headless gate)
+
+## Goal
+
+The client's transport + state engine room: open a same-origin
+WebSocket to a running game, fold `Hello`/`Applied`/`Rejected` into
+reactive Leptos signals, submit `ClientMessage::Submit`, reconnect on
+close, and prove the round-trip with a debug-dump render. No board
+rendering, action controls, or legality gating (those are P6.5–P6.7).
+
+## Decisions settled in the design brainstorm (2026-06-08)
+
+- **Game bootstrap: auto-create + localStorage.** On mount, reuse a
+  `game_id` saved in `localStorage`; on a miss, `POST /games
+  {scenario_id: "synthetic"}` and save the returned id. A page reload
+  rejoins the same game — exercising the phase's "reopening picks up
+  where it left off" goal inside P6.4. The scenario id is the toy
+  scenario (`scenarios::test_fixtures::synthetic::ID == "synthetic"`),
+  hardcoded as a literal with a `TODO(phase-7)` — matching D5's
+  synthetic-only-this-phase posture (depending on `scenarios` for one
+  string isn't worth it).
+- **Transport library: `gloo-net` + `web-sys`; defer `leptos-use`.**
+  `gloo-net` is already in the tree (via `leptos → server_fn`); we
+  enable its `websocket` feature and use its `http::Request` for
+  `POST /games`. localStorage is ~6 lines of `web-sys`. We hand-roll a
+  small reconnect loop. **`leptos-use` is deferred**, to be revisited
+  when a *second concrete* cluster of needs appears (e.g. responsive
+  board layout in P6.5 — `use_media_query`/`use_element_size` — or auth
+  in Phase 8 — `use_cookie`); adopting it is purely additive, so
+  deferring costs ~nothing. **This deferral + its revisit trigger must
+  be recorded in the phase-6 doc's *Decisions made* when this PR lands.**
+- **Pure reducer core (D4).** A library-agnostic
+  `reduce(&mut ClientState, ServerMessage)` plus a pure
+  `ws_url(...)` and stale-id decision are the natively-testable core;
+  the wasm shell stays thin. The headless gate exercises the
+  signal-into-DOM path.
+
+## Module layout (`crates/web/src/`)
+
+| Module | Responsibility | wasm-only | Tested by |
+|---|---|---|---|
+| `store.rs` | `ClientState` + pure `reduce(&mut ClientState, ServerMessage)`; the `RwSignal` wrapper / context helpers | reducer is pure | native unit + headless |
+| `transport.rs` | bootstrap (localStorage / `POST`), WS open + reconnect loop, outbound-channel send | yes | manual; pure helpers native-tested |
+| `url.rs` | pure `ws_url(location_protocol, host, game_id) -> String` (+ thin wasm reader of `window().location()`) | core no, reader yes | native |
+| `app.rs` | root component: provide store + outbound channel, spawn transport, render debug dump (+ one debug submit button) | — | headless |
+
+The wasm-only transport reader code is guarded so the native
+`test`/`clippy`/`doc` jobs skip it; the pure core compiles and tests
+everywhere.
+
+## State shape
+
+```rust
+pub struct ClientState {
+    pub game: Option<GameState>,
+    pub outcome: Option<EngineOutcome>,
+    pub status: ConnStatus,
+    pub last_rejection: Option<String>,
+}
+
+pub enum ConnStatus { Connecting, Connected, Reconnecting, Failed }
+```
+
+`reduce` handles **only the three `ServerMessage` variants** (data); the
+transport sets `status` directly (lifecycle). Both write one
+`RwSignal<ClientState>`.
+
+- `Hello { state, outcome }` → set `game`/`outcome`, clear
+  `last_rejection` (fresh baseline).
+- `Applied { state, outcome, events }` → set `game`/`outcome`. `events`
+  are ignored for state (D1: state is authoritative); the debug dump may
+  show a count.
+- `Rejected { reason }` → set `last_rejection`; **leave `game`/`outcome`
+  untouched** (mirrors the server: a rejection is sender-only and leaves
+  state unchanged).
+
+## Data flow
+
+```
+App mounts
+  └─ provide RwSignal<ClientState> + outbound mpsc<ClientMessage> (context)
+  └─ spawn_local(run()):
+       1. bootstrap(): localStorage "eldritch_game_id"?
+            hit  → use it
+            miss → POST /games {scenario_id:"synthetic"} → save id
+       2. connect loop (mirrors the server's tokio::select!):
+            status = Connecting; open WS at ws_url(...); status = Connected
+            select {
+              inbound frame             → reduce() into signal
+              outbound ClientMessage    → sink.send
+            }
+            on close → status = Reconnecting → backoff sleep → retry
+```
+
+**Send path.** Components push `ClientMessage` into a `futures` mpsc
+channel held in context; the connect loop owns the receiver and forwards
+to the *current* sink. This decouples "submit" from socket lifetime, so
+reconnect swaps the sink invisibly to callers — and it is the seam
+P6.7's action buttons plug into. P6.4 wires one debug "Submit EndTurn"
+button to prove the round-trip.
+
+## Same-origin WS URL (D3, load-bearing)
+
+```rust
+fn ws_url(location_protocol: &str, host: &str, game_id: &str) -> String {
+    let scheme = if location_protocol == "https:" { "wss" } else { "ws" };
+    format!("{scheme}://{host}/games/{game_id}/ws")
+}
+```
+
+A thin wasm wrapper reads `window().location().protocol()` / `.host()`.
+`host` includes the port, so production (`:8000`) and the dev proxy
+(`:3000`) both work with no hardcoded port.
+
+## Error handling / edge cases
+
+- **Stale localStorage id** — the saved game no longer exists on the
+  server (e.g. a DB reset); the server's WS handler silently drops the
+  socket. If the socket closes **before any `Hello` is received**,
+  discard the stored id, `POST` a fresh game, and reconnect. Prevents an
+  infinite reconnect loop against a dead id. Implemented as a pure
+  decision (`first_hello_seen: bool` → on-close branch) so it is unit
+  testable.
+- **`POST /games` fails** (network or non-201) → `status = Failed`,
+  surfaced in the debug dump; retry on a delay.
+- **Malformed inbound frame** → skip it (the server only ever emits
+  valid frames; defensive, not expected).
+- **Reconnect backoff** → short fixed delay (~1s), indefinite retry,
+  with `status` surfaced. Not exponential — overkill for a v0 solo
+  debug client.
+
+## Testing
+
+- **Native unit** (`store.rs` / `url.rs` `#[cfg(test)]`):
+  - `reduce`: `Hello` sets `game`/`outcome` and clears `last_rejection`;
+    `Applied` updates `game`/`outcome`; `Rejected` sets `last_rejection`
+    without touching `game`/`outcome`.
+  - `ws_url`: `http:` → `ws://…`, `https:` → `wss://…`, path/port shape.
+  - stale-id decision as a pure function.
+- **Headless** (`crates/web/tests/store.rs`,
+  `#![cfg(target_arch = "wasm32")]` per the P6.3 pattern): mount a
+  harness exposing the signal, feed a `Hello` / `Applied` through the
+  reducer-into-signal, assert the signal updated and the debug-dump DOM
+  reflects it (the issue's acceptance test).
+- **Out of automated scope:** a live socket reconnect — covered by the
+  manual check now and P6.8's closing demo. We test the pure pieces, not
+  a mocked socket.
+
+## Deliverable / "done"
+
+- Debug-dump view shows connection status, outcome, `last_rejection`,
+  and a `{:#?}` of `GameState`.
+- Connecting to a running server shows the toy scenario's initial state;
+  a refresh rejoins the same game (localStorage); dropping the socket
+  reconnects and restores (re-`Hello`, including any in-flight
+  `AwaitingInput`).
+- Headless `wasm-bindgen-test` green; the full CI gauntlet passes.
+
+## Scope guard (YAGNI)
+
+No board rendering (P6.5), no real action controls beyond the single
+debug button (P6.7), no legality gating (P6.6). Just transport + store +
+proof-of-round-trip.


### PR DESCRIPTION
## Summary

Phase-6 slot **P6.4**: the web client's transport + state engine room. The Leptos/WASM client opens a same-origin WebSocket to a running game, folds `Hello`/`Applied`/`Rejected` into a reactive store, submits actions, reconnects on close, and proves the round-trip with a debug-dump render. Board rendering, real action controls, and legality gating are later slots (P6.5–P6.7).

## What changed

**`protocol` (shared contract):**
- Hoisted `GameId` + the `POST /games` DTOs (`CreateGameRequest`/`CreateGameResponse`) out of `server` into `protocol` so the client reuses the real types. `GameId` has no `sqlx`/`axum` impls, so the move is dependency-free for the wasm-safe `protocol` crate. Id-minting (`uuid`) stays server-side as `id::random_game_id`; `server` re-exports `protocol::GameId`, so all server call sites + tests are untouched.

**`web` (the client):**
- `store.rs` — `ClientState`/`ConnStatus` + a **pure** `reduce(&mut ClientState, ServerMessage)` (native unit-tested); `StoreSignal` context helpers wrap it in a Leptos `RwSignal`.
- `url.rs` — pure `ws_url(protocol, host, game_id)` (native-tested) + a wasm-only `current_ws_url` reading `window.location`, so one binary works in prod (`:8000`) and the dev proxy (`:3000`) with no hardcoded port (D3).
- `transport.rs` (wasm-only) — bootstrap (reuse a localStorage game id, else `POST /games {scenario_id:"synthetic"}`), a `select!` connect loop folding inbound frames via `reduce` and forwarding outbound `ClientMessage`s to the current sink, fixed-interval reconnect, and **stale-id recovery** (discard a saved id whose game the server no longer knows).
- `app.rs` — a `DebugDump` view (status / state presence / rejection / pretty-printed `GameState`) and a wasm-only `DebugSubmit` button exercising the outbound send path (the seam P6.7 builds on).

**Native/wasm split:** wasm-only deps live under a `cfg(target_arch = "wasm32")` target table; the transport module + reader + debug button are cfg-gated. The native `test`/`clippy`/`doc` jobs are unaffected.

## Test notes

- **Native:** unit tests for `reduce` (all three `ServerMessage` variants, incl. the "Rejected leaves game/outcome untouched" and "Applied leaves last_rejection untouched" invariants) and `ws_url` (`ws`/`wss`, port preservation).
- **Headless (`wasm-bindgen-test`, 6th CI job):** `tests/store.rs` feeds a `Hello` through reduce-into-signal and asserts the rendered DOM flips `state: none` → `state: present`.
- **Full local gauntlet green:** `test` (615), `clippy -D warnings`, `fmt`, `doc -D warnings`, `wasm-build`, and `wasm-pack test --headless --firefox` (smoke + store).
- **Manual (recommended before merge):** `cargo run -p server` + `trunk serve --proxy-backend=http://localhost:8000`, open the client → debug dump shows the toy scenario; refresh rejoins the same game (localStorage); the debug button advances the turn; restarting the server reconnects and restores.

Design spec: `docs/superpowers/specs/2026-06-08-p6.4-ws-client-store-design.md` · plan: `docs/superpowers/plans/2026-06-08-p6.4-ws-client-store.md`.

## Linked issues

Closes #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)