### PR TITLE
docs: Phase 7 Slice 1 kickoff — spec + engine-spine plans + breakdown

### DIFF
--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -32,6 +32,36 @@ Group A *extends* the existing `reaction_windows.rs` OnEvent machinery
 (not greenfield); forced scenario effects take a separate immediate path
 (`fire_forced_triggers`) distinct from player reaction windows.
 
+## Future slices (after Slice 1)
+
+Not yet specced/planned in detail — recorded here so the arc survives a
+fresh session. Rough order; each becomes its own spec → plan → issues
+when picked up.
+
+- **Slice 2+ — investigator breadth.** The other four original-Core
+  investigators (Daisy Walker, "Skids" O'Toole, Agnes Baker, Wendy
+  Adams), each with their signature asset/weakness pair and starter
+  deck — the same content shape as Roland in Slice 1, reusing the engine
+  spine. Likely one slice per investigator (or grouped) once Slice 1
+  proves the pipe. Goal: all five picker-eligible.
+- **Difficulty selection.** Slice 1 ships **Standard** only. Add Easy /
+  Hard / Expert chaos bags + a difficulty picker.
+- **Solo-with-2 UX.** One client driving two investigators — how the
+  picker, turn flow, and board present two characters under one player.
+  Genuinely open design question (see Open questions).
+- **Deferred optional Gathering content** (off the win/lose path, so cut
+  from Slice 1): Lita Chantler's parley/take-control and the Parlor
+  (`01115`) **Resign** action.
+- **Engine north-star (cross-slice, may be its own slice).** `emit_event`
+  dispatch unification (`#212`) + iterative simultaneous-trigger ordering
+  (`#213`, RR p.17 — player picks order even in solo) + the trigger
+  index (`#117`); plus the optional click-to-resolve UX for *lone* forced
+  effects. Slice 1's `fire_forced_triggers` is a forward-compatible
+  subset; this work replaces its single-trigger-only limitation.
+
+Campaign sequencing beyond The Gathering (The Midnight Masks, The
+Devourer Below, campaign log + `Fact` enum) is **Phase 9**, not Phase 7.
+
 ## Issues (filed)
 
 | # | Title | Notes |
@@ -47,14 +77,18 @@ Group A *extends* the existing `reaction_windows.rs` OnEvent machinery
 
 ## Open questions
 
-⏳ **Scoping TBD.** When Phase 6 closes, file:
+The Phase-6-era "scoping TBD" list is now addressed by the slice
+structure above — the scenario module, encounter/act/agenda/location
+impls, Roland, and Standard difficulty are **Slice 1** (kickoff `#216`);
+the other investigators, difficulties, solo-2 UX, and optional content
+map to **Future slices**. Genuinely-open design questions that remain:
 
