### PR TITLE
ui: core-loop action controls (P6.7a)

### DIFF
--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -23,26 +23,10 @@ pub fn App() -> impl IntoView {
             <BoardView/>
             {
                 #[cfg(target_arch = "wasm32")]
-                { view! { <crate::input::AwaitingInputView/><DebugSubmit/> }.into_any() }
+                { view! { <crate::input::AwaitingInputView/><crate::controls::ActionControls/> }.into_any() }
                 #[cfg(not(target_arch = "wasm32"))]
                 { ().into_any() }
             }
         </main>
     }
-}
-
-/// Wasm-only debug control: pushes a `ClientMessage::Submit { EndTurn }`
-/// onto the transport's outbound channel, exercising the send path
-/// end-to-end. P6.7 builds the real action controls on this seam.
-#[cfg(target_arch = "wasm32")]
-#[component]
-fn DebugSubmit() -> impl IntoView {
-    let tx = use_context::<crate::transport::OutboundTx>()
-        .expect("OutboundTx provided by transport::start");
-    let on_click = move |_| {
-        let _ = tx.unbounded_send(protocol::ClientMessage::Submit {
-            action: game_core::PlayerAction::EndTurn,
-        });
-    };
-    view! { <button on:click=on_click>"Submit EndTurn (debug)"</button> }
 }

--- a/crates/web/src/controls.rs
+++ b/crates/web/src/controls.rs
@@ -1,0 +1,103 @@
+//! Core-loop action controls (P6.7a, wasm-only). Buttons that submit the
+//! toy scenario's actions, each `disabled` per the P6.6 legality helper
+//! ([`enabled_controls`](crate::legality::enabled_controls)) — a UX
+//! affordance, not a correctness gate (the server stays authoritative).
+//! Move/PlayCard use inline pickers; Mulligan has its own multi-select.
+//! `board.rs` stays read-only — all interactivity lives here.
+
+use game_core::PlayerAction;
+use leptos::prelude::*;
+use protocol::ClientMessage;
+
+use crate::legality::{enabled_controls, ActionControl};
+use crate::store::use_store;
+use crate::transport::OutboundTx;
+
+/// A single zero-payload action button. `class` carries a test-stable hook
+/// (e.g. `"action end-turn"`); `disabled` reflects legality; the click
+/// submits `action` when an `OutboundTx` is present (absent in
+/// render-only contexts → no-op, matching `AwaitingInputView`).
+fn submit_button(
+    class: &'static str,
+    label: &'static str,
+    disabled: bool,
+    tx: Option<OutboundTx>,
+    action: PlayerAction,
+) -> impl IntoView {
+    view! {
+        <button
+            class=class
+            disabled=disabled
+            on:click=move |_| {
+                if let Some(tx) = tx.clone() {
+                    let _ = tx.unbounded_send(ClientMessage::Submit { action: action.clone() });
+                }
+            }
+        >
+            {label}
+        </button>
+    }
+}
+
+/// All core-loop action controls. Reads the store reactively; nothing
+/// renders until both a `game` and an `outcome` are present.
+#[component]
+pub fn ActionControls() -> impl IntoView {
+    let store = use_store();
+    let tx = use_context::<OutboundTx>();
+
+    view! {
+        {move || {
+            let state = store.get();
+            let (Some(game), Some(outcome)) = (state.game.clone(), state.outcome.clone()) else {
+                return ().into_any();
+            };
+            let enabled = enabled_controls(&game, &outcome);
+            let has = |c: ActionControl| enabled.contains(&c);
+            let active = game.active_investigator;
+
+            // Investigator-bearing buttons only render with an active
+            // investigator; the toy scenario always has one in Investigation.
+            let investigate = active.map(|inv| {
+                submit_button(
+                    "action investigate",
+                    "Investigate",
+                    !has(ActionControl::Investigate),
+                    tx.clone(),
+                    PlayerAction::Investigate { investigator: inv },
+                )
+            });
+            let advance_act = active.map(|inv| {
+                submit_button(
+                    "action advance-act",
+                    "Advance act",
+                    !has(ActionControl::AdvanceAct),
+                    tx.clone(),
+                    PlayerAction::AdvanceAct { investigator: inv },
+                )
+            });
+
+            view! {
+                <section class="controls">
+                    {investigate}
+                    {advance_act}
+                    {submit_button(
+                        "action end-turn",
+                        "End turn",
+                        !has(ActionControl::EndTurn),
+                        tx.clone(),
+                        PlayerAction::EndTurn,
+                    )}
+                    {submit_button(
+                        "action draw-encounter",
+                        "Draw encounter",
+                        !has(ActionControl::DrawEncounter),
+                        tx.clone(),
+                        PlayerAction::DrawEncounterCard,
+                    )}
+                </section>
+            }
+            .into_any()
+        }}
+    }
+}

--- a/crates/web/src/controls.rs
+++ b/crates/web/src/controls.rs
@@ -77,6 +77,47 @@ pub fn ActionControls() -> impl IntoView {
                 )
             });
 
