### PR TITLE
engine: roster/seating + StartScenario investigator selection (Slice 1 B2)

### DIFF
--- a/crates/cards/tests/roster_seating.rs
+++ b/crates/cards/tests/roster_seating.rs
@@ -1,0 +1,95 @@
+//! B2: seating a roster resolves investigator stats from the real corpus
+//! ([`game_core::CardRegistry`]) and takes the deck from the payload. Integration test so
+//! it can install `cards::REGISTRY` in its own process (per CLAUDE.md test
+//! layering).
+
+use std::sync::Once;
+
+use game_core::action::{PlayerAction, RosterEntry};
+use game_core::engine::{apply, EngineOutcome};
+use game_core::state::{CardCode, InvestigatorId, Skills};
+use game_core::test_support::TestGame;
+use game_core::Action;
+
+/// Install the real card registry exactly once for this integration-test
+/// binary. Idempotent at the `OnceLock` level; the `Once` wrapper avoids
+/// the futile second `install` call.
+fn install_registry() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+#[test]
+fn seats_roland_with_corpus_stats_and_payload_deck() {
+    install_registry();
+    let deck = vec![CardCode::new("01030"), CardCode::new("01030")];
+    let roster = vec![RosterEntry {
+        investigator: CardCode::new("01001"),
+        deck: deck.clone(),
+    }];
+    let state = TestGame::new().build();
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::StartScenario { roster }),
+    );
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    let inv = result
+        .state
+        .investigators
+        .get(&InvestigatorId(1))
+        .expect("Roland seated at id 1");
+    assert_eq!(inv.name, "Roland Banks");
+    assert_eq!(
+        inv.skills,
+        Skills {
+            willpower: 3,
+            intellect: 3,
+            combat: 4,
+            agility: 2
+        }
+    );
+    assert_eq!(inv.max_health, 9);
+    assert_eq!(inv.max_sanity, 5);
+    // Deck + hand together account for the 2 supplied cards (the 5-card
+    // opening-hand draw takes only what's available).
+    assert_eq!(inv.deck.len() + inv.hand.len(), deck.len());
+}
+
+#[test]
+fn rejects_non_investigator_code() {
+    install_registry();
+    // 01030 (Magnifying Glass) is an Asset, not an investigator.
+    let roster = vec![RosterEntry {
+        investigator: CardCode::new("01030"),
+        deck: vec![],
+    }];
+    let state = TestGame::new().build();
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::StartScenario { roster }),
+    );
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert_eq!(result.state.round, 0);
+    assert!(result.events.is_empty());
+}
+
+#[test]
+fn rejects_unknown_code() {
+    install_registry();
+    let roster = vec![RosterEntry {
+        investigator: CardCode::new("99999"),
+        deck: vec![],
+    }];
+    let state = TestGame::new().build();
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::StartScenario { roster }),
+    );
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert_eq!(result.state.round, 0);
+    assert!(result.events.is_empty());
+}

--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -16,7 +16,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::state::{CardInstanceId, EnemyId, InvestigatorId, LocationId, SkillKind};
+use crate::state::{CardCode, CardInstanceId, EnemyId, InvestigatorId, LocationId, SkillKind};
 
 /// A single entry in the action log.
 ///