-- **Scenario module: The Gathering.** Locations, encounter set wiring, act/agenda decks, resolution conditions.
-- **Card implementations** for every card in The Gathering's encounter sets and every card in the five investigators' starter decks. Substantial volume.
-- **Investigator card implementations** for the 5 original-Core investigators. Each has stats, max-health/sanity, signature card pairings.
-- **Story-asset/weakness implementations.** Cover Up, Lita Chantler, Hospital Debts, etc. — the campaign-driven mods.
-- **Difficulty selection.** Easy / Standard / Hard / Expert chaos bags.
-- **Solo-with-2 UX.** One player controls two investigators; how does the client present that?
+- **Solo-with-2 UX.** One player controls two investigators; how does
+  the client present that (picker, whose-turn, two boards vs. tabbed)?
+  Unresolved — a Future-slice design question.
+- **Story-asset/weakness shape.** Cover Up (Roland's, in Slice 1) is
+  scoped, but the broader campaign-driven mods (Lita Chantler, Hospital
+  Debts, …) need a pattern; revisit as they land.
 
 ## Dependencies
 

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -2,11 +2,35 @@
 
 ## Status
 
-📐 Architecture only. Two issues filed (`#65`, `#77`) tagged here; the rest TBD.
+🛠️ **Slice 1 planned** (kickoff [#216](https://github.com/talelburg/eldritch/issues/216)).
+Phase decomposed into vertical slices; Slice 1 (Roland through The
+Gathering, solo, Standard) is specced and the engine spine is planned.
+Design spec:
+[`docs/superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md`](../superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md).
 
 ## Goal
 
 First real scenario playable in browser, solo, all 5 investigators.
+
+## Slice 1 — Roland through The Gathering
+
+Vertical-slice-first: one investigator playable end-to-end (solo,
+Standard, win/lose-path fidelity) before breadth. Deferred north-star
+work: `emit_event` dispatch unification (`#212`) + iterative
+trigger-ordering (`#213`), folding in `#117`.
+
+| Order | Issue | Plan | State |
+|---|---|---|---|
+| — | [#216](https://github.com/talelburg/eldritch/issues/216) — kickoff: spec + engine-spine plans + breakdown | — | 🔜 PR open |
+| A1 | [#214](https://github.com/talelburg/eldritch/issues/214) — engine-spine primitives (DealDamage/DealHorror, EnteredLocation, Act/Agenda CardCode) | `plans/2026-06-10-…-engine-spine-primitives.md` | ⏳ planned |
+| A2 | [#215](https://github.com/talelburg/eldritch/issues/215) — forced-trigger dispatch (`fire_forced_triggers`) — depends on A1 | `plans/2026-06-10-…-forced-trigger-dispatch.md` | ⏳ planned |
+| B | scenario plumbing: `reference_card` + symbol routing; roster/seating + `StartScenario` selection; real-registry swap (D5) | TBD | 📐 spec'd |
+| C | content: Gathering scenario cards + setup + Roland + signature/weakness + starter deck | TBD | 📐 spec'd |
+| D | integration & web: investigator/scenario picker; end-to-end Won/Lost gate | TBD | 📐 spec'd |
+
+Group A *extends* the existing `reaction_windows.rs` OnEvent machinery
+(not greenfield); forced scenario effects take a separate immediate path
+(`fire_forced_triggers`) distinct from player reaction windows.
 
 ## Issues (filed)
 

--- a/docs/superpowers/plans/2026-06-10-phase-7-slice-1-engine-spine-primitives.md
+++ b/docs/superpowers/plans/2026-06-10-phase-7-slice-1-engine-spine-primitives.md
@@ -1,0 +1,418 @@
+# Phase 7 Slice 1 — Engine-Spine Primitives (Plan A1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the three mechanical, self-contained engine primitives The Gathering needs — `Effect::DealDamage` / `Effect::DealHorror`, an inert `EventPattern::EnteredLocation` DSL variant, and a `CardCode` on `Act`/`Agenda` — each independently tested and mergeable.
+
+**Architecture:** Pure additive changes following existing patterns. The two effects mirror `Effect::GainResources` (enum variant + `apply_effect` match arm + builder fn + a helper that delegates to the existing numeric/defeat helpers in `dispatch`). The `EventPattern` variant lands inert exactly as `CardRevealed`/`EnemySpawned` did (DSL surface only; firing wired in Plan A2). The `Act`/`Agenda` `code` field mirrors `Location.code`.
+
+**Tech Stack:** Rust workspace (`card-dsl`, `game-core`); `cargo test`/`clippy`/`fmt`/`doc` under the strict CI flags in `CLAUDE.md`.
+
+**Scope note:** This is Plan A1 of Group A. The forced-trigger *dispatch extension* (widening `scan_pending_triggers` to location/act/agenda sources, the forced auto-fire path, new trigger windows) is **Plan A2** — it reshapes `PendingTrigger`/`fire_pending_trigger` (which key on in-play card `instance_id`s) to address non-instance scenario-structure sources, and is designed separately. A1 deliberately leaves the new `EventPattern` variant inert.
+
+---
+
+## File Structure
+
+- `crates/card-dsl/src/dsl.rs` — add `Effect::DealDamage`/`DealHorror` variants, `deal_damage`/`deal_horror` builder fns, and `EventPattern::EnteredLocation` variant. One file: the DSL data types and their builders already live here.
+- `crates/game-core/src/engine/dispatch/elimination.rs` — add a `pub(crate) take_damage` twin to the existing `take_horror`; widen `take_horror` to `pub(crate)`.
+- `crates/game-core/src/engine/evaluator.rs` — add `apply_effect` match arms + `deal_damage`/`deal_horror` evaluator helpers (mirror `gain_resources`).
+- `crates/game-core/src/state/game_state.rs` — add `code: CardCode` to `Act` and `Agenda`.
+- `crates/scenarios/src/test_fixtures/synthetic.rs` — set the new `code` on the synthetic fixture's acts/agendas (construction site that must compile).
+
+---
+
+## Task 1: `Effect::DealDamage` / `Effect::DealHorror` primitives
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs` (Effect enum ~line 375; builder fns ~line 672)
+- Modify: `crates/game-core/src/engine/dispatch/elimination.rs:186` (`take_horror`; add `take_damage`)
+- Modify: `crates/game-core/src/engine/evaluator.rs:131` (`apply_effect` match; add helpers)
+- Test: inline `#[cfg(test)]` in `crates/game-core/src/engine/evaluator.rs`
+
+- [ ] **Step 1: Add the two `Effect` variants**
+
+In `crates/card-dsl/src/dsl.rs`, inside `pub enum Effect`, after the `DiscoverClue` variant:
+
+```rust
+    /// Deal `amount` damage to the resolved target investigator,
+    /// applying defeat if the new total reaches their max health.
+    /// `amount == 0` is a no-op (no event, no target resolution).
+    DealDamage { target: InvestigatorTarget, amount: u8 },
+    /// Deal `amount` horror to the resolved target investigator,
+    /// applying defeat if the new total reaches their max sanity.
+    /// `amount == 0` is a no-op.
+    DealHorror { target: InvestigatorTarget, amount: u8 },
+```
+
+- [ ] **Step 2: Add builder fns**
+
+In `crates/card-dsl/src/dsl.rs`, after the `discover_clue` builder (~line 678):
+
+```rust
+/// Build an [`Effect::DealDamage`] against `target` for `amount`.
+#[must_use]
+pub fn deal_damage(target: InvestigatorTarget, amount: u8) -> Effect {
+    Effect::DealDamage { target, amount }
+}
+
+/// Build an [`Effect::DealHorror`] against `target` for `amount`.
+#[must_use]
+pub fn deal_horror(target: InvestigatorTarget, amount: u8) -> Effect {
+    Effect::DealHorror { target, amount }
+}
+```
+
+- [ ] **Step 3: Write the failing evaluator test**
+
+In `crates/game-core/src/engine/evaluator.rs`, inside the existing `#[cfg(test)] mod tests`, add (mirror the `gain_resources` tests already there; confirm the exact `TestGame` setup helpers against a neighbouring test before finalising):
+
+```rust
+#[test]
+fn deal_damage_adds_damage_and_emits_event() {
+    let mut state = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_active_investigator(InvestigatorId(1))
+        .build();
+    let mut events = Vec::new();
+    let mut cx = Cx { state: &mut state, events: &mut events };
+    let outcome = apply_effect(
+        &mut cx,
+        &deal_damage(InvestigatorTarget::Controller, 2),
+        EvalContext::for_controller(InvestigatorId(1)),
+    );
+    assert_eq!(outcome, EngineOutcome::Done);
+    assert_eq!(state.investigators[&InvestigatorId(1)].damage, 2);
+    assert!(events.iter().any(|e| matches!(
+        e,
+        Event::DamageTaken { investigator, amount: 2 } if *investigator == InvestigatorId(1)
+    )));
+}
+
+#[test]
+fn deal_horror_adds_horror_and_emits_event() {
+    let mut state = TestGame::new()
+        .with_investigator(test_investigator(1))
+        .with_active_investigator(InvestigatorId(1))
+        .build();
+    let mut events = Vec::new();
+    let mut cx = Cx { state: &mut state, events: &mut events };
+    let outcome = apply_effect(
+        &mut cx,
+        &deal_horror(InvestigatorTarget::Controller, 1),
+        EvalContext::for_controller(InvestigatorId(1)),
+    );
+    assert_eq!(outcome, EngineOutcome::Done);
+    assert_eq!(state.investigators[&InvestigatorId(1)].horror, 1);
+    assert!(events.iter().any(|e| matches!(
+        e,
+        Event::HorrorTaken { investigator, amount: 1 } if *investigator == InvestigatorId(1)
+    )));
+}
+```
+
+Add any missing `use` lines the test needs (`deal_damage`, `deal_horror`, `Event`, `InvestigatorTarget`, `Cx`, `test_investigator`) following the imports the neighbouring `gain_resources` tests use.
+
+- [ ] **Step 4: Run the test to verify it fails to compile**
+
+Run: `cargo test -p game-core deal_damage_adds_damage_and_emits_event 2>&1 | tail -20`
+Expected: compile error — `Effect::DealDamage` has no `apply_effect` arm (non-exhaustive match) / `deal_damage` unresolved if builder not imported.
+
+- [ ] **Step 5: Add the `take_damage` twin and widen visibility**
+
+In `crates/game-core/src/engine/dispatch/elimination.rs`, change `take_horror`'s signature to `pub(crate)` and add the `take_damage` twin immediately after it:
+
+```rust
+/// Apply `amount` damage to `investigator` via the numeric helper,
+/// then apply defeat (cause [`DefeatCause::Damage`]) if it was lethal.
+/// The single-source-damage twin of [`take_horror`] — the first such
+/// caller is [`Effect::DealDamage`]'s evaluator.
+pub(crate) fn take_damage(cx: &mut Cx, investigator: InvestigatorId, amount: u8) {
+    if super::combat::apply_damage_numeric(cx, investigator, amount) {
+        apply_investigator_defeat(cx, investigator, DefeatCause::Damage);
+    }
+}
+```
+
+Change `pub(super) fn take_horror` → `pub(crate) fn take_horror`.
+
+- [ ] **Step 6: Add the `apply_effect` match arms + evaluator helpers**
+
+In `crates/game-core/src/engine/evaluator.rs`, add to the `apply_effect` match (after `DiscoverClue`):
+
+```rust
+        Effect::DealDamage { target, amount } => deal_damage_effect(cx, eval_ctx, *target, *amount),
+        Effect::DealHorror { target, amount } => deal_horror_effect(cx, eval_ctx, *target, *amount),
+```
+
+Then add the helpers (mirror `gain_resources`, ~line where `gain_resources` is defined):
+
+```rust
+fn deal_damage_effect(
+    cx: &mut Cx,
+    eval_ctx: EvalContext,
+    target: InvestigatorTarget,
+    amount: u8,
+) -> EngineOutcome {
+    if amount == 0 {
+        return EngineOutcome::Done;
+    }
+    let target_id = match resolve_investigator_target(cx.state, eval_ctx, target) {
+        Ok(id) => id,
+        Err(reason) => return EngineOutcome::Rejected { reason: reason.into() },
+    };
+    if !cx.state.investigators.contains_key(&target_id) {
+        return EngineOutcome::Rejected {
+            reason: format!("DealDamage: investigator {target_id:?} is not in the state").into(),
+        };
+    }
+    crate::engine::dispatch::elimination::take_damage(cx, target_id, amount);
+    EngineOutcome::Done
+}
+
+fn deal_horror_effect(
+    cx: &mut Cx,
+    eval_ctx: EvalContext,
+    target: InvestigatorTarget,
+    amount: u8,
+) -> EngineOutcome {
+    if amount == 0 {
+        return EngineOutcome::Done;
+    }
+    let target_id = match resolve_investigator_target(cx.state, eval_ctx, target) {
+        Ok(id) => id,
+        Err(reason) => return EngineOutcome::Rejected { reason: reason.into() },
+    };
+    if !cx.state.investigators.contains_key(&target_id) {
+        return EngineOutcome::Rejected {
+            reason: format!("DealHorror: investigator {target_id:?} is not in the state").into(),
+        };
+    }
+    crate::engine::dispatch::elimination::take_horror(cx, target_id, amount);
+    EngineOutcome::Done
+}
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `cargo test -p game-core deal_damage_adds_damage_and_emits_event deal_horror_adds_horror_and_emits_event 2>&1 | tail -20`
+Expected: both PASS.
+
+- [ ] **Step 8: Run the strict gauntlet for the touched crates**
+
+Run:
+```sh
+RUSTFLAGS="-D warnings" cargo test -p card-dsl -p game-core --all-features 2>&1 | tail -15
+cargo clippy -p card-dsl -p game-core --all-targets --all-features -- -D warnings 2>&1 | tail -15
+RUSTDOCFLAGS="-D warnings" cargo doc -p card-dsl -p game-core --no-deps --all-features 2>&1 | tail -10
+cargo fmt --check
+```
+Expected: all clean. (Builder fns are `#[must_use]` to satisfy clippy; doc links resolve.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/card-dsl/src/dsl.rs crates/game-core/src/engine/evaluator.rs crates/game-core/src/engine/dispatch/elimination.rs
+git commit -m "dsl,engine: DealDamage/DealHorror effect primitives
+
+First single-source-damage caller (the take_horror doc anticipated it);
+adds the take_damage twin and the two evaluator helpers mirroring
+GainResources. Needed by Cellar (01114) / Attic (01113) forced-on-enter
+and treachery damage/horror in The Gathering.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: inert `EventPattern::EnteredLocation` DSL variant
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs` (`EventPattern` enum, ~line 196)
+- Test: inline `#[cfg(test)]` in `crates/card-dsl/src/dsl.rs`
+
+This lands the DSL surface only — exactly as `CardRevealed`/`EnemySpawned` did. The engine does **not** match it yet; firing is Plan A2. `game-core`'s `trigger_matches` exhaustively matches `EventPattern`, so adding a variant forces a deliberate `_ => false` (or explicit arm) there.
+
+- [ ] **Step 1: Write the failing round-trip test**
+
+In `crates/card-dsl/src/dsl.rs` `#[cfg(test)] mod tests` (mirror any existing serde round-trip test for `EventPattern`; if none, this is the first):
+
+```rust
+#[test]
+fn entered_location_pattern_round_trips() {
+    let p = EventPattern::EnteredLocation;
+    let json = serde_json::to_string(&p).unwrap();
+    let back: EventPattern = serde_json::from_str(&json).unwrap();
+    assert_eq!(p, back);
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p card-dsl entered_location_pattern_round_trips 2>&1 | tail -10`
+Expected: compile error — `EventPattern::EnteredLocation` does not exist.
+
+- [ ] **Step 3: Add the variant**
+
+In `crates/card-dsl/src/dsl.rs`, inside `pub enum EventPattern`, after `EnemySpawned`:
+
+```rust
+    /// An investigator entered the location this ability is printed on
+    /// (Forced "after you enter <location>" effects: Attic `01113`
+    /// takes 1 horror, Cellar `01114` takes 1 damage).
+    ///
+    /// Intentionally bare: the engine binds *you* = the entering
+    /// investigator and *this location* = the ability's own location
+    /// from the trigger context — no narrowing fields needed.
+    ///
+    /// DSL surface only in Plan A1; the matching + forced auto-fire
+    /// wiring lands in Plan A2. Until then the engine ignores it.
+    EnteredLocation,
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p card-dsl entered_location_pattern_round_trips 2>&1 | tail -10`
+Expected: PASS.
+
+- [ ] **Step 5: Keep `game-core` compiling (exhaustive match)**
+
+Build `game-core` to surface the now-non-exhaustive `trigger_matches`:
+
+Run: `cargo build -p game-core 2>&1 | tail -15`
+Expected: compile error in `crates/game-core/src/engine/dispatch/reaction_windows.rs` at `trigger_matches` (non-exhaustive `EventPattern` match).
+
+Fix it by adding an explicit inert arm in `trigger_matches` (find the `match pattern` there):
+
+```rust
+        // Plan A2 wires the entered-location forced window; until then
+        // this pattern never matches any open WindowKind.
+        EventPattern::EnteredLocation => false,
+```
+
+Run again: `cargo build -p game-core 2>&1 | tail -5` → clean.
+
+- [ ] **Step 6: Strict gauntlet + commit**
+
+```sh
+RUSTFLAGS="-D warnings" cargo test -p card-dsl -p game-core --all-features 2>&1 | tail -10
+cargo clippy -p card-dsl -p game-core --all-targets --all-features -- -D warnings 2>&1 | tail -10
+cargo fmt --check
+```
+Then:
+```bash
+git add crates/card-dsl/src/dsl.rs crates/game-core/src/engine/dispatch/reaction_windows.rs
+git commit -m "dsl: EventPattern::EnteredLocation (inert; firing in Plan A2)
+
+DSL surface for Forced after-you-enter-location effects, landed inert
+per the CardRevealed/EnemySpawned precedent. trigger_matches gets an
+explicit false arm; Plan A2 wires the window + forced auto-fire.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `CardCode` on `Act` and `Agenda`
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (`Act` ~line 261, `Agenda` ~line 244)
+- Modify: `crates/scenarios/src/test_fixtures/synthetic.rs:83-105` (construction sites)
+- Test: inline `#[cfg(test)]` in `crates/game-core/src/state/game_state.rs`
+
+Mirrors `Location.code`. The field is the prerequisite for Plan A2's widened scan (resolving act/agenda abilities through the registry by code). Pure data plumbing — no behavior yet.
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/game-core/src/state/game_state.rs` `#[cfg(test)] mod tests`:
+
+```rust
+#[test]
+fn act_and_agenda_carry_card_code() {
+    let act = Act { code: CardCode::new("01108"), clue_threshold: 2, resolution: None };
+    let agenda = Agenda { code: CardCode::new("01105"), doom_threshold: 3, resolution: None };
+    assert_eq!(act.code, CardCode::new("01108"));
+    assert_eq!(agenda.code, CardCode::new("01105"));
+}
+```
+
+(Confirm the exact `CardCode` constructor — `CardCode::new` vs `CardCode("…".into())` — against existing uses in this file before finalising.)
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p game-core act_and_agenda_carry_card_code 2>&1 | tail -10`
+Expected: compile error — `Act`/`Agenda` have no `code` field.
+
+- [ ] **Step 3: Add the `code` field to both structs**
+
+In `crates/game-core/src/state/game_state.rs`, add as the first field of `Agenda`:
+
+```rust
+    /// The encounter-card code this agenda is printed on (e.g.
+    /// `01105`). Lets the trigger dispatcher resolve the agenda's
+    /// `Trigger::OnEvent` abilities through the card registry — the
+    /// agenda owns its Forced effects like any other card.
+    pub code: CardCode,
+```
+
+And as the first field of `Act`:
+
+```rust
+    /// The encounter-card code this act is printed on (e.g. `01108`).
+    /// Lets the trigger dispatcher resolve the act's `Trigger::OnEvent`
+    /// abilities through the card registry.
+    pub code: CardCode,
+```
+
+- [ ] **Step 4: Fix the synthetic fixture construction sites**
+
+In `crates/scenarios/src/test_fixtures/synthetic.rs`, the `state.agenda_deck = vec![...]` and `state.act_deck = vec![...]` literals (~lines 83 and 95) construct `Agenda`/`Act` directly. Add `code:` to each literal, reusing the synthetic codes already in `synth_cards` if present, or literal placeholders:
+
+```rust
+    // in each Agenda { ... } literal:
+    code: CardCode("synth-agenda".into()),
+    // in each Act { ... } literal:
+    code: CardCode("synth-act".into()),
+```
+
+(Match the `CardCode` constructor form used elsewhere in this file.)
+
+- [ ] **Step 5: Run the test + verify the fixture compiles**
+
+Run: `cargo test -p game-core act_and_agenda_carry_card_code 2>&1 | tail -10`
+Run: `cargo build -p scenarios --features test_fixtures 2>&1 | tail -10`
+Expected: test PASS; scenarios builds.
+
+- [ ] **Step 6: Full strict gauntlet (touches state shape → broad)**
+
+Run:
+```sh
+RUSTFLAGS="-D warnings" cargo test --all --all-features 2>&1 | tail -15
+cargo clippy --all-targets --all-features -- -D warnings 2>&1 | tail -10
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features 2>&1 | tail -10
+cargo fmt --check
+cargo build -p web --target wasm32-unknown-unknown 2>&1 | tail -10
+```
+Expected: all clean. (State shape is serde-derived; the new required field may surface in any test that builds an `Act`/`Agenda` literal — fix each by adding `code:`.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/game-core/src/state/game_state.rs crates/scenarios/src/test_fixtures/synthetic.rs
+git commit -m "engine: Act/Agenda carry CardCode
+
+Mirrors Location.code. Prerequisite for Plan A2's widened trigger scan,
+which resolves act/agenda Forced abilities through the registry by code.
+Pure data plumbing; no behavior yet.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** A1 covers the spec's Group A items 1 (DSL primitives — DealDamage/DealHorror + forced-on-enter `EventPattern`) and 2 (Act/Agenda `CardCode`). Group A items 3–5 (widen scan, forced auto-fire, new windows) are explicitly deferred to Plan A2 and called out in the header. No silent gaps.
+- **Placeholder scan:** no TODO/TBD; every code step shows complete code. The synthetic-fixture `code:` values are real string literals, not placeholders.
+- **Type consistency:** `Effect::DealDamage { target, amount }` / `DealHorror` field names match across enum, builders, match arms, and helpers. `take_damage`/`take_horror` signatures match their call sites in the evaluator helpers. `EventPattern::EnteredLocation` is bare in both the variant and the `trigger_matches` arm. `Act`/`Agenda` `code: CardCode` matches the test and fixture literals.
+- **Open verification points flagged inline:** exact `CardCode` constructor form, exact `TestGame` helper names, and the neighbouring-test import set — each step says to confirm against an adjacent example before finalising, since those are the spots most likely to drift from this plan's assumptions.

--- a/docs/superpowers/plans/2026-06-10-phase-7-slice-1-forced-trigger-dispatch.md
+++ b/docs/superpowers/plans/2026-06-10-phase-7-slice-1-forced-trigger-dispatch.md
@@ -1,0 +1,665 @@
+# Phase 7 Slice 1 — Forced-Trigger Dispatch (Plan A2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fire Forced (`Trigger::OnEvent`) abilities printed on scenario-structure cards (locations, acts, agendas) at the right timing windows, via a separate immediate path that does not touch the player-reaction machinery.
+
+**Architecture:** A new `fire_forced_triggers(cx, point)` chokepoint, invoked explicitly at two emission sites (after `InvestigatorMoved`; at `enemy_phase_end` / `upkeep_phase_end`). It scans only the relevant scenario-structure card(s), collects matching forced abilities, and — for the single-trigger case the slice's content produces — resolves immediately via the existing `apply_effect` evaluator. If 2+ are ever simultaneously pending it **rejects loudly** (the iterative-ordering loop is #213, the `emit_event` unification is #212) rather than silently choosing an order. This is a clean, forward-compatible subset of #212.
+
+**Tech Stack:** Rust workspace (`card-dsl`, `game-core`); strict CI flags from `CLAUDE.md`.
+
+**Prerequisite:** Plan A1 must be merged (this plan uses `Effect::DealHorror`/`DealDamage`, `EventPattern::EnteredLocation`, and `Act`/`Agenda.code`).
+
+**Scope (explicit):**
+- IN: forced-on-enter (location) + forced phase-end (act/agenda) dispatch; single-trigger resolution; the 2+ loud-reject guard; `EventPattern::PhaseEnded`.
+- OUT: the iterative ordering loop (#213); the universal `emit_event` chokepoint (#212); player-optional ("may") scenario-card reactions (none exist in the slice; player reactions stay on the existing reaction-window path); Roland's reaction (unchanged — already on `AfterEnemyDefeated`).
+
+---
+
+## File Structure
+
+- `crates/card-dsl/src/dsl.rs` — add `EventPattern::PhaseEnded { phase }` variant. (`Phase` is `game_core`'s type; `card-dsl` must not depend on `game-core`. Mirror the phase as a `card-dsl`-local enum if `card-dsl` has no `Phase`, OR carry the discriminant some `card-dsl`-safe way — see Task 1 for the resolved approach.)
+- `crates/game-core/src/engine/dispatch/forced_triggers.rs` — **new**. `ForcedTriggerPoint` enum + `fire_forced_triggers` + the scan/collect/resolve/guard logic.
+- `crates/game-core/src/engine/dispatch/mod.rs` — declare the new module; no dispatch-arm changes (forced firing is called from handlers, not from the top-level action match).
+- `crates/game-core/src/engine/dispatch/actions.rs:271` — wire `fire_forced_triggers` after the `InvestigatorMoved` emit in `move_action`.
+- `crates/game-core/src/engine/dispatch/phases.rs:389,464` — wire `fire_forced_triggers` into `enemy_phase_end` and `upkeep_phase_end`.
+- `crates/game-core/src/engine/dispatch/reaction_windows.rs` — add the inert `EventPattern::PhaseEnded` arm to `trigger_matches` (keeps the exhaustive match compiling; forced patterns never match reaction windows).
+
+---
+
+## Task 0 (decision, no code): where does `Phase` live for `EventPattern::PhaseEnded`?
+
+`card-dsl` must not depend on `game-core` (layering). `Phase` (`Mythos`/`Investigation`/`Enemy`/`Upkeep`) lives in `game-core::state::phase`. Options:
+
+- **(A, chosen)** Add a `card-dsl`-local `Phase` mirror enum in `card-dsl` and have `EventPattern::PhaseEnded { phase: card_dsl::Phase }`. `game-core` already re-exports `card_dsl` types; `forced_triggers` maps `card_dsl::Phase` ↔ `state::Phase` at the boundary (a 4-arm match). Keeps layering clean.
+- (B) Make `EventPattern::PhaseEnded` carry no phase and have `fire_forced_triggers` infer the phase from the call site. Rejected: a card author can't then say "at the end of the *enemy* phase" declaratively — the discriminant belongs on the pattern.
+
+**Resolution:** Option A. Task 1 adds `card_dsl::Phase` and the boundary map.
+
+(If `card-dsl` already has a `Phase`-like type, reuse it and skip the new enum — confirm with `grep -n "enum Phase" crates/card-dsl/src/`.)
+
+---
+
+## Task 1: `EventPattern::PhaseEnded { phase }` (DSL, inert in `trigger_matches`)
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs` (`EventPattern` enum; new `Phase` mirror if absent)
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (`trigger_matches` inert arm)
+- Test: inline `#[cfg(test)]` in `crates/card-dsl/src/dsl.rs`
+
+- [ ] **Step 1: Confirm whether `card-dsl` already has a `Phase`**
+
+Run: `grep -n "enum Phase" crates/card-dsl/src/dsl.rs crates/card-dsl/src/lib.rs`
+Expected: no match → add the mirror in Step 3. (If it matches, reuse it and adjust Step 3.)
+
+- [ ] **Step 2: Write the failing round-trip test**
+
+In `crates/card-dsl/src/dsl.rs` `#[cfg(test)] mod tests`:
+
+```rust
+#[test]
+fn phase_ended_pattern_round_trips() {
+    let p = EventPattern::PhaseEnded { phase: Phase::Enemy };
+    let json = serde_json::to_string(&p).unwrap();
+    let back: EventPattern = serde_json::from_str(&json).unwrap();
+    assert_eq!(p, back);
+}
+```
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `cargo test -p card-dsl phase_ended_pattern_round_trips 2>&1 | tail -10`
+Expected: compile error — `EventPattern::PhaseEnded` and/or `Phase` do not exist.
+
+- [ ] **Step 4: Add the `card-dsl` `Phase` mirror (if absent) and the variant**
+
+In `crates/card-dsl/src/dsl.rs`, add the mirror enum near the other DSL data types:
+
+```rust
+/// The four game phases, mirrored in `card-dsl` so `EventPattern` can
+/// name a phase without `card-dsl` depending on `game-core` (layering).
+/// `game-core` maps this to its own `state::Phase` at the dispatch
+/// boundary (see `engine::dispatch::forced_triggers`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Phase {
+    Mythos,
+    Investigation,
+    Enemy,
+    Upkeep,
+}
+```
+
+Then add to `pub enum EventPattern`, after `EnteredLocation` (added in A1):
+
+```rust
+    /// A game phase ended. Forced agenda/act effects keyed to a phase
+    /// boundary listen here: agenda `01107` moves Ghouls at
+    /// `PhaseEnded { phase: Enemy }` and places doom at the end of the
+    /// round (`PhaseEnded { phase: Upkeep }`).
+    ///
+    /// Matched only by the forced dispatch path
+    /// (`engine::dispatch::forced_triggers`), never by player reaction
+    /// windows — `trigger_matches` returns `false` for it.
+    PhaseEnded { phase: Phase },
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cargo test -p card-dsl phase_ended_pattern_round_trips 2>&1 | tail -10`
+Expected: PASS.
+
+- [ ] **Step 6: Keep `game-core` compiling — inert `trigger_matches` arm**
+
+Run: `cargo build -p game-core 2>&1 | tail -15`
+Expected: non-exhaustive-match error in `trigger_matches` (`reaction_windows.rs`).
+
+Add `EventPattern::PhaseEnded { .. }` to the existing inert tuple arm in `trigger_matches` (the one that already lists `EnemyDefeated | CardRevealed | EnemySpawned | EnteredLocation` returning `false`):
+
+```rust
+        (
+            WindowKind::PlayerWindow(_) | WindowKind::AfterEnemyDefeated { .. },
+            EventPattern::EnemyDefeated { .. }
+            | EventPattern::CardRevealed { .. }
+            | EventPattern::EnemySpawned
+            | EventPattern::EnteredLocation
+            | EventPattern::PhaseEnded { .. },
+        ) => false,
+```
+
+Run: `cargo build -p game-core 2>&1 | tail -5` → clean.
+
+- [ ] **Step 7: Strict gauntlet + commit**
+
+```sh
+RUSTFLAGS="-D warnings" cargo test -p card-dsl -p game-core --all-features 2>&1 | tail -10
+cargo clippy -p card-dsl -p game-core --all-targets --all-features -- -D warnings 2>&1 | tail -10
+cargo fmt --check
+```
+```bash
+git add crates/card-dsl/src/dsl.rs crates/game-core/src/engine/dispatch/reaction_windows.rs
+git commit -m "dsl: EventPattern::PhaseEnded { phase } (inert in reaction windows)
+
+Mirror Phase into card-dsl to keep the layering boundary; the variant
+is matched only by the forced dispatch path (Task 2+), never by player
+reaction windows. Needed by agenda 01107's phase-end forced effects.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `forced_triggers` module — `ForcedTriggerPoint` + `fire_forced_triggers` skeleton
+
+**Files:**
+- Create: `crates/game-core/src/engine/dispatch/forced_triggers.rs`
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (add `mod forced_triggers;`)
+- Test: inline `#[cfg(test)]` in `forced_triggers.rs`
+
+This task builds the scan/collect/resolve/guard core against the **EnteredLocation** point (the simplest), with a synthetic location carrying a forced `DealHorror`-on-enter ability. Task 4 adds the PhaseEnded point.
+
+- [ ] **Step 1: Declare the module**
+
+In `crates/game-core/src/engine/dispatch/mod.rs`, add alongside the other `mod` declarations:
+
+```rust
+mod forced_triggers;
+```
+
+- [ ] **Step 2: Write the failing test (single forced-on-enter resolves immediately)**
+
+Create `crates/game-core/src/engine/dispatch/forced_triggers.rs` with only this test module to start (the test references items defined in Step 4):
+
+```rust
+//! Forced-trigger dispatch: fires `Trigger::OnEvent` abilities printed
+//! on scenario-structure cards (locations, acts, agendas) at framework
+//! timing points, via an immediate path separate from the player
+//! reaction-window machinery. Single-trigger only in this slice; 2+
+//! simultaneous pending triggers reject loudly (#213 adds the ordering
+//! loop, #212 the universal emit_event chokepoint).
+
+use crate::card_data::CardType; // adjust imports to what the impl needs
+use crate::dsl::Phase as DslPhase;
+use crate::engine::dispatch::Cx;
+use crate::engine::outcome::EngineOutcome;
+use crate::state::{InvestigatorId, LocationId, Phase};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::card_registry;
+    use crate::dsl::{ability_on_event, deal_horror, EventPattern, EventTiming, InvestigatorTarget};
+    use crate::event::Event;
+    use crate::state::CardCode;
+    use crate::test_support::{test_investigator, test_location, TestGame};
+
+    // A registry whose only card (the test location code) carries a
+    // forced "after you enter: take 1 horror" ability.
+    fn forced_horror_abilities(code: &CardCode) -> Option<Vec<crate::dsl::Ability>> {
+        if code == &CardCode::new("test-attic") {
+            Some(vec![ability_on_event(
+                EventPattern::EnteredLocation,
+                EventTiming::After,
+                deal_horror(InvestigatorTarget::Controller, 1),
+            )])
+        } else {
+            None
+        }
+    }
+
+    fn no_metadata(_: &CardCode) -> Option<&'static crate::card_data::CardMetadata> {
+        None
+    }
+
+    #[test]
+    fn forced_on_enter_resolves_immediately() {
+        let _ = card_registry::install(card_registry::CardRegistry {
+            metadata_for: no_metadata,
+            abilities_for: forced_horror_abilities,
+        });
+
+        let mut loc = test_location(10, "Attic");
+        loc.code = CardCode::new("test-attic");
+        let mut state = TestGame::new()
+            .with_investigator_at(test_investigator(1), LocationId(10))
+            .with_location(loc)
+            .with_active_investigator(InvestigatorId(1))
+            .build();
+        let mut events = Vec::new();
+        let mut cx = Cx { state: &mut state, events: &mut events };
+
+        let outcome = fire_forced_triggers(
+            &mut cx,
+            ForcedTriggerPoint::EnteredLocation {
+                investigator: InvestigatorId(1),
+                location: LocationId(10),
+            },
+        );
+
+        assert_eq!(outcome, EngineOutcome::Done);
+        assert_eq!(state.investigators[&InvestigatorId(1)].horror, 1);
+        assert!(events.iter().any(|e| matches!(e, Event::HorrorTaken { amount: 1, .. })));
+    }
+}
+```
+
+> NOTE for the implementer: confirm exact names before finalising — the registry struct/field names (`card_registry::CardRegistry`, `metadata_for`, `abilities_for`), the `ability_on_event` builder (it exists per `dsl.rs` ~line 623 — `ability_on_event(pattern, timing, effect)`), and `TestGame` helpers — by reading `crates/cards/tests/play_card.rs` and `reaction_windows.rs`'s own tests. Because the process-global registry is a `OnceLock`, run this test in a file that does not also install a different registry (a dedicated integration test in `crates/cards/tests/` may be cleaner than an in-crate test if collisions arise — mirror the existing reaction tests' choice).
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `cargo test -p game-core forced_on_enter_resolves_immediately 2>&1 | tail -20`
+Expected: compile error — `fire_forced_triggers` / `ForcedTriggerPoint` undefined.
+
+- [ ] **Step 4: Implement `ForcedTriggerPoint` + `fire_forced_triggers` (EnteredLocation arm)**
+
+In `forced_triggers.rs`, above the test module:
+
+```rust
+/// A framework timing point at which Forced (`Trigger::OnEvent`)
+/// abilities on scenario-structure cards may fire. Each variant carries
+/// the binding context the fired effect needs (the "you", the phase).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ForcedTriggerPoint {
+    /// An investigator entered a location. Scans that location's card
+    /// for `EventPattern::EnteredLocation` forced abilities; binds
+    /// controller = the entering investigator.
+    EnteredLocation { investigator: InvestigatorId, location: LocationId },
+    /// A phase ended. Scans the current act and agenda for
+    /// `EventPattern::PhaseEnded { phase }` forced abilities; binds
+    /// controller = the lead investigator (board-wide effects ignore it).
+    PhaseEnded { phase: Phase },
+}
+
+/// One forced ability to resolve: the source card's code, the ability
+/// index within that card, and the controller to evaluate it as.
+struct ForcedHit {
+    code: crate::state::CardCode,
+    ability_index: usize,
+    controller: InvestigatorId,
+}
+
+/// Fire Forced abilities matching `point`. Single-trigger path for this
+/// slice: 0 → `Done`; 1 → resolve via `apply_effect`; 2+ → reject loudly
+/// (no silently-chosen order — #213 adds the ordering loop). Reaction
+/// ("may") scenario abilities do not exist in-slice and are not handled
+/// here; player reactions stay on the reaction-window path.
+pub(super) fn fire_forced_triggers(cx: &mut Cx, point: ForcedTriggerPoint) -> EngineOutcome {
+    let hits = collect_forced_hits(cx.state, point);
+    match hits.len() {
+        0 => EngineOutcome::Done,
+        1 => resolve_one(cx, &hits[0]),
+        n => EngineOutcome::Rejected {
+            reason: format!(
+                "fire_forced_triggers: {n} simultaneous forced triggers at {point:?}; \
+                 ordering not yet implemented (see #213). Slice-1 content never produces \
+                 this — investigate the source."
+            )
+            .into(),
+        },
+    }
+}
+
+/// Collect the forced abilities matching `point` from the relevant
+/// scenario-structure source(s), in source order. Returns an empty vec
+/// when the registry isn't installed.
+fn collect_forced_hits(state: &crate::state::GameState, point: ForcedTriggerPoint) -> Vec<ForcedHit> {
+    let Some(reg) = crate::card_registry::current() else {
+        return Vec::new();
+    };
+    let mut hits = Vec::new();
+    match point {
+        ForcedTriggerPoint::EnteredLocation { investigator, location } => {
+            let Some(loc) = state.locations.get(&location) else {
+                return hits;
+            };
+            push_matching(&reg, &loc.code, investigator, &mut hits, |p| {
+                matches!(p, crate::dsl::EventPattern::EnteredLocation)
+            });
+        }
+        ForcedTriggerPoint::PhaseEnded { phase } => {
+            // Task 4 fills this in (act + agenda scan). Left empty here
+            // so Task 2's EnteredLocation test passes in isolation.
+            let _ = phase;
+        }
+    }
+    hits
+}
+
+/// Push every Forced `OnEvent` ability on `code` whose pattern passes
+/// `want` (and whose timing is `After`) as a `ForcedHit`.
+fn push_matching(
+    reg: &crate::card_registry::CardRegistry,
+    code: &crate::state::CardCode,
+    controller: InvestigatorId,
+    out: &mut Vec<ForcedHit>,
+    want: impl Fn(crate::dsl::EventPattern) -> bool,
+) {
+    let Some(abilities) = (reg.abilities_for)(code) else {
+        return;
+    };
+    for (idx, ability) in abilities.iter().enumerate() {
+        if let crate::dsl::Trigger::OnEvent { pattern, timing } = ability.trigger {
+            if timing == crate::dsl::EventTiming::After && want(pattern) {
+                out.push(ForcedHit { code: code.clone(), ability_index: idx, controller });
+            }
+        }
+    }
+}
+
+/// Resolve a single forced ability via the evaluator.
+fn resolve_one(cx: &mut Cx, hit: &ForcedHit) -> EngineOutcome {
+    let Some(reg) = crate::card_registry::current() else {
+        return EngineOutcome::Rejected {
+            reason: "fire_forced_triggers: registry vanished between collect and resolve".into(),
+        };
+    };
+    let Some(abilities) = (reg.abilities_for)(&hit.code) else {
+        return EngineOutcome::Rejected {
+            reason: format!("fire_forced_triggers: {} has no abilities at resolve time", hit.code).into(),
+        };
+    };
+    let effect = abilities[hit.ability_index].effect.clone();
+    crate::engine::evaluator::apply_effect(
+        cx,
+        &effect,
+        crate::engine::evaluator::EvalContext::for_controller(hit.controller),
+    )
+}
+```
+
+Adjust the top-of-file `use` lines to exactly what the implementation references (drop the placeholder `CardType`/`DslPhase` imports if unused; `cargo clippy` will flag them).
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cargo test -p game-core forced_on_enter_resolves_immediately 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 6: Strict gauntlet + commit**
+
+```sh
+RUSTFLAGS="-D warnings" cargo test -p game-core --all-features 2>&1 | tail -12
+cargo clippy -p game-core --all-targets --all-features -- -D warnings 2>&1 | tail -12
+cargo fmt --check
+```
+```bash
+git add crates/game-core/src/engine/dispatch/forced_triggers.rs crates/game-core/src/engine/dispatch/mod.rs
+git commit -m "engine: forced_triggers module — fire_forced_triggers (EnteredLocation)
+
+Separate immediate path for Forced OnEvent abilities on scenario-structure
+cards. Single-trigger resolution via the evaluator; 2+ simultaneous reject
+loudly (ordering loop is #213). PhaseEnded arm stubbed for Task 4.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: wire `fire_forced_triggers` into `move_action`
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/actions.rs:271` (`move_action`)
+- Test: inline `#[cfg(test)]` in `actions.rs` (or extend an existing move test)
+
+- [ ] **Step 1: Write the failing test (moving into a forced location applies its effect)**
+
+Add to `actions.rs` tests (mirror the registry-install pattern from Task 2 — if `OnceLock` collisions arise with other `actions.rs` tests, move this to a dedicated `crates/cards/tests/forced_on_enter.rs` integration test instead):
+
+```rust
+#[test]
+fn moving_into_forced_location_fires_its_effect() {
+    // install a registry where "test-attic" has forced DealHorror-on-enter
+    // (same helper shape as forced_triggers::tests::forced_horror_abilities)
+    // ... build a two-location board: investigator at 10, connected to 11
+    //     where 11.code == "test-attic"; then:
+    let result = apply(state, Action::Player(PlayerAction::Move {
+        investigator: InvestigatorId(1),
+        destination: LocationId(11),
+    }));
+    assert!(matches!(result.outcome, EngineOutcome::Done));
+    assert_eq!(result.state.investigators[&InvestigatorId(1)].horror, 1);
+}
+```
+
+> Flesh out the board setup against an existing `move_action` test in this file (connections, phase, active investigator). Use the full `apply(...)` entry point so the wiring is exercised end-to-end.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p game-core moving_into_forced_location_fires_its_effect 2>&1 | tail -15`
+Expected: FAIL — horror is 0 (the move succeeds but no forced effect fires).
+
+- [ ] **Step 3: Wire the call**
+
+In `crates/game-core/src/engine/dispatch/actions.rs`, replace `move_action`'s terminal `EngineOutcome::Done` (right after the `InvestigatorMoved` push, ~line 274) with:
+
+```rust
+    super::forced_triggers::fire_forced_triggers(
+        cx,
+        super::forced_triggers::ForcedTriggerPoint::EnteredLocation {
+            investigator,
+            location: destination,
+        },
+    )
+```
+
+(`super::forced_triggers` because `actions` and `forced_triggers` are sibling modules under `dispatch`. Make `ForcedTriggerPoint`/`fire_forced_triggers` `pub(super)` — already specified in Task 2.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p game-core moving_into_forced_location_fires_its_effect 2>&1 | tail -15`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full move/action test set (regression — Move now does more)**
+
+Run: `cargo test -p game-core move_ 2>&1 | tail -20`
+Expected: all existing move tests still PASS (a plain move to a location with no forced ability returns `Done` exactly as before — `fire_forced_triggers` returns `Done` on 0 hits).
+
+- [ ] **Step 6: Strict gauntlet + commit**
+
+```sh
+RUSTFLAGS="-D warnings" cargo test -p game-core --all-features 2>&1 | tail -12
+cargo clippy -p game-core --all-targets --all-features -- -D warnings 2>&1 | tail -10
+cargo fmt --check
+```
+```bash
+git add crates/game-core/src/engine/dispatch/actions.rs
+git commit -m "engine: fire forced-on-enter effects from move_action
+
+Move now fires the entered location's Forced OnEvent abilities via
+fire_forced_triggers. No-op (Done) for locations without one, so existing
+move behavior is unchanged.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: PhaseEnded dispatch (act + agenda scan) + wire into phase-end
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/forced_triggers.rs` (fill the `PhaseEnded` arm + `card_dsl::Phase` ↔ `state::Phase` map)
+- Modify: `crates/game-core/src/engine/dispatch/phases.rs:389` (`enemy_phase_end`), `:464` (`upkeep_phase_end`)
+- Test: inline `#[cfg(test)]` in `forced_triggers.rs`
+
+- [ ] **Step 1: Write the failing test (forced agenda effect fires at enemy-phase end)**
+
+In `forced_triggers.rs` tests, add a test that installs a registry where an agenda code (e.g. `"test-agenda"`) carries a forced ability with `EventPattern::PhaseEnded { phase: DslPhase::Enemy }` whose effect is observable (e.g. `deal_horror` to the lead investigator — board-wide effects are Rust impls, but a DSL effect keeps the test simple and exercises the path). Build a state whose `agenda_deck[agenda_index].code == "test-agenda"` and one investigator (the lead), then call:
+
+```rust
+let outcome = fire_forced_triggers(&mut cx, ForcedTriggerPoint::PhaseEnded { phase: Phase::Enemy });
+assert_eq!(outcome, EngineOutcome::Done);
+assert_eq!(state.investigators[&InvestigatorId(1)].horror, 1);
+```
+
+(And a negative assertion: `PhaseEnded { phase: Phase::Mythos }` fires nothing → horror stays 0.)
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p game-core -- forced_triggers 2>&1 | tail -20`
+Expected: FAIL — the `PhaseEnded` arm is empty (Task 2 stub), horror stays 0.
+
+- [ ] **Step 3: Implement the `PhaseEnded` arm + phase map**
+
+In `forced_triggers.rs`, add the boundary map and fill the arm in `collect_forced_hits`:
+
+```rust
+/// Map the engine's `state::Phase` to the `card-dsl` mirror so a
+/// `PhaseEnded` pattern can be compared. (4-arm total — see Task 0.)
+fn dsl_phase(phase: Phase) -> crate::dsl::Phase {
+    match phase {
+        Phase::Mythos => crate::dsl::Phase::Mythos,
+        Phase::Investigation => crate::dsl::Phase::Investigation,
+        Phase::Enemy => crate::dsl::Phase::Enemy,
+        Phase::Upkeep => crate::dsl::Phase::Upkeep,
+    }
+}
+```
+
+Replace the stubbed `PhaseEnded` arm in `collect_forced_hits`:
+
+```rust
+        ForcedTriggerPoint::PhaseEnded { phase } => {
+            let want_phase = dsl_phase(phase);
+            // Lead investigator binds the controller for board-wide
+            // effects (which ignore it). First of turn_order is the lead.
+            let Some(lead) = state.turn_order.first().copied() else {
+                return hits;
+            };
+            // Current act, then current agenda (source order).
+            if let Some(act) = state.act_deck.get(state.act_index) {
+                push_matching(&reg, &act.code, lead, &mut hits, |p| {
+                    matches!(p, crate::dsl::EventPattern::PhaseEnded { phase } if phase == want_phase)
+                });
+            }
+            if let Some(agenda) = state.agenda_deck.get(state.agenda_index) {
+                push_matching(&reg, &agenda.code, lead, &mut hits, |p| {
+                    matches!(p, crate::dsl::EventPattern::PhaseEnded { phase } if phase == want_phase)
+                });
+            }
+        }
+```
+
+> Confirm the cursor field names (`act_index`, `agenda_index`) against `game_state.rs` (Task A1 worked near them). If `turn_order` can be empty at phase-end in valid states, `lead` falls back to no-hits, which is correct (no investigators ⇒ no forced firing).
+
+- [ ] **Step 4: Run the forced-trigger tests to verify they pass**
+
+Run: `cargo test -p game-core -- forced_triggers 2>&1 | tail -20`
+Expected: PASS (both the Enemy-phase positive and the Mythos negative).
+
+- [ ] **Step 5: Wire into `enemy_phase_end` and `upkeep_phase_end`**
+
+In `crates/game-core/src/engine/dispatch/phases.rs`:
+
+`enemy_phase_end` (returns `EngineOutcome`) — after its `PhaseEnded { phase: Enemy }` emit and before its return, thread the forced outcome. If `enemy_phase_end` currently ends with `step_phase(cx)` or a `Done`, fire first and short-circuit on non-`Done`:
+
+```rust
+    let forced = super::forced_triggers::fire_forced_triggers(
+        cx,
+        super::forced_triggers::ForcedTriggerPoint::PhaseEnded { phase: Phase::Enemy },
+    );
+    if !matches!(forced, EngineOutcome::Done) {
+        return forced; // 2+-trigger loud reject (unreachable in-slice); propagate
+    }
+    // ... existing transition (e.g. step_phase(cx) / Done) ...
+```
+
+`upkeep_phase_end` (returns `()`) — it cannot propagate an outcome. Fire and assert `Done` in debug (the 2+ reject is unreachable in-slice; surfacing it loudly in debug is the honest guard):
+
+```rust
+    let forced = super::forced_triggers::fire_forced_triggers(
+        cx,
+        super::forced_triggers::ForcedTriggerPoint::PhaseEnded { phase: Phase::Upkeep },
+    );
+    debug_assert!(
+        matches!(forced, EngineOutcome::Done),
+        "upkeep_phase_end forced trigger did not resolve to Done: {forced:?} \
+         (2+ simultaneous forced at round end needs #213)"
+    );
+```
+
+> Read both functions' exact tails first (`phases.rs:389` and `:464`) and splice the call after the `PhaseEnded` emit. The `()` return on `upkeep_phase_end` is a known limitation the `emit_event` restructure (#212) resolves by centralising suspension/propagation — note it in a code comment.
+
+- [ ] **Step 6: Run the phase + round-flow tests (regression)**
+
+Run: `cargo test -p game-core phase 2>&1 | tail -20`
+Run: `cargo test -p game-core upkeep 2>&1 | tail -10`
+Expected: all PASS — phases with no forced act/agenda abilities are unchanged (`fire_forced_triggers` returns `Done` on 0 hits).
+
+- [ ] **Step 7: Strict gauntlet + commit**
+
+```sh
+RUSTFLAGS="-D warnings" cargo test --all --all-features 2>&1 | tail -15
+cargo clippy --all-targets --all-features -- -D warnings 2>&1 | tail -10
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features 2>&1 | tail -10
+cargo fmt --check
+```
+```bash
+git add crates/game-core/src/engine/dispatch/forced_triggers.rs crates/game-core/src/engine/dispatch/phases.rs
+git commit -m "engine: fire forced act/agenda effects at phase-end
+
+fire_forced_triggers now scans the current act + agenda for
+EventPattern::PhaseEnded forced abilities, wired into enemy_phase_end and
+upkeep_phase_end. upkeep_phase_end's () return can't propagate the 2+
+reject (debug_assert guards it); #212 resolves that by centralising
+suspension. Needed by agenda 01107.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: the 2+-simultaneous loud-reject guard (explicit test)
+
+**Files:**
+- Test: inline `#[cfg(test)]` in `forced_triggers.rs`
+
+The guard already exists (Task 2's `n =>` arm). This task pins it with a test so a future refactor can't silently turn it into "pick whatever order."
+
+- [ ] **Step 1: Write the test**
+
+In `forced_triggers.rs` tests, install a registry where one location code carries **two** forced `EnteredLocation` abilities (e.g. two `deal_horror`), build a board with the investigator entering it, and assert the reject:
+
+```rust
+#[test]
+fn two_simultaneous_forced_triggers_reject_loudly() {
+    // registry: "test-double" has TWO forced DealHorror-on-enter abilities
+    // ... build board, investigator at the double-forced location ...
+    let outcome = fire_forced_triggers(
+        &mut cx,
+        ForcedTriggerPoint::EnteredLocation { investigator: InvestigatorId(1), location: LocationId(10) },
+    );
+    assert!(matches!(outcome, EngineOutcome::Rejected { .. }));
+    // and: no horror applied (rejected before resolving either) —
+    // confirm against the validate-first contract (apply() restores state
+    // on Rejected; here we call the helper directly, so assert the helper
+    // itself did not resolve an effect before rejecting).
+    assert_eq!(cx.state.investigators[&InvestigatorId(1)].horror, 0);
+}
+```
+
+> The helper rejects *before* `resolve_one` (it counts hits first), so no effect is applied — assert horror stayed 0. If you route this through full `apply(...)` instead, the transactional restore also guarantees it.
+
+- [ ] **Step 2: Run it to verify it passes**
+
+Run: `cargo test -p game-core two_simultaneous_forced_triggers_reject_loudly 2>&1 | tail -10`
+Expected: PASS (the guard is already implemented).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/forced_triggers.rs
+git commit -m "test: pin the 2+-simultaneous forced-trigger loud reject (#213)
+
+Guards against a future refactor silently choosing an order instead of
+rejecting. The ordering loop lands in #213.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** A2 covers spec Group A items 3–5 (widen the trigger scan to scenario-structure sources via the separate forced path; the forced auto-fire; the new `EventPattern` + trigger-point wiring at `InvestigatorMoved` / `PhaseEnded(Enemy)` / round-end). The reaction-window path and Roland's reaction are untouched, as the spec requires. The 2+-ordering deferral points explicitly at #213; the `emit_event` unification at #212 — both filed.
+- **Placeholder scan:** the only deliberately-deferred body is Task 2's `PhaseEnded` arm, filled in Task 4 (not a placeholder — it's a documented two-step build with a passing test at each step). No TODO/TBD left at plan end.
+- **Type consistency:** `ForcedTriggerPoint` variants (`EnteredLocation { investigator, location }`, `PhaseEnded { phase }`) match across the enum, `collect_forced_hits`, and all three call sites. `fire_forced_triggers`/`ForcedTriggerPoint` are `pub(super)` and called as `super::forced_triggers::…` from sibling `actions`/`phases`. `card_dsl::Phase` ↔ `state::Phase` is bridged by `dsl_phase` (Task 4). `EventPattern::PhaseEnded { phase }` is inert in `trigger_matches` (Task 1) and matched only in `collect_forced_hits`.
+- **Verification points flagged inline:** registry struct/field names, the `ability_on_event` builder, `TestGame` helpers, `act_index`/`agenda_index` cursor names, and the `OnceLock` install-collision risk (with the "move to `crates/cards/tests/`" escape hatch) — each step says to confirm against a named existing example.
+- **Regression coverage:** Tasks 3 and 4 each run the existing move/phase test sets to prove no-forced-ability paths are unchanged (`Done` on 0 hits).

--- a/docs/superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md
+++ b/docs/superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md
@@ -284,6 +284,40 @@ mechanical once A/B exist.
   outcome approximation.
 - **Exact encounter-set card list and Roland deck list** — enumerated
   against the snapshot at plan time.
+- **Trigger ordering & resolution UX (mostly a later Phase-7 slice).**
+  Rules Reference p.17: *"If two or more forced abilities (including
+  delayed effects) would resolve at the same time, the lead investigator
+  determines the order in which the abilities resolve."* The target model
+  (confirmed with the user):
+  - The player chooses order **even in solo** (they are the lead).
+  - **Iterative, not order-the-whole-list**: present the pending triggers
+    → player names which resolves *first* → resolve it → re-present the
+    remaining (minus that one) → repeat. More correct than an upfront
+    total order, since resolving one trigger mutates state and can
+    add/remove others.
+  - Uniform across **forced and optional**, with **skip available only
+    when every remaining trigger is optional** (forced are mandatory).
+  - There is also a future click-to-resolve argument even for a *lone*
+    forced trigger (agency / feel-in-charge) — out of scope now.
+
+  This full pipeline lands with the **`emit_event` event-window
+  restructure** — a later Phase-7 slice, not Slice 1. Slice 1's A2 ships
+  only the **single-trigger path**: `fire_forced_triggers` resolves a lone
+  forced trigger immediately and **rejects loudly (TODO)** if 2+ are ever
+  simultaneously pending — no silently-chosen order. The slice's content
+  never produces 2+ simultaneous forced triggers, so that guard is
+  unreachable in practice; it exists to refuse rather than fake.
+
+- **`emit_event` dispatch unification (later Phase-7 slice).** North-star
+  architecture: make event emission itself the dispatch chokepoint — an
+  `emit_event(cx, event)` that consults an event-keyed trigger registry
+  (folding in the #117 index) and routes forced/optional listeners,
+  rather than wiring windows by hand at each emission site. Deferred from
+  Slice 1 because it needs reentrancy handling, mid-emit `AwaitingInput`
+  suspension, and the iterative-ordering pipeline above — none of which
+  Slice 1's content exercises (YAGNI). A1/A2 are forward-compatible: the
+  explicit `fire_forced_triggers` is a clean subset `emit_event` can later
+  absorb. File as a Phase-7 issue (or re-scope #117 to cover it).
 
 ## What "Slice 1 done" looks like
 

--- a/docs/superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md
+++ b/docs/superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md
@@ -24,8 +24,9 @@ engine framework is already substantial (combat, encounter draws,
 hunters, the enemy phase, skill tests, act/agenda advancement,
 elimination, reaction windows all exist), so Phase 7 is far more a
 **content + integration** phase than an engine-building one. The slice
-surfaces exactly the engine gaps real content needs — chiefly the
-Forced/reaction trigger dispatcher — and builds them once, properly.
+surfaces exactly the engine gaps real content needs — chiefly extending
+the existing reaction-window machinery to forced effects and scenario-card
+sources — and builds them once, properly.
 
 ## Fidelity bar
 
@@ -90,33 +91,63 @@ Two orthogonal axes, kept separate:
   scenario-specific). Per the existing rule: *don't add DSL primitives
   until 2+ cards want the pattern.*
 
-### The trigger spine (the load-bearing new machinery)
+### The trigger spine — *extend* the existing reaction-window machinery
 
-**1. OnEvent/Forced dispatcher (kernel).** The DSL already defines
-`Trigger::OnEvent { pattern, timing }` and `EventPattern` / `Timing`,
-but nothing *fires* OnEvent abilities yet. We build one dispatcher: after
-each event is emitted into the buffer, scan active cards' `OnEvent`
-abilities whose `pattern` matches and run their `Effect` via the existing
-evaluator, under the validate-first contract.
+**Reality check (verified 2026-06-10):** the OnEvent firing pipeline is
+**not** greenfield. `engine/dispatch/reaction_windows.rs` already has a
+full queue/scan/fire pipeline: `scan_pending_triggers` walks in-play
+cards for `Trigger::OnEvent` abilities, matches them against a
+`WindowKind`, honors per-instance usage limits, and fires them;
+windows already open at `AfterEnemyDefeated` (exactly Roland's reaction
+window) and several `PlayerWindow(PhaseStep::…)` points. `PendingTrigger`
+even carries a `forced: bool` field, hardwired `false` today with a
+comment that the DSL had no forced primitive yet. So this slice
+**extends** that machinery rather than building a dispatcher from
+scratch. Four concrete extensions:
 
-- **Scan set:** in-play assets + encounter cards + the current
-  location(s) + the current act + the current agenda.
-- This single piece fires *all* Forced/reaction effects uniformly —
-  treachery/enemy forced effects, location/act/agenda forced effects,
-  **and** Roland's reaction signature.
-- Highest-risk engine piece in the slice; isolate with focused tests.
+**1. Widen the scan set.** `scan_pending_triggers` iterates only
+`inv.cards_in_play`. Extend it to also scan the current **location(s),
+act, and agenda** for `Trigger::OnEvent` abilities, resolved through the
+registry by `CardCode` (same `abilities_for` call). This is what lets
+location/act/agenda forced effects participate.
 
-**2. Kernel trigger windows.** For a card's Forced ability to listen,
-the engine must emit the events: `LocationEntered`, `PhaseEnded(phase)`,
-`RoundEnded`, `EnemyDefeated`, etc. The *effect* lives on the card; the
-*window* that fires it is a kernel concern. Audit which events exist
-today; add the gaps.
+**2. Forced (mandatory) firing.** The `forced` field exists but is always
+`false`. Forced abilities (Attic horror, agenda `01107` movement) must
+fire **mandatorily** — no player "may" window, no `AwaitingInput`
+suspension. This is a real semantic addition: reaction windows suspend
+for a player choice; Forced effects auto-resolve in place. Recommended
+shape: Forced abilities reuse the scan pipeline but take a direct
+auto-fire path (evaluate the effect immediately, in resolution order)
+instead of opening a suspending window. A `Trigger::OnEvent` ability is
+Forced vs. reaction based on whether the printed text is "Forced —" vs.
+"[reaction] … you may"; the card author encodes which.
 
-**3. Acts/agendas carry `CardCode`.** Locations already have `code`; Act
-and Agenda gain one so the dispatcher can resolve their abilities through
-the registry. The thin structs keep only mechanical **state** (clue/doom
-thresholds, resolution latch, shroud, clues, connections); **behavior**
-comes from the registry.
+**3. Open windows / fire forced triggers at new points.** Today windows
+open at defeat + specific phase steps. Add trigger points after
+`InvestigatorMoved` (location entry), at `PhaseEnded(Enemy)` (agenda
+movement), and at end of round (agenda doom). These reuse the existing
+events below — no new events needed for the slice.
+
+**4. Add the `EventPattern` / `WindowKind` variants** the new trigger
+points need (entered-this-location, phase-ended, round-end), matched by
+the existing `trigger_matches`.
+
+**Events already exist.** Audit confirms `InvestigatorMoved`,
+`PhaseEnded { phase }`, `EnemyDefeated`, `DamageTaken`, `HorrorTaken`,
+`ActAdvanced`, `AgendaAdvanced` are all present. "End of round" is the
+`PhaseEnded(Upkeep)` window. So the slice needs **no new `Event`
+variants** — only new `EventPattern`/`WindowKind` variants and the
+trigger-point wiring. Roland's reaction likely already fires through the
+existing `AfterEnemyDefeated` window, making it largely a content task.
+
+**Risk note:** lower than greenfield, but the Forced-vs-reaction split
+(extension 2) and agenda `01107` are the pieces to isolate and test hard.
+
+**Acts/agendas carry `CardCode` (prerequisite for extension 1).**
+Locations already have `code`; Act and Agenda gain one so the widened
+scan can resolve their abilities through the registry. The thin structs
+keep only mechanical **state** (clue/doom thresholds, resolution latch,
+shroud, clues, connections); **behavior** comes from the registry.
 
 ### Symbol-token resolution — through the scenario, owned by the reference card
 
@@ -193,15 +224,19 @@ must populate `deck` before that step runs.
 
 ## Decomposition & build order
 
-**Group A — Engine spine** (unblocks everything; build and prove first)
+**Group A — Engine spine** (unblocks everything; build and prove first).
+*Extends the existing `reaction_windows.rs` machinery — not greenfield.*
 
 1. DSL primitives: `Effect::DealDamage` / `Effect::DealHorror`;
-   forced-on-enter trigger pattern. Pure `card-dsl`.
-2. Kernel trigger windows: emit `LocationEntered`, `PhaseEnded(phase)`,
-   `RoundEnded`, `EnemyDefeated`. Audit + fill gaps.
-3. OnEvent/Forced dispatcher (scan set above; validate-first; focused
-   tests incl. the Roland-reaction case). **Riskiest piece.**
-4. Act/Agenda carry `CardCode`.
+   forced-on-enter `EventPattern`. Pure `card-dsl`.
+2. Act/Agenda carry `CardCode` (prerequisite for the widened scan).
+3. Widen `scan_pending_triggers` to also scan current location/act/agenda
+   via the registry.
+4. Forced (mandatory) auto-fire path (wire the existing `forced` field;
+   no window suspension). **Riskiest piece** alongside agenda `01107`.
+5. New `EventPattern` / `WindowKind` variants + trigger-point wiring at
+   `InvestigatorMoved`, `PhaseEnded(Enemy)`, and round end
+   (`PhaseEnded(Upkeep)`). No new `Event` variants needed.
 
 **Group B — Scenario plumbing**
 
@@ -235,9 +270,9 @@ must populate `deck` before that step runs.
 13. End-to-end gate: integration test driving a solo-Roland Standard run
     to **both** a Won and a Lost resolution, plus the browser demo.
 
-Riskiest pieces to isolate and test hard: the OnEvent dispatcher (#3) and
-agenda `01107` (#8). Everything in C/D is mostly mechanical once A/B
-exist.
+Riskiest pieces to isolate and test hard: the Forced auto-fire path
+(Group A #4) and agenda `01107` (Group C #8). Everything in C/D is mostly
+mechanical once A/B exist.
 
 ## Open questions (settle at plan time; not blockers)
 

--- a/docs/superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md
+++ b/docs/superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md
@@ -1,0 +1,258 @@
+# Phase 7 — Slice 1: Roland through The Gathering: design spec
+
+**Date:** 2026-06-10
+**Status:** Design approved; issues to be filed.
+**Milestone:** `phase-7-the-gathering`
+
+## Goal
+
+A solo human picks **Roland Banks**, plays **The Gathering** at **Standard**
+difficulty in the browser, and reaches a real **Won** or **Lost**
+resolution. Reconnecting mid-scenario restores the board (Phase-6
+machinery already provides this).
+
+This is the first **vertical slice** of Phase 7. Breadth — the other four
+investigators, the other difficulties, and solo-with-two UX — comes in
+later Phase-7 slices. The slice exists to de-risk the scenario +
+registry + trigger-dispatch integration on a small card surface before
+committing to the full deck-card corpus.
+
+## Strategy: vertical slice, not layer-by-layer
+
+Get **one** investigator playable end-to-end before going wide. The
+engine framework is already substantial (combat, encounter draws,
+hunters, the enemy phase, skill tests, act/agenda advancement,
+elimination, reaction windows all exist), so Phase 7 is far more a
+**content + integration** phase than an engine-building one. The slice
+surfaces exactly the engine gaps real content needs — chiefly the
+Forced/reaction trigger dispatcher — and builds them once, properly.
+
+## Fidelity bar
+
+**Everything on the win/lose path is rules-faithful.** No silent
+approximation: anything we don't fully model is **out of scope and
+explicitly deferred**, never faked.
+
+**In scope (full fidelity):**
+
+- The Gathering scenario: 5 starting locations (Study, Hallway, Attic,
+  Cellar, Parlor) + connections; the 3-act / 3-agenda decks; the real
+  encounter sets; Standard chaos bag.
+- Forced location effects (Attic `01113`: 1 horror on enter; Cellar
+  `01114`: 1 damage on enter), victory points (Attic/Cellar).
+- Agenda forced effects: `01107` Ghoul-movement-toward-Parlor (at end of
+  the **enemy phase**) and doom-per-Ghoul-in-Hallway/Parlor (at end of
+  the **round**); the doom clock generally.
+- Act objectives: the clue-spend gate (`01109` Act 2) and "if the Ghoul
+  Priest is defeated, advance" (`01110` Act 3).
+- Scenario symbol-token effects on reference card `01104`: skull
+  `-X` (X = Ghoul enemies at your location), cultist `-1` + 1 horror on
+  failure, tablet `-2` + 1 damage if a Ghoul is at your location.
+- Roland's real Core starter deck + his signature asset (Roland's .45
+  Automatic), his weakness (Cover Up), and his reaction ability.
+- The encounter cards a solo-Roland Standard run can actually draw
+  (Ghouls, Rats, Striking Fear, Ancient Evils, Chilling Cold sets).
+
+**Out of scope — explicit follow-up issues, not faked:**
+
+- Lita Chantler's parley/take-control and the Parlor (`01115`) **Resign**
+  action — both genuinely optional, off the win/lose path.
+- The other four investigators; Easy/Hard/Expert chaos bags;
+  solo-with-two UX — later Phase-7 slices.
+
+> **Card-text provenance:** every card quoted above was read from
+> `data/arkhamdb-snapshot/pack/core/core_encounter.json` /
+> `core.json` on 2026-06-10. The exact encounter-set card list and
+> Roland's deck list are enumerated against the snapshot at plan time,
+> not in this spec.
+
+## Architecture
+
+### Principle: every effect is owned by the card it's printed on
+
+The engine already routes enemy/treachery behavior through the
+`CardRegistry` by `CardCode` (`encounter.rs` calls `abilities_for`).
+Locations, acts, and agendas are encounter cards too (`01111`, `01110`,
+`01107`, …), so they get the **same** treatment: their behavior comes
+from `abilities_for(code)`, not from a monolithic per-scenario switch.
+Attic's "after you enter: 1 horror" is a Forced ability on `01113`;
+agenda `01107`'s Ghoul-movement is a Forced ability on `01107`.
+
+Consequence: the `ScenarioModule` collapses to **`setup` +
+`apply_resolution` + `reference_card`**. No per-scenario trigger switch.
+This is more local and generalizes to every future scenario.
+
+Two orthogonal axes, kept separate:
+
+- **Ownership** — always the card the effect is printed on.
+- **Expression** — DSL `Effect` where it fits (generic/simple);
+  hand-written Rust where the DSL lacks the primitive (complex /
+  scenario-specific). Per the existing rule: *don't add DSL primitives
+  until 2+ cards want the pattern.*
+
+### The trigger spine (the load-bearing new machinery)
+
+**1. OnEvent/Forced dispatcher (kernel).** The DSL already defines
+`Trigger::OnEvent { pattern, timing }` and `EventPattern` / `Timing`,
+but nothing *fires* OnEvent abilities yet. We build one dispatcher: after
+each event is emitted into the buffer, scan active cards' `OnEvent`
+abilities whose `pattern` matches and run their `Effect` via the existing
+evaluator, under the validate-first contract.
+
+- **Scan set:** in-play assets + encounter cards + the current
+  location(s) + the current act + the current agenda.
+- This single piece fires *all* Forced/reaction effects uniformly —
+  treachery/enemy forced effects, location/act/agenda forced effects,
+  **and** Roland's reaction signature.
+- Highest-risk engine piece in the slice; isolate with focused tests.
+
+**2. Kernel trigger windows.** For a card's Forced ability to listen,
+the engine must emit the events: `LocationEntered`, `PhaseEnded(phase)`,
+`RoundEnded`, `EnemyDefeated`, etc. The *effect* lives on the card; the
+*window* that fires it is a kernel concern. Audit which events exist
+today; add the gaps.
+
+**3. Acts/agendas carry `CardCode`.** Locations already have `code`; Act
+and Agenda gain one so the dispatcher can resolve their abilities through
+the registry. The thin structs keep only mechanical **state** (clue/doom
+thresholds, resolution latch, shroud, clues, connections); **behavior**
+comes from the registry.
+
+### Symbol-token resolution — through the scenario, owned by the reference card
+
+Each scenario has exactly one reference card, whose chaos symbols are
+printed on it. `ScenarioModule` gains a `reference_card: CardCode` field
+(plain data). The skill-test resolver already has `scenario_id →
+module`, so on a symbol token it asks the module for its reference card,
+then evaluates *that card's* symbol ability against current state.
+Ownership stays on the card (`01104` owns skull/cultist/tablet); access
+flows through the scenario.
+
+The "skull = `-(Ghouls at your location)`" board-count logic is a Rust
+impl on `01104` for now (only the reference card wants it). A second
+scenario with board-count-driven symbols is the trigger to add a DSL
+dynamic-count primitive.
+
+### Forced-on-enter as a DSL variant
+
+"After you enter this location, take N damage/horror" clears the "2+
+cards plus known future demand" bar (Attic, Cellar, plus many in future
+scenarios), so it's promoted to **pure DSL**, not Rust:
+
+- A Forced trigger (`Trigger::OnEvent` with an "entered the location this
+  ability is printed on" pattern, `timing: After`); the dispatcher binds
+  *you* = the entering investigator and *this location* = the card's own
+  location.
+- Two new `Effect` primitives — `DealDamage` and `DealHorror` to a target
+  investigator — needed broadly anyway (treacheries, combat).
+
+So Attic/Cellar become declarative data.
+
+### Agenda 01107 — separate forced movement, not a pathfinding override
+
+`01107` has **two** forced abilities at **two** windows:
+
+- *"At the end of the enemy phase: each unengaged Ghoul moves 1 toward
+  the Parlor"* → fires on `PhaseEnded(Enemy)`.
+- *"At the end of the round: place 1 doom per Ghoul in the Hallway or
+  Parlor"* → fires on `RoundEnded`.
+
+The movement is **not** a modification of the enemy-phase hunter step
+(3.2). It is a discrete forced movement that runs *after* the enemy
+phase's normal steps. Mechanically: the agenda's Rust ability iterates
+unengaged Ghoul-trait enemies and, for each, calls the existing shared
+primitive `engine::pathfinding::shortest_first_steps(state, ghoul_loc,
+PARLOR)` and moves it one step — an independent caller of the same BFS
+helper the hunter code uses, with a fixed destination, at a different
+window. The hunter step is untouched.
+
+The data confirms this is simpler than it looks: only the Ghoul Priest
+(`01116`) is a Hunter; Flesh-Eater, Icy Ghoul, Ghoul Minion, and
+Ravenous Ghoul have no Hunter keyword and never move during 3.2 — the
+agenda is their *only* mover, so there is nothing to override. The Priest
+can move twice in one enemy phase (hunting the highest-combat
+investigator during 3.2, then toward the Parlor at phase-end) — two
+moves, two targets, both callers of the same primitive. Rules-correct.
+
+It stays a **Rust-backed ability on `01107`** (trait-filtered mass
+movement + conditional doom is too scenario-specific to DSL-ify for one
+card).
+
+### Investigator seating
+
+`ScenarioModule.setup: fn() -> GameState` takes no arguments, so there is
+no channel for "which investigator." Split responsibilities: the scenario
+module builds the **world** (locations, decks, bag); a separate
+**roster/seating step** takes host-supplied investigator selection, loads
+each chosen investigator's deck, and seats them. `StartScenario` carries
+the selection through the protocol (a protocol change). This keeps
+deck-loading scenario-agnostic and reusable across scenarios rather than
+overloading `setup` with a roster parameter. `StartScenario` already
+shuffles each investigator's `deck` and deals the opening hand, so seating
+must populate `deck` before that step runs.
+
+## Decomposition & build order
+
+**Group A — Engine spine** (unblocks everything; build and prove first)
+
+1. DSL primitives: `Effect::DealDamage` / `Effect::DealHorror`;
+   forced-on-enter trigger pattern. Pure `card-dsl`.
+2. Kernel trigger windows: emit `LocationEntered`, `PhaseEnded(phase)`,
+   `RoundEnded`, `EnemyDefeated`. Audit + fill gaps.
+3. OnEvent/Forced dispatcher (scan set above; validate-first; focused
+   tests incl. the Roland-reaction case). **Riskiest piece.**
+4. Act/Agenda carry `CardCode`.
+
+**Group B — Scenario plumbing**
+
+5. `ScenarioModule += reference_card: CardCode`; symbol resolution routes
+   resolver → module → reference card ability.
+6. Roster/seating step; `StartScenario` carries investigator selection
+   (protocol change).
+7. Registry-swap foundation (D5): server installs `cards::REGISTRY` + the
+   real scenario registry instead of the synthetic set. (Synthetic stays
+   for existing per-process tests.)
+
+**Group C — Content** (largest; ordered Act 1 → full run at plan time)
+
+8. The Gathering scenario cards: 5 locations (forced-on-enter as DSL on
+   Attic/Cellar), 3 acts (objectives incl. Ghoul-Priest-defeated on
+   `01110`), 3 agendas (`01107` Rust movement@`PhaseEnded(Enemy)` +
+   doom@`RoundEnded`), reference card `01104` (symbols), reachable
+   enemies (Ghoul Priest, Flesh-Eater, Icy Ghoul, Ghoul Minion, Ravenous
+   Ghoul) and treacheries (Ancient Evils / Striking Fear / Chilling Cold).
+9. The Gathering `setup()`: locations + connections, act/agenda decks,
+   encounter deck from the real sets, Standard chaos bag.
+10. Roland + his reaction ability + Roland's .45 Automatic + Cover Up.
+11. Roland's starter-deck player cards not yet implemented (enumerate
+    against the corpus at plan time).
+
+**Group D — Integration & web**
+
+12. Web picker: minimal investigator + scenario selection (Roland + The
+    Gathering) wired into `StartScenario`; resolution surfacing already
+    exists.
+13. End-to-end gate: integration test driving a solo-Roland Standard run
+    to **both** a Won and a Lost resolution, plus the browser demo.
+
+Riskiest pieces to isolate and test hard: the OnEvent dispatcher (#3) and
+agenda `01107` (#8). Everything in C/D is mostly mechanical once A/B
+exist.
+
+## Open questions (settle at plan time; not blockers)
+
+- **Equidistant-tie handling** in agenda `01107`'s movement: a
+  deterministic tiebreak (e.g., lowest `LocationId` among equally-short
+  first steps) for Slice 1, vs a player `AwaitingInput`. Lean
+  deterministic now, `AwaitingInput` when multiplayer lands — any
+  equidistant step is rules-legal, so this is an agency choice, not an
+  outcome approximation.
+- **Exact encounter-set card list and Roland deck list** — enumerated
+  against the snapshot at plan time.
+
+## What "Slice 1 done" looks like
+
+A solo human, in the browser, picks Roland, sets up The Gathering at
+Standard, and plays to a real Won or Lost resolution. An integration test
+drives both outcomes headlessly. The other investigators, difficulties,
+and solo-with-two UX remain for later Phase-7 slices.


### PR DESCRIPTION
## Summary

Phase 7 Slice 1 **kickoff** (mirrors the Phase-6 #191 → #192 kickoff): lands the design spec, both engine-spine plans, and the phase-7 doc breakdown. Docs only — no code.

## What changed

- **Design spec** `docs/superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md` — vertical-slice-first; win/lose-path fidelity; "every effect owned by its card"; `ScenarioModule` → `setup` + `apply_resolution` + `reference_card`; Group A *extends* the existing `reaction_windows.rs` OnEvent machinery; forced scenario effects take a separate immediate path.
- **Plan A1** (engine-spine primitives) and **Plan A2** (forced-trigger dispatch) — code-complete TDD task plans.
- **Phase-7 doc** — Slice-1 ordering table (A1 #214, A2 #215, Groups B–D).

## Design decisions worth a second look

- OnEvent firing **already exists** — verified against `reaction_windows.rs`; A2 extends it rather than building greenfield, and keeps Roland's reaction path untouched via a separate `fire_forced_triggers`.
- Deferred north-star (`emit_event` unification #212, iterative ordering #213, index #117) split out so the slice ships a small forward-compatible subset.

## Test notes

Docs only; no tests. The plans carry the test specs for A1/A2.

## Linked issues

Closes #216
