### PR TITLE
ui: read-only board rendering (P6.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3289,6 +3289,7 @@ dependencies = [
  "leptos",
  "protocol",
  "serde_json",
+ "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -26,3 +26,5 @@ web-sys = { version = "0.3", features = ["Storage", "Location", "Window"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = ["Element", "NodeList"] }

--- a/crates/web/index.html
+++ b/crates/web/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Eldritch</title>
+    <link data-trunk rel="css" href="style.css" />
     <link data-trunk rel="rust" data-bin="web" />
   </head>
   <body></body>

--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -2,7 +2,8 @@
 
 use leptos::prelude::*;
 
-use crate::store::{provide_store, use_store, ConnStatus};
+use crate::board::BoardView;
+use crate::store::provide_store;
 
 #[component]
 pub fn App() -> impl IntoView {
@@ -12,14 +13,14 @@ pub fn App() -> impl IntoView {
     // builds render from a signal that tests drive directly.
     #[cfg(target_arch = "wasm32")]
     {
-        let store = use_store();
+        let store = crate::store::use_store();
         crate::transport::start(store);
     }
 
     view! {
         <main>
             <h1>"Eldritch"</h1>
-            <DebugDump/>
+            <BoardView/>
             {
                 #[cfg(target_arch = "wasm32")]
                 { view! { <DebugSubmit/> }.into_any() }
@@ -44,42 +45,4 @@ fn DebugSubmit() -> impl IntoView {
         });
     };
     view! { <button on:click=on_click>"Submit EndTurn (debug)"</button> }
-}
-
-/// Read-only dump of the client store — proves the round-trip before
-/// P6.5's real board. Renders a stable presence label (for the headless
-/// test) plus a human-facing pretty-print of the state.
-#[component]
-pub fn DebugDump() -> impl IntoView {
-    let store = use_store();
-
-    let status = move || match store.get().status {
-        ConnStatus::Connecting => "connecting",
-        ConnStatus::Connected => "connected",
-        ConnStatus::Reconnecting => "reconnecting",
-        ConnStatus::Failed => "failed",
-    };
-    let presence = move || {
-        if store.get().game.is_some() {
-            "present"
-        } else {
-            "none"
-        }
-    };
-    let rejection = move || store.get().last_rejection.unwrap_or_default();
-    let dump = move || {
-        store
-            .get()
-            .game
-            .map_or_else(|| "<no state yet>".to_string(), |g| format!("{g:#?}"))
-    };
-
-    view! {
-        <section>
-            <p>"status: " {status}</p>
-            <p>"state: " {presence}</p>
-            <p>"rejection: " {rejection}</p>
-            <pre>{dump}</pre>
-        </section>
-    }
 }

--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -1,0 +1,36 @@
+//! Read-only render of `GameState` into the DOM (P6.5). Panels are plain
+//! helper fns; `BoardView` is the only component. Cards render as their
+//! `CardCode` strings — the client has no card-name source.
+
+use leptos::prelude::*;
+
+use crate::store::{use_store, ConnStatus};
+
+/// Read-only board. Always renders a status line (connection status +
+/// last rejection); renders the panels when a game is present, else a
+/// placeholder.
+#[component]
+pub fn BoardView() -> impl IntoView {
+    let store = use_store();
+
+    let status = move || match store.get().status {
+        ConnStatus::Connecting => "connecting",
+        ConnStatus::Connected => "connected",
+        ConnStatus::Reconnecting => "reconnecting",
+        ConnStatus::Failed => "failed",
+    };
+    let rejection = move || store.get().last_rejection.unwrap_or_default();
+
+    let board = move || match store.get().game {
+        None => view! { <p class="no-game">"<no game>"</p> }.into_any(),
+        Some(_game) => view! { <p class="has-game">"game present"</p> }.into_any(),
+    };
+
+    view! {
+        <section class="board">
+            <p class="status">"status: " {status}</p>
+            <p class="rejection">"rejection: " {rejection}</p>
+            {board}
+        </section>
+    }
+}

--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -2,6 +2,7 @@
 //! helper fns; `BoardView` is the only component. Cards render as their
 //! `CardCode` strings — the client has no card-name source.
 
+use game_core::state::GameState;
 use leptos::prelude::*;
 
 use crate::store::{use_store, ConnStatus};
@@ -23,7 +24,12 @@ pub fn BoardView() -> impl IntoView {
 
     let board = move || match store.get().game {
         None => view! { <p class="no-game">"<no game>"</p> }.into_any(),
-        Some(_game) => view! { <p class="has-game">"game present"</p> }.into_any(),
+        Some(game) => view! {
+            <div class="game">
+                {phase_bar(&game)}
+            </div>
+        }
+        .into_any(),
     };
 
     view! {
@@ -32,5 +38,29 @@ pub fn BoardView() -> impl IntoView {
             <p class="rejection">"rejection: " {rejection}</p>
             {board}
         </section>
+    }
+}
+
+/// Phase + round, plus the current act's clue threshold and the current
+/// agenda's doom (`doom/threshold`). Act/agenda lines are omitted when
+/// their decks are empty (fixtures may omit them).
+fn phase_bar(game: &GameState) -> impl IntoView {
+    let phase = format!("{:?}", game.phase);
+    let round = game.round;
+    let act = game
+        .act_deck
+        .get(game.act_index)
+        .map(|a| format!("clues 0/{}", a.clue_threshold));
+    let agenda = game
+        .agenda_deck
+        .get(game.agenda_index)
+        .map(|a| format!("doom {}/{}", game.agenda_doom, a.doom_threshold));
+    view! {
+        <header class="phase-bar">
+            <span class="phase">{phase}</span>
+            <span class="round">"round " {round}</span>
+            {agenda.map(|t| view! { <span class="agenda">{t}</span> })}
+            {act.map(|t| view! { <span class="act">{t}</span> })}
+        </header>
     }
 }

--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -2,7 +2,7 @@
 //! helper fns; `BoardView` is the only component. Cards render as their
 //! `CardCode` strings — the client has no card-name source.
 
-use game_core::state::GameState;
+use game_core::state::{GameState, LocationId};
 use leptos::prelude::*;
 
 use crate::store::{use_store, ConnStatus};
@@ -28,6 +28,7 @@ pub fn BoardView() -> impl IntoView {
             <div class="game">
                 {phase_bar(&game)}
                 {locations_panel(&game)}
+                {investigators_panel(&game)}
             </div>
         }
         .into_any(),
@@ -68,6 +69,51 @@ fn locations_panel(game: &GameState) -> impl IntoView {
         <section class="locations">
             <h2>"Locations"</h2>
             <ul>{rows}</ul>
+        </section>
+    }
+}
+
+/// One panel per investigator: name, location, actions, resources,
+/// health (`damage/max_health`), sanity (`horror/max_sanity`), clues,
+/// status; hand and cards-in-play as text lists of card codes.
+fn investigators_panel(game: &GameState) -> impl IntoView {
+    let panels: Vec<_> = game
+        .investigators
+        .values()
+        .map(|inv| {
+            let location = inv
+                .current_location
+                .map_or_else(|| "—".to_string(), |LocationId(id)| format!("loc {id}"));
+            let hand: Vec<_> = inv
+                .hand
+                .iter()
+                .map(|code| view! { <li class="card">{code.to_string()}</li> })
+                .collect();
+            let in_play: Vec<_> = inv
+                .cards_in_play
+                .iter()
+                .map(|c| view! { <li class="card">{c.code.to_string()}</li> })
+                .collect();
+            view! {
+                <article class="investigator">
+                    <h3 class="inv-name">{inv.name.clone()}</h3>
+                    <span class="inv-location">{location}</span>
+                    <span class="inv-actions">"actions " {inv.actions_remaining}</span>
+                    <span class="inv-resources">"resources " {inv.resources}</span>
+                    <span class="inv-health">"health " {inv.damage} "/" {inv.max_health}</span>
+                    <span class="inv-sanity">"sanity " {inv.horror} "/" {inv.max_sanity}</span>
+                    <span class="inv-clues">"clues " {inv.clues}</span>
+                    <span class="inv-status">{format!("{:?}", inv.status)}</span>
+                    <div class="hand"><h4>"Hand"</h4><ul>{hand}</ul></div>
+                    <div class="in-play"><h4>"In play"</h4><ul>{in_play}</ul></div>
+                </article>
+            }
+        })
+        .collect();
+    view! {
+        <section class="investigators">
+            <h2>"Investigators"</h2>
+            {panels}
         </section>
     }
 }

--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -27,6 +27,7 @@ pub fn BoardView() -> impl IntoView {
         Some(game) => view! {
             <div class="game">
                 {phase_bar(&game)}
+                {locations_panel(&game)}
             </div>
         }
         .into_any(),
@@ -37,6 +38,36 @@ pub fn BoardView() -> impl IntoView {
             <p class="status">"status: " {status}</p>
             <p class="rejection">"rejection: " {rejection}</p>
             {board}
+        </section>
+    }
+}
+
+/// One row per location: name, shroud, clues, and a revealed flag.
+/// Iterates the `BTreeMap` in `LocationId` order (deterministic).
+fn locations_panel(game: &GameState) -> impl IntoView {
+    let rows: Vec<_> = game
+        .locations
+        .values()
+        .map(|loc| {
+            let revealed = if loc.revealed {
+                "revealed"
+            } else {
+                "unrevealed"
+            };
+            view! {
+                <li class="location">
+                    <span class="loc-name">{loc.name.clone()}</span>
+                    <span class="loc-shroud">"shroud " {loc.shroud}</span>
+                    <span class="loc-clues">"clues " {loc.clues}</span>
+                    <span class="loc-revealed">{revealed}</span>
+                </li>
+            }
+        })
+        .collect();
+    view! {
+        <section class="locations">
+            <h2>"Locations"</h2>
+            <ul>{rows}</ul>
         </section>
     }
 }

--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -2,7 +2,7 @@
 //! helper fns; `BoardView` is the only component. Cards render as their
 //! `CardCode` strings — the client has no card-name source.
 
-use game_core::state::{GameState, LocationId};
+use game_core::state::{GameState, InvestigatorId, LocationId};
 use leptos::prelude::*;
 
 use crate::store::{use_store, ConnStatus};
@@ -29,6 +29,7 @@ pub fn BoardView() -> impl IntoView {
                 {phase_bar(&game)}
                 {locations_panel(&game)}
                 {investigators_panel(&game)}
+                {enemies_panel(&game)}
             </div>
         }
         .into_any(),
@@ -114,6 +115,40 @@ fn investigators_panel(game: &GameState) -> impl IntoView {
         <section class="investigators">
             <h2>"Investigators"</h2>
             {panels}
+        </section>
+    }
+}
+
+/// One row per enemy: name, fight/evade, health (`damage/max_health`),
+/// location, and engagement.
+fn enemies_panel(game: &GameState) -> impl IntoView {
+    let rows: Vec<_> = game
+        .enemies
+        .values()
+        .map(|e| {
+            let engaged = match e.engaged_with {
+                Some(InvestigatorId(id)) => format!("engaged with {id}"),
+                None => "unengaged".to_string(),
+            };
+            let location = e
+                .current_location
+                .map_or_else(|| "—".to_string(), |LocationId(id)| format!("loc {id}"));
+            view! {
+                <li class="enemy">
+                    <span class="enemy-name">{e.name.clone()}</span>
+                    <span class="enemy-fight">"fight " {e.fight}</span>
+                    <span class="enemy-evade">"evade " {e.evade}</span>
+                    <span class="enemy-health">"health " {e.damage} "/" {e.max_health}</span>
+                    <span class="enemy-location">{location}</span>
+                    <span class="enemy-engaged">{engaged}</span>
+                </li>
+            }
+        })
+        .collect();
+    view! {
+        <section class="enemies">
+            <h2>"Enemies"</h2>
+            <ul>{rows}</ul>
         </section>
     }
 }

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -5,6 +5,7 @@
 //! components — can import them.
 
 pub mod app;
+pub mod board;
 pub mod store;
 pub mod url;
 

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -1,0 +1,11 @@
+/* P6.5 board — minimal functional layout. */
+.board { font-family: system-ui, sans-serif; margin: 1rem; }
+.status, .rejection { font-size: 0.85rem; color: #555; }
+.phase-bar { display: flex; gap: 1rem; font-weight: 600; padding: 0.5rem 0; border-bottom: 1px solid #ccc; }
+.game { display: flex; flex-direction: column; gap: 1rem; }
+.locations ul, .enemies ul, .hand ul, .in-play ul { list-style: none; padding-left: 0; margin: 0; }
+.location, .enemy { display: flex; gap: 0.75rem; padding: 0.25rem 0; }
+.investigators { display: flex; flex-wrap: wrap; gap: 1rem; }
+.investigator { border: 1px solid #ccc; border-radius: 4px; padding: 0.5rem; display: flex; flex-direction: column; gap: 0.25rem; min-width: 16rem; }
+.investigator span { font-size: 0.9rem; }
+.card { font-family: ui-monospace, monospace; font-size: 0.85rem; }

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -5,7 +5,7 @@
 
 use game_core::state::{Act, Agenda, Phase};
 use game_core::test_support::builder::TestGame;
-use game_core::test_support::fixtures::{test_investigator, test_location};
+use game_core::test_support::fixtures::{test_enemy, test_investigator, test_location};
 use game_core::EngineOutcome;
 use leptos::prelude::{provide_context, RwSignal, Update};
 use protocol::ServerMessage;
@@ -129,4 +129,25 @@ async fn investigators_panel_renders_stats_and_hand() {
         html.contains("_synth_treachery"),
         "hand card missing: {html}"
     );
+}
+
+#[wasm_bindgen_test]
+async fn enemies_panel_renders_name_stats_engagement() {
+    use game_core::state::InvestigatorId;
+
+    let mut enemy = test_enemy(4, "Swarm of Rats");
+    enemy.damage = 1; // 1/2
+    enemy.engaged_with = Some(InvestigatorId(1));
+    let state = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_enemy(enemy)
+        .build();
+
+    let html = render_state(state).await;
+
+    assert!(html.contains("Swarm of Rats"), "enemy name missing: {html}");
+    assert!(html.contains("fight 2"), "fight missing: {html}");
+    assert!(html.contains("evade 2"), "evade missing: {html}");
+    assert!(html.contains("1/2"), "enemy health missing: {html}");
+    assert!(html.contains("engaged"), "engagement missing: {html}");
 }

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -95,3 +95,38 @@ async fn locations_panel_renders_name_shroud_clues_revealed() {
     assert!(html.contains("clues 2"), "location clues missing: {html}");
     assert!(html.contains("revealed"), "revealed flag missing: {html}");
 }
+
+#[wasm_bindgen_test]
+async fn investigators_panel_renders_stats_and_hand() {
+    use game_core::state::CardCode;
+
+    let mut inv = test_investigator(1);
+    inv.name = "Roland Banks".to_string();
+    inv.damage = 2; // 2/8
+    inv.horror = 1; // 1/8
+    inv.clues = 3;
+    inv.resources = 4;
+    inv.actions_remaining = 2;
+    inv.hand = vec![
+        CardCode::new("_synth_fast_event"),
+        CardCode::new("_synth_treachery"),
+    ];
+    let state = TestGame::new().with_investigator(inv).build();
+
+    let html = render_state(state).await;
+
+    assert!(html.contains("Roland Banks"), "name missing: {html}");
+    assert!(html.contains("2/8"), "health damage missing: {html}");
+    assert!(html.contains("1/8"), "horror missing: {html}");
+    assert!(html.contains("actions 2"), "actions missing: {html}");
+    assert!(html.contains("resources 4"), "resources missing: {html}");
+    assert!(html.contains("clues 3"), "clues missing: {html}");
+    assert!(
+        html.contains("_synth_fast_event"),
+        "hand card missing: {html}"
+    );
+    assert!(
+        html.contains("_synth_treachery"),
+        "hand card missing: {html}"
+    );
+}

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -99,7 +99,7 @@ async fn locations_panel_renders_name_shroud_clues_revealed() {
 
 #[wasm_bindgen_test]
 async fn investigators_panel_renders_stats_and_hand() {
-    use game_core::state::CardCode;
+    use game_core::state::{CardCode, CardInPlay, CardInstanceId};
 
     let mut inv = test_investigator(1);
     inv.name = "Roland Banks".to_string();
@@ -112,6 +112,10 @@ async fn investigators_panel_renders_stats_and_hand() {
         CardCode::new("_synth_fast_event"),
         CardCode::new("_synth_treachery"),
     ];
+    inv.cards_in_play = vec![CardInPlay::enter_play(
+        CardCode::new("_synth_asset"),
+        CardInstanceId(0),
+    )];
     let state = TestGame::new().with_investigator(inv).build();
 
     let html = render_state(state).await;
@@ -129,6 +133,11 @@ async fn investigators_panel_renders_stats_and_hand() {
     assert!(
         html.contains("_synth_treachery"),
         "hand card missing: {html}"
+    );
+    assert!(html.contains("In play"), "in-play heading missing: {html}");
+    assert!(
+        html.contains("_synth_asset"),
+        "in-play card missing: {html}"
     );
 }
 
@@ -150,7 +159,10 @@ async fn enemies_panel_renders_name_stats_engagement() {
     assert!(html.contains("fight 2"), "fight missing: {html}");
     assert!(html.contains("evade 2"), "evade missing: {html}");
     assert!(html.contains("1/2"), "enemy health missing: {html}");
-    assert!(html.contains("engaged"), "engagement missing: {html}");
+    assert!(
+        html.contains("engaged with 1"),
+        "engagement missing: {html}"
+    );
 }
 
 #[wasm_bindgen_test]

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -1,0 +1,79 @@
+//! Headless render tests for `BoardView` (P6.5). Feed a constructed
+//! `GameState` through the store and assert on the rendered DOM.
+//! wasm32-only (browser DOM); native jobs skip this file.
+#![cfg(target_arch = "wasm32")]
+
+use game_core::state::{Act, Agenda, Phase};
+use game_core::test_support::builder::TestGame;
+use game_core::test_support::fixtures::test_investigator;
+use game_core::EngineOutcome;
+use leptos::prelude::{provide_context, RwSignal, Update};
+use protocol::ServerMessage;
+use wasm_bindgen_test::*;
+use web::board::BoardView;
+use web::store::{reduce, ClientState};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn body_html() -> String {
+    leptos::prelude::document()
+        .body()
+        .expect("body")
+        .inner_html()
+}
+
+/// Mount `BoardView` against a fresh store and feed it one `Hello`
+/// carrying `state`. Ticks once so CSR effects flush, then returns the
+/// rendered body HTML.
+async fn render_state(state: game_core::state::GameState) -> String {
+    let store = RwSignal::new(ClientState::default());
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        leptos::view! { <BoardView/> }
+    });
+    store.update(|s| {
+        reduce(
+            s,
+            ServerMessage::Hello {
+                state: Box::new(state),
+                outcome: EngineOutcome::Done,
+            },
+        );
+    });
+    leptos::task::tick().await;
+    body_html()
+}
+
+#[wasm_bindgen_test]
+async fn phase_bar_renders_phase_round_act_agenda() {
+    let mut state = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_phase(Phase::Investigation)
+        .with_round(3)
+        .build();
+    state.act_deck = vec![Act {
+        clue_threshold: 2,
+        resolution: None,
+    }];
+    state.agenda_deck = vec![Agenda {
+        doom_threshold: 5,
+        resolution: None,
+    }];
+    state.agenda_doom = 1;
+
+    let html = render_state(state).await;
+
+    assert!(html.contains("Investigation"), "phase missing: {html}");
+    assert!(
+        html.contains("round 3") || html.contains("Round 3"),
+        "round missing: {html}"
+    );
+    assert!(
+        html.contains("doom 1/5") || html.contains("1/5"),
+        "agenda doom missing: {html}"
+    );
+    assert!(
+        html.contains("clues 0/2") || html.contains("0/2"),
+        "act threshold missing: {html}"
+    );
+}

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -5,7 +5,7 @@
 
 use game_core::state::{Act, Agenda, Phase};
 use game_core::test_support::builder::TestGame;
-use game_core::test_support::fixtures::test_investigator;
+use game_core::test_support::fixtures::{test_investigator, test_location};
 use game_core::EngineOutcome;
 use leptos::prelude::{provide_context, RwSignal, Update};
 use protocol::ServerMessage;
@@ -76,4 +76,22 @@ async fn phase_bar_renders_phase_round_act_agenda() {
         html.contains("clues 0/2") || html.contains("0/2"),
         "act threshold missing: {html}"
     );
+}
+
+#[wasm_bindgen_test]
+async fn locations_panel_renders_name_shroud_clues_revealed() {
+    let mut loc = test_location(7, "Rivertown");
+    loc.shroud = 3;
+    loc.clues = 2;
+    let state = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_location(loc)
+        .build();
+
+    let html = render_state(state).await;
+
+    assert!(html.contains("Rivertown"), "location name missing: {html}");
+    assert!(html.contains("shroud 3"), "shroud missing: {html}");
+    assert!(html.contains("clues 2"), "location clues missing: {html}");
+    assert!(html.contains("revealed"), "revealed flag missing: {html}");
 }

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -9,6 +9,7 @@ use game_core::test_support::fixtures::{test_enemy, test_investigator, test_loca
 use game_core::EngineOutcome;
 use leptos::prelude::{provide_context, RwSignal, Update};
 use protocol::ServerMessage;
+use wasm_bindgen::JsCast as _;
 use wasm_bindgen_test::*;
 use web::board::BoardView;
 use web::store::{reduce, ClientState};
@@ -150,4 +151,41 @@ async fn enemies_panel_renders_name_stats_engagement() {
     assert!(html.contains("evade 2"), "evade missing: {html}");
     assert!(html.contains("1/2"), "enemy health missing: {html}");
     assert!(html.contains("engaged"), "engagement missing: {html}");
+}
+
+#[wasm_bindgen_test]
+async fn empty_board_renders_placeholder_without_panels() {
+    let store = RwSignal::new(ClientState::default());
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        leptos::view! { <BoardView/> }
+    });
+    leptos::task::tick().await;
+
+    // Scope to only the last mounted <section class="board"> so that
+    // accumulated DOM from earlier tests does not pollute this assertion.
+    let document = leptos::prelude::document();
+    let boards = document
+        .query_selector_all(".board")
+        .expect("query_selector_all");
+    let last = boards
+        .item(boards.length() - 1)
+        .expect("at least one .board section");
+    let html = last
+        .dyn_ref::<web_sys::Element>()
+        .expect("Element")
+        .inner_html();
+
+    assert!(
+        html.contains("&lt;no game&gt;"),
+        "placeholder missing: {html}"
+    );
+    assert!(
+        !html.contains("Investigators"),
+        "panels should be absent: {html}"
+    );
+    assert!(
+        !html.contains("Locations"),
+        "panels should be absent: {html}"
+    );
 }

--- a/crates/web/tests/store.rs
+++ b/crates/web/tests/store.rs
@@ -8,7 +8,7 @@ use game_core::EngineOutcome;
 use leptos::prelude::Update;
 use protocol::ServerMessage;
 use wasm_bindgen_test::*;
-use web::app::DebugDump;
+use web::board::BoardView;
 use web::store::{reduce, ClientState};
 
 wasm_bindgen_test_configure!(run_in_browser);
@@ -23,15 +23,15 @@ fn body_html() -> String {
 #[wasm_bindgen_test]
 async fn hello_renders_state_present() {
     let store = leptos::prelude::RwSignal::new(ClientState::default());
-    // Provide the same signal the component reads, then mount the dump;
+    // Provide the same signal the component reads, then mount the board;
     // it stays mounted (attached to the DOM) for the assertions.
     leptos::mount::mount_to_body(move || {
         leptos::prelude::provide_context(store);
-        leptos::view! { <DebugDump/> }
+        leptos::view! { <BoardView/> }
     });
 
     assert!(
-        body_html().contains("state: none"),
+        body_html().contains("&lt;no game&gt;"),
         "before: {}",
         body_html()
     );
@@ -54,7 +54,7 @@ async fn hello_renders_state_present() {
     leptos::task::tick().await;
 
     assert!(
-        body_html().contains("state: present"),
+        body_html().contains("game present"),
         "after: {}",
         body_html()
     );

--- a/crates/web/tests/store.rs
+++ b/crates/web/tests/store.rs
@@ -53,9 +53,5 @@ async fn hello_renders_state_present() {
     // with `update`. Yield so the DOM reflects the new signal value.
     leptos::task::tick().await;
 
-    assert!(
-        body_html().contains("game present"),
-        "after: {}",
-        body_html()
-    );
+    assert!(body_html().contains("phase-bar"), "after: {}", body_html());
 }

--- a/docs/phases/phase-6-web-client-v0.md
+++ b/docs/phases/phase-6-web-client-v0.md
@@ -23,7 +23,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | P6.4 | [#185](https://github.com/talelburg/eldritch/issues/185) — WS client + reactive state store | ✅ PR #197 |
 | P6.4a | [#199](https://github.com/talelburg/eldritch/issues/199) — restore trunk hot-reload dev loop | ✅ PR #200 |
 | P6.4b | [#198](https://github.com/talelburg/eldritch/issues/198) — WebSocket liveness (heartbeat + graceful shutdown) | ⏭️ deferred → Phase 8 (closed) |
-| P6.5 | [#186](https://github.com/talelburg/eldritch/issues/186) — board rendering (read-only) | ⏳ open |
+| P6.5 | [#186](https://github.com/talelburg/eldritch/issues/186) — board rendering (read-only) | ✅ PR #204 |
 | P6.6 | [#187](https://github.com/talelburg/eldritch/issues/187) — AwaitingInput resolution UI + legality gating | ⏳ open |
 | P6.7a | [#188](https://github.com/talelburg/eldritch/issues/188) — core-loop action controls | ⏳ open |
 | P6.7b | [#189](https://github.com/talelburg/eldritch/issues/189) — combat/edge action controls | ⏳ open |
@@ -39,7 +39,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | P6.4 | #185 WS client + reactive store ✅ PR #197 | The client's engine room; debug-dump render proves the round-trip | P6.1, P6.3 |
 | P6.4a | #199 hot-reload dev loop ✅ PR #200 | Restore hot-reload **before** the content-UI slots so P6.5+ iterate fast; moved the WS to a distinct `/ws/{id}` route so trunk can proxy REST + WS without colliding | P6.4 |
 | ~~P6.4b~~ | #198 WS liveness — **deferred to Phase 8** | Its triggering symptom is a WSL2 dev artifact, not a real-host bug; genuine liveness is Phase-8 production hardening. See *Decisions made* | — |
-| P6.5 | #186 board rendering | See the state | P6.4 |
+| P6.5 | #186 board rendering ✅ PR #204 | See the state | P6.4 |
 | P6.6 | #187 AwaitingInput UI + legality | Core-loop: `Investigate` opens a skill-test commit window (`AwaitingInput`), so this precedes the action controls | P6.5 |
 | P6.7a | #188 core-loop action controls | Toy scenario clickable to a **Won** resolution | P6.6 |
 | P6.7b | #189 combat/edge action controls | Rounds out the action surface (combat/Lost walk) | P6.7a |
@@ -50,8 +50,9 @@ independent and can land any time before P6.4. P6.4a
 ([#199](https://github.com/talelburg/eldritch/issues/199), trunk
 hot-reload) shipped before the content UI. P6.4b
 ([#198](https://github.com/talelburg/eldritch/issues/198), WS liveness)
-was **deferred to Phase 8 and closed** — see *Decisions made*. So the
-content UI (P6.5+) is next.
+was **deferred to Phase 8 and closed** — see *Decisions made*. P6.5
+(#186, board rendering ✅ PR #204) shipped the read-only board, so the
+interaction layer (P6.6, `AwaitingInput` UI + legality gating) is next.
 
 ## Decisions made
 
@@ -170,10 +171,29 @@ Settled while scoping P6.4b (#198), then **deferred to Phase 8**:
   reconnect-to-a-new-game flow. Both feed the Phase-8 adopt-vs-hand-roll
   (and `leptos-ws-pro`) decision.
 
+Settled implementing P6.5 (PR #204):
+
+- **`leptos-use` deferred again — the read-only board did not trigger
+  it.** P6.4 flagged P6.5's "responsive board layout" as a candidate
+  adopt point (`use_media_query` / `use_element_size`). It isn't one: a
+  read-only text board branches no component trees on viewport size, so
+  any responsiveness is plain CSS (flexbox/grid + media queries) with
+  zero Rust deps. Next concrete candidate stays Phase-8 auth
+  (`use_cookie`); the adopt decision rides with the Phase-8
+  `leptos-use` evaluation noted above.
+- **Headless component tests share one browser page; don't clear
+  `<body>`.** `wasm-bindgen-test` runs every `#[wasm_bindgen_test]` in a
+  single page and `mount_to_body` *appends*, so DOM accumulates across
+  tests — a test asserting an element is *absent* must scope to its own
+  mounted subtree (the empty-board test selects the last
+  `.board` section). `set_inner_html("")` on `<body>` is **not** an
+  option: it deletes the harness's own status elements and the runner
+  then reports "failed to detect test as having been run." Load-bearing
+  for every later interaction test (P6.6+).
+
 ## Open questions
 
-None blocking. Per-PR details: the precise legality-gating surface
-(P6.6); CSS/layout specifics (P6.5).
+None blocking. Per-PR detail: the precise legality-gating surface (P6.6).
 
 ## Dependencies
 

--- a/docs/superpowers/plans/2026-06-09-p6.5-board-rendering.md
+++ b/docs/superpowers/plans/2026-06-09-p6.5-board-rendering.md
@@ -1,0 +1,746 @@
+# P6.5 Board Rendering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `DebugDump` placeholder with a read-only render of `GameState` (phase/round, act/agenda + doom, locations, investigator panel, enemies) into the DOM.
+
+**Architecture:** One `#[component] BoardView` reads the reactive store and renders a status line plus, when a game is present, a set of panels. Each panel is a pure `fn(&…) -> impl IntoView` helper called inline — no per-panel component or context plumbing. The board re-renders wholesale on any store change (read-only; simplest correct behavior at this scale). Cards render as their `CardCode` strings (the client has no card-name source). Minimal CSS ships as a static Trunk-bundled stylesheet.
+
+**Tech Stack:** Rust + Leptos 0.8 (CSR/wasm32), Trunk, `wasm-bindgen-test` (headless Firefox).
+
+**Spec:** [`docs/superpowers/specs/2026-06-08-p6.5-board-rendering-design.md`](../specs/2026-06-08-p6.5-board-rendering-design.md). **Issue:** #186. **Branch:** `ui/board-rendering` (already created; the design-spec commit is its first commit).
+
+---
+
+## Orientation (read before starting)
+
+- The `web` crate is **lib + bin**: components live in `crates/web/src/*.rs` (exported from `lib.rs`) so `crates/web/tests/*.rs` can import them. `main.rs` is a thin mount shim.
+- **Headless tests are wasm32-only.** Every file in `crates/web/tests/` carries a crate-level `#![cfg(target_arch = "wasm32")]` (a `wasm-bindgen-test` mounts into a DOM that doesn't exist off-wasm). Only the `wasm-test` CI job runs them; the native `test`/`clippy`/`doc` jobs skip them.
+- The reactive store lives in `crates/web/src/store.rs`: `ClientState { game: Option<GameState>, outcome, status: ConnStatus, last_rejection: Option<String> }`, the pure `reduce(&mut ClientState, ServerMessage)` folder, `StoreSignal = RwSignal<ClientState>`, and `use_store()` / `provide_store()`.
+- The component-under-test pattern (see `crates/web/tests/store.rs`): make an `RwSignal::new(ClientState::default())`, `mount_to_body` a closure that `provide_context(store)` then renders the component, drive it with `store.update(|s| reduce(s, msg))`, `leptos::task::tick().await` to flush CSR effects, then assert on `document().body().inner_html()`.
+- `GameState` fields used here: `phase: Phase`, `round: u32`, `act_deck: Vec<Act>`, `act_index: usize`, `agenda_deck: Vec<Agenda>`, `agenda_index: usize`, `agenda_doom: u8`, `locations: BTreeMap<LocationId, Location>`, `investigators: BTreeMap<InvestigatorId, Investigator>`, `enemies: BTreeMap<EnemyId, Enemy>`. `Act { clue_threshold: u8, .. }`, `Agenda { doom_threshold: u8, .. }`.
+- `Investigator` fields: `id, name, current_location: Option<LocationId>, skills, max_health, damage, max_sanity, horror, clues, resources, actions_remaining, status, hand: Vec<CardCode>, cards_in_play: Vec<CardInPlay>, …`. `CardInPlay` carries `.code: CardCode` (plus per-instance state). `Location` fields: `id, code, name, shroud, clues, revealed, connections`. `Enemy` fields: `id, name, fight, evade, max_health, damage, current_location, exhausted, engaged_with, …`. `CardCode(pub String)` implements `Display`.
+- Fixtures (`game_core::test_support`): `test_investigator(id) -> Investigator` (name `"Test Investigator {id}"`, resources 5, max_health 8, max_sanity 8, actions 3), `test_location(id, name) -> Location` (shroud 2, 0 clues, revealed), `test_enemy(id, name) -> Enemy` (fight 2, evade 2, max_health 2). Builder: `TestGame::new().with_investigator(..).with_location(..).with_enemy(..).with_phase(..).with_round(..).build()`. No builder method for act/agenda — set those `pub` fields on the built `GameState` directly.
+
+## File structure
+
+- **Create** `crates/web/src/board.rs` — `BoardView` component + the panel helper fns. Single responsibility: render `GameState` read-only.
+- **Create** `crates/web/style.css` — minimal layout CSS, semantic class names.
+- **Create** `crates/web/tests/board.rs` — headless render tests (wasm32-only).
+- **Modify** `crates/web/src/lib.rs` — add `pub mod board;`.
+- **Modify** `crates/web/src/app.rs` — swap `<DebugDump/>` → `<BoardView/>`; delete `DebugDump`.
+- **Modify** `crates/web/index.html` — add the stylesheet `<link>`.
+- **Modify** `crates/web/tests/store.rs` — retarget the round-trip assertions from `DebugDump` strings to `BoardView` content.
+
+## Verification commands (the CI gauntlet for this crate)
+
+```sh
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+wasm-pack test --headless --firefox crates/web
+cargo fmt --check
+```
+
+The native `test`/`clippy`/`doc` jobs don't compile the wasm32-only board tests, but `cargo fmt --check` and a host `cargo clippy --all-targets --all-features -- -D warnings` still see `board.rs`'s non-cfg'd code — run the full host gauntlet from CLAUDE.md before the final push.
+
+---
+
+## Task 1: `BoardView` skeleton — status line + empty/present placeholder
+
+Stand up the component and wire it into the app, replacing `DebugDump`. No panels yet — just the always-on status line and the `Some`/`None` split. This keeps the round-trip test green at every step.
+
+**Files:**
+- Create: `crates/web/src/board.rs`
+- Modify: `crates/web/src/lib.rs`
+- Modify: `crates/web/src/app.rs`
+- Modify: `crates/web/tests/store.rs`
+- Test: `crates/web/tests/store.rs` (retargeted)
+
+- [ ] **Step 1: Create `board.rs` with the skeleton component**
+
+```rust
+//! Read-only render of `GameState` into the DOM (P6.5). Replaces the
+//! `DebugDump` placeholder. Panels are plain helper fns; `BoardView` is
+//! the only component. Cards render as their `CardCode` strings — the
+//! client has no card-name source.
+
+use leptos::prelude::*;
+
+use crate::store::{use_store, ConnStatus};
+
+/// Read-only board. Always renders a status line (connection status +
+/// last rejection); renders the panels when a game is present, else a
+/// placeholder.
+#[component]
+pub fn BoardView() -> impl IntoView {
+    let store = use_store();
+
+    let status = move || match store.get().status {
+        ConnStatus::Connecting => "connecting",
+        ConnStatus::Connected => "connected",
+        ConnStatus::Reconnecting => "reconnecting",
+        ConnStatus::Failed => "failed",
+    };
+    let rejection = move || store.get().last_rejection.unwrap_or_default();
+
+    let board = move || match store.get().game {
+        None => view! { <p class="no-game">"<no game>"</p> }.into_any(),
+        Some(_game) => view! { <p class="has-game">"game present"</p> }.into_any(),
+    };
+
+    view! {
+        <section class="board">
+            <p class="status">"status: " {status}</p>
+            <p class="rejection">"rejection: " {rejection}</p>
+            {board}
+        </section>
+    }
+}
+```
+
+- [ ] **Step 2: Export the module from `lib.rs`**
+
+In `crates/web/src/lib.rs`, add alongside the other `pub mod` lines (after `pub mod app;`):
+
+```rust
+pub mod board;
+```
+
+- [ ] **Step 3: Wire `BoardView` into `app.rs`, delete `DebugDump`**
+
+Three edits to `crates/web/src/app.rs`, in order:
+
+1. **Fix the imports.** After this task, `app.rs` uses `provide_store` (top of `App`) but no longer uses `ConnStatus` (only `DebugDump` did). `use_store` is referenced *only* inside the `#[cfg(target_arch = "wasm32")]` block — leaving it in an unconditional `use` would warn as unused on the **native** build (the block is cfg'd out there). So fully-qualify it at the call site (next edit) and drop it from the import. Change
+
+   ```rust
+   use crate::store::{provide_store, use_store, ConnStatus};
+   ```
+
+   to exactly these two lines:
+
+   ```rust
+   use crate::board::BoardView;
+   use crate::store::provide_store;
+   ```
+
+2. **Fully-qualify `use_store` in the wasm block** so no unconditional import is needed. Change
+
+   ```rust
+       #[cfg(target_arch = "wasm32")]
+       {
+           let store = use_store();
+           crate::transport::start(store);
+       }
+   ```
+
+   to
+
+   ```rust
+       #[cfg(target_arch = "wasm32")]
+       {
+           let store = crate::store::use_store();
+           crate::transport::start(store);
+       }
+   ```
+
+3. **Swap the view and delete `DebugDump`.** Replace `<DebugDump/>` with `<BoardView/>` in the `App` view, then **delete** the entire `DebugDump` component (its `#[component] pub fn DebugDump()` and the doc comment above it). Leave `DebugSubmit` and the rest of `App` untouched.
+
+The unused-import / unused-variable clippy lints (host job in the gauntlet, Task 7) are the backstop that this came out clean on **both** targets.
+
+- [ ] **Step 4: Retarget `store.rs` test assertions**
+
+In `crates/web/tests/store.rs`: change the import `use web::app::DebugDump;` to `use web::board::BoardView;`, and replace every `<DebugDump/>` with `<BoardView/>`. Update the assertion strings: `"state: none"` → `"<no game>"`, and `"state: present"` → `"game present"`. (The test mounts the component, asserts the empty state, feeds `Hello`, ticks, asserts the present state — only the component name and the two probe strings change.)
+
+- [ ] **Step 5: Run the wasm gauntlet — expect green**
+
+Run:
+```sh
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+wasm-pack test --headless --firefox crates/web
+```
+Expected: build clean, clippy clean (no unused-import warnings in `app.rs`), all `store.rs` + `smoke.rs` tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```sh
+git add crates/web/src/board.rs crates/web/src/lib.rs crates/web/src/app.rs crates/web/tests/store.rs
+git commit -m "$(printf 'ui: BoardView skeleton replacing DebugDump (P6.5)\n\nStatus line + present/absent split; panels follow. Round-trip test\nretargeted from DebugDump to BoardView.\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 2: Phase bar — phase, round, act, agenda + doom
+
+Render the top-of-board summary. Test-first.
+
+**Files:**
+- Modify: `crates/web/src/board.rs`
+- Create: `crates/web/tests/board.rs`
+- Test: `crates/web/tests/board.rs::phase_bar_renders_phase_round_act_agenda`
+
+- [ ] **Step 1: Write the failing test in a new `board.rs` test file**
+
+```rust
+//! Headless render tests for `BoardView` (P6.5). Feed a constructed
+//! `GameState` through the store and assert on the rendered DOM.
+//! wasm32-only (browser DOM); native jobs skip this file.
+#![cfg(target_arch = "wasm32")]
+
+use game_core::state::{Act, Agenda, Phase};
+use game_core::test_support::builder::TestGame;
+use game_core::test_support::fixtures::{test_enemy, test_investigator, test_location};
+use game_core::EngineOutcome;
+use leptos::prelude::{provide_context, RwSignal, Update};
+use protocol::ServerMessage;
+use wasm_bindgen_test::*;
+use web::board::BoardView;
+use web::store::{reduce, ClientState};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn body_html() -> String {
+    leptos::prelude::document()
+        .body()
+        .expect("body")
+        .inner_html()
+}
+
+/// Mount `BoardView` against a fresh store and feed it one `Hello`
+/// carrying `state`. Ticks once so CSR effects flush, then returns the
+/// rendered body HTML.
+async fn render_state(state: game_core::state::GameState) -> String {
+    let store = RwSignal::new(ClientState::default());
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        leptos::view! { <BoardView/> }
+    });
+    store.update(|s| {
+        reduce(
+            s,
+            ServerMessage::Hello {
+                state: Box::new(state),
+                outcome: EngineOutcome::Done,
+            },
+        );
+    });
+    leptos::task::tick().await;
+    body_html()
+}
+
+#[wasm_bindgen_test]
+async fn phase_bar_renders_phase_round_act_agenda() {
+    let mut state = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_phase(Phase::Investigation)
+        .with_round(3)
+        .build();
+    state.act_deck = vec![Act {
+        clue_threshold: 2,
+        resolution: None,
+    }];
+    state.agenda_deck = vec![Agenda {
+        doom_threshold: 5,
+        resolution: None,
+    }];
+    state.agenda_doom = 1;
+
+    let html = render_state(state).await;
+
+    assert!(html.contains("Investigation"), "phase missing: {html}");
+    assert!(html.contains("round 3") || html.contains("Round 3"), "round missing: {html}");
+    assert!(html.contains("doom 1/5") || html.contains("1/5"), "agenda doom missing: {html}");
+    assert!(html.contains("clues 0/2") || html.contains("0/2"), "act threshold missing: {html}");
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `wasm-pack test --headless --firefox crates/web`
+Expected: FAIL — `phase_bar_renders_phase_round_act_agenda` panics on the `assert!(html.contains("Investigation"))` (the skeleton renders only `"game present"`).
+
+- [ ] **Step 3: Add the `phase_bar` helper and call it from `BoardView`**
+
+In `crates/web/src/board.rs`, add the import for the state types at the top:
+
+```rust
+use game_core::state::GameState;
+```
+
+Add the helper fn (below `BoardView`):
+
+```rust
+/// Phase + round, plus the current act's clue threshold and the current
+/// agenda's doom (`doom/threshold`). Act/agenda lines are omitted when
+/// their decks are empty (fixtures may omit them).
+fn phase_bar(game: &GameState) -> impl IntoView {
+    let phase = format!("{:?}", game.phase);
+    let round = game.round;
+    let act = game
+        .act_deck
+        .get(game.act_index)
+        .map(|a| format!("clues 0/{}", a.clue_threshold));
+    let agenda = game
+        .agenda_deck
+        .get(game.agenda_index)
+        .map(|a| format!("doom {}/{}", game.agenda_doom, a.doom_threshold));
+    view! {
+        <header class="phase-bar">
+            <span class="phase">{phase}</span>
+            <span class="round">"round " {round}</span>
+            {agenda.map(|t| view! { <span class="agenda">{t}</span> })}
+            {act.map(|t| view! { <span class="act">{t}</span> })}
+        </header>
+    }
+}
+```
+
+Then in `BoardView`, replace the `Some(_game) => …` arm with one that calls `phase_bar`:
+
+```rust
+        Some(game) => view! {
+            <div class="game">
+                {phase_bar(&game)}
+            </div>
+        }
+        .into_any(),
+```
+
+(The `_game` binding becomes `game` since it's now used.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `wasm-pack test --headless --firefox crates/web`
+Expected: PASS (this test plus the Task-1 round-trip tests).
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add crates/web/src/board.rs crates/web/tests/board.rs
+git commit -m "$(printf 'ui: board phase bar — phase/round/act/agenda+doom (P6.5)\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 3: Locations panel
+
+**Files:**
+- Modify: `crates/web/src/board.rs`
+- Modify: `crates/web/tests/board.rs`
+- Test: `crates/web/tests/board.rs::locations_panel_renders_name_shroud_clues`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `crates/web/tests/board.rs`:
+
+```rust
+#[wasm_bindgen_test]
+async fn locations_panel_renders_name_shroud_clues() {
+    let mut loc = test_location(7, "Rivertown");
+    loc.shroud = 3;
+    loc.clues = 2;
+    let state = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_location(loc)
+        .build();
+
+    let html = render_state(state).await;
+
+    assert!(html.contains("Rivertown"), "location name missing: {html}");
+    assert!(html.contains("shroud 3"), "shroud missing: {html}");
+    assert!(html.contains("clues 2"), "location clues missing: {html}");
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `wasm-pack test --headless --firefox crates/web`
+Expected: FAIL — `locations_panel_renders_name_shroud_clues` panics on `assert!(html.contains("Rivertown"))`.
+
+- [ ] **Step 3: Add `locations_panel` and call it**
+
+In `crates/web/src/board.rs`, add the helper:
+
+```rust
+/// One row per location: name, shroud, clues, and a revealed flag.
+/// Iterates the `BTreeMap` in `LocationId` order (deterministic).
+fn locations_panel(game: &GameState) -> impl IntoView {
+    let rows: Vec<_> = game
+        .locations
+        .values()
+        .map(|loc| {
+            let revealed = if loc.revealed { "revealed" } else { "unrevealed" };
+            view! {
+                <li class="location">
+                    <span class="loc-name">{loc.name.clone()}</span>
+                    <span class="loc-shroud">"shroud " {loc.shroud}</span>
+                    <span class="loc-clues">"clues " {loc.clues}</span>
+                    <span class="loc-revealed">{revealed}</span>
+                </li>
+            }
+        })
+        .collect();
+    view! {
+        <section class="locations">
+            <h2>"Locations"</h2>
+            <ul>{rows}</ul>
+        </section>
+    }
+}
+```
+
+Then call it inside the `Some(game)` arm's `<div class="game">`, after `{phase_bar(&game)}`:
+
+```rust
+                {locations_panel(&game)}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `wasm-pack test --headless --firefox crates/web`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add crates/web/src/board.rs crates/web/tests/board.rs
+git commit -m "$(printf 'ui: board locations panel — name/shroud/clues (P6.5)\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 4: Investigators panel
+
+**Files:**
+- Modify: `crates/web/src/board.rs`
+- Modify: `crates/web/tests/board.rs`
+- Test: `crates/web/tests/board.rs::investigators_panel_renders_stats_and_hand`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `crates/web/tests/board.rs`:
+
+```rust
+#[wasm_bindgen_test]
+async fn investigators_panel_renders_stats_and_hand() {
+    use game_core::state::CardCode;
+
+    let mut inv = test_investigator(1);
+    inv.name = "Roland Banks".to_string();
+    inv.damage = 2; // 2/8
+    inv.horror = 1; // 1/8
+    inv.clues = 3;
+    inv.resources = 4;
+    inv.actions_remaining = 2;
+    inv.hand = vec![CardCode::new("_synth_fast_event"), CardCode::new("_synth_treachery")];
+    let state = TestGame::new().with_investigator(inv).build();
+
+    let html = render_state(state).await;
+
+    assert!(html.contains("Roland Banks"), "name missing: {html}");
+    assert!(html.contains("2/8"), "health damage missing: {html}");
+    assert!(html.contains("1/8"), "horror missing: {html}");
+    assert!(html.contains("actions 2"), "actions missing: {html}");
+    assert!(html.contains("resources 4"), "resources missing: {html}");
+    assert!(html.contains("_synth_fast_event"), "hand card missing: {html}");
+    assert!(html.contains("_synth_treachery"), "hand card missing: {html}");
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `wasm-pack test --headless --firefox crates/web`
+Expected: FAIL — panics on `assert!(html.contains("Roland Banks"))`.
+
+- [ ] **Step 3: Add `investigators_panel` and call it**
+
+In `crates/web/src/board.rs`, add:
+
+```rust
+/// One panel per investigator: name, location, actions, resources,
+/// health (`damage/max_health`), sanity (`horror/max_sanity`), clues,
+/// status; hand and cards-in-play as text lists of card codes.
+fn investigators_panel(game: &GameState) -> impl IntoView {
+    let panels: Vec<_> = game
+        .investigators
+        .values()
+        .map(|inv| {
+            let location = inv
+                .current_location
+                .map_or_else(|| "—".to_string(), |LocationId(id)| format!("loc {id}"));
+            let hand: Vec<_> = inv
+                .hand
+                .iter()
+                .map(|code| view! { <li class="card">{code.to_string()}</li> })
+                .collect();
+            let in_play: Vec<_> = inv
+                .cards_in_play
+                .iter()
+                .map(|c| view! { <li class="card">{c.code.to_string()}</li> })
+                .collect();
+            view! {
+                <article class="investigator">
+                    <h3 class="inv-name">{inv.name.clone()}</h3>
+                    <span class="inv-location">{location}</span>
+                    <span class="inv-actions">"actions " {inv.actions_remaining}</span>
+                    <span class="inv-resources">"resources " {inv.resources}</span>
+                    <span class="inv-health">"health " {inv.damage} "/" {inv.max_health}</span>
+                    <span class="inv-sanity">"sanity " {inv.horror} "/" {inv.max_sanity}</span>
+                    <span class="inv-clues">"clues " {inv.clues}</span>
+                    <span class="inv-status">{format!("{:?}", inv.status)}</span>
+                    <div class="hand"><h4>"Hand"</h4><ul>{hand}</ul></div>
+                    <div class="in-play"><h4>"In play"</h4><ul>{in_play}</ul></div>
+                </article>
+            }
+        })
+        .collect();
+    view! {
+        <section class="investigators">
+            <h2>"Investigators"</h2>
+            {panels}
+        </section>
+    }
+}
+```
+
+Add the `LocationId` import to the top-of-file `use` (alongside `GameState`):
+
+```rust
+use game_core::state::{GameState, LocationId};
+```
+
+Then call it in the `Some(game)` arm after `{locations_panel(&game)}`:
+
+```rust
+                {investigators_panel(&game)}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `wasm-pack test --headless --firefox crates/web`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add crates/web/src/board.rs crates/web/tests/board.rs
+git commit -m "$(printf 'ui: board investigators panel — stats + hand/in-play (P6.5)\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 5: Enemies panel
+
+**Files:**
+- Modify: `crates/web/src/board.rs`
+- Modify: `crates/web/tests/board.rs`
+- Test: `crates/web/tests/board.rs::enemies_panel_renders_name_stats_engagement`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `crates/web/tests/board.rs`:
+
+```rust
+#[wasm_bindgen_test]
+async fn enemies_panel_renders_name_stats_engagement() {
+    use game_core::state::InvestigatorId;
+
+    let mut enemy = test_enemy(4, "Swarm of Rats");
+    enemy.damage = 1; // 1/2
+    enemy.engaged_with = Some(InvestigatorId(1));
+    let state = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_enemy(enemy)
+        .build();
+
+    let html = render_state(state).await;
+
+    assert!(html.contains("Swarm of Rats"), "enemy name missing: {html}");
+    assert!(html.contains("fight 2"), "fight missing: {html}");
+    assert!(html.contains("1/2"), "enemy health missing: {html}");
+    assert!(html.contains("engaged"), "engagement missing: {html}");
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `wasm-pack test --headless --firefox crates/web`
+Expected: FAIL — panics on `assert!(html.contains("Swarm of Rats"))`.
+
+- [ ] **Step 3: Add `enemies_panel` and call it**
+
+In `crates/web/src/board.rs`, add:
+
+```rust
+/// One row per enemy: name, fight/evade, health (`damage/max_health`),
+/// location, engagement, exhausted flag.
+fn enemies_panel(game: &GameState) -> impl IntoView {
+    let rows: Vec<_> = game
+        .enemies
+        .values()
+        .map(|e| {
+            let engaged = match e.engaged_with {
+                Some(InvestigatorId(id)) => format!("engaged with {id}"),
+                None => "unengaged".to_string(),
+            };
+            let location = e
+                .current_location
+                .map_or_else(|| "—".to_string(), |LocationId(id)| format!("loc {id}"));
+            view! {
+                <li class="enemy">
+                    <span class="enemy-name">{e.name.clone()}</span>
+                    <span class="enemy-fight">"fight " {e.fight}</span>
+                    <span class="enemy-evade">"evade " {e.evade}</span>
+                    <span class="enemy-health">"health " {e.damage} "/" {e.max_health}</span>
+                    <span class="enemy-location">{location}</span>
+                    <span class="enemy-engaged">{engaged}</span>
+                </li>
+            }
+        })
+        .collect();
+    view! {
+        <section class="enemies">
+            <h2>"Enemies"</h2>
+            <ul>{rows}</ul>
+        </section>
+    }
+}
+```
+
+Extend the top-of-file import to include `InvestigatorId`:
+
+```rust
+use game_core::state::{GameState, InvestigatorId, LocationId};
+```
+
+Then call it in the `Some(game)` arm after `{investigators_panel(&game)}`:
+
+```rust
+                {enemies_panel(&game)}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `wasm-pack test --headless --firefox crates/web`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add crates/web/src/board.rs crates/web/tests/board.rs
+git commit -m "$(printf 'ui: board enemies panel — stats + engagement (P6.5)\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 6: Minimal stylesheet + Trunk wiring
+
+Ship a small static stylesheet and link it. CSS is invisible to the DOM-text assertions, so there's no new headless test — the check is that the bundle still builds and `trunk build` picks up the stylesheet.
+
+**Files:**
+- Create: `crates/web/style.css`
+- Modify: `crates/web/index.html`
+
+- [ ] **Step 1: Create `crates/web/style.css`**
+
+```css
+/* P6.5 board — minimal functional layout. */
+.board { font-family: system-ui, sans-serif; margin: 1rem; }
+.status, .rejection { font-size: 0.85rem; color: #555; }
+.phase-bar { display: flex; gap: 1rem; font-weight: 600; padding: 0.5rem 0; border-bottom: 1px solid #ccc; }
+.game { display: flex; flex-direction: column; gap: 1rem; }
+.locations ul, .enemies ul, .hand ul, .in-play ul { list-style: none; padding-left: 0; margin: 0; }
+.location, .enemy { display: flex; gap: 0.75rem; padding: 0.25rem 0; }
+.investigators { display: flex; flex-wrap: wrap; gap: 1rem; }
+.investigator { border: 1px solid #ccc; border-radius: 4px; padding: 0.5rem; display: flex; flex-direction: column; gap: 0.25rem; min-width: 16rem; }
+.investigator span { font-size: 0.9rem; }
+.card { font-family: ui-monospace, monospace; font-size: 0.85rem; }
+```
+
+- [ ] **Step 2: Link the stylesheet in `index.html`**
+
+In `crates/web/index.html`, inside `<head>` (after the `<title>` line, before the `data-trunk rel="rust"` link), add:
+
+```html
+    <link data-trunk rel="css" href="style.css" />
+```
+
+- [ ] **Step 3: Verify the bundle builds with the stylesheet**
+
+Run:
+```sh
+cd crates/web && trunk build && cd ../..
+ls crates/web/dist
+```
+Expected: `trunk build` succeeds; `crates/web/dist/` contains the hashed `web-*.js`/`.wasm` and a hashed `style-*.css`. (If `trunk` is unavailable in the environment, instead run `cargo build -p web --target wasm32-unknown-unknown` and visually confirm `index.html` references `style.css` — Trunk validates the `data-trunk` link at serve/build time.)
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add crates/web/style.css crates/web/index.html
+git commit -m "$(printf 'ui: minimal board stylesheet via Trunk (P6.5)\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 7: Empty-board regression test + final gauntlet
+
+Lock in the `None` path explicitly (Task 1's `store.rs` covers it, but a dedicated board-file assertion documents the contract), then run the full CI gauntlet.
+
+**Files:**
+- Modify: `crates/web/tests/board.rs`
+
+- [ ] **Step 1: Write the empty-board test**
+
+Append to `crates/web/tests/board.rs`:
+
+```rust
+#[wasm_bindgen_test]
+async fn empty_board_renders_placeholder_without_panels() {
+    let store = RwSignal::new(ClientState::default());
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        leptos::view! { <BoardView/> }
+    });
+    leptos::task::tick().await;
+
+    let html = body_html();
+    assert!(html.contains("<no game>"), "placeholder missing: {html}");
+    assert!(!html.contains("Investigators"), "panels should be absent: {html}");
+    assert!(!html.contains("Locations"), "panels should be absent: {html}");
+}
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `wasm-pack test --headless --firefox crates/web`
+Expected: PASS (the skeleton already renders `"<no game>"` and no panels when `game` is `None`).
+
+- [ ] **Step 3: Run the full CI gauntlet (host + wasm)**
+
+Run, from the repo root:
+```sh
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+wasm-pack test --headless --firefox crates/web
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+Expected: every command exits 0. (Host `clippy`/`fmt`/`doc` see `board.rs`'s non-cfg code; `wasm-*` see the full board + tests.)
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add crates/web/tests/board.rs
+git commit -m "$(printf 'test: empty-board placeholder regression (P6.5)\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## After the plan (handled outside these tasks)
+
+- Open the PR (`gh pr create`, repo template, `Closes #186.`), watch CI green (`gh pr checks --watch`).
+- **As the final commit before merge**, update `docs/phases/phase-6-web-client-v0.md`: move #186 to a Closed/✅ state in the Issues + Ordering tables, drop the settled "CSS/layout specifics (P6.5)" open question, and add a *Decisions made* entry only if load-bearing for a future PR (candidate: "leptos-use deferred *again* at P6.5 — read-only board needs no Rust-side viewport reactivity; next revisit Phase 8"). Follow `docs/phases/README.md`.
+- Merge only after explicit user approval.

--- a/docs/superpowers/specs/2026-06-08-p6.5-board-rendering-design.md
+++ b/docs/superpowers/specs/2026-06-08-p6.5-board-rendering-design.md
@@ -1,0 +1,108 @@
+# P6.5 — Board rendering (read-only) — design
+
+**Issue:** [#186](https://github.com/talelburg/eldritch/issues/186) ([ui] P6.5).
+**Parent spec:** [`2026-06-08-phase-6-web-client-v0-design.md`](./2026-06-08-phase-6-web-client-v0-design.md) (client layer 2).
+**Date:** 2026-06-08.
+
+## Goal
+
+Replace the `DebugDump` placeholder with a read-only render of
+`GameState`: phase/round, act/agenda + doom, locations, an investigator
+panel, and enemies. Text-only cards (codes), minimal CSS. No
+interaction — action controls and `AwaitingInput` are P6.6+.
+
+The client renders the server's authoritative snapshot (parent spec D1):
+the board is a pure function of the `GameState` in the store. This slot
+adds no new protocol, no engine change, no server change.
+
+## Decisions
+
+- **No `leptos-use`.** #186 is a read-only text board with minimal CSS
+  and no interaction. Responsive layout (if any) is plain CSS
+  flexbox/grid + CSS media queries — zero Rust deps. `use_media_query`
+  is only justified when component trees branch on viewport size in
+  Rust, which this slot does not do. The parent spec flagged P6.5 as a
+  *possible* adopt trigger; it isn't one. Defer again (revisit at the
+  next concrete need — e.g. Phase 8 auth `use_cookie`).
+- **Static stylesheet.** `crates/web/style.css` with semantic class
+  names, linked via `<link data-trunk rel="css" href="style.css">`.
+  Trunk bundles + hashes it. DOM tests assert structure/text, not
+  styles, so CSS is invisible to the gate.
+- **Card codes, not names.** The client carries only `CardCode` strings;
+  card *names* live in `CardMetadata`, reachable only through a registry
+  the wasm client does not install. Rendering the code (e.g.
+  `_synth_fast_event`) matches #186's "hand as a text list" and the
+  "no card art" non-goal. Real names arrive naturally in Phase 7 with
+  real cards + art.
+- **Panels are plain helper functions, not `#[component]`s.** One
+  `#[component] BoardView` reads the store; each panel is a pure
+  `fn(&…) -> impl IntoView` called inline. Avoids a `#[component]` +
+  context plumbing per single-use view. Whole-board re-render on any
+  store change — simplest correct behavior for a read-only view at this
+  scale (one investigator, a handful of locations/enemies).
+
+## Components
+
+New module `crates/web/src/board.rs`, exported from `lib.rs`.
+
+- **`BoardView`** (`#[component]`, `pub`) — reads `use_store()`. Always
+  renders a **status line** (connection status + last rejection,
+  preserved from `DebugDump` — load-bearing for the reconnect
+  acceptance). Then on `game`: `Some(g)` → the panels; `None` →
+  a `"<no game>"` placeholder.
+- **`phase_bar(&GameState)`** — phase name, round; current act (clue
+  threshold) and current agenda (doom threshold) + `agenda_doom`.
+  Guards empty `act_deck` / `agenda_deck` (fixtures may omit them).
+- **`locations_panel(&BTreeMap<LocationId, Location>)`** — per location:
+  name, shroud, clues, revealed flag.
+- **`investigators_panel(&BTreeMap<InvestigatorId, Investigator>)`** —
+  per investigator: name, location, actions remaining, resources,
+  health (`damage`/`max_health`), sanity (`horror`/`max_sanity`),
+  clues, status; hand as a text list of codes; cards-in-play as a text
+  list of codes.
+- **`enemies_panel(&BTreeMap<EnemyId, Enemy>)`** — per enemy: name,
+  fight/evade, health (`damage`/`max_health`), location, `engaged_with`,
+  exhausted.
+
+## Wiring changes (surgical)
+
+- `app.rs`: swap `<DebugDump/>` → `<BoardView/>`. Keep `<DebugSubmit/>`
+  (wasm-only) — it is the send-path seam P6.7 builds on.
+- Remove `DebugDump` (its status/rejection lines move into `BoardView`).
+- `index.html`: add `<link data-trunk rel="css" href="style.css">`.
+- `crates/web/tests/store.rs`: retarget the round-trip assertions from
+  `DebugDump`'s `"state: present"` strings to `BoardView`'s real board
+  content. The reduce→render round-trip test stays; it now checks the
+  real board.
+
+## Testing — headless `wasm-bindgen-test`
+
+Parent spec D4: the gate is a real headless browser. New file
+`crates/web/tests/board.rs` (crate-level `#![cfg(target_arch = "wasm32")]`,
+per the P6.3 convention). Feed a constructed `GameState` through the
+store via `reduce(Hello)` (the existing `store.rs` pattern), `tick()`,
+then assert on `body.inner_html()`.
+
+- **Populated board.** `TestGame` with an investigator (hand codes,
+  resources, damage, clues), a location (`test_location` — name /
+  shroud / clues), an enemy (`test_enemy`), a set phase / round; act /
+  agenda + `agenda_doom` set on the built state's `pub` fields (no
+  builder method exists for act/agenda, and adding one is out of scope).
+  Assert the DOM contains: phase name, round, location name / shroud /
+  clues, investigator name / actions / resources / `damage/health`,
+  each hand code, enemy name, and the doom value.
+- **Empty board.** No game → `"<no game>"` placeholder present, panels
+  absent.
+
+## Out of scope (named non-goals)
+
+Card art; card names; any interaction / buttons; the
+location-connection graph layout; responsive breakpoints beyond trivial
+CSS. The chaos bag, encounter deck/discard, pending-input queues, and
+other `GameState` internals not in #186's list are not rendered this
+slot.
+
+## Acceptance (from #186)
+
+A constructed `GameState` renders the expected DOM (phase, clues, hand
+contents, etc.); the headless `wasm-test` CI job is green.


### PR DESCRIPTION
## Summary

Replaces the `DebugDump` placeholder with `BoardView`, a read-only render of the server's authoritative `GameState` (parent spec D1): connection status, phase/round, act/agenda + doom, locations, an investigator panel (stats + hand/in-play card codes), and enemies. No interaction this slot — that's P6.6+.

## What changed

- New `crates/web/src/board.rs`: `#[component] BoardView` reads the reactive store; panels are plain `fn(&GameState) -> impl IntoView` helpers (`phase_bar`, `locations_panel`, `investigators_panel`, `enemies_panel`). Whole-board re-render on store change (read-only; simplest correct behavior).
- `app.rs`/`lib.rs`: wire in `BoardView`, delete `DebugDump`, keep `DebugSubmit` (the P6.7 send-path seam).
- `style.css` + Trunk `<link data-trunk rel="css">`: minimal functional layout.
- Headless `wasm-bindgen-test` per panel (`crates/web/tests/board.rs`), plus the empty-board placeholder; `store.rs` round-trip retargeted to `BoardView`.

### Design decisions (see spec)
- **Cards render as `CardCode` strings, not names** — the wasm client installs no registry, so names (in `CardMetadata`) aren't reachable; real names arrive in Phase 7. Matches the "no card art" non-goal.
- **`leptos-use` deferred again** — a read-only text board needs no Rust-side viewport reactivity (plain CSS covers any responsiveness); next revisit is Phase 8.
- **`format!("{:?}", …)` for phase/status display** — accepted for this synthetic/dev UI (no `Display` impls).
- **Empty-board test scopes via `query_selector_all(".board")`** — `wasm-bindgen-test` shares one browser page and `mount_to_body` accumulates DOM; clearing `<body>` breaks the harness's own status elements, so the negative assertions scope to the last mounted board section.

## Test notes

All seven CI jobs pass locally (test, host clippy, fmt, doc, wasm-build, wasm-test, wasm-clippy). `wasm-test`: 7 tests (5 board + store round-trip + smoke). Each panel is tested by feeding a constructed `GameState` through the store and asserting on rendered DOM.

Design spec: `docs/superpowers/specs/2026-06-08-p6.5-board-rendering-design.md`. Plan: `docs/superpowers/plans/2026-06-09-p6.5-board-rendering.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Linked issues

Closes #186