### PR TITLE
engine: Slice 1 A1 — engine-spine primitives (DealDamage/DealHorror, EnteredLocation, Act/Agenda CardCode)

### DIFF
--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -382,6 +382,20 @@ pub enum Effect {
     /// investigator. (Caller responsibility: validate the location
     /// has clues and the investigator can hold them.)
     DiscoverClue { from: LocationTarget, count: u8 },
+    /// Deal `amount` damage to the resolved target investigator,
+    /// applying defeat if the new total reaches their max health.
+    /// `amount == 0` is a no-op (no event, no target resolution).
+    DealDamage {
+        target: InvestigatorTarget,
+        amount: u8,
+    },
+    /// Deal `amount` horror to the resolved target investigator,
+    /// applying defeat if the new total reaches their max sanity.
+    /// `amount == 0` is a no-op.
+    DealHorror {
+        target: InvestigatorTarget,
+        amount: u8,
+    },
     /// Adjust a stat by `delta` for the duration described by `scope`.
     /// Most scopes are passive contributions to engine queries
     /// rather than mutations of the investigator's stored fields.
@@ -677,6 +691,18 @@ pub fn gain_resources(target: InvestigatorTarget, amount: u8) -> Effect {
 #[must_use]
 pub fn discover_clue(from: LocationTarget, count: u8) -> Effect {
     Effect::DiscoverClue { from, count }
+}
+
+/// Build an [`Effect::DealDamage`] against `target` for `amount`.
+#[must_use]
+pub fn deal_damage(target: InvestigatorTarget, amount: u8) -> Effect {
+    Effect::DealDamage { target, amount }
+}
+
+/// Build an [`Effect::DealHorror`] against `target` for `amount`.
+#[must_use]
+pub fn deal_horror(target: InvestigatorTarget, amount: u8) -> Effect {
+    Effect::DealHorror { target, amount }
 }
 
 /// Build an [`Effect::Modify`].

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -239,7 +239,7 @@ pub enum EventPattern {
     /// from the trigger context — no narrowing fields needed.
     ///
     /// DSL surface only here; the matching + forced auto-fire wiring
-    /// lands in a later task. Until then the engine ignores it.
+    /// lands in #215. Until then the engine ignores it.
     EnteredLocation,
 }
 

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -230,6 +230,17 @@ pub enum EventPattern {
     /// spawns at your location" reaction; that PR gets to extend
     /// this variant with whatever narrowing field it needs.
     EnemySpawned,
+    /// An investigator entered the location this ability is printed on
+    /// (Forced "after you enter \<location\>" effects: Attic `01113`
+    /// takes 1 horror, Cellar `01114` takes 1 damage).
+    ///
+    /// Intentionally bare: the engine binds *you* = the entering
+    /// investigator and *this location* = the ability's own location
+    /// from the trigger context — no narrowing fields needed.
+    ///
+    /// DSL surface only here; the matching + forced auto-fire wiring
+    /// lands in a later task. Until then the engine ignores it.
+    EnteredLocation,
 }
 
 /// When an [`Trigger::OnEvent`] ability fires relative to the
@@ -1145,6 +1156,14 @@ mod tests {
         let revealed = EventPattern::CardRevealed { card_type: None };
         assert_ne!(spawned, defeated);
         assert_ne!(spawned, revealed);
+    }
+
+    #[test]
+    fn entered_location_pattern_round_trips() {
+        let p = EventPattern::EnteredLocation;
+        let json = serde_json::to_string(&p).unwrap();
+        let back: EventPattern = serde_json::from_str(&json).unwrap();
+        assert_eq!(p, back);
     }
 
     /// Effects clone deeply (the recursive Box doesn't break Clone).

--- a/crates/game-core/src/engine/dispatch/act_agenda.rs
+++ b/crates/game-core/src/engine/dispatch/act_agenda.rs
@@ -192,9 +192,10 @@ mod doom_agenda_tests {
 
     #[test]
     fn place_doom_increments_agenda_doom() {
-        use crate::state::Agenda;
+        use crate::state::{Agenda, CardCode};
         let mut state = TestGame::new().build();
         state.agenda_deck = vec![Agenda {
+            code: CardCode("_test_agenda".into()),
             doom_threshold: 2,
             resolution: None,
         }];
@@ -214,14 +215,16 @@ mod doom_agenda_tests {
     #[test]
     fn doom_threshold_advances_non_terminal_agenda() {
         use crate::scenario::Resolution;
-        use crate::state::Agenda;
+        use crate::state::{Agenda, CardCode};
         let mut state = TestGame::new().build();
         state.agenda_deck = vec![
             Agenda {
+                code: CardCode("_test_agenda_1".into()),
                 doom_threshold: 2,
                 resolution: None,
             },
             Agenda {
+                code: CardCode("_test_agenda_2".into()),
                 doom_threshold: 2,
                 resolution: Some(Resolution::Lost {
                     reason: "agenda".into(),
@@ -246,9 +249,10 @@ mod doom_agenda_tests {
     #[test]
     fn doom_threshold_on_terminal_agenda_sets_resolution_latch() {
         use crate::scenario::Resolution;
-        use crate::state::Agenda;
+        use crate::state::{Agenda, CardCode};
         let mut state = TestGame::new().build();
         state.agenda_deck = vec![Agenda {
+            code: CardCode("_test_agenda".into()),
             doom_threshold: 2,
             resolution: Some(Resolution::Lost {
                 reason: "doom".into(),
@@ -270,9 +274,10 @@ mod doom_agenda_tests {
 
     #[test]
     fn doom_threshold_not_met_does_nothing() {
-        use crate::state::Agenda;
+        use crate::state::{Agenda, CardCode};
         let mut state = TestGame::new().build();
         state.agenda_deck = vec![Agenda {
+            code: CardCode("_test_agenda".into()),
             doom_threshold: 3,
             resolution: None,
         }];
@@ -320,7 +325,7 @@ mod advance_act_tests {
 
     #[test]
     fn advance_act_rejects_when_clues_insufficient() {
-        use crate::state::Act;
+        use crate::state::{Act, CardCode};
         let inv = InvestigatorId(1);
         let mut investigator = test_investigator(1);
         investigator.clues = 1;
@@ -331,6 +336,7 @@ mod advance_act_tests {
             .with_turn_order([inv])
             .build();
         state.act_deck = vec![Act {
+            code: CardCode("_test_act".into()),
             clue_threshold: 2,
             resolution: None,
         }];
@@ -350,7 +356,7 @@ mod advance_act_tests {
     #[test]
     fn advance_act_spends_clues_and_advances_non_terminal() {
         use crate::scenario::Resolution;
-        use crate::state::Act;
+        use crate::state::{Act, CardCode};
         let inv = InvestigatorId(1);
         let mut investigator = test_investigator(1);
         investigator.clues = 3;
@@ -362,10 +368,12 @@ mod advance_act_tests {
             .build();
         state.act_deck = vec![
             Act {
+                code: CardCode("_test_act_1".into()),
                 clue_threshold: 2,
                 resolution: None,
             },
             Act {
+                code: CardCode("_test_act_2".into()),
                 clue_threshold: 2,
                 resolution: Some(Resolution::Won { id: "demo".into() }),
             },
@@ -388,7 +396,7 @@ mod advance_act_tests {
     #[test]
     fn advance_act_on_terminal_act_sets_resolution_latch() {
         use crate::scenario::Resolution;
-        use crate::state::Act;
+        use crate::state::{Act, CardCode};
         let inv = InvestigatorId(1);
         let mut investigator = test_investigator(1);
         investigator.clues = 2;
@@ -399,6 +407,7 @@ mod advance_act_tests {
             .with_turn_order([inv])
             .build();
         state.act_deck = vec![Act {
+            code: CardCode("_test_act".into()),
             clue_threshold: 2,
             resolution: Some(Resolution::Won { id: "demo".into() }),
         }];
@@ -422,7 +431,7 @@ mod advance_act_tests {
 
     #[test]
     fn advance_act_spends_acting_investigator_first_then_turn_order() {
-        use crate::state::Act;
+        use crate::state::{Act, CardCode};
         let acting = InvestigatorId(1);
         let other = InvestigatorId(2);
         let mut inv1 = test_investigator(1);
@@ -442,10 +451,12 @@ mod advance_act_tests {
         // irrelevant to this spend-order test.
         state.act_deck = vec![
             Act {
+                code: CardCode("_test_act_1".into()),
                 clue_threshold: 2,
                 resolution: None,
             },
             Act {
+                code: CardCode("_test_act_2".into()),
                 clue_threshold: 2,
                 resolution: None,
             },

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -65,7 +65,7 @@ pub(super) fn damage_enemy(cx: &mut Cx, enemy_id: EnemyId, amount: u8, by: Optio
 /// don't accumulate more damage.
 ///
 /// [`Status`]: crate::state::Status
-pub(super) fn apply_damage_numeric(cx: &mut Cx, investigator: InvestigatorId, amount: u8) -> bool {
+pub(crate) fn apply_damage_numeric(cx: &mut Cx, investigator: InvestigatorId, amount: u8) -> bool {
     if amount == 0 {
         return false;
     }

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -65,7 +65,7 @@ pub(super) fn damage_enemy(cx: &mut Cx, enemy_id: EnemyId, amount: u8, by: Optio
 /// don't accumulate more damage.
 ///
 /// [`Status`]: crate::state::Status
-pub(crate) fn apply_damage_numeric(cx: &mut Cx, investigator: InvestigatorId, amount: u8) -> bool {
+pub(super) fn apply_damage_numeric(cx: &mut Cx, investigator: InvestigatorId, amount: u8) -> bool {
     if amount == 0 {
         return false;
     }

--- a/crates/game-core/src/engine/dispatch/elimination.rs
+++ b/crates/game-core/src/engine/dispatch/elimination.rs
@@ -177,10 +177,8 @@ fn run_elimination_steps(cx: &mut Cx, investigator: InvestigatorId) {
 /// with simultaneous-placement semantics (i.e. [`enemy_attack`](super::combat::enemy_attack) and
 /// any future card effect that deals both) compose the lower-level
 /// [`apply_damage_numeric`](super::combat::apply_damage_numeric) + [`apply_horror_numeric`](super::combat::apply_horror_numeric) +
-/// [`apply_investigator_defeat`] triple instead. A `take_damage`
-/// twin is not provided because no single-source-damage caller exists
-/// yet; the recipe (numeric helper + defeat application on `true`
-/// return) is one line per call site.
+/// [`apply_investigator_defeat`] triple instead. The single-source-damage
+/// twin [`take_damage`] follows the same recipe for [`DefeatCause::Damage`].
 ///
 /// [`Status::Insane`]: crate::state::Status::Insane
 pub(crate) fn take_horror(cx: &mut Cx, investigator: InvestigatorId, amount: u8) {

--- a/crates/game-core/src/engine/dispatch/elimination.rs
+++ b/crates/game-core/src/engine/dispatch/elimination.rs
@@ -183,9 +183,19 @@ fn run_elimination_steps(cx: &mut Cx, investigator: InvestigatorId) {
 /// return) is one line per call site.
 ///
 /// [`Status::Insane`]: crate::state::Status::Insane
-pub(super) fn take_horror(cx: &mut Cx, investigator: InvestigatorId, amount: u8) {
+pub(crate) fn take_horror(cx: &mut Cx, investigator: InvestigatorId, amount: u8) {
     if super::combat::apply_horror_numeric(cx, investigator, amount) {
         apply_investigator_defeat(cx, investigator, DefeatCause::Horror);
+    }
+}
+
+/// Apply `amount` damage to `investigator` via the numeric helper,
+/// then apply defeat (cause [`DefeatCause::Damage`]) if it was lethal.
+/// The single-source-damage twin of [`take_horror`] — the first such
+/// caller is [`Effect::DealDamage`]'s evaluator.
+pub(crate) fn take_damage(cx: &mut Cx, investigator: InvestigatorId, amount: u8) {
+    if super::combat::apply_damage_numeric(cx, investigator, amount) {
+        apply_investigator_defeat(cx, investigator, DefeatCause::Damage);
     }
 }
 

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -23,7 +23,9 @@ mod actions;
 pub(super) mod cards;
 mod combat;
 mod cursor;
-mod elimination;
+// pub(super): evaluator reaches take_damage/take_horror via the full path
+// crate::engine::dispatch::elimination (a sibling of dispatch).
+pub(super) mod elimination;
 mod encounter;
 mod hunters;
 mod phases;

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -169,7 +169,7 @@ fn trigger_matches(
         // spawned" in Phase 4. A future PR (likely Phase-7+) that wants
         // to react to spawns will add the corresponding WindowKind
         // variant and update this arm.
-        // EnteredLocation is matched by the forced auto-fire path (a later task),
+        // EnteredLocation is matched by the forced auto-fire path (#215),
         // not by reaction windows.
         (
             WindowKind::PlayerWindow(_) | WindowKind::AfterEnemyDefeated { .. },

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -169,11 +169,14 @@ fn trigger_matches(
         // spawned" in Phase 4. A future PR (likely Phase-7+) that wants
         // to react to spawns will add the corresponding WindowKind
         // variant and update this arm.
+        // EnteredLocation is matched by the forced auto-fire path (a later task),
+        // not by reaction windows.
         (
             WindowKind::PlayerWindow(_) | WindowKind::AfterEnemyDefeated { .. },
             EventPattern::EnemyDefeated { .. }
             | EventPattern::CardRevealed { .. }
-            | EventPattern::EnemySpawned,
+            | EventPattern::EnemySpawned
+            | EventPattern::EnteredLocation,
         ) => false,
     }
 }

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -132,6 +132,8 @@ pub(crate) fn apply_effect(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) 
     match effect {
         Effect::GainResources { target, amount } => gain_resources(cx, eval_ctx, *target, *amount),
         Effect::DiscoverClue { from, count } => discover_clue(cx, eval_ctx, *from, *count),
+        Effect::DealDamage { target, amount } => deal_damage_effect(cx, eval_ctx, *target, *amount),
+        Effect::DealHorror { target, amount } => deal_horror_effect(cx, eval_ctx, *target, *amount),
         Effect::Seq(effects) => apply_seq(cx, effects, eval_ctx),
         Effect::Modify { stat, delta, scope } => modify(cx, eval_ctx, *stat, *delta, *scope),
         Effect::If {
@@ -390,6 +392,58 @@ fn discover_clue(
     EngineOutcome::Done
 }
 
+fn deal_damage_effect(
+    cx: &mut Cx,
+    eval_ctx: EvalContext,
+    target: InvestigatorTarget,
+    amount: u8,
+) -> EngineOutcome {
+    if amount == 0 {
+        return EngineOutcome::Done;
+    }
+    let target_id = match resolve_investigator_target(cx.state, eval_ctx, target) {
+        Ok(id) => id,
+        Err(reason) => {
+            return EngineOutcome::Rejected {
+                reason: reason.into(),
+            }
+        }
+    };
+    if !cx.state.investigators.contains_key(&target_id) {
+        return EngineOutcome::Rejected {
+            reason: format!("DealDamage: investigator {target_id:?} is not in the state").into(),
+        };
+    }
+    crate::engine::dispatch::elimination::take_damage(cx, target_id, amount);
+    EngineOutcome::Done
+}
+
+fn deal_horror_effect(
+    cx: &mut Cx,
+    eval_ctx: EvalContext,
+    target: InvestigatorTarget,
+    amount: u8,
+) -> EngineOutcome {
+    if amount == 0 {
+        return EngineOutcome::Done;
+    }
+    let target_id = match resolve_investigator_target(cx.state, eval_ctx, target) {
+        Ok(id) => id,
+        Err(reason) => {
+            return EngineOutcome::Rejected {
+                reason: reason.into(),
+            }
+        }
+    };
+    if !cx.state.investigators.contains_key(&target_id) {
+        return EngineOutcome::Rejected {
+            reason: format!("DealHorror: investigator {target_id:?} is not in the state").into(),
+        };
+    }
+    crate::engine::dispatch::elimination::take_horror(cx, target_id, amount);
+    EngineOutcome::Done
+}
+
 fn apply_seq(cx: &mut Cx, effects: &[Effect], eval_ctx: EvalContext) -> EngineOutcome {
     // Stop at the first non-Done outcome. A Rejected mid-Seq leaves
     // earlier effects committed *within this apply*, but the `apply`
@@ -611,8 +665,8 @@ fn stat_matches_skill(stat: Stat, skill: SkillKind) -> bool {
 mod tests {
     use crate::card_registry::CardRegistry;
     use crate::dsl::{
-        constant, discover_clue, gain_resources, modify, on_play, seq, Ability, Effect,
-        InvestigatorTarget, LocationTarget, ModifierScope, SkillTestKind, Stat,
+        constant, deal_damage, deal_horror, discover_clue, gain_resources, modify, on_play, seq,
+        Ability, Effect, InvestigatorTarget, LocationTarget, ModifierScope, SkillTestKind, Stat,
     };
     use crate::event::Event;
     use crate::state::{
@@ -1623,5 +1677,53 @@ mod tests {
         ] {
             assert_eq!(pending_skill_modifier(&state, id, skill), 0);
         }
+    }
+
+    #[test]
+    fn deal_damage_adds_damage_and_emits_event() {
+        let mut state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_active_investigator(InvestigatorId(1))
+            .build();
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+        let outcome = apply_effect(
+            &mut cx,
+            &deal_damage(InvestigatorTarget::Controller, 2),
+            EvalContext::for_controller(InvestigatorId(1)),
+        );
+        assert_eq!(outcome, EngineOutcome::Done);
+        assert_eq!(state.investigators[&InvestigatorId(1)].damage, 2);
+        assert!(events.iter().any(|e| matches!(
+            e,
+            Event::DamageTaken { investigator, amount: 2 } if *investigator == InvestigatorId(1)
+        )));
+    }
+
+    #[test]
+    fn deal_horror_adds_horror_and_emits_event() {
+        let mut state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_active_investigator(InvestigatorId(1))
+            .build();
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+        let outcome = apply_effect(
+            &mut cx,
+            &deal_horror(InvestigatorTarget::Controller, 1),
+            EvalContext::for_controller(InvestigatorId(1)),
+        );
+        assert_eq!(outcome, EngineOutcome::Done);
+        assert_eq!(state.investigators[&InvestigatorId(1)].horror, 1);
+        assert!(events.iter().any(|e| matches!(
+            e,
+            Event::HorrorTaken { investigator, amount: 1 } if *investigator == InvestigatorId(1)
+        )));
     }
 }

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -1697,10 +1697,10 @@ mod tests {
         );
         assert_eq!(outcome, EngineOutcome::Done);
         assert_eq!(state.investigators[&InvestigatorId(1)].damage, 2);
-        assert!(events.iter().any(|e| matches!(
-            e,
+        assert_event!(
+            events,
             Event::DamageTaken { investigator, amount: 2 } if *investigator == InvestigatorId(1)
-        )));
+        );
     }
 
     #[test]
@@ -1721,9 +1721,36 @@ mod tests {
         );
         assert_eq!(outcome, EngineOutcome::Done);
         assert_eq!(state.investigators[&InvestigatorId(1)].horror, 1);
-        assert!(events.iter().any(|e| matches!(
-            e,
+        assert_event!(
+            events,
             Event::HorrorTaken { investigator, amount: 1 } if *investigator == InvestigatorId(1)
-        )));
+        );
+    }
+
+    #[test]
+    fn deal_damage_at_max_health_defeats_investigator() {
+        // Build an investigator with a known low max_health (3), then
+        // apply exactly 3 damage via Effect::DealDamage and assert the
+        // investigator is Killed and InvestigatorDefeated is emitted.
+        use crate::state::Status;
+        let id = InvestigatorId(1);
+        let mut inv = test_investigator(1);
+        inv.max_health = 3;
+        let mut state = TestGame::new().with_investigator(inv).build();
+        let mut events = Vec::new();
+        let outcome = apply_effect(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            &deal_damage(InvestigatorTarget::Controller, 3),
+            EvalContext::for_controller(id),
+        );
+        assert_eq!(outcome, EngineOutcome::Done);
+        assert_eq!(state.investigators[&id].status, Status::Killed);
+        assert_event!(
+            events,
+            Event::InvestigatorDefeated { investigator, .. } if *investigator == id
+        );
     }
 }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -3928,6 +3928,7 @@ mod tests {
         }
         let mut state = builder.build();
         state.act_deck = vec![Act {
+            code: CardCode("_test_act".into()),
             clue_threshold: 1,
             resolution: Some(Resolution::Won { id: "test".into() }),
         }];

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -242,6 +242,11 @@ pub struct GameState {
 /// `#[non_exhaustive]` struct forbids cross-crate.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Agenda {
+    /// The encounter-card code this agenda is printed on (e.g.
+    /// `01105`). Lets the trigger dispatcher resolve the agenda's
+    /// `Trigger::OnEvent` abilities through the card registry — the
+    /// agenda owns its Forced effects like any other card.
+    pub code: CardCode,
     /// Total doom in play required to advance (Rules Reference p.24
     /// step 1.3). Flat value only for now; per-investigator scaling
     /// and `Objective –` overrides are deferred until a real
@@ -259,6 +264,10 @@ pub struct Agenda {
 /// [`Agenda`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Act {
+    /// The encounter-card code this act is printed on (e.g. `01108`).
+    /// Lets the trigger dispatcher resolve the act's `Trigger::OnEvent`
+    /// abilities through the card registry.
+    pub code: CardCode,
     /// Clues the investigators must spend to advance (Rules Reference
     /// p.3). Flat value only for now.
     pub clue_threshold: u8,
@@ -1035,6 +1044,27 @@ mod hand_size_discard_tests {
         let json = serde_json::to_string(&original).expect("serialize");
         let back: HandSizeDiscard = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, original);
+    }
+}
+
+#[cfg(test)]
+mod act_agenda_code_tests {
+    use super::*;
+
+    #[test]
+    fn act_and_agenda_carry_card_code() {
+        let act = Act {
+            code: CardCode("01108".into()),
+            clue_threshold: 2,
+            resolution: None,
+        };
+        let agenda = Agenda {
+            code: CardCode("01105".into()),
+            doom_threshold: 3,
+            resolution: None,
+        };
+        assert_eq!(act.code, CardCode("01108".into()));
+        assert_eq!(agenda.code, CardCode("01105".into()));
     }
 }
 

--- a/crates/scenarios/src/test_fixtures/synthetic.rs
+++ b/crates/scenarios/src/test_fixtures/synthetic.rs
@@ -82,10 +82,12 @@ pub fn setup() -> GameState {
         .push_back(CardCode(SYNTH_TREACHERY_CODE.into()));
     state.agenda_deck = vec![
         Agenda {
+            code: CardCode("_synth_agenda_1".into()),
             doom_threshold: 2,
             resolution: None,
         },
         Agenda {
+            code: CardCode("_synth_agenda_2".into()),
             doom_threshold: 2,
             resolution: Some(Resolution::Lost {
                 reason: "agenda".into(),
@@ -94,10 +96,12 @@ pub fn setup() -> GameState {
     ];
     state.act_deck = vec![
         Act {
+            code: CardCode("_synth_act_1".into()),
             clue_threshold: 2,
             resolution: None,
         },
         Act {
+            code: CardCode("_synth_act_2".into()),
             clue_threshold: 2,
             resolution: Some(Resolution::Won { id: "demo".into() }),
         },

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -3,7 +3,7 @@
 //! wasm32-only (browser DOM); native jobs skip this file.
 #![cfg(target_arch = "wasm32")]
 
-use game_core::state::{Act, Agenda, Phase};
+use game_core::state::{Act, Agenda, CardCode, Phase};
 use game_core::test_support::builder::TestGame;
 use game_core::test_support::fixtures::{test_enemy, test_investigator, test_location};
 use game_core::EngineOutcome;
@@ -53,10 +53,12 @@ async fn phase_bar_renders_phase_round_act_agenda() {
         .with_round(3)
         .build();
     state.act_deck = vec![Act {
+        code: CardCode("_test_act".into()),
         clue_threshold: 2,
         resolution: None,
     }];
     state.agenda_deck = vec![Agenda {
+        code: CardCode("_test_agenda".into()),
         doom_threshold: 5,
         resolution: None,
     }];

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -21,8 +21,8 @@ trigger-ordering (`#213`), folding in `#117`.
 
 | Order | Issue | Plan | State |
 |---|---|---|---|
-| — | [#216](https://github.com/talelburg/eldritch/issues/216) — kickoff: spec + engine-spine plans + breakdown | — | 🔜 PR open |
-| A1 | [#214](https://github.com/talelburg/eldritch/issues/214) — engine-spine primitives (DealDamage/DealHorror, EnteredLocation, Act/Agenda CardCode) | `plans/2026-06-10-…-engine-spine-primitives.md` | ⏳ planned |
+| — | [#216](https://github.com/talelburg/eldritch/issues/216) — kickoff: spec + engine-spine plans + breakdown | — | ✅ PR #217 |
+| A1 | [#214](https://github.com/talelburg/eldritch/issues/214) — engine-spine primitives (DealDamage/DealHorror, EnteredLocation, Act/Agenda CardCode) | `plans/2026-06-10-…-engine-spine-primitives.md` | ✅ PR #218 |
 | A2 | [#215](https://github.com/talelburg/eldritch/issues/215) — forced-trigger dispatch (`fire_forced_triggers`) — depends on A1 | `plans/2026-06-10-…-forced-trigger-dispatch.md` | ⏳ planned |
 | B | scenario plumbing: `reference_card` + symbol routing; roster/seating + `StartScenario` selection; real-registry swap (D5) | TBD | 📐 spec'd |
 | C | content: Gathering scenario cards + setup + Roland + signature/weakness + starter deck | TBD | 📐 spec'd |


### PR DESCRIPTION
## Summary

Phase 7 Slice 1, **Plan A1** — the three mechanical engine-spine primitives the forced-trigger dispatch (#215) and Gathering content build on. All additive/forward-compatible; no behavior change to existing paths.

## What changed

- **`Effect::DealDamage` / `Effect::DealHorror`** (`card-dsl`) + builders + evaluator helpers, mirroring `GainResources` and routing through `elimination::take_damage`/`take_horror` (defeat applied on lethal). This is the first single-source-damage caller the `take_horror` doc anticipated; adds the `take_damage` twin.
- **`EventPattern::EnteredLocation`** — **inert** DSL variant (surface only, per the `CardRevealed`/`EnemySpawned` precedent); `trigger_matches` returns `false` for it. Firing wires up in #215.
- **`code: CardCode` on `Act` / `Agenda`** — mirrors `Location.code`; pure data plumbing, prerequisite for #215's registry-based ability lookup. All 14 construction sites updated.

## Test notes

- TDD throughout; new tests cover the damage/horror happy paths, the `DealDamage`→defeat path, the `EnteredLocation` round-trip, and `Act`/`Agenda` carrying `code`.
- Full strict gauntlet green (test/clippy/doc/fmt + wasm build), `RUSTFLAGS="-D warnings"`.
- Reviewed per task (spec + quality) and a final holistic pass: READY TO MERGE.

## Linked issues

Closes #214
