### PR TITLE
infra: harden wasm CI against release-CDN flakiness (#196)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,27 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: Swatinem/rust-cache@v2
+      # taiki-e/install-action fetches prebuilt tool binaries with retries
+      # and a cargo-binstall fallback, replacing jetli/trunk-action's bare,
+      # no-retry GitHub-release download (#196). Version pinned (was
+      # `latest`) so behavior is deterministic.
       - name: Install trunk
-        uses: jetli/trunk-action@v0.5.1
+        uses: taiki-e/install-action@v2
         with:
-          version: latest
+          tool: trunk@0.21.14
       - name: Build web crate
         working-directory: crates/web
-        run: trunk build --release
+        # `trunk build` fetches wasm-bindgen + wasm-opt from GitHub releases
+        # at build time; a transient release-CDN 504 (#196) must not redden
+        # CI. Retry with backoff so an in-run blip is absorbed.
+        run: |
+          for attempt in 1 2 3; do
+            if trunk build --release; then exit 0; fi
+            echo "::warning::trunk build attempt ${attempt} failed (transient tool download?); retrying in $((attempt * 15))s"
+            sleep "$((attempt * 15))"
+          done
+          echo "::error::trunk build failed after 3 attempts"
+          exit 1
 
   wasm-test:
     name: wasm-test
@@ -75,7 +89,13 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: Swatinem/rust-cache@v2
-      - uses: jetli/wasm-pack-action@v0.4.0
+      # taiki-e/install-action (retry + binstall fallback, pinned version)
+      # replaces jetli/wasm-pack-action's bare GitHub-release download —
+      # the wasm-pack fetch that 504'd in #196.
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.15.0
       - name: Headless wasm tests
         run: wasm-pack test --headless --firefox crates/web
 

--- a/docs/phases/README.md
+++ b/docs/phases/README.md
@@ -41,7 +41,6 @@ Some issues don't belong to a single phase. They live unmilestoned with `p2-late
 - `#174` — periodic state snapshots for replay perf (deferred from Phase 5; build only when profiling demands it).
 - `#83` — `enemy_attack` cleanup (apply both damage and horror when one defeats).
 - `#93` — split DSL types into a shared `card-dsl` crate (architectural improvement; not phase-gated).
-- `#196` — harden wasm CI against GitHub release-CDN 504s (cache/pin `wasm-bindgen`/`wasm-opt`/`wasm-pack`; flaked four reruns on `main` after #195).
 
 ## Template
 


### PR DESCRIPTION
## Summary

The `wasm-build` and `wasm-test` jobs fetched their toolchain from GitHub Releases on every run with no caching or retry, so a transient release-CDN `504` reddened perfectly good builds — #196 observed **four reruns** to go green after #195.

## What changed

- **`wasm-build`** — replaced `jetli/trunk-action@v0.5.1` (bare, no-retry download, `version: latest`) with `taiki-e/install-action@v2` installing pinned `trunk@0.21.14` (retries + `cargo-binstall` fallback). Wrapped `trunk build --release` — which fetches `wasm-bindgen` + `wasm-opt` from GitHub releases at build time — in a 3-attempt backoff retry loop so an in-run blip is absorbed.
- **`wasm-test`** — replaced `jetli/wasm-pack-action@v0.4.0` with `taiki-e/install-action@v2` installing pinned `wasm-pack@0.15.0` (the wasm-pack fetch that 504'd).

This covers all four download points the issue observed (trunk binary, wasm-bindgen, wasm-opt, wasm-pack), each now retried; pinned versions remove the `version: latest` nondeterminism.

## Design note

Acceptance allowed "tools from cache **or** a retry absorbs the blip." Retry (via `taiki-e/install-action`'s built-in retries + the explicit `trunk build` loop) is the durable fix and the smaller change; the pinned versions are what would make caching deterministic if we add it later. Versions pinned to what `latest` currently resolves to (trunk 0.21.14, wasm-pack 0.15.0) and the locked `wasm-bindgen` 0.2.120, so this freezes current behavior — no toolchain bump.

## Test notes

CI-only change (no Rust touched); the real verification is this PR's `wasm-build`/`wasm-test` jobs going green via the new install path. YAML + the retry-loop bash validated locally.

## Linked issues

Closes #196