### PR TITLE
engine: Slice 1 A2 — forced-trigger dispatch (fire_forced_triggers)

### DIFF
--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -241,6 +241,27 @@ pub enum EventPattern {
     /// DSL surface only here; the matching + forced auto-fire wiring
     /// lands in #215. Until then the engine ignores it.
     EnteredLocation,
+    /// A game phase ended. Forced agenda/act effects keyed to a phase
+    /// boundary listen here: agenda `01107` moves Ghouls at
+    /// `PhaseEnded { phase: Enemy }` and places doom at the end of the
+    /// round (`PhaseEnded { phase: Upkeep }`).
+    ///
+    /// Matched only by the forced dispatch path
+    /// (`engine::dispatch::forced_triggers`, a later task), never by
+    /// player reaction windows — `trigger_matches` returns `false` for it.
+    PhaseEnded { phase: Phase },
+}
+
+/// The four game phases, mirrored in `card-dsl` so [`EventPattern`] can
+/// name a phase without `card-dsl` depending on `game-core` (layering).
+/// `game-core` maps this to its own `state::Phase` at the dispatch
+/// boundary (see `engine::dispatch::forced_triggers`, a later task).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Phase {
+    Mythos,
+    Investigation,
+    Enemy,
+    Upkeep,
 }
 
 /// When an [`Trigger::OnEvent`] ability fires relative to the
@@ -1161,6 +1182,16 @@ mod tests {
     #[test]
     fn entered_location_pattern_round_trips() {
         let p = EventPattern::EnteredLocation;
+        let json = serde_json::to_string(&p).unwrap();
+        let back: EventPattern = serde_json::from_str(&json).unwrap();
+        assert_eq!(p, back);
+    }
+
+    #[test]
+    fn phase_ended_pattern_round_trips() {
+        let p = EventPattern::PhaseEnded {
+            phase: Phase::Enemy,
+        };
         let json = serde_json::to_string(&p).unwrap();
         let back: EventPattern = serde_json::from_str(&json).unwrap();
         assert_eq!(p, back);

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -238,8 +238,8 @@ pub enum EventPattern {
     /// investigator and *this location* = the ability's own location
     /// from the trigger context — no narrowing fields needed.
     ///
-    /// DSL surface only here; the matching + forced auto-fire wiring
-    /// lands in #215. Until then the engine ignores it.
+    /// The forced dispatch path matches this pattern and fires it from
+    /// `move_action` on entry (`engine::dispatch::forced_triggers`).
     EnteredLocation,
     /// A game phase ended. Forced agenda/act effects keyed to a phase
     /// boundary listen here: agenda `01107` moves Ghouls at
@@ -247,15 +247,17 @@ pub enum EventPattern {
     /// round (`PhaseEnded { phase: Upkeep }`).
     ///
     /// Matched only by the forced dispatch path
-    /// (`engine::dispatch::forced_triggers`, a later task), never by
-    /// player reaction windows — `trigger_matches` returns `false` for it.
+    /// (`engine::dispatch::forced_triggers`), never by player reaction
+    /// windows — `trigger_matches` returns `false` for it. Currently
+    /// wired for Enemy and Upkeep phase-ends only; Mythos and
+    /// Investigation are not wired (see #212).
     PhaseEnded { phase: Phase },
 }
 
 /// The four game phases, mirrored in `card-dsl` so [`EventPattern`] can
 /// name a phase without `card-dsl` depending on `game-core` (layering).
 /// `game-core` maps this to its own `state::Phase` at the dispatch
-/// boundary (see `engine::dispatch::forced_triggers`, a later task).
+/// boundary (see `engine::dispatch::forced_triggers`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Phase {
     Mythos,

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -273,7 +273,13 @@ pub(super) fn move_action(
         from,
         to: destination,
     });
-    EngineOutcome::Done
+    super::forced_triggers::fire_forced_triggers(
+        cx,
+        super::forced_triggers::ForcedTriggerPoint::EnteredLocation {
+            investigator,
+            location: destination,
+        },
+    )
 }
 
 /// Validate the prefix shared by Fight and Evade: phase, active

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -273,6 +273,12 @@ pub(super) fn move_action(
         from,
         to: destination,
     });
+    // Terminal step: the entered location's Forced on-enter abilities fire,
+    // and their outcome becomes the move's outcome. This runs *after* the
+    // move is applied, so if it returns Rejected (e.g. 2+ simultaneous
+    // forced triggers, #213), `apply`'s structural rollback restores the
+    // pre-move state — the partial mutation above is safe (same reliance on
+    // the apply-loop snapshot that `play_card` documents).
     super::forced_triggers::fire_forced_triggers(
         cx,
         super::forced_triggers::ForcedTriggerPoint::EnteredLocation {

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -96,7 +96,7 @@ fn collect_forced_hits(
                     &act.code,
                     lead,
                     &mut hits,
-                    |p| matches!(p, crate::dsl::EventPattern::PhaseEnded { phase } if phase == want_phase),
+                    |p| matches!(p, EventPattern::PhaseEnded { phase } if phase == want_phase),
                 );
             }
             if let Some(agenda) = state.agenda_deck.get(state.agenda_index) {
@@ -105,7 +105,7 @@ fn collect_forced_hits(
                     &agenda.code,
                     lead,
                     &mut hits,
-                    |p| matches!(p, crate::dsl::EventPattern::PhaseEnded { phase } if phase == want_phase),
+                    |p| matches!(p, EventPattern::PhaseEnded { phase } if phase == want_phase),
                 );
             }
         }

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -7,7 +7,7 @@
 
 use crate::card_registry;
 use crate::dsl::{EventPattern, EventTiming, Trigger};
-use crate::state::{CardCode, InvestigatorId, LocationId};
+use crate::state::{CardCode, InvestigatorId, LocationId, Phase};
 
 use super::super::evaluator::{apply_effect, EvalContext};
 use super::super::outcome::EngineOutcome;
@@ -32,7 +32,10 @@ pub(crate) enum ForcedTriggerPoint {
         /// The location that was entered.
         location: LocationId,
     },
-    // PhaseEnded variant added in a later task.
+    /// A phase ended. Scans the current act and agenda for
+    /// `EventPattern::PhaseEnded { phase }` forced abilities; binds
+    /// controller = the lead investigator (board-wide effects ignore it).
+    PhaseEnded { phase: Phase },
 }
 
 struct ForcedHit {
@@ -80,8 +83,45 @@ fn collect_forced_hits(
                 matches!(p, EventPattern::EnteredLocation)
             });
         }
+        ForcedTriggerPoint::PhaseEnded { phase } => {
+            let want_phase = dsl_phase(phase);
+            // Lead investigator binds the controller for board-wide effects
+            // (which ignore it). First of turn_order is the lead.
+            let Some(lead) = state.turn_order.first().copied() else {
+                return hits;
+            };
+            if let Some(act) = state.act_deck.get(state.act_index) {
+                push_matching(
+                    reg,
+                    &act.code,
+                    lead,
+                    &mut hits,
+                    |p| matches!(p, crate::dsl::EventPattern::PhaseEnded { phase } if phase == want_phase),
+                );
+            }
+            if let Some(agenda) = state.agenda_deck.get(state.agenda_index) {
+                push_matching(
+                    reg,
+                    &agenda.code,
+                    lead,
+                    &mut hits,
+                    |p| matches!(p, crate::dsl::EventPattern::PhaseEnded { phase } if phase == want_phase),
+                );
+            }
+        }
     }
     hits
