### PR TITLE
ui: combat/edge action controls — Fight, Evade, Draw (P6.7b)

### DIFF
--- a/crates/web/src/controls.rs
+++ b/crates/web/src/controls.rs
@@ -7,7 +7,7 @@
 
 use std::collections::BTreeSet;
 
-use game_core::state::{GameState, InvestigatorId};
+use game_core::state::{EnemyId, GameState, InvestigatorId};
 use game_core::PlayerAction;
 use leptos::prelude::*;
 use protocol::ClientMessage;
@@ -140,6 +140,61 @@ fn play_picker(
         Vec::new()
     };
     view! { <ul class="play-picker">{buttons}</ul> }
+}
+
+fn fight_action(investigator: InvestigatorId, enemy: EnemyId) -> PlayerAction {
+    PlayerAction::Fight { investigator, enemy }
+}
+
+fn evade_action(investigator: InvestigatorId, enemy: EnemyId) -> PlayerAction {
+    PlayerAction::Evade { investigator, enemy }
+}
+
+/// Enemy picker: one button per enemy currently engaged with the active
+/// investigator, labeled `"{verb} {enemy name}"`. Empty when `legal` is
+/// false, there is no active investigator, or no enemies are engaged —
+/// same empty-render behavior as `move_picker`.
+fn enemy_picker(
+    game: &GameState,
+    active: Option<InvestigatorId>,
+    legal: bool,
+    class: &'static str,
+    verb: &'static str,
+    make_action: fn(InvestigatorId, EnemyId) -> PlayerAction,
+    tx: Option<&OutboundTx>,
+) -> impl IntoView {
+    let buttons: Vec<_> = if legal {
+        active
+            .map(|inv| {
+                game.enemies
+                    .values()
+                    .filter(|e| e.engaged_with == Some(inv))
+                    .map(|enemy| {
+                        let enemy_id = enemy.id;
+                        let name = enemy.name.clone();
+                        let tx = tx.cloned();
+                        view! {
+                            <button
+                                class=class
+                                on:click=move |_| {
+                                    if let Some(tx) = tx.clone() {
+                                        let _ = tx.unbounded_send(ClientMessage::Submit {
+                                            action: make_action(inv, enemy_id),
+                                        });
+                                    }
+                                }
+                            >
+                                {verb} " " {name}
+                            </button>
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    view! { <div class=format!("{class}-picker")>{buttons}</div> }
 }
 
 /// Mulligan multi-select: setup-only (gated on the `mulligan_pending`
@@ -290,6 +345,8 @@ pub fn ActionControls() -> impl IntoView {
                     )}
                     {move_picker(&game, active, has(ActionControl::Move), tx.as_ref())}
                     {play_picker(&game, active, has(ActionControl::PlayCard), tx.as_ref())}
+                    {enemy_picker(&game, active, has(ActionControl::Fight), "fight-target", "Fight", fight_action, tx.as_ref())}
+                    {enemy_picker(&game, active, has(ActionControl::Evade), "evade-target", "Evade", evade_action, tx.as_ref())}
                     {mulligan_picker(
                         &game,
                         has(ActionControl::Mulligan),

--- a/crates/web/src/controls.rs
+++ b/crates/web/src/controls.rs
@@ -143,11 +143,17 @@ fn play_picker(
 }
 
 fn fight_action(investigator: InvestigatorId, enemy: EnemyId) -> PlayerAction {
-    PlayerAction::Fight { investigator, enemy }
+    PlayerAction::Fight {
+        investigator,
+        enemy,
+    }
 }
 
 fn evade_action(investigator: InvestigatorId, enemy: EnemyId) -> PlayerAction {
-    PlayerAction::Evade { investigator, enemy }
+    PlayerAction::Evade {
+        investigator,
+        enemy,
+    }
 }
 
 /// Enemy picker: one button per enemy currently engaged with the active

--- a/crates/web/src/controls.rs
+++ b/crates/web/src/controls.rs
@@ -252,6 +252,15 @@ pub fn ActionControls() -> impl IntoView {
                     PlayerAction::AdvanceAct { investigator: inv },
                 )
             });
+            let draw = active.map(|inv| {
+                submit_button(
+                    "action draw",
+                    "Draw",
+                    !has(ActionControl::Draw),
+                    tx.clone(),
+                    PlayerAction::Draw { investigator: inv },
+                )
+            });
 
             view! {
                 <section class="controls">
@@ -264,6 +273,7 @@ pub fn ActionControls() -> impl IntoView {
                     )}
                     {investigate}
                     {advance_act}
+                    {draw}
                     {submit_button(
                         "action end-turn",
                         "End turn",

--- a/crates/web/src/legality.rs
+++ b/crates/web/src/legality.rs
@@ -64,7 +64,14 @@ pub fn enabled_controls(game: &GameState, outcome: &EngineOutcome) -> BTreeSet<A
     }
     match game.phase {
         Phase::Investigation => BTreeSet::from([
-            Move, Investigate, PlayCard, EndTurn, AdvanceAct, Fight, Evade, Draw,
+            Move,
+            Investigate,
+            PlayCard,
+            EndTurn,
+            AdvanceAct,
+            Fight,
+            Evade,
+            Draw,
         ]),
         Phase::Mythos | Phase::Enemy | Phase::Upkeep => BTreeSet::new(),
     }
@@ -142,7 +149,14 @@ mod tests {
         assert_eq!(
             enabled_controls(&game, &EngineOutcome::Done),
             BTreeSet::from([
-                Move, Investigate, PlayCard, EndTurn, AdvanceAct, Fight, Evade, Draw
+                Move,
+                Investigate,
+                PlayCard,
+                EndTurn,
+                AdvanceAct,
+                Fight,
+                Evade,
+                Draw
             ])
         );
     }

--- a/crates/web/src/legality.rs
+++ b/crates/web/src/legality.rs
@@ -8,8 +8,7 @@ use std::collections::BTreeSet;
 use game_core::state::{GameState, Phase};
 use game_core::EngineOutcome;
 
-/// A clickable core-loop action in the client. Combat controls
-/// (`Fight`/`Evade`/`Draw`) join in P6.7b.
+/// A clickable core-loop action in the client.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ActionControl {
     StartScenario,
@@ -20,6 +19,9 @@ pub enum ActionControl {
     Mulligan,
     DrawEncounter,
     AdvanceAct,
+    Fight,
+    Evade,
+    Draw,
 }
 
 /// The controls the player may click right now.
@@ -44,7 +46,8 @@ pub enum ActionControl {
 #[must_use]
 pub fn enabled_controls(game: &GameState, outcome: &EngineOutcome) -> BTreeSet<ActionControl> {
     use ActionControl::{
-        AdvanceAct, DrawEncounter, EndTurn, Investigate, Move, Mulligan, PlayCard, StartScenario,
+        AdvanceAct, Draw, DrawEncounter, EndTurn, Evade, Fight, Investigate, Move, Mulligan,
+        PlayCard, StartScenario,
     };
 
     if matches!(outcome, EngineOutcome::AwaitingInput { .. }) {
@@ -60,14 +63,18 @@ pub fn enabled_controls(game: &GameState, outcome: &EngineOutcome) -> BTreeSet<A
         return BTreeSet::from([DrawEncounter]);
     }
     match game.phase {
-        Phase::Investigation => BTreeSet::from([Move, Investigate, PlayCard, EndTurn, AdvanceAct]),
+        Phase::Investigation => BTreeSet::from([
+            Move, Investigate, PlayCard, EndTurn, AdvanceAct, Fight, Evade, Draw,
+        ]),
         Phase::Mythos | Phase::Enemy | Phase::Upkeep => BTreeSet::new(),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::ActionControl::{AdvanceAct, EndTurn, Investigate, Move, PlayCard};
+    use super::ActionControl::{
+        AdvanceAct, Draw, EndTurn, Evade, Fight, Investigate, Move, PlayCard,
+    };
     use super::{enabled_controls, ActionControl};
     use game_core::state::{InvestigatorId, Phase};
     use game_core::test_support::builder::TestGame;
@@ -134,7 +141,9 @@ mod tests {
         let game = investigation_game();
         assert_eq!(
             enabled_controls(&game, &EngineOutcome::Done),
-            BTreeSet::from([Move, Investigate, PlayCard, EndTurn, AdvanceAct])
+            BTreeSet::from([
+                Move, Investigate, PlayCard, EndTurn, AdvanceAct, Fight, Evade, Draw
+            ])
         );
     }
 

--- a/crates/web/tests/controls.rs
+++ b/crates/web/tests/controls.rs
@@ -5,9 +5,9 @@
 #![cfg(target_arch = "wasm32")]
 
 use futures::channel::mpsc;
-use game_core::state::{CardCode, InvestigatorId, LocationId, Phase};
+use game_core::state::{CardCode, EnemyId, InvestigatorId, LocationId, Phase};
 use game_core::test_support::builder::TestGame;
-use game_core::test_support::fixtures::{test_investigator, test_location};
+use game_core::test_support::fixtures::{test_enemy, test_investigator, test_location};
 use game_core::{EngineOutcome, PlayerAction};
 use leptos::prelude::*;
 use protocol::{ClientMessage, ServerMessage};
@@ -329,6 +329,20 @@ async fn mulligan_with_no_selection_keeps_hand() {
     }
 }
 
+/// An Investigation-phase game with one enemy (id 7) engaged with the
+/// active investigator (id 1).
+fn investigation_game_with_engaged_enemy() -> game_core::state::GameState {
+    let mut enemy = test_enemy(7, "Ghoul");
+    enemy.engaged_with = Some(InvestigatorId(1));
+    TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_active_investigator(InvestigatorId(1))
+        .with_phase(Phase::Investigation)
+        .with_round(1)
+        .with_enemy(enemy)
+        .build()
+}
+
 #[wasm_bindgen_test]
 async fn draw_button_submits_draw() {
     let game = investigation_game();
@@ -342,6 +356,46 @@ async fn draw_button_submits_draw() {
             assert_eq!(investigator, InvestigatorId(1));
         }
         other => panic!("expected Draw, got {other:?}"),
+    }
+}
+
+#[wasm_bindgen_test]
+async fn fight_target_submits_fight_with_chosen_enemy() {
+    let game = investigation_game_with_engaged_enemy();
+    let mut rx = mount(game, EngineOutcome::Done).await;
+    let controls = last_controls();
+    click_in(&controls, ".fight-target");
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame after tick");
+    match submit_action(frame) {
+        PlayerAction::Fight {
+            investigator,
+            enemy,
+        } => {
+            assert_eq!(investigator, InvestigatorId(1));
+            assert_eq!(enemy, EnemyId(7));
+        }
+        other => panic!("expected Fight, got {other:?}"),
+    }
+}
+
+#[wasm_bindgen_test]
+async fn evade_target_submits_evade_with_chosen_enemy() {
+    let game = investigation_game_with_engaged_enemy();
+    let mut rx = mount(game, EngineOutcome::Done).await;
+    let controls = last_controls();
+    click_in(&controls, ".evade-target");
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame after tick");
+    match submit_action(frame) {
+        PlayerAction::Evade {
+            investigator,
+            enemy,
+        } => {
+            assert_eq!(investigator, InvestigatorId(1));
+            assert_eq!(enemy, EnemyId(7));
+        }
+        other => panic!("expected Evade, got {other:?}"),
     }
 }
 

--- a/crates/web/tests/controls.rs
+++ b/crates/web/tests/controls.rs
@@ -330,6 +330,22 @@ async fn mulligan_with_no_selection_keeps_hand() {
 }
 
 #[wasm_bindgen_test]
+async fn draw_button_submits_draw() {
+    let game = investigation_game();
+    let mut rx = mount(game, EngineOutcome::Done).await;
+    let controls = last_controls();
+    click_in(&controls, ".action.draw");
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame after tick");
+    match submit_action(frame) {
+        PlayerAction::Draw { investigator } => {
+            assert_eq!(investigator, InvestigatorId(1));
+        }
+        other => panic!("expected Draw, got {other:?}"),
+    }
+}
+
+#[wasm_bindgen_test]
 async fn start_scenario_is_the_only_control_at_round_zero() {
     // The state straight from a scenario `setup()`: phase Mythos, round 0,
     // no cursors, no active investigator. The only legal action is

--- a/docs/phases/phase-6-web-client-v0.md
+++ b/docs/phases/phase-6-web-client-v0.md
@@ -257,6 +257,16 @@ Settled implementing P6.7b (PR #209):
   not a gap. `Fight`/`Evade` are named-field struct variants, so they're
   adapted to the picker's `fn(InvestigatorId, EnemyId) -> PlayerAction`
   constructor slot via thin `fight_action`/`evade_action` wrappers.
+- **Fight/Evade are wired + headless-tested but not reachable in the live
+  toy scenario yet.** `synthetic::setup()` seeds the encounter deck with
+  only `_synth_treachery`; `_synth_enemy` exists but is pushed onto the
+  deck only by integration tests, so no enemy ever spawns/engages through
+  in-browser play and the combat pickers stay empty. The headless tests
+  build an engaged-enemy state directly. Making combat reachable
+  (seeding the enemy so a draw spawns + engages it) is **deferred to P6.8**
+  (#190) — the closing demo's *Lost* path runs through agenda doom, not
+  combat, so this is demo polish, not a milestone blocker. Draw *is*
+  reachable now (rendered in Investigation like Investigate/AdvanceAct).
 
 ## Open questions
 

--- a/docs/phases/phase-6-web-client-v0.md
+++ b/docs/phases/phase-6-web-client-v0.md
@@ -26,7 +26,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | P6.5 | [#186](https://github.com/talelburg/eldritch/issues/186) — board rendering (read-only) | ✅ PR #204 |
 | P6.6 | [#187](https://github.com/talelburg/eldritch/issues/187) — AwaitingInput resolution UI + legality gating | ✅ PR #207 |
 | P6.7a | [#188](https://github.com/talelburg/eldritch/issues/188) — core-loop action controls | ✅ PR #208 |
-| P6.7b | [#189](https://github.com/talelburg/eldritch/issues/189) — combat/edge action controls | ⏳ open |
+| P6.7b | [#189](https://github.com/talelburg/eldritch/issues/189) — combat/edge action controls | ✅ PR #209 |
 | P6.8 | [#190](https://github.com/talelburg/eldritch/issues/190) — resolution surfacing + closing demo | ⏳ open |
 
 ## Ordering
@@ -42,7 +42,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | P6.5 | #186 board rendering ✅ PR #204 | See the state | P6.4 |
 | P6.6 | #187 AwaitingInput UI + legality ✅ PR #207 | Core-loop: `Investigate` opens a skill-test commit window (`AwaitingInput`), so this precedes the action controls | P6.5 |
 | P6.7a | #188 core-loop action controls ✅ PR #208 | Toy scenario clickable to a **Won** resolution | P6.6 |
-| P6.7b | #189 combat/edge action controls | Rounds out the action surface (combat/Lost walk) | P6.7a |
+| P6.7b | #189 combat/edge action controls ✅ PR #209 | Rounds out the action surface (combat/Lost walk) | P6.7a |
 | P6.8 | #190 resolution + closing demo | Milestone close | all |
 
 P6.1 and P6.2 both touch `server`; sequence to avoid churn. P6.3 is
@@ -53,8 +53,10 @@ hot-reload) shipped before the content UI. P6.4b
 was **deferred to Phase 8 and closed** — see *Decisions made*. P6.5
 (#186, board rendering ✅ PR #204) shipped the read-only board and P6.6
 (#187, `AwaitingInput` UI + legality ✅ PR #207) shipped the interaction
-plumbing, and P6.7a (#188, core-loop action controls ✅ PR #208) shipped
-the action buttons, so the combat/edge controls (P6.7b, #189) are next.
+plumbing, P6.7a (#188, core-loop action controls ✅ PR #208) shipped the
+action buttons, and P6.7b (#189, combat/edge controls ✅ PR #209) added
+Fight/Evade/Draw, so resolution surfacing + the closing demo (P6.8, #190)
+is the last slot before milestone close.
 
 ## Decisions made
 
@@ -240,6 +242,21 @@ Settled implementing P6.7a (PR #208):
   `StartScenario`, so the client loaded with every control disabled and no
   way to begin — and the headless tests masked it by building in-progress
   states with the builder's default `round 0`, an impossible real state.
+
+Settled implementing P6.7b (PR #209):
+
+- **Fight/Evade use the empty-picker (Move) pattern, not hide-unless-
+  engaged.** The two controls are enabled by `Phase::Investigation` like
+  any other core-loop action, and a single parameterized `enemy_picker`
+  renders one target button per enemy with `engaged_with == Some(active)`
+  — zero buttons when none are engaged, exactly as `move_picker` renders
+  nothing with no connections. This keeps the enemy scan out of the
+  legality layer (which stays phase-coarse) and out of any new
+  conditional-render path. A future combat-UI PR weighing "only show
+  Fight when a target exists" should treat that as a deliberate UX change,
+  not a gap. `Fight`/`Evade` are named-field struct variants, so they're
+  adapted to the picker's `fn(InvestigatorId, EnemyId) -> PlayerAction`
+  constructor slot via thin `fight_action`/`evade_action` wrappers.
 
 ## Open questions
 

--- a/docs/superpowers/plans/2026-06-09-p6.7b-combat-action-controls.md
+++ b/docs/superpowers/plans/2026-06-09-p6.7b-combat-action-controls.md
@@ -1,0 +1,443 @@
+# P6.7b Combat/Edge Action Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Fight/Evade engaged-enemy target pickers and a player-deck Draw button to the web client's `ActionControls` panel.
+
+**Architecture:** Pure client wiring extending the P6.7a pattern. `legality.rs` gains three `ActionControl` enum variants enabled in the Investigation phase; `controls.rs` gains a `Draw` submit button plus two target pickers (shaped like the existing `move_picker`) that scan `game.enemies` for enemies engaged with the active investigator. No engine or board changes — the `Fight`/`Evade`/`Draw` `PlayerAction`s already exist.
+
+**Tech Stack:** Rust, Leptos (CSR/wasm32), `wasm-bindgen-test` (headless Firefox) for component tests, native `cargo test` for legality unit tests.
+
+---
+
+## Reference
+
+- Design spec: `docs/superpowers/specs/2026-06-09-p6.7b-combat-action-controls-design.md`
+- Engine actions (already exist, no change):
+  - `PlayerAction::Fight { investigator: InvestigatorId, enemy: EnemyId }`
+  - `PlayerAction::Evade { investigator: InvestigatorId, enemy: EnemyId }`
+  - `PlayerAction::Draw { investigator: InvestigatorId }`
+- Enemy engagement: `game.enemies: BTreeMap<EnemyId, Enemy>`; an enemy is engaged with investigator `i` iff `enemy.engaged_with == Some(i)`. `Enemy` has `id: EnemyId`, `name: String`.
+- Test fixtures: `game_core::test_support::fixtures::test_enemy(id: u32, name: impl Into<String>) -> Enemy`; builder `TestGame::with_enemy(Enemy) -> Self`.
+- Patterns to mirror: `move_picker` (target picker shape) and `submit_button` (zero-payload button) in `crates/web/src/controls.rs`.
+- CI gate for wasm tests: `wasm-pack test --headless --firefox crates/web`.
+
+---
+
+## Task 1: Legality — enable Fight/Evade/Draw in the Investigation phase
+
+**Files:**
+- Modify: `crates/web/src/legality.rs` (enum at lines 13-23; `enabled_controls` at 45-66; test `investigation_phase_enables_the_core_loop` at 132-139)
+
+- [ ] **Step 1: Update the failing test**
+
+In `crates/web/src/legality.rs`, replace the body of `investigation_phase_enables_the_core_loop` (lines 132-139) so it asserts the new full set. Also extend the test module's `use super::ActionControl::{...}` import (line 70) to include `Draw`, `Evade`, `Fight`:
+
+```rust
+use super::ActionControl::{
+    AdvanceAct, Draw, EndTurn, Evade, Fight, Investigate, Move, PlayCard,
+};
+```
+
+```rust
+    #[test]
+    fn investigation_phase_enables_the_core_loop() {
+        let game = investigation_game();
+        assert_eq!(
+            enabled_controls(&game, &EngineOutcome::Done),
+            BTreeSet::from([
+                Move, Investigate, PlayCard, EndTurn, AdvanceAct, Fight, Evade, Draw
+            ])
+        );
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p web --lib legality::tests::investigation_phase_enables_the_core_loop`
+Expected: FAIL — either a compile error (`Fight`/`Evade`/`Draw` not found on `ActionControl`) or an assertion mismatch.
+
+- [ ] **Step 3: Add the enum variants**
+
+In `crates/web/src/legality.rs`, replace the `ActionControl` enum (lines 13-23) — add `Fight`, `Evade`, `Draw` and update the doc comment so it no longer says they "join in P6.7b":
+
+```rust
+/// A clickable core-loop action in the client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ActionControl {
+    StartScenario,
+    Move,
+    Investigate,
+    PlayCard,
+    EndTurn,
+    Mulligan,
+    DrawEncounter,
+    AdvanceAct,
+    Fight,
+    Evade,
+    Draw,
+}
+```
+
+- [ ] **Step 4: Add them to the Investigation phase set**
+
+In `enabled_controls`, update the `use ActionControl::{...}` line (46-48) and the `Phase::Investigation` arm (line 63):
+
+```rust
+    use ActionControl::{
+        AdvanceAct, Draw, DrawEncounter, EndTurn, Evade, Fight, Investigate, Move, Mulligan,
+        PlayCard, StartScenario,
+    };
+```
+
+```rust
+        Phase::Investigation => BTreeSet::from([
+            Move, Investigate, PlayCard, EndTurn, AdvanceAct, Fight, Evade, Draw,
+        ]),
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cargo test -p web --lib legality::tests`
+Expected: PASS (all legality tests, including the updated one).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/web/src/legality.rs
+git commit -m "$(cat <<'EOF'
+ui: enable Fight/Evade/Draw controls in Investigation (P6.7b)
+
+Adds the three combat/edge ActionControl variants and gates them on the
+Investigation phase, matching the existing coarse-affordance approach
+(phase-gated only; the server stays authoritative). Wires nothing yet.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Draw button in the controls panel
+
+**Files:**
+- Modify: `crates/web/src/controls.rs` (`ActionControls` component, around the other `submit_button` calls at lines 256-289)
+- Test: `crates/web/tests/controls.rs`
+
+- [ ] **Step 1: Write the failing headless test**
+
+Append to `crates/web/tests/controls.rs`. This mirrors the existing zero-payload-button tests (e.g. EndTurn). `investigation_game()` and `mount`/`last_controls`/`click_in`/`next_msg`-style helpers already exist in the file — reuse them; read the file's existing tests to match the exact assertion helper used for `Submit { action }`.
+
+```rust
+#[wasm_bindgen_test]
+async fn draw_button_submits_draw() {
+    let game = investigation_game();
+    let mut rx = mount(game, EngineOutcome::Done).await;
+
+    let controls = last_controls();
+    click_in(&controls, ".action.draw");
+
+    let msg = rx.try_next().expect("a message").expect("not closed");
+    assert_eq!(
+        msg,
+        ClientMessage::Submit {
+            action: PlayerAction::Draw { investigator: InvestigatorId(1) }
+        }
+    );
+}
+```
+
+> Note: if existing tests in this file read the channel via a helper rather than `rx.try_next()`, use that helper instead so the style matches. The selector `.action.draw` must match the button's `class="action draw"`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `wasm-pack test --headless --firefox crates/web -- --test controls draw_button_submits_draw`
+Expected: FAIL — the `.action.draw` element is not present (no Draw button rendered yet), so `click_in`'s `.expect("element present")` panics.
+
+- [ ] **Step 3: Add the Draw button**
+
+In `crates/web/src/controls.rs`, the `Draw` action needs the active investigator, so render it like `investigate`/`advance_act` (the `active.map(...)` buttons). Add, alongside the existing `let investigate = ...` / `let advance_act = ...` bindings (lines 237-254):
+
+```rust
+            let draw = active.map(|inv| {
+                submit_button(
+                    "action draw",
+                    "Draw",
+                    !has(ActionControl::Draw),
+                    tx.clone(),
+                    PlayerAction::Draw { investigator: inv },
+                )
+            });
+```
+
+Then render `{draw}` inside the `<section class="controls">` view, immediately after the existing `{advance_act}` (line 266):
+
+```rust
+                    {investigate}
+                    {advance_act}
+                    {draw}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `wasm-pack test --headless --firefox crates/web -- --test controls draw_button_submits_draw`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/web/src/controls.rs crates/web/tests/controls.rs
+git commit -m "$(cat <<'EOF'
+ui: Draw button in the action controls panel (P6.7b)
+
+Player-deck Draw, rendered like Investigate/AdvanceAct (needs the active
+investigator). Distinct from the existing Draw-encounter button.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Fight/Evade engaged-enemy target pickers
+
+**Files:**
+- Modify: `crates/web/src/controls.rs` (add an `enemy_picker` helper near `move_picker`/`play_picker`; render two instances in `ActionControls`)
+- Test: `crates/web/tests/controls.rs`
+
+- [ ] **Step 1: Write the failing headless tests**
+
+First add a small helper near the top of `crates/web/tests/controls.rs` (after the existing `investigation_game` helper) that adds one engaged enemy:
+
+```rust
+use game_core::state::EnemyId;
+use game_core::test_support::fixtures::test_enemy;
+
+/// An Investigation-phase game with one enemy (id 7) engaged with the
+/// active investigator (id 1).
+fn investigation_game_with_engaged_enemy() -> game_core::state::GameState {
+    let mut enemy = test_enemy(7, "Ghoul");
+    enemy.engaged_with = Some(InvestigatorId(1));
+    TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_active_investigator(InvestigatorId(1))
+        .with_phase(Phase::Investigation)
+        .with_round(1)
+        .with_enemy(enemy)
+        .build()
+}
+```
+
+> If `test_investigator`/`test_location` are already imported at the top of the file, extend that `use` line rather than adding a duplicate; same for `Phase`/`InvestigatorId`. Confirm `with_enemy` is in scope via `TestGame` (it is a method, no extra import).
+
+Then append the two tests:
+
+```rust
+#[wasm_bindgen_test]
+async fn fight_target_submits_fight_with_chosen_enemy() {
+    let game = investigation_game_with_engaged_enemy();
+    let mut rx = mount(game, EngineOutcome::Done).await;
+
+    let controls = last_controls();
+    click_in(&controls, ".fight-target");
+
+    let msg = rx.try_next().expect("a message").expect("not closed");
+    assert_eq!(
+        msg,
+        ClientMessage::Submit {
+            action: PlayerAction::Fight {
+                investigator: InvestigatorId(1),
+                enemy: EnemyId(7),
+            }
+        }
+    );
+}
+
+#[wasm_bindgen_test]
+async fn evade_target_submits_evade_with_chosen_enemy() {
+    let game = investigation_game_with_engaged_enemy();
+    let mut rx = mount(game, EngineOutcome::Done).await;
+
+    let controls = last_controls();
+    click_in(&controls, ".evade-target");
+
+    let msg = rx.try_next().expect("a message").expect("not closed");
+    assert_eq!(
+        msg,
+        ClientMessage::Submit {
+            action: PlayerAction::Evade {
+                investigator: InvestigatorId(1),
+                enemy: EnemyId(7),
+            }
+        }
+    );
+}
+```
+
+> Use the same channel-read helper the file's other tests use if it isn't `rx.try_next()`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `wasm-pack test --headless --firefox crates/web -- --test controls _target_submits_`
+Expected: FAIL — `.fight-target` / `.evade-target` elements are not present yet (no picker rendered), so `click_in` panics.
+
+- [ ] **Step 3: Add the `enemy_picker` helper**
+
+In `crates/web/src/controls.rs`, add this helper next to `move_picker` (it follows the same shape). It is parameterized by the CSS class, label prefix, and an action constructor so one helper serves both Fight and Evade:
+
+```rust
+/// Engaged-enemy target picker: one button per enemy currently engaged
+/// with the active investigator (`engaged_with == Some(active)`), labeled
+/// `"{verb} {name}"`. Empty when `legal` is false, there is no active
+/// investigator, or no enemy is engaged — the same empty-render behavior
+/// as `move_picker`. `make_action` builds the action for the chosen enemy.
+fn enemy_picker(
+    game: &GameState,
+    active: Option<InvestigatorId>,
+    legal: bool,
+    class: &'static str,
+    verb: &'static str,
+    make_action: fn(InvestigatorId, EnemyId) -> PlayerAction,
+    tx: Option<&OutboundTx>,
+) -> impl IntoView {
+    let buttons: Vec<_> = if legal {
+        active
+            .map(|inv| {
+                game.enemies
+                    .values()
+                    .filter(|e| e.engaged_with == Some(inv))
+                    .map(|enemy| {
+                        let enemy_id = enemy.id;
+                        let name = enemy.name.clone();
+                        let tx = tx.cloned();
+                        view! {
+                            <button
+                                class=class
+                                on:click=move |_| {
+                                    if let Some(tx) = tx.clone() {
+                                        let _ = tx.unbounded_send(ClientMessage::Submit {
+                                            action: make_action(inv, enemy_id),
+                                        });
+                                    }
+                                }
+                            >
+                                {verb} " " {name}
+                            </button>
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    view! { <div class=class>{buttons}</div> }
+}
+```
+
+> Add `EnemyId` to the `use game_core::state::{...}` import at the top of the file (line 10): `use game_core::state::{EnemyId, GameState, InvestigatorId};`. `enemy.id` is an `EnemyId` (`Copy`); `make_action` is a plain `fn` pointer, so the two call sites pass `PlayerAction::Fight`/`PlayerAction::Evade` as constructors — both have signature `fn(investigator, enemy) -> PlayerAction` only if the fields are positional; they are **named struct variants**, so wrap them in closures instead (see Step 4).
+
+- [ ] **Step 4: Render both pickers in `ActionControls`**
+
+`PlayerAction::Fight`/`Evade` are struct variants, so they can't be passed as bare `fn` pointers. Pass small `fn` wrappers. Add these two free functions just above the `enemy_picker` definition:
+
+```rust
+fn fight_action(investigator: InvestigatorId, enemy: EnemyId) -> PlayerAction {
+    PlayerAction::Fight { investigator, enemy }
+}
+
+fn evade_action(investigator: InvestigatorId, enemy: EnemyId) -> PlayerAction {
+    PlayerAction::Evade { investigator, enemy }
+}
+```
+
+Then, inside `ActionControls`'s `<section class="controls">` view, after the `{play_picker(...)}` line (line 282), add:
+
+```rust
+                    {enemy_picker(
+                        &game,
+                        active,
+                        has(ActionControl::Fight),
+                        "fight-target",
+                        "Fight",
+                        fight_action,
+                        tx.as_ref(),
+                    )}
+                    {enemy_picker(
+                        &game,
+                        active,
+                        has(ActionControl::Evade),
+                        "evade-target",
+                        "Evade",
+                        evade_action,
+                        tx.as_ref(),
+                    )}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `wasm-pack test --headless --firefox crates/web -- --test controls _target_submits_`
+Expected: PASS (both fight and evade tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/web/src/controls.rs crates/web/tests/controls.rs
+git commit -m "$(cat <<'EOF'
+ui: Fight/Evade engaged-enemy target pickers (P6.7b)
+
+One enemy_picker helper (parameterized by class/verb/action-constructor)
+renders a button per enemy engaged with the active investigator,
+following the move_picker empty-render pattern. Closes #189.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Full CI gauntlet
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full local gauntlet**
+
+Run each, from the repo root:
+
+```bash
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+wasm-pack test --headless --firefox crates/web
+```
+
+Expected: all green. Fix any warnings/failures before proceeding (formatting via `cargo fmt`, clippy lints surgically).
+
+- [ ] **Step 2: Commit any gauntlet fixes**
+
+If `cargo fmt` or clippy required changes:
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+ui: satisfy fmt/clippy for P6.7b controls
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Notes for the phase-doc update (final commit, after CI green on the PR)
+
+Per `docs/phases/README.md`, do this **only** once the PR is open and CI is green, as the last commit:
+
+- In `docs/phases/phase-6-web-client-v0.md`: flip the P6.7b Issues-table row and the Ordering-table row to `✅ PR #N`; update the prose paragraph (lines 54-57) so P6.8 (#190) is named as next; add a **Decisions made** entry for P6.7b **only if** it records something a future PR-author couldn't grep — e.g. the empty-picker (Move-pattern) choice and the `enemy_picker` parameterization, if judged load-bearing. Apply the README's test; lean toward skipping.
+- Move #189 to the Closed table / bump counts per the README spec.

--- a/docs/superpowers/specs/2026-06-09-p6.7b-combat-action-controls-design.md
+++ b/docs/superpowers/specs/2026-06-09-p6.7b-combat-action-controls-design.md
@@ -1,0 +1,68 @@
+# P6.7b — Combat/edge action controls (Fight, Evade, Draw)
+
+Phase 6, slot P6.7b ([#189](https://github.com/talelburg/eldritch/issues/189)).
+Extends the P6.7a action panel (client layer 4 of the phase-6 design spec).
+
+## Goal
+
+Round out the action surface with the controls that matter on the
+combat/Lost walk: **Fight** and **Evade** (engaged-enemy target pickers)
+and **Draw** (player-deck draw action). All three `PlayerAction`s already
+exist in the engine (`Fight { investigator, enemy }`,
+`Evade { investigator, enemy }`, `Draw { investigator }`); this slot is
+pure client wiring — no engine or board changes.
+
+## Design
+
+Builds directly on the P6.7a pattern. Two files change.
+
+### `crates/web/src/legality.rs`
+
+- Add `Fight`, `Evade`, `Draw` to the `ActionControl` enum.
+- In `enabled_controls`, add all three to the `Phase::Investigation`
+  set. Phase-gated only — consistent with the existing coarse-affordance
+  approach (`Move` is enabled even with no connections). The helper does
+  **not** mirror "is an enemy actually engaged" or the action budget; the
+  server stays authoritative and rejects illegal submissions (P6.6
+  decision S2).
+
+### `crates/web/src/controls.rs`
+
+- **Draw:** a plain `submit_button` (like `Investigate`/`EndTurn`), class
+  `"action draw"`, submitting `PlayerAction::Draw { investigator: active }`.
+  Distinct from the existing `"action draw-encounter"` button (Mythos
+  player-deck vs. encounter-deck draw).
+- **Fight + Evade target pickers:** two pickers following the
+  `move_picker` shape. Each scans `game.enemies` for
+  `engaged_with == Some(active)` and renders one button per engaged
+  enemy, labeled by name (e.g. `"Fight {name}"`), submitting
+  `Fight`/`Evade { investigator, enemy }`. Empty when not legal or no
+  engaged enemy — the same way `move_picker` renders nothing when there
+  are no destinations (the **empty-picker** behavior, chosen over
+  hide-unless-engaged for consistency and zero new legality logic).
+  Classes `"fight-target"` / `"evade-target"`.
+
+## Tests
+
+- **`legality.rs` unit test:** update the existing
+  `investigation_phase_enables_the_core_loop` assertion to the new set
+  `{Move, Investigate, PlayCard, EndTurn, AdvanceAct, Fight, Evade, Draw}`.
+- **`controls.rs` headless tests** (wasm32): build an Investigation-phase
+  game with one enemy engaged with the active investigator (`with_enemy`
+  + `engaged_with`); click the `fight-target` / `evade-target` button →
+  assert `Submit { Fight/Evade { enemy } }` with the chosen target; click
+  Draw → assert `Submit { Draw { investigator } }`.
+
+## Acceptance (issue #189)
+
+- Headless test: each control submits the correct action with the chosen
+  enemy target.
+- Manual: engage the synthetic enemy and Fight/Evade it; Draw a card.
+
+## Out of scope (deliberately)
+
+- Board-as-interactive-surface (deferred per P6.7a; controls stay in the
+  panel).
+- Finer legality (engaged-enemy / action-budget mirroring — server's job;
+  richer "show exactly what's legal" is [#206](https://github.com/talelburg/eldritch/issues/206), Phase 8).
+- Resolution surfacing (P6.8, #190).


### PR DESCRIPTION
## Summary

Phase 6, slot **P6.7b** ([#189](https://github.com/talelburg/eldritch/issues/189)): rounds out the web client's action surface with the controls that matter on the combat/Lost walk — **Fight** and **Evade** (engaged-enemy target pickers) and a player-deck **Draw** button. Pure client wiring; the `Fight`/`Evade`/`Draw` `PlayerAction`s already exist, so no engine or board changes.

## What changed

- **`legality.rs`** — adds `Fight`, `Evade`, `Draw` to `ActionControl` and enables all three in the `Phase::Investigation` set. Phase-gated only, consistent with the existing coarse-affordance approach (`Move` is enabled even with no connections): the helper does **not** mirror "is an enemy actually engaged" or the action budget — the server stays authoritative (P6.6 decision S2).
- **`controls.rs`** — `Draw` renders as a plain `submit_button` (like Investigate/AdvanceAct, needs the active investigator), class `action draw`, distinct from the existing `action draw-encounter`. A single parameterized `enemy_picker` helper (class/verb/action-constructor) renders one button per enemy with `engaged_with == Some(active)`, submitting `Fight`/`Evade { investigator, enemy }`. Empty-renders when illegal or no engaged enemy — the same pattern as `move_picker`. `board.rs` stays read-only.

## Design decisions

- **Empty-picker (Move pattern) over hide-unless-engaged.** Fight/Evade are enabled by phase and the picker simply renders zero target buttons when no enemy is engaged — consistent with `move_picker`/`play_picker` and adds no enemy-scan into the legality path.
- **`enemy_picker` parameterized by an action-constructor `fn`.** `PlayerAction::Fight`/`Evade` are named-field struct variants and can't be passed as bare `fn` pointers, so two thin `fight_action`/`evade_action` wrappers adapt them; one helper then serves both pickers.
- The picker's outer `<div>` uses class `"{class}-picker"` (e.g. `fight-target-picker`) so the buttons own the bare `.fight-target` selector — mirrors `move-picker`/`move-dest`.

## Test notes

- **Legality unit test** (native): `investigation_phase_enables_the_core_loop` updated to the full set `{Move, Investigate, PlayCard, EndTurn, AdvanceAct, Fight, Evade, Draw}`.
- **Headless `wasm-bindgen-test`** (`crates/web/tests/controls.rs`): clicking the `fight-target`/`evade-target` button submits `Fight`/`Evade` with the chosen enemy; clicking Draw submits `Draw { investigator }`. A new `investigation_game_with_engaged_enemy()` fixture seeds one engaged enemy.
- Full local gauntlet green: `fmt`, host `clippy`, `wasm-clippy`, `test` (`RUSTFLAGS=-D warnings`), `doc` (`RUSTDOCFLAGS=-D warnings`), `wasm-build`, and headless `wasm-test`.

Design spec: `docs/superpowers/specs/2026-06-09-p6.7b-combat-action-controls-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Linked issues

Closes #189