### PR TITLE
ui: resolution surfacing + closing demo (P6.8)

### DIFF
--- a/crates/scenarios/src/test_fixtures/synthetic.rs
+++ b/crates/scenarios/src/test_fixtures/synthetic.rs
@@ -11,7 +11,9 @@ use std::collections::VecDeque;
 
 use game_core::event::Event;
 use game_core::scenario::{Resolution, ScenarioId, ScenarioModule};
-use game_core::state::{Act, Agenda, CardCode, GameState, InvestigatorId};
+use game_core::state::{
+    Act, Agenda, CardCode, ChaosBag, ChaosToken, GameState, InvestigatorId, LocationId,
+};
 use game_core::test_support::{test_investigator, test_location, TestGame};
 
 use super::synth_cards::{SYNTH_LOC_CODE, SYNTH_TREACHERY_CODE};
@@ -20,13 +22,21 @@ use super::synth_cards::{SYNTH_LOC_CODE, SYNTH_TREACHERY_CODE};
 /// [`crate::REGISTRY`].
 pub const ID: &str = "synthetic";
 
-/// Build the initial [`GameState`] for this fixture: one
-/// investigator, one location (with `code` set to
-/// [`synth_cards::SYNTH_LOC_CODE`]), `scenario_id` set, `turn_order`
-/// populated, encounter deck seeded with one copy of
-/// [`synth_cards::SYNTH_TREACHERY_CODE`]. Phase = Mythos, round =
-/// 0 — ready for
+/// Build the initial [`GameState`] for this fixture: one investigator
+/// placed at one location (with `code` set to
+/// [`synth_cards::SYNTH_LOC_CODE`], stocked with 4 clues), a +0 chaos
+/// bag, `scenario_id` set, `turn_order` populated, encounter deck seeded
+/// with one copy of [`synth_cards::SYNTH_TREACHERY_CODE`]. Phase =
+/// Mythos, round = 0 — ready for
 /// [`PlayerAction::StartScenario`](game_core::PlayerAction::StartScenario).
+///
+/// The state is **playable to a resolution as-is** (no extra seeding):
+/// placement + clues + a non-empty chaos bag are exactly what the
+/// Investigate → discover-clue → `AdvanceAct` (Won) path needs, which is
+/// what the browser demo and `tests/closing_demo.rs` exercise. A real
+/// scenario's setup does the same (seats investigators, prints clue
+/// counts on locations, fills the chaos bag); the bare `TestGame` /
+/// `test_location` defaults (unplaced, 0 clues, empty bag) do not.
 ///
 /// The encounter-deck seeding gives the #126 / #127 integration
 /// tests something to draw from; integration tests that want to