@@ -38,10 +38,15 @@ pub enum Action {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum PlayerAction {
-    /// Begin a scenario session. Carries no payload at this stage; later
-    /// phases will attach scenario code, investigator selections, deck
-    /// snapshots, etc.
-    StartScenario,
+    /// Begin a scenario session, seating the chosen investigators.
+    ///
+    /// `roster` pairs each investigator card code with the deck the
+    /// player chose for them. Stats are resolved from card data at
+    /// seat time (not carried here); the deck is taken verbatim — a
+    /// free input that Phase 9's decklist import will populate.
+    /// An empty roster seats no one; `start_scenario` rejects unless at
+    /// least one investigator ends up seated.
+    StartScenario { roster: Vec<RosterEntry> },
     /// Active investigator ends their turn during the Investigation phase.
     EndTurn,
     /// Spend clues to advance the current act. Rules Reference p.3:
@@ -251,6 +256,18 @@ pub enum PlayerAction {
         /// The chosen response payload.
         response: InputResponse,
     },
+}
+
+/// One seat in a scenario: which investigator, and the deck the player
+/// chose for them. Crosses the wire and lands in the action log, so the
+/// deck composition replays deterministically.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RosterEntry {
+    /// Investigator card code (e.g. `"01001"` for Roland Banks).
+    pub investigator: CardCode,
+    /// The player's chosen deck, top-to-bottom. Taken verbatim by
+    /// seating; deckbuilding-legality validation is Phase 9.
+    pub deck: Vec<CardCode>,
 }
 
 /// Engine-recorded events.

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -139,7 +139,7 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
     }
 
     let outcome = match action {
-        PlayerAction::StartScenario { .. } => phases::start_scenario(cx),
+        PlayerAction::StartScenario { roster } => phases::start_scenario(cx, roster),
         PlayerAction::EndTurn => phases::end_turn(cx),
         PlayerAction::PerformSkillTest {
             investigator,

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -52,7 +52,7 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
     if cx.state.mulligan_pending.is_some()
         && !matches!(
             action,
-            PlayerAction::Mulligan { .. } | PlayerAction::StartScenario
+            PlayerAction::Mulligan { .. } | PlayerAction::StartScenario { .. }
         )
     {
         return EngineOutcome::Rejected {
@@ -139,7 +139,7 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
     }
 
     let outcome = match action {
-        PlayerAction::StartScenario => phases::start_scenario(cx),
+        PlayerAction::StartScenario { .. } => phases::start_scenario(cx),
         PlayerAction::EndTurn => phases::end_turn(cx),
         PlayerAction::PerformSkillTest {
             investigator,

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -9,7 +9,31 @@ use crate::state::{
     Zone,
 };
 
+use crate::card_data::{CardMetadata, CardType};
+use crate::state::Skills;
+
 use super::Cx;
+
+/// Base skill values for an investigator card, or `None` for any other
+/// card type. For investigator cards `skill_icons` carries the printed
+/// base skills (`wild` is always 0 and ignored); this reinterprets them
+/// as [`Skills`]. `i8::try_from` never fails for real base skills
+/// (single-digit) — an impossible overflow yields `None` rather than a
+/// panic. Lives here, not on `CardMetadata`, because `Skills` is a
+/// `game-core` type and `card-dsl` must not depend on `game-core`.
+// used by start_scenario seating in the next task
+#[allow(dead_code)]
+fn investigator_skills(meta: &CardMetadata) -> Option<Skills> {
+    if meta.card_type != CardType::Investigator {
+        return None;
+    }
+    Some(Skills {
+        willpower: i8::try_from(meta.skill_icons.willpower).ok()?,
+        intellect: i8::try_from(meta.skill_icons.intellect).ok()?,
+        combat: i8::try_from(meta.skill_icons.combat).ok()?,
+        agility: i8::try_from(meta.skill_icons.agility).ok()?,
+    })
+}
 
 /// Action points granted to an investigator at the start of their
 /// turn during the Investigation phase. Per the Arkham Horror LCG
@@ -3000,5 +3024,77 @@ mod hand_size_tests {
             "rejected: still pending"
         );
         assert!(events.is_empty(), "rejected: no events");
+    }
+}
+
+#[cfg(test)]
+mod investigator_skills_tests {
+    use super::*;
+    use crate::card_data::{CardMetadata, CardType, Class, SkillIcons};
+    use crate::state::Skills;
+
+    fn meta(card_type: CardType, icons: SkillIcons) -> CardMetadata {
+        CardMetadata {
+            code: "x".to_owned(),
+            name: "x".to_owned(),
+            class: Class::Guardian,
+            card_type,
+            cost: None,
+            xp: None,
+            text: None,
+            flavor: None,
+            illustrator: None,
+            traits: Vec::new(),
+            slots: Vec::new(),
+            skill_icons: icons,
+            health: Some(9),
+            sanity: Some(5),
+            deck_limit: 0,
+            quantity: 1,
+            pack_code: "core".to_owned(),
+            position: 1,
+            is_fast: false,
+            spawn: None,
+            surge: false,
+            peril: false,
+        }
+    }
+
+    #[test]
+    fn investigator_skills_reads_base_skills_for_investigator_cards() {
+        let m = meta(
+            CardType::Investigator,
+            SkillIcons {
+                willpower: 3,
+                intellect: 3,
+                combat: 4,
+                agility: 2,
+                wild: 0,
+            },
+        );
+        assert_eq!(
+            investigator_skills(&m),
+            Some(Skills {
+                willpower: 3,
+                intellect: 3,
+                combat: 4,
+                agility: 2,
+            }),
+        );
+    }
+
+    #[test]
+    fn investigator_skills_is_none_for_non_investigator_cards() {
+        let m = meta(
+            CardType::Asset,
+            SkillIcons {
+                willpower: 1,
+                intellect: 0,
+                combat: 0,
+                agility: 0,
+                wild: 0,
+            },
+        );
+        assert_eq!(investigator_skills(&m), None);
     }
 }

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -98,7 +98,12 @@ pub(super) fn start_scenario(cx: &mut Cx, roster: &[RosterEntry]) -> EngineOutco
 
     // --- mutate (all validations passed) ---
     // Seat resolved investigators. Ids are sequential (1-based) in roster
-    // order; production seats into an empty investigator set.
+    // order. This ASSUMES an empty investigator set when the roster is
+    // non-empty — true for production (setup() seats nobody) and every
+    // test (pre-seated states pass an empty roster). Mixing a non-empty
+    // roster with pre-seated investigators would overwrite id 1; #224
+    // removes the pre-seated path and makes the roster the sole seater,
+    // retiring this assumption.
     for (idx, (skills, health, sanity, name, deck)) in resolved.into_iter().enumerate() {
         let id = InvestigatorId(u32::try_from(idx).unwrap_or(0) + 1);
         cx.state.investigators.insert(

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -9,8 +9,9 @@ use crate::state::{
     Zone,
 };
 
+use crate::action::RosterEntry;
 use crate::card_data::{CardMetadata, CardType};
-use crate::state::Skills;
+use crate::state::{Investigator, Skills, Status};
 
 use super::Cx;
 
@@ -21,8 +22,6 @@ use super::Cx;
 /// (single-digit) — an impossible overflow yields `None` rather than a
 /// panic. Lives here, not on `CardMetadata`, because `Skills` is a
 /// `game-core` type and `card-dsl` must not depend on `game-core`.
-// used by start_scenario seating in the next task
-#[allow(dead_code)]
 fn investigator_skills(meta: &CardMetadata) -> Option<Skills> {
     if meta.card_type != CardType::Investigator {
         return None;
@@ -40,7 +39,7 @@ fn investigator_skills(meta: &CardMetadata) -> Option<Skills> {
 /// rulebook.
 pub(super) const ACTIONS_PER_TURN: u8 = 3;
 
-pub(super) fn start_scenario(cx: &mut Cx) -> EngineOutcome {
+pub(super) fn start_scenario(cx: &mut Cx, roster: &[RosterEntry]) -> EngineOutcome {
     // The GameState constructor places the world in its initial shape;
     // this action is the explicit "session has begun" marker that lands
     // in the action log. Replaying it on an already-started state is a
@@ -51,6 +50,82 @@ pub(super) fn start_scenario(cx: &mut Cx) -> EngineOutcome {
             reason: "StartScenario applied to a state that is already in progress".into(),
         };
     }
+
+    // Validate-first: resolve every roster entry's stats from card data
+    // before mutating anything. Any failure rejects with state unchanged.
+    let registry = crate::card_registry::current();
+    let mut resolved: Vec<(Skills, u8, u8, String, Vec<CardCode>)> =
+        Vec::with_capacity(roster.len());
+    for entry in roster {
+        let Some(reg) = registry else {
+            return EngineOutcome::Rejected {
+                reason: "no card registry installed; cannot resolve investigator stats".into(),
+            };
+        };
+        let Some(meta) = (reg.metadata_for)(&entry.investigator) else {
+            return EngineOutcome::Rejected {
+                reason: format!("unknown investigator code {}", entry.investigator).into(),
+            };
+        };
+        let (Some(skills), Some(health), Some(sanity)) =
+            (investigator_skills(meta), meta.health, meta.sanity)
+        else {
+            return EngineOutcome::Rejected {
+                reason: format!("card {} is not a seatable investigator", entry.investigator)
+                    .into(),
+            };
+        };
+        resolved.push((
+            skills,
+            health,
+            sanity,
+            meta.name.clone(),
+            entry.deck.clone(),
+        ));
+    }
+
+    // A scenario requires at least one investigator (pre-seated or
+    // roster-seated). In production setup() seats none, so this makes the
+    // roster mandatory: an empty roster rejects. The pre-seated test path
+    // (>=1 already present, empty roster) passes — temporary scaffolding
+    // until TODO(#224) migrates tests to roster seating and tightens this
+    // to require a non-empty roster.
+    if cx.state.investigators.is_empty() && resolved.is_empty() {
+        return EngineOutcome::Rejected {
+            reason: "a scenario requires at least one investigator".into(),
+        };
+    }
+
+    // --- mutate (all validations passed) ---
+    // Seat resolved investigators. Ids are sequential (1-based) in roster
+    // order; production seats into an empty investigator set.
+    for (idx, (skills, health, sanity, name, deck)) in resolved.into_iter().enumerate() {
+        let id = InvestigatorId(u32::try_from(idx).unwrap_or(0) + 1);
+        cx.state.investigators.insert(
+            id,
+            Investigator {
+                id,
+                name,
+                current_location: None,
+                skills,
+                max_health: health,
+                damage: 0,
+                max_sanity: sanity,
+                horror: 0,
+                clues: 0,
+                resources: 5,
+                actions_remaining: 0,
+                status: Status::Active,
+                deck,
+                hand: Vec::new(),
+                discard: Vec::new(),
+                cards_in_play: Vec::new(),
+                removed_from_game: Vec::new(),
+            },
+        );
+        cx.state.turn_order.push(id);
+    }
+
     // Round 1: scenario starts directly in Investigation phase —
     // Mythos is skipped entirely per Rules Reference p.24 "During
     // the first round of the game, skip the mythos phase." No
@@ -3024,6 +3099,59 @@ mod hand_size_tests {
             "rejected: still pending"
         );
         assert!(events.is_empty(), "rejected: no events");
+    }
+}
+
+#[cfg(test)]
+mod start_scenario_tests {
+    use super::*;
+    use crate::action::{Action, PlayerAction, RosterEntry};
+    use crate::engine::apply;
+    use crate::state::CardCode;
+    use crate::test_support::builder::TestGame;
+    use crate::test_support::fixtures::test_investigator;
+
+    #[test]
+    fn start_scenario_rejects_when_roster_would_seat_zero_investigators() {
+        let state = TestGame::new().build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert_eq!(result.state.round, 0, "state unchanged on reject");
+        assert!(result.events.is_empty(), "no events on reject");
+    }
+
+    #[test]
+    fn start_scenario_empty_roster_passes_through_with_preseated_investigator() {
+        let id = crate::state::InvestigatorId(1);
+        let state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_turn_order([id])
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_eq!(result.state.round, 1);
+    }
+
+    #[test]
+    fn start_scenario_rejects_non_empty_roster_when_no_registry_installed() {
+        let state = TestGame::new().build();
+        let roster = vec![RosterEntry {
+            investigator: CardCode::new("01001"),
+            deck: vec![],
+        }];
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::StartScenario { roster }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert_eq!(result.state.round, 0, "state unchanged on reject");
+        assert!(result.events.is_empty());
     }
 }
 

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -3138,8 +3138,17 @@ mod start_scenario_tests {
         assert_eq!(result.state.round, 1);
     }
 
+    // A non-empty roster whose entry cannot be resolved to investigator
+    // stats rejects with state unchanged. game-core unit tests install no
+    // real `CardRegistry`, so resolution fails — via the "no registry"
+    // path, or (if another test in this binary already installed a fake
+    // registry, since `card_registry::current()` is a process-global
+    // `OnceLock`) via the "unknown code" path, as "01001" is not in the
+    // fake. Either way it rejects; the registry-backed happy and
+    // unknown-code paths are pinned deterministically by the
+    // `crates/cards` integration test, which installs `cards::REGISTRY`.
     #[test]
-    fn start_scenario_rejects_non_empty_roster_when_no_registry_installed() {
+    fn start_scenario_rejects_unresolvable_roster_entry() {
         let state = TestGame::new().build();
         let roster = vec![RosterEntry {
             investigator: CardCode::new("01001"),

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -222,7 +222,10 @@ mod tests {
             .with_investigator(test_investigator(1))
             .with_turn_order([id])
             .build();
-        let start_result = apply(state, Action::Player(PlayerAction::StartScenario));
+        let start_result = apply(
+            state,
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
+        );
 
         assert_eq!(start_result.outcome, EngineOutcome::Done);
         assert_eq!(start_result.state.round, 1);
@@ -295,7 +298,10 @@ mod tests {
     #[test]
     fn start_scenario_on_already_started_state_is_rejected() {
         let state = TestGame::new().with_round(7).build();
-        let result = apply(state, Action::Player(PlayerAction::StartScenario));
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
+        );
 
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
         assert_eq!(result.state.round, 7);
@@ -1056,7 +1062,10 @@ mod tests {
         // StartScenario: round 0 → 1, phase Investigation (mulligan window
         // open). The Investigation phase does NOT begin until the last
         // investigator mulligans — active_investigator is None here.
-        let result = apply(state, Action::Player(PlayerAction::StartScenario));
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
+        );
         let state = result.state;
         assert_eq!(state.round, 1);
         assert_eq!(state.phase, Phase::Investigation);
@@ -1182,7 +1191,11 @@ mod tests {
 
         // StartScenario: round 0 → 1, mulligan window opens.
         // active_investigator is None until mulligan completion.
-        let after_start = apply(state, Action::Player(PlayerAction::StartScenario)).state;
+        let after_start = apply(
+            state,
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
+        )
+        .state;
         assert_eq!(after_start.round, 1);
         assert_eq!(
             after_start.active_investigator, None,
@@ -1264,7 +1277,10 @@ mod tests {
             .with_turn_order([id])
             .with_rng_seed(42)
             .build();
-        let result = apply(state, Action::Player(PlayerAction::StartScenario));
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
+        );
 
         assert_eq!(result.outcome, EngineOutcome::Done);
         assert_event!(
@@ -1297,7 +1313,10 @@ mod tests {
             .with_investigator(test_investigator(1))
             .with_turn_order([id])
             .build();
-        let result = apply(state, Action::Player(PlayerAction::StartScenario));
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
+        );
 
         assert_eq!(result.outcome, EngineOutcome::Done);
         // Empty-deck no-op shuffle: no event.
@@ -1324,7 +1343,10 @@ mod tests {
             .with_turn_order([id])
             .with_rng_seed(7)
             .build();
-        let result = apply(state, Action::Player(PlayerAction::StartScenario));
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
+        );
 
         assert_eq!(result.outcome, EngineOutcome::Done);
         assert_event!(
@@ -1351,8 +1373,14 @@ mod tests {
             .with_rng_seed(123)
             .build();
 
-        let result_a = apply(state_a, Action::Player(PlayerAction::StartScenario));
-        let result_b = apply(state_b, Action::Player(PlayerAction::StartScenario));
+        let result_a = apply(
+            state_a,
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
+        );
+        let result_b = apply(
+            state_b,
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
+        );
 
         assert_eq!(
             result_a.state.investigators[&id].deck,
@@ -1409,7 +1437,10 @@ mod tests {
             inv.deck = make_test_deck(8);
             tg = tg.with_investigator(inv);
         }
-        let result = apply(tg.build(), Action::Player(PlayerAction::StartScenario));
+        let result = apply(
+            tg.build(),
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
+        );
         assert_eq!(result.outcome, EngineOutcome::Done);
 
         // Each investigator drew 5 cards and has 3 left in deck.
@@ -3148,7 +3179,10 @@ mod tests {
             .with_investigator(inv)
             .with_turn_order([id])
             .build();
-        let result = apply(state, Action::Player(PlayerAction::StartScenario));
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
+        );
         assert_eq!(result.outcome, EngineOutcome::Done);
         assert_eq!(result.state.mulligan_pending, Some(id));
     }

--- a/crates/scenarios/tests/closing_demo.rs
+++ b/crates/scenarios/tests/closing_demo.rs
@@ -104,7 +104,7 @@ fn won_walk_full_cycle_replays_identically() {
         response: InputResponse::CommitCards { indices: vec![] },
     });
     let log = vec![
-        Action::Player(PlayerAction::StartScenario),
+        Action::Player(PlayerAction::StartScenario { roster: vec![] }),
         Action::Player(PlayerAction::Mulligan {
             investigator: inv,
             indices_to_redraw: vec![],
@@ -173,7 +173,7 @@ fn lost_walk_spawn_attack_doom_replays_identically() {
     // when a Mythos draw is pending and breaking on resolution. Record the
     // realized action log so the round-trip replays exactly what ran.
     let mut log = vec![
-        Action::Player(PlayerAction::StartScenario),
+        Action::Player(PlayerAction::StartScenario { roster: vec![] }),
         Action::Player(PlayerAction::Mulligan {
             investigator: inv,
             indices_to_redraw: vec![],

--- a/crates/scenarios/tests/mythos_phase.rs
+++ b/crates/scenarios/tests/mythos_phase.rs
@@ -68,7 +68,7 @@ fn setup_at_mythos_draw(state: game_core::state::GameState) -> game_core::state:
         state,
         vec![
             // Round 1 begins; mulligan window opens.
-            Action::Player(PlayerAction::StartScenario),
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
             // Close mulligan window (empty redraw = keep hand).
             Action::Player(PlayerAction::Mulligan {
                 investigator: inv1,
@@ -264,7 +264,7 @@ fn mythos_phase_multi_investigator_spawn_suspends_then_resumes_chain() {
     let (state, _) = drive(
         base,
         vec![
-            Action::Player(PlayerAction::StartScenario),
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
             Action::Player(PlayerAction::Mulligan {
                 investigator: InvestigatorId(1),
                 indices_to_redraw: vec![],
@@ -360,7 +360,7 @@ fn mythos_phase_multi_investigator_player_order() {
     let (state, _) = drive(
         base,
         vec![
-            Action::Player(PlayerAction::StartScenario),
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
             Action::Player(PlayerAction::Mulligan {
                 investigator: inv1,
                 indices_to_redraw: vec![],
@@ -473,7 +473,7 @@ fn mythos_phase_multi_investigator_surge_does_not_spill() {
     let (state, _) = drive(
         base,
         vec![
-            Action::Player(PlayerAction::StartScenario),
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
             Action::Player(PlayerAction::Mulligan {
                 investigator: inv1,
                 indices_to_redraw: vec![],

--- a/crates/scenarios/tests/synthetic_resolution.rs
+++ b/crates/scenarios/tests/synthetic_resolution.rs
@@ -61,7 +61,7 @@ fn synthetic_scenario_resolves_won_via_act_advance() {
     let (mut state, _) = drive(
         state,
         vec![
-            Action::Player(PlayerAction::StartScenario),
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
             Action::Player(PlayerAction::Mulligan {
                 investigator: inv,
                 indices_to_redraw: vec![],
@@ -98,7 +98,7 @@ fn synthetic_scenario_resolves_lost_via_doom() {
     let (mut state, _) = drive(
         base,
         vec![
-            Action::Player(PlayerAction::StartScenario),
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
             Action::Player(PlayerAction::Mulligan {
                 investigator: inv,
                 indices_to_redraw: vec![],

--- a/crates/scenarios/tests/upkeep_hand_size.rs
+++ b/crates/scenarios/tests/upkeep_hand_size.rs
@@ -48,7 +48,10 @@ fn upkeep_prompts_and_discards_down_to_eight() {
     }
 
     // StartScenario → mulligan (keep hand).
-    let r1 = apply(base, Action::Player(PlayerAction::StartScenario));
+    let r1 = apply(
+        base,
+        Action::Player(PlayerAction::StartScenario { roster: vec![] }),
+    );
     assert_eq!(r1.outcome, EngineOutcome::Done);
 
     let r2 = apply(
@@ -186,7 +189,7 @@ fn upkeep_hand_size_discard_replay_is_deterministic() {
     let indices: Vec<u32> = (0..discard_count).collect();
 
     let actions = vec![
-        Action::Player(PlayerAction::StartScenario),
+        Action::Player(PlayerAction::StartScenario { roster: vec![] }),
         Action::Player(PlayerAction::Mulligan {
             investigator: inv1,
             indices_to_redraw: vec![],

--- a/crates/scenarios/tests/upkeep_phase.rs
+++ b/crates/scenarios/tests/upkeep_phase.rs
@@ -53,7 +53,10 @@ fn upkeep_full_round_draws_and_grants_then_pauses_at_mythos() {
     }
 
     // StartScenario → mulligan (keep hand).
-    let r1 = apply(base, Action::Player(PlayerAction::StartScenario));
+    let r1 = apply(
+        base,
+        Action::Player(PlayerAction::StartScenario { roster: vec![] }),
+    );
     assert_eq!(r1.outcome, EngineOutcome::Done);
 
     let r2 = apply(
@@ -128,7 +131,7 @@ fn upkeep_round_replay_is_deterministic() {
 
     // --- First pass: drive and collect the action log. ---
     let actions = vec![
-        Action::Player(PlayerAction::StartScenario),
+        Action::Player(PlayerAction::StartScenario { roster: vec![] }),
         Action::Player(PlayerAction::Mulligan {
             investigator: inv1,
             indices_to_redraw: vec![],

--- a/crates/server/tests/game_session.rs
+++ b/crates/server/tests/game_session.rs
@@ -95,7 +95,10 @@ async fn apply_persists_accepted_action_and_advances_state() {
         .await
         .unwrap();
 
-    let (_events, outcome) = session.apply(PlayerAction::StartScenario).await.unwrap();
+    let (_events, outcome) = session
+        .apply(PlayerAction::StartScenario { roster: vec![] })
+        .await
+        .unwrap();
 
     assert!(!matches!(outcome, EngineOutcome::Rejected { .. }));
     // StartScenario moves the round from 0 to 1.
@@ -142,7 +145,10 @@ async fn load_replays_log_to_reproduce_live_state() {
     let mut session = GameSession::create(pool.clone(), "g4", ScenarioId::new(TEST_SCENARIO_ID))
         .await
         .unwrap();
-    session.apply(PlayerAction::StartScenario).await.unwrap();
+    session
+        .apply(PlayerAction::StartScenario { roster: vec![] })
+        .await
+        .unwrap();
 
     let loaded = GameSession::load(pool.clone(), &GameId::new("g4"))
         .await

--- a/crates/server/tests/ws.rs
+++ b/crates/server/tests/ws.rs
@@ -51,7 +51,7 @@ async fn accepted_action_broadcasts_applied_to_all_clients() {
     send(
         &mut a,
         &ClientMessage::Submit {
-            action: PlayerAction::StartScenario,
+            action: PlayerAction::StartScenario { roster: vec![] },
         },
     )
     .await;

--- a/crates/web/src/controls.rs
+++ b/crates/web/src/controls.rs
@@ -330,7 +330,7 @@ pub fn ActionControls() -> impl IntoView {
                         "Start scenario",
                         !has(ActionControl::StartScenario),
                         tx.clone(),
-                        PlayerAction::StartScenario,
+                        PlayerAction::StartScenario { roster: vec![] },
                     )}
                     {investigate}
                     {advance_act}

--- a/crates/web/tests/controls.rs
+++ b/crates/web/tests/controls.rs
@@ -433,7 +433,7 @@ async fn start_scenario_is_the_only_control_at_round_zero() {
     leptos::task::tick().await;
     let frame = rx.try_recv().expect("a frame after tick");
     match submit_action(frame) {
-        PlayerAction::StartScenario => {}
+        PlayerAction::StartScenario { .. } => {}
         other => panic!("expected StartScenario, got {other:?}"),
     }
 }

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -25,7 +25,7 @@ trigger-ordering (`#213`), folding in `#117`.
 | A1 | [#214](https://github.com/talelburg/eldritch/issues/214) — engine-spine primitives (DealDamage/DealHorror, EnteredLocation, Act/Agenda CardCode) | `plans/2026-06-10-…-engine-spine-primitives.md` | ✅ PR #218 |
 | A2 | [#215](https://github.com/talelburg/eldritch/issues/215) — forced-trigger dispatch (`fire_forced_triggers`) — depends on A1 | `plans/2026-06-10-…-forced-trigger-dispatch.md` | ✅ PR #219 |
 | B1 | [#220](https://github.com/talelburg/eldritch/issues/220) — `reference_card` field + symbol-token lookup plumbing | `plans/2026-06-10-…-reference-card-routing.md` | ✅ PR #223 |
-| B2 | [#221](https://github.com/talelburg/eldritch/issues/221) — roster/seating step + `StartScenario` investigator selection (protocol change) | TBD | 📐 spec'd |
+| B2 | [#221](https://github.com/talelburg/eldritch/issues/221) — roster/seating step + `StartScenario` investigator selection (protocol change) | `plans/2026-06-10-…-b2-roster-seating.md` | ✅ PR #225 |
 | B3 | [#222](https://github.com/talelburg/eldritch/issues/222) — registry-swap foundation (server installs real card + scenario registries; D5) | TBD | 📐 spec'd |
 | C | content: Gathering scenario cards + setup + Roland + signature/weakness + starter deck | TBD | 📐 spec'd |
 | D | integration & web: investigator/scenario picker; end-to-end Won/Lost gate | TBD | 📐 spec'd |
@@ -76,6 +76,7 @@ Devourer Below, campaign log + `Fact` enum) is **Phase 9**, not Phase 7.
 - **The Gathering** is the first scenario of the original Core Set's *Night of the Zealot* campaign. Three locations to start (Study + connections), with the campaign expanding from there.
 - **"Solo with 1–2 investigators" is the supported mode** for this phase. Multiplayer (two human investigators on different machines) is Phase 8.
 - **All 5 original-Core investigators implementable:** Roland Banks (`#55`, already filed in Phase 3), Daisy Walker, "Skids" O'Toole, Agnes Baker, Wendy Adams. Each needs their card impl + signature cards.
+- **Investigator seating (B2):** stats are read from `CardMetadata` via the existing `CardRegistry` (no new registry); the deck is a player-supplied `RosterEntry { investigator, deck }` field on `StartScenario` (the Phase-9 decklist-import seam). `start_scenario` rejects unless ≥1 investigator is seated; the pre-seated synthetic-test path is tolerated until [#224](https://github.com/talelburg/eldritch/issues/224) migrates tests to roster seating and requires a non-empty roster.
 
 ## Open questions
 

--- a/docs/superpowers/plans/2026-06-10-phase-7-slice-1-b2-roster-seating.md
+++ b/docs/superpowers/plans/2026-06-10-phase-7-slice-1-b2-roster-seating.md
@@ -1,0 +1,550 @@
+# Phase 7 Slice 1 B2 — Roster/seating + `StartScenario` selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `StartScenario` carry a roster of `{ investigator, deck }` entries; `start_scenario` resolves each investigator's stats from `CardMetadata` (existing `CardRegistry`), seats them with the payload deck, and rejects unless ≥1 investigator ends up seated — then the existing shuffle/deal runs unchanged.
+
+**Architecture:** No new registry. A free helper `investigator_skills(&CardMetadata) -> Option<Skills>` (in `game-core`, since `Skills` is a `game-core` type and `card-dsl` can't depend on it) reinterprets an investigator card's `skill_icons` as base skills. `PlayerAction::StartScenario` becomes a struct variant `{ roster: Vec<RosterEntry> }`. Seating is validate-first: resolve+validate the whole roster before any mutation.
+
+**Tech Stack:** Rust; `game-core` kernel, `protocol`/`web`/`server`/`scenarios` consumers, `cards` corpus for the integration test.
+
+---
+
+## Key facts (verified against the codebase)
+
+- `Cx<'a> { state: &'a mut GameState, events: &'a mut Vec<Event> }` — `crates/game-core/src/engine/cx.rs`.
+- Dispatch routing: `crates/game-core/src/engine/dispatch/mod.rs:142` `PlayerAction::StartScenario => phases::start_scenario(cx)`, and a `matches!` guard at `:54-56` `PlayerAction::Mulligan { .. } | PlayerAction::StartScenario`.
+- `start_scenario(cx: &mut Cx) -> EngineOutcome` — `crates/game-core/src/engine/dispatch/phases.rs:19`. Order today: reject if `round != 0` → set `round=1`/`phase` → push `ScenarioStarted` → shuffle+deal each investigator → seed mulligan cursor → `reset_actions`.
+- `Investigator` literal fields — `crates/game-core/src/test_support/fixtures.rs:36-59`. `Skills { willpower, intellect, combat, agility }` are `i8`; `SkillIcons { willpower, intellect, combat, agility, wild }` are `u8`.
+- `card_registry::current() -> Option<&'static CardRegistry>`; `(reg.metadata_for)(&CardCode) -> Option<&'static CardMetadata>` — `crates/game-core/src/card_registry.rs:79,50`.
+- `CardType`, `CardMetadata`, `SkillIcons`, `Class`, `Slot` reachable in `game-core` via `crate::card_data::*`. `Roland 01001`: `skill_icons { willpower:3, intellect:3, combat:4, agility:2, wild:0 }`, `health: Some(9)`, `sanity: Some(5)`. `01030` (Magnifying Glass) is an Asset — a valid non-investigator reject fixture.
+- No existing test relies on `StartScenario` succeeding with zero investigators (the round-7 reject test trips the `round != 0` guard first). Every `start_scenario` happy-path test uses `with_investigator`.
+
+## File map
+
+- **Modify** `crates/game-core/src/action.rs` — add `RosterEntry`; change `StartScenario` to a struct variant.
+- **Modify** `crates/game-core/src/engine/dispatch/mod.rs` — `matches!` guard + routing pass `roster`.
+- **Modify** `crates/game-core/src/engine/dispatch/phases.rs` — `investigator_skills` helper + `start_scenario` signature/seating + unit tests.
+- **Mechanical edits** (compiler-driven, `roster: vec![]` / `{ .. }`): every other `StartScenario` construction or match site across `game-core`, `scenarios`, `server`, `web`.
+- **Create** `crates/cards/tests/roster_seating.rs` — integration test (installs `cards::REGISTRY`).
+
+---
+
+### Task 1: Protocol shape — `RosterEntry` + `StartScenario { roster }`, migrate all sites (behavior-preserving)
+
+**Files:**
+- Modify: `crates/game-core/src/action.rs:43-48`
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs:54-56,142`
+- Modify: every other `StartScenario` site (compiler-driven)
+
+This task changes only the *shape*; `start_scenario` still ignores the roster, so all existing tests pass unchanged.
+
+- [ ] **Step 1: Add `RosterEntry` and convert the variant**
+
+In `crates/game-core/src/action.rs`, replace the unit `StartScenario` variant and add the struct. Confirm `CardCode` is imported (it is used elsewhere in this file; add `use crate::state::CardCode;` if not in scope):
+
+```rust
+    /// Begin a scenario session, seating the chosen investigators.
+    ///
+    /// `roster` pairs each investigator card code with the deck the
+    /// player chose for them. Stats are resolved from card data at
+    /// seat time (not carried here); the deck is taken verbatim — a
+    /// free input that Phase 9's decklist import will populate.
+    /// An empty roster seats no one; `start_scenario` rejects unless at
+    /// least one investigator ends up seated.
+    StartScenario { roster: Vec<RosterEntry> },
+```
+
+Add this struct near the enum (after it, before the next `///`-doc item):
+
+```rust
+/// One seat in a scenario: which investigator, and the deck the player
+/// chose for them. Crosses the wire and lands in the action log, so the
+/// deck composition replays deterministically.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RosterEntry {
+    /// Investigator card code (e.g. `"01001"` for Roland Banks).
+    pub investigator: CardCode,
+    /// The player's chosen deck, top-to-bottom. Taken verbatim by
+    /// seating; deckbuilding-legality validation is Phase 9.
+    pub deck: Vec<CardCode>,
+}
+```
+
+- [ ] **Step 2: Update the dispatch match arm + guard (these are matches, not construction)**
+
+In `crates/game-core/src/engine/dispatch/mod.rs`, the `matches!` guard (`:54-56`):
+
+```rust
+            PlayerAction::Mulligan { .. } | PlayerAction::StartScenario { .. }
+```
+
+and the routing arm (`:142`) — still ignore the roster this task:
+
+```rust
+        PlayerAction::StartScenario { .. } => phases::start_scenario(cx),
+```
+
+- [ ] **Step 3: Build to surface every remaining site, fix mechanically**
+
+Run: `cargo build --all --all-features --tests 2>&1 | grep -E "error" | head -40`
+
+For each error: a **construction** site (`PlayerAction::StartScenario` as a value) becomes `PlayerAction::StartScenario { roster: vec![] }`; a **match/`matches!`** site becomes `PlayerAction::StartScenario { .. }`. These span `crates/game-core/src/engine/mod.rs`, `state/game_state.rs`, `test_support/builder.rs`, `crates/scenarios/tests/*`, `crates/server/tests/*`, `crates/web/src/controls.rs`, `crates/web/tests/controls.rs`. (Note: `ActionControl::StartScenario` in `crates/web/src/legality.rs` is a *different* enum — leave it.) Re-run until the build is clean.
+
+- [ ] **Step 4: Confirm green, no behavior change**
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features 2>&1 | tail -5`
+Expected: all existing tests pass (roster is ignored; behavior identical).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "protocol: StartScenario carries a roster of RosterEntry
+
+Struct variant { roster: Vec<RosterEntry> } + RosterEntry { investigator,
+deck }. Roster ignored by start_scenario this commit (behavior-preserving
+migration); seating wired in a follow-up commit.
+
+Part of #221.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `investigator_skills` helper + unit test
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/phases.rs` (helper + `#[cfg(test)]`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the test module in `crates/game-core/src/engine/dispatch/phases.rs` (a `#[cfg(test)] mod tests` already exists there — append these). The local `meta` builder fills every `CardMetadata` field (the struct isn't `#[non_exhaustive]`):
+
+```rust
+    use crate::card_data::{CardMetadata, CardType, Class, SkillIcons};
+    use crate::state::Skills;
+
+    fn meta(card_type: CardType, icons: SkillIcons) -> CardMetadata {
+        CardMetadata {
+            code: "x".to_owned(),
+            name: "x".to_owned(),
+            class: Class::Guardian,
+            card_type,
+            cost: None,
+            xp: None,
+            text: None,
+            flavor: None,
+            illustrator: None,
+            traits: Vec::new(),
+            slots: Vec::new(),
+            skill_icons: icons,
+            health: Some(9),
+            sanity: Some(5),
+            deck_limit: 0,
+            quantity: 1,
+            pack_code: "core".to_owned(),
+            position: 1,
+            is_fast: false,
+            spawn: None,
+            surge: false,
+            peril: false,
+        }
+    }
+
+    #[test]
+    fn investigator_skills_reads_base_skills_for_investigator_cards() {
+        let m = meta(
+            CardType::Investigator,
+            SkillIcons { willpower: 3, intellect: 3, combat: 4, agility: 2, wild: 0 },
+        );
+        assert_eq!(
+            investigator_skills(&m),
+            Some(Skills { willpower: 3, intellect: 3, combat: 4, agility: 2 }),
+        );
+    }
+
+    #[test]
+    fn investigator_skills_is_none_for_non_investigator_cards() {
+        let m = meta(
+            CardType::Asset,
+            SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 },
+        );
+        assert_eq!(investigator_skills(&m), None);
+    }
+```
+
+If `CardType::Asset` / `Class::Guardian` aren't the exact variant names, adjust to the real ones (check `crates/card-dsl/src/card_data.rs`); the *behavior* is what matters.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p game-core investigator_skills 2>&1 | grep -E "cannot find|error" | head`
+Expected: FAIL — `cannot find function \`investigator_skills\``.
+
+- [ ] **Step 3: Implement the helper**
+
+Add near the top of `crates/game-core/src/engine/dispatch/phases.rs` (after the imports; extend the `use crate::card_data::…` / `use crate::state::…` lines as needed for `CardMetadata`, `CardType`, `Skills`):
+
+```rust
+/// Base skill values for an investigator card, or `None` for any other
+/// card type. For investigator cards `skill_icons` carries the printed
+/// base skills (`wild` is always 0 and ignored); this reinterprets them
+/// as [`Skills`]. `i8::try_from` never fails for real base skills
+/// (single-digit) — an impossible overflow yields `None` rather than a
+/// panic. Lives here, not on `CardMetadata`, because `Skills` is a
+/// `game-core` type and `card-dsl` must not depend on `game-core`.
+fn investigator_skills(meta: &CardMetadata) -> Option<Skills> {
+    if meta.card_type != CardType::Investigator {
+        return None;
+    }
+    Some(Skills {
+        willpower: i8::try_from(meta.skill_icons.willpower).ok()?,
+        intellect: i8::try_from(meta.skill_icons.intellect).ok()?,
+        combat: i8::try_from(meta.skill_icons.combat).ok()?,
+        agility: i8::try_from(meta.skill_icons.agility).ok()?,
+    })
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p game-core investigator_skills 2>&1 | grep -E "test result|investigator_skills"`
+Expected: both tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/phases.rs
+git commit -m "engine: investigator_skills helper (skill_icons -> Skills, type-guarded)
+
+Part of #221.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Seat the roster in `start_scenario` (validate-first) + invariant
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/phases.rs:19-64` (`start_scenario`)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs:142` (pass roster)
+- Test: `crates/game-core/src/engine/dispatch/phases.rs` (`#[cfg(test)]`)
+
+- [ ] **Step 1: Write the failing tests** (no card registry needed for these)
+
+Append to the phases.rs test module. These exercise the registry-absent and zero-investigator paths, plus empty-roster passthrough:
+
+```rust
+    use crate::action::{PlayerAction, RosterEntry};
+    use crate::engine::apply;
+    use crate::action::Action;
+    use crate::state::CardCode;
+    use crate::test_support::builder::TestGame;
+    use crate::test_support::fixtures::test_investigator;
+
+    #[test]
+    fn start_scenario_rejects_when_roster_would_seat_zero_investigators() {
+        // Empty roster, no pre-seated investigators -> zero investigators.
+        let state = TestGame::new().build();
+        let result = apply(state, Action::Player(PlayerAction::StartScenario { roster: vec![] }));
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert_eq!(result.state.round, 0, "state unchanged on reject");
+        assert!(result.events.is_empty(), "no events on reject");
+    }
+
+    #[test]
+    fn start_scenario_empty_roster_passes_through_with_preseated_investigator() {
+        // Pre-seated investigator + empty roster: ≥1 investigator, Done.
+        let id = crate::state::InvestigatorId(1);
+        let state = TestGame::new()
+            .with_investigator(test_investigator(1))
+            .with_turn_order([id])
+            .build();
+        let result = apply(state, Action::Player(PlayerAction::StartScenario { roster: vec![] }));
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_eq!(result.state.round, 1);
+    }
+
+    #[test]
+    fn start_scenario_rejects_non_empty_roster_when_no_registry_installed() {
+        // game-core unit tests install no CardRegistry; resolving a code fails.
+        let state = TestGame::new().build();
+        let roster = vec![RosterEntry { investigator: CardCode::new("01001"), deck: vec![] }];
+        let result = apply(state, Action::Player(PlayerAction::StartScenario { roster }));
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert_eq!(result.state.round, 0, "state unchanged on reject");
+        assert!(result.events.is_empty());
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p game-core start_scenario_rejects_when_roster 2>&1 | tail -15`
+Expected: FAIL — the variant now needs `{ roster }` (compile error) and/or the zero-investigator reject doesn't exist yet (the current `start_scenario` returns `Done` with an empty `turn_order`).
+
+- [ ] **Step 3: Thread the roster and implement validate-first seating**
+
+In `crates/game-core/src/engine/dispatch/mod.rs:142`:
+
+```rust
+        PlayerAction::StartScenario { roster } => phases::start_scenario(cx, roster),
+```
+
+Rewrite `start_scenario` in `phases.rs`. Change the signature and insert resolve→invariant→seat **before** any mutation. Add `use crate::action::RosterEntry;` and `use crate::state::{CardCode, Investigator, Skills, Status};` imports as needed (some are already present):
+
+```rust
+pub(super) fn start_scenario(cx: &mut Cx, roster: &[RosterEntry]) -> EngineOutcome {
+    if cx.state.round != 0 {
+        return EngineOutcome::Rejected {
+            reason: "StartScenario applied to a state that is already in progress".into(),
+        };
+    }
+
+    // Validate-first: resolve every roster entry's stats from card data
+    // before mutating anything. Any failure rejects with state unchanged.
+    let registry = crate::card_registry::current();
+    let mut resolved: Vec<(Skills, u8, u8, String, Vec<CardCode>)> = Vec::with_capacity(roster.len());
+    for entry in roster {
+        let Some(reg) = registry else {
+            return EngineOutcome::Rejected {
+                reason: "no card registry installed; cannot resolve investigator stats".into(),
+            };
+        };
+        let Some(meta) = (reg.metadata_for)(&entry.investigator) else {
+            return EngineOutcome::Rejected {
+                reason: format!("unknown investigator code {}", entry.investigator),
+            };
+        };
+        let (Some(skills), Some(health), Some(sanity)) =
+            (investigator_skills(meta), meta.health, meta.sanity)
+        else {
+            return EngineOutcome::Rejected {
+                reason: format!("card {} is not a seatable investigator", entry.investigator),
+            };
+        };
+        resolved.push((skills, health, sanity, meta.name.clone(), entry.deck.clone()));
+    }
+
+    // A scenario requires at least one investigator (pre-seated or
+    // roster-seated). In production setup() seats none, so this makes the
+    // roster mandatory: an empty roster rejects. The pre-seated test path
+    // (≥1 already present, empty roster) passes — temporary scaffolding
+    // until TODO(#224) migrates tests to roster seating and tightens this
+    // to require a non-empty roster.
+    if cx.state.investigators.is_empty() && resolved.is_empty() {
+        return EngineOutcome::Rejected {
+            reason: "a scenario requires at least one investigator".into(),
+        };
+    }
+
+    // --- mutate (all validations passed) ---
+    // Seat resolved investigators. Ids are sequential (1-based) in roster
+    // order; production seats into an empty investigator set.
+    for (idx, (skills, health, sanity, name, deck)) in resolved.into_iter().enumerate() {
+        let id = InvestigatorId(u32::try_from(idx).unwrap_or(0) + 1);
+        cx.state.investigators.insert(
+            id,
+            Investigator {
+                id,
+                name,
+                current_location: None,
+                skills,
+                max_health: health,
+                damage: 0,
+                max_sanity: sanity,
+                horror: 0,
+                clues: 0,
+                resources: 5,
+                actions_remaining: 0,
+                status: Status::Active,
+                deck,
+                hand: Vec::new(),
+                discard: Vec::new(),
+                cards_in_play: Vec::new(),
+                removed_from_game: Vec::new(),
+            },
+        );
+        cx.state.turn_order.push(id);
+    }
+
+    cx.state.round = 1;
+    cx.state.phase = Phase::Investigation;
+    cx.events.push(Event::ScenarioStarted);
+
+    let inv_ids: Vec<InvestigatorId> = cx.state.investigators.keys().copied().collect();
+    for inv_id in inv_ids {
+        super::cards::shuffle_player_deck(cx, inv_id);
+        super::cards::draw_cards(cx, inv_id, super::cards::INITIAL_HAND_SIZE);
+    }
+
+    cx.state.mulligan_pending = super::cursor::first_active_investigator(cx.state);
+    reset_actions(cx);
+    EngineOutcome::Done
+}
+```
+
+(Keep the existing explanatory comments from the original body where they still apply — round-1/Mythos-skip, mulligan-cursor seeding, action seed. They're elided above for brevity but should remain.)
+
+- [ ] **Step 4: Run the new tests + the full game-core suite**
+
+Run: `RUSTFLAGS="-D warnings" cargo test -p game-core 2>&1 | tail -8`
+Expected: the three new tests pass; all pre-existing `start_scenario` tests still pass (they pre-seat investigators, empty roster).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/phases.rs crates/game-core/src/engine/dispatch/mod.rs
+git commit -m "engine: seat StartScenario roster from card data (validate-first)
+
+Resolve each roster entry's stats via CardRegistry/CardMetadata, seat with
+the payload deck, reject unless >=1 investigator ends up seated. Pre-seated
+empty-roster test path tolerated until #224.
+
+Part of #221.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Integration test — seat Roland from the real corpus
+
+**Files:**
+- Create: `crates/cards/tests/roster_seating.rs`
+
+- [ ] **Step 1: Write the test**
+
+```rust
+//! B2: seating a roster resolves investigator stats from the real corpus
+//! (CardRegistry) and takes the deck from the payload. Integration test so
+//! it can install `cards::REGISTRY` in its own process (per CLAUDE.md test
+//! layering).
+
+use game_core::action::{Action, PlayerAction, RosterEntry};
+use game_core::engine::apply;
+use game_core::state::{CardCode, InvestigatorId, Skills};
+use game_core::test_support::builder::TestGame;
+use game_core::EngineOutcome;
+
+fn install_registry() {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+}
+
+#[test]
+fn seats_roland_with_corpus_stats_and_payload_deck() {
+    install_registry();
+    let deck = vec![CardCode::new("01030"), CardCode::new("01030")];
+    let roster = vec![RosterEntry { investigator: CardCode::new("01001"), deck: deck.clone() }];
+    let state = TestGame::new().build();
+
+    let result = apply(state, Action::Player(PlayerAction::StartScenario { roster }));
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    let inv = result
+        .state
+        .investigators
+        .get(&InvestigatorId(1))
+        .expect("Roland seated at id 1");
+    assert_eq!(inv.name, "Roland Banks");
+    assert_eq!(inv.skills, Skills { willpower: 3, intellect: 3, combat: 4, agility: 2 });
+    assert_eq!(inv.max_health, 9);
+    assert_eq!(inv.max_sanity, 5);
+    // Deck (2) + hand were sourced from the payload; combined they account
+    // for the 2 supplied cards (5-card opening hand draws what's available).
+    assert_eq!(inv.deck.len() + inv.hand.len(), deck.len());
+}
+
+#[test]
+fn rejects_non_investigator_code() {
+    install_registry();
+    // 01030 (Magnifying Glass) is an Asset, not an investigator.
+    let roster = vec![RosterEntry { investigator: CardCode::new("01030"), deck: vec![] }];
+    let state = TestGame::new().build();
+    let result = apply(state, Action::Player(PlayerAction::StartScenario { roster }));
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert_eq!(result.state.round, 0);
+    assert!(result.events.is_empty());
+}
+
+#[test]
+fn rejects_unknown_code() {
+    install_registry();
+    let roster = vec![RosterEntry { investigator: CardCode::new("99999"), deck: vec![] }];
+    let state = TestGame::new().build();
+    let result = apply(state, Action::Player(PlayerAction::StartScenario { roster }));
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert_eq!(result.state.round, 0);
+    assert!(result.events.is_empty());
+}
+```
+
+- [ ] **Step 2: Run the integration test**
+
+Run: `cargo test -p cards --test roster_seating 2>&1 | tail -12`
+Expected: all three PASS. If `inv.skills`/field names differ, reconcile against `crates/game-core/src/state/investigator.rs`. If `game_core::engine::apply` / `game_core::EngineOutcome` import paths differ, match `crates/cards/tests/play_card.rs`'s imports.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cards/tests/roster_seating.rs
+git commit -m "test: integration — seat Roland (01001) from corpus + reject paths
+
+Part of #221.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Full strict gauntlet, PR, phase doc
+
+**Files:** none (verification), then phase doc.
+
+- [ ] **Step 1: Run the full gauntlet**
+
+```bash
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+
+Expected: all green. `RosterEntry`'s public fields and the new `StartScenario` variant carry doc comments (doc job). Fix any clippy lint on the new code (e.g. prefer `let-else`, which is already used).
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+git push -u origin engine/roster-seating
+gh pr create --fill --label engine
+```
+
+PR body: design-decisions paragraph — no new registry (stats from `CardMetadata` via `CardRegistry`); deck is player-supplied payload input (Phase-9 forward-compatible); reject-if-zero-investigators invariant with the synthetic pre-seeded test path tolerated until #224. End with `Closes #221.`
+
+- [ ] **Step 3: Watch CI**
+
+Run: `gh pr checks <PR#> --watch` (background). Expected: all seven jobs green.
+
+- [ ] **Step 4: Phase doc (final commit, only once CI is green)**
+
+In `docs/phases/phase-7-the-gathering.md`: flip the B2 row to `✅ PR #<PR#>` with the plan link. Add a **Decisions made** entry only if it passes the would-a-future-author-choose-differently test — candidate: *"Investigator stats are read from `CardMetadata` (existing `CardRegistry`), not a new registry; the deck is a player-supplied `RosterEntry` payload field (Phase-9 import seam). `start_scenario` rejects unless ≥1 investigator is seated; the pre-seated test path is tolerated until #224."*
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Component 1 (`investigator_skills`, layering-correct as a `game-core` free fn) → Task 2. ✅
+- Component 2 (`StartScenario { roster }`, `RosterEntry`, deck-in-payload, serde) → Task 1. ✅
+- Component 3 (validate-first seating, resolve via `CardRegistry`/`CardMetadata`, ids/turn-order/location/resources, ≥1-investigator invariant) → Task 3. ✅
+- Error handling (all reject paths, state unchanged) → Task 3 (no-registry, zero-investigator) + Task 4 (unknown, non-investigator). ✅
+- Scaffolding/#224 tolerance → Task 3 comment + Task 5 phase-doc decision. ✅
+- Testing (integration seats 01001; unit reject/passthrough) → Tasks 3 & 4. ✅
+- Deferrals (placement at `None`, Roland deck contents) → seating sets `current_location: None`; deck supplied inline by the test, real contents are Group C. ✅
+
+**Placeholder scan:** No TBD/TODO-as-instruction; every code step shows full code; the only `TODO(#224)` is a deliberate source comment, not a plan gap. ✅
+
+**Type consistency:** `RosterEntry { investigator: CardCode, deck: Vec<CardCode> }`, `investigator_skills(&CardMetadata) -> Option<Skills>`, `start_scenario(cx, roster: &[RosterEntry])`, and `StartScenario { roster }` are used identically across Tasks 1–4. `Skills`/`SkillIcons` field names match the codebase. ✅

--- a/docs/superpowers/specs/2026-06-10-phase-7-slice-1-b2-roster-seating-design.md
+++ b/docs/superpowers/specs/2026-06-10-phase-7-slice-1-b2-roster-seating-design.md
@@ -1,0 +1,105 @@
+# Phase 7 Slice 1 B2 — Roster/seating + `StartScenario` investigator selection
+
+**Issue:** [#221](https://github.com/talelburg/eldritch/issues/221). Follow-up cleanup: [#224](https://github.com/talelburg/eldritch/issues/224).
+**Parent spec:** [`2026-06-10-phase-7-slice-1-gathering-design.md`](2026-06-10-phase-7-slice-1-gathering-design.md) (§"Investigator seating", build-order step 6).
+
+## Goal
+
+Let a host pick which investigators play a scenario. The scenario module builds the **world** (locations, decks, bag) with no investigators; a **roster** carried on `StartScenario` seats the chosen investigators — resolving each one's stats from card data and taking their deck as a player-supplied input — before the existing shuffle/deal step runs.
+
+## Why this shape
+
+`ScenarioModule.setup: fn() -> GameState` takes no arguments, so there is no channel for "which investigator." Rather than overload `setup` with a roster parameter (couples deck-loading to every scenario), the selection rides on the `StartScenario` action and seating happens in `start_scenario`, which already owns the per-investigator shuffle/deal loop.
+
+Two facts drive the design:
+
+1. **Investigator stats are static card data that already exist in the corpus.** The pipeline emits an investigator's base skills into `CardMetadata.skill_icons` and max health/sanity into `CardMetadata.health` / `.sanity`. E.g. Roland (`01001`): `skill_icons { willpower: 3, intellect: 3, combat: 4, agility: 2, wild: 0 }`, `health: Some(9)`, `sanity: Some(5)`. So seating needs **no new registry** — it reads stats through the existing [`CardRegistry`]. (A second bridge for data that is already card data would be redundant; key→data lookup via `metadata_for` is the idiomatic, established pattern.)
+2. **A deck is *not* intrinsic to an investigator** — the player builds it (and Phase 9 will import decklists from an external source). So the deck must be a separate, free input, not something resolved from the investigator code.
+
+## Architecture
+
+### Component 1 — investigator-skills helper (game-core seating)
+
+For player cards, `skill_icons` means "icons committed to a test"; for **investigator** cards the same fields are *base skills*. A type-guarded conversion makes that read explicit and prevents misuse on non-investigator cards.
+
+**Layering:** `Skills` is a `game-core` type (`game_core::state`) and `CardMetadata` lives in `card-dsl`, which must **not** depend on `game-core` (the dependency runs the other way). So this is **not** a method on `CardMetadata` (that would be a circular dep) — it is a free helper in the `game-core` seating module, reading `card-dsl` types it already has in scope:
+
+```rust
+// in game-core seating code
+fn investigator_skills(meta: &CardMetadata) -> Option<Skills> {
+    if meta.card_type != CardType::Investigator { return None; }
+    Some(Skills {
+        willpower: i8::try_from(meta.skill_icons.willpower).ok()?,
+        intellect: i8::try_from(meta.skill_icons.intellect).ok()?,
+        combat:    i8::try_from(meta.skill_icons.combat).ok()?,
+        agility:   i8::try_from(meta.skill_icons.agility).ok()?,
+    })
+}
+```
+
+`Skills` fields are `i8`; `SkillIcons` fields are `u8`. Conversion is via `i8::try_from` (base skills are single-digit, so this never fails in practice — `None`/reject on the impossible overflow rather than panic). `CardType` is re-exported through `game_core::card_data`, so the `card_type` guard is in scope without a new dependency.
+
+### Component 2 — protocol: `StartScenario { roster }`
+
+```rust
+pub enum PlayerAction {
+    StartScenario { roster: Vec<RosterEntry> },
+    // …
+}
+
+/// One seat in the scenario: which investigator, and the deck the player
+/// chose for them. The deck is a free input (Phase 9 will populate it
+/// from an external decklist import); seating takes it verbatim.
+pub struct RosterEntry {
+    pub investigator: CardCode,
+    pub deck: Vec<CardCode>,
+}
+```
+
+Was a unit variant. Every existing `StartScenario` construction site gains `roster: vec![]`. `RosterEntry` is `Serialize`/`Deserialize` (it crosses the wire and lands in the action log). The decklist is logged (deck composition is load-bearing for deterministic replay and is player-authored); stats are **not** logged — they're resolved from the code, so a client cannot inject inflated stats. That authority split is deliberate.
+
+### Component 3 — seating in `start_scenario` (validate-first)
+
+Before the existing shuffle/deal loop:
+
+1. If `roster` is non-empty, for each entry resolve stats: `card_registry::current()` → `metadata_for(&entry.investigator)` → require `investigator_skills(meta)` to be `Some` (i.e. `card_type == Investigator`) and `health`/`sanity` both present. **Any failure → `Rejected`, state and events unchanged** (no registry installed, unknown code, non-investigator card, or missing health/sanity).
+2. Seat an `Investigator` per entry: ids assigned sequentially in roster order, `turn_order` in that order, `current_location: None`, `skills`/`max_health`/`max_sanity` from card data, `deck` = `entry.deck`, `resources: 5` (Rules Reference setup), other counters zeroed; `actions_remaining` left to the existing `reset_actions(cx)` call.
+3. **Invariant:** after seating, if `state.investigators` is empty → `Rejected { "a scenario requires at least one investigator" }`. In production `setup()` seats nobody, so this makes the roster mandatory: empty roster ⇒ reject.
+4. Then the existing shuffle/deal + mulligan-cursor + `reset_actions` logic runs unchanged.
+
+### Data flow
+
+```
+host picks investigators + decks
+  → ClientMessage::Submit { StartScenario { roster } }
+    → start_scenario: resolve stats (CardRegistry) + seat (deck from payload)
+      → invariant: ≥1 investigator
+        → existing shuffle/deal/mulligan
+```
+
+## Error handling
+
+All seating failures are `EngineOutcome::Rejected` with unchanged state/events (validate-first, per the kernel handler contract): missing registry, unknown code, non-investigator code, missing health/sanity, and the zero-investigator invariant. No partial seating — validate the whole roster before mutating.
+
+## Scope & deferrals
+
+- **Map placement** is *not* done here: seated investigators get `current_location: None`. Placing them at the scenario's starting location (the Study, for The Gathering) is scenario content — **Group C**.
+- **Roland's signature/weakness cards and starter decklist contents** are **Group C**. B2's test supplies a deck inline.
+- **Server install of the real registries** so a browser game can seat is **B3 (#222) / Group D**; B2's engine path returns `Rejected` cleanly when no registry is installed.
+
+## Temporary scaffolding → follow-up #224
+
+The zero-investigator invariant (not "non-empty roster required") is chosen so the **pre-seated unit-test path survives**: `TestGame::new().with_investigator(…)` + `roster: vec![]` still works because the count is ≥1. ~15 engine tests and ~10 `crates/cards/tests/` / `crates/scenarios/tests/` files seat **synthetic** investigators (`test_investigator(N)`) whose codes have no real `CardMetadata` and so cannot resolve stats from the registry — forcing them onto the roster now would mean a fake-metadata install per test for no domain gain.
+
+This tolerance is temporary scaffolding tied to the synthetic cards. It carries a `TODO(#224)`. When real cards become the test default (synthetic-card removal), **#224** migrates every `StartScenario` test to roster seating and tightens `start_scenario` to require a non-empty roster (dropping the tolerance), leaving a single seating path.
+
+## Testing
+
+- **Integration** (`crates/cards/tests/`, installs `cards::REGISTRY`): a roster of `[{ investigator: "01001", deck: <inline codes> }]` seats Roland with W3/I3/C4/A2, max_health 9, max_sanity 5, and the payload deck; the deck is shuffled and the opening hand dealt by the existing flow.
+- **Engine unit** (`game-core`): empty roster + pre-seated investigator passes (passthrough); empty roster + zero investigators rejects; unknown code rejects; a non-investigator code (e.g. an asset like `01030`) rejects; all reject paths leave state/events unchanged.
+
+## Decisions made
+
+- **No new registry** — investigator stats resolve from `CardMetadata` via the existing `CardRegistry`; the deck is a separate payload input. (Eliminates the `InvestigatorRegistry` bridge considered earlier.)
+- **`StartScenario` carries the roster** (not `CreateGameRequest`); deck is player-supplied for Phase-9-import forward-compatibility.
+- **Invariant is ≥1-investigator-after-seating**, not non-empty-roster, to preserve the pre-seated test affordance until #224.


### PR DESCRIPTION
## Summary

Phase 7 Slice 1 **B2**: a host picks which investigators play a scenario. `StartScenario` now carries a roster; `start_scenario` resolves each investigator's stats from card data, seats them with the player-supplied deck, and rejects unless ≥1 investigator ends up seated.

- `PlayerAction::StartScenario { roster: Vec<RosterEntry> }`; `RosterEntry { investigator: CardCode, deck: Vec<CardCode> }`.
- `start_scenario` (validate-first): resolve each entry's stats via the existing `CardRegistry`/`CardMetadata`, seat an `Investigator` (1-based ids, `current_location: None`, `resources: 5`) with the payload deck, then the existing shuffle/deal/mulligan flow runs unchanged.
- `investigator_skills(&CardMetadata) -> Option<Skills>` — type-guarded reinterpretation of an investigator card's `skill_icons` as base skills (lives in `game-core`, since `Skills` is a `game-core` type and `card-dsl` can't depend on it).
- Remaining churn is the mechanical migration of `StartScenario` construction/match sites to the struct variant.

## Design decisions

- **No new registry.** Investigator stats are static card data already in the corpus (`skill_icons` + `health`/`sanity`), read through the existing `CardRegistry` — eliminating a second bridge. The **deck** is a separate player-supplied payload input, so Phase 9's external decklist import drops in with zero change to the seam.
- **Invariant is ≥1-investigator-after-seating**, not "non-empty roster". In production `setup()` seats nobody, so the roster is effectively mandatory (empty roster ⇒ reject). The pre-seated unit-test path is tolerated as temporary scaffolding tied to the synthetic cards; **#224** migrates those tests to roster seating and tightens this to require a non-empty roster.
- **Deferred to Group C:** map placement (seated at `current_location: None`) and Roland's signature/weakness + real starter decklist contents.

## Testing

Full strict gauntlet green (test, clippy, fmt, doc, wasm-build, wasm-clippy). Integration test (`crates/cards/tests/roster_seating.rs`, installs `cards::REGISTRY`) seats Roland (`01001`) with W3/I3/C4/A2, health 9, sanity 5 + payload deck, and pins the non-investigator (`01030`) and unknown-code reject paths. Engine unit tests cover empty-roster reject, pre-seated passthrough, and unresolvable-entry reject. An independent code review (validate-first focus) returned ready-to-merge with no critical/important issues.

Closes #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)