### PR TITLE
engine: rename DSL target variants to "you" vocabulary (#248)

### DIFF
--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -536,11 +536,13 @@ pub enum SkillTestKind {
 /// Single-investigator target spec.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum InvestigatorTarget {
-    /// The controller of the ability — the investigator who played /
-    /// activated this card.
-    Controller,
+    /// The investigator this ability acts on — "you" in card text. For
+    /// a played/activated card that's whoever played it; for a forced
+    /// trigger it's the affected investigator the dispatcher binds (e.g.
+    /// the one entering a location for an "After you enter" effect).
+    You,
     /// The active investigator at evaluation time. May or may not be
-    /// the controller; matters during reactions across turns.
+    /// "you"; matters during reactions across turns.
     Active,
     /// The controller picks an investigator. The evaluator presents
     /// the choice via `AwaitingInput`.
@@ -559,8 +561,9 @@ pub enum InvestigatorTargetSet {
 /// Single-location target spec.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum LocationTarget {
-    /// The location the controller is currently at.
-    ControllerLocation,
+    /// The location "you" are currently at — the location of the
+    /// investigator this ability acts on (see [`InvestigatorTarget::You`]).
+    YourLocation,
     /// The controller picks a location.
     ChosenByController,
     /// The location associated with the in-flight skill test. For
@@ -854,12 +857,12 @@ mod tests {
     /// — the canonical `OnPlay` + `DiscoverClue` shape.
     #[test]
     fn working_a_hunch_compiles() {
-        let ability = on_play(discover_clue(LocationTarget::ControllerLocation, 1));
+        let ability = on_play(discover_clue(LocationTarget::YourLocation, 1));
         assert_eq!(ability.trigger, Trigger::OnPlay);
         assert!(matches!(
             ability.effect,
             Effect::DiscoverClue {
-                from: LocationTarget::ControllerLocation,
+                from: LocationTarget::YourLocation,
                 count: 1,
             }
         ));
@@ -875,7 +878,7 @@ mod tests {
             Condition::SkillTest {
                 outcome: TestOutcome::Success,
             },
-            discover_clue(LocationTarget::ControllerLocation, 1),
+            discover_clue(LocationTarget::YourLocation, 1),
         ));
         assert_eq!(ability.trigger, Trigger::OnCommit);
         // Distinct enum variant — compiler enforces the difference at
@@ -913,8 +916,8 @@ mod tests {
     #[test]
     fn seq_composition_nests_two_effects() {
         let effect = seq([
-            gain_resources(InvestigatorTarget::Controller, 1),
-            discover_clue(LocationTarget::ControllerLocation, 1),
+            gain_resources(InvestigatorTarget::You, 1),
+            discover_clue(LocationTarget::YourLocation, 1),
         ]);
         match effect {
             Effect::Seq(inner) => assert_eq!(inner.len(), 2),
@@ -929,14 +932,14 @@ mod tests {
             Condition::SkillTest {
                 outcome: TestOutcome::Success,
             },
-            discover_clue(LocationTarget::ControllerLocation, 1),
+            discover_clue(LocationTarget::YourLocation, 1),
         );
         let with_else = if_else(
             Condition::SkillTest {
                 outcome: TestOutcome::Success,
             },
-            discover_clue(LocationTarget::ControllerLocation, 1),
-            gain_resources(InvestigatorTarget::Controller, 1),
+            discover_clue(LocationTarget::YourLocation, 1),
+            gain_resources(InvestigatorTarget::You, 1),
         );
         assert!(matches!(bare, Effect::If { else_: None, .. }));
         assert!(matches!(with_else, Effect::If { else_: Some(_), .. }));
@@ -962,8 +965,8 @@ mod tests {
     #[test]
     fn choose_one_collects_alternatives() {
         let effect = choose_one([
-            gain_resources(InvestigatorTarget::Controller, 2),
-            discover_clue(LocationTarget::ControllerLocation, 1),
+            gain_resources(InvestigatorTarget::You, 2),
+            discover_clue(LocationTarget::YourLocation, 1),
         ]);
         match effect {
             Effect::ChooseOne(alts) => assert_eq!(alts.len(), 2),
@@ -971,15 +974,15 @@ mod tests {
         }
     }
 
-    /// `InvestigatorTarget::Controller` and `Active` are distinct
+    /// `InvestigatorTarget::You` and `Active` are distinct
     /// variants — they coincide during the controller's own turn but
     /// differ during reactions across turns. The compiler enforces
     /// the difference at every match site; this test pins the
     /// distinction at the type level.
     #[test]
     fn investigator_target_controller_and_active_are_distinct() {
-        assert_ne!(InvestigatorTarget::Controller, InvestigatorTarget::Active);
-        let controller_effect = gain_resources(InvestigatorTarget::Controller, 1);
+        assert_ne!(InvestigatorTarget::You, InvestigatorTarget::Active);
+        let controller_effect = gain_resources(InvestigatorTarget::You, 1);
         let active_effect = gain_resources(InvestigatorTarget::Active, 1);
         assert_ne!(controller_effect, active_effect);
     }
@@ -1001,8 +1004,8 @@ mod tests {
                 modify(Stat::Intellect, -1, ModifierScope::ThisSkillTest),
             ),
             choose_one([
-                discover_clue(LocationTarget::ControllerLocation, 1),
-                gain_resources(InvestigatorTarget::Controller, 2),
+                discover_clue(LocationTarget::YourLocation, 1),
+                gain_resources(InvestigatorTarget::You, 2),
             ]),
         ]);
         let json = serde_json::to_string(&original).expect("serialize");
@@ -1022,7 +1025,7 @@ mod tests {
                 by_controller: true,
             },
             EventTiming::After,
-            discover_clue(LocationTarget::ControllerLocation, 1),
+            discover_clue(LocationTarget::YourLocation, 1),
         );
         assert_eq!(
             ability.trigger,
@@ -1036,7 +1039,7 @@ mod tests {
         assert!(matches!(
             ability.effect,
             Effect::DiscoverClue {
-                from: LocationTarget::ControllerLocation,
+                from: LocationTarget::YourLocation,
                 count: 1,
             },
         ));
@@ -1091,7 +1094,7 @@ mod tests {
                     by_controller: true,
                 },
                 timing,
-                discover_clue(LocationTarget::ControllerLocation, 1),
+                discover_clue(LocationTarget::YourLocation, 1),
             );
             let json = serde_json::to_string(&original).expect("serialize");
             let recovered: Ability = serde_json::from_str(&json).expect("deserialize");
@@ -1104,12 +1107,12 @@ mod tests {
     /// level so the compiler enforces the difference at every match site.
     #[test]
     fn revelation_builder_constructs_treachery_shape() {
-        let ability = revelation(gain_resources(InvestigatorTarget::Controller, 1));
+        let ability = revelation(gain_resources(InvestigatorTarget::You, 1));
         assert_eq!(ability.trigger, Trigger::Revelation);
         assert!(matches!(
             ability.effect,
             Effect::GainResources {
-                target: InvestigatorTarget::Controller,
+                target: InvestigatorTarget::You,
                 amount: 1,
             },
         ));
@@ -1126,7 +1129,7 @@ mod tests {
 
     #[test]
     fn revelation_ability_round_trips_through_serde_json() {
-        let original = revelation(gain_resources(InvestigatorTarget::Controller, 1));
+        let original = revelation(gain_resources(InvestigatorTarget::You, 1));
         let json = serde_json::to_string(&original).expect("serialize");
         let recovered: Ability = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(original, recovered);
@@ -1214,8 +1217,8 @@ mod tests {
                 modify(Stat::Intellect, -1, ModifierScope::ThisSkillTest),
             ),
             choose_one([
-                discover_clue(LocationTarget::ControllerLocation, 1),
-                gain_resources(InvestigatorTarget::Controller, 2),
+                discover_clue(LocationTarget::YourLocation, 1),
+                gain_resources(InvestigatorTarget::You, 2),
             ]),
         ]);
         let cloned = original.clone();

--- a/crates/cards/src/impls/roland_banks.rs
+++ b/crates/cards/src/impls/roland_banks.rs
@@ -22,14 +22,14 @@
 //! [`EventPattern::EnemyDefeated`] pattern narrowed by
 //! `by_controller: true` (Roland's "After **you** defeat an enemy")
 //! at [`EventTiming::After`], discovering 1 clue at
-//! [`LocationTarget::ControllerLocation`]. The "Limit once per round"
+//! [`LocationTarget::YourLocation`]. The "Limit once per round"
 //! clause attaches as a [`UsageLimit`] with `count: 1, period:
 //! UsagePeriod::Round`.
 //!
 //! [`Trigger::OnEvent`]: card_dsl::dsl::Trigger::OnEvent
 //! [`EventPattern::EnemyDefeated`]: card_dsl::dsl::EventPattern::EnemyDefeated
 //! [`EventTiming::After`]: card_dsl::dsl::EventTiming::After
-//! [`LocationTarget::ControllerLocation`]: card_dsl::dsl::LocationTarget::ControllerLocation
+//! [`LocationTarget::YourLocation`]: card_dsl::dsl::LocationTarget::YourLocation
 //! [`UsageLimit`]: card_dsl::dsl::UsageLimit
 
 use card_dsl::dsl::{
@@ -50,7 +50,7 @@ pub fn abilities() -> Vec<Ability> {
             by_controller: true,
         },
         EventTiming::After,
-        discover_clue(LocationTarget::ControllerLocation, 1),
+        discover_clue(LocationTarget::YourLocation, 1),
     )
     .with_usage_limit(UsageLimit {
         count: 1,
@@ -80,7 +80,7 @@ mod tests {
         assert!(matches!(
             abilities[0].effect,
             Effect::DiscoverClue {
-                from: LocationTarget::ControllerLocation,
+                from: LocationTarget::YourLocation,
                 count: 1,
             },
         ));

--- a/crates/cards/src/impls/working_a_hunch.rs
+++ b/crates/cards/src/impls/working_a_hunch.rs
@@ -19,10 +19,7 @@ pub const CODE: &str = "01037";
 /// On play, discover 1 clue at the controller's location.
 #[must_use]
 pub fn abilities() -> Vec<Ability> {
-    vec![on_play(discover_clue(
-        LocationTarget::ControllerLocation,
-        1,
-    ))]
+    vec![on_play(discover_clue(LocationTarget::YourLocation, 1))]
 }
 
 #[cfg(test)]
@@ -37,7 +34,7 @@ mod tests {
         assert!(matches!(
             abilities[0].effect,
             Effect::DiscoverClue {
-                from: LocationTarget::ControllerLocation,
+                from: LocationTarget::YourLocation,
                 count: 1,
             }
         ));

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -470,7 +470,7 @@ fn apply_skill_test_follow_up(
     match follow_up {
         SkillTestFollowUp::None => {}
         SkillTestFollowUp::Investigate => {
-            let effect = discover_clue(LocationTarget::ControllerLocation, 1);
+            let effect = discover_clue(LocationTarget::YourLocation, 1);
             let eval_ctx = EvalContext::for_controller(investigator);
             // Same caveat as the pre-refactor `investigate`: the only
             // remaining rejection path inside `discover_clue` is

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -74,8 +74,8 @@ use super::Cx;
 #[non_exhaustive]
 pub struct EvalContext {
     /// The investigator whose card-effect we're resolving — the
-    /// "you" in card text. Resolves [`InvestigatorTarget::Controller`]
-    /// and [`LocationTarget::ControllerLocation`].
+    /// "you" in card text. Resolves [`InvestigatorTarget::You`]
+    /// and [`LocationTarget::YourLocation`].
     pub controller: crate::state::InvestigatorId,
     /// The in-play card-instance that triggered this effect, if any.
     /// Set by [`activate_ability`](crate::engine) so pushed
@@ -475,7 +475,7 @@ fn apply_seq(cx: &mut Cx, effects: &[Effect], eval_ctx: EvalContext) -> EngineOu
 /// (outside the Investigation phase). Card authors reaching for
 /// `Active` from a Mythos- or Enemy-phase reaction will silently
 /// fail until reaction windows wire an active-investigator-equivalent
-/// into `EvalContext`. Use [`InvestigatorTarget::Controller`] for
+/// into `EvalContext`. Use [`InvestigatorTarget::You`] for
 /// "the player who triggered this" — it doesn't depend on phase.
 fn resolve_investigator_target(
     state: &GameState,
@@ -483,7 +483,7 @@ fn resolve_investigator_target(
     target: InvestigatorTarget,
 ) -> Result<crate::state::InvestigatorId, &'static str> {
     match target {
-        InvestigatorTarget::Controller => Ok(ctx.controller),
+        InvestigatorTarget::You => Ok(ctx.controller),
         InvestigatorTarget::Active => state
             .active_investigator
             .ok_or("InvestigatorTarget::Active but no active investigator (outside Investigation)"),
@@ -502,11 +502,11 @@ fn resolve_location_target(
     target: LocationTarget,
 ) -> Result<crate::state::LocationId, &'static str> {
     match target {
-        LocationTarget::ControllerLocation => state
+        LocationTarget::YourLocation => state
             .investigators
             .get(&ctx.controller)
             .and_then(|i| i.current_location)
-            .ok_or("LocationTarget::ControllerLocation but the controller is between locations"),
+            .ok_or("LocationTarget::YourLocation but the controller is between locations"),
         LocationTarget::ChosenByController => {
             Err("LocationTarget::ChosenByController requires AwaitingInput plumbing")
         }
@@ -696,7 +696,7 @@ mod tests {
                 state: &mut state,
                 events: &mut events,
             },
-            &gain_resources(InvestigatorTarget::Controller, 3),
+            &gain_resources(InvestigatorTarget::You, 3),
             ctx(1),
         );
 
@@ -776,7 +776,7 @@ mod tests {
                 state: &mut state,
                 events: &mut events,
             },
-            &discover_clue(LocationTarget::ControllerLocation, 1),
+            &discover_clue(LocationTarget::YourLocation, 1),
             ctx(1),
         );
 
@@ -814,7 +814,7 @@ mod tests {
                 state: &mut state,
                 events: &mut events,
             },
-            &discover_clue(LocationTarget::ControllerLocation, 3),
+            &discover_clue(LocationTarget::YourLocation, 3),
             ctx(1),
         );
 
@@ -850,7 +850,7 @@ mod tests {
                 state: &mut state,
                 events: &mut events,
             },
-            &discover_clue(LocationTarget::ControllerLocation, 1),
+            &discover_clue(LocationTarget::YourLocation, 1),
             ctx(1),
         );
 
@@ -862,8 +862,8 @@ mod tests {
 
     #[test]
     fn discover_clue_rejects_when_controller_is_between_locations() {
-        // Controller has no current_location — LocationTarget::
-        // ControllerLocation can't resolve.
+        // "You" has no current_location — LocationTarget::
+        // YourLocation can't resolve.
         let mut state = TestGame::new()
             .with_investigator(test_investigator(1)) // current_location = None
             .build();
@@ -874,7 +874,7 @@ mod tests {
                 state: &mut state,
                 events: &mut events,
             },
-            &discover_clue(LocationTarget::ControllerLocation, 1),
+            &discover_clue(LocationTarget::YourLocation, 1),
             ctx(1),
         );
 
@@ -1043,7 +1043,7 @@ mod tests {
         let effect = if_else(
             Condition::SkillTestKind(SkillTestKind::Investigate),
             discover_clue(LocationTarget::TestedLocation, 1),
-            gain_resources(InvestigatorTarget::Controller, 2),
+            gain_resources(InvestigatorTarget::You, 2),
         );
         let resources_before = state.investigators[&InvestigatorId(1)].resources;
 
@@ -1179,8 +1179,8 @@ mod tests {
                 events: &mut events,
             },
             &seq([
-                gain_resources(InvestigatorTarget::Controller, 2),
-                discover_clue(LocationTarget::ControllerLocation, 1),
+                gain_resources(InvestigatorTarget::You, 2),
+                discover_clue(LocationTarget::YourLocation, 1),
             ]),
             ctx(1),
         );
@@ -1215,7 +1215,7 @@ mod tests {
             },
             &seq([
                 gain_resources(InvestigatorTarget::Active, 1), // rejects
-                discover_clue(LocationTarget::ControllerLocation, 1), // shouldn't run
+                discover_clue(LocationTarget::YourLocation, 1), // shouldn't run
             ]),
             ctx(1),
         );
@@ -1322,7 +1322,7 @@ mod tests {
                 state: &mut state,
                 events: &mut events,
             },
-            &Effect::ChooseOne(vec![gain_resources(InvestigatorTarget::Controller, 1)]),
+            &Effect::ChooseOne(vec![gain_resources(InvestigatorTarget::You, 1)]),
             ctx(1),
         );
         match outcome {
@@ -1692,7 +1692,7 @@ mod tests {
         };
         let outcome = apply_effect(
             &mut cx,
-            &deal_damage(InvestigatorTarget::Controller, 2),
+            &deal_damage(InvestigatorTarget::You, 2),
             EvalContext::for_controller(InvestigatorId(1)),
         );
         assert_eq!(outcome, EngineOutcome::Done);
@@ -1716,7 +1716,7 @@ mod tests {
         };
         let outcome = apply_effect(
             &mut cx,
-            &deal_horror(InvestigatorTarget::Controller, 1),
+            &deal_horror(InvestigatorTarget::You, 1),
             EvalContext::for_controller(InvestigatorId(1)),
         );
         assert_eq!(outcome, EngineOutcome::Done);
@@ -1743,7 +1743,7 @@ mod tests {
                 state: &mut state,
                 events: &mut events,
             },
-            &deal_damage(InvestigatorTarget::Controller, 3),
+            &deal_damage(InvestigatorTarget::You, 3),
             EvalContext::for_controller(id),
         );
         assert_eq!(outcome, EngineOutcome::Done);

--- a/crates/game-core/tests/activate_ability.rs
+++ b/crates/game-core/tests/activate_ability.rs
@@ -61,12 +61,12 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
         FAST_RESOURCE_LOOP => Some(vec![activated(
             0,
             vec![Cost::Resources(1)],
-            gain_resources(InvestigatorTarget::Controller, 1),
+            gain_resources(InvestigatorTarget::You, 1),
         )]),
         ACTION_EXHAUST_GAIN => Some(vec![activated(
             1,
             vec![Cost::Exhaust],
-            gain_resources(InvestigatorTarget::Controller, 1),
+            gain_resources(InvestigatorTarget::You, 1),
         )]),
         CONSTANT_ONLY => Some(vec![constant(modify(
             Stat::Willpower,
@@ -76,7 +76,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
         DISCARD_COST_ABILITY => Some(vec![activated(
             0,
             vec![Cost::DiscardCardFromHand],
-            gain_resources(InvestigatorTarget::Controller, 1),
+            gain_resources(InvestigatorTarget::You, 1),
         )]),
         SKILL_BOOST => Some(vec![activated(
             0,

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -56,7 +56,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
         Some(vec![on_event(
             EventPattern::EnteredLocation,
             EventTiming::After,
-            deal_horror(InvestigatorTarget::Controller, 1),
+            deal_horror(InvestigatorTarget::You, 1),
         )])
     } else if code.as_str() == DOOM_AGENDA || code.as_str() == DOOM_ACT {
         Some(vec![on_event(
@@ -64,7 +64,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
                 phase: DslPhase::Enemy,
             },
             EventTiming::After,
-            deal_horror(InvestigatorTarget::Controller, 1),
+            deal_horror(InvestigatorTarget::You, 1),
         )])
     } else if code.as_str() == DOUBLE_FORCED {
         // Two distinct forced `EnteredLocation` abilities at the same timing
@@ -73,12 +73,12 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
             on_event(
                 EventPattern::EnteredLocation,
                 EventTiming::After,
-                deal_horror(InvestigatorTarget::Controller, 1),
+                deal_horror(InvestigatorTarget::You, 1),
             ),
             on_event(
                 EventPattern::EnteredLocation,
                 EventTiming::After,
-                deal_horror(InvestigatorTarget::Controller, 1),
+                deal_horror(InvestigatorTarget::You, 1),
             ),
         ])
     } else {

--- a/crates/game-core/tests/reaction_windows.rs
+++ b/crates/game-core/tests/reaction_windows.rs
@@ -58,14 +58,14 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
                 by_controller: true,
             },
             EventTiming::After,
-            discover_clue(LocationTarget::ControllerLocation, 1),
+            discover_clue(LocationTarget::YourLocation, 1),
         )]),
         BYSTANDER_REACTION => Some(vec![on_event(
             EventPattern::EnemyDefeated {
                 by_controller: false,
             },
             EventTiming::After,
-            gain_resources(InvestigatorTarget::Controller, 1),
+            gain_resources(InvestigatorTarget::You, 1),
         )]),
         TWO_REACTIONS => Some(vec![
             on_event(
@@ -73,14 +73,14 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
                     by_controller: true,
                 },
                 EventTiming::After,
-                discover_clue(LocationTarget::ControllerLocation, 1),
+                discover_clue(LocationTarget::YourLocation, 1),
             ),
             on_event(
                 EventPattern::EnemyDefeated {
                     by_controller: true,
                 },
                 EventTiming::After,
-                gain_resources(InvestigatorTarget::Controller, 1),
+                gain_resources(InvestigatorTarget::You, 1),
             ),
         ]),
         _ => None,

--- a/crates/scenarios/src/test_fixtures/synth_cards.rs
+++ b/crates/scenarios/src/test_fixtures/synth_cards.rs
@@ -240,13 +240,10 @@ fn metadata_for(code: &CardCode) -> Option<&'static CardMetadata> {
 /// `abilities_for` function pointer used by [`TEST_REGISTRY`].
 fn abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
     match code.as_str() {
-        SYNTH_TREACHERY_CODE | SYNTH_SURGE_TREACHERY_CODE => Some(vec![revelation(
-            gain_resources(InvestigatorTarget::Controller, 1),
-        )]),
-        SYNTH_FAST_EVENT_CODE => Some(vec![on_play(gain_resources(
-            InvestigatorTarget::Controller,
-            1,
-        ))]),
+        SYNTH_TREACHERY_CODE | SYNTH_SURGE_TREACHERY_CODE => {
+            Some(vec![revelation(gain_resources(InvestigatorTarget::You, 1))])
+        }
+        SYNTH_FAST_EVENT_CODE => Some(vec![on_play(gain_resources(InvestigatorTarget::You, 1))]),
         // SYNTH_ENEMY_CODE intentionally returns None — the synthetic
         // enemy has no Revelation effect; the spawn handler is the
         // only thing exercised by the integration test.


### PR DESCRIPTION
## Summary

Rename the two DSL effect-target variants that mean "you" in card text:
`InvestigatorTarget::Controller → You` and
`LocationTarget::ControllerLocation → YourLocation`. Pure mechanical rename,
**no behavior change** — prep so the upcoming Gathering location cards read
naturally (`deal_horror(You, 1)`).

## What changed

- `InvestigatorTarget::Controller` → `You`; `LocationTarget::ControllerLocation`
  → `YourLocation`, across `card-dsl`, `game-core` (evaluator/skill-test +
  integration tests), `cards` impls, and the synthetic fixture.
- Variant doc comments rewritten to explain the binding ("the investigator this
  ability acts on — 'you' in card text; for a forced trigger, the affected
  investigator, e.g. the one entering a location").

## Design decision — scope (slight narrowing from the issue)

The issue mentioned also renaming `EvalContext::for_controller`. I deliberately
kept the **engine internals** on "controller" vocabulary:

- `EvalContext::for_controller` / the `controller` field name the investigator
  the eval context is centered on — not card-author-facing. The resolver reads
  `InvestigatorTarget::You => Ok(ctx.controller)`, which is self-documenting.
- The skill-test path's "controller's cards" is the genuine **card-control**
  concept (who controls an in-play card), distinct from the DSL "you" *target*.
- `ChosenByController` / `AtControllerLocation` refer to the controlling player
  as decision-maker/locus and are intentionally left.

Renaming those would either muddy the card-control concept or make internal
error messages read awkwardly ("you is not in the state"). Happy to widen if
you'd rather.

## Test notes

No tests added (behavior-preserving rename); existing suite updated to the new
names. Local gauntlet green: `test` (`-D warnings`), host `clippy`, `fmt
--check`, `doc` (`-D warnings`), `wasm-build`, `wasm-clippy`. `wasm-test`
(headless Firefox) left to CI — unaffected by a rename.

## Linked issues

Closes #248