+}
+
+/// Map the engine's `state::Phase` to the `card-dsl` mirror so a
+/// `PhaseEnded` pattern can be compared.
+fn dsl_phase(phase: Phase) -> crate::dsl::Phase {
+    match phase {
+        Phase::Mythos => crate::dsl::Phase::Mythos,
+        Phase::Investigation => crate::dsl::Phase::Investigation,
+        Phase::Enemy => crate::dsl::Phase::Enemy,
+        Phase::Upkeep => crate::dsl::Phase::Upkeep,
+    }
 }
 
 fn push_matching(

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -20,7 +20,8 @@ use super::Cx;
 /// `pub(crate)` — not part of the public API. [`crate::test_support`]
 /// constructs it internally via `fire_forced_on_enter` (a primitive-arg
 /// helper), so integration tests never need to name this type directly.
-/// Task 3 wires this into `move_action`.
+/// Wired into `move_action` (`EnteredLocation`) and
+/// `enemy_phase_end`/`upkeep_phase_end` (`PhaseEnded`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ForcedTriggerPoint {
     /// An investigator entered a location. Scans that location's card
@@ -136,6 +137,9 @@ fn push_matching(
     };
     for (idx, ability) in abilities.iter().enumerate() {
         if let Trigger::OnEvent { pattern, timing } = ability.trigger {
+            // Only `After` timing is handled in this slice; no in-scope
+            // Forced card uses `Before` ("when X would Y") timing.
+            // Revisit when such a card lands.
             if timing == EventTiming::After && want(pattern) {
                 out.push(ForcedHit {
                     code: code.clone(),

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -1,0 +1,125 @@
+//! Forced-trigger dispatch: fires `Trigger::OnEvent` abilities printed
+//! on scenario-structure cards (locations, acts, agendas) at framework
+//! timing points, via an immediate path separate from the player
+//! reaction-window machinery. Single-trigger only in this slice; 2+
+//! simultaneous pending triggers reject loudly (#213 adds the ordering
+//! loop, #212 the universal `emit_event` chokepoint).
+
+use crate::card_registry;
+use crate::dsl::{EventPattern, EventTiming, Trigger};
+use crate::state::{CardCode, InvestigatorId, LocationId};
+
+use super::super::evaluator::{apply_effect, EvalContext};
+use super::super::outcome::EngineOutcome;
+use super::Cx;
+
+/// A framework timing point at which Forced (`Trigger::OnEvent`)
+/// abilities on scenario-structure cards may fire. Each variant carries
+/// the binding context the fired effect needs.
+///
+/// `pub` so [`crate::test_support`] can expose it as part of the
+/// `fire_forced_at` test-helper API. Task 3 wires this into `move_action`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForcedTriggerPoint {
+    /// An investigator entered a location. Scans that location's card
+    /// for `EventPattern::EnteredLocation` forced abilities; binds
+    /// controller = the entering investigator.
+    EnteredLocation {
+        /// The investigator who entered the location.
+        investigator: InvestigatorId,
+        /// The location that was entered.
+        location: LocationId,
+    },
+    // PhaseEnded variant added in a later task.
+}
+
+struct ForcedHit {
+    code: CardCode,
+    ability_index: usize,
+    controller: InvestigatorId,
+}
+
+/// Fire Forced abilities matching `point`. Single-trigger path: 0 → Done;
+/// 1 → resolve via `apply_effect`; 2+ → reject loudly (no silently-chosen
+/// order — #213 adds the ordering loop).
+pub(crate) fn fire_forced_triggers(cx: &mut Cx, point: ForcedTriggerPoint) -> EngineOutcome {
+    let hits = collect_forced_hits(cx.state, point);
+    match hits.len() {
+        0 => EngineOutcome::Done,
+        1 => resolve_one(cx, &hits[0]),
+        n => EngineOutcome::Rejected {
+            reason: format!(
+                "fire_forced_triggers: {n} simultaneous forced triggers at {point:?}; \
+                 ordering not yet implemented (see #213). Slice-1 content never produces \
+                 this — investigate the source."
+            )
+            .into(),
+        },
+    }
+}
+
+fn collect_forced_hits(
+    state: &crate::state::GameState,
+    point: ForcedTriggerPoint,
+) -> Vec<ForcedHit> {
+    let Some(reg) = card_registry::current() else {
+        return Vec::new();
+    };
+    let mut hits = Vec::new();
+    match point {
+        ForcedTriggerPoint::EnteredLocation {
+            investigator,
+            location,
+        } => {
+            let Some(loc) = state.locations.get(&location) else {
+                return hits;
+            };
+            push_matching(reg, &loc.code, investigator, &mut hits, |p| {
+                matches!(p, EventPattern::EnteredLocation)
+            });
+        }
+    }
+    hits
+}
+
+fn push_matching(
+    reg: &card_registry::CardRegistry,
+    code: &CardCode,
+    controller: InvestigatorId,
+    out: &mut Vec<ForcedHit>,
+    want: impl Fn(EventPattern) -> bool,
+) {
+    let Some(abilities) = (reg.abilities_for)(code) else {
+        return;
+    };
+    for (idx, ability) in abilities.iter().enumerate() {
+        if let Trigger::OnEvent { pattern, timing } = ability.trigger {
+            if timing == EventTiming::After && want(pattern) {
+                out.push(ForcedHit {
+                    code: code.clone(),
+                    ability_index: idx,
+                    controller,
+                });
+            }
+        }
+    }
+}
+
+fn resolve_one(cx: &mut Cx, hit: &ForcedHit) -> EngineOutcome {
+    let Some(reg) = card_registry::current() else {
+        return EngineOutcome::Rejected {
+            reason: "fire_forced_triggers: registry vanished between collect and resolve".into(),
+        };
+    };
+    let Some(abilities) = (reg.abilities_for)(&hit.code) else {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "fire_forced_triggers: {} has no abilities at resolve time",
+                hit.code
+            )
+            .into(),
+        };
+    };
+    let effect = abilities[hit.ability_index].effect.clone();
+    apply_effect(cx, &effect, EvalContext::for_controller(hit.controller))
+}

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -17,10 +17,12 @@ use super::Cx;
 /// abilities on scenario-structure cards may fire. Each variant carries
 /// the binding context the fired effect needs.
 ///
-/// `pub` so [`crate::test_support`] can expose it as part of the
-/// `fire_forced_at` test-helper API. Task 3 wires this into `move_action`.
+/// `pub(crate)` — not part of the public API. [`crate::test_support`]
+/// constructs it internally via `fire_forced_on_enter` (a primitive-arg
+/// helper), so integration tests never need to name this type directly.
+/// Task 3 wires this into `move_action`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ForcedTriggerPoint {
+pub(crate) enum ForcedTriggerPoint {
     /// An investigator entered a location. Scans that location's card
     /// for `EventPattern::EnteredLocation` forced abilities; binds
     /// controller = the entering investigator.

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -27,6 +27,9 @@ mod cursor;
 // crate::engine::dispatch::elimination (a sibling of dispatch).
 pub(super) mod elimination;
 mod encounter;
+// pub(super): engine/mod.rs re-exports ForcedTriggerPoint + fire_forced_triggers
+// via pub(crate) for test_support::fire_forced_at (Task 2 of #215).
+pub(super) mod forced_triggers;
 mod hunters;
 mod phases;
 mod reaction_windows;

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -391,6 +391,18 @@ pub(super) fn enemy_phase_end(cx: &mut Cx) -> EngineOutcome {
     cx.events.push(Event::PhaseEnded {
         phase: Phase::Enemy,
     });
+    // Fire forced act/agenda abilities keyed to `PhaseEnded { Enemy }`.
+    // Single-trigger path: 0 → Done (no-op); 1 → resolves immediately;
+    // 2+ → rejects loudly (#213 adds the ordering loop).
+    let forced = super::forced_triggers::fire_forced_triggers(
+        cx,
+        super::forced_triggers::ForcedTriggerPoint::PhaseEnded {
+            phase: Phase::Enemy,
+        },
+    );
+    if !matches!(forced, EngineOutcome::Done) {
+        return forced; // 2+-trigger loud reject (unreachable in-slice); propagate
+    }
     // Enemy → Upkeep; calls upkeep_phase. This may now suspend at step
     // 4.5 (hand-size discard, #111), so the outcome propagates rather
     // than being asserted Done.
@@ -466,6 +478,22 @@ fn upkeep_phase_end(cx: &mut Cx) {
     cx.events.push(Event::PhaseEnded {
         phase: Phase::Upkeep,
     });
+    // Fire forced act/agenda abilities keyed to `PhaseEnded { Upkeep }`
+    // ("at end of round"). The () return cannot propagate a 2+-trigger
+    // reject; `debug_assert!` guards it for now. #212's `emit_event`
+    // restructure will centralise forced-trigger dispatch and remove this
+    // limitation.
+    let forced = super::forced_triggers::fire_forced_triggers(
+        cx,
+        super::forced_triggers::ForcedTriggerPoint::PhaseEnded {
+            phase: Phase::Upkeep,
+        },
+    );
+    debug_assert!(
+        matches!(forced, EngineOutcome::Done),
+        "upkeep_phase_end forced trigger did not resolve to Done: {forced:?} \
+         (2+ simultaneous forced at round end needs #213)"
+    );
     // Upkeep → Mythos; calls mythos_phase. Only the Investigation→Enemy
     // transition can suspend (hunter movement), so this never does.
     let outcome = step_phase(cx);

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -181,6 +181,10 @@ pub(super) fn begin_investigator_turn(cx: &mut Cx, who: InvestigatorId) {
 /// Enemy phase. Called only from `end_turn`'s terminal branch (the last
 /// investigator has taken a turn this round).
 fn investigation_phase_end(cx: &mut Cx) -> EngineOutcome {
+    // No forced-trigger dispatch here: only Enemy and Upkeep phase-ends have
+    // slice consumers (agenda 01107). A `PhaseEnded { Investigation }` forced
+    // ability would NOT fire until #212's emit_event restructure centralises
+    // forced dispatch across all framework windows.
     cx.events.push(Event::PhaseEnded {
         phase: Phase::Investigation,
     });
@@ -422,6 +426,10 @@ pub(super) fn mythos_phase_end(cx: &mut Cx) {
     //     driver — mirror of step 1.1's PhaseStarted ownership in
     //     mythos_phase. Rules Reference p.24: "This step formalizes
     //     the end of the mythos phase."
+    // No forced-trigger dispatch here: only Enemy and Upkeep phase-ends have
+    // slice consumers (agenda 01107). A `PhaseEnded { Mythos }` forced ability
+    // would NOT fire until #212's emit_event restructure centralises forced
+    // dispatch across all framework windows.
     cx.events.push(Event::PhaseEnded {
         phase: Phase::Mythos,
     });

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -169,11 +169,12 @@ fn trigger_matches(
         // spawned" in Phase 4. A future PR (likely Phase-7+) that wants
         // to react to spawns will add the corresponding WindowKind
         // variant and update this arm.
-        // EnteredLocation is matched by the forced auto-fire path (#215),
+        // EnteredLocation is matched by the forced auto-fire path in
+        // `engine::dispatch::forced_triggers` (fired from `move_action`),
         // not by reaction windows.
         // PhaseEnded is matched only by the forced dispatch path
-        // (engine::dispatch::forced_triggers, a later task), never by
-        // player reaction windows.
+        // (`engine::dispatch::forced_triggers`), never by player reaction
+        // windows.
         (
             WindowKind::PlayerWindow(_) | WindowKind::AfterEnemyDefeated { .. },
             EventPattern::EnemyDefeated { .. }

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -171,12 +171,16 @@ fn trigger_matches(
         // variant and update this arm.
         // EnteredLocation is matched by the forced auto-fire path (#215),
         // not by reaction windows.
+        // PhaseEnded is matched only by the forced dispatch path
+        // (engine::dispatch::forced_triggers, a later task), never by
+        // player reaction windows.
         (
             WindowKind::PlayerWindow(_) | WindowKind::AfterEnemyDefeated { .. },
             EventPattern::EnemyDefeated { .. }
             | EventPattern::CardRevealed { .. }
             | EventPattern::EnemySpawned
-            | EventPattern::EnteredLocation,
+            | EventPattern::EnteredLocation
+            | EventPattern::PhaseEnded { .. },
         ) => false,
     }
 }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -20,6 +20,14 @@ pub(crate) mod pathfinding;
 pub use evaluator::EvalContext;
 pub use outcome::{EngineOutcome, InputRequest, ResumeToken};
 
+// Re-exported for `test_support::fire_forced_at` — the only consumer
+// before Task 3 wires `fire_forced_triggers` into `move_action`.
+// `ForcedTriggerPoint` is pub so the integration test at
+// `crates/game-core/tests/forced_triggers.rs` can name it via
+// `game_core::test_support::ForcedTriggerPoint`.
+pub(crate) use dispatch::forced_triggers::fire_forced_triggers;
+pub use dispatch::forced_triggers::ForcedTriggerPoint;
+
 use crate::action::Action;
 use crate::event::Event;
 use crate::scenario::ScenarioRegistry;

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -20,13 +20,12 @@ pub(crate) mod pathfinding;
 pub use evaluator::EvalContext;
 pub use outcome::{EngineOutcome, InputRequest, ResumeToken};
 
-// Re-exported for `test_support::fire_forced_at` — the only consumer
-// before Task 3 wires `fire_forced_triggers` into `move_action`.
-// `ForcedTriggerPoint` is pub so the integration test at
-// `crates/game-core/tests/forced_triggers.rs` can name it via
-// `game_core::test_support::ForcedTriggerPoint`.
-pub(crate) use dispatch::forced_triggers::fire_forced_triggers;
-pub use dispatch::forced_triggers::ForcedTriggerPoint;
+// Crate-internal re-exports for `test_support::fire_forced_on_enter`.
+// Neither is public API: `ForcedTriggerPoint` stays internal; the
+// integration test constructs it through the primitive-arg helper so
+// it never needs to name the enum. Task 3 wires `fire_forced_triggers`
+// into `move_action`.
+pub(crate) use dispatch::forced_triggers::{fire_forced_triggers, ForcedTriggerPoint};
 
 use crate::action::Action;
 use crate::event::Event;

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -23,8 +23,9 @@ pub use outcome::{EngineOutcome, InputRequest, ResumeToken};
 // Crate-internal re-exports for `test_support::fire_forced_on_enter`.
 // Neither is public API: `ForcedTriggerPoint` stays internal; the
 // integration test constructs it through the primitive-arg helper so
-// it never needs to name the enum. Task 3 wires `fire_forced_triggers`
-// into `move_action`.
+// it never needs to name the enum. `fire_forced_triggers` is wired into
+// `move_action` (EnteredLocation) and `enemy_phase_end`/`upkeep_phase_end`
+// (PhaseEnded).
 pub(crate) use dispatch::forced_triggers::{fire_forced_triggers, ForcedTriggerPoint};
 
 use crate::action::Action;

--- a/crates/game-core/src/test_support/mod.rs
+++ b/crates/game-core/src/test_support/mod.rs
@@ -13,3 +13,29 @@ pub mod resolver;
 pub use builder::TestGame;
 pub use fixtures::{awaiting_commit_input, test_enemy, test_investigator, test_location};
 pub use resolver::{apply_no_commits, drive, ChoiceResolver, ScriptedResolver, TestSession};
+
+// Re-export `ForcedTriggerPoint` so integration tests at
+// `crates/game-core/tests/forced_triggers.rs` (a separate binary with
+// their own `OnceLock<CardRegistry>`) can test `fire_forced_at` without
+// reaching into the private `dispatch` module. The function is not yet
+// wired into any action handler — Task 3 of #215 does the wiring.
+pub use crate::engine::ForcedTriggerPoint;
+
+/// Test helper: build a `Cx` from `state` and `events`, call
+/// `fire_forced_triggers(point)`, and return the `EngineOutcome`.
+///
+/// Lives in `test_support` (rather than in-crate tests) because
+/// `fire_forced_triggers` needs a custom `CardRegistry` and
+/// `OnceLock<CardRegistry>` is process-global — an in-crate install
+/// would collide with `card_registry::tests::install_is_idempotent`.
+/// Integration tests in `crates/game-core/tests/` run in separate
+/// processes, each with their own `OnceLock`, so collision is
+/// impossible.
+pub fn fire_forced_at(
+    state: &mut crate::state::GameState,
+    events: &mut Vec<crate::event::Event>,
+    point: ForcedTriggerPoint,
+) -> crate::engine::EngineOutcome {
+    let mut cx = crate::engine::Cx { state, events };
+    crate::engine::fire_forced_triggers(&mut cx, point)
+}

--- a/crates/game-core/src/test_support/mod.rs
+++ b/crates/game-core/src/test_support/mod.rs
@@ -22,7 +22,8 @@ pub use resolver::{apply_no_commits, drive, ChoiceResolver, ScriptedResolver, Te
 /// `CardRegistry` and `OnceLock<CardRegistry>` is process-global — an
 /// in-crate install would collide with `card_registry::tests`. Integration
 /// tests in `crates/game-core/tests/` run in separate processes.
-/// Not yet wired into a handler — Task 3 of #215 wires `move_action`.
+/// Wired into `move_action` (`EnteredLocation`); this helper exists for
+/// unit-style coverage of the dispatch path in isolation.
 pub fn fire_forced_on_enter(
     state: &mut crate::state::GameState,
     events: &mut Vec<crate::event::Event>,

--- a/crates/game-core/src/test_support/mod.rs
+++ b/crates/game-core/src/test_support/mod.rs
@@ -14,28 +14,27 @@ pub use builder::TestGame;
 pub use fixtures::{awaiting_commit_input, test_enemy, test_investigator, test_location};
 pub use resolver::{apply_no_commits, drive, ChoiceResolver, ScriptedResolver, TestSession};
 
-// Re-export `ForcedTriggerPoint` so integration tests at
-// `crates/game-core/tests/forced_triggers.rs` (a separate binary with
-// their own `OnceLock<CardRegistry>`) can test `fire_forced_at` without
-// reaching into the private `dispatch` module. The function is not yet
-// wired into any action handler — Task 3 of #215 does the wiring.
-pub use crate::engine::ForcedTriggerPoint;
-
-/// Test helper: build a `Cx` from `state` and `events`, call
-/// `fire_forced_triggers(point)`, and return the `EngineOutcome`.
+/// Test helper: fire forced triggers for an investigator entering a
+/// location, returning the `EngineOutcome`. Constructs the internal
+/// `ForcedTriggerPoint` so integration tests don't need it public.
 ///
-/// Lives in `test_support` (rather than in-crate tests) because
-/// `fire_forced_triggers` needs a custom `CardRegistry` and
-/// `OnceLock<CardRegistry>` is process-global — an in-crate install
-/// would collide with `card_registry::tests::install_is_idempotent`.
-/// Integration tests in `crates/game-core/tests/` run in separate
-/// processes, each with their own `OnceLock`, so collision is
-/// impossible.
-pub fn fire_forced_at(
+/// Lives in `test_support` because `fire_forced_triggers` needs a custom
+/// `CardRegistry` and `OnceLock<CardRegistry>` is process-global — an
+/// in-crate install would collide with `card_registry::tests`. Integration
+/// tests in `crates/game-core/tests/` run in separate processes.
+/// Not yet wired into a handler — Task 3 of #215 wires `move_action`.
+pub fn fire_forced_on_enter(
     state: &mut crate::state::GameState,
     events: &mut Vec<crate::event::Event>,
-    point: ForcedTriggerPoint,
+    investigator: crate::state::InvestigatorId,
+    location: crate::state::LocationId,
 ) -> crate::engine::EngineOutcome {
     let mut cx = crate::engine::Cx { state, events };
-    crate::engine::fire_forced_triggers(&mut cx, point)
+    crate::engine::fire_forced_triggers(
+        &mut cx,
+        crate::engine::ForcedTriggerPoint::EnteredLocation {
+            investigator,
+            location,
+        },
+    )
 }

--- a/crates/game-core/src/test_support/mod.rs
+++ b/crates/game-core/src/test_support/mod.rs
@@ -38,3 +38,18 @@ pub fn fire_forced_on_enter(
         },
     )
 }
+
+/// Test helper: fire forced triggers for a phase ending, returning the
+/// `EngineOutcome`. Constructs the internal `ForcedTriggerPoint` so
+/// integration tests don't need it public. See `fire_forced_on_enter`.
+pub fn fire_forced_on_phase_end(
+    state: &mut crate::state::GameState,
+    events: &mut Vec<crate::event::Event>,
+    phase: crate::state::Phase,
+) -> crate::engine::EngineOutcome {
+    let mut cx = crate::engine::Cx { state, events };
+    crate::engine::fire_forced_triggers(
+        &mut cx,
+        crate::engine::ForcedTriggerPoint::PhaseEnded { phase },
+    )
+}

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -41,6 +41,12 @@ const DOOM_AGENDA: &str = "test-agenda";
 /// ability that deals 1 horror to the controller (lead investigator).
 const DOOM_ACT: &str = "test-act";
 
+/// Mock location code: TWO `EventPattern::EnteredLocation` forced abilities,
+/// both dealing 1 horror to the entering investigator. Used to test that a
+/// single timing point with 2+ simultaneous forced triggers rejects loudly
+/// instead of silently choosing an order.
+const DOUBLE_FORCED: &str = "test-double-forced";
+
 fn mock_metadata_for(_: &CardCode) -> Option<&'static CardMetadata> {
     None
 }
@@ -60,6 +66,21 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
             EventTiming::After,
             deal_horror(InvestigatorTarget::Controller, 1),
         )])
+    } else if code.as_str() == DOUBLE_FORCED {
+        // Two distinct forced `EnteredLocation` abilities at the same timing
+        // point — exercises the 2+-simultaneous reject path.
+        Some(vec![
+            on_event(
+                EventPattern::EnteredLocation,
+                EventTiming::After,
+                deal_horror(InvestigatorTarget::Controller, 1),
+            ),
+            on_event(
+                EventPattern::EnteredLocation,
+                EventTiming::After,
+                deal_horror(InvestigatorTarget::Controller, 1),
+            ),
+        ])
     } else {
         None
     }
@@ -370,5 +391,37 @@ fn forced_on_phase_end_fires_act_ability() {
     assert_event!(
         events,
         Event::HorrorTaken { investigator, amount: 1 } if *investigator == InvestigatorId(1)
+    );
+}
+
+#[test]
+fn two_simultaneous_forced_triggers_reject_loudly() {
+    install_mock_registry();
+
+    let mut loc = test_location(10, "Double-Forced Room");
+    loc.code = CardCode(DOUBLE_FORCED.into());
+
+    let mut state = TestGame::new()
+        .with_investigator_at(test_investigator(1), LocationId(10))
+        .with_location(loc)
+        .with_active_investigator(InvestigatorId(1))
+        .build();
+
+    let mut events = Vec::new();
+    let outcome = fire_forced_on_enter(&mut state, &mut events, InvestigatorId(1), LocationId(10));
+
+    // 2+ simultaneous forced triggers reject loudly — no order is chosen.
+    // `fire_forced_triggers` counts hits first, before calling `apply_effect`,
+    // so the reject happens before any effect is resolved.
+    assert!(
+        matches!(outcome, EngineOutcome::Rejected { .. }),
+        "expected Rejected for 2+ simultaneous forced triggers; got {outcome:?}"
+    );
+    // No horror was applied — the reject fires before any effect runs.
+    assert_eq!(state.investigators[&InvestigatorId(1)].horror, 0);
+    // No events were emitted on this path.
+    assert!(
+        events.is_empty(),
+        "no events should be emitted on the 2+ reject path"
     );
 }

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -125,7 +125,11 @@ fn move_into_forced_location_fires_its_effect() {
     assert!(
         result.events.iter().any(|e| matches!(
             e,
-            Event::InvestigatorMoved { investigator: InvestigatorId(1), to: LocationId(11), .. }
+            Event::InvestigatorMoved {
+                investigator: InvestigatorId(1),
+                to: LocationId(11),
+                ..
+            }
         )),
         "expected InvestigatorMoved to 11 in events; got {:?}",
         result.events

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -123,6 +123,14 @@ fn move_into_forced_location_fires_its_effect() {
     );
     assert_eq!(result.state.investigators[&InvestigatorId(1)].horror, 1);
     assert!(
+        result.events.iter().any(|e| matches!(
+            e,
+            Event::InvestigatorMoved { investigator: InvestigatorId(1), to: LocationId(11), .. }
+        )),
+        "expected InvestigatorMoved to 11 in events; got {:?}",
+        result.events
+    );
+    assert!(
         result
             .events
             .iter()

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -23,7 +23,7 @@ use game_core::dsl::{
 };
 use game_core::engine::EngineOutcome;
 use game_core::event::Event;
-use game_core::state::{Agenda, CardCode, InvestigatorId, LocationId, Phase};
+use game_core::state::{Act, Agenda, CardCode, InvestigatorId, LocationId, Phase};
 use game_core::test_support::{
     fire_forced_on_enter, fire_forced_on_phase_end, test_investigator, test_location, TestGame,
 };
@@ -37,6 +37,10 @@ const HORROR_ATTIC: &str = "test-attic";
 /// ability that deals 1 horror to the controller (lead investigator).
 const DOOM_AGENDA: &str = "test-agenda";
 
+/// Mock act code: one `EventPattern::PhaseEnded { phase: Enemy }` forced
+/// ability that deals 1 horror to the controller (lead investigator).
+const DOOM_ACT: &str = "test-act";
+
 fn mock_metadata_for(_: &CardCode) -> Option<&'static CardMetadata> {
     None
 }
@@ -48,7 +52,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
             EventTiming::After,
             deal_horror(InvestigatorTarget::Controller, 1),
         )])
-    } else if code.as_str() == DOOM_AGENDA {
+    } else if code.as_str() == DOOM_AGENDA || code.as_str() == DOOM_ACT {
         Some(vec![on_event(
             EventPattern::PhaseEnded {
                 phase: DslPhase::Enemy,
@@ -244,14 +248,8 @@ fn forced_on_phase_end_wrong_phase_fires_nothing() {
     );
 }
 
-/// Cover all four `dsl_phase` mappings: each phase fires the ability only for
-/// the matching engine `Phase`. We reuse four separate agenda codes whose
-/// abilities are keyed to each dsl `Phase`, all mapped into the mock registry
-/// via a local helper.
-///
-/// Because the mock registry is installed once per process (`OnceLock`), this
-/// test uses `DOOM_AGENDA` (Enemy) and separately verifies the three non-Enemy
-/// phases all produce zero hits (the agenda is only keyed to Enemy).
+/// The three non-Enemy phases do not fire an Enemy-keyed forced ability —
+/// exercises the `dsl_phase` mapping's negative side.
 #[test]
 fn dsl_phase_mapping_non_enemy_phases_produce_no_hits() {
     install_mock_registry();
@@ -335,4 +333,42 @@ fn forced_on_phase_end_no_op_when_no_lead_investigator() {
 
     assert_eq!(outcome, EngineOutcome::Done);
     assert!(events.is_empty(), "no events without a lead investigator");
+}
+
+#[test]
+fn forced_on_phase_end_fires_act_ability() {
+    install_mock_registry();
+
+    let inv = test_investigator(1);
+    let mut state = TestGame::new()
+        .with_investigator(inv)
+        .with_turn_order([InvestigatorId(1)])
+        .build();
+    // Set current act to DOOM_ACT, no matching agenda (plain code → None).
+    state.act_deck = vec![Act {
+        code: CardCode(DOOM_ACT.into()),
+        clue_threshold: 3,
+        resolution: None,
+    }];
+    state.act_index = 0;
+    state.agenda_deck = vec![Agenda {
+        code: CardCode("plain-agenda".into()),
+        doom_threshold: 3,
+        resolution: None,
+    }];
+    state.agenda_index = 0;
+
+    let mut events = Vec::new();
+    let outcome = fire_forced_on_phase_end(&mut state, &mut events, Phase::Enemy);
+
+    assert_eq!(outcome, EngineOutcome::Done);
+    assert_eq!(
+        state.investigators[&InvestigatorId(1)].horror,
+        1,
+        "lead investigator should have taken 1 horror from act forced ability"
+    );
+    assert_event!(
+        events,
+        Event::HorrorTaken { investigator, amount: 1 } if *investigator == InvestigatorId(1)
+    );
 }

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -23,9 +23,7 @@ use game_core::dsl::{
 use game_core::engine::EngineOutcome;
 use game_core::event::Event;
 use game_core::state::{CardCode, InvestigatorId, LocationId};
-use game_core::test_support::{
-    fire_forced_at, test_investigator, test_location, ForcedTriggerPoint, TestGame,
-};
+use game_core::test_support::{fire_forced_on_enter, test_investigator, test_location, TestGame};
 
 /// Mock location code: one `EventPattern::EnteredLocation` forced ability
 /// that deals 1 horror to the entering investigator.
@@ -71,14 +69,7 @@ fn forced_on_enter_resolves_immediately() {
         .build();
 
     let mut events = Vec::new();
-    let outcome = fire_forced_at(
-        &mut state,
-        &mut events,
-        ForcedTriggerPoint::EnteredLocation {
-            investigator: InvestigatorId(1),
-            location: LocationId(10),
-        },
-    );
+    let outcome = fire_forced_on_enter(&mut state, &mut events, InvestigatorId(1), LocationId(10));
 
     assert_eq!(outcome, EngineOutcome::Done);
     assert_eq!(state.investigators[&InvestigatorId(1)].horror, 1);
@@ -103,14 +94,7 @@ fn forced_on_enter_no_op_when_location_has_no_abilities() {
         .build();
 
     let mut events = Vec::new();
-    let outcome = fire_forced_at(
-        &mut state,
-        &mut events,
-        ForcedTriggerPoint::EnteredLocation {
-            investigator: InvestigatorId(1),
-            location: LocationId(10),
-        },
-    );
+    let outcome = fire_forced_on_enter(&mut state, &mut events, InvestigatorId(1), LocationId(10));
 
     assert_eq!(outcome, EngineOutcome::Done);
     assert_eq!(state.investigators[&InvestigatorId(1)].horror, 0);

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -17,18 +17,25 @@ use std::sync::OnceLock;
 use game_core::assert_event;
 use game_core::card_data::CardMetadata;
 use game_core::card_registry::CardRegistry;
+use game_core::dsl::Phase as DslPhase;
 use game_core::dsl::{
     deal_horror, on_event, Ability, EventPattern, EventTiming, InvestigatorTarget,
 };
 use game_core::engine::EngineOutcome;
 use game_core::event::Event;
-use game_core::state::{CardCode, InvestigatorId, LocationId, Phase};
-use game_core::test_support::{fire_forced_on_enter, test_investigator, test_location, TestGame};
+use game_core::state::{Agenda, CardCode, InvestigatorId, LocationId, Phase};
+use game_core::test_support::{
+    fire_forced_on_enter, fire_forced_on_phase_end, test_investigator, test_location, TestGame,
+};
 use game_core::{apply, Action, PlayerAction};
 
 /// Mock location code: one `EventPattern::EnteredLocation` forced ability
 /// that deals 1 horror to the entering investigator.
 const HORROR_ATTIC: &str = "test-attic";
+
+/// Mock agenda code: one `EventPattern::PhaseEnded { phase: Enemy }` forced
+/// ability that deals 1 horror to the controller (lead investigator).
+const DOOM_AGENDA: &str = "test-agenda";
 
 fn mock_metadata_for(_: &CardCode) -> Option<&'static CardMetadata> {
     None
@@ -38,6 +45,14 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
     if code.as_str() == HORROR_ATTIC {
         Some(vec![on_event(
             EventPattern::EnteredLocation,
+            EventTiming::After,
+            deal_horror(InvestigatorTarget::Controller, 1),
+        )])
+    } else if code.as_str() == DOOM_AGENDA {
+        Some(vec![on_event(
+            EventPattern::PhaseEnded {
+                phase: DslPhase::Enemy,
+            },
             EventTiming::After,
             deal_horror(InvestigatorTarget::Controller, 1),
         )])
@@ -167,4 +182,157 @@ fn forced_on_enter_no_op_when_location_has_no_abilities() {
         events.is_empty(),
         "no events for a location with no forced abilities"
     );
+}
+
+// ── PhaseEnded tests ──────────────────────────────────────────────────────────
+
+/// Build a `GameState` with the mock agenda (`test-agenda`, Enemy-phase
+/// forced horror) as the current agenda and `InvestigatorId(1)` as the lead.
+fn state_with_doom_agenda() -> game_core::state::GameState {
+    let inv = test_investigator(1);
+    let mut state = TestGame::new()
+        .with_investigator(inv)
+        .with_turn_order([InvestigatorId(1)])
+        .build();
+    state.agenda_deck = vec![Agenda {
+        code: CardCode(DOOM_AGENDA.into()),
+        doom_threshold: 3,
+        resolution: None,
+    }];
+    state.agenda_index = 0;
+    state
+}
+
+#[test]
+fn forced_on_enemy_phase_end_fires_agenda_ability() {
+    install_mock_registry();
+
+    let mut state = state_with_doom_agenda();
+    let mut events = Vec::new();
+    let outcome = fire_forced_on_phase_end(&mut state, &mut events, Phase::Enemy);
+
+    assert_eq!(outcome, EngineOutcome::Done);
+    assert_eq!(
+        state.investigators[&InvestigatorId(1)].horror,
+        1,
+        "lead investigator should have taken 1 horror from agenda forced ability"
+    );
+    assert_event!(
+        events,
+        Event::HorrorTaken { investigator, amount: 1 } if *investigator == InvestigatorId(1)
+    );
+}
+
+#[test]
+fn forced_on_phase_end_wrong_phase_fires_nothing() {
+    install_mock_registry();
+
+    // The agenda ability is keyed to Enemy; firing Mythos should be a no-op.
+    let mut state = state_with_doom_agenda();
+    let mut events = Vec::new();
+    let outcome = fire_forced_on_phase_end(&mut state, &mut events, Phase::Mythos);
+
+    assert_eq!(outcome, EngineOutcome::Done);
+    assert_eq!(
+        state.investigators[&InvestigatorId(1)].horror,
+        0,
+        "no horror for a non-matching phase"
+    );
+    assert!(
+        events.is_empty(),
+        "no events when phase doesn't match agenda ability"
+    );
+}
+
+/// Cover all four `dsl_phase` mappings: each phase fires the ability only for
+/// the matching engine `Phase`. We reuse four separate agenda codes whose
+/// abilities are keyed to each dsl `Phase`, all mapped into the mock registry
+/// via a local helper.
+///
+/// Because the mock registry is installed once per process (`OnceLock`), this
+/// test uses `DOOM_AGENDA` (Enemy) and separately verifies the three non-Enemy
+/// phases all produce zero hits (the agenda is only keyed to Enemy).
+#[test]
+fn dsl_phase_mapping_non_enemy_phases_produce_no_hits() {
+    install_mock_registry();
+
+    for phase in [Phase::Mythos, Phase::Investigation, Phase::Upkeep] {
+        let mut state = state_with_doom_agenda();
+        let mut events = Vec::new();
+        let outcome = fire_forced_on_phase_end(&mut state, &mut events, phase);
+
+        assert_eq!(
+            outcome,
+            EngineOutcome::Done,
+            "expected Done for phase {phase:?}"
+        );
+        assert_eq!(
+            state.investigators[&InvestigatorId(1)].horror,
+            0,
+            "no horror for phase {phase:?} (agenda keyed to Enemy only)"
+        );
+        assert!(
+            events.is_empty(),
+            "no events for phase {phase:?}; got {events:?}"
+        );
+    }
+}
+
+#[test]
+fn forced_on_phase_end_no_op_when_agenda_has_no_abilities() {
+    install_mock_registry();
+
+    let inv = test_investigator(1);
+    let mut state = TestGame::new()
+        .with_investigator(inv)
+        .with_turn_order([InvestigatorId(1)])
+        .build();
+    // "plain-agenda" → None from mock registry.
+    state.agenda_deck = vec![Agenda {
+        code: CardCode("plain-agenda".into()),
+        doom_threshold: 3,
+        resolution: None,
+    }];
+    state.agenda_index = 0;
+
+    let mut events = Vec::new();
+    let outcome = fire_forced_on_phase_end(&mut state, &mut events, Phase::Enemy);
+
+    assert_eq!(outcome, EngineOutcome::Done);
+    assert_eq!(state.investigators[&InvestigatorId(1)].horror, 0);
+    assert!(events.is_empty(), "no events for agenda with no abilities");
+}
+
+#[test]
+fn forced_on_phase_end_no_op_when_no_act_or_agenda() {
+    install_mock_registry();
+
+    // Empty decks — common fixture shape for tests not modeling scenarios.
+    let inv = test_investigator(1);
+    let mut state = TestGame::new()
+        .with_investigator(inv)
+        .with_turn_order([InvestigatorId(1)])
+        .build();
+    // state.agenda_deck / act_deck are empty by default from TestGame.
+
+    let mut events = Vec::new();
+    let outcome = fire_forced_on_phase_end(&mut state, &mut events, Phase::Enemy);
+
+    assert_eq!(outcome, EngineOutcome::Done);
+    assert!(events.is_empty(), "no events when decks are empty");
+}
+
+#[test]
+fn forced_on_phase_end_no_op_when_no_lead_investigator() {
+    install_mock_registry();
+
+    // No turn_order set → no lead investigator → early return.
+    let mut state = state_with_doom_agenda();
+    state.turn_order.clear();
+
+    let mut events = Vec::new();
+    let outcome = fire_forced_on_phase_end(&mut state, &mut events, Phase::Enemy);
+
+    assert_eq!(outcome, EngineOutcome::Done);
+    assert!(events.is_empty(), "no events without a lead investigator");
 }

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -1,0 +1,121 @@
+//! End-to-end `fire_forced_triggers` flow with a mock `CardRegistry`
+//! covering a single `EventPattern::EnteredLocation` forced ability.
+//!
+//! Lives at `crates/game-core/tests/` (a separate integration-test
+//! binary, hence its own process and its own `OnceLock<CardRegistry>`)
+//! so installing a mock registry here doesn't collide with game-core's
+//! in-crate tests or with `card_registry::tests::install_is_idempotent`.
+//! Mirrors `activate_ability.rs` / `on_skill_test_resolution.rs`.
+//!
+//! No real card carries `EventPattern::EnteredLocation` yet — the
+//! first consumer will land when a scenario-structure card with a
+//! location-entry forced ability is implemented. Until then, mock
+//! cards are the only way to exercise the full path.
+
+use std::sync::OnceLock;
+
+use game_core::assert_event;
+use game_core::card_data::CardMetadata;
+use game_core::card_registry::CardRegistry;
+use game_core::dsl::{
+    deal_horror, on_event, Ability, EventPattern, EventTiming, InvestigatorTarget,
+};
+use game_core::engine::EngineOutcome;
+use game_core::event::Event;
+use game_core::state::{CardCode, InvestigatorId, LocationId};
+use game_core::test_support::{
+    fire_forced_at, test_investigator, test_location, ForcedTriggerPoint, TestGame,
+};
+
+/// Mock location code: one `EventPattern::EnteredLocation` forced ability
+/// that deals 1 horror to the entering investigator.
+const HORROR_ATTIC: &str = "test-attic";
+
+fn mock_metadata_for(_: &CardCode) -> Option<&'static CardMetadata> {
+    None
+}
+
+fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
+    if code.as_str() == HORROR_ATTIC {
+        Some(vec![on_event(
+            EventPattern::EnteredLocation,
+            EventTiming::After,
+            deal_horror(InvestigatorTarget::Controller, 1),
+        )])
+    } else {
+        None
+    }
+}
+
+fn install_mock_registry() {
+    static INSTALL: OnceLock<()> = OnceLock::new();
+    INSTALL.get_or_init(|| {
+        let _ = game_core::card_registry::install(CardRegistry {
+            metadata_for: mock_metadata_for,
+            abilities_for: mock_abilities_for,
+        });
+    });
+}
+
+#[test]
+fn forced_on_enter_resolves_immediately() {
+    install_mock_registry();
+
+    let mut loc = test_location(10, "Attic");
+    loc.code = CardCode(HORROR_ATTIC.into());
+
+    let mut state = TestGame::new()
+        .with_investigator_at(test_investigator(1), LocationId(10))
+        .with_location(loc)
+        .with_active_investigator(InvestigatorId(1))
+        .build();
+
+    let mut events = Vec::new();
+    let outcome = fire_forced_at(
+        &mut state,
+        &mut events,
+        ForcedTriggerPoint::EnteredLocation {
+            investigator: InvestigatorId(1),
+            location: LocationId(10),
+        },
+    );
+
+    assert_eq!(outcome, EngineOutcome::Done);
+    assert_eq!(state.investigators[&InvestigatorId(1)].horror, 1);
+    assert_event!(
+        events,
+        Event::HorrorTaken { investigator, amount: 1 } if *investigator == InvestigatorId(1)
+    );
+}
+
+#[test]
+fn forced_on_enter_no_op_when_location_has_no_abilities() {
+    install_mock_registry();
+
+    // "plain-loc" is not HORROR_ATTIC — mock registry returns None.
+    let mut loc = test_location(10, "Plain Room");
+    loc.code = CardCode("plain-loc".into());
+
+    let mut state = TestGame::new()
+        .with_investigator_at(test_investigator(1), LocationId(10))
+        .with_location(loc)
+        .with_active_investigator(InvestigatorId(1))
+        .build();
+
+    let mut events = Vec::new();
+    let outcome = fire_forced_at(
+        &mut state,
+        &mut events,
+        ForcedTriggerPoint::EnteredLocation {
+            investigator: InvestigatorId(1),
+            location: LocationId(10),
+        },
+    );
+
+    assert_eq!(outcome, EngineOutcome::Done);
+    assert_eq!(state.investigators[&InvestigatorId(1)].horror, 0);
+    assert!(
+        events.is_empty(),
+        "no events for a location with no forced abilities"
+    );
+}

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -22,8 +22,9 @@ use game_core::dsl::{
 };
 use game_core::engine::EngineOutcome;
 use game_core::event::Event;
-use game_core::state::{CardCode, InvestigatorId, LocationId};
+use game_core::state::{CardCode, InvestigatorId, LocationId, Phase};
 use game_core::test_support::{fire_forced_on_enter, test_investigator, test_location, TestGame};
+use game_core::{apply, Action, PlayerAction};
 
 /// Mock location code: one `EventPattern::EnteredLocation` forced ability
 /// that deals 1 horror to the entering investigator.
@@ -76,6 +77,58 @@ fn forced_on_enter_resolves_immediately() {
     assert_event!(
         events,
         Event::HorrorTaken { investigator, amount: 1 } if *investigator == InvestigatorId(1)
+    );
+}
+
+#[test]
+fn move_into_forced_location_fires_its_effect() {
+    install_mock_registry();
+
+    // Location A (id 10) — plain starting location, connected to B.
+    let mut from = test_location(10, "Hallway");
+    from.connections = vec![LocationId(11)];
+
+    // Location B (id 11) — has the forced on-enter horror ability.
+    let mut attic = test_location(11, "Attic");
+    attic.code = CardCode(HORROR_ATTIC.into());
+
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(LocationId(10));
+    inv.actions_remaining = 3;
+
+    let state = TestGame::new()
+        .with_investigator(inv)
+        .with_location(from)
+        .with_location(attic)
+        .with_phase(Phase::Investigation)
+        .with_active_investigator(InvestigatorId(1))
+        .build();
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::Move {
+            investigator: InvestigatorId(1),
+            destination: LocationId(11),
+        }),
+    );
+
+    assert!(
+        matches!(result.outcome, EngineOutcome::Done),
+        "outcome was {:?}",
+        result.outcome
+    );
+    assert_eq!(
+        result.state.investigators[&InvestigatorId(1)].current_location,
+        Some(LocationId(11))
+    );
+    assert_eq!(result.state.investigators[&InvestigatorId(1)].horror, 1);
+    assert!(
+        result
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::HorrorTaken { amount: 1, .. })),
+        "expected HorrorTaken {{ amount: 1 }} in events; got {:?}",
+        result.events
     );
 }
 

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -23,7 +23,7 @@ trigger-ordering (`#213`), folding in `#117`.
 |---|---|---|---|
 | — | [#216](https://github.com/talelburg/eldritch/issues/216) — kickoff: spec + engine-spine plans + breakdown | — | ✅ PR #217 |
 | A1 | [#214](https://github.com/talelburg/eldritch/issues/214) — engine-spine primitives (DealDamage/DealHorror, EnteredLocation, Act/Agenda CardCode) | `plans/2026-06-10-…-engine-spine-primitives.md` | ✅ PR #218 |
-| A2 | [#215](https://github.com/talelburg/eldritch/issues/215) — forced-trigger dispatch (`fire_forced_triggers`) — depends on A1 | `plans/2026-06-10-…-forced-trigger-dispatch.md` | ⏳ planned |
+| A2 | [#215](https://github.com/talelburg/eldritch/issues/215) — forced-trigger dispatch (`fire_forced_triggers`) — depends on A1 | `plans/2026-06-10-…-forced-trigger-dispatch.md` | ✅ PR #219 |
 | B | scenario plumbing: `reference_card` + symbol routing; roster/seating + `StartScenario` selection; real-registry swap (D5) | TBD | 📐 spec'd |
 | C | content: Gathering scenario cards + setup + Roland + signature/weakness + starter deck | TBD | 📐 spec'd |
 | D | integration & web: investigator/scenario picker; end-to-end Won/Lost gate | TBD | 📐 spec'd |


### PR DESCRIPTION
## Summary

Phase 7 Slice 1, **Plan A2** — a separate, immediate dispatch path for **Forced** (`Trigger::OnEvent`) abilities printed on scenario-structure cards (locations / acts / agendas), distinct from the player reaction-window machinery. Builds on A1 (#218). The path is a forward-compatible subset of the future `emit_event` unification (#212).

## What changed

- **`EventPattern::PhaseEnded { phase }`** (inert in `trigger_matches`) + a `card-dsl` `Phase` mirror enum (keeps the `card-dsl ← game-core` layering; `dsl_phase` maps at the boundary).
- **`forced_triggers` module** — `ForcedTriggerPoint` (`pub(crate)`, **not** public API) + `fire_forced_triggers`: collects matching forced abilities from the relevant scenario-structure source, then **0→Done, 1→resolve via `apply_effect`, 2+→reject loudly** (no silently-chosen order — the ordering loop is #213).
- **Wired in:** `move_action` (forced-on-enter; e.g. Attic horror / Cellar damage) and `enemy_phase_end` / `upkeep_phase_end` (forced act/agenda effects; e.g. agenda 01107's end-of-enemy-phase + end-of-round abilities).
- **`test_support` helpers** (`fire_forced_on_enter`, `fire_forced_on_phase_end`) take primitive args so `ForcedTriggerPoint` stays internal.

## Design notes worth a look

- **Separate path, reaction windows untouched** — the only `reaction_windows.rs` change is the two inert `trigger_matches` arms; Roland's reaction path is unaffected.
- **Mutate-then-fire + rollback** — `move_action`/phase-end mutate then fire; a `Rejected` (the unreachable-in-slice 2+ case) is rolled back atomically by `apply()`'s transactional snapshot (documented at the call sites, per the `play_card` precedent).
- **`upkeep_phase_end`'s `()` return** can't propagate the 2+ reject — guarded by `debug_assert!`, with #212 noted as the real fix.
- **Mythos/Investigation phase-ends are intentionally not wired** (no slice consumers) — documented as a deliberate omission, not silent.

## Test notes

- 11 integration tests in `crates/game-core/tests/forced_triggers.rs` (separate process → own `OnceLock<CardRegistry>`): forced-on-enter via the public `apply()`, PhaseEnded for **both** act and agenda, the phase-mapping negative side, the 2+ loud-reject guard, and the no-op cases (no abilities / empty decks / no lead).
- Full strict gauntlet green (test/clippy/doc/fmt + wasm), `RUSTFLAGS="-D warnings"`.
- Each task reviewed (spec + quality); final holistic review: READY TO MERGE.

## Linked issues

Closes #215