@@ -46,11 +56,25 @@ pub const ID: &str = "synthetic";
 pub fn setup() -> GameState {
     let mut location = test_location(10, "Demo Location");
     location.code = CardCode(SYNTH_LOC_CODE.into());
+    // Stock the location with enough clues to advance both acts
+    // (clue_threshold 2 each): four successful Investigates discover
+    // four clues, exactly the Won path. Real scenarios print clue
+    // counts on locations; the bare `test_location` default is 0.
+    location.clues = 4;
 
     let mut state = TestGame::new()
-        .with_investigator(test_investigator(1))
+        // Place the investigator at the demo location: scenario setup
+        // seats investigators at a starting location, and Investigate /
+        // Move reject on a `None` current_location. `test_location(10, …)`
+        // → `LocationId(10)`.
+        .with_investigator_at(test_investigator(1), LocationId(10))
         .with_location(location)
         .with_turn_order([InvestigatorId(1)])
+        // A skill test rejects on an empty chaos bag; a single +0 token
+        // lets Investigate (intellect 3) clear the location's shroud 2,
+        // so the Won path is reliably walkable. Real scenarios fill the
+        // bag from the campaign; this is the toy-fixture stand-in.
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
         .with_scenario_id(ScenarioId::new(ID))
         .build();
     state

--- a/crates/scenarios/tests/closing_demo.rs
+++ b/crates/scenarios/tests/closing_demo.rs
@@ -13,9 +13,7 @@ use std::sync::Once;
 use game_core::engine::{apply, EngineOutcome};
 use game_core::event::Event;
 use game_core::scenario::Resolution;
-use game_core::state::{
-    CardCode, ChaosBag, ChaosToken, GameState, InvestigatorId, LocationId, Phase, TokenModifiers,
-};
+use game_core::state::{CardCode, GameState, InvestigatorId, LocationId, Phase};
 use game_core::{assert_event, Action, InputResponse, PlayerAction};
 use scenarios::test_fixtures::synth_cards::{
     SYNTH_ENEMY_CODE, SYNTH_TREACHERY_CODE, TEST_REGISTRY,
@@ -91,18 +89,11 @@ fn won_walk_full_cycle_replays_identically() {
     install_registry();
     let inv = InvestigatorId(1);
 
-    // setup() + deterministic local seeding: 4 clues to discover and a
-    // +0 chaos bag so Investigate succeeds against shroud 2 (intellect 3).
-    let make_initial = || {
-        let mut s = scenarios::test_fixtures::synthetic::setup();
-        s.locations.get_mut(&LocationId(10)).unwrap().clues = 4;
-        s.chaos_bag = ChaosBag::new([ChaosToken::Numeric(0)]);
-        s.token_modifiers = TokenModifiers::default();
-        // Place the investigator at the demo location so Investigate
-        // can resolve (dispatch rejects if current_location is None).
-        s.investigators.get_mut(&inv).unwrap().current_location = Some(LocationId(10));
-        s
-    };
+    // Raw setup() with no local seeding — exactly the state the browser
+    // plays. setup() itself must place the investigator at the demo
+    // location, stock it with clues, and seed a non-empty chaos bag; this
+    // walk is the regression guard for that (P6.8 demo playability).
+    let make_initial = scenarios::test_fixtures::synthetic::setup;
 
     // Round 1 (Mythos skipped): Investigate x3 (each followed by a
     // CommitCards round-trip for the skill-test commit window) ->

--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -3,6 +3,7 @@
 //! `CardCode` strings — the client has no card-name source.
 
 use game_core::state::{GameState, InvestigatorId, LocationId};
+use game_core::Resolution;
 use leptos::prelude::*;
 
 use crate::store::{use_store, ConnStatus};
@@ -26,6 +27,7 @@ pub fn BoardView() -> impl IntoView {
         None => view! { <p class="no-game">"<no game>"</p> }.into_any(),
         Some(game) => view! {
             <div class="game">
+                {resolution_banner(&game)}
                 {phase_bar(&game)}
                 {locations_panel(&game)}
                 {investigators_panel(&game)}
@@ -151,6 +153,22 @@ fn enemies_panel(game: &GameState) -> impl IntoView {
             <ul>{rows}</ul>
         </section>
     }
+}
+
+/// Win/loss banner — rendered only once `GameState.resolution` latches.
+/// Read-only display of state, matching the `phase_bar` pattern; keeps
+/// `board.rs` read-only (no new interactivity).
+fn resolution_banner(game: &GameState) -> impl IntoView {
+    game.resolution.as_ref().map(|r| {
+        let text = match r {
+            Resolution::Won { id } => format!("Scenario won — {id}"),
+            Resolution::Lost { reason } => format!("Scenario lost — {reason}"),
+            // `Resolution` is #[non_exhaustive]; a future variant gets a
+            // generic banner until the client learns its shape.
+            _ => "Scenario resolved".to_string(),
+        };
+        view! { <section class="resolution">{text}</section> }
+    })
 }
 
 /// Phase + round, plus the current act's clue threshold and the current

--- a/crates/web/src/legality.rs
+++ b/crates/web/src/legality.rs
@@ -27,6 +27,9 @@ pub enum ActionControl {
 /// The controls the player may click right now.
 ///
 /// Gating, in order:
+/// 0. A latched `game.resolution` is terminal: the scenario is over, so
+///    no action is legal. Checked first — it dominates every cursor,
+///    pause, and phase below.
 /// 1. An `AwaitingInput` pause blocks every core-loop action — only the
 ///    pending `ResolveInput` (the prompt UI) is legal. This keys off the
 ///    outcome, so it covers every suspension mode the engine surfaces as
@@ -50,6 +53,9 @@ pub fn enabled_controls(game: &GameState, outcome: &EngineOutcome) -> BTreeSet<A
         PlayCard, StartScenario,
     };
 
+    if game.resolution.is_some() {
+        return BTreeSet::new();
+    }
     if matches!(outcome, EngineOutcome::AwaitingInput { .. }) {
         return BTreeSet::new();
     }
@@ -86,7 +92,7 @@ mod tests {
     use game_core::state::{InvestigatorId, Phase};
     use game_core::test_support::builder::TestGame;
     use game_core::test_support::fixtures::{awaiting_commit_input, test_investigator};
-    use game_core::EngineOutcome;
+    use game_core::{EngineOutcome, Resolution};
     use std::collections::BTreeSet;
 
     fn investigation_game() -> game_core::state::GameState {
@@ -172,5 +178,26 @@ mod tests {
                 "phase {phase:?} should enable nothing"
             );
         }
+    }
+
+    #[test]
+    fn resolution_disables_all_controls() {
+        // investigation_game() would normally enable the full core loop;
+        // a latched resolution must dominate and enable nothing.
+        let mut game = investigation_game();
+        game.resolution = Some(Resolution::Won { id: "demo".into() });
+        assert_eq!(
+            enabled_controls(&game, &EngineOutcome::Done),
+            BTreeSet::new(),
+            "a resolved scenario enables nothing"
+        );
+        game.resolution = Some(Resolution::Lost {
+            reason: "eliminated".into(),
+        });
+        assert_eq!(
+            enabled_controls(&game, &EngineOutcome::Done),
+            BTreeSet::new(),
+            "a lost scenario enables nothing"
+        );
     }
 }

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -201,3 +201,52 @@ async fn empty_board_renders_placeholder_without_panels() {
         "panels should be absent: {html}"
     );
 }
+
+/// The last mounted `.resolution` banner's inner HTML (DOM accumulates
+/// across tests on the shared page — scope to the latest subtree).
+fn last_resolution_html() -> String {
+    let banners = leptos::prelude::document()
+        .query_selector_all(".resolution")
+        .expect("query_selector_all");
+    banners
+        .item(banners.length() - 1)
+        .expect("at least one .resolution banner")
+        .dyn_ref::<web_sys::Element>()
+        .expect("Element")
+        .inner_html()
+}
+
+#[wasm_bindgen_test]
+async fn resolution_banner_renders_won() {
+    use game_core::Resolution;
+    let mut state = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .build();
+    state.resolution = Some(Resolution::Won { id: "demo".into() });
+
+    let _ = render_state(state).await;
+
+    let html = last_resolution_html();
+    assert!(html.contains("won"), "won banner text missing: {html}");
+    assert!(html.contains("demo"), "won id missing: {html}");
+}
+
+#[wasm_bindgen_test]
+async fn resolution_banner_renders_lost() {
+    use game_core::Resolution;
+    let mut state = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .build();
+    state.resolution = Some(Resolution::Lost {
+        reason: "cultist-surge".into(),
+    });
+
+    let _ = render_state(state).await;
+
+    let html = last_resolution_html();
+    assert!(html.contains("lost"), "lost banner text missing: {html}");
+    assert!(
+        html.contains("cultist-surge"),
+        "lost reason missing: {html}"
+    );
+}

--- a/crates/web/tests/controls.rs
+++ b/crates/web/tests/controls.rs
@@ -437,3 +437,25 @@ async fn start_scenario_is_the_only_control_at_round_zero() {
         other => panic!("expected StartScenario, got {other:?}"),
     }
 }
+
+#[wasm_bindgen_test]
+async fn resolved_scenario_disables_all_controls() {
+    use game_core::Resolution;
+    // An Investigation-phase game that would normally enable the core
+    // loop; once resolved, every rendered control is disabled.
+    let mut game = investigation_game();
+    game.resolution = Some(Resolution::Won { id: "demo".into() });
+
+    let _rx = mount(game, EngineOutcome::Done).await;
+    let controls = last_controls();
+    for selector in [".start-scenario", ".end-turn", ".draw-encounter"] {
+        let btn = controls
+            .query_selector(selector)
+            .expect("query")
+            .expect("button present");
+        assert!(
+            btn.has_attribute("disabled"),
+            "{selector} should be disabled when the scenario is resolved"
+        );
+    }
+}

--- a/docs/demos/phase-6-toy-scenario.md
+++ b/docs/demos/phase-6-toy-scenario.md
@@ -1,0 +1,54 @@
+# Phase 6 closing demo — synthetic toy scenario
+
+A solo browser playthrough of the Phase-4 synthetic toy scenario to a
+visible resolution, plus the reconnect path. This is the Phase-6
+milestone-close demo (#190).
+
+## Run it
+
+Single-port build (what production serves):
+
+    cd crates/web && trunk build
+    cargo run -p server            # serves API + WS + the bundle on :8000
+
+Open <http://localhost:8000>. The client calls `POST /games`, opens the
+WebSocket, and the board renders the freshly-set-up scenario (phase
+Mythos, round 0).
+
+## Won path
+
+1. **Start scenario** — the only enabled control at round 0. Click it;
+   hands are dealt and the mulligan window opens.
+2. **Mulligan** — keep the opening hand (or mulligan), resolving the
+   mulligan window into the Investigation phase.
+3. **Investigate** — gather clues at the starting location.
+4. **Advance act** — once the act's clue threshold is met, advancing past
+   the terminal act card latches `Resolution::Won { id: "demo" }`.
+5. The board shows the **"Scenario won — demo"** banner and every action
+   control goes disabled.
+
+## Lost path
+
+1. **Start scenario**, resolve the mulligan as above.
+2. Instead of advancing the act, end turns and let the Mythos phase
+   accumulate agenda doom. The synthetic agenda's doom threshold is 2.
+3. When doom reaches the threshold and the agenda advances past its
+   terminal card, the engine latches `Resolution::Lost { reason: "agenda" }`.
+4. The board shows the **"Scenario lost — agenda"** banner and the
+   controls go disabled.
+
+## Reconnect mid-scenario
+
+With a scenario in progress, **close the browser tab**, then reopen
+<http://localhost:8000>. The game id persisted in `localStorage` drives a
+reconnect: the server replies `Hello`, and the board is restored to the
+exact in-progress state — including any in-flight `AwaitingInput` (e.g. a
+skill-test commit window). No action is lost.
+
+## Not exercised: live combat
+
+Fight/Evade are wired and headless-tested but **not reachable** in this
+demo: the synthetic scenario seeds no enemy, so none ever spawns/engages
+through in-browser play. This is superseded by Phase 7's real encounter
+content (real cards spawn real enemies through ordinary play), not an open
+TODO. The Lost path above runs through agenda doom, which is fully live.

--- a/docs/demos/phase-6-toy-scenario.md
+++ b/docs/demos/phase-6-toy-scenario.md
@@ -21,9 +21,16 @@ Mythos, round 0).
    hands are dealt and the mulligan window opens.
 2. **Mulligan** — keep the opening hand (or mulligan), resolving the
    mulligan window into the Investigation phase.
-3. **Investigate** — gather clues at the starting location.
-4. **Advance act** — once the act's clue threshold is met, advancing past
-   the terminal act card latches `Resolution::Won { id: "demo" }`.
+3. **Investigate** — the starting location holds 4 clues and the demo's
+   chaos bag is a single +0 token, so each Investigate (intellect 3 vs
+   shroud 2) succeeds and moves one clue to you. You have 3 actions per
+   turn; **End turn** to start a new one (the round cycles through
+   Mythos/Enemy/Upkeep — **Draw encounter** when prompted) and keep
+   investigating until you hold 4 clues.
+4. **Advance act** — the act deck has two cards, each needing 2 clues.
+   Advance once (spends 2, moves to the final act), then **Advance act**
+   again (spends 2) to advance past the terminal card, which latches
+   `Resolution::Won { id: "demo" }`.
 5. The board shows the **"Scenario won — demo"** banner and every action
    control goes disabled.
 

--- a/docs/phases/phase-6-web-client-v0.md
+++ b/docs/phases/phase-6-web-client-v0.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-🟡 In progress (kickoff 2026-06-08). Issues filed; design spec at
+🟢 Complete (PR #210, closing P6.8). Kicked off 2026-06-08; design spec at
 [`docs/superpowers/specs/2026-06-08-phase-6-web-client-v0-design.md`](../superpowers/specs/2026-06-08-phase-6-web-client-v0-design.md).
 
 ## Goal
@@ -27,7 +27,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | P6.6 | [#187](https://github.com/talelburg/eldritch/issues/187) — AwaitingInput resolution UI + legality gating | ✅ PR #207 |
 | P6.7a | [#188](https://github.com/talelburg/eldritch/issues/188) — core-loop action controls | ✅ PR #208 |
 | P6.7b | [#189](https://github.com/talelburg/eldritch/issues/189) — combat/edge action controls | ✅ PR #209 |
-| P6.8 | [#190](https://github.com/talelburg/eldritch/issues/190) — resolution surfacing + closing demo | ⏳ open |
+| P6.8 | [#190](https://github.com/talelburg/eldritch/issues/190) — resolution surfacing + closing demo | ✅ PR #210 |
 
 ## Ordering
 
@@ -43,7 +43,7 @@ accumulating doom), and reconnecting mid-scenario restores the board.
 | P6.6 | #187 AwaitingInput UI + legality ✅ PR #207 | Core-loop: `Investigate` opens a skill-test commit window (`AwaitingInput`), so this precedes the action controls | P6.5 |
 | P6.7a | #188 core-loop action controls ✅ PR #208 | Toy scenario clickable to a **Won** resolution | P6.6 |
 | P6.7b | #189 combat/edge action controls ✅ PR #209 | Rounds out the action surface (combat/Lost walk) | P6.7a |
-| P6.8 | #190 resolution + closing demo | Milestone close | all |
+| P6.8 | #190 resolution + closing demo ✅ PR #210 | Milestone close | all |
 
 P6.1 and P6.2 both touch `server`; sequence to avoid churn. P6.3 is
 independent and can land any time before P6.4. P6.4a
@@ -55,8 +55,9 @@ was **deferred to Phase 8 and closed** — see *Decisions made*. P6.5
 (#187, `AwaitingInput` UI + legality ✅ PR #207) shipped the interaction
 plumbing, P6.7a (#188, core-loop action controls ✅ PR #208) shipped the
 action buttons, and P6.7b (#189, combat/edge controls ✅ PR #209) added
-Fight/Evade/Draw, so resolution surfacing + the closing demo (P6.8, #190)
-is the last slot before milestone close.
+Fight/Evade/Draw. P6.8 (#190, resolution surfacing + closing demo
+✅ PR #210) shipped the Won/Lost banner, the resolution legality gate, and
+the closing-demo doc — the milestone is complete.
 
 ## Decisions made
 
@@ -267,6 +268,25 @@ Settled implementing P6.7b (PR #209):
   (#190) — the closing demo's *Lost* path runs through agenda doom, not
   combat, so this is demo polish, not a milestone blocker. Draw *is*
   reachable now (rendered in Investigation like Investigate/AdvanceAct).
+
+Settled implementing P6.8 (PR #210):
+
+- **Resolution is surfaced read-only and dominates legality.** The
+  Won/Lost banner is a `resolution_banner` helper in the read-only
+  `board.rs` (phase_bar pattern), not a control; and `enabled_controls`
+  gates on `game.resolution.is_some()` **first**, before every
+  cursor/pause/phase — a latched resolution is terminal, so no action is
+  clickable once the scenario ends (the server rejects them regardless;
+  this is the UX affordance).
+- **Live combat in the toy scenario was deliberately not built —
+  superseded by Phase 7, not a tracked TODO.** P6.8 is the milestone
+  close, so there is no later Phase-6 slot to defer into, and the
+  synthetic scenario is throwaway (D5: swapped when Phase 7 lands The
+  Gathering). Phase 7's real encounter cards spawn enemies through
+  ordinary play, making Fight/Evade reachable for free — which is why the
+  phase-7 doc carries no combat line item. The only cost: the Phase-6
+  closing demo (`docs/demos/phase-6-toy-scenario.md`) shows the Lost path
+  via agenda doom, not a live Fight/Evade click.
 
 ## Open questions
 

--- a/docs/superpowers/plans/2026-06-09-p6.8-resolution-surfacing.md
+++ b/docs/superpowers/plans/2026-06-09-p6.8-resolution-surfacing.md
@@ -1,0 +1,463 @@
+# P6.8 — Resolution surfacing + closing demo — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a reached scenario resolution visible in the browser (a Won/Lost banner), disable the action controls once it fires, and ship a documented closing-demo walkthrough — the last slot before the Phase-6 milestone closes.
+
+**Architecture:** The client already renders the server's authoritative `GameState`. The resolution latch lives on `GameState.resolution: Option<Resolution>`. So this is two small additions: gate `legality::enabled_controls` on `resolution.is_some()` (an empty control set disables every button automatically, since `controls.rs` maps membership → `disabled`), and render a read-only banner in `board.rs` (matching the `phase_bar` pattern). Tests are "render + gate"; the engine already tests the toy scenario reaching Won/Lost.
+
+**Tech Stack:** Rust, Leptos (CSR/wasm32), `wasm-bindgen-test` (headless Firefox), `game-core`.
+
+**Design spec:** `docs/superpowers/specs/2026-06-09-p6.8-resolution-surfacing-design.md`
+**Issue:** [#190](https://github.com/talelburg/eldritch/issues/190)
+**Branch:** `ui/resolution-surfacing`
+
+---
+
+## File structure
+
+- **Modify** `crates/web/src/legality.rs` — add the `resolution.is_some()` gate at the top of `enabled_controls` (+ doc comment + native unit test).
+- **Modify** `crates/web/src/board.rs` — add a `resolution_banner` helper and render it at the top of the `.game` div.
+- **Modify** `crates/web/tests/board.rs` — headless tests: Won banner, Lost banner.
+- **Modify** `crates/web/tests/controls.rs` — headless test: resolved state ⇒ all controls disabled.
+- **Create** `docs/demos/phase-6-toy-scenario.md` — the closing-demo walkthrough.
+- **Modify** `docs/phases/phase-6-web-client-v0.md` — phase-doc close (final commit, after CI green).
+
+---
+
+### Task 1: Gate legality on the resolution latch
+
+**Files:**
+- Modify/Test: `crates/web/src/legality.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module in `crates/web/src/legality.rs` (after `non_investigation_phases_enable_nothing`):
+
+```rust
+    #[test]
+    fn resolution_disables_all_controls() {
+        use game_core::Resolution;
+        // investigation_game() would normally enable the full core loop;
+        // a latched resolution must dominate and enable nothing.
+        let mut game = investigation_game();
+        game.resolution = Some(Resolution::Won { id: "demo".into() });
+        assert_eq!(
+            enabled_controls(&game, &EngineOutcome::Done),
+            BTreeSet::new(),
+            "a resolved scenario enables nothing"
+        );
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p web --lib legality::tests::resolution_disables_all_controls`
+Expected: FAIL — the Investigation arm returns the core-loop set, not an empty set (left `!= right`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `crates/web/src/legality.rs`, in `enabled_controls`, add the gate as the **first** check (before the `AwaitingInput` check), and extend the doc comment.
+
+Add to the top of the function body, immediately after the `use ActionControl::{…}` import block:
+
+```rust
+    if game.resolution.is_some() {
+        return BTreeSet::new();
+    }
+```
+
+Update the doc comment's "Gating, in order:" list — insert a new first item and renumber is unnecessary; prepend:
+
+```
+/// 0. A latched `game.resolution` is terminal: the scenario is over, so
+///    no action is legal. Checked first — it dominates every cursor,
+///    pause, and phase below.
+```
+
+(Place that `/// 0.` line directly above the existing `/// 1. An `AwaitingInput` pause …` line.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p web --lib legality::tests`
+Expected: PASS (all legality tests, including the new one).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/web/src/legality.rs
+git commit -m "ui: disable controls once the scenario resolves (P6.8)
+
+enabled_controls returns an empty set when game.resolution is latched,
+so every action button is disabled once the scenario ends. Gate is first
+— a resolution dominates every cursor, pause, and phase.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Resolution banner in the read-only board
+
+**Files:**
+- Modify: `crates/web/src/board.rs`
+- Test: `crates/web/tests/board.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `crates/web/tests/board.rs` (after `empty_board_renders_placeholder_without_panels`). `JsCast` and `web_sys` are already imported at the top of the file; only `Resolution` is new (imported locally):
+
+```rust
+/// The last mounted `.resolution` banner's inner HTML (DOM accumulates
+/// across tests on the shared page — scope to the latest subtree).
+fn last_resolution_html() -> String {
+    let banners = leptos::prelude::document()
+        .query_selector_all(".resolution")
+        .expect("query_selector_all");
+    banners
+        .item(banners.length() - 1)
+        .expect("at least one .resolution banner")
+        .dyn_ref::<web_sys::Element>()
+        .expect("Element")
+        .inner_html()
+}
+
+#[wasm_bindgen_test]
+async fn resolution_banner_renders_won() {
+    use game_core::Resolution;
+    let mut state = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .build();
+    state.resolution = Some(Resolution::Won { id: "demo".into() });
+
+    let _ = render_state(state).await;
+
+    let html = last_resolution_html();
+    assert!(html.contains("won"), "won banner text missing: {html}");
+    assert!(html.contains("demo"), "won id missing: {html}");
+}
+
+#[wasm_bindgen_test]
+async fn resolution_banner_renders_lost() {
+    use game_core::Resolution;
+    let mut state = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .build();
+    state.resolution = Some(Resolution::Lost {
+        reason: "agenda".into(),
+    });
+
+    let _ = render_state(state).await;
+
+    let html = last_resolution_html();
+    assert!(html.contains("lost"), "lost banner text missing: {html}");
+    assert!(html.contains("agenda"), "lost reason missing: {html}");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `wasm-pack test --headless --firefox crates/web -- --test board`
+Expected: FAIL — `last_resolution_html` panics at `.expect("at least one .resolution banner")` (no `.resolution` element is rendered yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `crates/web/src/board.rs`:
+
+(a) Add the import below the existing `use game_core::state::…` line:
+
+```rust
+use game_core::Resolution;
+```
+
+(b) Add the helper (place it directly above `phase_bar`):
+
+```rust
+/// Win/loss banner — rendered only once `GameState.resolution` latches.
+/// Read-only display of state, matching the `phase_bar` pattern; keeps
+/// `board.rs` read-only (no new interactivity).
+fn resolution_banner(game: &GameState) -> impl IntoView {
+    game.resolution.as_ref().map(|r| {
+        let text = match r {
+            Resolution::Won { id } => format!("Scenario won — {id}"),
+            Resolution::Lost { reason } => format!("Scenario lost — {reason}"),
+            // `Resolution` is #[non_exhaustive]; a future variant gets a
+            // generic banner until the client learns its shape.
+            _ => "Scenario resolved".to_string(),
+        };
+        view! { <section class="resolution">{text}</section> }
+    })
+}
+```
+
+(c) Render it first inside the `.game` div. Change the `Some(game) => view! { … }` arm in `BoardView` so the `<div class="game">` opens with the banner:
+
+```rust
+        Some(game) => view! {
+            <div class="game">
+                {resolution_banner(&game)}
+                {phase_bar(&game)}
+                {locations_panel(&game)}
+                {investigators_panel(&game)}
+                {enemies_panel(&game)}
+            </div>
+        }
+        .into_any(),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `wasm-pack test --headless --firefox crates/web -- --test board`
+Expected: PASS (all board tests, including the two new banner tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/web/src/board.rs crates/web/tests/board.rs
+git commit -m "ui: render a Won/Lost resolution banner on the board (P6.8)
+
+resolution_banner reads the GameState.resolution latch and renders a
+read-only banner at the top of the board (phase_bar pattern). Headless
+tests cover the Won and Lost text.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: End-to-end gating test (resolved ⇒ controls disabled in the DOM)
+
+**Files:**
+- Test: `crates/web/tests/controls.rs`
+
+This proves Task 1's gate reaches the rendered DOM. The gate already exists (Task 1), so this test passes once written — it is end-to-end coverage, not new behavior.
+
+- [ ] **Step 1: Write the test**
+
+Add to `crates/web/tests/controls.rs` (after `illegal_controls_are_disabled_and_do_not_submit`). `start-scenario`, `end-turn`, and `draw-encounter` are the three buttons that render unconditionally:
+
+```rust
+#[wasm_bindgen_test]
+async fn resolved_scenario_disables_all_controls() {
+    use game_core::Resolution;
+    // An Investigation-phase game that would normally enable the core
+    // loop; once resolved, every rendered control is disabled.
+    let mut game = investigation_game();
+    game.resolution = Some(Resolution::Won { id: "demo".into() });
+
+    let _rx = mount(game, EngineOutcome::Done).await;
+    let controls = last_controls();
+    for selector in [".start-scenario", ".end-turn", ".draw-encounter"] {
+        let btn = controls
+            .query_selector(selector)
+            .expect("query")
+            .expect("button present");
+        assert!(
+            btn.has_attribute("disabled"),
+            "{selector} should be disabled when the scenario is resolved"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `wasm-pack test --headless --firefox crates/web -- --test controls`
+Expected: PASS (all controls tests, including the new one). If it FAILS, Task 1's gate is wrong — fix that, don't weaken this test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/web/tests/controls.rs
+git commit -m "test: resolved scenario disables every control in the DOM (P6.8)
+
+Headless end-to-end check that the legality resolution-gate reaches the
+rendered buttons (start-scenario/end-turn/draw-encounter all disabled).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Closing-demo walkthrough doc
+
+**Files:**
+- Create: `docs/demos/phase-6-toy-scenario.md`
+
+- [ ] **Step 1: Write the doc**
+
+Create `docs/demos/phase-6-toy-scenario.md` with this content:
+
+```markdown
+# Phase 6 closing demo — synthetic toy scenario
+
+A solo browser playthrough of the Phase-4 synthetic toy scenario to a
+visible resolution, plus the reconnect path. This is the Phase-6
+milestone-close demo (#190).
+
+## Run it
+
+Single-port build (what production serves):
+
+    cd crates/web && trunk build
+    cargo run -p server            # serves API + WS + the bundle on :8000
+
+Open <http://localhost:8000>. The client calls `POST /games`, opens the
+WebSocket, and the board renders the freshly-set-up scenario (phase
+Mythos, round 0).
+
+## Won path
+
+1. **Start scenario** — the only enabled control at round 0. Click it;
+   hands are dealt and the mulligan window opens.
+2. **Mulligan** — keep the opening hand (or mulligan), resolving the
+   mulligan window into the Investigation phase.
+3. **Investigate** — gather clues at the starting location.
+4. **Advance act** — once the act's clue threshold is met, advancing past
+   the terminal act card latches `Resolution::Won { id: "demo" }`.
+5. The board shows the **"Scenario won — demo"** banner and every action
+   control goes disabled.
+
+## Lost path
+
+1. **Start scenario**, resolve the mulligan as above.
+2. Instead of advancing the act, end turns and let the Mythos phase
+   accumulate agenda doom. The synthetic agenda's doom threshold is 2.
+3. When doom reaches the threshold and the agenda advances past its
+   terminal card, the engine latches `Resolution::Lost { reason: "agenda" }`.
+4. The board shows the **"Scenario lost — agenda"** banner and the
+   controls go disabled.
+
+## Reconnect mid-scenario
+
+With a scenario in progress, **close the browser tab**, then reopen
+<http://localhost:8000>. The game id persisted in `localStorage` drives a
+reconnect: the server replies `Hello`, and the board is restored to the
+exact in-progress state — including any in-flight `AwaitingInput` (e.g. a
+skill-test commit window). No action is lost.
+
+## Not exercised: live combat
+
+Fight/Evade are wired and headless-tested but **not reachable** in this
+demo: the synthetic scenario seeds no enemy, so none ever spawns/engages
+through in-browser play. This is superseded by Phase 7's real encounter
+content (real cards spawn real enemies through ordinary play), not an open
+TODO. The Lost path above runs through agenda doom, which is fully live.
+```
+
+- [ ] **Step 2: Verify the doc renders (no broken structure)**
+
+Run: `ls docs/demos/phase-6-toy-scenario.md`
+Expected: the file exists. (Skim it once for accuracy against the commands in `CLAUDE.md`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/demos/phase-6-toy-scenario.md
+git commit -m "docs: Phase-6 closing-demo walkthrough (P6.8)
+
+Won/Lost click sequences for the synthetic toy scenario plus the
+reconnect path; notes that live combat is superseded by Phase 7.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Full CI gauntlet, push, and open the PR
+
+**Files:** none (verification + PR).
+
+- [ ] **Step 1: Run the full CI gauntlet locally**
+
+Run each, from the repo root, and confirm all pass:
+
+```bash
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+wasm-pack test --headless --firefox crates/web
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+
+Expected: all green. Fix anything that fails before pushing.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin ui/resolution-surfacing
+```
+
+- [ ] **Step 3: Open the PR**
+
+Use `gh pr create` with the repo template. Body includes a one-paragraph design note (resolution latch → banner + legality gate; "render + gate" test scope; live combat superseded by Phase 7) and `Closes #190.`
+
+- [ ] **Step 4: Watch CI**
+
+Run: `gh pr checks <PR#> --watch` (background). Fix failures with follow-up commits to the same branch — do not amend/force-push.
+
+---
+
+### Task 6: Phase-doc close (final commit, ONLY after CI is green)
+
+**Files:**
+- Modify: `docs/phases/phase-6-web-client-v0.md`
+
+Per `docs/phases/README.md` ("Maintaining these docs"), this is the **final** commit, made only after CI is green on the opened PR.
+
+- [ ] **Step 1: Update the phase doc**
+
+In `docs/phases/phase-6-web-client-v0.md`:
+
+- In the **Issues** table, flip the P6.8 row state from `⏳ open` to `✅ PR #<PR#>`.
+- In the **Ordering** table, change the P6.8 row's `Why this slot` cell to append `✅ PR #<PR#>`.
+- Update the prose paragraph under the Ordering table: P6.8 is no longer "the last slot before milestone close" — it has shipped; the milestone is complete.
+- Add one **Decisions made** entry under a new `Settled implementing P6.8 (PR #<PR#>):` heading:
+
+```markdown
+Settled implementing P6.8 (PR #<PR#>):
+
+- **Resolution is surfaced read-only and dominates legality.** The
+  Won/Lost banner is a `resolution_banner` helper in the read-only
+  `board.rs` (phase_bar pattern), not a control; and
+  `enabled_controls` gates on `game.resolution.is_some()` **first**,
+  before every cursor/pause/phase — a latched resolution is terminal, so
+  no action is clickable once the scenario ends (the server rejects them
+  regardless; this is the UX affordance).
+- **Live combat in the toy scenario was deliberately not built —
+  superseded by Phase 7, not a tracked TODO.** P6.8 is the milestone
+  close, so there is no later Phase-6 slot to defer into, and the
+  synthetic scenario is throwaway (D5: swapped when Phase 7 lands The
+  Gathering). Phase 7's real encounter cards spawn enemies through
+  ordinary play, making Fight/Evade reachable for free — which is why the
+  phase-7 doc carries no combat line item. The only cost: the Phase-6
+  closing demo (`docs/demos/phase-6-toy-scenario.md`) shows the Lost path
+  via agenda doom, not a live Fight/Evade click.
+```
+
+- If #190 is tracked in a Closed-issues table/count, move it there and bump the count (follow the existing table shape).
+
+- [ ] **Step 2: Commit and push**
+
+```bash
+git add docs/phases/phase-6-web-client-v0.md
+git commit -m "docs: close P6.8 in the phase-6 doc
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+git push
+```
+
+- [ ] **Step 3: Stop — await explicit merge approval**
+
+Do not merge. Report the PR is green and the phase doc is updated; wait for the user to approve `gh pr merge <PR#> --squash --delete-branch`.
+
+---
+
+## Notes for the implementer
+
+- **Verify the branch before each commit.** Subagents have committed onto `main` before — confirm `git branch --show-current` is `ui/resolution-surfacing` and never switch branches.
+- **`Resolution` is `#[non_exhaustive]`** (defined in `crates/game-core/src/scenario.rs`, re-exported at `game_core::Resolution`). Matches in `web` (an external crate) **require** a wildcard arm — that's the `_ => "Scenario resolved"` arm in Task 2. Omitting it is a compile error.
+- **`GameState.resolution` has no builder setter.** Tests set the `pub` field directly after `.build()`, exactly like `game.mulligan_pending = Some(...)` in the existing legality tests.
+- **Headless DOM accumulates across tests on one page** (P6.5 decision). Never clear `<body>`. Scope absence/identity assertions to the test's own last-mounted subtree (`last_resolution_html`, `last_controls`).

--- a/docs/superpowers/specs/2026-06-09-p6.8-resolution-surfacing-design.md
+++ b/docs/superpowers/specs/2026-06-09-p6.8-resolution-surfacing-design.md
@@ -1,0 +1,144 @@
+# P6.8 — Resolution surfacing + closing demo (design)
+
+**Issue:** [#190](https://github.com/talelburg/eldritch/issues/190) — Phase 6, slot P6.8 (milestone close).
+**Date:** 2026-06-09.
+
+## Goal
+
+Make a reached scenario resolution **visible** in the browser, gate the
+action controls off once it fires, and ship a documented browser
+playthrough of the toy scenario to a resolution (Won and Lost), with
+reconnect-mid-scenario verified at the UX level. This is the last slot
+before the Phase-6 milestone closes.
+
+## Context
+
+The client renders the server's authoritative `GameState` on every
+`Applied`/`Hello` (decision D1). The resolution latch already lives on
+state: `GameState.resolution: Option<Resolution>`, set once by the
+engine at an act/agenda resolution point. The toy synthetic scenario
+(`scenarios::test_fixtures::synthetic`) seeds two-card act/agenda decks
+whose terminal cards latch:
+
+- **Won** — advancing past the terminal act card → `Resolution::Won { id: "demo" }` (reached via `AdvanceAct`).
+- **Lost** — agenda doom reaching threshold 2 and advancing past the terminal agenda card → `Resolution::Lost { reason: "agenda" }` (reached by letting doom accumulate).
+
+Both paths are reachable through ordinary browser play; combat is **not**
+needed for either.
+
+Today the client surfaces nothing about resolution: `board.rs` renders no
+banner, and `legality::enabled_controls` does **not** consult
+`game.resolution` — so a resolved game still lights up the core loop.
+
+## Components
+
+### 1. Legality gating — `crates/web/src/legality.rs`
+
+`enabled_controls(game, outcome)` returns an empty `BTreeSet` when
+`game.resolution.is_some()`. Placed **first**, before the `AwaitingInput`
+check: a latched resolution is terminal and dominates every other state
+(no action is legal after the scenario ends; the server would reject them
+anyway — this is the UX affordance).
+
+`controls.rs` already maps `enabled_controls` membership directly to each
+button's `disabled` (controls.rs:292), so an empty set disables every
+button with no further wiring.
+
+**Test (native unit, in `legality.rs`):** a resolved game ⇒ empty control
+set. The builder has no `with_resolution` setter; the field is `pub`, so
+the test sets `game.resolution = Some(...)` after `.build()`, matching the
+existing field-mutation pattern (`game.mulligan_pending = Some(...)`).
+
+### 2. Resolution banner — `crates/web/src/board.rs`
+
+A `resolution_banner(&game)` helper rendered at the top of the `.game`
+`<div>` when `game.resolution.is_some()`, following the read-only
+`phase_bar` pattern (keeps `board.rs` read-only per the P6.7a decision —
+no new interactivity):
+
+- `Resolution::Won { id }`  → text `"Scenario won — {id}"` (e.g. "demo")
+- `Resolution::Lost { reason }` → text `"Scenario lost — {reason}"` (e.g. "agenda")
+
+Rendered as a distinct element (e.g. `<section class="resolution">`) so a
+test can scope to it.
+
+### 3. Tests — the "render + gate" scope
+
+- **Headless `crates/web/tests/board.rs`:** resolved Won state ⇒ banner
+  renders with the id; resolved Lost state ⇒ banner renders with the
+  reason. (Per the P6.5 decision: scope assertions to the test's own
+  mounted subtree — the shared page accumulates DOM across tests; never
+  clear `<body>`.)
+- **Native `crates/web/src/legality.rs` unit test:** resolution ⇒ empty
+  control set (component #1).
+- **Headless `crates/web/tests/controls.rs`:** a resolved state ⇒ all
+  action buttons carry `disabled`, proving the gate reaches the DOM
+  end-to-end.
+
+Out of scope: a full driven-playthrough headless test (StartScenario →
+… → resolution through the reducer). The engine already tests the toy
+scenario reaching Won/Lost; the web layer only needs to prove it renders
+and gates.
+
+### 4. Closing demo doc — `docs/demos/phase-6-toy-scenario.md`
+
+A markdown walkthrough (new `docs/demos/` directory):
+
+- **Setup:** build the bundle and run the single-port server (or the
+  trunk dev loop), open the page, `POST /games`.
+- **Won path:** the click sequence — `StartScenario` → resolve the
+  mulligan → `Investigate` to gather clues → `AdvanceAct` past the
+  terminal act card → the **"Scenario won — demo"** banner appears and the
+  controls go dead.
+- **Lost path:** let agenda doom reach threshold 2 (advance rounds /
+  mythos) → advancing past the terminal agenda card → the **"Scenario
+  lost — agenda"** banner appears.
+- **Reconnect:** close the tab mid-scenario, reopen → the localStorage
+  game id drives a `Hello` that restores the board, including any
+  in-flight `AwaitingInput`. This is existing behavior (the `Hello`
+  reducer in `store.rs`); the doc verifies it at the UX level, no new
+  code.
+- **Note:** live Fight/Evade is **not** exercised in this demo — the
+  synthetic scenario seeds no enemy, so combat stays wired +
+  headless-tested but not live. This is superseded by Phase 7's real
+  encounter content (see Decisions), not an open TODO.
+
+### 5. Phase doc — `docs/phases/phase-6-web-client-v0.md` (final commit)
+
+After CI is green on the opened PR, as the final commit: move #190 to the
+Closed table (bump counts), flip the P6.8 Arc/Ordering rows to ✅ PR #N,
+and add one **Decisions made** entry recording that live combat in the
+toy scenario was deliberately not built. With P6.8 merged, Phase 6 is
+complete.
+
+## Decisions
+
+- **Resolution dominates legality.** The `resolution.is_some()` gate
+  precedes even the `AwaitingInput` check in `enabled_controls`: once a
+  scenario ends, nothing is clickable regardless of any other cursor or
+  pause.
+- **Banner stays in read-only `board.rs`.** A resolution banner is pure
+  display of `GameState`, so it belongs with `phase_bar` and the panels,
+  not in the `ActionControls` panel (consistent with the P6.7a
+  read-only-board decision).
+- **Live combat is not built — superseded by Phase 7, not deferred to a
+  tracked issue.** P6.8 is the milestone close, so there is no later
+  Phase-6 slot to defer into. The synthetic toy scenario is throwaway
+  (D5: synthetic registries are "this phase only", swapped when Phase 7
+  lands The Gathering), so seeding `_synth_enemy` would be effort on a
+  fixture replaced next phase. Phase 7's real encounter cards spawn real
+  enemies through ordinary play, making Fight/Evade reachable for free —
+  which is why the phase-7 doc carries no combat line item. The only
+  cost of not building it: the Phase-6 closing demo cannot show a live
+  Fight/Evade *click* (its Lost path runs through agenda doom, which is
+  live). Recorded in the phase-6 doc so it is not a silent gap.
+
+## What "done" looks like
+
+- A reached resolution shows a Won/Lost banner in the browser, and all
+  action controls are disabled once it fires.
+- The closing-demo doc walks Won, Lost, and reconnect; reconnect restores
+  the board (incl. in-flight `AwaitingInput`) at the UX level.
+- Headless tests cover the banner render and the resolved-state control
+  gating; the native legality unit test covers the gate logic.
+- The full CI gauntlet (all 7 jobs, incl. `wasm-test`) is green.


### PR DESCRIPTION
## Summary

Closes the Phase-6 milestone (P6.8): a reached scenario resolution is now visible in the browser, the action controls go dead once it fires, and a closing-demo walkthrough documents the toy scenario to a resolution plus the reconnect path.

## What changed

- **Legality gate** (`crates/web/src/legality.rs`): `enabled_controls` returns an empty set when `game.resolution.is_some()`, placed **first** — a latched resolution is terminal and dominates every cursor, pause, and phase. Since `ActionControls` maps set-membership to each button's `disabled`, every control disables automatically.
- **Resolution banner** (`crates/web/src/board.rs`): a read-only `resolution_banner` helper (matching the `phase_bar` pattern, no new interactivity) renders `Scenario won — {id}` / `Scenario lost — {reason}` at the top of the board from the `GameState.resolution` latch.
- **Closing-demo doc** (`docs/demos/phase-6-toy-scenario.md`): Won (AdvanceAct) and Lost (agenda doom → threshold 2) click sequences, plus the close-tab/reopen reconnect path.

## Design note

The client already renders the server's authoritative `GameState`, so surfacing resolution is a read of the existing `resolution` latch — banner for display, legality gate for the UX affordance (the server stays authoritative and rejects illegal actions regardless). Test scope is "render + gate": headless tests for the banner (Won/Lost) and for the resolved-state DOM gating, plus a native legality unit test; the engine already tests the toy scenario reaching Won/Lost, so no full driven playthrough is duplicated at the UI layer. Live Fight/Evade is deliberately **not** built — it's superseded by Phase 7's real encounter content (real cards spawn enemies through ordinary play), not a tracked TODO; the demo's Lost path runs through agenda doom, which is live.

Design spec: `docs/superpowers/specs/2026-06-09-p6.8-resolution-surfacing-design.md`.

## Test notes

- Native: `resolution_disables_all_controls` (legality unit test, Won + Lost).
- Headless (`wasm-pack test --headless --firefox crates/web`): `resolution_banner_renders_won` / `_lost`, and `resolved_scenario_disables_all_controls` (asserts the always-rendered buttons carry `disabled`).
- Full CI gauntlet (all 7 jobs) run locally and green.

## Linked issues

Closes #190