### PR TITLE
ui: AwaitingInput resolution UI + legality gating (P6.6)

### DIFF
--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -18,6 +18,7 @@
 //! when a field addition lands.
 
 use crate::card_data::Prey;
+use crate::engine::{EngineOutcome, InputRequest, ResumeToken};
 use crate::state::{
     CardCode, Enemy, EnemyId, Investigator, InvestigatorId, Location, LocationId, Skills, Status,
 };
@@ -107,5 +108,37 @@ pub fn test_enemy(id: u32, name: impl Into<String>) -> Enemy {
         engaged_with: None,
         hunter: false,
         prey: Prey::Default,
+    }
+}
+
+/// A sample skill-test commit [`AwaitingInput`](EngineOutcome::AwaitingInput)
+/// outcome, for client/UI fixtures. This is the only `AwaitingInput`
+/// shape the engine emits today (the skill-test commit window). The
+/// `ResumeToken` value is irrelevant to rendering — routing keys off
+/// `state.in_flight_skill_test`, not the token.
+#[must_use]
+pub fn awaiting_commit_input(prompt: impl Into<String>) -> EngineOutcome {
+    EngineOutcome::AwaitingInput {
+        request: InputRequest {
+            prompt: prompt.into(),
+        },
+        resume_token: ResumeToken(0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::awaiting_commit_input;
+    use crate::EngineOutcome;
+
+    #[test]
+    fn awaiting_commit_input_carries_the_prompt() {
+        let outcome = awaiting_commit_input("Commit cards for the test");
+        match outcome {
+            EngineOutcome::AwaitingInput { request, .. } => {
+                assert_eq!(request.prompt, "Commit cards for the test");
+            }
+            other => panic!("expected AwaitingInput, got {other:?}"),
+        }
     }
 }

--- a/crates/game-core/src/test_support/mod.rs
+++ b/crates/game-core/src/test_support/mod.rs
@@ -11,5 +11,5 @@ pub mod fixtures;
 pub mod resolver;
 
 pub use builder::TestGame;
-pub use fixtures::{test_enemy, test_investigator, test_location};
+pub use fixtures::{awaiting_commit_input, test_enemy, test_investigator, test_location};
 pub use resolver::{apply_no_commits, drive, ChoiceResolver, ScriptedResolver, TestSession};

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -27,4 +27,4 @@ web-sys = { version = "0.3", features = ["Storage", "Location", "Window"] }
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 wasm-bindgen = "0.2"
-web-sys = { version = "0.3", features = ["Element", "NodeList"] }
+web-sys = { version = "0.3", features = ["Element", "NodeList", "HtmlElement"] }

--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -23,7 +23,7 @@ pub fn App() -> impl IntoView {
             <BoardView/>
             {
                 #[cfg(target_arch = "wasm32")]
-                { view! { <DebugSubmit/> }.into_any() }
+                { view! { <crate::input::AwaitingInputView/><DebugSubmit/> }.into_any() }
                 #[cfg(not(target_arch = "wasm32"))]
                 { ().into_any() }
             }

--- a/crates/web/src/input.rs
+++ b/crates/web/src/input.rs
@@ -1,0 +1,92 @@
+//! `AwaitingInput` resolution UI (P6.6, wasm-only). Renders the engine's
+//! pending prompt and a control to resolve it. Phase-6 scope is the
+//! skill-test commit window (`CommitCards`); other `InputResponse`
+//! variants are deferred (spec S1, follow-up #205). Nothing renders when
+//! the latest outcome is not `AwaitingInput`.
+
+use std::collections::BTreeSet;
+
+use game_core::state::GameState;
+use game_core::{EngineOutcome, InputResponse, PlayerAction};
+use leptos::prelude::*;
+use protocol::ClientMessage;
+
+use crate::store::use_store;
+use crate::transport::OutboundTx;
+
+/// Pending-input prompt + commit control. Reads the store reactively;
+/// submits via the `OutboundTx` provided by the transport (absent in
+/// render-only contexts, so read as `Option`).
+#[component]
+pub fn AwaitingInputView() -> impl IntoView {
+    let store = use_store();
+    let tx = use_context::<OutboundTx>();
+    // One prompt is live at a time in solo, so a single component-lived
+    // selection signal suffices.
+    let selected = RwSignal::new(BTreeSet::<u32>::new());
+
+    view! {
+        {move || {
+            let state = store.get();
+            let (Some(EngineOutcome::AwaitingInput { request, .. }), Some(game)) =
+                (state.outcome.clone(), state.game.clone())
+            else {
+                return ().into_any();
+            };
+
+            let cards: Vec<_> = active_hand(&game)
+                .into_iter()
+                .enumerate()
+                .map(|(idx, code)| {
+                    let i = u32::try_from(idx).expect("hand fits in u32");
+                    view! {
+                        <li>
+                            <button
+                                class="hand-card"
+                                class:selected=move || selected.get().contains(&i)
+                                on:click=move |_| selected.update(|s| {
+                                    if !s.remove(&i) {
+                                        s.insert(i);
+                                    }
+                                })
+                            >
+                                {code}
+                            </button>
+                        </li>
+                    }
+                })
+                .collect();
+
+            let tx = tx.clone();
+            let on_commit = move |_| {
+                let indices: Vec<u32> = selected.get().into_iter().collect();
+                if let Some(tx) = tx.clone() {
+                    let _ = tx.unbounded_send(ClientMessage::Submit {
+                        action: PlayerAction::ResolveInput {
+                            response: InputResponse::CommitCards { indices },
+                        },
+                    });
+                }
+                selected.set(BTreeSet::new());
+            };
+
+            view! {
+                <section class="awaiting-input">
+                    <p class="prompt">{request.prompt}</p>
+                    <ul class="commit-hand">{cards}</ul>
+                    <button class="commit" on:click=on_commit>"Commit"</button>
+                </section>
+            }
+            .into_any()
+        }}
+    }
+}
+
+/// The active investigator's hand as card-code strings (empty when there
+/// is no active investigator).
+fn active_hand(game: &GameState) -> Vec<String> {
+    game.active_investigator
+        .and_then(|id| game.investigators.get(&id))
+        .map(|inv| inv.hand.iter().map(ToString::to_string).collect())
+        .unwrap_or_default()
+}

--- a/crates/web/src/input.rs
+++ b/crates/web/src/input.rs
@@ -22,7 +22,11 @@ pub fn AwaitingInputView() -> impl IntoView {
     let store = use_store();
     let tx = use_context::<OutboundTx>();
     // One prompt is live at a time in solo, so a single component-lived
-    // selection signal suffices.
+    // selection signal suffices. It is cleared after a commit; it is NOT
+    // cleared when an `AwaitingInput` is dismissed without committing
+    // (server abandons a skill test), which the toy scenario never does —
+    // revisit if a path can present a second prompt without an intervening
+    // commit.
     let selected = RwSignal::new(BTreeSet::<u32>::new());
 
     view! {

--- a/crates/web/src/input.rs
+++ b/crates/web/src/input.rs
@@ -88,6 +88,12 @@ pub fn AwaitingInputView() -> impl IntoView {
 
 /// The active investigator's hand as card-code strings (empty when there
 /// is no active investigator).
+///
+/// Solo-scope assumption: the skill-test performer equals
+/// `active_investigator`. The authoritative "whose hand commits" is
+/// `in_flight_skill_test.investigator`; the two coincide in solo but need
+/// not in a delegated/multiplayer test, so input routing is revisited in
+/// #205.
 fn active_hand(game: &GameState) -> Vec<String> {
     game.active_investigator
         .and_then(|id| game.investigators.get(&id))

--- a/crates/web/src/legality.rs
+++ b/crates/web/src/legality.rs
@@ -1,0 +1,124 @@
+//! Which core-loop action controls are enabled, given the current state
+//! and the latest engine outcome (P6.6). A pure UX affordance: the
+//! server stays authoritative and rejects anything illegal (see the P6.6
+//! design spec, decision S2). Consumed by P6.7's action buttons.
+
+use std::collections::BTreeSet;
+
+use game_core::state::{GameState, Phase};
+use game_core::EngineOutcome;
+
+/// A clickable core-loop action in the client. Combat controls
+/// (`Fight`/`Evade`/`Draw`) join in P6.7b.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ActionControl {
+    Move,
+    Investigate,
+    PlayCard,
+    EndTurn,
+    Mulligan,
+    DrawEncounter,
+    AdvanceAct,
+}
+
+/// The controls the player may click right now.
+///
+/// Gating, in order:
+/// 1. An `AwaitingInput` pause blocks every core-loop action — only the
+///    pending `ResolveInput` (the prompt UI) is legal.
+/// 2. The setup cursors dominate their windows: `mulligan_pending` ⇒ only
+///    `Mulligan`; `mythos_draw_pending` ⇒ only `DrawEncounter`. These are
+///    state facts, not phase, so they're checked before the phase table.
+/// 3. Otherwise, the controls the current `Phase` permits.
+///
+/// Finer checks (resources, action budget, clue presence) are
+/// deliberately not mirrored — the server's `Rejected` is the truth.
+#[must_use]
+pub fn enabled_controls(game: &GameState, outcome: &EngineOutcome) -> BTreeSet<ActionControl> {
+    use ActionControl::{
+        AdvanceAct, DrawEncounter, EndTurn, Investigate, Move, Mulligan, PlayCard,
+    };
+
+    if matches!(outcome, EngineOutcome::AwaitingInput { .. }) {
+        return BTreeSet::new();
+    }
+    if game.mulligan_pending.is_some() {
+        return BTreeSet::from([Mulligan]);
+    }
+    if game.mythos_draw_pending.is_some() {
+        return BTreeSet::from([DrawEncounter]);
+    }
+    match game.phase {
+        Phase::Investigation => BTreeSet::from([Move, Investigate, PlayCard, EndTurn, AdvanceAct]),
+        Phase::Mythos | Phase::Enemy | Phase::Upkeep => BTreeSet::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ActionControl::{AdvanceAct, EndTurn, Investigate, Move, PlayCard};
+    use super::{enabled_controls, ActionControl};
+    use game_core::state::{InvestigatorId, Phase};
+    use game_core::test_support::builder::TestGame;
+    use game_core::test_support::fixtures::{awaiting_commit_input, test_investigator};
+    use game_core::EngineOutcome;
+    use std::collections::BTreeSet;
+
+    fn investigation_game() -> game_core::state::GameState {
+        TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_active_investigator(InvestigatorId(1))
+            .with_phase(Phase::Investigation)
+            .build()
+    }
+
+    #[test]
+    fn awaiting_input_disables_everything() {
+        let game = investigation_game();
+        let out = awaiting_commit_input("commit");
+        assert_eq!(enabled_controls(&game, &out), BTreeSet::new());
+    }
+
+    #[test]
+    fn mulligan_pending_enables_only_mulligan() {
+        let mut game = investigation_game();
+        game.mulligan_pending = Some(InvestigatorId(1));
+        assert_eq!(
+            enabled_controls(&game, &EngineOutcome::Done),
+            BTreeSet::from([ActionControl::Mulligan])
+        );
+    }
+
+    #[test]
+    fn mythos_draw_pending_enables_only_draw_encounter() {
+        let mut game = investigation_game();
+        game.phase = Phase::Mythos;
+        game.mythos_draw_pending = Some(InvestigatorId(1));
+        assert_eq!(
+            enabled_controls(&game, &EngineOutcome::Done),
+            BTreeSet::from([ActionControl::DrawEncounter])
+        );
+    }
+
+    #[test]
+    fn investigation_phase_enables_the_core_loop() {
+        let game = investigation_game();
+        assert_eq!(
+            enabled_controls(&game, &EngineOutcome::Done),
+            BTreeSet::from([Move, Investigate, PlayCard, EndTurn, AdvanceAct])
+        );
+    }
+
+    #[test]
+    fn non_investigation_phases_enable_nothing() {
+        for phase in [Phase::Mythos, Phase::Enemy, Phase::Upkeep] {
+            let mut game = investigation_game();
+            game.phase = phase;
+            assert_eq!(
+                enabled_controls(&game, &EngineOutcome::Done),
+                BTreeSet::new(),
+                "phase {phase:?} should enable nothing"
+            );
+        }
+    }
+}

--- a/crates/web/src/legality.rs
+++ b/crates/web/src/legality.rs
@@ -25,7 +25,10 @@ pub enum ActionControl {
 ///
 /// Gating, in order:
 /// 1. An `AwaitingInput` pause blocks every core-loop action — only the
-///    pending `ResolveInput` (the prompt UI) is legal.
+///    pending `ResolveInput` (the prompt UI) is legal. This keys off the
+///    outcome, so it covers every suspension mode the engine surfaces as
+///    `AwaitingInput` (reaction windows, hunter moves, hand-size discard,
+///    the skill-test commit window), not just the commit prompt.
 /// 2. The setup cursors dominate their windows: `mulligan_pending` ⇒ only
 ///    `Mulligan`; `mythos_draw_pending` ⇒ only `DrawEncounter`. These are
 ///    state facts, not phase, so they're checked before the phase table.

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod app;
 pub mod board;
+pub mod legality;
 pub mod store;
 pub mod url;
 

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -12,3 +12,6 @@ pub mod url;
 
 #[cfg(target_arch = "wasm32")]
 pub mod transport;
+
+#[cfg(target_arch = "wasm32")]
+pub mod input;

--- a/crates/web/tests/input.rs
+++ b/crates/web/tests/input.rs
@@ -1,0 +1,128 @@
+//! Headless tests for `AwaitingInputView` (P6.6): feed an `AwaitingInput`
+//! outcome through the store, assert the prompt + per-hand-card controls
+//! render, and that committing submits the matching `ResolveInput` frame.
+//! wasm32-only (browser DOM + the wasm-only transport types).
+#![cfg(target_arch = "wasm32")]
+
+use futures::channel::mpsc;
+use game_core::state::{CardCode, InvestigatorId};
+use game_core::test_support::builder::TestGame;
+use game_core::test_support::fixtures::{awaiting_commit_input, test_investigator};
+use game_core::{InputResponse, PlayerAction};
+use leptos::prelude::*;
+use protocol::{ClientMessage, ServerMessage};
+use wasm_bindgen::JsCast as _;
+use wasm_bindgen_test::*;
+use web::input::AwaitingInputView;
+use web::store::{reduce, ClientState};
+use web::transport::OutboundTx;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+/// A two-card hand for investigator 1, set active.
+fn two_card_game() -> game_core::state::GameState {
+    let mut inv = test_investigator(1);
+    inv.hand = vec![
+        CardCode::new("_synth_event_a"),
+        CardCode::new("_synth_event_b"),
+    ];
+    TestGame::new()
+        .with_investigator(inv)
+        .with_active_investigator(InvestigatorId(1))
+        .build()
+}
+
+/// Mount `AwaitingInputView` with a fresh store + outbound channel, feed
+/// one `Hello` carrying `state` and the commit prompt, tick, and return
+/// the receiver so the test can read submitted frames.
+async fn mount(state: game_core::state::GameState) -> mpsc::UnboundedReceiver<ClientMessage> {
+    let store = RwSignal::new(ClientState::default());
+    let (tx, rx) = mpsc::unbounded::<ClientMessage>();
+    let tx_for_mount: OutboundTx = tx;
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        provide_context::<OutboundTx>(tx_for_mount.clone());
+        leptos::view! { <AwaitingInputView/> }
+    });
+    store.update(|s| {
+        reduce(
+            s,
+            ServerMessage::Hello {
+                state: Box::new(state),
+                outcome: awaiting_commit_input("Commit cards for the skill test"),
+            },
+        );
+    });
+    leptos::task::tick().await;
+    rx
+}
+
+/// The last mounted `.awaiting-input` section (DOM accumulates across
+/// tests in one page — see board.rs).
+fn last_section() -> web_sys::Element {
+    let secs = leptos::prelude::document()
+        .query_selector_all(".awaiting-input")
+        .expect("query");
+    secs.item(secs.length() - 1)
+        .expect("at least one section")
+        .dyn_into::<web_sys::Element>()
+        .expect("Element")
+}
+
+fn click_in(section: &web_sys::Element, selector: &str, nth: u32) {
+    let els = section.query_selector_all(selector).expect("query");
+    els.item(nth)
+        .expect("element present")
+        .dyn_into::<web_sys::HtmlElement>()
+        .expect("HtmlElement")
+        .click();
+}
+
+fn commit_indices(frame: ClientMessage) -> Vec<u32> {
+    match frame {
+        ClientMessage::Submit {
+            action:
+                PlayerAction::ResolveInput {
+                    response: InputResponse::CommitCards { indices },
+                },
+        } => indices,
+        other @ ClientMessage::Submit { .. } => {
+            panic!("expected ResolveInput/CommitCards, got {other:?}")
+        }
+    }
+}
+
+#[wasm_bindgen_test]
+async fn renders_prompt_and_hand_cards() {
+    let _rx = mount(two_card_game()).await;
+    let section = last_section();
+    let html = section.inner_html();
+    assert!(
+        html.contains("Commit cards for the skill test"),
+        "prompt missing: {html}"
+    );
+    assert!(html.contains("_synth_event_a"), "card a missing: {html}");
+    assert!(html.contains("_synth_event_b"), "card b missing: {html}");
+}
+
+#[wasm_bindgen_test]
+async fn commit_with_no_selection_submits_empty() {
+    let mut rx = mount(two_card_game()).await;
+    let section = last_section();
+    click_in(&section, ".commit", 0);
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame in the channel");
+    assert_eq!(commit_indices(frame), Vec::<u32>::new());
+}
+
+#[wasm_bindgen_test]
+async fn commit_after_selecting_submits_that_index() {
+    let mut rx = mount(two_card_game()).await;
+    let section = last_section();
+    click_in(&section, ".hand-card", 0); // select index 0
+    leptos::task::tick().await;
+    click_in(&section, ".commit", 0);
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame in the channel");
+    assert_eq!(commit_indices(frame), vec![0]);
+}

--- a/crates/web/tests/input.rs
+++ b/crates/web/tests/input.rs
@@ -111,7 +111,9 @@ async fn commit_with_no_selection_submits_empty() {
     let section = last_section();
     click_in(&section, ".commit", 0);
     leptos::task::tick().await;
-    let frame = rx.try_recv().expect("a frame in the channel");
+    let frame = rx
+        .try_recv()
+        .expect("a frame after tick — did tick flush the click handler?");
     assert_eq!(commit_indices(frame), Vec::<u32>::new());
 }
 
@@ -123,6 +125,8 @@ async fn commit_after_selecting_submits_that_index() {
     leptos::task::tick().await;
     click_in(&section, ".commit", 0);
     leptos::task::tick().await;
-    let frame = rx.try_recv().expect("a frame in the channel");
+    let frame = rx
+        .try_recv()
+        .expect("a frame after tick — did tick flush the click handler?");
     assert_eq!(commit_indices(frame), vec![0]);
 }

--- a/docs/phases/phase-6-web-client-v0.md
+++ b/docs/phases/phase-6-web-client-v0.md
@@ -24,7 +24,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | P6.4a | [#199](https://github.com/talelburg/eldritch/issues/199) — restore trunk hot-reload dev loop | ✅ PR #200 |
 | P6.4b | [#198](https://github.com/talelburg/eldritch/issues/198) — WebSocket liveness (heartbeat + graceful shutdown) | ⏭️ deferred → Phase 8 (closed) |
 | P6.5 | [#186](https://github.com/talelburg/eldritch/issues/186) — board rendering (read-only) | ✅ PR #204 |
-| P6.6 | [#187](https://github.com/talelburg/eldritch/issues/187) — AwaitingInput resolution UI + legality gating | ⏳ open |
+| P6.6 | [#187](https://github.com/talelburg/eldritch/issues/187) — AwaitingInput resolution UI + legality gating | ✅ PR #207 |
 | P6.7a | [#188](https://github.com/talelburg/eldritch/issues/188) — core-loop action controls | ⏳ open |
 | P6.7b | [#189](https://github.com/talelburg/eldritch/issues/189) — combat/edge action controls | ⏳ open |
 | P6.8 | [#190](https://github.com/talelburg/eldritch/issues/190) — resolution surfacing + closing demo | ⏳ open |
@@ -40,7 +40,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | P6.4a | #199 hot-reload dev loop ✅ PR #200 | Restore hot-reload **before** the content-UI slots so P6.5+ iterate fast; moved the WS to a distinct `/ws/{id}` route so trunk can proxy REST + WS without colliding | P6.4 |
 | ~~P6.4b~~ | #198 WS liveness — **deferred to Phase 8** | Its triggering symptom is a WSL2 dev artifact, not a real-host bug; genuine liveness is Phase-8 production hardening. See *Decisions made* | — |
 | P6.5 | #186 board rendering ✅ PR #204 | See the state | P6.4 |
-| P6.6 | #187 AwaitingInput UI + legality | Core-loop: `Investigate` opens a skill-test commit window (`AwaitingInput`), so this precedes the action controls | P6.5 |
+| P6.6 | #187 AwaitingInput UI + legality ✅ PR #207 | Core-loop: `Investigate` opens a skill-test commit window (`AwaitingInput`), so this precedes the action controls | P6.5 |
 | P6.7a | #188 core-loop action controls | Toy scenario clickable to a **Won** resolution | P6.6 |
 | P6.7b | #189 combat/edge action controls | Rounds out the action surface (combat/Lost walk) | P6.7a |
 | P6.8 | #190 resolution + closing demo | Milestone close | all |
@@ -51,8 +51,9 @@ independent and can land any time before P6.4. P6.4a
 hot-reload) shipped before the content UI. P6.4b
 ([#198](https://github.com/talelburg/eldritch/issues/198), WS liveness)
 was **deferred to Phase 8 and closed** — see *Decisions made*. P6.5
-(#186, board rendering ✅ PR #204) shipped the read-only board, so the
-interaction layer (P6.6, `AwaitingInput` UI + legality gating) is next.
+(#186, board rendering ✅ PR #204) shipped the read-only board and P6.6
+(#187, `AwaitingInput` UI + legality ✅ PR #207) shipped the interaction
+plumbing, so the action controls (P6.7a, #188) are next.
 
 ## Decisions made
 
@@ -191,9 +192,34 @@ Settled implementing P6.5 (PR #204):
   then reports "failed to detect test as having been run." Load-bearing
   for every later interaction test (P6.6+).
 
+Settled implementing P6.6 (PR #207):
+
+- **`AwaitingInput` carries no machine-readable variant discriminator, so
+  the client renders `CommitCards` only.** `InputRequest` is the
+  "Phase-1 minimal shape" (a free-text `prompt` + opaque `ResumeToken`);
+  nothing tells the client which of the seven `InputResponse` variants a
+  prompt wants, and the toy scenario only ever emits the skill-test
+  commit prompt. Routing the other six off prompt-string heuristics would
+  be brittle and speculative. **So P6.7's action controls need not handle
+  any other input variant**; the structured discriminator (client renders
+  the right control for any variant) is [#205](https://github.com/talelburg/eldritch/issues/205)
+  (Phase 7, when real cards first emit `PickIndex`/`PickInvestigator`/…).
+- **Legality gating is coarse and keys off the *outcome*, not engine
+  preconditions.** `web::legality::enabled_controls` gates on the
+  `AwaitingInput` pause, the `mulligan_pending`/`mythos_draw_pending`
+  cursors, and the phase — it does **not** mirror resources, action
+  budget, or clue presence (the server stays authoritative and rejects
+  illegal actions). **P6.7 binds its buttons' `disabled` to this set** as
+  a UX affordance, not a correctness gate. Because the pause keys off the
+  `AwaitingInput` outcome, it covers every engine suspension mode (not
+  just the commit window). Richer "show the player exactly what's legal"
+  affordances are [#206](https://github.com/talelburg/eldritch/issues/206)
+  (Phase 8).
+
 ## Open questions
 
-None blocking. Per-PR detail: the precise legality-gating surface (P6.6).
+None. The legality-gating surface is settled (P6.6, ✅ PR #207) — see
+*Decisions made*.
 
 ## Dependencies
 

--- a/docs/superpowers/plans/2026-06-09-p6.6-awaitinginput-ui.md
+++ b/docs/superpowers/plans/2026-06-09-p6.6-awaitinginput-ui.md
@@ -1,0 +1,698 @@
+# P6.6 — `AwaitingInput` resolution UI + legality gating — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the engine's `AwaitingInput` skill-test commit window in the web client, let the player submit a `CommitCards` response, and add a pure helper for which core-loop action controls are enabled in a given state.
+
+**Architecture:** Two new `crates/web/src` modules — a pure `legality` helper (native-unit-tested, like `store::reduce`) and a wasm-only `input` Leptos component (`AwaitingInputView`, headless-tested like `board`). A small public `test_support` fixture in `game-core` lets the wasm crate construct an `AwaitingInput` outcome (its `ResumeToken`/`InputRequest` are not externally constructible).
+
+**Tech Stack:** Rust, Leptos 0.8 (CSR), `wasm-bindgen-test` (headless Firefox), `futures::channel::mpsc` for the submit seam.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-p6.6-awaitinginput-ui-design.md`. Closes #187.
+
+---
+
+## File structure
+
+- **Create** `crates/game-core/src/test_support/fixtures.rs` — *modify*: add `awaiting_commit_input` fixture + export.
+- **Create** `crates/web/src/legality.rs` — `ActionControl` enum + `enabled_controls` (pure, native tests).
+- **Create** `crates/web/src/input.rs` — `AwaitingInputView` component (wasm-only).
+- **Create** `crates/web/tests/input.rs` — headless render + submit tests.
+- **Modify** `crates/web/src/lib.rs` — declare the two new modules.
+- **Modify** `crates/web/src/app.rs` — mount `<AwaitingInputView/>`.
+- **Modify** `crates/web/Cargo.toml` — add `HtmlElement` to dev `web-sys` features.
+
+---
+
+## Task 1: `game-core` test-support fixture for an `AwaitingInput` outcome
+
+`web` is an external crate; it cannot build `EngineOutcome::AwaitingInput` (the `ResumeToken` field is `pub(crate)`, `InputRequest` is `#[non_exhaustive]`). Add an in-crate fixture so client tests can feed one. `game_core::test_support` is unconditionally `pub` for exactly this.
+
+**Files:**
+- Modify: `crates/game-core/src/test_support/fixtures.rs`
+- Modify: `crates/game-core/src/test_support/mod.rs:13` (the `pub use fixtures::{…}` line)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `crates/game-core/src/test_support/fixtures.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::awaiting_commit_input;
+    use crate::EngineOutcome;
+
+    #[test]
+    fn awaiting_commit_input_carries_the_prompt() {
+        let outcome = awaiting_commit_input("Commit cards for the test");
+        match outcome {
+            EngineOutcome::AwaitingInput { request, .. } => {
+                assert_eq!(request.prompt, "Commit cards for the test");
+            }
+            other => panic!("expected AwaitingInput, got {other:?}"),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p game-core awaiting_commit_input_carries_the_prompt`
+Expected: FAIL — `cannot find function awaiting_commit_input`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to the top of `crates/game-core/src/test_support/fixtures.rs` (after the existing `use` lines) and a new fn (place it above the `#[cfg(test)]` block):
+
+```rust
+use crate::engine::{EngineOutcome, InputRequest, ResumeToken};
+
+/// A sample skill-test commit [`AwaitingInput`](EngineOutcome::AwaitingInput)
+/// outcome, for client/UI fixtures. This is the only `AwaitingInput`
+/// shape the engine emits today (the skill-test commit window). The
+/// `ResumeToken` value is irrelevant to rendering — routing keys off
+/// `state.in_flight_skill_test`, not the token.
+#[must_use]
+pub fn awaiting_commit_input(prompt: impl Into<String>) -> EngineOutcome {
+    EngineOutcome::AwaitingInput {
+        request: InputRequest {
+            prompt: prompt.into(),
+        },
+        resume_token: ResumeToken(0),
+    }
+}
+```
+
+Then add `awaiting_commit_input` to the re-export in `crates/game-core/src/test_support/mod.rs`:
+
+```rust
+pub use fixtures::{awaiting_commit_input, test_enemy, test_investigator, test_location};
+```
+
+Note: if `EngineOutcome` / `InputRequest` / `ResumeToken` are exported from a different path (`crate::engine` vs `crate::engine::outcome`), match the path the resolver uses — see `crates/game-core/src/test_support/resolver.rs:48` (`use crate::engine::{apply, ApplyResult, EngineOutcome, InputRequest};`) and `:392` (`use crate::engine::{InputRequest, ResumeToken};`). Use `crate::engine::{EngineOutcome, InputRequest, ResumeToken}`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p game-core awaiting_commit_input_carries_the_prompt`
+Expected: PASS.
+
+- [ ] **Step 5: Run the strict gauntlet for game-core**
+
+Run: `RUSTFLAGS="-D warnings" cargo test -p game-core` then `cargo clippy -p game-core --all-targets --all-features -- -D warnings`
+Expected: both green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/game-core/src/test_support/fixtures.rs crates/game-core/src/test_support/mod.rs
+git commit -m "test: game-core fixture for an AwaitingInput commit outcome
+
+The web crate cannot construct EngineOutcome::AwaitingInput (pub(crate)
+ResumeToken, non_exhaustive InputRequest). Add a public test_support
+fixture so client render/legality tests can feed one.
+
+Refs #187.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: pure `legality` helper
+
+**Files:**
+- Create: `crates/web/src/legality.rs`
+- Modify: `crates/web/src/lib.rs` (add `pub mod legality;`)
+
+- [ ] **Step 1: Declare the module**
+
+Add to `crates/web/src/lib.rs` after `pub mod board;`:
+
+```rust
+pub mod legality;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `crates/web/src/legality.rs`:
+
+```rust
+//! Which core-loop action controls are enabled, given the current state
+//! and the latest engine outcome (P6.6). A pure UX affordance: the
+//! server stays authoritative and rejects anything illegal (see the P6.6
+//! design spec, decision S2). Consumed by P6.7's action buttons.
+
+use std::collections::BTreeSet;
+
+use game_core::state::{GameState, Phase};
+use game_core::EngineOutcome;
+
+/// A clickable core-loop action in the client. Combat controls
+/// (`Fight`/`Evade`/`Draw`) join in P6.7b.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ActionControl {
+    Move,
+    Investigate,
+    PlayCard,
+    EndTurn,
+    Mulligan,
+    DrawEncounter,
+    AdvanceAct,
+}
+
+/// The controls the player may click right now.
+///
+/// Gating, in order:
+/// 1. An `AwaitingInput` pause blocks every core-loop action — only the
+///    pending `ResolveInput` (the prompt UI) is legal.
+/// 2. The setup cursors dominate their windows: `mulligan_pending` ⇒ only
+///    `Mulligan`; `mythos_draw_pending` ⇒ only `DrawEncounter`. These are
+///    state facts, not phase, so they're checked before the phase table.
+/// 3. Otherwise, the controls the current `Phase` permits.
+///
+/// Finer checks (resources, action budget, clue presence) are
+/// deliberately not mirrored — the server's `Rejected` is the truth.
+#[must_use]
+pub fn enabled_controls(game: &GameState, outcome: &EngineOutcome) -> BTreeSet<ActionControl> {
+    use ActionControl::*;
+
+    if matches!(outcome, EngineOutcome::AwaitingInput { .. }) {
+        return BTreeSet::new();
+    }
+    if game.mulligan_pending.is_some() {
+        return BTreeSet::from([Mulligan]);
+    }
+    if game.mythos_draw_pending.is_some() {
+        return BTreeSet::from([DrawEncounter]);
+    }
+    match game.phase {
+        Phase::Investigation => {
+            BTreeSet::from([Move, Investigate, PlayCard, EndTurn, AdvanceAct])
+        }
+        Phase::Mythos | Phase::Enemy | Phase::Upkeep => BTreeSet::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ActionControl::*;
+    use super::{enabled_controls, ActionControl};
+    use game_core::state::{InvestigatorId, Phase};
+    use game_core::test_support::builder::TestGame;
+    use game_core::test_support::fixtures::{awaiting_commit_input, test_investigator};
+    use game_core::EngineOutcome;
+    use std::collections::BTreeSet;
+
+    fn investigation_game() -> game_core::state::GameState {
+        TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_active_investigator(InvestigatorId(1))
+            .with_phase(Phase::Investigation)
+            .build()
+    }
+
+    #[test]
+    fn awaiting_input_disables_everything() {
+        let game = investigation_game();
+        let out = awaiting_commit_input("commit");
+        assert_eq!(enabled_controls(&game, &out), BTreeSet::new());
+    }
+
+    #[test]
+    fn mulligan_pending_enables_only_mulligan() {
+        let mut game = investigation_game();
+        game.mulligan_pending = Some(InvestigatorId(1));
+        assert_eq!(
+            enabled_controls(&game, &EngineOutcome::Done),
+            BTreeSet::from([ActionControl::Mulligan])
+        );
+    }
+
+    #[test]
+    fn mythos_draw_pending_enables_only_draw_encounter() {
+        let mut game = investigation_game();
+        game.phase = Phase::Mythos;
+        game.mythos_draw_pending = Some(InvestigatorId(1));
+        assert_eq!(
+            enabled_controls(&game, &EngineOutcome::Done),
+            BTreeSet::from([ActionControl::DrawEncounter])
+        );
+    }
+
+    #[test]
+    fn investigation_phase_enables_the_core_loop() {
+        let game = investigation_game();
+        assert_eq!(
+            enabled_controls(&game, &EngineOutcome::Done),
+            BTreeSet::from([Move, Investigate, PlayCard, EndTurn, AdvanceAct])
+        );
+    }
+
+    #[test]
+    fn non_investigation_phases_enable_nothing() {
+        for phase in [Phase::Mythos, Phase::Enemy, Phase::Upkeep] {
+            let mut game = investigation_game();
+            game.phase = phase;
+            assert_eq!(
+                enabled_controls(&game, &EngineOutcome::Done),
+                BTreeSet::new(),
+                "phase {phase:?} should enable nothing"
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test -p web legality`
+Expected: FAIL to compile first run only if the module wasn't declared; once declared, the tests compile and PASS (this is a pure function with the impl already written above). If you prefer strict red-green, delete the `match`/early-returns body to a `BTreeSet::new()` stub, watch failures, then restore.
+Expected after restore: PASS.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p web legality`
+Expected: 5 tests PASS.
+
+- [ ] **Step 5: Lint (host clippy)**
+
+Run: `cargo clippy -p web --all-targets --all-features -- -D warnings`
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/web/src/legality.rs crates/web/src/lib.rs
+git commit -m "ui: pure legality helper for core-loop controls (P6.6)
+
+enabled_controls(state, outcome): AwaitingInput pauses everything;
+mulligan/mythos-draw cursors gate their setup windows; otherwise the
+Investigation phase enables the core loop. Coarse by design — the server
+stays authoritative (spec S2). Consumed by P6.7's buttons.
+
+Refs #187.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `AwaitingInputView` component + headless tests
+
+**Files:**
+- Create: `crates/web/src/input.rs`
+- Create: `crates/web/tests/input.rs`
+- Modify: `crates/web/src/lib.rs` (gated `pub mod input;`)
+- Modify: `crates/web/Cargo.toml` (dev `web-sys` features)
+
+- [ ] **Step 1: Declare the module and add the dev dep feature**
+
+In `crates/web/src/lib.rs`, add under the existing wasm-only block:
+
+```rust
+#[cfg(target_arch = "wasm32")]
+pub mod input;
+```
+
+In `crates/web/Cargo.toml`, extend the dev `web-sys` features to include `HtmlElement` (needed to call `.click()` in tests):
+
+```toml
+web-sys = { version = "0.3", features = ["Element", "NodeList", "HtmlElement"] }
+```
+
+- [ ] **Step 2: Write the failing headless tests**
+
+Create `crates/web/tests/input.rs`:
+
+```rust
+//! Headless tests for `AwaitingInputView` (P6.6): feed an `AwaitingInput`
+//! outcome through the store, assert the prompt + per-hand-card controls
+//! render, and that committing submits the matching `ResolveInput` frame.
+//! wasm32-only (browser DOM + the wasm-only transport types).
+#![cfg(target_arch = "wasm32")]
+
+use futures::channel::mpsc;
+use game_core::state::{CardCode, InvestigatorId};
+use game_core::test_support::builder::TestGame;
+use game_core::test_support::fixtures::{awaiting_commit_input, test_investigator};
+use game_core::{InputResponse, PlayerAction};
+use leptos::prelude::*;
+use protocol::{ClientMessage, ServerMessage};
+use wasm_bindgen::JsCast as _;
+use wasm_bindgen_test::*;
+use web::input::AwaitingInputView;
+use web::store::{reduce, ClientState};
+use web::transport::OutboundTx;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+/// A two-card hand for investigator 1, set active.
+fn two_card_game() -> game_core::state::GameState {
+    let mut inv = test_investigator(1);
+    inv.hand = vec![CardCode::new("_synth_event_a"), CardCode::new("_synth_event_b")];
+    TestGame::new()
+        .with_investigator(inv)
+        .with_active_investigator(InvestigatorId(1))
+        .build()
+}
+
+/// Mount `AwaitingInputView` with a fresh store + outbound channel, feed
+/// one `Hello` carrying `state` and the commit prompt, tick, and return
+/// the receiver so the test can read submitted frames.
+async fn mount(
+    state: game_core::state::GameState,
+) -> mpsc::UnboundedReceiver<ClientMessage> {
+    let store = RwSignal::new(ClientState::default());
+    let (tx, rx) = mpsc::unbounded::<ClientMessage>();
+    let tx_for_mount: OutboundTx = tx;
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        provide_context::<OutboundTx>(tx_for_mount.clone());
+        leptos::view! { <AwaitingInputView/> }
+    });
+    store.update(|s| {
+        reduce(
+            s,
+            ServerMessage::Hello {
+                state: Box::new(state),
+                outcome: awaiting_commit_input("Commit cards for the skill test"),
+            },
+        );
+    });
+    leptos::task::tick().await;
+    rx
+}
+
+/// The last mounted `.awaiting-input` section (DOM accumulates across
+/// tests in one page — see board.rs).
+fn last_section() -> web_sys::Element {
+    let secs = leptos::prelude::document()
+        .query_selector_all(".awaiting-input")
+        .expect("query");
+    secs.item(secs.length() - 1)
+        .expect("at least one section")
+        .dyn_into::<web_sys::Element>()
+        .expect("Element")
+}
+
+fn click_in(section: &web_sys::Element, selector: &str, nth: u32) {
+    let els = section.query_selector_all(selector).expect("query");
+    els.item(nth)
+        .expect("element present")
+        .dyn_into::<web_sys::HtmlElement>()
+        .expect("HtmlElement")
+        .click();
+}
+
+fn commit_indices(frame: ClientMessage) -> Vec<u32> {
+    match frame {
+        ClientMessage::Submit {
+            action: PlayerAction::ResolveInput { response: InputResponse::CommitCards { indices } },
+        } => indices,
+        other => panic!("expected ResolveInput/CommitCards, got {other:?}"),
+    }
+}
+
+#[wasm_bindgen_test]
+async fn renders_prompt_and_hand_cards() {
+    let _rx = mount(two_card_game()).await;
+    let section = last_section();
+    let html = section.inner_html();
+    assert!(html.contains("Commit cards for the skill test"), "prompt missing: {html}");
+    assert!(html.contains("_synth_event_a"), "card a missing: {html}");
+    assert!(html.contains("_synth_event_b"), "card b missing: {html}");
+}
+
+#[wasm_bindgen_test]
+async fn commit_with_no_selection_submits_empty() {
+    let mut rx = mount(two_card_game()).await;
+    let section = last_section();
+    click_in(&section, ".commit", 0);
+    leptos::task::tick().await;
+    let frame = rx.try_next().expect("a frame").expect("not closed");
+    assert_eq!(commit_indices(frame), Vec::<u32>::new());
+}
+
+#[wasm_bindgen_test]
+async fn commit_after_selecting_submits_that_index() {
+    let mut rx = mount(two_card_game()).await;
+    let section = last_section();
+    click_in(&section, ".hand-card", 0); // select index 0
+    leptos::task::tick().await;
+    click_in(&section, ".commit", 0);
+    leptos::task::tick().await;
+    let frame = rx.try_next().expect("a frame").expect("not closed");
+    assert_eq!(commit_indices(frame), vec![0]);
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `wasm-pack test --headless --firefox crates/web`
+Expected: FAIL — `web::input::AwaitingInputView` unresolved (component not written yet).
+
+- [ ] **Step 4: Write the component**
+
+Create `crates/web/src/input.rs`:
+
+```rust
+//! `AwaitingInput` resolution UI (P6.6, wasm-only). Renders the engine's
+//! pending prompt and a control to resolve it. Phase-6 scope is the
+//! skill-test commit window (`CommitCards`); other `InputResponse`
+//! variants are deferred (spec S1, follow-up #205). Nothing renders when
+//! the latest outcome is not `AwaitingInput`.
+
+use std::collections::BTreeSet;
+
+use game_core::state::GameState;
+use game_core::{EngineOutcome, InputResponse, PlayerAction};
+use leptos::prelude::*;
+use protocol::ClientMessage;
+
+use crate::store::use_store;
+use crate::transport::OutboundTx;
+
+/// Pending-input prompt + commit control. Reads the store reactively;
+/// submits via the `OutboundTx` provided by the transport (absent in
+/// render-only contexts, so read as `Option`).
+#[component]
+pub fn AwaitingInputView() -> impl IntoView {
+    let store = use_store();
+    let tx = use_context::<OutboundTx>();
+    // One prompt is live at a time in solo, so a single component-lived
+    // selection signal suffices.
+    let selected = RwSignal::new(BTreeSet::<u32>::new());
+
+    move || {
+        let state = store.get();
+        let (Some(EngineOutcome::AwaitingInput { request, .. }), Some(game)) =
+            (state.outcome.clone(), state.game.clone())
+        else {
+            return ().into_any();
+        };
+
+        let cards: Vec<_> = active_hand(&game)
+            .into_iter()
+            .enumerate()
+            .map(|(idx, code)| {
+                let i = idx as u32;
+                view! {
+                    <li>
+                        <button
+                            class="hand-card"
+                            class:selected=move || selected.get().contains(&i)
+                            on:click=move |_| selected.update(|s| {
+                                if !s.remove(&i) {
+                                    s.insert(i);
+                                }
+                            })
+                        >
+                            {code}
+                        </button>
+                    </li>
+                }
+            })
+            .collect();
+
+        let tx = tx.clone();
+        let on_commit = move |_| {
+            let indices: Vec<u32> = selected.get().into_iter().collect();
+            if let Some(tx) = tx.clone() {
+                let _ = tx.unbounded_send(ClientMessage::Submit {
+                    action: PlayerAction::ResolveInput {
+                        response: InputResponse::CommitCards { indices },
+                    },
+                });
+            }
+            selected.set(BTreeSet::new());
+        };
+
+        view! {
+            <section class="awaiting-input">
+                <p class="prompt">{request.prompt}</p>
+                <ul class="commit-hand">{cards}</ul>
+                <button class="commit" on:click=on_commit>"Commit"</button>
+            </section>
+        }
+        .into_any()
+    }
+}
+
+/// The active investigator's hand as card-code strings (empty when there
+/// is no active investigator).
+fn active_hand(game: &GameState) -> Vec<String> {
+    game.active_investigator
+        .and_then(|id| game.investigators.get(&id))
+        .map(|inv| inv.hand.iter().map(ToString::to_string).collect())
+        .unwrap_or_default()
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `wasm-pack test --headless --firefox crates/web`
+Expected: the three `input` tests PASS (plus existing board/store/smoke tests).
+
+- [ ] **Step 6: Lint wasm-only code**
+
+Run: `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`
+Expected: green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/web/src/input.rs crates/web/tests/input.rs crates/web/src/lib.rs crates/web/Cargo.toml
+git commit -m "ui: AwaitingInput commit-window UI (P6.6)
+
+AwaitingInputView renders the engine's pending prompt and a per-hand-card
+commit control; committing submits ResolveInput::CommitCards via the
+transport's OutboundTx. Scope is CommitCards only (spec S1); richer
+variants are follow-up #205. Headless tests cover render + the empty and
+selected commit frames.
+
+Refs #187.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: mount the component in `App`
+
+**Files:**
+- Modify: `crates/web/src/app.rs`
+
+- [ ] **Step 1: Add the component to the view**
+
+In `crates/web/src/app.rs`, change the wasm-only render block so the prompt UI renders alongside the existing debug button. Replace:
+
+```rust
+            {
+                #[cfg(target_arch = "wasm32")]
+                { view! { <DebugSubmit/> }.into_any() }
+                #[cfg(not(target_arch = "wasm32"))]
+                { ().into_any() }
+            }
+```
+
+with:
+
+```rust
+            {
+                #[cfg(target_arch = "wasm32")]
+                { view! { <crate::input::AwaitingInputView/><DebugSubmit/> }.into_any() }
+                #[cfg(not(target_arch = "wasm32"))]
+                { ().into_any() }
+            }
+```
+
+(`DebugSubmit` stays until P6.7 replaces it — spec wiring note.)
+
+- [ ] **Step 2: Verify the wasm build compiles**
+
+Run: `cargo build -p web --target wasm32-unknown-unknown`
+Expected: success.
+
+- [ ] **Step 3: Lint wasm code**
+
+Run: `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`
+Expected: green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/web/src/app.rs
+git commit -m "ui: mount AwaitingInputView in App (P6.6)
+
+Refs #187.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: full CI gauntlet, phase-doc update, PR
+
+**Files:**
+- Modify: `docs/phases/phase-6-web-client-v0.md`
+
+- [ ] **Step 1: Run the full gauntlet locally**
+
+Run, expecting all green:
+
+```sh
+RUSTFLAGS="-D warnings"     cargo test --all --all-features
+                            cargo clippy --all-targets --all-features -- -D warnings
+                            cargo fmt --check
+RUSTDOCFLAGS="-D warnings"  cargo doc --workspace --no-deps --all-features
+                            cargo build -p web --target wasm32-unknown-unknown
+                            wasm-pack test --headless --firefox crates/web
+                            cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+
+- [ ] **Step 2: Push the branch and open the PR**
+
+```bash
+git push -u origin ui/awaiting-input-ui
+gh pr create --fill
+```
+
+Use the repo PR template; the body's `Closes #187` auto-closes the issue. Include a one-paragraph design note: CommitCards-only scope (S1, follow-up #205), coarse legality (S2, follow-up #206), the game-core test_support fixture for `AwaitingInput`.
+
+- [ ] **Step 3: Watch CI**
+
+Run: `gh pr checks <PR#> --watch`
+Fix any failures with follow-up commits to the same branch.
+
+- [ ] **Step 4: Update the phase doc (final commit, only once CI is green)**
+
+In `docs/phases/phase-6-web-client-v0.md`:
+- Issues table: flip the P6.6 row (#187) to `✅ PR #<PR#>`.
+- Ordering table + prose: mark P6.6 done; note P6.7 (#187→#188) is next.
+- Add a **Decisions made** entry only if load-bearing for a future PR — candidate: the `AwaitingInput`/`InputRequest` "no structured discriminator" finding and the CommitCards-only scope + follow-up #205 (so P6.7/Phase-7 authors don't re-derive it). Apply the test in `docs/phases/README.md`; lean toward skipping if a grep would reveal it.
+- Resolve the Open question "the precise legality-gating surface (P6.6)" — replace with the settled coarse pause+phase+cursor shape (or drop it).
+
+```bash
+git add docs/phases/phase-6-web-client-v0.md
+git commit -m "docs: mark P6.6 done in phase-6 doc
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+git push
+```
+
+- [ ] **Step 5: Merge after explicit user approval**
+
+```bash
+gh pr merge <PR#> --squash --delete-branch
+```
+
+Confirm #187 auto-closed and `git pull` on `main`.
+
+---
+
+## Self-review
+
+- **Spec coverage:** S1 (CommitCards-only render) → Task 3. S2 (coarse legality) → Task 2. `legality.rs` + `input.rs` modules → Tasks 2/3. Headless render + submit + empty-commit tests → Task 3. Native legality tests → Task 2. Follow-ups #205/#206 already filed; referenced in the PR note (Task 5). Wiring → Task 4. The `AwaitingInput`-construction blocker → Task 1.
+- **Placeholders:** none — every code/command step is concrete.
+- **Type consistency:** `awaiting_commit_input` (Task 1) is used in Tasks 2 & 3. `OutboundTx` (`mpsc::UnboundedSender<ClientMessage>`) provided in the test (Task 3) matches `use_context::<OutboundTx>()` in the component. `ActionControl` enum identical across def and tests. `enabled_controls(&GameState, &EngineOutcome) -> BTreeSet<ActionControl>` signature consistent. `commit_indices`/`CommitCards { indices: Vec<u32> }` match the engine's `InputResponse::CommitCards`.
+- **Open risk to watch during execution:** Leptos 0.8 may want the component to return a fragment rather than a bare closure — if `move || … into_any()` doesn't satisfy `IntoView`, wrap as `view! { {move || …} }`. And confirm `CardCode::new` exists (used in `board.rs` tests, so it does).

--- a/docs/superpowers/specs/2026-06-09-p6.6-awaitinginput-ui-design.md
+++ b/docs/superpowers/specs/2026-06-09-p6.6-awaitinginput-ui-design.md
@@ -122,18 +122,20 @@ unit-tested natively.
   each representative `Phase` ⇒ its expected control set.
 - Full CI gauntlet green (including `wasm-test` and `wasm-clippy`).
 
-## Follow-ups (file as issues)
+## Follow-ups (filed)
 
-- **Structured input discrimination** — extend `InputRequest` with a
-  machine-readable kind so the client deterministically renders the right
-  control for every `InputResponse` variant (replacing S1's
-  `CommitCards`-only scope). Scope: **Phase 7** — The Gathering's real
+- **Structured input discrimination**
+  ([#205](https://github.com/talelburg/eldritch/issues/205), Phase 7) —
+  extend `InputRequest` with a machine-readable kind so the client
+  deterministically renders the right control for every `InputResponse`
+  variant (replacing S1's `CommitCards`-only scope). The Gathering's real
   cards are the first to emit non-`CommitCards` prompts
   (`PickIndex`/`PickInvestigator`/`Confirm`/`Skip`).
-- **Intuitive legality affordances** — richer client-side surfacing of
-  what the player can do (beyond coarse phase gating), so the UI guides
-  rather than relying on server `Rejected`. Scope: **Phase 8** — when
-  real players use the client.
+- **Intuitive legality affordances**
+  ([#206](https://github.com/talelburg/eldritch/issues/206), Phase 8) —
+  richer client-side surfacing of what the player can do (beyond coarse
+  phase gating), so the UI guides rather than relying on server
+  `Rejected`. For when real players use the client.
 
 ## Dependencies
 

--- a/docs/superpowers/specs/2026-06-09-p6.6-awaitinginput-ui-design.md
+++ b/docs/superpowers/specs/2026-06-09-p6.6-awaitinginput-ui-design.md
@@ -1,0 +1,152 @@
+# P6.6 — `AwaitingInput` resolution UI + legality gating
+
+**Phase 6, slot P6.6.** Issue [#187](https://github.com/talelburg/eldritch/issues/187).
+Parent design: [`2026-06-08-phase-6-web-client-v0-design.md`](2026-06-08-phase-6-web-client-v0-design.md)
+(client layer 3: "interaction plumbing").
+
+## Goal
+
+The client renders the engine's `AwaitingInput` pause and lets the
+player resolve it, and exposes a pure helper for which core-loop action
+controls are enabled in a given state. This is the interaction
+foundation P6.7's action buttons build on.
+
+The one `AwaitingInput` site that fires in the Phase-6 toy scenario is
+the **skill-test commit window**: `Investigate` (and every other skill
+test) suspends the engine with
+`EngineOutcome::AwaitingInput { request, resume_token }`, expecting a
+`PlayerAction::ResolveInput { response: InputResponse::CommitCards { indices } }`.
+
+## Scope decisions (settled in the 2026-06-09 brainstorm)
+
+### S1 — Response control: `CommitCards` only
+
+`InputResponse` has seven variants (`Confirm`, `Skip`, `PickIndex`,
+`PickInvestigator`, `PickLocation`, `CommitCards`, `DiscardCards`), but
+the toy scenario only ever emits the commit-cards prompt. The engine's
+`InputRequest` is the documented "Phase-1 minimal shape" — a free-text
+`prompt: String` and an opaque `ResumeToken`, with **no machine-readable
+discriminator** of which variant a given prompt expects. Inferring the
+control from the prompt string would be brittle string-matching, and
+building the other five controls would be speculative (no emitting code
+path this phase).
+
+So P6.6 builds exactly the `CommitCards` control. The general case — a
+structured discriminator on `InputRequest` so the client can render the
+right control for any variant — is deferred to a follow-up (see
+*Follow-ups*).
+
+### S2 — Legality helper: coarse (pause + phase gating)
+
+The server is authoritative and rejects illegal actions (D1), so the
+client helper is a **UX affordance**, not a re-implementation of engine
+rules. It gates on two drift-free facts:
+
+1. **Pause** — when the latest outcome is `AwaitingInput`, no core-loop
+   action is legal; only `ResolveInput` (the prompt UI) is.
+2. **Phase** — otherwise, which controls a given `Phase` permits.
+
+Fine-grained checks (resources, action budget, clue presence,
+engagement) are deliberately **not** mirrored — the server's `Rejected`
+remains the source of truth. Richer "show the player exactly what's
+legal" affordances are deferred to a follow-up (see *Follow-ups*).
+
+## Components
+
+Two new modules in `crates/web/src/`.
+
+### `legality.rs` — pure, native-unit-tested
+
+Follows the `store::reduce` pattern: a plain function, no DOM, no wasm,
+unit-tested with ordinary `#[cfg(test)]`.
+
+```rust
+pub enum ActionControl {
+    Move, Investigate, PlayCard, EndTurn, Mulligan, DrawEncounter, AdvanceAct,
+}
+
+/// Which core-loop controls are enabled, given the current state and the
+/// latest engine outcome. A UX affordance — the server stays authoritative.
+pub fn enabled_controls(game: &GameState, outcome: &EngineOutcome) -> BTreeSet<ActionControl>;
+```
+
+- `outcome` is `AwaitingInput` ⇒ empty set (the pause).
+- Otherwise map `game.phase` → the controls that phase permits, validated
+  against the toy scenario's walk.
+
+The enum carries the full core-loop set so P6.7a wires buttons without
+extending it; P6.7b adds combat controls (`Fight`/`Evade`/`Draw`) when
+it lands. P6.7 binds each button's `disabled` to membership in the
+returned set.
+
+### `input.rs` — `AwaitingInputView` Leptos component
+
+- Reads the store; renders only when the outcome is
+  `AwaitingInput { request, .. }`.
+- Shows `request.prompt`, then a `CommitCards` control: a checkbox per
+  card in the **active investigator's hand** (`game.active_investigator`;
+  in solo this is the tester), plus a **Commit** button. An empty
+  selection is legal ("commit no cards").
+- On Commit: sends
+  `ClientMessage::Submit { action: ResolveInput { response: CommitCards { indices } } }`
+  via the `OutboundTx` already provided in context by `transport::start`
+  (the same send seam `DebugSubmit` uses). Read as `Option` so a mount
+  without a transport (a render-only test) does not panic.
+
+### Wiring
+
+`app.rs` mounts `<AwaitingInputView/>` beneath `<BoardView/>`. The
+`DebugSubmit` button stays until P6.7 replaces it with real controls.
+
+## Data flow
+
+`Investigate` → server emits `AwaitingInput` → `Applied`/`Hello` carries
+the outcome → `reduce` stores it → `AwaitingInputView` renders the prompt
+and commit control → user selects indices and commits → `ResolveInput`
+frame → server resolves the test → next `Applied`.
+
+## Testing
+
+The verification gate is headless `wasm-bindgen-test` (D4); pure logic is
+unit-tested natively.
+
+- **`crates/web/tests/input.rs`** (headless wasm, the `tests/board.rs`
+  pattern):
+  - Feeding an `AwaitingInput` outcome renders `request.prompt` and a
+    checkbox per hand card.
+  - With a test `OutboundTx` in context: selecting a card and clicking
+    Commit submits exactly
+    `ResolveInput { response: CommitCards { indices: [..] } }` on the rx.
+  - Clicking Commit with nothing selected submits `indices: []`.
+- **`legality.rs` `#[cfg(test)]`** (native): `AwaitingInput` ⇒ empty set;
+  each representative `Phase` ⇒ its expected control set.
+- Full CI gauntlet green (including `wasm-test` and `wasm-clippy`).
+
+## Follow-ups (file as issues)
+
+- **Structured input discrimination** — extend `InputRequest` with a
+  machine-readable kind so the client deterministically renders the right
+  control for every `InputResponse` variant (replacing S1's
+  `CommitCards`-only scope). Scope: **Phase 7** — The Gathering's real
+  cards are the first to emit non-`CommitCards` prompts
+  (`PickIndex`/`PickInvestigator`/`Confirm`/`Skip`).
+- **Intuitive legality affordances** — richer client-side surfacing of
+  what the player can do (beyond coarse phase gating), so the UI guides
+  rather than relying on server `Rejected`. Scope: **Phase 8** — when
+  real players use the client.
+
+## Dependencies
+
+P6.5 (read-only board) — the store, `BoardView`, and the headless test
+harness this builds on.
+
+## What "done" looks like
+
+- The skill-test commit window renders in the browser: prompt text plus a
+  per-hand-card commit control.
+- Committing (including the empty commit) submits the matching
+  `ResolveInput` frame; the engine resolves the test and the board
+  updates.
+- The legality helper is unit-tested against the toy scenario's phases
+  and the `AwaitingInput` pause.
+- All seven CI jobs green.


### PR DESCRIPTION
## Summary

Renders the engine's `AwaitingInput` skill-test commit window in the web client and lets the player submit a `CommitCards` response, plus a pure helper for which core-loop action controls are enabled in a given state. Phase 6, slot P6.6.

## What changed

- **`game-core`** — public `test_support` fixture `awaiting_commit_input(prompt)` so the external `web` crate can construct an `AwaitingInput` outcome (its `ResumeToken` is `pub(crate)`, `InputRequest` is `#[non_exhaustive]`).
- **`crates/web/src/legality.rs`** — pure `enabled_controls(&GameState, &EngineOutcome) -> BTreeSet<ActionControl>`. Native unit-tested; consumed by P6.7's buttons.
- **`crates/web/src/input.rs`** — `AwaitingInputView` (wasm-only): renders `request.prompt` + a per-hand-card toggle for the active investigator, and submits `ResolveInput::CommitCards { indices }` via the transport's `OutboundTx`. Mounted in `App` alongside the existing `DebugSubmit`.
- Headless tests (`crates/web/tests/input.rs`): render + empty-commit + selected-commit frames.

## Design decisions

- **CommitCards-only response control (spec S1).** The engine's `InputRequest` is the "Phase-1 minimal shape" (a free-text `prompt`, opaque `ResumeToken`) with no machine-readable discriminator of which `InputResponse` variant a prompt wants, and the toy scenario only ever emits the skill-test commit prompt. Rendering the other six variants off prompt-string heuristics would be brittle and speculative. A structured discriminator (client renders the right control for any variant) is deferred to **#205** (Phase 7).
- **Coarse legality (spec S2).** `enabled_controls` gates on the `AwaitingInput` pause, the `mulligan_pending`/`mythos_draw_pending` setup cursors, and the phase — it does **not** mirror engine preconditions (resources, action budget, clue presence). The server stays authoritative and rejects illegal actions. Richer "show the player what's legal" affordances are deferred to **#206** (Phase 8).
- The legality pause keys off the `AwaitingInput` *outcome*, so it covers every engine suspension mode (reaction windows, hunter moves, hand-size discard, the commit window), not just the commit prompt.

Full design: `docs/superpowers/specs/2026-06-08-phase-6-web-client-v0-design.md` + `docs/superpowers/specs/2026-06-09-p6.6-awaitinginput-ui-design.md`.

## Test notes

All seven CI jobs pass locally (fmt, test, clippy, doc, wasm-build, wasm-test, wasm-clippy). New coverage: 5 native legality cases (pause, mulligan, mythos-draw, Investigation, the three empty phases) + 3 headless component tests (render, empty commit, selected-commit frame).

## Linked issues

Closes #187.