### PR TITLE
docs: Group C decomposition spec + issue breakdown (Slice 1 kickoff)

### DIFF
--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -2,11 +2,14 @@
 
 ## Status
 
-🛠️ **Slice 1 planned** (kickoff [#216](https://github.com/talelburg/eldritch/issues/216)).
-Phase decomposed into vertical slices; Slice 1 (Roland through The
-Gathering, solo, Standard) is specced and the engine spine is planned.
-Design spec:
-[`docs/superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md`](../superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md).
+🛠️ **Slice 1 in progress** (kickoff [#216](https://github.com/talelburg/eldritch/issues/216)).
+Engine spine (A1/A2) and scenario plumbing (B1/B2) shipped; **Group C**
+(the Gathering content) is decomposed into sub-slices C1–C7
+([#227](https://github.com/talelburg/eldritch/issues/227)–[#245](https://github.com/talelburg/eldritch/issues/245),
+kickoff [#246](https://github.com/talelburg/eldritch/issues/246)).
+Design specs:
+[Gathering design](../superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md),
+[Group C decomposition](../superpowers/specs/2026-06-11-phase-7-slice-1-group-c-decomposition-design.md).
 
 ## Goal
 
@@ -26,13 +29,43 @@ trigger-ordering (`#213`), folding in `#117`.
 | A2 | [#215](https://github.com/talelburg/eldritch/issues/215) — forced-trigger dispatch (`fire_forced_triggers`) — depends on A1 | `plans/2026-06-10-…-forced-trigger-dispatch.md` | ✅ PR #219 |
 | B1 | [#220](https://github.com/talelburg/eldritch/issues/220) — `reference_card` field + symbol-token lookup plumbing | `plans/2026-06-10-…-reference-card-routing.md` | ✅ PR #223 |
 | B2 | [#221](https://github.com/talelburg/eldritch/issues/221) — roster/seating step + `StartScenario` investigator selection (protocol change) | `plans/2026-06-10-…-b2-roster-seating.md` | ✅ PR #225 |
-| B3 | [#222](https://github.com/talelburg/eldritch/issues/222) — registry-swap foundation (server installs real card registry; D5) | — | 🔀 folded into C |
-| C | content: Gathering scenario cards + setup + Roland + signature/weakness + starter deck (incl. the B3 card-registry swap + web `SCENARIO_ID` repoint) | TBD | 📐 spec'd |
-| D | integration & web: investigator/scenario picker; end-to-end Won/Lost gate | TBD | 📐 spec'd |
+| B3 | [#222](https://github.com/talelburg/eldritch/issues/222) — registry-swap foundation (server installs real card registry; D5) | — | 🔀 folded into C (C7a [#244](https://github.com/talelburg/eldritch/issues/244)) |
+| — | [#246](https://github.com/talelburg/eldritch/issues/246) — kickoff: Group C decomposition spec + issue breakdown | [`…group-c-decomposition…`](../superpowers/specs/2026-06-11-phase-7-slice-1-group-c-decomposition-design.md) | ✅ PR #247 |
+| C | content: Gathering scenario cards + setup + Roland + signature/weakness + starter deck — **decomposed into C1–C7** ([#227](https://github.com/talelburg/eldritch/issues/227)–[#245](https://github.com/talelburg/eldritch/issues/245)); see breakdown below | [`…group-c-decomposition…`](../superpowers/specs/2026-06-11-phase-7-slice-1-group-c-decomposition-design.md) | 🛠️ in progress |
+| D | integration & web: investigator/scenario picker (end-to-end Won/Lost gate is C7b [#245](https://github.com/talelburg/eldritch/issues/245)) | TBD | 📐 spec'd |
 
 Group A *extends* the existing `reaction_windows.rs` OnEvent machinery
 (not greenfield); forced scenario effects take a separate immediate path
 (`fire_forced_triggers`) distinct from player reaction windows.
+
+### Group C breakdown (C1–C7)
+
+Decomposed in
+[`…group-c-decomposition…`](../superpowers/specs/2026-06-11-phase-7-slice-1-group-c-decomposition-design.md).
+Split along the engine-machinery / card-content seam. `C1a` (#227) is the
+root dependency; C7 is the playable Won/Lost gate; #212 lands after C.
+
+| Sub | Issue | What |
+|---|---|---|
+| C1a | [#227](https://github.com/talelburg/eldritch/issues/227) | `setup()` world-build + forced location effects |
+| C1b | [#228](https://github.com/talelburg/eldritch/issues/228) | act-advancement objective types (01109 / 01110) |
+| C2 | [#229](https://github.com/talelburg/eldritch/issues/229) | 01104 symbol-token effects + victory points |
+| C3a | [#230](https://github.com/talelburg/eldritch/issues/230) | Prey variants + Retaliate |
+| C3b | [#231](https://github.com/talelburg/eldritch/issues/231) | the six encounter enemies |
+| C3c | [#232](https://github.com/talelburg/eldritch/issues/232) | agenda 01107 forced (movement + doom; +`RoundEnded`) |
+| C4a | [#233](https://github.com/talelburg/eldritch/issues/233) | threat-area zone + shared scan source (in-C consolidation seam) |
+| C4b | [#234](https://github.com/talelburg/eldritch/issues/234) | one-shot Revelation treacheries (×4) |
+| C4c | [#235](https://github.com/talelburg/eldritch/issues/235) | persistent threat-area treacheries (×3) |
+| C5a | [#236](https://github.com/talelburg/eldritch/issues/236) | Cover Up before-timing interrupt + `GameEnd` |
+| C5b | [#237](https://github.com/talelburg/eldritch/issues/237) | Guard Dog damage-from-enemy window |
+| C5c | [#238](https://github.com/talelburg/eldritch/issues/238) | .38 Special signature + Cover Up content |
+| C5d | [#239](https://github.com/talelburg/eldritch/issues/239) | Guardian L0 assets (×6) |
+| C5e | [#240](https://github.com/talelburg/eldritch/issues/240) | Guardian L0 events + skill (×4) |
+| C6a | [#241](https://github.com/talelburg/eldritch/issues/241) | Dr. Milan after-investigate window |
+| C6b | [#242](https://github.com/talelburg/eldritch/issues/242) | Seeker deck cards |
+| C6c | [#243](https://github.com/talelburg/eldritch/issues/243) | Neutral deck cards |
+| C7a | [#244](https://github.com/talelburg/eldritch/issues/244) | registry swap + web `SCENARIO_ID` repoint (B3) |
+| C7b | [#245](https://github.com/talelburg/eldritch/issues/245) | end-to-end Won/Lost integration test |
 
 ## Future slices (after Slice 1)
 
@@ -78,6 +111,8 @@ Devourer Below, campaign log + `Fact` enum) is **Phase 9**, not Phase 7.
 - **All 5 original-Core investigators implementable:** Roland Banks (`#55`, already filed in Phase 3), Daisy Walker, "Skids" O'Toole, Agnes Baker, Wendy Adams. Each needs their card impl + signature cards.
 - **Investigator seating (B2):** stats are read from `CardMetadata` via the existing `CardRegistry` (no new registry); the deck is a player-supplied `RosterEntry { investigator, deck }` field on `StartScenario` (the Phase-9 decklist-import seam). `start_scenario` rejects unless ≥1 investigator is seated; the pre-seated synthetic-test path is tolerated until [#224](https://github.com/talelburg/eldritch/issues/224) migrates tests to roster seating and requires a non-empty roster.
 - **Registry swap (B3, [#222](https://github.com/talelburg/eldritch/issues/222)) folds into Group C, not a standalone PR.** `server` already depends on `cards` and installs the real `scenarios::REGISTRY`; the only work is swapping the *card* registry (`synth_cards::TEST_REGISTRY` → `cards::REGISTRY`) in `server/src/lib.rs`. But that swap is coupled to C: the synthetic scenario's encounter deck draws synth-only card codes, so swapping with no real scenario to serve would break the `"synthetic"` web demo mid-play and `server/tests/registries.rs` for the whole B3→C window. So the swap + the web `SCENARIO_ID` repoint to `"the-gathering"` land in the Group C PR alongside the real scenario; synthetic registries stay for per-process tests.
+
+- **`emit_event` unification (#212) lands *after* Group C, not before it.** C is built on the existing `ForcedTriggerPoint` enum-dispatcher + reaction-window pipeline, extended with new timing points (`RoundEnded`, `EndOfTurn`, `AfterLocationInvestigated`, `GameEnd`, damage/investigate windows) as content demands them; #212 then consolidates those into one emit-driven chokepoint, validated against all of C's real content. The dispatch surface C adds is a handful of points through already-generic machinery (the 7 treacheries share one Revelation hook; locations and Beat Cop reuse existing paths), so front-loading #212 would design its event taxonomy before the cards defining its requirements exist. **#213** (player-choice simultaneous-trigger ordering) is deferred further still — until then simultaneous triggers resolve in a fixed **deterministic** order. C4a (#233) lands the one in-C consolidation seam (shared scan source over `cards_in_play` + threat area) that #212 later absorbs.
 
 ## Open questions
 

--- a/docs/superpowers/specs/2026-06-11-phase-7-slice-1-group-c-decomposition-design.md
+++ b/docs/superpowers/specs/2026-06-11-phase-7-slice-1-group-c-decomposition-design.md
@@ -1,0 +1,156 @@
+# Phase 7 Slice 1 — Group C decomposition
+
+Decomposition of **Group C** (the Gathering content) of Phase 7 Slice 1 into
+mergeable sub-slices and concrete issues, and the placement of the `emit_event`
+dispatch unification (#212) relative to that content.
+
+Companion to the Slice 1 design: `2026-06-10-phase-7-slice-1-gathering-design.md`.
+That doc scoped C as a single "spec'd" group; this doc breaks it down.
+
+## Why C needs decomposing
+
+C as originally framed ("Gathering cards + setup + Roland + signature/weakness +
+starter deck") is **~47 distinct cards** — 26 encounter + Roland's full suggested
+30-card deck (~21 new) — plus the scenario setup module, Standard chaos bag,
+symbol-token logic, victory points, and act/agenda advancement. Only ~5 of those
+cards are already implemented. That is far too large for one plan; it is really
+**seven sub-slices** (C1–C7) feeding a final playable gate, followed by a
+dispatch-cleanup refactor.
+
+Decision input: **the full suggested 30-card Roland deck is in scope** (not a
+minimal playable subset).
+
+## Where #212 (emit_event unification) factors in
+
+**Decision: build C on the existing rails, extend the existing
+`ForcedTriggerPoint` enum-dispatcher with new variants as content demands them,
+and land the full #212 chokepoint as a single post-C refactor** validated against
+all of C's real content. #213 (player-choice simultaneous-trigger ordering) is
+deferred further still; until then, simultaneous triggers resolve in a fixed
+**deterministic order**.
+
+Rationale (the count that drove it): tracing C's actual dispatch needs, the
+"thread forced/optional triggers in millions of places" fear does not
+materialize, because the bulk shares hooks:
+
+- The **7 treacheries** fire through the **one existing Revelation hook** in
+  `encounter.rs` — adding a treachery is writing an effect, not wiring dispatch.
+- **2 forced locations** reuse the existing `EnteredLocation` path; **Beat Cop**
+  reuses the existing `AfterEnemyDefeated` window.
+- The genuinely-new dispatch surface is a **handful of framework timing points**
+  (`RoundEnded`, `EndOfTurn`, `AfterLocationInvestigated`, `GameEnd`, a
+  damage-from-enemy window, an after-investigate window) plus **Cover Up's
+  before-timing interrupt** — each a small, locally-correct addition through the
+  existing `ForcedTriggerPoint` dispatcher / reaction-window pipeline.
+
+Front-loading #212 would mean designing its event taxonomy **before** the cards
+that define its requirements exist (the full 30-deck makes that worse), and its
+hard machinery (reentrancy, mid-emit suspension) still is not exercised by C's
+content. The existing `resume_reaction_window` loop already does the iterative
+multi-optional-trigger resolution, so C's many optional reactions are already
+covered. A1/A2 were built forward-compatible specifically so `emit_event` can
+absorb `fire_forced_triggers` later without rework.
+
+**In-C consolidation seam:** C4a unifies the forced-scan and reaction-scan onto a
+**single shared scan source** (spanning `cards_in_play` + the new threat-area
+zone). #212 later absorbs that one clean seam instead of several scattered ones.
+
+## Engine capabilities confirmed present (reused, not rebuilt)
+
+- Act/agenda advancement: `check_doom_threshold`, `advance_agenda`,
+  `advance_act_action` (`act_agenda.rs`). C1b adds only new objective *types*.
+- Revelation resolution + spawn-at-location + Hunter movement (`encounter.rs`,
+  `hunters.rs`). C reuses these.
+- Reaction-window pipeline with iterative multi-trigger resolution
+  (`reaction_windows.rs`).
+- `ForcedTriggerPoint` enum-dispatcher (`forced_triggers.rs`) — extended, not
+  replaced.
+
+Confirmed **absent** (real new work): a **threat-area zone** (C4a), **Prey
+variants + Retaliate** (C3a), **before-timing interrupt windows** (C5a).
+
+## Sub-slices and issues
+
+Split along the repo's engine-machinery / card-content seam. Issue numbers under
+milestone `phase-7-the-gathering`.
+
+### C1 — Scenario skeleton
+- **#227** [scenario] C1a — `setup()` world-build (locations + connections,
+  act/agenda decks + thresholds, Standard chaos bag) + forced location effects
+  (Attic/Cellar) on existing `EnteredLocation` rails.
+- **#228** [engine] C1b — new act-advancement objective types: 01109 round-end
+  group clue-spend gate; 01110 advance-on-Ghoul-Priest-defeated.
+
+### C2 — Reference card + victory
+- **#229** [card] C2 — 01104 symbol-token effects (skull/cultist/tablet,
+  board-count Rust impl) via B1 plumbing; Attic/Cellar victory points.
+
+### C3 — Encounter enemies
+- **#230** [engine] C3a — Prey variants (highest-combat, lowest-remaining-health)
+  + Retaliate.
+- **#231** [card] C3b — Ghoul Priest, Flesh-Eater, Icy Ghoul, Ghoul Minion,
+  Ravenous Ghoul, Swarm of Rats.
+- **#232** [engine/card] C3c — agenda 01107 forced movement (existing
+  `PhaseEnded(Enemy)`) + doom (new `ForcedTriggerPoint::RoundEnded`).
+
+### C4 — Treacheries + threat area
+- **#233** [engine] C4a — threat-area zone + shared forced/reaction scan source +
+  `ForcedTriggerPoint::{EndOfTurn, AfterLocationInvestigated}`. *(in-C
+  consolidation seam.)*
+- **#234** [card] C4b — one-shot Revelations: Grasping Hands, Rotting Remains,
+  Crypt Chill, Ancient Evils (existing Revelation hook).
+- **#235** [card] C4c — persistent threat-area/attachment: Frozen in Fear,
+  Dissonant Voices, Obscuring Fog.
+
+### C5 — Roland deck: Guardian + signature + weakness
+- **#236** [engine] C5a — Cover Up before-timing interrupt window +
+  `ForcedTriggerPoint::GameEnd`.
+- **#237** [engine] C5b — Guard Dog reaction window (after enemy deals damage).
+- **#238** [card] C5c — .38 Special signature + Cover Up weakness content.
+- **#239** [card] C5d — Guardian L0 assets (.45 Automatic, Physical Training,
+  Beat Cop, First Aid, Machete, Guard Dog).
+- **#240** [card] C5e — Guardian L0 events + skill (Evidence!, Dodge, Dynamite
+  Blast, Vicious Blow).
+
+### C6 — Roland deck: Seeker + Neutral
+- **#241** [engine] C6a — Dr. Milan after-successful-investigate reaction window.
+- **#242** [card] C6b — Seeker cards (Old Book of Lore, Research Librarian, Dr.
+  Milan, Medical Texts, Mind over Matter, Barricade).
+- **#243** [card] C6c — Neutral cards (Knife, Flashlight, Emergency Cache, Guts,
+  Perception, Overpower, Manual Dexterity, Unexpected Courage).
+
+### C7 — Closeout (the "Slice 1 done" gate)
+- **#244** [infra] C7a — registry swap (`synth_cards::TEST_REGISTRY` →
+  `cards::REGISTRY`) + web `SCENARIO_ID` → `"the-gathering"` (folded-in B3).
+- **#245** [test] C7b — end-to-end integration test: solo Roland, full deck,
+  Standard, drives to Won and Lost. Pairs with **#224** (roster-seating test
+  migration).
+
+### Post-C
+- **#212** emit_event chokepoint (deterministic-order variant) — consolidates the
+  `ForcedTriggerPoint` dispatcher + reaction-window queue sites + Revelation hook.
+- **#213** player-choice simultaneous-trigger ordering — separate, later.
+
+## Ordering & parallelism
+
+`C1a (#227)` is the root dependency. After it:
+
+- C1b, C2, C3*, C4*, C5*, C6* proceed largely in parallel.
+- Within C3: C3a → C3b → C3c. Within C4: C4a → {C4b, C4c}. Within C5: {C5a, C5b}
+  → {C5c, C5d} → C5e. Within C6: C6a → C6b; C6c independent.
+- `C7a (#244)` and `C7b (#245)` are last, after C1–C6.
+- `#212` after C7.
+
+## Out of scope (deferred to later Slice-1 / Phase-7 work)
+
+- Lita Chantler's parley/take-control and the Parlor (01115) Resign action
+  (per the Gathering design).
+- Difficulty selection beyond Standard.
+- #213 player-choice trigger ordering.
+- Roland's investigator elder-sign + reaction (#118).
+
+## Corrections folded in
+
+- The Gathering design spec named Roland's signature ".45 Automatic"; the real
+  signature is **Roland's .38 Special (01006)** (snapshot-verified). .45
+  Automatic (01016) is a separate Guardian deck card.


### PR DESCRIPTION
## Summary

Group C (the Gathering content) of Phase 7 Slice 1 is ~47 distinct cards plus the scenario setup module, Standard chaos bag, symbol-token logic, and act/agenda advancement — too large for a single plan. This PR decomposes it into seven sub-slices (C1–C7) feeding a playable Won/Lost gate, and pins where the `emit_event` dispatch unification (#212) lands.

- **Spec:** `docs/superpowers/specs/2026-06-11-phase-7-slice-1-group-c-decomposition-design.md`
- **19 sub-slice issues filed:** #227–#245 (engine-machinery / card-content seam, matching the repo's A1/A2 pattern).
- **Phase-7 doc** updated to point at the decomposition + the sub-slice issues.

## Design decision (#212 placement)

Build C on the existing `ForcedTriggerPoint` / reaction-window rails, extending with new timing points as content demands them, and land the full `emit_event` chokepoint as a **single post-C refactor** validated against real content. #213 (player-choice simultaneous-trigger ordering) is deferred further; deterministic ordering until then.

Rationale: tracing C's actual dispatch needs, the new surface is a handful of framework timing points through already-generic machinery — the 7 treacheries share one Revelation hook, locations and Beat Cop reuse existing paths. Front-loading #212 would mean designing its event taxonomy before the cards that define its requirements exist, and its hard machinery (reentrancy, mid-emit suspension) is still unexercised by C's content.

Docs-only change.

Closes #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)