### PR TITLE
docs: fold B3 registry swap into Group C

### DIFF
--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -26,8 +26,8 @@ trigger-ordering (`#213`), folding in `#117`.
 | A2 | [#215](https://github.com/talelburg/eldritch/issues/215) — forced-trigger dispatch (`fire_forced_triggers`) — depends on A1 | `plans/2026-06-10-…-forced-trigger-dispatch.md` | ✅ PR #219 |
 | B1 | [#220](https://github.com/talelburg/eldritch/issues/220) — `reference_card` field + symbol-token lookup plumbing | `plans/2026-06-10-…-reference-card-routing.md` | ✅ PR #223 |
 | B2 | [#221](https://github.com/talelburg/eldritch/issues/221) — roster/seating step + `StartScenario` investigator selection (protocol change) | `plans/2026-06-10-…-b2-roster-seating.md` | ✅ PR #225 |
-| B3 | [#222](https://github.com/talelburg/eldritch/issues/222) — registry-swap foundation (server installs real card + scenario registries; D5) | TBD | 📐 spec'd |
-| C | content: Gathering scenario cards + setup + Roland + signature/weakness + starter deck | TBD | 📐 spec'd |
+| B3 | [#222](https://github.com/talelburg/eldritch/issues/222) — registry-swap foundation (server installs real card registry; D5) | — | 🔀 folded into C |
+| C | content: Gathering scenario cards + setup + Roland + signature/weakness + starter deck (incl. the B3 card-registry swap + web `SCENARIO_ID` repoint) | TBD | 📐 spec'd |
 | D | integration & web: investigator/scenario picker; end-to-end Won/Lost gate | TBD | 📐 spec'd |
 
 Group A *extends* the existing `reaction_windows.rs` OnEvent machinery
@@ -77,6 +77,7 @@ Devourer Below, campaign log + `Fact` enum) is **Phase 9**, not Phase 7.
 - **"Solo with 1–2 investigators" is the supported mode** for this phase. Multiplayer (two human investigators on different machines) is Phase 8.
 - **All 5 original-Core investigators implementable:** Roland Banks (`#55`, already filed in Phase 3), Daisy Walker, "Skids" O'Toole, Agnes Baker, Wendy Adams. Each needs their card impl + signature cards.
 - **Investigator seating (B2):** stats are read from `CardMetadata` via the existing `CardRegistry` (no new registry); the deck is a player-supplied `RosterEntry { investigator, deck }` field on `StartScenario` (the Phase-9 decklist-import seam). `start_scenario` rejects unless ≥1 investigator is seated; the pre-seated synthetic-test path is tolerated until [#224](https://github.com/talelburg/eldritch/issues/224) migrates tests to roster seating and requires a non-empty roster.
+- **Registry swap (B3, [#222](https://github.com/talelburg/eldritch/issues/222)) folds into Group C, not a standalone PR.** `server` already depends on `cards` and installs the real `scenarios::REGISTRY`; the only work is swapping the *card* registry (`synth_cards::TEST_REGISTRY` → `cards::REGISTRY`) in `server/src/lib.rs`. But that swap is coupled to C: the synthetic scenario's encounter deck draws synth-only card codes, so swapping with no real scenario to serve would break the `"synthetic"` web demo mid-play and `server/tests/registries.rs` for the whole B3→C window. So the swap + the web `SCENARIO_ID` repoint to `"the-gathering"` land in the Group C PR alongside the real scenario; synthetic registries stay for per-process tests.
 
 ## Open questions
 


### PR DESCRIPTION
Records the sequencing decision from B2 wrap-up: the B3 card-registry swap (#222) is **coupled to Group C** and folds into the Gathering PR rather than shipping standalone (it would otherwise break the `"synthetic"` web demo for the whole B3→C window, with no real scenario to serve).

- Phase-7 Slice 1 table: B3 row → 🔀 folded into C; C row notes it now carries the card-registry swap + web `SCENARIO_ID` repoint.
- Decisions: added the rationale.

#222 closed as folded-into-C. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)