### PR TITLE
infra: lint wasm-target code in CI (wasm-clippy job)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,18 @@ jobs:
       - uses: jetli/wasm-pack-action@v0.4.0
       - name: Headless wasm tests
         run: wasm-pack test --headless --firefox crates/web
+
+  # The `clippy` job lints the host target, so `#[cfg(target_arch =
+  # "wasm32")]` code (the whole transport, the wasm reader, the debug
+  # controls, the headless test files) is cfg'd out and never seen. Lint it
+  # on the wasm target. Scoped to `web` — `server`/`card-data-pipeline`
+  # aren't wasm-safe. The toolchain already has the target + clippy via
+  # rust-toolchain.toml.
+  wasm-clippy:
+    name: wasm-clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Likewise, **invoke** the `karpathy-guidelines` skill (don't just recall it) when
 
 ## Commands
 
-CI runs six jobs (`fmt`, `clippy`, `test`, `doc`, `wasm-build`, `wasm-test`), all warnings-as-errors. Match the strict flags locally before pushing — `cargo test` alone misses broken intra-doc links and clippy lints CI fails on.
+CI runs seven jobs (`fmt`, `clippy`, `test`, `doc`, `wasm-build`, `wasm-test`, `wasm-clippy`), all warnings-as-errors. Match the strict flags locally before pushing — `cargo test` alone misses broken intra-doc links and clippy lints CI fails on, and the host `clippy` job never sees `#[cfg(target_arch = "wasm32")]` code (only `wasm-clippy` does).
 
 ```sh
 # Match CI's strict flags
@@ -26,6 +26,7 @@ RUSTFLAGS="-D warnings"     cargo test --all --all-features
 RUSTDOCFLAGS="-D warnings"  cargo doc --workspace --no-deps --all-features
                             cargo build -p web --target wasm32-unknown-unknown
                             wasm-pack test --headless --firefox crates/web   # headless browser tests (6th CI job)
+                            cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings   # lints wasm-only code (7th CI job)
 
 # Single test (binary name from `cargo test` output)
 cargo test -p game-core <test_fn_name>

--- a/crates/web/tests/smoke.rs
+++ b/crates/web/tests/smoke.rs
@@ -10,9 +10,9 @@ wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn app_renders_greeting() {
-    // mount_to_body returns an unmount handle; bind it (not `_`) so the view
-    // stays mounted through the assertion.
-    let _handle = leptos::mount::mount_to_body(web::app::App);
+    // Mount the app into the document body; it stays mounted (attached to
+    // the DOM) for the assertion.
+    leptos::mount::mount_to_body(web::app::App);
 
     let body = leptos::prelude::document()
         .body()

--- a/crates/web/tests/store.rs
+++ b/crates/web/tests/store.rs
@@ -23,10 +23,9 @@ fn body_html() -> String {
 #[wasm_bindgen_test]
 async fn hello_renders_state_present() {
     let store = leptos::prelude::RwSignal::new(ClientState::default());
-    // Provide the same signal the component reads, then mount the dump.
-    // Bind the unmount handle (not `_`) so the view stays mounted through
-    // the assertions.
-    let _handle = leptos::mount::mount_to_body(move || {
+    // Provide the same signal the component reads, then mount the dump;
+    // it stays mounted (attached to the DOM) for the assertions.
+    leptos::mount::mount_to_body(move || {
         leptos::prelude::provide_context(store);
         leptos::view! { <DebugDump/> }
     });


### PR DESCRIPTION
## Summary

Close the CI gap where `#[cfg(target_arch = "wasm32")]` code is never clippy-linted. Adds a `wasm-clippy` job and fixes the two lints it immediately flagged.

## The gap

The `clippy` job runs on the **host** target (`cargo clippy --all-targets` with no `--target`), so all wasm-gated code in `crates/web` — the whole `transport.rs`, `current_ws_url`, the `DebugSubmit` control + the wasm block in `app.rs`, and the headless test files — is cfg'd out and never linted. rustc warnings *are* enforced there (global `RUSTFLAGS: -D warnings` covers `wasm-build`/`wasm-test`), but clippy-only lints weren't.

Proof: `main` was **red** under `cargo clippy -p web --target wasm32-unknown-unknown -- -D warnings` — two `let_unit_value` lints that no CI job caught.

## What changed

- **New `wasm-clippy` CI job:** `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`. Scoped to `web` (`server`/`card-data-pipeline` aren't wasm-safe). `rust-toolchain.toml` already provides the target + clippy component, so no extra install.
- **Fixed the flagged lints:** dropped the `let _handle = mount_to_body(...)` bindings in `tests/smoke.rs` and `tests/store.rs`. `mount_to_body` returns `()` here, so the bindings did nothing — the view stays mounted because it's attached to the DOM (the "keeps it mounted" comments were incorrect; updated).
- **CLAUDE.md:** six → seven jobs, and the wasm-clippy command added to the local strict-flags gauntlet.

## Test notes

- New job green locally: `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`.
- Headless tests still pass after the binding removal (behavior-neutral): `wasm-pack test --headless --firefox crates/web` → smoke + store green.

## Linked issues

Closes #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)