### PR TITLE
infra: restore trunk hot-reload dev loop via dedicated /ws route (P6.4a)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,15 +34,16 @@ cargo test -p cards --test play_card <test_fn_name>     # integration tests in c
 # Regenerate the card corpus (only after bumping data/arkhamdb-snapshot)
 cargo run -p card-data-pipeline
 
-# Dev loop — single port (serves the WASM bundle + API + WS together)
-cd crates/web && trunk build      # rebuild after client changes (no hot-reload)
-cargo run -p server               # serves crates/web/dist + API/WS on :8000
-# then open http://localhost:8000
+# Dev loop (two terminals) — hot-reload on :3000, proxying to the server
+cargo run -p server                                  # API + WS on :8000
+cd crates/web && trunk serve                         # WASM + hot-reload on :3000
+# then open http://localhost:3000
+#   Proxy config lives in crates/web/Trunk.toml (REST /games + WS /ws, the
+#   latter needing a ws:// backend); a root proxy panics on trunk 0.21.x.
 #
-# `trunk serve --proxy-backend=…` (hot-reload on :3000) does NOT work with
-# trunk 0.21.x: its proxy mounts as an axum `.nest()`, which panics at the
-# root `/`, and our REST (`POST /games`) + WS (`/games/{id}/ws`) share the
-# `/games` prefix so no two-entry proxy config works either. Use single-port.
+# Single-port alternative (no hot-reload; what production serves): build the
+# bundle and let the server serve it on one origin —
+#   cd crates/web && trunk build  &&  cargo run -p server   # open :8000
 ```
 
 ## Architecture

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -62,7 +62,7 @@ pub enum ServerMessage {
 
 /// Stable identifier for a persisted game. Part of the client/server
 /// contract: returned by `POST /games` and used in the WebSocket path
-/// `/games/{game_id}/ws`. Lives here (not in `game-core`) because it is a
+/// `/ws/{game_id}`. Lives here (not in `game-core`) because it is a
 /// host/transport concept, not a kernel domain id like `ScenarioId`.
 /// Transparent over `String` — serializes as a bare JSON string, binds to
 /// a `SQLite` TEXT column, and extracts from a URL path segment. Id

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -85,7 +85,7 @@ pub fn app(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health))
         .route("/games", post(lifecycle::create_game))
-        .route("/games/{game_id}/ws", get(ws::game_ws))
+        .route("/ws/{game_id}", get(ws::game_ws))
         .fallback_service(static_files)
         .with_state(state)
 }

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -58,7 +58,7 @@ async fn get_or_load_room(state: &AppState, game_id: &GameId) -> Option<Arc<Game
     Some(room)
 }
 
-/// Axum handler: upgrade a `GET /games/{game_id}/ws` request to a
+/// Axum handler: upgrade a `GET /ws/{game_id}` request to a
 /// websocket attached to that game's broadcast group.
 pub(crate) async fn game_ws(
     State(state): State<AppState>,

--- a/crates/server/tests/common/mod.rs
+++ b/crates/server/tests/common/mod.rs
@@ -77,7 +77,7 @@ pub type Client = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
 
 /// Open a websocket to a game.
 pub async fn connect(addr: SocketAddr, game_id: &str) -> Client {
-    let url = format!("ws://{addr}/games/{game_id}/ws");
+    let url = format!("ws://{addr}/ws/{game_id}");
     let (ws, _response) = connect_async(url).await.expect("ws connect");
     ws
 }

--- a/crates/web/Trunk.toml
+++ b/crates/web/Trunk.toml
@@ -5,10 +5,17 @@ target = "index.html"
 port = 3000
 addresses = ["127.0.0.1"]
 
-# NOTE: no `[[proxy]]` here. trunk 0.21's proxy mounts each entry as an
-# axum `.nest()`, which (a) panics at the root `/`, and (b) can't serve
-# our REST (`POST /games`) and WebSocket (`/games/{id}/ws`) — they share
-# the `/games` prefix, so two entries collide on one wildcard route while
-# a single entry serves only one of HTTP/WS. For local dev, use the
-# single-port path instead (it's what production runs): `trunk build`,
-# then `cargo run -p server`, and open http://localhost:8000.
+# Proxy the API + WebSocket to the server during dev. Two entries at
+# DISTINCT prefixes so trunk's per-entry axum `.nest()` doesn't collide:
+# `/games` carries the REST (`POST /games`), `/ws` carries the WebSocket
+# upgrade (`/ws/{game_id}` — the reason the WS lives at its own top-level
+# route, not under `/games`). Neither is at the root `/`, which trunk 0.21
+# panics on. The WS backend MUST use the `ws://` scheme: with `http://`,
+# trunk completes the client handshake but fails to open the upstream
+# socket (`Url(UnsupportedUrlScheme)`) and the connection dies (close 1006).
+[[proxy]]
+backend = "http://localhost:8000/games"
+
+[[proxy]]
+backend = "ws://localhost:8000/ws"
+ws = true

--- a/crates/web/src/url.rs
+++ b/crates/web/src/url.rs
@@ -9,7 +9,7 @@ pub fn ws_url(location_protocol: &str, host: &str, game_id: &str) -> String {
     } else {
         "ws"
     };
-    format!("{scheme}://{host}/games/{game_id}/ws")
+    format!("{scheme}://{host}/ws/{game_id}")
 }
 
 /// Read `window.location` and build this game's WebSocket URL.