+            // Move picker: one button per connected destination, labeled by
+            // the destination's name. Renders only when Move is legal and
+            // the active investigator has a current location.
+            let move_dests: Vec<_> = if has(ActionControl::Move) {
+                active
+                    .and_then(|inv| game.investigators.get(&inv))
+                    .and_then(|inv| inv.current_location)
+                    .and_then(|loc_id| game.locations.get(&loc_id))
+                    .map(|loc| loc.connections.clone())
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|dest_id| {
+                        let inv = active?;
+                        let name = game
+                            .locations
+                            .get(&dest_id)
+                            .map_or_else(|| format!("loc {}", dest_id.0), |l| l.name.clone());
+                        let tx = tx.clone();
+                        Some(view! {
+                            <button
+                                class="move-dest"
+                                on:click=move |_| {
+                                    if let Some(tx) = tx.clone() {
+                                        let _ = tx.unbounded_send(ClientMessage::Submit {
+                                            action: PlayerAction::Move {
+                                                investigator: inv,
+                                                destination: dest_id,
+                                            },
+                                        });
+                                    }
+                                }
+                            >
+                                "Move to " {name}
+                            </button>
+                        })
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
+
             view! {
                 <section class="controls">
                     {investigate}
@@ -95,6 +136,7 @@ pub fn ActionControls() -> impl IntoView {
                         tx.clone(),
                         PlayerAction::DrawEncounterCard,
                     )}
+                    <div class="move-picker">{move_dests}</div>
                 </section>
             }
             .into_any()

--- a/crates/web/src/controls.rs
+++ b/crates/web/src/controls.rs
@@ -5,6 +5,8 @@
 //! Move/PlayCard use inline pickers; Mulligan has its own multi-select.
 //! `board.rs` stays read-only — all interactivity lives here.
 
+use std::collections::BTreeSet;
+
 use game_core::state::{GameState, InvestigatorId};
 use game_core::PlayerAction;
 use leptos::prelude::*;
@@ -140,12 +142,85 @@ fn play_picker(
     view! { <ul class="play-picker">{buttons}</ul> }
 }
 
+/// Mulligan multi-select: setup-only (gated on the `mulligan_pending`
+/// cursor via the legality helper). Toggling a card flips its index in
+/// `selected`; submitting sends the selected indices (empty = legal "keep
+/// my hand"). Kept separate from the P6.6 commit window — the shapes
+/// diverge (see the design spec). The cursor's investigator owns the
+/// redraw, not necessarily the active one.
+fn mulligan_picker(
+    game: &GameState,
+    legal: bool,
+    selected: RwSignal<BTreeSet<u32>>,
+    tx: Option<&OutboundTx>,
+) -> impl IntoView {
+    if !legal {
+        return ().into_any();
+    }
+    let cursor = game.mulligan_pending;
+    let hand: Vec<String> = cursor
+        .and_then(|id| game.investigators.get(&id))
+        .map(|inv| inv.hand.iter().map(ToString::to_string).collect())
+        .unwrap_or_default();
+    let cards: Vec<_> = hand
+        .into_iter()
+        .enumerate()
+        .map(|(idx, code)| {
+            let i = u32::try_from(idx).expect("hand fits in u32");
+            view! {
+                <li>
+                    <button
+                        class="mull-card"
+                        class:selected=move || selected.get().contains(&i)
+                        on:click=move |_| selected.update(|s| {
+                            if !s.remove(&i) {
+                                s.insert(i);
+                            }
+                        })
+                    >
+                        {code}
+                    </button>
+                </li>
+            }
+        })
+        .collect();
+    let tx = tx.cloned();
+    let on_submit = move |_| {
+        if let Some(inv) = cursor {
+            let indices: Vec<u8> = selected
+                .get()
+                .into_iter()
+                .map(|i| u8::try_from(i).expect("hand fits in u8"))
+                .collect();
+            if let Some(tx) = tx.clone() {
+                let _ = tx.unbounded_send(ClientMessage::Submit {
+                    action: PlayerAction::Mulligan {
+                        investigator: inv,
+                        indices_to_redraw: indices,
+                    },
+                });
+            }
+        }
+        selected.set(BTreeSet::new());
+    };
+    view! {
+        <section class="mulligan">
+            <ul>{cards}</ul>
+            <button class="mulligan-submit" on:click=on_submit>"Mulligan"</button>
+        </section>
+    }
+    .into_any()
+}
+
 /// All core-loop action controls. Reads the store reactively; nothing
 /// renders until both a `game` and an `outcome` are present.
 #[component]
 pub fn ActionControls() -> impl IntoView {
     let store = use_store();
     let tx = use_context::<OutboundTx>();
+    // Mulligan's own selection signal — component-lived so it survives the
+    // reactive re-render and is cleared on submit.
+    let mulligan_sel = RwSignal::new(BTreeSet::<u32>::new());
 
     view! {
         {move || {
@@ -198,6 +273,12 @@ pub fn ActionControls() -> impl IntoView {
                     )}
                     {move_picker(&game, active, has(ActionControl::Move), tx.as_ref())}
                     {play_picker(&game, active, has(ActionControl::PlayCard), tx.as_ref())}
+                    {mulligan_picker(
+                        &game,
+                        has(ActionControl::Mulligan),
+                        mulligan_sel,
+                        tx.as_ref(),
+                    )}
                 </section>
             }
             .into_any()

--- a/crates/web/src/controls.rs
+++ b/crates/web/src/controls.rs
@@ -255,6 +255,13 @@ pub fn ActionControls() -> impl IntoView {
 
             view! {
                 <section class="controls">
+                    {submit_button(
+                        "action start-scenario",
+                        "Start scenario",
+                        !has(ActionControl::StartScenario),
+                        tx.clone(),
+                        PlayerAction::StartScenario,
+                    )}
                     {investigate}
                     {advance_act}
                     {submit_button(

--- a/crates/web/src/controls.rs
+++ b/crates/web/src/controls.rs
@@ -5,6 +5,7 @@
 //! Move/PlayCard use inline pickers; Mulligan has its own multi-select.
 //! `board.rs` stays read-only — all interactivity lives here.
 
+use game_core::state::{GameState, InvestigatorId};
 use game_core::PlayerAction;
 use leptos::prelude::*;
 use protocol::ClientMessage;
@@ -37,6 +38,106 @@ fn submit_button(
             {label}
         </button>
     }
+}
+
+/// Move picker: one button per connected destination (from the active
+/// investigator's location's `connections`), labeled by destination name.
+/// Empty when `legal` is false or there is no active investigator/location.
+fn move_picker(
+    game: &GameState,
+    active: Option<InvestigatorId>,
+    legal: bool,
+    tx: Option<&OutboundTx>,
+) -> impl IntoView {
+    let dests: Vec<_> = if legal {
+        active
+            .and_then(|inv| game.investigators.get(&inv))
+            .and_then(|inv| inv.current_location)
+            .and_then(|loc_id| game.locations.get(&loc_id))
+            .map(|loc| loc.connections.clone())
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|dest_id| {
+                let inv = active?;
+                let name = game
+                    .locations
+                    .get(&dest_id)
+                    .map_or_else(|| format!("loc {}", dest_id.0), |l| l.name.clone());
+                let tx = tx.cloned();
+                Some(view! {
+                    <button
+                        class="move-dest"
+                        on:click=move |_| {
+                            if let Some(tx) = tx.clone() {
+                                let _ = tx.unbounded_send(ClientMessage::Submit {
+                                    action: PlayerAction::Move {
+                                        investigator: inv,
+                                        destination: dest_id,
+                                    },
+                                });
+                            }
+                        }
+                    >
+                        "Move to " {name}
+                    </button>
+                })
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    view! { <div class="move-picker">{dests}</div> }
+}
+
+/// `PlayCard` picker: a "Play" button per card in the active
+/// investigator's hand (`hand_index` = position). Empty when `legal` is
+/// false or there is no active investigator.
+fn play_picker(
+    game: &GameState,
+    active: Option<InvestigatorId>,
+    legal: bool,
+    tx: Option<&OutboundTx>,
+) -> impl IntoView {
+    let buttons: Vec<_> = if legal {
+        active
+            .and_then(|inv| game.investigators.get(&inv))
+            .map(|inv_state| {
+                inv_state
+                    .hand
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, code)| {
+                        let hand_index = u8::try_from(idx).expect("hand fits in u8");
+                        let inv = active.expect("active present in this branch");
+                        let label = code.to_string();
+                        let tx = tx.cloned();
+                        view! {
+                            <li>
+                                <button
+                                    class="play-card"
+                                    on:click=move |_| {
+                                        if let Some(tx) = tx.clone() {
+                                            let _ = tx.unbounded_send(ClientMessage::Submit {
+                                                action: PlayerAction::PlayCard {
+                                                    investigator: inv,
+                                                    hand_index,
+                                                },
+                                            });
+                                        }
+                                    }
+                                >
+                                    "Play " {label}
+                                </button>
+                            </li>
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    view! { <ul class="play-picker">{buttons}</ul> }
 }
 
 /// All core-loop action controls. Reads the store reactively; nothing
@@ -77,47 +178,6 @@ pub fn ActionControls() -> impl IntoView {
                 )
             });
 
-            // Move picker: one button per connected destination, labeled by
-            // the destination's name. Renders only when Move is legal and
-            // the active investigator has a current location.
-            let move_dests: Vec<_> = if has(ActionControl::Move) {
-                active
-                    .and_then(|inv| game.investigators.get(&inv))
-                    .and_then(|inv| inv.current_location)
-                    .and_then(|loc_id| game.locations.get(&loc_id))
-                    .map(|loc| loc.connections.clone())
-                    .unwrap_or_default()
-                    .into_iter()
-                    .filter_map(|dest_id| {
-                        let inv = active?;
-                        let name = game
-                            .locations
-                            .get(&dest_id)
-                            .map_or_else(|| format!("loc {}", dest_id.0), |l| l.name.clone());
-                        let tx = tx.clone();
-                        Some(view! {
-                            <button
-                                class="move-dest"
-                                on:click=move |_| {
-                                    if let Some(tx) = tx.clone() {
-                                        let _ = tx.unbounded_send(ClientMessage::Submit {
-                                            action: PlayerAction::Move {
-                                                investigator: inv,
-                                                destination: dest_id,
-                                            },
-                                        });
-                                    }
-                                }
-                            >
-                                "Move to " {name}
-                            </button>
-                        })
-                    })
-                    .collect()
-            } else {
-                Vec::new()
-            };
-
             view! {
                 <section class="controls">
                     {investigate}
@@ -136,7 +196,8 @@ pub fn ActionControls() -> impl IntoView {
                         tx.clone(),
                         PlayerAction::DrawEncounterCard,
                     )}
-                    <div class="move-picker">{move_dests}</div>
+                    {move_picker(&game, active, has(ActionControl::Move), tx.as_ref())}
+                    {play_picker(&game, active, has(ActionControl::PlayCard), tx.as_ref())}
                 </section>
             }
             .into_any()

--- a/crates/web/src/legality.rs
+++ b/crates/web/src/legality.rs
@@ -12,6 +12,7 @@ use game_core::EngineOutcome;
 /// (`Fight`/`Evade`/`Draw`) join in P6.7b.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ActionControl {
+    StartScenario,
     Move,
     Investigate,
     PlayCard,
@@ -29,21 +30,28 @@ pub enum ActionControl {
 ///    outcome, so it covers every suspension mode the engine surfaces as
 ///    `AwaitingInput` (reaction windows, hunter moves, hand-size discard,
 ///    the skill-test commit window), not just the commit prompt.
-/// 2. The setup cursors dominate their windows: `mulligan_pending` ⇒ only
+/// 2. `round == 0` is the pre-start state straight from a scenario
+///    `setup()` (the engine bumps to round 1 at `StartScenario` and only
+///    ever increments), so `StartScenario` is the sole legal action — it
+///    seeds hands and the mulligan cursor.
+/// 3. The setup cursors dominate their windows: `mulligan_pending` ⇒ only
 ///    `Mulligan`; `mythos_draw_pending` ⇒ only `DrawEncounter`. These are
 ///    state facts, not phase, so they're checked before the phase table.
-/// 3. Otherwise, the controls the current `Phase` permits.
+/// 4. Otherwise, the controls the current `Phase` permits.
 ///
 /// Finer checks (resources, action budget, clue presence) are
 /// deliberately not mirrored — the server's `Rejected` is the truth.
 #[must_use]
 pub fn enabled_controls(game: &GameState, outcome: &EngineOutcome) -> BTreeSet<ActionControl> {
     use ActionControl::{
-        AdvanceAct, DrawEncounter, EndTurn, Investigate, Move, Mulligan, PlayCard,
+        AdvanceAct, DrawEncounter, EndTurn, Investigate, Move, Mulligan, PlayCard, StartScenario,
     };
 
     if matches!(outcome, EngineOutcome::AwaitingInput { .. }) {
         return BTreeSet::new();
+    }
+    if game.round == 0 {
+        return BTreeSet::from([StartScenario]);
     }
     if game.mulligan_pending.is_some() {
         return BTreeSet::from([Mulligan]);
@@ -68,11 +76,29 @@ mod tests {
     use std::collections::BTreeSet;
 
     fn investigation_game() -> game_core::state::GameState {
+        // round 1: an in-progress game is never round 0 (the engine bumps
+        // to 1 at StartScenario), and round 0 now gates to StartScenario.
         TestGame::new()
             .with_investigator(test_investigator(1))
             .with_active_investigator(InvestigatorId(1))
             .with_phase(Phase::Investigation)
+            .with_round(1)
             .build()
+    }
+
+    #[test]
+    fn round_zero_enables_only_start_scenario() {
+        // The state straight from a scenario `setup()`: phase Mythos,
+        // round 0, no cursors. The only legal action is StartScenario.
+        let game = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_active_investigator(InvestigatorId(1))
+            .build();
+        assert_eq!(game.round, 0, "precondition: pre-start state");
+        assert_eq!(
+            enabled_controls(&game, &EngineOutcome::Done),
+            BTreeSet::from([ActionControl::StartScenario])
+        );
     }
 
     #[test]

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -15,3 +15,6 @@ pub mod transport;
 
 #[cfg(target_arch = "wasm32")]
 pub mod input;
+
+#[cfg(target_arch = "wasm32")]
+pub mod controls;

--- a/crates/web/tests/controls.rs
+++ b/crates/web/tests/controls.rs
@@ -5,7 +5,7 @@
 #![cfg(target_arch = "wasm32")]
 
 use futures::channel::mpsc;
-use game_core::state::{InvestigatorId, LocationId, Phase};
+use game_core::state::{CardCode, InvestigatorId, LocationId, Phase};
 use game_core::test_support::builder::TestGame;
 use game_core::test_support::fixtures::{test_investigator, test_location};
 use game_core::{EngineOutcome, PlayerAction};
@@ -219,5 +219,42 @@ async fn move_picker_submits_move_to_connected_destination() {
             assert_eq!(destination, LocationId(2));
         }
         other => panic!("expected Move, got {other:?}"),
+    }
+}
+
+#[wasm_bindgen_test]
+async fn play_picker_submits_play_card_by_hand_index() {
+    let mut inv = test_investigator(1);
+    inv.hand = vec![
+        CardCode::new("_synth_event_a"),
+        CardCode::new("_synth_event_b"),
+    ];
+    let game = TestGame::new()
+        .with_investigator(inv)
+        .with_active_investigator(InvestigatorId(1))
+        .with_phase(Phase::Investigation)
+        .build();
+
+    let mut rx = mount(game, EngineOutcome::Done).await;
+    let controls = last_controls();
+    // Click the second card's Play button → hand_index 1.
+    let buttons = controls.query_selector_all(".play-card").expect("query");
+    buttons
+        .item(1)
+        .expect("second play button")
+        .dyn_into::<web_sys::HtmlElement>()
+        .expect("HtmlElement")
+        .click();
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame after tick");
+    match submit_action(frame) {
+        PlayerAction::PlayCard {
+            investigator,
+            hand_index,
+        } => {
+            assert_eq!(investigator, InvestigatorId(1));
+            assert_eq!(hand_index, 1);
+        }
+        other => panic!("expected PlayCard, got {other:?}"),
     }
 }

--- a/crates/web/tests/controls.rs
+++ b/crates/web/tests/controls.rs
@@ -258,3 +258,65 @@ async fn play_picker_submits_play_card_by_hand_index() {
         other => panic!("expected PlayCard, got {other:?}"),
     }
 }
+
+/// A setup game where investigator 1 is on the mulligan cursor with a
+/// two-card hand.
+fn mulligan_game() -> game_core::state::GameState {
+    let mut inv = test_investigator(1);
+    inv.hand = vec![
+        CardCode::new("_synth_event_a"),
+        CardCode::new("_synth_event_b"),
+    ];
+    TestGame::new()
+        .with_investigator(inv)
+        .with_active_investigator(InvestigatorId(1))
+        .with_phase(Phase::Investigation)
+        .with_mulligan_pending(InvestigatorId(1))
+        .build()
+}
+
+#[wasm_bindgen_test]
+async fn mulligan_submits_selected_indices() {
+    let mut rx = mount(mulligan_game(), EngineOutcome::Done).await;
+    let controls = last_controls();
+    // Select the first card, then submit.
+    let cards = controls.query_selector_all(".mull-card").expect("query");
+    cards
+        .item(0)
+        .expect("first mull-card")
+        .dyn_into::<web_sys::HtmlElement>()
+        .expect("HtmlElement")
+        .click();
+    leptos::task::tick().await;
+    click_in(&controls, ".mulligan-submit");
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame after tick");
+    match submit_action(frame) {
+        PlayerAction::Mulligan {
+            investigator,
+            indices_to_redraw,
+        } => {
+            assert_eq!(investigator, InvestigatorId(1));
+            assert_eq!(indices_to_redraw, vec![0]);
+        }
+        other => panic!("expected Mulligan, got {other:?}"),
+    }
+}
+
+#[wasm_bindgen_test]
+async fn mulligan_with_no_selection_keeps_hand() {
+    let mut rx = mount(mulligan_game(), EngineOutcome::Done).await;
+    click_in(&last_controls(), ".mulligan-submit");
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame after tick");
+    match submit_action(frame) {
+        PlayerAction::Mulligan {
+            investigator,
+            indices_to_redraw,
+        } => {
+            assert_eq!(investigator, InvestigatorId(1));
+            assert_eq!(indices_to_redraw, Vec::<u8>::new());
+        }
+        other => panic!("expected Mulligan, got {other:?}"),
+    }
+}

--- a/crates/web/tests/controls.rs
+++ b/crates/web/tests/controls.rs
@@ -1,0 +1,185 @@
+//! Headless tests for `ActionControls` (P6.7a): feed a `GameState` +
+//! `EngineOutcome` through the store, then assert each control, when
+//! legal, submits the matching `ClientMessage::Submit { action }`.
+//! wasm32-only (browser DOM + the wasm-only transport types).
+#![cfg(target_arch = "wasm32")]
+
+use futures::channel::mpsc;
+use game_core::state::{InvestigatorId, Phase};
+use game_core::test_support::builder::TestGame;
+use game_core::test_support::fixtures::test_investigator;
+use game_core::{EngineOutcome, PlayerAction};
+use leptos::prelude::*;
+use protocol::{ClientMessage, ServerMessage};
+use wasm_bindgen::JsCast as _;
+use wasm_bindgen_test::*;
+use web::controls::ActionControls;
+use web::store::{reduce, ClientState};
+use web::transport::OutboundTx;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+/// Mount `ActionControls` with a fresh store + outbound channel, feed one
+/// `Hello { state, outcome }`, tick, and return the receiver.
+async fn mount(
+    state: game_core::state::GameState,
+    outcome: EngineOutcome,
+) -> mpsc::UnboundedReceiver<ClientMessage> {
+    let store = RwSignal::new(ClientState::default());
+    let (tx, rx) = mpsc::unbounded::<ClientMessage>();
+    let tx_for_mount: OutboundTx = tx;
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        provide_context::<OutboundTx>(tx_for_mount.clone());
+        leptos::view! { <ActionControls/> }
+    });
+    store.update(|s| {
+        reduce(
+            s,
+            ServerMessage::Hello {
+                state: Box::new(state),
+                outcome,
+            },
+        );
+    });
+    leptos::task::tick().await;
+    rx
+}
+
+/// The last mounted `.controls` section (DOM accumulates across tests).
+fn last_controls() -> web_sys::Element {
+    let secs = leptos::prelude::document()
+        .query_selector_all(".controls")
+        .expect("query");
+    secs.item(secs.length() - 1)
+        .expect("at least one controls section")
+        .dyn_into::<web_sys::Element>()
+        .expect("Element")
+}
+
+/// Click the first element matching `selector` within `section`.
+fn click_in(section: &web_sys::Element, selector: &str) {
+    section
+        .query_selector(selector)
+        .expect("query")
+        .expect("element present")
+        .dyn_into::<web_sys::HtmlElement>()
+        .expect("HtmlElement")
+        .click();
+}
+
+/// An Investigation-phase game with one active investigator.
+fn investigation_game() -> game_core::state::GameState {
+    TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_active_investigator(InvestigatorId(1))
+        .with_phase(Phase::Investigation)
+        .build()
+}
+
+/// Extract the submitted `PlayerAction`. `ClientMessage` has no
+/// `PartialEq`, so tests match the action rather than `assert_eq!` the
+/// whole frame (the `input.rs` pattern). `Submit` is the only variant, so
+/// the destructure is irrefutable.
+fn submit_action(frame: ClientMessage) -> PlayerAction {
+    let ClientMessage::Submit { action } = frame;
+    action
+}
+
+#[wasm_bindgen_test]
+async fn end_turn_submits_end_turn() {
+    let mut rx = mount(investigation_game(), EngineOutcome::Done).await;
+    click_in(&last_controls(), ".end-turn");
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame after tick");
+    match submit_action(frame) {
+        PlayerAction::EndTurn => {}
+        other => panic!("expected EndTurn, got {other:?}"),
+    }
+}
+
+#[wasm_bindgen_test]
+async fn investigate_submits_investigate_for_active() {
+    let mut rx = mount(investigation_game(), EngineOutcome::Done).await;
+    click_in(&last_controls(), ".investigate");
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame after tick");
+    match submit_action(frame) {
+        PlayerAction::Investigate { investigator } => {
+            assert_eq!(investigator, InvestigatorId(1));
+        }
+        other => panic!("expected Investigate, got {other:?}"),
+    }
+}
+
+#[wasm_bindgen_test]
+async fn advance_act_submits_advance_act_for_active() {
+    let mut rx = mount(investigation_game(), EngineOutcome::Done).await;
+    click_in(&last_controls(), ".advance-act");
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame after tick");
+    match submit_action(frame) {
+        PlayerAction::AdvanceAct { investigator } => {
+            assert_eq!(investigator, InvestigatorId(1));
+        }
+        other => panic!("expected AdvanceAct, got {other:?}"),
+    }
+}
+
+#[wasm_bindgen_test]
+async fn draw_encounter_submits_draw_encounter_card() {
+    // Mythos phase with this investigator on the draw cursor: only
+    // DrawEncounter is legal. `mythos_draw_pending` has no builder setter,
+    // so mutate the built state directly (legality.rs tests do the same).
+    let mut game = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_active_investigator(InvestigatorId(1))
+        .with_phase(Phase::Mythos)
+        .build();
+    game.mythos_draw_pending = Some(InvestigatorId(1));
+
+    let mut rx = mount(game, EngineOutcome::Done).await;
+    click_in(&last_controls(), ".draw-encounter");
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame after tick");
+    match submit_action(frame) {
+        PlayerAction::DrawEncounterCard => {}
+        other => panic!("expected DrawEncounterCard, got {other:?}"),
+    }
+}
+
+#[wasm_bindgen_test]
+async fn illegal_controls_are_disabled_and_do_not_submit() {
+    // Mythos + draw cursor: only DrawEncounter is legal, so End turn is
+    // disabled and DrawEncounter is not.
+    let mut game = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_active_investigator(InvestigatorId(1))
+        .with_phase(Phase::Mythos)
+        .build();
+    game.mythos_draw_pending = Some(InvestigatorId(1));
+
+    let mut rx = mount(game, EngineOutcome::Done).await;
+    let controls = last_controls();
+    let end_turn = controls
+        .query_selector(".end-turn")
+        .expect("query")
+        .expect("end-turn present");
+    let draw = controls
+        .query_selector(".draw-encounter")
+        .expect("query")
+        .expect("draw-encounter present");
+    assert!(
+        end_turn.has_attribute("disabled"),
+        "End turn should be disabled"
+    );
+    assert!(
+        !draw.has_attribute("disabled"),
+        "Draw encounter should be enabled"
+    );
+
+    // A disabled button does not fire click → no frame.
+    click_in(&controls, ".end-turn");
+    leptos::task::tick().await;
+    assert!(rx.try_recv().is_err(), "disabled button must not submit");
+}

--- a/crates/web/tests/controls.rs
+++ b/crates/web/tests/controls.rs
@@ -5,9 +5,9 @@
 #![cfg(target_arch = "wasm32")]
 
 use futures::channel::mpsc;
-use game_core::state::{InvestigatorId, Phase};
+use game_core::state::{InvestigatorId, LocationId, Phase};
 use game_core::test_support::builder::TestGame;
-use game_core::test_support::fixtures::test_investigator;
+use game_core::test_support::fixtures::{test_investigator, test_location};
 use game_core::{EngineOutcome, PlayerAction};
 use leptos::prelude::*;
 use protocol::{ClientMessage, ServerMessage};
@@ -182,4 +182,42 @@ async fn illegal_controls_are_disabled_and_do_not_submit() {
     click_in(&controls, ".end-turn");
     leptos::task::tick().await;
     assert!(rx.try_recv().is_err(), "disabled button must not submit");
+}
+
+#[wasm_bindgen_test]
+async fn move_picker_submits_move_to_connected_destination() {
+    // Investigator at location 1, which connects to location 2.
+    let mut loc1 = test_location(1, "Study");
+    loc1.connections = vec![LocationId(2)];
+    let loc2 = test_location(2, "Hallway");
+    let game = TestGame::new()
+        .with_investigator_at(test_investigator(1), LocationId(1))
+        .with_active_investigator(InvestigatorId(1))
+        .with_location(loc1)
+        .with_location(loc2)
+        .with_phase(Phase::Investigation)
+        .build();
+
+    let mut rx = mount(game, EngineOutcome::Done).await;
+    let controls = last_controls();
+    // The single destination button is labeled by the destination name.
+    let dest = controls
+        .query_selector(".move-dest")
+        .expect("query")
+        .expect("a move destination button");
+    assert!(dest.text_content().unwrap_or_default().contains("Hallway"));
+
+    click_in(&controls, ".move-dest");
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame after tick");
+    match submit_action(frame) {
+        PlayerAction::Move {
+            investigator,
+            destination,
+        } => {
+            assert_eq!(investigator, InvestigatorId(1));
+            assert_eq!(destination, LocationId(2));
+        }
+        other => panic!("expected Move, got {other:?}"),
+    }
 }

--- a/crates/web/tests/controls.rs
+++ b/crates/web/tests/controls.rs
@@ -68,12 +68,15 @@ fn click_in(section: &web_sys::Element, selector: &str) {
         .click();
 }
 
-/// An Investigation-phase game with one active investigator.
+/// An in-progress Investigation-phase game with one active investigator.
+/// `round 1` because an in-progress game is never round 0 (round 0 is the
+/// pre-start state that gates to `StartScenario`).
 fn investigation_game() -> game_core::state::GameState {
     TestGame::new()
         .with_investigator(test_investigator(1))
         .with_active_investigator(InvestigatorId(1))
         .with_phase(Phase::Investigation)
+        .with_round(1)
         .build()
 }
 
@@ -135,6 +138,7 @@ async fn draw_encounter_submits_draw_encounter_card() {
         .with_investigator(test_investigator(1))
         .with_active_investigator(InvestigatorId(1))
         .with_phase(Phase::Mythos)
+        .with_round(1)
         .build();
     game.mythos_draw_pending = Some(InvestigatorId(1));
 
@@ -156,6 +160,7 @@ async fn illegal_controls_are_disabled_and_do_not_submit() {
         .with_investigator(test_investigator(1))
         .with_active_investigator(InvestigatorId(1))
         .with_phase(Phase::Mythos)
+        .with_round(1)
         .build();
     game.mythos_draw_pending = Some(InvestigatorId(1));
 
@@ -196,6 +201,7 @@ async fn move_picker_submits_move_to_connected_destination() {
         .with_location(loc1)
         .with_location(loc2)
         .with_phase(Phase::Investigation)
+        .with_round(1)
         .build();
 
     let mut rx = mount(game, EngineOutcome::Done).await;
@@ -233,6 +239,7 @@ async fn play_picker_submits_play_card_by_hand_index() {
         .with_investigator(inv)
         .with_active_investigator(InvestigatorId(1))
         .with_phase(Phase::Investigation)
+        .with_round(1)
         .build();
 
     let mut rx = mount(game, EngineOutcome::Done).await;
@@ -271,6 +278,7 @@ fn mulligan_game() -> game_core::state::GameState {
         .with_investigator(inv)
         .with_active_investigator(InvestigatorId(1))
         .with_phase(Phase::Investigation)
+        .with_round(1)
         .with_mulligan_pending(InvestigatorId(1))
         .build()
 }
@@ -318,5 +326,44 @@ async fn mulligan_with_no_selection_keeps_hand() {
             assert_eq!(indices_to_redraw, Vec::<u8>::new());
         }
         other => panic!("expected Mulligan, got {other:?}"),
+    }
+}
+
+#[wasm_bindgen_test]
+async fn start_scenario_is_the_only_control_at_round_zero() {
+    // The state straight from a scenario `setup()`: phase Mythos, round 0,
+    // no cursors, no active investigator. The only legal action is
+    // StartScenario — this is the state the server hands a freshly created
+    // game, so the player must be able to start it.
+    let game = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .build();
+    assert_eq!(game.round, 0, "precondition: pre-start state");
+
+    let mut rx = mount(game, EngineOutcome::Done).await;
+    let controls = last_controls();
+    let end_turn = controls
+        .query_selector(".end-turn")
+        .expect("query")
+        .expect("end-turn present");
+    let start = controls
+        .query_selector(".start-scenario")
+        .expect("query")
+        .expect("start-scenario present");
+    assert!(
+        end_turn.has_attribute("disabled"),
+        "core-loop buttons should be disabled pre-start"
+    );
+    assert!(
+        !start.has_attribute("disabled"),
+        "Start scenario should be enabled pre-start"
+    );
+
+    click_in(&controls, ".start-scenario");
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame after tick");
+    match submit_action(frame) {
+        PlayerAction::StartScenario => {}
+        other => panic!("expected StartScenario, got {other:?}"),
     }
 }

--- a/docs/phases/phase-6-web-client-v0.md
+++ b/docs/phases/phase-6-web-client-v0.md
@@ -231,6 +231,15 @@ Settled implementing P6.7a (PR #208):
   P6.6 commit window (`input.rs`); the extract-into-a-shared-component
   trigger is a third multi-select-hand use (the deferred upkeep discard
   prompt, #205).
+- **`StartScenario` is the browser entry point, gated on `round == 0`.**
+  The server hands a freshly created game the raw `setup()` state (phase
+  Mythos, round 0, empty hands), whose only legal action is
+  `StartScenario`. `enabled_controls` keys that off `round == 0` (the
+  round counter only increments from 1, so it uniquely marks the pre-start
+  state). This was a post-review fix: the initial cut omitted
+  `StartScenario`, so the client loaded with every control disabled and no
+  way to begin — and the headless tests masked it by building in-progress
+  states with the builder's default `round 0`, an impossible real state.
 
 ## Open questions
 

--- a/docs/phases/phase-6-web-client-v0.md
+++ b/docs/phases/phase-6-web-client-v0.md
@@ -25,7 +25,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | P6.4b | [#198](https://github.com/talelburg/eldritch/issues/198) — WebSocket liveness (heartbeat + graceful shutdown) | ⏭️ deferred → Phase 8 (closed) |
 | P6.5 | [#186](https://github.com/talelburg/eldritch/issues/186) — board rendering (read-only) | ✅ PR #204 |
 | P6.6 | [#187](https://github.com/talelburg/eldritch/issues/187) — AwaitingInput resolution UI + legality gating | ✅ PR #207 |
-| P6.7a | [#188](https://github.com/talelburg/eldritch/issues/188) — core-loop action controls | ⏳ open |
+| P6.7a | [#188](https://github.com/talelburg/eldritch/issues/188) — core-loop action controls | ✅ PR #208 |
 | P6.7b | [#189](https://github.com/talelburg/eldritch/issues/189) — combat/edge action controls | ⏳ open |
 | P6.8 | [#190](https://github.com/talelburg/eldritch/issues/190) — resolution surfacing + closing demo | ⏳ open |
 
@@ -41,7 +41,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | ~~P6.4b~~ | #198 WS liveness — **deferred to Phase 8** | Its triggering symptom is a WSL2 dev artifact, not a real-host bug; genuine liveness is Phase-8 production hardening. See *Decisions made* | — |
 | P6.5 | #186 board rendering ✅ PR #204 | See the state | P6.4 |
 | P6.6 | #187 AwaitingInput UI + legality ✅ PR #207 | Core-loop: `Investigate` opens a skill-test commit window (`AwaitingInput`), so this precedes the action controls | P6.5 |
-| P6.7a | #188 core-loop action controls | Toy scenario clickable to a **Won** resolution | P6.6 |
+| P6.7a | #188 core-loop action controls ✅ PR #208 | Toy scenario clickable to a **Won** resolution | P6.6 |
 | P6.7b | #189 combat/edge action controls | Rounds out the action surface (combat/Lost walk) | P6.7a |
 | P6.8 | #190 resolution + closing demo | Milestone close | all |
 
@@ -53,7 +53,8 @@ hot-reload) shipped before the content UI. P6.4b
 was **deferred to Phase 8 and closed** — see *Decisions made*. P6.5
 (#186, board rendering ✅ PR #204) shipped the read-only board and P6.6
 (#187, `AwaitingInput` UI + legality ✅ PR #207) shipped the interaction
-plumbing, so the action controls (P6.7a, #188) are next.
+plumbing, and P6.7a (#188, core-loop action controls ✅ PR #208) shipped
+the action buttons, so the combat/edge controls (P6.7b, #189) are next.
 
 ## Decisions made
 
@@ -215,6 +216,21 @@ Settled implementing P6.6 (PR #207):
   just the commit window). Richer "show the player exactly what's legal"
   affordances are [#206](https://github.com/talelburg/eldritch/issues/206)
   (Phase 8).
+
+Settled implementing P6.7a (PR #208):
+
+- **Action affordances live in a dedicated controls panel; `board.rs`
+  stays read-only.** `ActionControls` (`crates/web/src/controls.rs`)
+  renders the buttons and inline Move/PlayCard pickers; it does not make
+  board locations or hand cards directly clickable. Making the board
+  itself interactive (click a location to move, a card to play) is the
+  preferred surface for real player UX and is **deliberately deferred** —
+  a future-phase change, not an oversight. Future UI PRs adding richer
+  interaction should weigh promoting interactivity into the board against
+  extending the panel. The Mulligan multi-select is kept separate from the
+  P6.6 commit window (`input.rs`); the extract-into-a-shared-component
+  trigger is a third multi-select-hand use (the deferred upkeep discard
+  prompt, #205).
 
 ## Open questions
 

--- a/docs/superpowers/plans/2026-06-09-p6-7a-action-controls.md
+++ b/docs/superpowers/plans/2026-06-09-p6-7a-action-controls.md
@@ -1,0 +1,852 @@
+# P6.7a Core-Loop Action Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a wasm-only `ActionControls` Leptos component that lets the player click the toy scenario's core-loop actions (Investigate, EndTurn, DrawEncounterCard, AdvanceAct, Move, PlayCard, Mulligan), each gated by the P6.6 legality helper and submitting the correct `ClientMessage::Submit { action }`.
+
+**Architecture:** One new module `crates/web/src/controls.rs` (wasm-only, like `input`/`transport`). The `ActionControls` component reads the store reactively, computes `legality::enabled_controls`, and renders buttons whose `disabled` binds to that set. Zero-payload actions are plain buttons; Move and PlayCard use inline pickers; Mulligan has its own multi-select hand. `board.rs` stays read-only. Headless `wasm-bindgen-test`s mount the component with an `mpsc` outbound channel and assert the submitted frame — mirroring `crates/web/tests/input.rs`.
+
+**Tech Stack:** Rust, Leptos (CSR), `wasm-bindgen-test` (headless Firefox), `futures::channel::mpsc`, `protocol`, `game-core`.
+
+**Spec:** [`docs/superpowers/specs/2026-06-09-p6-7a-action-controls-design.md`](../specs/2026-06-09-p6-7a-action-controls-design.md)
+
+---
+
+## Reference patterns (read before starting)
+
+- `crates/web/src/input.rs` — the `AwaitingInputView` component: reactive `move || { store.get() … }.into_any()` body, `OutboundTx` read as `Option` from context, multi-select via a component-scoped `RwSignal<BTreeSet<u32>>`, `tx.unbounded_send(ClientMessage::Submit { … })`.
+- `crates/web/tests/input.rs` — the headless harness: `mount_to_body` providing `store` + `OutboundTx` context, drive state via `reduce(s, ServerMessage::Hello { … })`, `leptos::task::tick().await`, then `rx.try_recv()`. The DOM accumulates across tests in one page, so absence/selection assertions scope to the **last** mounted `.controls` section.
+- `crates/web/src/legality.rs` — `enabled_controls(&GameState, &EngineOutcome) -> BTreeSet<ActionControl>` and the `ActionControl` enum (note: `ActionControl::DrawEncounter`, but the action is `PlayerAction::DrawEncounterCard`).
+- `crates/web/src/board.rs` — read-only render; do **not** modify it.
+
+## CI gauntlet for this crate (run after each task before committing)
+
+```sh
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+wasm-pack test --headless --firefox crates/web
+```
+
+The host `fmt`/`clippy`/`test` jobs do not compile the wasm-only `controls` module, but run `cargo fmt --check` before committing regardless.
+
+## File structure
+
+- **Create:** `crates/web/src/controls.rs` — the `ActionControls` component + a private `submit_button` helper.
+- **Modify:** `crates/web/src/lib.rs` — declare the wasm-only module.
+- **Modify:** `crates/web/src/app.rs` — mount `<ActionControls/>`, remove the obsolete `DebugSubmit`.
+- **Create:** `crates/web/tests/controls.rs` — headless component tests.
+
+---
+
+## Task 1: Module scaffold, zero-payload buttons, wiring, and harness
+
+**Files:**
+- Create: `crates/web/src/controls.rs`
+- Modify: `crates/web/src/lib.rs:16-17`
+- Modify: `crates/web/src/app.rs:24-48`
+- Create: `crates/web/tests/controls.rs`
+
+This task stands up the module with the four zero-payload buttons (Investigate, EndTurn, DrawEncounterCard, AdvanceAct), wires it into the app, and establishes the test harness with one submit test per button plus a gating test.
+
+- [ ] **Step 1: Create the test file with the harness and the first failing test**
+
+Create `crates/web/tests/controls.rs`:
+
+```rust
+//! Headless tests for `ActionControls` (P6.7a): feed a `GameState` +
+//! `EngineOutcome` through the store, then assert each control, when
+//! legal, submits the matching `ClientMessage::Submit { action }`.
+//! wasm32-only (browser DOM + the wasm-only transport types).
+#![cfg(target_arch = "wasm32")]
+
+use futures::channel::mpsc;
+use game_core::state::{CardCode, InvestigatorId, LocationId, Phase};
+use game_core::test_support::builder::TestGame;
+use game_core::test_support::fixtures::{test_investigator, test_location};
+use game_core::{EngineOutcome, PlayerAction};
+use leptos::prelude::*;
+use protocol::{ClientMessage, ServerMessage};
+use wasm_bindgen::JsCast as _;
+use wasm_bindgen_test::*;
+use web::controls::ActionControls;
+use web::store::{reduce, ClientState};
+use web::transport::OutboundTx;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+/// Mount `ActionControls` with a fresh store + outbound channel, feed one
+/// `Hello { state, outcome }`, tick, and return the receiver.
+async fn mount(
+    state: game_core::state::GameState,
+    outcome: EngineOutcome,
+) -> mpsc::UnboundedReceiver<ClientMessage> {
+    let store = RwSignal::new(ClientState::default());
+    let (tx, rx) = mpsc::unbounded::<ClientMessage>();
+    let tx_for_mount: OutboundTx = tx;
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        provide_context::<OutboundTx>(tx_for_mount.clone());
+        leptos::view! { <ActionControls/> }
+    });
+    store.update(|s| {
+        reduce(
+            s,
+            ServerMessage::Hello {
+                state: Box::new(state),
+                outcome,
+            },
+        );
+    });
+    leptos::task::tick().await;
+    rx
+}
+
+/// The last mounted `.controls` section (DOM accumulates across tests).
+fn last_controls() -> web_sys::Element {
+    let secs = leptos::prelude::document()
+        .query_selector_all(".controls")
+        .expect("query");
+    secs.item(secs.length() - 1)
+        .expect("at least one controls section")
+        .dyn_into::<web_sys::Element>()
+        .expect("Element")
+}
+
+/// Click the first element matching `selector` within `section`.
+fn click_in(section: &web_sys::Element, selector: &str) {
+    section
+        .query_selector(selector)
+        .expect("query")
+        .expect("element present")
+        .dyn_into::<web_sys::HtmlElement>()
+        .expect("HtmlElement")
+        .click();
+}
+
+/// An Investigation-phase game with one active investigator.
+fn investigation_game() -> game_core::state::GameState {
+    TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_active_investigator(InvestigatorId(1))
+        .with_phase(Phase::Investigation)
+        .build()
+}
+
+#[wasm_bindgen_test]
+async fn end_turn_submits_end_turn() {
+    let mut rx = mount(investigation_game(), EngineOutcome::Done).await;
+    click_in(&last_controls(), ".end-turn");
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame after tick");
+    assert_eq!(
+        frame,
+        ClientMessage::Submit {
+            action: PlayerAction::EndTurn
+        }
+    );
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails to compile**
+
+Run: `wasm-pack test --headless --firefox crates/web 2>&1 | tail -20`
+Expected: compile error — `unresolved import web::controls` / `ActionControls` not found.
+
+- [ ] **Step 3: Create the module with the `submit_button` helper and the four zero-payload buttons**
+
+Create `crates/web/src/controls.rs`:
+
+```rust
+//! Core-loop action controls (P6.7a, wasm-only). Buttons that submit the
+//! toy scenario's actions, each `disabled` per the P6.6 legality helper
+//! ([`enabled_controls`](crate::legality::enabled_controls)) — a UX
+//! affordance, not a correctness gate (the server stays authoritative).
+//! Move/PlayCard use inline pickers; Mulligan has its own multi-select.
+//! `board.rs` stays read-only — all interactivity lives here.
+
+use std::collections::BTreeSet;
+
+use game_core::{EngineOutcome, PlayerAction};
+use leptos::prelude::*;
+use protocol::ClientMessage;
+
+use crate::legality::{enabled_controls, ActionControl};
+use crate::store::use_store;
+use crate::transport::OutboundTx;
+
+/// A single zero-payload action button. `class` carries a test-stable hook
+/// (e.g. `"action end-turn"`); `disabled` reflects legality; the click
+/// submits `action` when an `OutboundTx` is present (absent in
+/// render-only contexts → no-op, matching `AwaitingInputView`).
+fn submit_button(
+    class: &'static str,
+    label: &'static str,
+    disabled: bool,
+    tx: Option<OutboundTx>,
+    action: PlayerAction,
+) -> impl IntoView {
+    view! {
+        <button
+            class=class
+            disabled=disabled
+            on:click=move |_| {
+                if let Some(tx) = tx.clone() {
+                    let _ = tx.unbounded_send(ClientMessage::Submit { action: action.clone() });
+                }
+            }
+        >
+            {label}
+        </button>
+    }
+}
+
+/// All core-loop action controls. Reads the store reactively; nothing
+/// renders until both a `game` and an `outcome` are present.
+#[component]
+pub fn ActionControls() -> impl IntoView {
+    let store = use_store();
+    let tx = use_context::<OutboundTx>();
+
+    view! {
+        {move || {
+            let state = store.get();
+            let (Some(game), Some(outcome)) = (state.game.clone(), state.outcome.clone()) else {
+                return ().into_any();
+            };
+            let enabled = enabled_controls(&game, &outcome);
+            let has = |c: ActionControl| enabled.contains(&c);
+            let active = game.active_investigator;
+
+            // Investigator-bearing buttons only render with an active
+            // investigator; the toy scenario always has one in Investigation.
+            let investigate = active.map(|inv| {
+                submit_button(
+                    "action investigate",
+                    "Investigate",
+                    !has(ActionControl::Investigate),
+                    tx.clone(),
+                    PlayerAction::Investigate { investigator: inv },
+                )
+            });
+            let advance_act = active.map(|inv| {
+                submit_button(
+                    "action advance-act",
+                    "Advance act",
+                    !has(ActionControl::AdvanceAct),
+                    tx.clone(),
+                    PlayerAction::AdvanceAct { investigator: inv },
+                )
+            });
+
+            view! {
+                <section class="controls">
+                    {investigate}
+                    {advance_act}
+                    {submit_button(
+                        "action end-turn",
+                        "End turn",
+                        !has(ActionControl::EndTurn),
+                        tx.clone(),
+                        PlayerAction::EndTurn,
+                    )}
+                    {submit_button(
+                        "action draw-encounter",
+                        "Draw encounter",
+                        !has(ActionControl::DrawEncounter),
+                        tx.clone(),
+                        PlayerAction::DrawEncounterCard,
+                    )}
+                </section>
+            }
+            .into_any()
+        }}
+    }
+}
+```
+
+- [ ] **Step 4: Wire the module into `lib.rs`**
+
+In `crates/web/src/lib.rs`, add a `controls` declaration next to `input` (both wasm-only). The end of the file becomes:
+
+```rust
+#[cfg(target_arch = "wasm32")]
+pub mod transport;
+
+#[cfg(target_arch = "wasm32")]
+pub mod input;
+
+#[cfg(target_arch = "wasm32")]
+pub mod controls;
+```
+
+- [ ] **Step 5: Mount `<ActionControls/>` in `app.rs` and remove `DebugSubmit`**
+
+In `crates/web/src/app.rs`, replace the wasm-only branch that renders `AwaitingInputView` + `DebugSubmit`:
+
+```rust
+            {
+                #[cfg(target_arch = "wasm32")]
+                { view! { <crate::input::AwaitingInputView/><crate::controls::ActionControls/> }.into_any() }
+                #[cfg(not(target_arch = "wasm32"))]
+                { ().into_any() }
+            }
+```
+
+Then delete the entire `DebugSubmit` function (the `#[cfg(target_arch = "wasm32")] #[component] fn DebugSubmit() { … }` block at the bottom of the file) — its doc-comment names P6.7 as its replacement, so this change obsoletes it.
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `wasm-pack test --headless --firefox crates/web 2>&1 | tail -20`
+Expected: PASS for `end_turn_submits_end_turn` (and the existing `input`/`board`/`store`/`smoke` tests still pass).
+
+- [ ] **Step 7: Add submit tests for the other three zero-payload buttons**
+
+Append to `crates/web/tests/controls.rs`:
+
+```rust
+#[wasm_bindgen_test]
+async fn investigate_submits_investigate_for_active() {
+    let mut rx = mount(investigation_game(), EngineOutcome::Done).await;
+    click_in(&last_controls(), ".investigate");
+    leptos::task::tick().await;
+    assert_eq!(
+        rx.try_recv().expect("a frame after tick"),
+        ClientMessage::Submit {
+            action: PlayerAction::Investigate {
+                investigator: InvestigatorId(1)
+            }
+        }
+    );
+}
+
+#[wasm_bindgen_test]
+async fn advance_act_submits_advance_act_for_active() {
+    let mut rx = mount(investigation_game(), EngineOutcome::Done).await;
+    click_in(&last_controls(), ".advance-act");
+    leptos::task::tick().await;
+    assert_eq!(
+        rx.try_recv().expect("a frame after tick"),
+        ClientMessage::Submit {
+            action: PlayerAction::AdvanceAct {
+                investigator: InvestigatorId(1)
+            }
+        }
+    );
+}
+
+#[wasm_bindgen_test]
+async fn draw_encounter_submits_draw_encounter_card() {
+    // Mythos phase with this investigator on the draw cursor: only
+    // DrawEncounter is legal. `mythos_draw_pending` has no builder setter,
+    // so mutate the built state directly (legality.rs tests do the same).
+    let mut game = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_active_investigator(InvestigatorId(1))
+        .with_phase(Phase::Mythos)
+        .build();
+    game.mythos_draw_pending = Some(InvestigatorId(1));
+
+    let mut rx = mount(game, EngineOutcome::Done).await;
+    click_in(&last_controls(), ".draw-encounter");
+    leptos::task::tick().await;
+    assert_eq!(
+        rx.try_recv().expect("a frame after tick"),
+        ClientMessage::Submit {
+            action: PlayerAction::DrawEncounterCard
+        }
+    );
+}
+```
+
+- [ ] **Step 8: Add the gating test (disabled buttons carry the attribute and do not submit)**
+
+Append to `crates/web/tests/controls.rs`:
+
+```rust
+#[wasm_bindgen_test]
+async fn illegal_controls_are_disabled_and_do_not_submit() {
+    // Mythos + draw cursor: only DrawEncounter is legal, so End turn is
+    // disabled and DrawEncounter is not.
+    let mut game = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_active_investigator(InvestigatorId(1))
+        .with_phase(Phase::Mythos)
+        .build();
+    game.mythos_draw_pending = Some(InvestigatorId(1));
+
+    let mut rx = mount(game, EngineOutcome::Done).await;
+    let controls = last_controls();
+    let end_turn = controls
+        .query_selector(".end-turn")
+        .expect("query")
+        .expect("end-turn present");
+    let draw = controls
+        .query_selector(".draw-encounter")
+        .expect("query")
+        .expect("draw-encounter present");
+    assert!(end_turn.has_attribute("disabled"), "End turn should be disabled");
+    assert!(!draw.has_attribute("disabled"), "Draw encounter should be enabled");
+
+    // A disabled button does not fire click → no frame.
+    click_in(&controls, ".end-turn");
+    leptos::task::tick().await;
+    assert!(rx.try_recv().is_err(), "disabled button must not submit");
+}
+```
+
+- [ ] **Step 9: Run the full crate gauntlet**
+
+Run:
+```sh
+cargo fmt --check
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+wasm-pack test --headless --firefox crates/web 2>&1 | tail -25
+```
+Expected: fmt clean, build clean, clippy clean, all `controls` tests pass plus the pre-existing tests.
+
+- [ ] **Step 10: Commit**
+
+```sh
+git add crates/web/src/controls.rs crates/web/src/lib.rs crates/web/src/app.rs crates/web/tests/controls.rs
+git commit -m "ui: core-loop action controls — zero-payload buttons (P6.7a)
+
+Refs #188.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Move picker (connected-destination buttons)
+
+**Files:**
+- Modify: `crates/web/src/controls.rs`
+- Modify: `crates/web/tests/controls.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `crates/web/tests/controls.rs`:
+
+```rust
+#[wasm_bindgen_test]
+async fn move_picker_submits_move_to_connected_destination() {
+    // Investigator at location 1, which connects to location 2.
+    let mut loc1 = test_location(1, "Study");
+    loc1.connections = vec![LocationId(2)];
+    let loc2 = test_location(2, "Hallway");
+    let game = TestGame::new()
+        .with_investigator_at(test_investigator(1), LocationId(1))
+        .with_active_investigator(InvestigatorId(1))
+        .with_location(loc1)
+        .with_location(loc2)
+        .with_phase(Phase::Investigation)
+        .build();
+
+    let mut rx = mount(game, EngineOutcome::Done).await;
+    let controls = last_controls();
+    // The single destination button is labeled by the destination name.
+    let dest = controls
+        .query_selector(".move-dest")
+        .expect("query")
+        .expect("a move destination button");
+    assert!(dest.text_content().unwrap_or_default().contains("Hallway"));
+
+    click_in(&controls, ".move-dest");
+    leptos::task::tick().await;
+    assert_eq!(
+        rx.try_recv().expect("a frame after tick"),
+        ClientMessage::Submit {
+            action: PlayerAction::Move {
+                investigator: InvestigatorId(1),
+                destination: LocationId(2),
+            }
+        }
+    );
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `wasm-pack test --headless --firefox crates/web 2>&1 | tail -20`
+Expected: FAIL — no `.move-dest` element (`expected "a move destination button"` panics).
+
+- [ ] **Step 3: Add the Move picker to the component**
+
+In `crates/web/src/controls.rs`, inside the reactive closure in `ActionControls`, after `advance_act` and before the returned `view!`, build the destination buttons:
+
+```rust
+            // Move picker: one button per connected destination, labeled
+            // by the destination's name. Renders only when Move is legal
+            // and the active investigator has a current location.
+            let move_dests: Vec<_> = if has(ActionControl::Move) {
+                active
+                    .and_then(|inv| game.investigators.get(&inv))
+                    .and_then(|inv| inv.current_location)
+                    .and_then(|loc_id| game.locations.get(&loc_id))
+                    .map(|loc| loc.connections.clone())
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|dest_id| {
+                        let inv = active?;
+                        let name = game
+                            .locations
+                            .get(&dest_id)
+                            .map_or_else(|| format!("loc {}", dest_id.0), |l| l.name.clone());
+                        let tx = tx.clone();
+                        Some(view! {
+                            <button
+                                class="move-dest"
+                                on:click=move |_| {
+                                    if let Some(tx) = tx.clone() {
+                                        let _ = tx.unbounded_send(ClientMessage::Submit {
+                                            action: PlayerAction::Move {
+                                                investigator: inv,
+                                                destination: dest_id,
+                                            },
+                                        });
+                                    }
+                                }
+                            >
+                                "Move to " {name}
+                            </button>
+                        })
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
+```
+
+Then add `<div class="move-picker">{move_dests}</div>` into the returned `<section class="controls">` (after the four buttons).
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `wasm-pack test --headless --firefox crates/web 2>&1 | tail -20`
+Expected: PASS for `move_picker_submits_move_to_connected_destination`.
+
+- [ ] **Step 5: Gauntlet + commit**
+
+```sh
+cargo fmt --check
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+wasm-pack test --headless --firefox crates/web 2>&1 | tail -25
+git add crates/web/src/controls.rs crates/web/tests/controls.rs
+git commit -m "ui: Move picker — connected-destination buttons (P6.7a)
+
+Refs #188.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: PlayCard picker (per-hand-card play button)
+
+**Files:**
+- Modify: `crates/web/src/controls.rs`
+- Modify: `crates/web/tests/controls.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `crates/web/tests/controls.rs`:
+
+```rust
+#[wasm_bindgen_test]
+async fn play_picker_submits_play_card_by_hand_index() {
+    let mut inv = test_investigator(1);
+    inv.hand = vec![
+        CardCode::new("_synth_event_a"),
+        CardCode::new("_synth_event_b"),
+    ];
+    let game = TestGame::new()
+        .with_investigator(inv)
+        .with_active_investigator(InvestigatorId(1))
+        .with_phase(Phase::Investigation)
+        .build();
+
+    let mut rx = mount(game, EngineOutcome::Done).await;
+    let controls = last_controls();
+    // Click the second card's Play button → hand_index 1.
+    let buttons = controls.query_selector_all(".play-card").expect("query");
+    buttons
+        .item(1)
+        .expect("second play button")
+        .dyn_into::<web_sys::HtmlElement>()
+        .expect("HtmlElement")
+        .click();
+    leptos::task::tick().await;
+    assert_eq!(
+        rx.try_recv().expect("a frame after tick"),
+        ClientMessage::Submit {
+            action: PlayerAction::PlayCard {
+                investigator: InvestigatorId(1),
+                hand_index: 1,
+            }
+        }
+    );
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `wasm-pack test --headless --firefox crates/web 2>&1 | tail -20`
+Expected: FAIL — no `.play-card` elements (`expected "second play button"` panics).
+
+- [ ] **Step 3: Add the PlayCard picker to the component**
+
+In `crates/web/src/controls.rs`, inside the reactive closure after `move_dests`, build the hand play buttons:
+
+```rust
+            // PlayCard picker: a "Play" button per card in the active
+            // investigator's hand (hand_index = position). Renders only
+            // when PlayCard is legal.
+            let play_buttons: Vec<_> = if has(ActionControl::PlayCard) {
+                active
+                    .and_then(|inv| game.investigators.get(&inv))
+                    .map(|inv_state| {
+                        inv_state
+                            .hand
+                            .iter()
+                            .enumerate()
+                            .map(|(idx, code)| {
+                                let hand_index = u8::try_from(idx).expect("hand fits in u8");
+                                let inv = active.expect("active present in this branch");
+                                let label = code.to_string();
+                                let tx = tx.clone();
+                                view! {
+                                    <li>
+                                        <button
+                                            class="play-card"
+                                            on:click=move |_| {
+                                                if let Some(tx) = tx.clone() {
+                                                    let _ = tx.unbounded_send(ClientMessage::Submit {
+                                                        action: PlayerAction::PlayCard {
+                                                            investigator: inv,
+                                                            hand_index,
+                                                        },
+                                                    });
+                                                }
+                                            }
+                                        >
+                                            "Play " {label}
+                                        </button>
+                                    </li>
+                                }
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            };
+```
+
+Then add `<ul class="play-picker">{play_buttons}</ul>` into the returned `<section class="controls">` (after `move-picker`).
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `wasm-pack test --headless --firefox crates/web 2>&1 | tail -20`
+Expected: PASS for `play_picker_submits_play_card_by_hand_index`.
+
+- [ ] **Step 5: Gauntlet + commit**
+
+```sh
+cargo fmt --check
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+wasm-pack test --headless --firefox crates/web 2>&1 | tail -25
+git add crates/web/src/controls.rs crates/web/tests/controls.rs
+git commit -m "ui: PlayCard picker — per-hand-card play buttons (P6.7a)
+
+Refs #188.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Mulligan multi-select
+
+**Files:**
+- Modify: `crates/web/src/controls.rs`
+- Modify: `crates/web/tests/controls.rs`
+
+- [ ] **Step 1: Write the two failing tests**
+
+Append to `crates/web/tests/controls.rs`:
+
+```rust
+/// A setup game where investigator 1 is on the mulligan cursor with a
+/// two-card hand.
+fn mulligan_game() -> game_core::state::GameState {
+    let mut inv = test_investigator(1);
+    inv.hand = vec![
+        CardCode::new("_synth_event_a"),
+        CardCode::new("_synth_event_b"),
+    ];
+    TestGame::new()
+        .with_investigator(inv)
+        .with_active_investigator(InvestigatorId(1))
+        .with_phase(Phase::Investigation)
+        .with_mulligan_pending(InvestigatorId(1))
+        .build()
+}
+
+#[wasm_bindgen_test]
+async fn mulligan_submits_selected_indices() {
+    let mut rx = mount(mulligan_game(), EngineOutcome::Done).await;
+    let controls = last_controls();
+    // Select the first card, then submit.
+    let cards = controls.query_selector_all(".mull-card").expect("query");
+    cards
+        .item(0)
+        .expect("first mull-card")
+        .dyn_into::<web_sys::HtmlElement>()
+        .expect("HtmlElement")
+        .click();
+    leptos::task::tick().await;
+    click_in(&controls, ".mulligan-submit");
+    leptos::task::tick().await;
+    assert_eq!(
+        rx.try_recv().expect("a frame after tick"),
+        ClientMessage::Submit {
+            action: PlayerAction::Mulligan {
+                investigator: InvestigatorId(1),
+                indices_to_redraw: vec![0],
+            }
+        }
+    );
+}
+
+#[wasm_bindgen_test]
+async fn mulligan_with_no_selection_keeps_hand() {
+    let mut rx = mount(mulligan_game(), EngineOutcome::Done).await;
+    click_in(&last_controls(), ".mulligan-submit");
+    leptos::task::tick().await;
+    assert_eq!(
+        rx.try_recv().expect("a frame after tick"),
+        ClientMessage::Submit {
+            action: PlayerAction::Mulligan {
+                investigator: InvestigatorId(1),
+                indices_to_redraw: vec![],
+            }
+        }
+    );
+}
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `wasm-pack test --headless --firefox crates/web 2>&1 | tail -20`
+Expected: FAIL — no `.mull-card` / `.mulligan-submit` elements.
+
+- [ ] **Step 3: Add a component-scoped selection signal and the Mulligan picker**
+
+In `crates/web/src/controls.rs`, add the selection signal at the top of `ActionControls` (after `let tx = …`):
+
+```rust
+    // Mulligan's own selection signal — kept separate from the P6.6 commit
+    // window (the shapes diverge; see the design spec). Cleared on submit.
+    let mulligan_sel = RwSignal::new(BTreeSet::<u32>::new());
+```
+
+Then, inside the reactive closure after `play_buttons`, build the Mulligan view:
+
+```rust
+            // Mulligan multi-select: setup-only (gated on the
+            // `mulligan_pending` cursor via the legality helper). Toggling a
+            // card flips its index in `mulligan_sel`; submitting sends the
+            // selected indices (empty = legal "keep my hand"). The cursor's
+            // investigator owns the redraw, not necessarily `active`.
+            let mulligan_view = if has(ActionControl::Mulligan) {
+                let cursor = game.mulligan_pending;
+                let hand: Vec<String> = cursor
+                    .and_then(|id| game.investigators.get(&id))
+                    .map(|inv| inv.hand.iter().map(ToString::to_string).collect())
+                    .unwrap_or_default();
+                let cards: Vec<_> = hand
+                    .into_iter()
+                    .enumerate()
+                    .map(|(idx, code)| {
+                        let i = u32::try_from(idx).expect("hand fits in u32");
+                        view! {
+                            <li>
+                                <button
+                                    class="mull-card"
+                                    class:selected=move || mulligan_sel.get().contains(&i)
+                                    on:click=move |_| mulligan_sel.update(|s| {
+                                        if !s.remove(&i) {
+                                            s.insert(i);
+                                        }
+                                    })
+                                >
+                                    {code}
+                                </button>
+                            </li>
+                        }
+                    })
+                    .collect();
+                let tx = tx.clone();
+                let on_submit = move |_| {
+                    if let Some(inv) = cursor {
+                        let indices: Vec<u8> = mulligan_sel
+                            .get()
+                            .into_iter()
+                            .map(|i| u8::try_from(i).expect("hand fits in u8"))
+                            .collect();
+                        if let Some(tx) = tx.clone() {
+                            let _ = tx.unbounded_send(ClientMessage::Submit {
+                                action: PlayerAction::Mulligan {
+                                    investigator: inv,
+                                    indices_to_redraw: indices,
+                                },
+                            });
+                        }
+                    }
+                    mulligan_sel.set(BTreeSet::new());
+                };
+                view! {
+                    <section class="mulligan">
+                        <ul>{cards}</ul>
+                        <button class="mulligan-submit" on:click=on_submit>"Mulligan"</button>
+                    </section>
+                }
+                .into_any()
+            } else {
+                ().into_any()
+            };
+```
+
+Then add `{mulligan_view}` into the returned `<section class="controls">` (after `play-picker`).
+
+- [ ] **Step 4: Run them to verify they pass**
+
+Run: `wasm-pack test --headless --firefox crates/web 2>&1 | tail -25`
+Expected: PASS for both mulligan tests.
+
+- [ ] **Step 5: Final gauntlet + commit**
+
+```sh
+cargo fmt --check
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+wasm-pack test --headless --firefox crates/web 2>&1 | tail -30
+git add crates/web/src/controls.rs crates/web/tests/controls.rs
+git commit -m "ui: Mulligan multi-select control (P6.7a)
+
+Refs #188.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Manual verification (after Task 4)
+
+Per the dev loop in `CLAUDE.md` (server on :8000, `trunk serve` on :3000), open the client, create a game, and confirm the toy scenario is clickable end-to-end to a **Won** state: Mulligan through setup, then Investigate → accumulate clues → AdvanceAct. The Won/Lost banner itself is P6.8; here "Won" is observed via the resulting board state (act advanced).
+
+## After all tasks: PR + phase doc
+
+Follow `CLAUDE.md`'s PR procedure: push `ui/action-controls`, open the PR with `Closes #188`, watch CI (the `wasm-build`/`wasm-test`/`wasm-clippy` jobs are the load-bearing ones here), then — only once CI is green — update `docs/phases/phase-6-web-client-v0.md` as the final commit (move #188 to a Closed/✅ state, flip the P6.7a ordering rows, add a Decisions-made entry only if load-bearing for a future PR — e.g. the keep-Mulligan-separate / interactive-board-deferred calls if not already captured by the spec). Merge only after explicit approval.
+```
+

--- a/docs/superpowers/specs/2026-06-09-p6-7a-action-controls-design.md
+++ b/docs/superpowers/specs/2026-06-09-p6-7a-action-controls-design.md
@@ -33,7 +33,7 @@ correctness gate** — the server stays authoritative and rejects anything
 illegal (P6.6 decision S2). When the store has no game (or no outcome),
 the set is empty and everything is disabled.
 
-## The seven controls
+## The controls
 
 "active" investigator = `game.active_investigator`. Mulligan instead uses
 the `mulligan_pending` cursor (the legality helper guarantees only
@@ -41,6 +41,7 @@ Mulligan is enabled in that window).
 
 | Control | UI | Submitted `PlayerAction` |
 |---|---|---|
+| StartScenario | button | `StartScenario` |
 | Investigate | button | `Investigate { investigator: active }` |
 | EndTurn | button | `EndTurn` |
 | DrawEncounterCard | button | `DrawEncounterCard` |
@@ -51,6 +52,20 @@ Mulligan is enabled in that window).
 
 Each action is wrapped in `ClientMessage::Submit { action }` and pushed
 onto the `OutboundTx` channel.
+
+### StartScenario is the entry point
+
+The server hands a freshly created game the raw scenario `setup()` state:
+`phase = Mythos`, `round = 0`, no cursors, empty hands. The only legal
+action there is `StartScenario` (the engine rejects it unless `round == 0`,
+then bumps to round 1, deals hands, and seeds `mulligan_pending`). So
+`enabled_controls` gates `StartScenario` on `round == 0` — which uniquely
+identifies the pre-start state, since the round counter only ever
+increments from 1 — and it is the sole enabled control until the player
+clicks it. (This was missed in the original draft of this spec, which
+enumerated only the in-progress controls; without it the toy scenario
+cannot be started from the browser, failing the "clickable end-to-end"
+acceptance.)
 
 ### Mulligan stays separate from the commit window
 

--- a/docs/superpowers/specs/2026-06-09-p6-7a-action-controls-design.md
+++ b/docs/superpowers/specs/2026-06-09-p6-7a-action-controls-design.md
@@ -1,0 +1,125 @@
+# P6.7a — Core-loop action controls
+
+**Issue:** [#188](https://github.com/talelburg/eldritch/issues/188) (Phase 6, slot P6.7a).
+**Depends on:** P6.6 (`AwaitingInput` UI + `enabled_controls` legality helper, PR #207).
+**Parent spec:** [`2026-06-08-phase-6-web-client-v0-design.md`](2026-06-08-phase-6-web-client-v0-design.md) (client layer 4).
+
+## Goal
+
+The action buttons that drive the synthetic toy scenario to a **Won**
+resolution, built on P6.6's submit + legality plumbing. Acceptance: each
+control, when legal, submits the correct `ClientMessage::Submit { action }`;
+the toy scenario is clickable end-to-end to a Won state (Investigate →
+clues → AdvanceAct).
+
+## Module
+
+New `crates/web/src/controls.rs`, wasm-only — declared
+`#[cfg(target_arch = "wasm32")] pub mod controls;` in `lib.rs`, matching
+`input` / `transport`. One component, `ActionControls`:
+
+- Reads the store reactively via `use_store()`.
+- Pulls `OutboundTx` from context as an `Option` (absent in render-only /
+  test-without-channel contexts → clicks no-op), exactly as
+  `AwaitingInputView` does.
+- `board.rs` stays strictly read-only. All interactivity is isolated here.
+
+## Gating
+
+Each render computes `legality::enabled_controls(&game, &outcome)` (the
+P6.6 helper). Every button binds its `disabled` to whether its
+`ActionControl` is in that set. This is a **UX affordance, not a
+correctness gate** — the server stays authoritative and rejects anything
+illegal (P6.6 decision S2). When the store has no game (or no outcome),
+the set is empty and everything is disabled.
+
+## The seven controls
+
+"active" investigator = `game.active_investigator`. Mulligan instead uses
+the `mulligan_pending` cursor (the legality helper guarantees only
+Mulligan is enabled in that window).
+
+| Control | UI | Submitted `PlayerAction` |
+|---|---|---|
+| Investigate | button | `Investigate { investigator: active }` |
+| EndTurn | button | `EndTurn` |
+| DrawEncounterCard | button | `DrawEncounterCard` |
+| AdvanceAct | button | `AdvanceAct { investigator: active }` |
+| Move | one button per connected destination, from the active investigator's location `connections`, labeled by destination name | `Move { investigator: active, destination }` |
+| PlayCard | a "Play" button per hand card (hand index = position) | `PlayCard { investigator: active, hand_index }` |
+| Mulligan | own multi-select hand (`RwSignal<BTreeSet<u32>>`) + a submit button; empty selection = legal "keep" | `Mulligan { investigator: cursor, indices_to_redraw }` (indices downcast `u32` → `u8`) |
+
+Each action is wrapped in `ClientMessage::Submit { action }` and pushed
+onto the `OutboundTx` channel.
+
+### Mulligan stays separate from the commit window
+
+`AwaitingInputView` (P6.6) already has a multi-select-hand → submit shape,
+and Mulligan is a second instance of it. They are **kept separate**: the
+genuinely shared part (toggle a `BTreeSet`, render a hand of buttons) is
+~12–15 lines, while the divergent parts are most of each component —
+different index type (`u32` vs `u8`), different action
+(`ResolveInput { CommitCards }` vs `Mulligan`), different gating
+(`AwaitingInput` outcome vs the `mulligan_pending` cursor), different
+investigator source, different label. Extracting now would also rewrite
+shipped, tested P6.6 code to serve a new caller — wider blast radius than
+the duplication saves. The clean extract trigger is a **third** concrete
+use (the upkeep max-hand-size discard prompt, `InputResponse::Discard`,
+deferred with #205); three real call sites will inform the shared shape.
+
+## app.rs wiring
+
+Add `<ActionControls/>` alongside `<AwaitingInputView/>` in the wasm-only
+branch of `App`. **Remove `DebugSubmit`** — its doc-comment states "P6.7
+builds the real action controls on this seam," so this change obsoletes
+it (surgical cleanup of our own predecessor placeholder, not unrelated
+refactoring).
+
+## Edge handling
+
+- **No game / no active investigator** → `enabled_controls` is empty, so
+  every gated button is disabled. Move/PlayCard pickers render nothing
+  (no location/hand to iterate).
+- **Absent `OutboundTx`** → click handlers no-op (same `Option` guard as
+  `AwaitingInputView`).
+
+## Tests
+
+`crates/web/tests/controls.rs`, `#![cfg(target_arch = "wasm32")]`,
+mirroring `tests/input.rs`'s harness: mount `ActionControls` with a fresh
+store + an `mpsc` outbound channel, feed a `Hello { state, outcome }`
+through `reduce`, `tick()`, then read submitted frames off the receiver.
+Because the headless runner shares one page and `mount_to_body` appends,
+absence/selection assertions scope to the last-mounted subtree (board.rs
+precedent).
+
+One test per control — build a state where it is legal, click, assert the
+exact `ClientMessage::Submit { action }` frame:
+
+- Investigate (Investigation phase, active inv) → `Investigate { inv }`
+- EndTurn → `EndTurn`
+- AdvanceAct → `AdvanceAct { inv }`
+- DrawEncounterCard (Mythos + `mythos_draw_pending`) → `DrawEncounterCard`
+- Move (two connected locations) — click a destination → `Move { inv, dest }`
+- PlayCard (hand with a card) — click a card's Play → `PlayCard { inv, hand_index }`
+- Mulligan (`mulligan_pending` set) — select indices + submit →
+  `Mulligan { inv, indices_to_redraw }`; and the empty/"keep" path
+- One gating test: in a phase where a control is illegal, its button is
+  `disabled` (and clicking submits no frame)
+
+## Manual acceptance
+
+Toy scenario clickable end-to-end to a **Won** state (Investigate →
+accumulate clues → AdvanceAct). The Won/Lost *banner* is P6.8, so "Won"
+is observed here via the resulting board state (act advanced), not a
+dedicated resolution surface.
+
+## Out of scope / follow-ups
+
+- **Combat/edge controls** (Fight, Evade, Draw with enemy-target pickers)
+  — P6.7b (#189).
+- **Resolution banner** (Won/Lost surfacing) — P6.8 (#190).
+- **Interactive board** — clicking board locations/hand cards directly to
+  Move/PlayCard (rather than dedicated controls-panel pickers). Preferred
+  for real player UX; deferred to a future phase. Recorded here as the
+  brainstormed direction; this slot keeps `board.rs` read-only.


### PR DESCRIPTION
## Summary

Adds the core-loop action controls (P6.7a, #188): a wasm-only `ActionControls` component that makes the toy scenario clickable. Each control is gated by the P6.6 `enabled_controls` legality helper and submits the matching `ClientMessage::Submit { action }`. `board.rs` stays read-only — all interactivity lives in the new module.

## What changed

- **New `crates/web/src/controls.rs`** with the `ActionControls` component:
  - Zero-payload buttons: Investigate, EndTurn, DrawEncounterCard, AdvanceAct (each `disabled` per legality).
  - `move_picker` — one button per connected destination (from the active investigator's location `connections`), submitting `Move { investigator, destination }`.
  - `play_picker` — a "Play" button per hand card, submitting `PlayCard { investigator, hand_index }`.
  - `mulligan_picker` — setup-only multi-select hand (gated on `mulligan_pending`), submitting `Mulligan { investigator, indices_to_redraw }`; empty selection is the legal "keep my hand" path.
- **`app.rs`**: mounts `<ActionControls/>` and removes the obsolete `DebugSubmit` placeholder (its doc-comment named P6.7 as its replacement).
- **`lib.rs`**: declares the wasm-only `controls` module.

## Design decisions

- **Mulligan kept separate from the P6.6 commit window.** Both are multi-select-hand → submit, but the shapes diverge (`u8` vs `u32` indices, `Mulligan` vs `ResolveInput`, `mulligan_pending` vs `AwaitingInput` gating, different investigator source). Extracting a shared component would also rewrite shipped P6.6 code; the clean extract trigger is a third use (the deferred upkeep discard prompt, #205). See the design spec.
- **Pickers in a controls panel, not an interactive board.** `board.rs` stays read-only this slot; clicking board locations/cards directly is the preferred direction for real player UX and is deferred to a future phase (recorded in the spec).
- **Tests match-extract the action** rather than `assert_eq!`-ing the frame, since `protocol::ClientMessage` has no `PartialEq` (the `tests/input.rs` pattern).

## Test notes

- `crates/web/tests/controls.rs` (headless `wasm-bindgen-test`, mirroring `tests/input.rs`): one test per control asserting the exact submitted action, plus a gating test (illegal control is `disabled` and submits nothing) and the Mulligan "keep" path — 9 tests.
- Full local CI gauntlet green: `fmt`, host `clippy`, host `test`, `doc` (strict flags), `wasm build`, `wasm clippy`, `wasm-pack test --headless --firefox` (9/9 controls tests).
- Manual end-to-end (browser → Won) deferred to the milestone-close demo (P6.8); the Won/Lost banner itself is P6.8.

## Linked issues

Closes #188