@@ -29,7 +29,7 @@ mod tests {
     fn plain_http_uses_ws_and_keeps_port() {
         assert_eq!(
             ws_url("http:", "localhost:3000", "abc"),
-            "ws://localhost:3000/games/abc/ws"
+            "ws://localhost:3000/ws/abc"
         );
     }
 
@@ -37,7 +37,7 @@ mod tests {
     fn https_upgrades_to_wss() {
         assert_eq!(
             ws_url("https:", "play.example.com", "g1"),
-            "wss://play.example.com/games/g1/ws"
+            "wss://play.example.com/ws/g1"
         );
     }
 }

--- a/docs/phases/phase-6-web-client-v0.md
+++ b/docs/phases/phase-6-web-client-v0.md
@@ -21,7 +21,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | P6.2 | [#183](https://github.com/talelburg/eldritch/issues/183) — server production-playable: synthetic registries + static WASM serving | ✅ PR #194 |
 | P6.3 | [#184](https://github.com/talelburg/eldritch/issues/184) — headless browser test harness + 6th CI job | ✅ PR #195 |
 | P6.4 | [#185](https://github.com/talelburg/eldritch/issues/185) — WS client + reactive state store | ✅ PR #197 |
-| P6.4a | [#199](https://github.com/talelburg/eldritch/issues/199) — restore trunk hot-reload dev loop | ⏳ open |
+| P6.4a | [#199](https://github.com/talelburg/eldritch/issues/199) — restore trunk hot-reload dev loop | ✅ PR #200 |
 | P6.4b | [#198](https://github.com/talelburg/eldritch/issues/198) — WebSocket liveness (heartbeat + graceful shutdown) | ⏳ open |
 | P6.5 | [#186](https://github.com/talelburg/eldritch/issues/186) — board rendering (read-only) | ⏳ open |
 | P6.6 | [#187](https://github.com/talelburg/eldritch/issues/187) — AwaitingInput resolution UI + legality gating | ⏳ open |
@@ -37,7 +37,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | P6.2 | #183 server registries + static WASM ✅ PR #194 | The thing the client connects to | — (parallel w/ P6.1) |
 | P6.3 | #184 headless harness + 6th CI job ✅ PR #195 | Testing foundation before TDD-ing components; de-risks browser-in-CI early | — |
 | P6.4 | #185 WS client + reactive store ✅ PR #197 | The client's engine room; debug-dump render proves the round-trip | P6.1, P6.3 |
-| P6.4a | #199 hot-reload dev loop | Restore hot-reload **before** the content-UI slots so P6.5+ iterate fast; likely moves the WS to a distinct `/ws/{id}` path | P6.4 |
+| P6.4a | #199 hot-reload dev loop ✅ PR #200 | Restore hot-reload **before** the content-UI slots so P6.5+ iterate fast; moved the WS to a distinct `/ws/{id}` route so trunk can proxy REST + WS without colliding | P6.4 |
 | P6.4b | #198 WS liveness | Heartbeat + graceful shutdown so the client detects silently-dropped connections — finishes the transport before content builds on it; revisit `leptos-use` here (P6.4 deferral trigger) | P6.4a |
 | P6.5 | #186 board rendering | See the state | P6.4 |
 | P6.6 | #187 AwaitingInput UI + legality | Core-loop: `Investigate` opens a skill-test commit window (`AwaitingInput`), so this precedes the action controls | P6.5 |


### PR DESCRIPTION
## Summary

Phase-6 **P6.4a**: restore the `trunk serve` hot-reload dev loop, which was unusable on trunk 0.21.x. The fix moves the WebSocket to its own top-level route so trunk's proxy can serve REST and WS without colliding.

## What changed

- **Server route:** `GET /games/{game_id}/ws` → **`GET /ws/{game_id}`** (`crates/server/src/lib.rs`). The handler is unchanged; only the path moves.
- **Client:** `ws_url` builds `/ws/{game_id}` (`crates/web/src/url.rs` + its unit tests).
- **Test helper + doc comments:** `crates/server/tests/common/mod.rs`, `ws.rs`, `protocol`'s `GameId` doc.
- **`crates/web/Trunk.toml`:** two `[[proxy]]` entries at distinct prefixes — `/games` (REST, `http://` backend) and `/ws` (`ws = true`, **`ws://`** backend).
- **`CLAUDE.md`:** dev loop restored to two-terminal `trunk serve` (hot-reload on :3000), with single-port kept as the no-hot-reload alternative.

## Why the route had to move

trunk 0.21.x mounts each `[[proxy]]`/`--proxy-backend` as an axum `.nest()`. That (a) panics at the root `/`, and (b) couldn't serve our REST (`POST /games`) and WS (`/games/{id}/ws`) together — sharing the `/games` prefix made two entries collide on one wildcard route, while a single entry serves only HTTP *or* WS. Giving the WS its own `/ws` prefix removes the collision.

## The `ws://` detail (found by a live spike)

A live spike before building this out caught a detail the issue's design missed: the WS proxy backend **must** use the `ws://` scheme. With `http://`, trunk completes the *client* handshake (`WS OPEN`) but fails to open the *upstream* socket — `error establishing WebSocket connection ... Url(UnsupportedUrlScheme)` — and the connection dies (close `1006`) with no frame relayed. With `ws://`, the full round-trip works.

## Test notes

- **Existing suites green on the new route:** `server` `ws`/`lifecycle`/`resume` integration tests (real `connect_async` to `/ws/{id}` → `Hello`), `web` `ws_url` unit tests, headless `wasm-bindgen-test`.
- **Live spike verified end-to-end through `trunk serve` on :3000:** `POST /games` → `201`; a real WebSocket (Node global `WebSocket`) → `OPEN` + `{"hello":{"state":…}}`.
- Full local gauntlet (test/clippy/fmt/doc/wasm-build/wasm-test) green.

## Linked issues

Closes #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)