### PR TITLE
engine: promote TestGame to a first-class GameStateBuilder (#251)

### DIFF
--- a/crates/cards/tests/deduction.rs
+++ b/crates/cards/tests/deduction.rs
@@ -17,7 +17,7 @@ use game_core::state::{
     CardCode, ChaosBag, ChaosToken, InvestigatorId, LocationId, Phase, SkillKind, TokenModifiers,
 };
 use game_core::test_support::{
-    drive, test_investigator, test_location, ScriptedResolver, TestGame,
+    drive, test_investigator, test_location, GameStateBuilder, ScriptedResolver,
 };
 use game_core::{assert_event, assert_event_count, assert_no_event, Action, PlayerAction};
 
@@ -46,7 +46,7 @@ fn state_with_deduction(
     let mut location = test_location(10, "Study");
     location.shroud = shroud;
     location.clues = initial_clues;
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_investigator(inv)
         .with_active_investigator(id)

--- a/crates/cards/tests/fast_play.rs
+++ b/crates/cards/tests/fast_play.rs
@@ -37,7 +37,7 @@ use game_core::state::{
     CardCode, CardInPlay, CardInstanceId, FastActorScope, InvestigatorId, LocationId, Phase,
     PhaseStep, WindowKind,
 };
-use game_core::test_support::{test_investigator, test_location, TestGame};
+use game_core::test_support::{test_investigator, test_location, GameStateBuilder};
 
 fn install_cards_registry() {
     static INSTALL: Once = Once::new();
@@ -58,7 +58,7 @@ fn fast_asset_playable_by_owner_during_permissive_window() {
     let mut a = test_investigator(1);
     a.resources = 5;
     a.hand.push(CardCode::new("01030")); // Magnifying Glass — Fast.
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_investigator(a)
         .with_phase(Phase::Mythos)
         .with_active_investigator(InvestigatorId(1))
@@ -96,7 +96,7 @@ fn fast_asset_rejected_by_non_owner_even_with_permissive_window() {
     let mut b = test_investigator(2);
     b.resources = 5;
     b.hand.push(CardCode::new("01030")); // Magnifying Glass — Fast.
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_investigator(a)
         .with_investigator(b)
         .with_phase(Phase::Investigation)
@@ -136,7 +136,7 @@ fn non_fast_asset_still_rejected_when_not_active_investigator() {
     let mut b = test_investigator(2);
     b.resources = 5;
     b.hand.push(CardCode::new("01059")); // Holy Rosary — non-Fast asset, cost 2.
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_investigator(a)
         .with_investigator(b)
         .with_phase(Phase::Investigation)
@@ -176,7 +176,7 @@ fn fast_asset_still_playable_by_active_investigator_during_investigation() {
     let mut a = test_investigator(1);
     a.resources = 5;
     a.hand.push(CardCode::new("01030")); // Magnifying Glass — Fast.
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_investigator(a)
         .with_phase(Phase::Investigation)
         .with_active_investigator(InvestigatorId(1))
@@ -206,7 +206,7 @@ fn fast_activated_ability_usable_by_non_active_investigator_when_window_permits(
         CardCode::new("01034"),
         CardInstanceId(1),
     ));
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_investigator(a)
         .with_investigator(b)
         .with_phase(Phase::Investigation)
@@ -244,7 +244,7 @@ fn fast_activated_ability_rejected_when_no_permissive_window() {
         CardCode::new("01034"),
         CardInstanceId(1),
     ));
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_investigator(a)
         .with_investigator(b)
         .with_phase(Phase::Investigation)
@@ -288,7 +288,7 @@ fn fast_event_playable_by_active_investigator_outside_investigation_in_permissiv
     a.hand.push(CardCode::new("01037"));
     let mut location = test_location(101, "Study");
     location.clues = 1;
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_investigator(a)
         .with_location(location)
         .with_phase(Phase::Mythos)
@@ -350,7 +350,7 @@ fn fast_event_playable_by_non_owner_when_window_permits() {
     b.hand.push(CardCode::new("01037"));
     let mut location = test_location(101, "Study");
     location.clues = 1;
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_investigator(a)
         .with_investigator(b)
         .with_location(location)
@@ -388,7 +388,7 @@ fn fast_asset_rejected_by_owner_outside_investigation_with_no_window() {
     let mut a = test_investigator(1);
     a.resources = 5;
     a.hand.push(CardCode::new("01030")); // Magnifying Glass — Fast asset.
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_investigator(a)
         .with_phase(Phase::Mythos)
         .with_active_investigator(InvestigatorId(1))

--- a/crates/cards/tests/holy_rosary.rs
+++ b/crates/cards/tests/holy_rosary.rs
@@ -15,7 +15,7 @@ use game_core::event::Event;
 use game_core::state::{
     CardCode, ChaosBag, ChaosToken, InvestigatorId, Phase, SkillKind, TokenModifiers,
 };
-use game_core::test_support::{apply_no_commits, test_investigator, TestGame};
+use game_core::test_support::{apply_no_commits, test_investigator, GameStateBuilder};
 use game_core::{assert_event, Action, PlayerAction};
 
 const HOLY_ROSARY: &str = "01059";
@@ -39,7 +39,7 @@ fn state_with_rosary_in_hand() -> (game_core::GameState, InvestigatorId) {
     let mut inv = test_investigator(1);
     inv.hand = vec![CardCode::new(HOLY_ROSARY)];
 
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_investigator(inv)
         .with_active_investigator(id)

--- a/crates/cards/tests/hyperawareness.rs
+++ b/crates/cards/tests/hyperawareness.rs
@@ -17,7 +17,7 @@ use game_core::state::{
     CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, InvestigatorId, Phase, SkillKind,
     TokenModifiers,
 };
-use game_core::test_support::{apply_no_commits, test_investigator, TestGame};
+use game_core::test_support::{apply_no_commits, test_investigator, GameStateBuilder};
 use game_core::{assert_event, Action, PlayerAction};
 
 const HYPERAWARENESS: &str = "01034";
@@ -48,7 +48,7 @@ fn state_with_hyperawareness() -> (game_core::GameState, InvestigatorId, CardIns
         instance_id,
     ));
 
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_investigator(inv)
         .with_active_investigator(id)

--- a/crates/cards/tests/magnifying_glass.rs
+++ b/crates/cards/tests/magnifying_glass.rs
@@ -13,7 +13,9 @@ use game_core::event::Event;
 use game_core::state::{
     CardCode, ChaosBag, ChaosToken, InvestigatorId, LocationId, Phase, SkillKind, TokenModifiers,
 };
-use game_core::test_support::{apply_no_commits, test_investigator, test_location, TestGame};
+use game_core::test_support::{
+    apply_no_commits, test_investigator, test_location, GameStateBuilder,
+};
 use game_core::{assert_event, Action, PlayerAction};
 
 const MAGNIFYING_GLASS: &str = "01030";
@@ -44,7 +46,7 @@ fn state_with_mg_in_hand() -> (game_core::GameState, InvestigatorId, LocationId)
     location.shroud = 4;
     location.clues = 1;
 
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_investigator(inv)
         .with_active_investigator(id)

--- a/crates/cards/tests/play_card.rs
+++ b/crates/cards/tests/play_card.rs
@@ -18,7 +18,7 @@ use std::sync::Once;
 use game_core::engine::{apply, EngineOutcome};
 use game_core::event::Event;
 use game_core::state::{CardCode, InvestigatorId, Phase, Status, Zone};
-use game_core::test_support::{test_investigator, test_location, TestGame};
+use game_core::test_support::{test_investigator, test_location, GameStateBuilder};
 use game_core::PlayerAction;
 use game_core::{assert_event, assert_event_count, assert_event_sequence, assert_no_event};
 use game_core::{Action, LocationId};
@@ -74,7 +74,7 @@ fn play_state(hand: Vec<&str>) -> (game_core::GameState, InvestigatorId, Locatio
 
     let location = test_location(101, "Study");
 
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_investigator(inv)
         .with_active_investigator(id)
@@ -358,7 +358,7 @@ fn play_card_after_defeat_is_rejected() {
     inv.hand = vec![CardCode::new(HOLY_ROSARY)];
     inv.status = Status::Killed;
 
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_investigator(inv)
         .with_active_investigator(id)

--- a/crates/cards/tests/reject_rollback.rs
+++ b/crates/cards/tests/reject_rollback.rs
@@ -15,7 +15,7 @@ use game_core::dsl::{gain_resources, modify, on_play, seq, Ability};
 use game_core::dsl::{InvestigatorTarget, ModifierScope, Stat};
 use game_core::engine::{apply, EngineOutcome};
 use game_core::state::{CardCode, InvestigatorId, LocationId, Phase};
-use game_core::test_support::{test_investigator, test_location, TestGame};
+use game_core::test_support::{test_investigator, test_location, GameStateBuilder};
 use game_core::{Action, PlayerAction};
 
 /// Code for the synthetic probe card. Not in the real corpus; only the
@@ -87,7 +87,7 @@ fn mid_resolution_reject_leaves_state_and_events_untouched() {
     inv.current_location = Some(loc_id);
     inv.hand = vec![CardCode::new(PROBE)];
 
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_investigator(inv)
         .with_active_investigator(id)

--- a/crates/cards/tests/roland_banks.rs
+++ b/crates/cards/tests/roland_banks.rs
@@ -24,8 +24,8 @@ use game_core::state::{
     InvestigatorId, LocationId, Phase, TokenModifiers, WindowKind,
 };
 use game_core::test_support::{
-    apply_no_commits, drive, test_enemy, test_investigator, test_location, ScriptedResolver,
-    TestGame,
+    apply_no_commits, drive, test_enemy, test_investigator, test_location, GameStateBuilder,
+    ScriptedResolver,
 };
 use game_core::{assert_event, assert_no_event, Action, PlayerAction};
 
@@ -75,7 +75,7 @@ fn roland_at_location_with_enemy(
     let mut loc = test_location(10, "Study");
     loc.clues = location_clues;
 
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_round(round)
         .with_active_investigator(inv_id)

--- a/crates/cards/tests/roster_seating.rs
+++ b/crates/cards/tests/roster_seating.rs
@@ -8,7 +8,7 @@ use std::sync::Once;
 use game_core::action::{PlayerAction, RosterEntry};
 use game_core::engine::{apply, EngineOutcome};
 use game_core::state::{CardCode, InvestigatorId, Skills};
-use game_core::test_support::TestGame;
+use game_core::test_support::GameStateBuilder;
 use game_core::Action;
 
 /// Install the real card registry exactly once for this integration-test
@@ -29,7 +29,7 @@ fn seats_roland_with_corpus_stats_and_payload_deck() {
         investigator: CardCode::new("01001"),
         deck: deck.clone(),
     }];
-    let state = TestGame::new().build();
+    let state = GameStateBuilder::new().build();
 
     let result = apply(
         state,
@@ -67,7 +67,7 @@ fn rejects_non_investigator_code() {
         investigator: CardCode::new("01030"),
         deck: vec![],
     }];
-    let state = TestGame::new().build();
+    let state = GameStateBuilder::new().build();
     let result = apply(
         state,
         Action::Player(PlayerAction::StartScenario { roster }),
@@ -84,7 +84,7 @@ fn rejects_unknown_code() {
         investigator: CardCode::new("99999"),
         deck: vec![],
     }];
-    let state = TestGame::new().build();
+    let state = GameStateBuilder::new().build();
     let result = apply(
         state,
         Action::Player(PlayerAction::StartScenario { roster }),

--- a/crates/cards/tests/skill_test_commits.rs
+++ b/crates/cards/tests/skill_test_commits.rs
@@ -20,7 +20,7 @@ use game_core::event::Event;
 use game_core::state::{
     CardCode, ChaosBag, ChaosToken, InvestigatorId, SkillKind, TokenModifiers, Zone,
 };
-use game_core::test_support::{drive, test_investigator, ScriptedResolver, TestGame};
+use game_core::test_support::{drive, test_investigator, GameStateBuilder, ScriptedResolver};
 use game_core::{assert_event, assert_event_count, assert_no_event, Action, PlayerAction};
 
 const PERCEPTION: &str = "01090";
@@ -45,7 +45,7 @@ fn state_with_hand(hand: &[&str]) -> (game_core::GameState, InvestigatorId) {
     let id = InvestigatorId(1);
     let mut inv = test_investigator(1);
     inv.hand = hand.iter().map(|c| CardCode::new(*c)).collect();
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_investigator(inv)
         .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
         .with_token_modifiers(TokenModifiers::default())

--- a/crates/game-core/src/card_registry.rs
+++ b/crates/game-core/src/card_registry.rs
@@ -28,7 +28,7 @@
 //!
 //! `OnceLock` is process-global, so all tests in a process share the
 //! same registry. Today no test mocks card data — tests use the real
-//! corpus or skip card lookups entirely via the `TestGame` builder —
+//! corpus or skip card lookups entirely via the `GameStateBuilder` builder —
 //! so this is fine. If/when per-test mocking is needed, we'll move to
 //! a registry threaded through `apply()` or stored on `GameState`.
 

--- a/crates/game-core/src/engine/dispatch/act_agenda.rs
+++ b/crates/game-core/src/engine/dispatch/act_agenda.rs
@@ -187,13 +187,13 @@ pub(super) fn request_resolution(state: &mut GameState, resolution: crate::scena
 mod doom_agenda_tests {
     use super::*;
     use crate::event::Event;
-    use crate::test_support::TestGame;
+    use crate::test_support::GameStateBuilder;
     use crate::{assert_event, assert_no_event};
 
     #[test]
     fn place_doom_increments_agenda_doom() {
         use crate::state::{Agenda, CardCode};
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         state.agenda_deck = vec![Agenda {
             code: CardCode("_test_agenda".into()),
             doom_threshold: 2,
@@ -216,7 +216,7 @@ mod doom_agenda_tests {
     fn doom_threshold_advances_non_terminal_agenda() {
         use crate::scenario::Resolution;
         use crate::state::{Agenda, CardCode};
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         state.agenda_deck = vec![
             Agenda {
                 code: CardCode("_test_agenda_1".into()),
@@ -250,7 +250,7 @@ mod doom_agenda_tests {
     fn doom_threshold_on_terminal_agenda_sets_resolution_latch() {
         use crate::scenario::Resolution;
         use crate::state::{Agenda, CardCode};
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         state.agenda_deck = vec![Agenda {
             code: CardCode("_test_agenda".into()),
             doom_threshold: 2,
@@ -275,7 +275,7 @@ mod doom_agenda_tests {
     #[test]
     fn doom_threshold_not_met_does_nothing() {
         use crate::state::{Agenda, CardCode};
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         state.agenda_deck = vec![Agenda {
             code: CardCode("_test_agenda".into()),
             doom_threshold: 3,
@@ -295,7 +295,7 @@ mod doom_agenda_tests {
     #[test]
     fn request_resolution_is_first_writer_wins() {
         use crate::scenario::Resolution;
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         request_resolution(
             &mut state,
             Resolution::Lost {
@@ -320,7 +320,7 @@ mod advance_act_tests {
     use crate::engine::{apply, EngineOutcome};
     use crate::event::Event;
     use crate::state::{InvestigatorId, Phase};
-    use crate::test_support::{test_investigator, TestGame};
+    use crate::test_support::{test_investigator, GameStateBuilder};
     use crate::{assert_event, assert_no_event};
 
     #[test]
@@ -329,7 +329,7 @@ mod advance_act_tests {
         let inv = InvestigatorId(1);
         let mut investigator = test_investigator(1);
         investigator.clues = 1;
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_investigator(investigator)
             .with_active_investigator(inv)
@@ -360,7 +360,7 @@ mod advance_act_tests {
         let inv = InvestigatorId(1);
         let mut investigator = test_investigator(1);
         investigator.clues = 3;
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_investigator(investigator)
             .with_active_investigator(inv)
@@ -400,7 +400,7 @@ mod advance_act_tests {
         let inv = InvestigatorId(1);
         let mut investigator = test_investigator(1);
         investigator.clues = 2;
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_investigator(investigator)
             .with_active_investigator(inv)
@@ -438,7 +438,7 @@ mod advance_act_tests {
         inv1.clues = 1;
         let mut inv2 = test_investigator(2);
         inv2.clues = 2;
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_investigator(inv1)
             .with_investigator(inv2)

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -534,12 +534,12 @@ pub(super) fn play_card(
 mod grant_resources_tests {
     use super::*;
     use crate::state::InvestigatorId;
-    use crate::test_support::{test_investigator, TestGame};
+    use crate::test_support::{test_investigator, GameStateBuilder};
 
     #[test]
     fn grant_resources_adds_to_wallet_and_emits() {
         let id = InvestigatorId(1);
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .build();
         let before = state.investigators[&id].resources;
@@ -564,7 +564,7 @@ mod grant_resources_tests {
     #[test]
     fn grant_resources_zero_is_silent_noop() {
         let id = InvestigatorId(1);
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .build();
         let before = state.investigators[&id].resources;
@@ -588,7 +588,7 @@ mod grant_resources_tests {
 mod draw_one_with_deckout_tests {
     use super::*;
     use crate::state::{CardCode, InvestigatorId};
-    use crate::test_support::{test_investigator, TestGame};
+    use crate::test_support::{test_investigator, GameStateBuilder};
 
     #[test]
     fn draw_one_with_deckout_empty_deck_reshuffles_and_takes_horror() {
@@ -598,7 +598,7 @@ mod draw_one_with_deckout_tests {
         inv.discard = vec![CardCode::new("01000"), CardCode::new("01001")];
         inv.horror = 0;
         let hand_before = inv.hand.len();
-        let mut state = TestGame::default().with_investigator(inv).build();
+        let mut state = GameStateBuilder::default().with_investigator(inv).build();
         let mut events = Vec::new();
 
         draw_one_with_deckout(

--- a/crates/game-core/src/engine/dispatch/elimination.rs
+++ b/crates/game-core/src/engine/dispatch/elimination.rs
@@ -250,7 +250,7 @@ mod elimination_tests {
     use super::*;
     use crate::assert_event;
     use crate::assert_no_event;
-    use crate::test_support::{test_enemy, test_investigator, test_location, TestGame};
+    use crate::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
 
     #[test]
     fn elimination_step1_removes_controlled_and_owned_cards() {
@@ -265,7 +265,7 @@ mod elimination_tests {
             CardInstanceId(1),
         )];
 
-        let mut state = TestGame::default().with_investigator(inv).build();
+        let mut state = GameStateBuilder::default().with_investigator(inv).build();
         let mut events = Vec::new();
 
         apply_investigator_defeat(
@@ -308,7 +308,7 @@ mod elimination_tests {
         let mut loc = test_location(1, "Study");
         loc.clues = 1;
 
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(inv)
             .with_location(loc)
             .build();
@@ -358,7 +358,7 @@ mod elimination_tests {
             e
         };
 
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(dying)
             .with_investigator(survivor)
             .with_location(test_location(1, "Study"))
@@ -408,7 +408,7 @@ mod elimination_tests {
             e
         };
 
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(dying)
             .with_location(test_location(1, "Study"))
             .with_enemy(enemy)
@@ -442,7 +442,7 @@ mod elimination_tests {
         let inv = InvestigatorId(1);
         let mut investigator = test_investigator(1);
         investigator.max_sanity = 1;
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_investigator(investigator)
             .with_active_investigator(inv)
@@ -491,7 +491,7 @@ mod elimination_tests {
             e
         };
 
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(dying)
             .with_investigator(survivor)
             .with_location(test_location(1, "Study"))
@@ -540,7 +540,7 @@ mod elimination_tests {
             e
         };
 
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(dying)
             .with_investigator(survivor)
             .with_location(test_location(1, "Study"))
@@ -576,7 +576,7 @@ mod elimination_tests {
         inv.clues = 3;
         inv.resources = 2;
 
-        let mut state = TestGame::default().with_investigator(inv).build();
+        let mut state = GameStateBuilder::default().with_investigator(inv).build();
         let mut events = Vec::new();
 
         apply_investigator_defeat(

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -617,7 +617,7 @@ pub(super) fn advance_mythos_draw_pending(cx: &mut Cx) {
 #[cfg(test)]
 mod encounter_card_revealed_tests {
     use crate::state::CardCode;
-    use crate::test_support::{test_investigator, TestGame};
+    use crate::test_support::{test_investigator, GameStateBuilder};
 
     /// Exercises the early-reject guard: when the handler cannot
     /// proceed past the registry / metadata checks, it must reject
@@ -645,7 +645,7 @@ mod encounter_card_revealed_tests {
     fn rejects_when_no_card_registry_installed() {
         use crate::action::EngineRecord;
         use crate::state::InvestigatorId;
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
         // Seed the encounter deck so we can prove the reject fires
@@ -702,11 +702,11 @@ mod encounter_deck_helper_tests {
     use crate::event::Event;
     use crate::rng::RngState;
     use crate::state::CardCode;
-    use crate::test_support::TestGame;
+    use crate::test_support::GameStateBuilder;
 
     #[test]
     fn shuffle_encounter_deck_emits_event_when_two_or_more_cards() {
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         state.rng = RngState::new(42);
         state.encounter_deck.push_back(CardCode("a".into()));
         state.encounter_deck.push_back(CardCode("b".into()));
@@ -735,7 +735,7 @@ mod encounter_deck_helper_tests {
     #[test]
     fn shuffle_encounter_deck_is_silent_on_zero_or_one_card() {
         for n in 0..=1 {
-            let mut state = TestGame::new().build();
+            let mut state = GameStateBuilder::new().build();
             for i in 0..n {
                 state.encounter_deck.push_back(CardCode(format!("c{i}")));
             }
@@ -750,7 +750,7 @@ mod encounter_deck_helper_tests {
 
     #[test]
     fn reshuffle_encounter_discard_moves_discard_into_deck_and_shuffles() {
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         state.rng = RngState::new(7);
         for i in 0..5 {
             state.encounter_discard.push(CardCode(format!("d{i}")));
@@ -775,7 +775,7 @@ mod encounter_deck_helper_tests {
 
     #[test]
     fn reshuffle_encounter_discard_is_silent_when_discard_has_one_card() {
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         state.encounter_discard.push(CardCode("solo".into()));
 
         let mut events = Vec::new();
@@ -791,7 +791,7 @@ mod encounter_deck_helper_tests {
 
     #[test]
     fn draw_encounter_top_drains_deck_then_returns_none() {
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         state.encounter_deck.push_back(CardCode("a".into()));
         state.encounter_deck.push_back(CardCode("b".into()));
         state.encounter_deck.push_back(CardCode("c".into()));
@@ -834,7 +834,7 @@ mod encounter_deck_helper_tests {
 
     #[test]
     fn draw_encounter_top_reshuffles_discard_on_empty_deck() {
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         state.rng = RngState::new(13);
         state.encounter_discard.push(CardCode("x".into()));
         state.encounter_discard.push(CardCode("y".into()));
@@ -870,7 +870,7 @@ mod encounter_deck_helper_tests {
 
     #[test]
     fn draw_encounter_top_returns_none_when_deck_and_discard_both_empty() {
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         let mut events = Vec::new();
         assert_eq!(
             draw_encounter_top(&mut Cx {
@@ -887,7 +887,7 @@ mod encounter_deck_helper_tests {
         use crate::action::{Action, EngineRecord};
         use crate::engine::apply;
 
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         state.rng = RngState::new(99);
         for i in 0..4 {
             state.encounter_deck.push_back(CardCode(format!("c{i}")));
@@ -915,7 +915,7 @@ mod encounter_deck_helper_tests {
     #[test]
     fn encounter_deck_shuffle_is_deterministic_from_seed() {
         fn shuffle_with_seed(seed: u64) -> Vec<CardCode> {
-            let mut state = TestGame::new().build();
+            let mut state = GameStateBuilder::new().build();
             state.rng = RngState::new(seed);
             for i in 0..10 {
                 state.encounter_deck.push_back(CardCode(format!("c{i:02}")));
@@ -944,7 +944,7 @@ mod encounter_deck_helper_tests {
 mod spawn_enemy_tests {
     use super::*;
     use crate::state::{CardCode, InvestigatorId, LocationId, Phase};
-    use crate::test_support::{test_investigator, test_location, TestGame};
+    use crate::test_support::{test_investigator, test_location, GameStateBuilder};
     use crate::{assert_event, assert_event_sequence, assert_no_event};
     use card_dsl::card_data::{CardMetadata, CardType, Class, SkillIcons, Spawn, SpawnLocation};
 
@@ -979,7 +979,7 @@ mod spawn_enemy_tests {
     fn spawn_at_specific_location_with_one_investigator_engages_them() {
         let mut loc = test_location(10, "Synth Loc");
         loc.code = CardCode("_synth_loc".into());
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_location(loc)
             .with_turn_order([InvestigatorId(1)])
@@ -1027,7 +1027,7 @@ mod spawn_enemy_tests {
     fn spawn_at_specific_location_with_no_investigators_leaves_unengaged() {
         let mut loc = test_location(10, "Synth Loc");
         loc.code = CardCode("_synth_loc".into());
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_location(loc)
             .build();
@@ -1057,7 +1057,7 @@ mod spawn_enemy_tests {
 
     #[test]
     fn spawn_at_specific_location_rejects_when_location_not_in_play() {
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
         let metadata = synth_enemy_metadata(Some(Spawn {
@@ -1089,7 +1089,7 @@ mod spawn_enemy_tests {
     fn spawn_with_no_instruction_places_at_drawing_investigators_location() {
         let mut loc = test_location(10, "Demo");
         loc.code = CardCode("_demo_loc".into());
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_location(loc)
             .with_turn_order([InvestigatorId(1)])
@@ -1126,7 +1126,7 @@ mod spawn_enemy_tests {
 
     #[test]
     fn spawn_with_no_instruction_rejects_when_drawing_investigator_has_no_location() {
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
         // Investigator has no current_location.
@@ -1160,7 +1160,7 @@ mod spawn_enemy_tests {
         loc.code = CardCode("_loc".into());
         let mut inv = test_investigator(1);
         inv.current_location = Some(LocationId(1));
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Mythos)
             .with_location(loc)
             .with_investigator(inv)
@@ -1190,7 +1190,7 @@ mod spawn_enemy_tests {
         i1.current_location = Some(LocationId(1));
         let mut i2 = test_investigator(2);
         i2.current_location = Some(LocationId(1));
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Mythos)
             .with_location(loc)
             .with_investigator(i1)
@@ -1227,7 +1227,7 @@ mod spawn_enemy_tests {
         i1.current_location = Some(LocationId(1));
         let mut i2 = test_investigator(2);
         i2.current_location = Some(LocationId(1));
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Mythos)
             .with_location(loc)
             .with_investigator(i1)
@@ -1272,7 +1272,7 @@ mod spawn_enemy_tests {
     fn spawn_mints_distinct_enemy_ids() {
         let mut loc = test_location(10, "L");
         loc.code = CardCode("_l".into());
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_location(loc)
             .build();
@@ -1316,7 +1316,7 @@ mod spawn_enemy_tests {
 mod mythos_draw_for_tests {
     use super::*;
     use crate::state::{CardCode, InvestigatorId, Phase};
-    use crate::test_support::{test_investigator, TestGame};
+    use crate::test_support::{test_investigator, GameStateBuilder};
 
     /// Exercises the early-reject guard for the registry / unknown-card
     /// checks. Depending on which tests have run in this process:
@@ -1333,7 +1333,7 @@ mod mythos_draw_for_tests {
     /// at most one) matching the `encounter_card_revealed_tests` pattern.
     #[test]
     fn rejects_when_registry_not_installed_or_unknown_code() {
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_phase(Phase::Mythos)
             .build();
@@ -1379,11 +1379,11 @@ mod mythos_draw_for_tests {
 mod draw_encounter_card_tests {
     use super::*;
     use crate::state::{InvestigatorId, Phase};
-    use crate::test_support::{test_investigator, TestGame};
+    use crate::test_support::{test_investigator, GameStateBuilder};
 
     #[test]
     fn rejects_outside_mythos_phase() {
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_phase(Phase::Investigation)
             .build();
@@ -1404,7 +1404,7 @@ mod draw_encounter_card_tests {
 
     #[test]
     fn rejects_when_no_draw_pending() {
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_phase(Phase::Mythos)
             .build();
@@ -1425,7 +1425,7 @@ mod draw_encounter_card_tests {
 
     #[test]
     fn rejects_when_out_of_order() {
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .with_phase(Phase::Mythos)

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -451,11 +451,11 @@ pub(super) fn resume_spawn_engage(
 #[cfg(test)]
 mod resolve_prey_tests {
     use super::*;
-    use crate::test_support::{test_investigator, TestGame};
+    use crate::test_support::{test_investigator, GameStateBuilder};
 
     #[test]
     fn resolve_prey_default_single_candidate_is_one() {
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
         let r = resolve_prey(
@@ -468,7 +468,7 @@ mod resolve_prey_tests {
 
     #[test]
     fn resolve_prey_default_multiple_is_tie() {
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .build();
@@ -482,7 +482,7 @@ mod resolve_prey_tests {
 
     #[test]
     fn resolve_prey_empty_is_none() {
-        let state = TestGame::new().build();
+        let state = GameStateBuilder::new().build();
         let r = resolve_prey(&state, crate::card_data::Prey::Default, &[]);
         assert!(matches!(r, PreyResolution::None));
     }
@@ -493,7 +493,7 @@ mod resolve_prey_tests {
         hi.skills.combat = 5;
         let mut lo = test_investigator(2);
         lo.skills.combat = 2;
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(hi)
             .with_investigator(lo)
             .build();
@@ -511,7 +511,7 @@ mod resolve_prey_tests {
         a.skills.combat = 4;
         let mut b = test_investigator(2);
         b.skills.combat = 4;
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(a)
             .with_investigator(b)
             .build();
@@ -529,7 +529,7 @@ mod hunter_movement_tests {
     use super::*;
     use crate::engine::Cx;
     use crate::state::{EnemyId, InvestigatorId, LocationId, Phase};
-    use crate::test_support::{test_enemy, test_investigator, test_location, TestGame};
+    use crate::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
     use crate::{assert_event, assert_no_event};
 
     #[test]
@@ -547,7 +547,7 @@ mod hunter_movement_tests {
         let mut ghoul = test_enemy(1, "Swarm");
         ghoul.hunter = true;
         ghoul.current_location = Some(LocationId(1));
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Enemy)
             .with_location(a)
             .with_location(b)
@@ -583,7 +583,7 @@ mod hunter_movement_tests {
         let mut h = test_enemy(1, "Hunter");
         h.hunter = true;
         h.current_location = Some(LocationId(1));
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Enemy)
             .with_location(a)
             .with_location(b)
@@ -617,7 +617,7 @@ mod hunter_movement_tests {
         let mut h = test_enemy(1, "Hunter");
         h.hunter = true;
         h.current_location = Some(LocationId(9));
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Enemy)
             .with_location(a)
             .with_location(island)
@@ -649,7 +649,7 @@ mod hunter_movement_tests {
         h.hunter = true;
         h.exhausted = true;
         h.current_location = Some(LocationId(1));
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Enemy)
             .with_location(a)
             .with_location(b)
@@ -680,7 +680,7 @@ mod hunter_movement_tests {
         let mut e = test_enemy(1, "Slug");
         e.hunter = false;
         e.current_location = Some(LocationId(1));
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Enemy)
             .with_location(a)
             .with_location(b)
@@ -713,7 +713,7 @@ mod hunter_movement_tests {
         let mut h = test_enemy(1, "Hunter");
         h.hunter = true;
         h.current_location = Some(LocationId(1));
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Enemy)
             .with_location(a)
             .with_location(b)
@@ -746,7 +746,7 @@ mod hunter_resume_tests {
     use crate::assert_event;
     use crate::engine::Cx;
     use crate::state::{EnemyId, InvestigatorId, LocationId, Phase};
-    use crate::test_support::{test_enemy, test_investigator, test_location, TestGame};
+    use crate::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
 
     #[test]
     fn hunter_move_tie_suspends_then_resumes_on_pick_location() {
@@ -765,7 +765,7 @@ mod hunter_resume_tests {
         let mut hunter = test_enemy(1, "Hunter");
         hunter.hunter = true;
         hunter.current_location = Some(LocationId(1));
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Enemy)
             .with_location(loc_a)
             .with_location(loc_b)
@@ -816,7 +816,7 @@ mod hunter_resume_tests {
         let mut hunter = test_enemy(1, "Hunter");
         hunter.hunter = true;
         hunter.current_location = Some(LocationId(1));
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Enemy)
             .with_location(loc_a)
             .with_location(loc_b)
@@ -862,7 +862,7 @@ mod hunter_resume_tests {
         let mut h = test_enemy(1, "Hunter");
         h.hunter = true;
         h.current_location = Some(LocationId(1));
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Enemy)
             .with_location(a)
             .with_location(b)
@@ -919,7 +919,7 @@ mod hunter_resume_tests {
         hunter.hunter = true;
         hunter.prey = crate::card_data::Prey::HighestStat(crate::dsl::Stat::Combat);
         hunter.current_location = Some(LocationId(1));
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Enemy)
             .with_location(loc_a)
             .with_location(loc_b)
@@ -968,7 +968,7 @@ mod hunter_resume_tests {
         let mut clean_hunter = test_enemy(2, "Clean Hunter");
         clean_hunter.hunter = true;
         clean_hunter.current_location = Some(LocationId(2)); // single step B->D
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Enemy)
             .with_location(loc_a)
             .with_location(loc_b)
@@ -1024,7 +1024,7 @@ mod hunter_resume_tests {
         let mut hunter = test_enemy(1, "Hunter");
         hunter.hunter = true;
         hunter.current_location = Some(LocationId(1));
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Enemy)
             .with_location(loc_a)
             .with_location(loc_b)
@@ -1077,7 +1077,7 @@ mod hunter_resume_tests {
         let mut hunter = test_enemy(1, "Hunter");
         hunter.hunter = true;
         hunter.current_location = Some(LocationId(1));
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Enemy)
             .with_location(loc_a)
             .with_location(loc_b)
@@ -1124,7 +1124,7 @@ mod reengage_tests {
     use crate::assert_event;
     use crate::assert_no_event;
     use crate::engine::Cx;
-    use crate::test_support::{test_enemy, test_investigator, test_location, TestGame};
+    use crate::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
 
     #[test]
     fn reengage_at_location_engages_sole_co_located_survivor() {
@@ -1141,7 +1141,7 @@ mod reengage_tests {
             e.engaged_with = None;
             e
         };
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(survivor)
             .with_location(test_location(1, "Study"))
             .with_enemy(enemy)
@@ -1171,7 +1171,7 @@ mod reengage_tests {
             e.engaged_with = None;
             e
         };
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_location(test_location(1, "Study"))
             .with_enemy(enemy)
             .with_turn_order([])
@@ -1208,7 +1208,7 @@ mod reengage_tests {
             e.prey = crate::card_data::Prey::Default;
             e
         };
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(mk(2))
             .with_investigator(mk(3))
             .with_location(test_location(1, "Study"))
@@ -1250,7 +1250,7 @@ mod reengage_tests {
             e.exhausted = true; // exhausted unengaged enemy does not engage (RR p.10)
             e
         };
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(survivor)
             .with_location(test_location(1, "Study"))
             .with_enemy(enemy)
@@ -1278,7 +1278,7 @@ mod reengage_tests {
             e.engaged_with = None;
             e
         };
-        let mut state = TestGame::default().with_enemy(enemy).build();
+        let mut state = GameStateBuilder::default().with_enemy(enemy).build();
         let mut events = Vec::new();
         reengage_at_location(
             &mut Cx {

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -867,14 +867,14 @@ mod investigation_phase_tests {
     use crate::engine::dispatch::apply_player_action;
     use crate::engine::outcome::EngineOutcome;
     use crate::state::{InvestigatorId, Phase, Status, WindowKind};
-    use crate::test_support::{test_investigator, TestGame};
+    use crate::test_support::{test_investigator, GameStateBuilder};
 
     #[test]
     fn mulligan_completion_kicks_off_investigation_phase() {
         // After the last investigator mulligans, setup ends and the
         // Investigation phase begins (Rules Reference p.27: no action
         // windows during setup; the game begins after mulligans).
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_phase(Phase::Investigation)
             .build();
@@ -939,7 +939,7 @@ mod investigation_phase_tests {
         // window (which auto-skips in tests — no card registry installed),
         // and then rotate to the first investigator in turn_order
         // (Rules Reference p.24 step 2.1 → window → step 2.2 lead-first).
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .with_phase(Phase::Mythos)
@@ -995,7 +995,9 @@ mod investigation_phase_tests {
         // Phase starts as Investigation (matching the real call-site
         // shape: step_phase sets state.phase before calling
         // investigation_phase).
-        let mut state = TestGame::default().with_phase(Phase::Investigation).build();
+        let mut state = GameStateBuilder::default()
+            .with_phase(Phase::Investigation)
+            .build();
         state.turn_order.clear();
         state.active_investigator = None;
 
@@ -1025,7 +1027,7 @@ mod investigation_phase_tests {
     fn investigation_phase_skips_defeated_lead_and_picks_first_active() {
         // Investigator 1 (lead) is Killed; investigator 2 is Active.
         // investigation_phase must skip Id(1) and rotate to Id(2).
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .with_phase(Phase::Mythos)
@@ -1056,7 +1058,7 @@ mod investigation_phase_tests {
         // Single investigator ends their turn: TurnEnded (2.2.2), then
         // PhaseEnded(Investigation) (2.3) from investigation_phase_end,
         // then the cascade enters the Enemy phase.
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_phase(Phase::Investigation)
             .with_active_investigator(InvestigatorId(1))
@@ -1107,7 +1109,7 @@ mod investigation_phase_tests {
     fn end_turn_rotates_to_next_active_and_opens_turn_window() {
         // Two investigators: ending #1's turn returns to 2.2 for #2 and
         // opens the InvestigatorTurnBegins window for them.
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .with_phase(Phase::Investigation)
@@ -1150,7 +1152,7 @@ mod investigation_phase_tests {
         // step_phase must NOT emit PhaseEnded(Investigation); the
         // downstream cascade may emit PhaseEnded for Enemy/Upkeep via
         // their own *_end helpers, but that's correct and expected.
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_phase(Phase::Investigation)
             .build();
@@ -1177,7 +1179,7 @@ mod investigation_phase_tests {
         // Round ≥2 entry via step_phase (Mythos→Investigation) auto-skips
         // both windows (no registry → nothing Fast-eligible) and lands
         // the lead active, with no PhaseEnded yet.
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_phase(Phase::Mythos)
             .build();
@@ -1223,11 +1225,11 @@ mod investigation_phase_tests {
 mod mythos_phase_tests {
     use super::*;
     use crate::state::{InvestigatorId, Phase, Status};
-    use crate::test_support::{test_investigator, TestGame};
+    use crate::test_support::{test_investigator, GameStateBuilder};
 
     #[test]
     fn mythos_phase_emits_phase_started_and_seeds_draw_pending() {
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .with_phase(Phase::Mythos)
@@ -1255,7 +1257,9 @@ mod mythos_phase_tests {
 
     #[test]
     fn mythos_phase_with_empty_turn_order_opens_after_draws_window_inline() {
-        let mut state = TestGame::default().with_phase(Phase::Mythos).build();
+        let mut state = GameStateBuilder::default()
+            .with_phase(Phase::Mythos)
+            .build();
         state.turn_order.clear();
         state.mythos_draw_pending = None;
         let mut events = Vec::new();
@@ -1310,7 +1314,7 @@ mod mythos_phase_tests {
 
     #[test]
     fn mythos_phase_end_emits_phase_ended_and_steps_to_investigation() {
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_phase(Phase::Mythos)
             .build();
@@ -1349,7 +1353,7 @@ mod mythos_phase_tests {
     /// than blindly taking `turn_order.first()`.
     #[test]
     fn mythos_phase_skips_eliminated_lead_when_seeding_cursor() {
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .with_phase(Phase::Mythos)
@@ -1384,7 +1388,7 @@ mod mythos_phase_tests {
     /// `mythos_phase_with_empty_turn_order_opens_after_draws_window_inline`.
     #[test]
     fn mythos_phase_with_all_investigators_eliminated_opens_after_draws_window() {
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_phase(Phase::Mythos)
             .build();
@@ -1416,7 +1420,7 @@ mod mythos_phase_tests {
     /// advance from inv1 to inv3.
     #[test]
     fn advance_mythos_draw_pending_skips_eliminated_middle_investigator() {
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .with_investigator(test_investigator(3))
@@ -1446,7 +1450,7 @@ mod mythos_phase_tests {
 
     #[test]
     fn first_active_investigator_finds_first_active_skipping_eliminated() {
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .with_investigator(test_investigator(3))
@@ -1472,7 +1476,7 @@ mod mythos_phase_tests {
 
     #[test]
     fn first_active_investigator_returns_none_when_all_eliminated() {
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .build();
         state.turn_order = vec![InvestigatorId(1)];
@@ -1490,7 +1494,7 @@ mod mythos_phase_tests {
 
     #[test]
     fn first_active_investigator_returns_none_when_turn_order_empty() {
-        let state = TestGame::default().build();
+        let state = GameStateBuilder::default().build();
         assert_eq!(
             super::super::cursor::first_active_investigator(&state),
             None
@@ -1499,7 +1503,7 @@ mod mythos_phase_tests {
 
     #[test]
     fn next_active_investigator_after_skips_eliminated_middle() {
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .with_investigator(test_investigator(3))
@@ -1536,7 +1540,7 @@ mod mythos_phase_tests {
 
     #[test]
     fn next_active_investigator_after_returns_none_when_current_not_in_turn_order() {
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .build();
         state.turn_order = vec![InvestigatorId(1)];
@@ -1552,7 +1556,7 @@ mod mythos_phase_tests {
         // Defeated-mid-loop semantics: `current` may be Killed by the
         // time we advance from them. The cursor still finds the right
         // successor.
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .build();
@@ -1580,7 +1584,7 @@ mod upkeep_phase_tests {
     use crate::state::{
         CardCode, CardInPlay, CardInstanceId, EnemyId, InvestigatorId, LocationId, Phase, Status,
     };
-    use crate::test_support::{test_enemy, test_investigator, test_location, TestGame};
+    use crate::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
     use crate::{assert_event, assert_event_sequence, assert_no_event};
 
     #[test]
@@ -1589,7 +1593,7 @@ mod upkeep_phase_tests {
         // window auto-skips inline, the continuation runs, and the
         // cascade lands in Mythos.
         let id = InvestigatorId(1);
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_phase(Phase::Enemy)
             .build();
@@ -1670,7 +1674,7 @@ mod upkeep_phase_tests {
         inv.cards_in_play = vec![card];
         let mut enemy = test_enemy(1, "Test Enemy");
         enemy.exhausted = true;
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(inv)
             .with_enemy(enemy)
             .build();
@@ -1701,7 +1705,7 @@ mod upkeep_phase_tests {
         let mut enemy = test_enemy(1, "Test Enemy");
         enemy.exhausted = true; // exhausted + disengaged, e.g. survived a successful Evade
         enemy.current_location = Some(LocationId(10));
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator_at(test_investigator(1), LocationId(10))
             .with_location(loc)
             .with_enemy(enemy)
@@ -1733,7 +1737,7 @@ mod upkeep_phase_tests {
     fn ready_exhausted_cards_leaves_ready_cards_untouched() {
         let mut enemy = test_enemy(1, "Test Enemy");
         enemy.exhausted = false; // already ready
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_enemy(enemy)
             .build();
@@ -1758,7 +1762,7 @@ mod upkeep_phase_tests {
         let mut enemy = test_enemy(1, "Test Enemy");
         enemy.exhausted = true;
         enemy.current_location = Some(LocationId(10));
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1)) // current_location stays None — NOT co-located
             .with_location(loc)
             .with_enemy(enemy)
@@ -1786,7 +1790,7 @@ mod upkeep_phase_tests {
         let mut enemy = test_enemy(1, "Test Enemy");
         enemy.exhausted = true; // exhausted but still engaged (e.g. attacked last Enemy phase)
         enemy.engaged_with = Some(inv_id);
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_enemy(enemy)
             .build();
@@ -1820,7 +1824,7 @@ mod upkeep_phase_tests {
         let res_b = inv_b.resources;
         let res_c = inv_c.resources;
         let hand_a = inv_a.hand.len();
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(inv_a)
             .with_investigator(inv_b)
             .with_investigator(inv_c)
@@ -1855,7 +1859,7 @@ mod upkeep_phase_tests {
         inv_a.deck = vec![CardCode::new("01000")];
         let mut inv_b = test_investigator(2);
         inv_b.deck = vec![CardCode::new("01001")];
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(inv_a)
             .with_investigator(inv_b)
             .build();
@@ -1889,7 +1893,7 @@ mod upkeep_phase_tests {
         let mut inv_b = test_investigator(2);
         inv_b.actions_remaining = 0;
         inv_b.status = Status::Killed;
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(inv_a)
             .with_investigator(inv_b)
             .build();
@@ -1921,7 +1925,7 @@ mod upkeep_phase_tests {
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
         inv.actions_remaining = ACTIONS_PER_TURN;
-        let mut state = TestGame::default().with_investigator(inv).build();
+        let mut state = GameStateBuilder::default().with_investigator(inv).build();
         state.turn_order = vec![id];
         let mut events = Vec::new();
 
@@ -1939,7 +1943,7 @@ mod upkeep_phase_tests {
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
         inv.actions_remaining = 1;
-        let mut state = TestGame::default().with_investigator(inv).build();
+        let mut state = GameStateBuilder::default().with_investigator(inv).build();
         let mut events = Vec::new();
 
         rotate_to_active(
@@ -1967,7 +1971,7 @@ mod upkeep_phase_tests {
         // The bump now lives in mythos_phase step 1.1 (this task);
         // the test asserts observable behavior, which is unchanged.
         let id = InvestigatorId(1);
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_phase(Phase::Upkeep)
             .build();
@@ -1999,7 +2003,7 @@ mod upkeep_phase_tests {
         inv.cards_in_play = vec![card];
         let res_before = inv.resources;
         let hand_before = inv.hand.len();
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(inv)
             .with_phase(Phase::Investigation)
             .build();
@@ -2041,7 +2045,7 @@ mod enemy_phase_tests {
     use crate::state::{
         EnemyId, FastActorScope, InvestigatorId, LocationId, OpenWindow, Phase, Status, WindowKind,
     };
-    use crate::test_support::{test_enemy, test_investigator, test_location, TestGame};
+    use crate::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
 
     #[test]
     fn enemy_phase_runs_hunters_then_attack_loop_when_no_tie() {
@@ -2054,7 +2058,7 @@ mod enemy_phase_tests {
         let mut hunter = test_enemy(1, "Hunter");
         hunter.hunter = true;
         hunter.current_location = Some(LocationId(1));
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_location(loc_a)
             .with_location(loc_b)
@@ -2098,7 +2102,7 @@ mod enemy_phase_tests {
         let mut hunter = test_enemy(1, "Hunter");
         hunter.hunter = true;
         hunter.current_location = Some(LocationId(1));
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_location(loc_a)
             .with_location(loc_b)
@@ -2139,7 +2143,7 @@ mod enemy_phase_tests {
         enemy.engaged_with = Some(inv_id);
         enemy.attack_damage = 1;
         enemy.attack_horror = 0;
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_enemy(enemy)
             .build();
@@ -2210,7 +2214,7 @@ mod enemy_phase_tests {
         e3.engaged_with = Some(inv_id);
         e3.attack_damage = 1;
 
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_enemy(e1)
             .with_enemy(e2)
@@ -2276,7 +2280,7 @@ mod enemy_phase_tests {
         e_higher.engaged_with = Some(inv_id);
         e_higher.attack_damage = 2;
 
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator({
                 let mut inv = test_investigator(1);
                 inv.max_health = 100; // survive both attacks
@@ -2325,7 +2329,7 @@ mod enemy_phase_tests {
         e2.engaged_with = Some(inv_id);
         e2.attack_damage = 5;
 
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator({
                 let mut inv = test_investigator(1);
                 inv.max_health = 1; // e1's attack defeats
@@ -2385,7 +2389,7 @@ mod enemy_phase_tests {
         // cascades through both windows + enemy_phase_end +
         // Upkeep → Mythos.
         let inv_id = InvestigatorId(1);
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_phase(Phase::Investigation)
             .build();
@@ -2481,7 +2485,7 @@ mod enemy_phase_tests {
     fn enemy_phase_with_two_investigators_iterates_in_turn_order() {
         let id1 = InvestigatorId(1);
         let id2 = InvestigatorId(2);
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .with_phase(Phase::Investigation)
@@ -2532,7 +2536,7 @@ mod enemy_phase_tests {
         let id1 = InvestigatorId(1);
         let id2 = InvestigatorId(2);
         let id3 = InvestigatorId(3);
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .with_investigator(test_investigator(3))
@@ -2566,7 +2570,7 @@ mod enemy_phase_tests {
     #[test]
     fn enemy_phase_with_all_eliminated_opens_after_all_directly() {
         let id1 = InvestigatorId(1);
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_phase(Phase::Investigation)
             .build();
@@ -2614,7 +2618,7 @@ mod enemy_phase_tests {
         let mut enemy = test_enemy(1, "Test Enemy");
         enemy.engaged_with = Some(inv_id);
         enemy.attack_damage = 1;
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_enemy(enemy)
             .with_phase(Phase::Investigation)
@@ -2653,7 +2657,7 @@ mod enemy_phase_tests {
         // Direct unit-level check: step_phase emits no PhaseEnded itself,
         // so the Enemy→Upkeep step must not emit PhaseEnded(Enemy)
         // (enemy_phase_end owns that emit).
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_phase(Phase::Enemy)
             .build();
@@ -2714,7 +2718,7 @@ mod enemy_phase_tests {
         let mut enemy = test_enemy(1, "Test Enemy");
         enemy.engaged_with = Some(inv_id);
         enemy.attack_damage = 1;
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_enemy(enemy)
             .with_phase(Phase::Enemy)
@@ -2785,13 +2789,13 @@ mod hand_size_tests {
     use super::*;
     use crate::assert_no_event;
     use crate::state::{CardCode, InvestigatorId};
-    use crate::test_support::{test_investigator, TestGame};
+    use crate::test_support::{test_investigator, GameStateBuilder};
 
     #[test]
     fn over_cap_investigators_lists_only_over_eight_in_player_order() {
         let inv1 = InvestigatorId(1);
         let inv2 = InvestigatorId(2);
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .with_turn_order([inv2, inv1]) // player order: inv2 first
@@ -2811,7 +2815,7 @@ mod hand_size_tests {
     fn check_hand_size_suspends_for_over_cap_investigator() {
         use crate::state::CardCode;
         let id = InvestigatorId(1);
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_turn_order([id])
             .with_phase(Phase::Upkeep)
@@ -2841,7 +2845,7 @@ mod hand_size_tests {
     fn check_hand_size_is_noop_when_all_at_or_below_cap() {
         use crate::state::CardCode;
         let id = InvestigatorId(1);
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_turn_order([id])
             .with_phase(Phase::Upkeep)
@@ -2862,7 +2866,7 @@ mod hand_size_tests {
     fn upkeep_resume_parks_at_hand_size_discard() {
         use crate::state::CardCode;
         let id = InvestigatorId(1);
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_turn_order([id])
             .with_phase(Phase::Upkeep)
@@ -2900,7 +2904,7 @@ mod hand_size_tests {
         use crate::action::InputResponse;
         use crate::state::CardCode;
         let id = InvestigatorId(1);
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_turn_order([id])
             .with_phase(Phase::Upkeep)
@@ -2955,7 +2959,7 @@ mod hand_size_tests {
         use crate::action::InputResponse;
         use crate::state::CardCode;
         let id = InvestigatorId(1);
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_turn_order([id])
             .with_phase(Phase::Upkeep)
@@ -2993,7 +2997,7 @@ mod hand_size_tests {
         use crate::state::CardCode;
         let id = InvestigatorId(1);
         let build = || {
-            let mut s = TestGame::new()
+            let mut s = GameStateBuilder::new()
                 .with_investigator(test_investigator(1))
                 .with_turn_order([id])
                 .with_phase(Phase::Upkeep)
@@ -3041,7 +3045,7 @@ mod hand_size_tests {
         use crate::state::CardCode;
         let inv1 = InvestigatorId(1);
         let inv2 = InvestigatorId(2);
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .with_turn_order([inv1, inv2])
@@ -3079,7 +3083,7 @@ mod hand_size_tests {
         use crate::action::InputResponse;
         use crate::state::CardCode;
         let id = InvestigatorId(1);
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_turn_order([id])
             .with_phase(Phase::Upkeep)
@@ -3117,12 +3121,12 @@ mod start_scenario_tests {
     use crate::action::{Action, PlayerAction, RosterEntry};
     use crate::engine::apply;
     use crate::state::CardCode;
-    use crate::test_support::builder::TestGame;
+    use crate::state::GameStateBuilder;
     use crate::test_support::fixtures::test_investigator;
 
     #[test]
     fn start_scenario_rejects_when_roster_would_seat_zero_investigators() {
-        let state = TestGame::new().build();
+        let state = GameStateBuilder::new().build();
         let result = apply(
             state,
             Action::Player(PlayerAction::StartScenario { roster: vec![] }),
@@ -3135,7 +3139,7 @@ mod start_scenario_tests {
     #[test]
     fn start_scenario_empty_roster_passes_through_with_preseated_investigator() {
         let id = crate::state::InvestigatorId(1);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_turn_order([id])
             .build();
@@ -3158,7 +3162,7 @@ mod start_scenario_tests {
     // `crates/cards` integration test, which installs `cards::REGISTRY`.
     #[test]
     fn start_scenario_rejects_unresolvable_roster_entry() {
-        let state = TestGame::new().build();
+        let state = GameStateBuilder::new().build();
         let roster = vec![RosterEntry {
             investigator: CardCode::new("01001"),
             deck: vec![],

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -1007,11 +1007,11 @@ pub(super) fn any_fast_play_eligible(state: &GameState) -> bool {
 #[cfg(test)]
 mod check_play_card_tests {
     use super::*;
-    use crate::test_support::{test_investigator, TestGame};
+    use crate::test_support::{test_investigator, GameStateBuilder};
 
     #[test]
     fn check_play_card_returns_err_for_unknown_hand_index() {
-        let state = TestGame::default()
+        let state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_active_investigator(InvestigatorId(1))
             .build();
@@ -1025,7 +1025,7 @@ mod check_play_card_tests {
 
     #[test]
     fn check_play_card_returns_err_when_investigator_missing() {
-        let state = TestGame::default().build();
+        let state = GameStateBuilder::default().build();
         let err = check_play_card(&state, InvestigatorId(99), 0)
             .expect_err("missing investigator should reject");
         assert!(
@@ -1038,11 +1038,11 @@ mod check_play_card_tests {
 #[cfg(test)]
 mod check_activate_ability_tests {
     use super::*;
-    use crate::test_support::{test_investigator, TestGame};
+    use crate::test_support::{test_investigator, GameStateBuilder};
 
     #[test]
     fn check_activate_ability_returns_err_for_missing_instance() {
-        let state = TestGame::default()
+        let state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_active_investigator(InvestigatorId(1))
             .build();
@@ -1056,7 +1056,7 @@ mod check_activate_ability_tests {
 
     #[test]
     fn check_activate_ability_returns_err_when_investigator_missing() {
-        let state = TestGame::default().build();
+        let state = GameStateBuilder::default().build();
         let err = check_activate_ability(&state, InvestigatorId(99), CardInstanceId(1), 0)
             .expect_err("missing investigator should reject");
         assert!(
@@ -1069,17 +1069,17 @@ mod check_activate_ability_tests {
 #[cfg(test)]
 mod any_fast_play_eligible_tests {
     use super::*;
-    use crate::test_support::{test_investigator, TestGame};
+    use crate::test_support::{test_investigator, GameStateBuilder};
 
     #[test]
     fn returns_false_when_no_investigators() {
-        let state = TestGame::default().build();
+        let state = GameStateBuilder::default().build();
         assert!(!any_fast_play_eligible(&state));
     }
 
     #[test]
     fn returns_false_when_hands_and_in_play_empty() {
-        let state = TestGame::default()
+        let state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .build();
         assert!(!any_fast_play_eligible(&state));
@@ -1091,13 +1091,13 @@ mod open_fast_window_tests {
     use super::*;
     use crate::event::Event;
     use crate::state::{EnemyId, WindowKind};
-    use crate::test_support::{test_investigator, TestGame};
+    use crate::test_support::{test_investigator, GameStateBuilder};
 
     #[test]
     fn open_fast_window_with_no_eligibility_emits_open_then_close_inline() {
         // No reactions, no Fast-eligible cards → auto-skip: window
         // opens and closes without ever landing on state.open_windows.
-        let mut state = TestGame::default()
+        let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .build();
         let mut events = Vec::new();
@@ -1138,7 +1138,7 @@ mod open_fast_window_tests {
     fn run_window_continuation_for_no_continuation_kind_does_nothing() {
         // AfterEnemyDefeated has no continuation. Calling it must be a
         // no-op (no events, no state change).
-        let mut state = TestGame::default().build();
+        let mut state = GameStateBuilder::default().build();
         let mut events = Vec::new();
         let result = run_window_continuation(
             &mut Cx {

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -672,7 +672,7 @@ mod tests {
     use crate::state::{
         CardCode, CardInPlay, CardInstanceId, InvestigatorId, LocationId, SkillKind,
     };
-    use crate::test_support::{test_investigator, test_location, TestGame};
+    use crate::test_support::{test_investigator, test_location, GameStateBuilder};
     use crate::{assert_event, assert_no_event};
 
     use super::{apply_effect, constant_skill_modifier, EngineOutcome, EvalContext};
@@ -685,7 +685,7 @@ mod tests {
     #[test]
     fn gain_resources_increments_target_wallet_and_emits_event() {
         let id = InvestigatorId(1);
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
         let resources_before = state.investigators[&id].resources;
@@ -715,7 +715,7 @@ mod tests {
         // skips target resolution, so an `Active` target with no
         // active investigator doesn't reject for amount=0.
         let id = InvestigatorId(1);
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
         let resources_before = state.investigators[&id].resources;
@@ -739,7 +739,7 @@ mod tests {
     fn gain_resources_active_target_rejects_without_active_investigator() {
         // No active investigator (default phase is Mythos), so
         // InvestigatorTarget::Active should fail to resolve.
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
         let mut events = Vec::new();
@@ -765,7 +765,7 @@ mod tests {
         let mut location = test_location(10, "Study");
         location.clues = 3;
 
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(investigator)
             .with_location(location)
             .build();
@@ -803,7 +803,7 @@ mod tests {
         let mut location = test_location(10, "Study");
         location.clues = 1;
 
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(investigator)
             .with_location(location)
             .build();
@@ -839,7 +839,7 @@ mod tests {
         investigator.current_location = Some(loc_id);
         let location = test_location(10, "Study"); // 0 clues by default
 
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(investigator)
             .with_location(location)
             .build();
@@ -864,7 +864,7 @@ mod tests {
     fn discover_clue_rejects_when_controller_is_between_locations() {
         // "You" has no current_location — LocationTarget::
         // YourLocation can't resolve.
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1)) // current_location = None
             .build();
         let mut events = Vec::new();
@@ -897,7 +897,7 @@ mod tests {
         tested_loc.clues = 2;
         let elsewhere_loc = test_location(30, "Hall");
 
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(investigator)
             .with_location(tested_loc)
             .with_location(elsewhere_loc)
@@ -934,7 +934,7 @@ mod tests {
         // No in-flight skill test → TestedLocation can't resolve.
         let mut investigator = test_investigator(1);
         investigator.current_location = Some(LocationId(10));
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(investigator)
             .with_location({
                 let mut l = test_location(10, "Study");
@@ -960,7 +960,7 @@ mod tests {
     // ---- Effect::If + Condition::SkillTestKind tests -------------
 
     fn state_with_in_flight_kind(kind: SkillTestKind) -> crate::state::GameState {
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator({
                 let mut inv = test_investigator(1);
                 inv.current_location = Some(LocationId(10));
@@ -1068,7 +1068,7 @@ mod tests {
     #[test]
     fn if_skill_test_kind_rejects_without_in_flight_test() {
         use crate::dsl::{discover_clue, if_, Condition};
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
         let mut events = Vec::new();
@@ -1130,7 +1130,7 @@ mod tests {
     fn tested_location_rejects_when_test_has_no_location_snapshot() {
         // In-flight test exists but tested_location is None (e.g.
         // bare PerformSkillTest invoked while between locations).
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
         state.in_flight_skill_test = Some(crate::state::InFlightSkillTest {
@@ -1167,7 +1167,7 @@ mod tests {
         let mut location = test_location(10, "Study");
         location.clues = 1;
 
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(investigator)
             .with_location(location)
             .build();
@@ -1202,7 +1202,7 @@ mod tests {
         let mut location = test_location(10, "Study");
         location.clues = 1;
 
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(investigator)
             .with_location(location)
             .build();
@@ -1231,7 +1231,7 @@ mod tests {
         // WhileInPlay belongs under Trigger::Constant; reaching the
         // evaluator with this combination means the card author
         // wired the ability wrong. Reject loudly.
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         let mut events = Vec::new();
         let outcome = apply_effect(
             &mut Cx {
@@ -1247,7 +1247,7 @@ mod tests {
     #[test]
     fn modify_with_this_skill_test_scope_pushes_pending_modifier() {
         let id = InvestigatorId(1);
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
         let mut events = Vec::new();
@@ -1273,7 +1273,7 @@ mod tests {
     fn modify_pushes_source_when_ctx_has_one() {
         let id = InvestigatorId(1);
         let src = CardInstanceId(42);
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
         let mut events = Vec::new();
@@ -1292,7 +1292,7 @@ mod tests {
 
     #[test]
     fn modify_with_this_turn_scope_rejects_with_todo() {
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         let mut events = Vec::new();
         let outcome = apply_effect(
             &mut Cx {
@@ -1315,7 +1315,7 @@ mod tests {
 
     #[test]
     fn choose_one_is_rejected_with_todo_message() {
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         let mut events = Vec::new();
         let outcome = apply_effect(
             &mut Cx {
@@ -1407,7 +1407,7 @@ mod tests {
                 )
             })
             .collect();
-        let state = TestGame::new().with_investigator(inv).build();
+        let state = GameStateBuilder::new().with_investigator(inv).build();
         (state, id)
     }
 
@@ -1511,7 +1511,7 @@ mod tests {
 
     #[test]
     fn constant_modifier_zero_for_unknown_controller() {
-        let state = TestGame::new().build();
+        let state = GameStateBuilder::new().build();
         let reg = fake_registry();
         assert_eq!(
             constant_skill_modifier(
@@ -1599,7 +1599,7 @@ mod tests {
     use crate::state::PendingSkillModifier;
 
     fn state_with_pending(pending: Vec<PendingSkillModifier>) -> crate::state::GameState {
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
         state.pending_skill_modifiers = pending;
@@ -1681,7 +1681,7 @@ mod tests {
 
     #[test]
     fn deal_damage_adds_damage_and_emits_event() {
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_active_investigator(InvestigatorId(1))
             .build();
@@ -1705,7 +1705,7 @@ mod tests {
 
     #[test]
     fn deal_horror_adds_horror_and_emits_event() {
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_active_investigator(InvestigatorId(1))
             .build();
@@ -1736,7 +1736,7 @@ mod tests {
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
         inv.max_health = 3;
-        let mut state = TestGame::new().with_investigator(inv).build();
+        let mut state = GameStateBuilder::new().with_investigator(inv).build();
         let mut events = Vec::new();
         let outcome = apply_effect(
             &mut Cx {

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -200,7 +200,7 @@ mod tests {
         TokenModifiers, TokenResolution, Zone,
     };
     use crate::test_support::{
-        apply_no_commits, test_enemy, test_investigator, test_location, TestGame,
+        apply_no_commits, test_enemy, test_investigator, test_location, GameStateBuilder,
     };
     use crate::{assert_event, assert_event_count, assert_no_event};
 
@@ -218,7 +218,7 @@ mod tests {
         // fired) is covered by
         // `investigation_phase_tests::mulligan_completion_kicks_off_investigation_phase`.
         let id = InvestigatorId(1);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_turn_order([id])
             .build();
@@ -297,7 +297,7 @@ mod tests {
 
     #[test]
     fn start_scenario_on_already_started_state_is_rejected() {
-        let state = TestGame::new().with_round(7).build();
+        let state = GameStateBuilder::new().with_round(7).build();
         let result = apply(
             state,
             Action::Player(PlayerAction::StartScenario { roster: vec![] }),
@@ -313,7 +313,7 @@ mod tests {
         let id = InvestigatorId(1);
         let mut roland = test_investigator(1);
         roland.actions_remaining = 3;
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_investigator(roland)
             .with_active_investigator(id)
@@ -335,7 +335,9 @@ mod tests {
 
     #[test]
     fn end_turn_with_no_active_investigator_is_rejected() {
-        let state = TestGame::new().with_phase(Phase::Investigation).build();
+        let state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .build();
 
         let result = apply(state, Action::Player(PlayerAction::EndTurn));
 
@@ -346,7 +348,7 @@ mod tests {
     #[test]
     fn end_turn_outside_investigation_phase_is_rejected() {
         let id = InvestigatorId(1);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_phase(Phase::Mythos)
             .with_investigator(test_investigator(1))
             .with_active_investigator(id)
@@ -360,7 +362,7 @@ mod tests {
 
     #[test]
     fn rejected_actions_do_not_mutate_state() {
-        let state = TestGame::new().build();
+        let state = GameStateBuilder::new().build();
         let round_before = state.round;
         let phase_before = state.phase;
         let active_before = state.active_investigator;
@@ -391,7 +393,7 @@ mod tests {
         // rollback path — where a handler mutates *then* rejects — is
         // covered by `rejected_resolve_input_rewinds_to_pause_state_not_pre_action`
         // and the integration test in `crates/cards/tests/reject_rollback.rs`.
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_investigator(test_investigator(1))
             .with_active_investigator(InvestigatorId(1))
@@ -418,7 +420,7 @@ mod tests {
         // Drive a skill test to its commit-window AwaitingInput, then submit
         // a malformed response. The reject must rewind to the *pause* state
         // (in_flight_skill_test still set), not to before the skill test.
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_investigator(test_investigator(1))
             .with_active_investigator(InvestigatorId(1))
@@ -479,7 +481,9 @@ mod tests {
 
     #[test]
     fn perform_skill_test_with_unknown_investigator_is_rejected() {
-        let state = TestGame::new().with_chaos_bag(bag_only_zero()).build();
+        let state = GameStateBuilder::new()
+            .with_chaos_bag(bag_only_zero())
+            .build();
         let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::PerformSkillTest {
@@ -495,7 +499,7 @@ mod tests {
     #[test]
     fn perform_skill_test_with_empty_bag_is_rejected() {
         let id = InvestigatorId(1);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
         let result = apply_no_commits(
@@ -513,7 +517,7 @@ mod tests {
     #[test]
     fn perform_skill_test_with_negative_difficulty_is_rejected() {
         let id = InvestigatorId(1);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_chaos_bag(bag_only_zero())
             .build();
@@ -534,7 +538,7 @@ mod tests {
         // Default skills are 3/3/3/3; bag only has Numeric(0), so total=3.
         // Difficulty 3 → margin 0 → success.
         let id = InvestigatorId(1);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_chaos_bag(bag_only_zero())
             .build();
@@ -578,7 +582,7 @@ mod tests {
         let id = InvestigatorId(1);
         let mut strong = test_investigator(1);
         strong.skills.combat = 5;
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(strong)
             .with_chaos_bag(bag_only_zero())
             .build();
@@ -604,7 +608,7 @@ mod tests {
         // Skills 3/3/3/3, bag Numeric(0), difficulty 5 → margin -2 →
         // FailureReason::Total, by: 2.
         let id = InvestigatorId(1);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_chaos_bag(bag_only_zero())
             .build();
@@ -639,7 +643,7 @@ mod tests {
         let id = InvestigatorId(1);
         let mut high = test_investigator(1);
         high.skills.willpower = 99;
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(high)
             .with_chaos_bag(crate::state::ChaosBag::new([ChaosToken::AutoFail]))
             .build();
@@ -670,7 +674,7 @@ mod tests {
         // but AutoFail forces total = 0 AND tags the result as a
         // failure regardless. by = 0 here, reason = AutoFail.
         let id = InvestigatorId(1);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_chaos_bag(crate::state::ChaosBag::new([ChaosToken::AutoFail]))
             .build();
@@ -700,7 +704,7 @@ mod tests {
         // skill 3 + Skull(−6) = −3, clamped to 0. Difficulty 2 →
         // by = 2, reason Total (NOT AutoFail).
         let id = InvestigatorId(1);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_chaos_bag(crate::state::ChaosBag::new([ChaosToken::Skull]))
             .with_token_modifiers(TokenModifiers {
@@ -733,7 +737,7 @@ mod tests {
         // ElderSign as +0 placeholder until per-investigator ability
         // dispatch lands. Skill 3, difficulty 3 → margin 0 → success.
         let id = InvestigatorId(1);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_chaos_bag(crate::state::ChaosBag::new([ChaosToken::ElderSign]))
             .build();
@@ -762,7 +766,7 @@ mod tests {
         // Bag is one Skull. Standard-difficulty NotZ: skull = -1.
         // Skill 3 + (-1) = 2 vs difficulty 2 → margin 0 → success.
         let id = InvestigatorId(1);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_chaos_bag(crate::state::ChaosBag::new([ChaosToken::Skull]))
             .with_token_modifiers(night_of_the_zealot_standard())
@@ -794,7 +798,7 @@ mod tests {
         // leave inv2's intact for their own future test.
         let id1 = InvestigatorId(1);
         let id2 = InvestigatorId(2);
-        let mut state = TestGame::new()
+        let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .with_chaos_bag(bag_only_zero())
@@ -836,7 +840,7 @@ mod tests {
         // Determinism: applying the same PerformSkillTest action twice
         // from identical initial state produces identical post-state.
         let id = InvestigatorId(1);
-        let initial = TestGame::new()
+        let initial = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_chaos_bag(crate::state::ChaosBag::new([
                 ChaosToken::Numeric(1),
@@ -878,7 +882,7 @@ mod tests {
         let mut loc = test_location(10, "Study");
         loc.clues = clues;
         loc.shroud = shroud;
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(inv)
             .with_location(loc)
             .with_chaos_bag(bag_only_zero())
@@ -1053,7 +1057,7 @@ mod tests {
     fn last_end_turn_advances_to_mythos_and_pauses_for_draw_two_investigators() {
         let inv1 = InvestigatorId(1);
         let inv2 = InvestigatorId(2);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .with_turn_order([inv1, inv2])
@@ -1184,7 +1188,7 @@ mod tests {
         // subsequent DrawEncounterCard action (needs registry, covered by
         // crates/scenarios/tests/mythos_phase.rs).
         let id = InvestigatorId(1);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_turn_order([id])
             .build();
@@ -1246,7 +1250,7 @@ mod tests {
 
     #[test]
     fn deck_shuffled_engine_record_with_unknown_investigator_is_rejected() {
-        let state = TestGame::new().build();
+        let state = GameStateBuilder::new().build();
         let result = apply(
             state,
             Action::Engine(EngineRecord::DeckShuffled {
@@ -1272,7 +1276,7 @@ mod tests {
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
         inv.deck = make_test_deck(10);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(inv)
             .with_turn_order([id])
             .with_rng_seed(42)
@@ -1309,7 +1313,7 @@ mod tests {
     #[test]
     fn start_scenario_with_empty_deck_yields_empty_hand_and_no_events() {
         let id = InvestigatorId(1);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_turn_order([id])
             .build();
@@ -1338,7 +1342,7 @@ mod tests {
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
         inv.deck = make_test_deck(3);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(inv)
             .with_turn_order([id])
             .with_rng_seed(7)
@@ -1362,12 +1366,12 @@ mod tests {
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
         inv.deck = make_test_deck(20);
-        let state_a = TestGame::new()
+        let state_a = GameStateBuilder::new()
             .with_investigator(inv.clone())
             .with_turn_order([id])
             .with_rng_seed(123)
             .build();
-        let state_b = TestGame::new()
+        let state_b = GameStateBuilder::new()
             .with_investigator(inv)
             .with_turn_order([id])
             .with_rng_seed(123)
@@ -1399,7 +1403,7 @@ mod tests {
         let mut inv = test_investigator(1);
         inv.deck = make_test_deck(8);
         let original_deck = inv.deck.clone();
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(inv)
             .with_rng_seed(99)
             .build();
@@ -1431,7 +1435,7 @@ mod tests {
         // iteration is sorted, so shuffle order is deterministic.
         // Each investigator gets their own deck + hand independently.
         let ids = [InvestigatorId(1), InvestigatorId(5), InvestigatorId(9)];
-        let mut tg = TestGame::new().with_rng_seed(2026);
+        let mut tg = GameStateBuilder::new().with_rng_seed(2026);
         for id in ids {
             let mut inv = test_investigator(id.0);
             inv.deck = make_test_deck(8);
@@ -1488,7 +1492,7 @@ mod tests {
         let mut loc_a = test_location(10, "A");
         loc_a.connections = vec![b];
         let loc_b = test_location(11, "B");
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(inv)
             .with_location(loc_a)
             .with_location(loc_b)
@@ -1709,7 +1713,7 @@ mod tests {
         enemy.evade = 3;
         enemy.max_health = 2;
         enemy.engaged_with = Some(inv_id);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(inv)
             .with_enemy(enemy)
             .with_chaos_bag(bag_only_zero())
@@ -2625,7 +2629,7 @@ mod tests {
         let b = crate::state::LocationId(11);
         let mut loc_a = test_location(10, "A");
         loc_a.connections = vec![b];
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(i1)
             .with_investigator(i2)
             .with_location(loc_a)
@@ -2721,7 +2725,7 @@ mod tests {
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
         inv.status = Status::Killed;
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(inv)
             .with_chaos_bag(bag_only_zero())
             .build();
@@ -2750,7 +2754,7 @@ mod tests {
         let mut inv = test_investigator(1);
         inv.current_location = Some(a);
         inv.actions_remaining = 3;
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(inv)
             .with_location(test_location(10, "A"))
             .with_phase(Phase::Investigation)
@@ -2973,7 +2977,7 @@ mod tests {
             CardCode::new("d-3"),
             CardCode::new("d-4"),
         ];
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(inv)
             .with_rng_seed(2026)
             .with_turn_order([id])
@@ -3125,7 +3129,7 @@ mod tests {
         let mut a = test_investigator(1);
         a.status = Status::Killed;
         let b = test_investigator(2);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(a)
             .with_investigator(b)
             .with_turn_order([inv1, inv2])
@@ -3175,7 +3179,7 @@ mod tests {
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
         inv.deck = make_test_deck(10);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(inv)
             .with_turn_order([id])
             .build();
@@ -3200,7 +3204,7 @@ mod tests {
         inv.actions_remaining = 3;
         let mut loc_a = test_location(10, "A");
         loc_a.connections = vec![b];
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(inv)
             .with_location(loc_a)
             .with_location(test_location(11, "B"))
@@ -3247,7 +3251,7 @@ mod tests {
         let mut b = test_investigator(2);
         a.hand = vec![CardCode::new("a-0")];
         b.hand = vec![CardCode::new("b-0")];
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(a)
             .with_investigator(b)
             .with_turn_order([inv1, inv2])
@@ -3286,7 +3290,7 @@ mod tests {
         let mut b = test_investigator(2);
         a.hand = vec![CardCode::new("a-0")];
         b.hand = vec![CardCode::new("b-0")];
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(a)
             .with_investigator(b)
             .with_turn_order([inv1, inv2])
@@ -3329,7 +3333,7 @@ mod tests {
         ];
         b.hand = vec![CardCode::new("b-h-0"), CardCode::new("b-h-1")];
         b.deck = vec![CardCode::new("b-d-0")];
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(a)
             .with_investigator(b)
             .with_turn_order([inv1, inv2])
@@ -3392,7 +3396,7 @@ mod tests {
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
         inv.hand = hand;
-        let mut builder = TestGame::new()
+        let mut builder = GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_investigator(inv);
         if active {
@@ -3406,7 +3410,7 @@ mod tests {
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
         inv.hand = vec![CardCode::new("01059")];
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_phase(Phase::Mythos)
             .with_investigator(inv)
             .with_active_investigator(id)
@@ -3447,7 +3451,7 @@ mod tests {
         let mut inv = test_investigator(1);
         inv.hand = vec![CardCode::new("01059")];
         inv.status = Status::Killed;
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_investigator(inv)
             .with_active_investigator(id)
@@ -3508,7 +3512,7 @@ mod tests {
             CardCode::new("01059"),
             instance_id,
         ));
-        let mut builder = TestGame::new()
+        let mut builder = GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_investigator(inv);
         if active {
@@ -3526,7 +3530,7 @@ mod tests {
             CardCode::new("01059"),
             instance_id,
         ));
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_phase(Phase::Mythos)
             .with_investigator(inv)
             .with_active_investigator(id)
@@ -3583,7 +3587,7 @@ mod tests {
             CardCode::new("01059"),
             instance_id,
         ));
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_investigator(inv)
             .with_active_investigator(id)
@@ -3608,7 +3612,7 @@ mod tests {
         // and ChaosTokenRevealed. The first `apply` returns
         // AwaitingInput with only SkillTestStarted on the events list.
         let id = InvestigatorId(1);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_chaos_bag(bag_only_zero())
             .build();
@@ -3644,7 +3648,7 @@ mod tests {
         // ChaosTokenRevealed and the rest of resolution fire on the
         // second apply.
         let id = InvestigatorId(1);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_chaos_bag(bag_only_zero())
             .build();
@@ -3690,7 +3694,7 @@ mod tests {
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
         inv.hand = vec![CardCode::new("A"), CardCode::new("B")];
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(inv)
             .with_chaos_bag(bag_only_zero())
             .build();
@@ -3750,7 +3754,7 @@ mod tests {
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
         inv.hand = vec![CardCode::new("A")];
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(inv)
             .with_chaos_bag(bag_only_zero())
             .build();
@@ -3787,7 +3791,7 @@ mod tests {
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
         inv.hand = vec![CardCode::new("A"), CardCode::new("B")];
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(inv)
             .with_chaos_bag(bag_only_zero())
             .build();
@@ -3824,7 +3828,7 @@ mod tests {
         // rejects every other player action (mirrors the
         // mulligan_pending guard).
         let id = InvestigatorId(1);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_investigator(test_investigator(1))
             .with_active_investigator(id)
@@ -3855,7 +3859,7 @@ mod tests {
     #[test]
     fn resolve_input_with_wrong_response_variant_rejects() {
         let id = InvestigatorId(1);
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_chaos_bag(bag_only_zero())
             .build();
@@ -3882,7 +3886,7 @@ mod tests {
     fn resolve_input_without_any_outstanding_prompt_rejects() {
         // No prior `apply` opened a commit window — the engine has
         // nothing to resume.
-        let state = TestGame::new().build();
+        let state = GameStateBuilder::new().build();
         let result = apply(
             state,
             Action::Player(PlayerAction::ResolveInput {
@@ -3937,7 +3941,7 @@ mod tests {
     }
 
     fn unused_setup() -> crate::state::GameState {
-        TestGame::new().build()
+        GameStateBuilder::new().build()
     }
 
     static STAMP_MODULE: ScenarioModule = ScenarioModule {
@@ -3961,7 +3965,7 @@ mod tests {
         let inv = InvestigatorId(1);
         let mut investigator = test_investigator(1);
         investigator.clues = 1;
-        let mut builder = TestGame::new()
+        let mut builder = GameStateBuilder::new()
             .with_phase(crate::state::Phase::Investigation)
             .with_investigator(investigator)
             .with_active_investigator(inv)

--- a/crates/game-core/src/engine/pathfinding.rs
+++ b/crates/game-core/src/engine/pathfinding.rs
@@ -68,7 +68,7 @@ pub(crate) fn shortest_first_steps(
 mod tests {
     use super::*;
     use crate::state::{LocationId, Phase};
-    use crate::test_support::{test_location, TestGame};
+    use crate::test_support::{test_location, GameStateBuilder};
 
     /// Build a diamond: A(1) connects to B(2) and C(3); both connect to
     /// D(4). Bidirectional edges.
@@ -81,7 +81,7 @@ mod tests {
         b.connections = vec![LocationId(1), LocationId(4)];
         c.connections = vec![LocationId(1), LocationId(4)];
         d.connections = vec![LocationId(2), LocationId(3)];
-        TestGame::new()
+        GameStateBuilder::new()
             .with_phase(Phase::Enemy)
             .with_location(a)
             .with_location(b)
@@ -113,7 +113,7 @@ mod tests {
         let mut a = test_location(1, "A");
         let island = test_location(9, "Island");
         a.connections = vec![];
-        let s = TestGame::new()
+        let s = GameStateBuilder::new()
             .with_phase(Phase::Enemy)
             .with_location(a)
             .with_location(island)
@@ -130,7 +130,7 @@ mod tests {
         a.connections = vec![LocationId(2)];
         b.connections = vec![LocationId(1), LocationId(4)];
         d.connections = vec![LocationId(2)];
-        let s = TestGame::new()
+        let s = GameStateBuilder::new()
             .with_phase(Phase::Enemy)
             .with_location(a)
             .with_location(b)
@@ -156,7 +156,7 @@ mod tests {
         let mut a = test_location(1, "A");
         let island = test_location(9, "Island");
         a.connections = vec![];
-        let s = TestGame::new()
+        let s = GameStateBuilder::new()
             .with_phase(Phase::Enemy)
             .with_location(a)
             .with_location(island)

--- a/crates/game-core/src/scenario.rs
+++ b/crates/game-core/src/scenario.rs
@@ -160,10 +160,10 @@ fn reference_card_with_registry(
 mod tests {
     use super::*;
     use crate::state::GameState;
-    use crate::test_support::TestGame;
+    use crate::test_support::GameStateBuilder;
 
     fn dummy_setup() -> GameState {
-        TestGame::new().build()
+        GameStateBuilder::new().build()
     }
     fn dummy_resolution(_: &Resolution, _: &mut GameState, _: &mut Vec<Event>) {}
 
@@ -183,7 +183,7 @@ mod tests {
 
     #[test]
     fn returns_reference_card_for_active_scenario() {
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_scenario_id(ScenarioId::new("the-gathering"))
             .build();
         assert_eq!(
@@ -194,7 +194,7 @@ mod tests {
 
     #[test]
     fn returns_none_when_no_scenario_id() {
-        let state = TestGame::new().build();
+        let state = GameStateBuilder::new().build();
         assert_eq!(
             reference_card_with_registry(&state, Some(&registry())),
             None,
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn returns_none_when_no_registry_installed() {
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_scenario_id(ScenarioId::new("the-gathering"))
             .build();
         assert_eq!(reference_card_with_registry(&state, None), None);
@@ -211,7 +211,7 @@ mod tests {
 
     #[test]
     fn returns_none_for_unknown_scenario() {
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_scenario_id(ScenarioId::new("nonexistent"))
             .build();
         assert_eq!(

--- a/crates/game-core/src/scenario_registry.rs
+++ b/crates/game-core/src/scenario_registry.rs
@@ -68,10 +68,10 @@ mod tests {
     use crate::event::Event;
     use crate::scenario::{Resolution, ScenarioId, ScenarioModule};
     use crate::state::GameState;
-    use crate::test_support::TestGame;
+    use crate::test_support::GameStateBuilder;
 
     fn empty_state() -> GameState {
-        TestGame::new().build()
+        GameStateBuilder::new().build()
     }
 
     fn no_op_apply(_res: &Resolution, _state: &mut GameState, _events: &mut Vec<Event>) {}

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -1,19 +1,22 @@
-//! Fluent [`TestGame`] builder.
+//! Fluent [`GameStateBuilder`].
 //!
-//! The single most important piece of test infrastructure in the
-//! engine. Every card, scenario, and engine test that follows depends
-//! on this — if the API is awkward, every test pays the cost. Keep it
-//! ergonomic.
+//! The cross-crate constructor for [`GameState`] (which is
+//! `#[non_exhaustive]`, so it can't be struct-literalled outside this
+//! crate). Scenario `setup()` functions use it to build the initial
+//! board, and it is also the single most-used piece of engine test
+//! infrastructure — every card, scenario, and engine test depends on it,
+//! so if the API is awkward, every caller pays. Keep it ergonomic.
 //!
 //! # Example
 //!
 //! ```
 //! use game_core::{
 //!     apply, Action, PlayerAction, Phase, InvestigatorId,
-//!     test_support::{test_investigator, test_location, TestGame},
+//!     state::GameStateBuilder,
+//!     test_support::{test_investigator, test_location},
 //! };
 //!
-//! let state = TestGame::new()
+//! let state = GameStateBuilder::new()
 //!     .with_phase(Phase::Investigation)
 //!     .with_investigator(test_investigator(1))
 //!     .with_location(test_location(10, "Study"))
@@ -34,12 +37,12 @@ use crate::state::{
 
 /// Fluent builder for a [`GameState`].
 ///
-/// Construct with [`TestGame::new`], chain `.with_*` setters and
-/// adders, then call [`build`](TestGame::build) to get a `GameState`
+/// Construct with [`GameStateBuilder::new`], chain `.with_*` setters and
+/// adders, then call [`build`](GameStateBuilder::build) to get a `GameState`
 /// ready for [`apply`](crate::apply).
 #[derive(Debug, Clone)]
-#[must_use = "TestGame is a builder; call .build() to produce a GameState"]
-pub struct TestGame {
+#[must_use = "GameStateBuilder is a builder; call .build() to produce a GameState"]
+pub struct GameStateBuilder {
     investigators: BTreeMap<InvestigatorId, Investigator>,
     locations: BTreeMap<crate::state::LocationId, Location>,
     enemies: BTreeMap<EnemyId, Enemy>,
@@ -56,7 +59,7 @@ pub struct TestGame {
     scenario_id: Option<ScenarioId>,
 }
 
-impl TestGame {
+impl GameStateBuilder {
     /// Start a new builder with empty investigators / locations / chaos
     /// bag, `Phase::Mythos`, round 0, no active investigator, RNG
     /// seeded at zero. Most tests override the seed explicitly via
@@ -102,10 +105,10 @@ impl TestGame {
     /// ```
     /// use game_core::{
     ///     InvestigatorId, LocationId,
-    ///     test_support::{test_investigator, test_location, TestGame},
+    ///     test_support::{test_investigator, test_location, GameStateBuilder},
     /// };
     ///
-    /// let state = TestGame::new()
+    /// let state = GameStateBuilder::new()
     ///     .with_investigator_at(test_investigator(1), LocationId(10))
     ///     .with_location(test_location(10, "Study"))
     ///     .build();
@@ -237,7 +240,7 @@ impl TestGame {
     }
 
     /// Set the scenario id this state belongs to. `None` (the
-    /// default from [`TestGame::new`]) means the engine's post-apply
+    /// default from [`GameStateBuilder::new`]) means the engine's post-apply
     /// resolution hook will short-circuit. Passing a `ScenarioId`
     /// means a `ScenarioRegistry` capable of resolving it must be
     /// installed *if you want resolutions to fire* — the resolution
@@ -246,19 +249,6 @@ impl TestGame {
     pub fn with_scenario_id(mut self, id: ScenarioId) -> Self {
         self.scenario_id = Some(id);
         self
-    }
-
-    /// Build into a [`TestSession`] for driving the engine with a
-    /// scripted [`ChoiceResolver`].
-    ///
-    /// Equivalent to `TestSession::new(self.build())`; sugar so
-    /// resolver-driven tests can write
-    /// `TestGame::new()...session().apply(...).resolve_choices(...).run()`.
-    ///
-    /// [`TestSession`]: super::resolver::TestSession
-    /// [`ChoiceResolver`]: super::resolver::ChoiceResolver
-    pub fn session(self) -> super::resolver::TestSession {
-        super::resolver::TestSession::new(self.build())
     }
 
     /// Materialize the configured [`GameState`].
@@ -299,7 +289,7 @@ impl TestGame {
     }
 }
 
-impl Default for TestGame {
+impl Default for GameStateBuilder {
     fn default() -> Self {
         Self::new()
     }
@@ -313,7 +303,7 @@ mod with_open_window_tests {
 
     #[test]
     fn with_open_window_pushes_onto_the_stack() {
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_open_window(
                 WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins),
@@ -327,7 +317,7 @@ mod with_open_window_tests {
 
     #[test]
     fn with_open_window_stacks_in_order() {
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_open_window(
                 WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws),

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -915,17 +915,17 @@ mod fast_actor_scope_tests {
 #[cfg(test)]
 mod next_enemy_id_tests {
     use super::*;
-    use crate::test_support::TestGame;
+    use crate::test_support::GameStateBuilder;
 
     #[test]
     fn game_state_has_next_enemy_id_counter_starting_at_zero() {
-        let state = TestGame::new().build();
+        let state = GameStateBuilder::new().build();
         assert_eq!(state.next_enemy_id, 0);
     }
 
     #[test]
     fn next_enemy_id_round_trips_through_serde() {
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         state.next_enemy_id = 42;
         let json = serde_json::to_string(&state).expect("serialize");
         let back: GameState = serde_json::from_str(&json).expect("deserialize");
@@ -935,11 +935,11 @@ mod next_enemy_id_tests {
 
 #[cfg(test)]
 mod mythos_draw_pending_tests {
-    use crate::test_support::TestGame;
+    use crate::test_support::GameStateBuilder;
 
     #[test]
     fn game_state_default_has_no_mythos_draw_pending() {
-        let state = TestGame::new().build();
+        let state = GameStateBuilder::new().build();
         assert_eq!(state.mythos_draw_pending, None);
     }
 }
@@ -948,17 +948,17 @@ mod mythos_draw_pending_tests {
 mod enemy_attack_pending_tests {
     use super::*;
     use crate::state::InvestigatorId;
-    use crate::test_support::TestGame;
+    use crate::test_support::GameStateBuilder;
 
     #[test]
     fn game_state_default_has_no_enemy_attack_pending() {
-        let state = TestGame::new().build();
+        let state = GameStateBuilder::new().build();
         assert_eq!(state.enemy_attack_pending, None);
     }
 
     #[test]
     fn enemy_attack_pending_round_trips_through_serde() {
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         state.enemy_attack_pending = Some(InvestigatorId(7));
         let json = serde_json::to_string(&state).expect("serialize");
         let back: GameState = serde_json::from_str(&json).expect("deserialize");
@@ -970,11 +970,11 @@ mod enemy_attack_pending_tests {
 mod encounter_deck_tests {
     use super::*;
     use crate::state::CardCode;
-    use crate::test_support::TestGame;
+    use crate::test_support::GameStateBuilder;
 
     #[test]
     fn encounter_deck_and_discard_serde_roundtrip() {
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         state.encounter_deck.push_back(CardCode("01001".into()));
         state.encounter_deck.push_back(CardCode("01002".into()));
         state.encounter_discard.push(CardCode("01099".into()));
@@ -991,7 +991,7 @@ mod encounter_deck_tests {
 
     #[test]
     fn fresh_state_has_empty_encounter_deck_and_discard() {
-        let state = TestGame::new().build();
+        let state = GameStateBuilder::new().build();
         assert!(state.encounter_deck.is_empty());
         assert!(state.encounter_discard.is_empty());
     }
@@ -1088,11 +1088,11 @@ mod partial_eq_tests {
 #[cfg(test)]
 mod starting_location_tests {
     use super::*;
-    use crate::test_support::TestGame;
+    use crate::test_support::GameStateBuilder;
 
     #[test]
     fn game_state_starting_location_defaults_to_none_and_roundtrips() {
-        let mut state = TestGame::new().build();
+        let mut state = GameStateBuilder::new().build();
         assert_eq!(state.starting_location, None, "default must be None");
 
         state.starting_location = Some(crate::state::LocationId(7));

--- a/crates/game-core/src/state/location.rs
+++ b/crates/game-core/src/state/location.rs
@@ -40,6 +40,36 @@ pub struct Location {
     pub connections: Vec<LocationId>,
 }
 
+impl Location {
+    /// Construct a revealed location with no connections, from its
+    /// printed identity and stats (`code`, `name`, `shroud`, `clues`).
+    ///
+    /// Set `connections` (and `revealed`, for cards that enter play
+    /// face-down) afterward via the public fields — those are
+    /// scenario-layout concerns, not printed on the card. This is the
+    /// cross-crate constructor scenarios use to build their board; the
+    /// struct is `#[non_exhaustive]`, so a struct literal won't compile
+    /// outside `game-core`.
+    #[must_use]
+    pub fn new(
+        id: LocationId,
+        code: CardCode,
+        name: impl Into<String>,
+        shroud: u8,
+        clues: u8,
+    ) -> Self {
+        Self {
+            id,
+            code,
+            name: name.into(),
+            shroud,
+            clues,
+            revealed: true,
+            connections: Vec::new(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod location_code_tests {
     use super::*;
@@ -57,6 +87,18 @@ mod location_code_tests {
             connections: Vec::new(),
         };
         assert_eq!(loc.code, CardCode("01112".into()));
+    }
+
+    #[test]
+    fn location_new_builds_revealed_unconnected_location() {
+        let loc = Location::new(LocationId(3), CardCode("01111".into()), "Study", 2, 2);
+        assert_eq!(loc.id, LocationId(3));
+        assert_eq!(loc.code, CardCode("01111".into()));
+        assert_eq!(loc.name, "Study");
+        assert_eq!(loc.shroud, 2);
+        assert_eq!(loc.clues, 2);
+        assert!(loc.revealed, "new locations are revealed");
+        assert!(loc.connections.is_empty(), "new locations are unconnected");
     }
 
     #[test]

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -5,6 +5,7 @@
 //! These are pure data with no engine logic — they describe the world,
 //! they don't run the game.
 
+pub mod builder;
 pub mod card;
 pub mod chaos_bag;
 pub mod enemy;
@@ -13,6 +14,7 @@ pub mod investigator;
 pub mod location;
 pub mod phase;
 
+pub use builder::GameStateBuilder;
 pub use card::{AbilityUsageRecord, CardCode, CardInPlay, CardInstanceId, UseKind, Zone};
 pub use chaos_bag::{resolve_token, ChaosBag, ChaosToken, TokenModifiers, TokenResolution};
 pub use enemy::{Enemy, EnemyId};

--- a/crates/game-core/src/test_support/assertions.rs
+++ b/crates/game-core/src/test_support/assertions.rs
@@ -26,10 +26,10 @@
 //! use game_core::{
 //!     apply, Action, Event, InvestigatorId, PlayerAction, Phase,
 //!     assert_event, assert_no_event,
-//!     test_support::{test_investigator, TestGame},
+//!     test_support::{test_investigator, GameStateBuilder},
 //! };
 //!
-//! let state = TestGame::new()
+//! let state = GameStateBuilder::new()
 //!     .with_phase(Phase::Investigation)
 //!     .with_investigator(test_investigator(1))
 //!     .with_active_investigator(InvestigatorId(1))

--- a/crates/game-core/src/test_support/mod.rs
+++ b/crates/game-core/src/test_support/mod.rs
@@ -1,16 +1,19 @@
-//! Test-only support: fluent state builder, fixtures, event-assertion
-//! macros.
+//! Test-only support: fixtures, event-assertion macros, and a
+//! convenience re-export of the production [`GameStateBuilder`].
 //!
 //! The macros are exported at the crate root via `#[macro_export]`,
 //! so callers see [`assert_event!`](crate::assert_event) regardless
 //! of where they import the supporting types from.
+//!
+//! The state builder itself lives in [`crate::state`] (it constructs
+//! production `GameState`s, not just test ones); it is re-exported here
+//! so the existing test imports keep working.
 
 pub mod assertions;
-pub mod builder;
 pub mod fixtures;
 pub mod resolver;
 
-pub use builder::TestGame;
+pub use crate::state::GameStateBuilder;
 pub use fixtures::{awaiting_commit_input, test_enemy, test_investigator, test_location};
 pub use resolver::{apply_no_commits, drive, ChoiceResolver, ScriptedResolver, TestSession};
 

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -30,12 +30,12 @@
 //! ```
 //! use game_core::action::{Action, PlayerAction};
 //! use game_core::engine::EngineOutcome;
-//! use game_core::test_support::TestGame;
+//! use game_core::test_support::GameStateBuilder;
 //!
 //! // A skill-test action with no investigator in state still rejects
 //! // — useful as a tiny smoke test for the fluent API without needing
 //! // a real chaos bag.
-//! let result = TestGame::new()
+//! let result = GameStateBuilder::new()
 //!     .session()
 //!     .apply(Action::Player(PlayerAction::EndTurn))
 //!     .run();
@@ -329,7 +329,7 @@ where
 /// a scripted resolver, then [`run`](Self::run) the engine through to a
 /// terminal outcome.
 ///
-/// Construct via [`TestGame::session`](super::TestGame::session) or
+/// Construct via [`GameStateBuilder::session`](super::GameStateBuilder::session) or
 /// [`TestSession::new`].
 #[derive(Debug)]
 #[must_use = "TestSession does nothing until you call .run()"]
@@ -337,6 +337,20 @@ pub struct TestSession {
     state: GameState,
     action: Option<Action>,
     resolver: ScriptedResolver,
+}
+
+impl crate::state::GameStateBuilder {
+    /// Build into a [`TestSession`] for driving the engine with a
+    /// scripted [`ChoiceResolver`].
+    ///
+    /// Equivalent to `TestSession::new(self.build())`; sugar so
+    /// resolver-driven tests can write
+    /// `GameStateBuilder::new()...session().apply(...).resolve_choices(...).run()`.
+    /// Lives here (test-only) rather than on the builder itself so the
+    /// production builder in [`crate::state`] carries no test dependency.
+    pub fn session(self) -> TestSession {
+        TestSession::new(self.build())
+    }
 }
 
 impl TestSession {
@@ -362,9 +376,9 @@ impl TestSession {
     /// sequence:
     ///
     /// ```
-    /// # use game_core::test_support::TestGame;
+    /// # use game_core::test_support::GameStateBuilder;
     /// # use game_core::action::{Action, PlayerAction};
-    /// let _session = TestGame::new()
+    /// let _session = GameStateBuilder::new()
     ///     .session()
     ///     .resolve_choices(|c| {
     ///         c.confirm();
@@ -391,10 +405,10 @@ mod tests {
     use crate::action::{Action, InputResponse, PlayerAction};
     use crate::engine::{InputRequest, ResumeToken};
     use crate::state::{CardCode, InvestigatorId, LocationId, Phase};
-    use crate::test_support::{test_investigator, test_location, TestGame};
+    use crate::test_support::{test_investigator, test_location, GameStateBuilder};
 
     fn empty_state() -> GameState {
-        TestGame::new().build()
+        GameStateBuilder::new().build()
     }
 
     fn req(prompt: &str) -> InputRequest {
@@ -445,7 +459,7 @@ mod tests {
         let id = InvestigatorId(1);
         let mut inv = crate::test_support::test_investigator(1);
         inv.hand = hand.iter().map(|c| CardCode::new(*c)).collect();
-        let mut state = TestGame::new().with_investigator(inv).build();
+        let mut state = GameStateBuilder::new().with_investigator(inv).build();
         state.in_flight_skill_test = Some(InFlightSkillTest {
             investigator: id,
             skill: crate::state::SkillKind::Intellect,
@@ -708,7 +722,7 @@ mod tests {
     #[test]
     fn test_session_fluent_round_trip() {
         let id = InvestigatorId(1);
-        let result = TestGame::new()
+        let result = GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_investigator(test_investigator(1))
             .with_location(test_location(10, "Study"))
@@ -727,6 +741,6 @@ mod tests {
     #[test]
     #[should_panic(expected = "call .apply(action) before .run()")]
     fn test_session_run_without_apply_panics() {
-        let _ = TestGame::new().session().run();
+        let _ = GameStateBuilder::new().session().run();
     }
 }

--- a/crates/game-core/tests/activate_ability.rs
+++ b/crates/game-core/tests/activate_ability.rs
@@ -24,7 +24,7 @@ use game_core::state::{
     CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, InvestigatorId, Phase, SkillKind,
     Status, TokenModifiers,
 };
-use game_core::test_support::{apply_no_commits, test_investigator, TestGame};
+use game_core::test_support::{apply_no_commits, test_investigator, GameStateBuilder};
 use game_core::{assert_event, assert_event_count, assert_no_event};
 use game_core::{Action, PlayerAction};
 
@@ -109,7 +109,7 @@ fn state_with_in_play(code: &str) -> (game_core::GameState, InvestigatorId, Card
     inv.cards_in_play
         .push(CardInPlay::enter_play(CardCode::new(code), instance_id));
 
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_investigator(inv)
         .with_active_investigator(id)
@@ -317,7 +317,7 @@ fn activating_with_defeated_status_doesnt_need_registry() {
         instance_id,
     ));
 
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_investigator(inv)
         .with_active_investigator(id)

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -25,7 +25,8 @@ use game_core::engine::EngineOutcome;
 use game_core::event::Event;
 use game_core::state::{Act, Agenda, CardCode, InvestigatorId, LocationId, Phase};
 use game_core::test_support::{
-    fire_forced_on_enter, fire_forced_on_phase_end, test_investigator, test_location, TestGame,
+    fire_forced_on_enter, fire_forced_on_phase_end, test_investigator, test_location,
+    GameStateBuilder,
 };
 use game_core::{apply, Action, PlayerAction};
 
@@ -103,7 +104,7 @@ fn forced_on_enter_resolves_immediately() {
     let mut loc = test_location(10, "Attic");
     loc.code = CardCode(HORROR_ATTIC.into());
 
-    let mut state = TestGame::new()
+    let mut state = GameStateBuilder::new()
         .with_investigator_at(test_investigator(1), LocationId(10))
         .with_location(loc)
         .with_active_investigator(InvestigatorId(1))
@@ -136,7 +137,7 @@ fn move_into_forced_location_fires_its_effect() {
     inv.current_location = Some(LocationId(10));
     inv.actions_remaining = 3;
 
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_investigator(inv)
         .with_location(from)
         .with_location(attic)
@@ -192,7 +193,7 @@ fn forced_on_enter_no_op_when_location_has_no_abilities() {
     let mut loc = test_location(10, "Plain Room");
     loc.code = CardCode("plain-loc".into());
 
-    let mut state = TestGame::new()
+    let mut state = GameStateBuilder::new()
         .with_investigator_at(test_investigator(1), LocationId(10))
         .with_location(loc)
         .with_active_investigator(InvestigatorId(1))
@@ -215,7 +216,7 @@ fn forced_on_enter_no_op_when_location_has_no_abilities() {
 /// forced horror) as the current agenda and `InvestigatorId(1)` as the lead.
 fn state_with_doom_agenda() -> game_core::state::GameState {
     let inv = test_investigator(1);
-    let mut state = TestGame::new()
+    let mut state = GameStateBuilder::new()
         .with_investigator(inv)
         .with_turn_order([InvestigatorId(1)])
         .build();
@@ -302,7 +303,7 @@ fn forced_on_phase_end_no_op_when_agenda_has_no_abilities() {
     install_mock_registry();
 
     let inv = test_investigator(1);
-    let mut state = TestGame::new()
+    let mut state = GameStateBuilder::new()
         .with_investigator(inv)
         .with_turn_order([InvestigatorId(1)])
         .build();
@@ -328,11 +329,11 @@ fn forced_on_phase_end_no_op_when_no_act_or_agenda() {
 
     // Empty decks — common fixture shape for tests not modeling scenarios.
     let inv = test_investigator(1);
-    let mut state = TestGame::new()
+    let mut state = GameStateBuilder::new()
         .with_investigator(inv)
         .with_turn_order([InvestigatorId(1)])
         .build();
-    // state.agenda_deck / act_deck are empty by default from TestGame.
+    // state.agenda_deck / act_deck are empty by default from GameStateBuilder.
 
     let mut events = Vec::new();
     let outcome = fire_forced_on_phase_end(&mut state, &mut events, Phase::Enemy);
@@ -361,7 +362,7 @@ fn forced_on_phase_end_fires_act_ability() {
     install_mock_registry();
 
     let inv = test_investigator(1);
-    let mut state = TestGame::new()
+    let mut state = GameStateBuilder::new()
         .with_investigator(inv)
         .with_turn_order([InvestigatorId(1)])
         .build();
@@ -401,7 +402,7 @@ fn two_simultaneous_forced_triggers_reject_loudly() {
     let mut loc = test_location(10, "Double-Forced Room");
     loc.code = CardCode(DOUBLE_FORCED.into());
 
-    let mut state = TestGame::new()
+    let mut state = GameStateBuilder::new()
         .with_investigator_at(test_investigator(1), LocationId(10))
         .with_location(loc)
         .with_active_investigator(InvestigatorId(1))

--- a/crates/game-core/tests/on_skill_test_resolution.rs
+++ b/crates/game-core/tests/on_skill_test_resolution.rs
@@ -25,7 +25,7 @@ use game_core::state::{
     CardCode, ChaosBag, ChaosToken, InvestigatorId, LocationId, Phase, SkillKind, TokenModifiers,
 };
 use game_core::test_support::{
-    apply_no_commits, drive, test_investigator, test_location, ScriptedResolver, TestGame,
+    apply_no_commits, drive, test_investigator, test_location, GameStateBuilder, ScriptedResolver,
 };
 use game_core::{assert_event, assert_event_count, assert_no_event, Action, PlayerAction};
 
@@ -95,7 +95,7 @@ fn state_with_hand_and_location(
     inv.hand = hand.iter().map(|c| CardCode::new(*c)).collect();
     let mut location = test_location(10, "Study");
     location.clues = initial_clues;
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_active_investigator(id)
         .with_investigator(inv)

--- a/crates/game-core/tests/reaction_windows.rs
+++ b/crates/game-core/tests/reaction_windows.rs
@@ -27,7 +27,7 @@ use game_core::state::{
     InvestigatorId, LocationId, OpenWindow, Phase, PhaseStep, TokenModifiers, WindowKind,
 };
 use game_core::test_support::{
-    apply_no_commits, test_enemy, test_investigator, test_location, TestGame,
+    apply_no_commits, test_enemy, test_investigator, test_location, GameStateBuilder,
 };
 use game_core::{
     assert_event, assert_event_count, assert_no_event, Action, InputResponse, PlayerAction,
@@ -124,7 +124,7 @@ fn fight_to_defeat_scenario(
     enemy.engaged_with = Some(inv_id);
     let mut loc = test_location(10, "Mock Location");
     loc.clues = 3;
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_active_investigator(inv_id)
         .with_turn_order([inv_id])
@@ -340,7 +340,7 @@ fn by_controller_filter_excludes_unrelated_investigators() {
     enemy.engaged_with = Some(attacker);
     let mut loc = test_location(10, "Mock Location");
     loc.clues = 3;
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_active_investigator(attacker)
         .with_turn_order([attacker, bystander])
@@ -386,7 +386,7 @@ fn unqualified_pattern_matches_any_defeat() {
     enemy.max_health = 2;
     enemy.damage = 1;
     enemy.engaged_with = Some(attacker);
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_active_investigator(attacker)
         .with_turn_order([attacker, bystander])
@@ -675,7 +675,7 @@ fn reaction_window_closes_before_on_skill_test_resolution_fires() {
     enemy.engaged_with = Some(inv_id);
     let mut loc = test_location(10, "Mock Location");
     loc.clues = 3;
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_active_investigator(inv_id)
         .with_turn_order([inv_id])
@@ -784,7 +784,7 @@ fn pending_triggers_order_active_investigator_first_then_turn_order() {
     enemy.max_health = 2;
     enemy.damage = 1;
     enemy.engaged_with = Some(active);
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_active_investigator(active)
         .with_turn_order([active, other])

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -120,12 +120,12 @@ mod id_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use game_core::test_support::builder::TestGame;
+    use game_core::state::GameStateBuilder;
     use game_core::test_support::fixtures::test_investigator;
 
     #[test]
     fn hello_round_trips_through_json() {
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
         let msg = ServerMessage::Hello {
@@ -144,7 +144,7 @@ mod tests {
 
     #[test]
     fn applied_round_trips_through_json() {
-        let state = TestGame::new()
+        let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
         let msg = ServerMessage::Applied {

--- a/crates/scenarios/src/test_fixtures/synthetic.rs
+++ b/crates/scenarios/src/test_fixtures/synthetic.rs
@@ -14,7 +14,7 @@ use game_core::scenario::{Resolution, ScenarioId, ScenarioModule};
 use game_core::state::{
     Act, Agenda, CardCode, ChaosBag, ChaosToken, GameState, InvestigatorId, LocationId,
 };
-use game_core::test_support::{test_investigator, test_location, TestGame};
+use game_core::test_support::{test_investigator, test_location, GameStateBuilder};
 
 use super::synth_cards::{SYNTH_LOC_CODE, SYNTH_TREACHERY_CODE};
 
@@ -35,7 +35,7 @@ pub const ID: &str = "synthetic";
 /// Investigate → discover-clue → `AdvanceAct` (Won) path needs, which is
 /// what the browser demo and `tests/closing_demo.rs` exercise. A real
 /// scenario's setup does the same (seats investigators, prints clue
-/// counts on locations, fills the chaos bag); the bare `TestGame` /
+/// counts on locations, fills the chaos bag); the bare `GameStateBuilder` /
 /// `test_location` defaults (unplaced, 0 clues, empty bag) do not.
 ///
 /// The encounter-deck seeding gives the #126 / #127 integration
@@ -62,7 +62,7 @@ pub fn setup() -> GameState {
     // counts on locations; the bare `test_location` default is 0.
     location.clues = 4;
 
-    let mut state = TestGame::new()
+    let mut state = GameStateBuilder::new()
         // Place the investigator at the demo location: scenario setup
         // seats investigators at a starting location, and Investigate /
         // Move reject on a `None` current_location. `test_location(10, …)`

--- a/crates/scenarios/src/the_gathering.rs
+++ b/crates/scenarios/src/the_gathering.rs
@@ -17,9 +17,9 @@
 use game_core::event::Event;
 use game_core::scenario::{Resolution, ScenarioId, ScenarioModule};
 use game_core::state::{
-    Act, Agenda, CardCode, ChaosBag, ChaosToken, GameState, LocationId, TokenModifiers,
+    Act, Agenda, CardCode, ChaosBag, ChaosToken, GameState, GameStateBuilder, Location, LocationId,
+    TokenModifiers,
 };
-use game_core::test_support::{test_location, TestGame};
 
 /// String id used to look this module up in [`crate::REGISTRY`].
 pub const ID: &str = "the-gathering";
@@ -60,16 +60,10 @@ fn standard_chaos_bag() -> ChaosBag {
 /// No investigators — the `StartScenario` roster step seats them.
 pub fn setup() -> GameState {
     // The Study (01111): shroud 2, clues 2, revealed, no connections
-    // (Act 1 is "trapped in the Study"). `test_location` is the only
-    // cross-crate GameState/Location constructor (both are
-    // `#[non_exhaustive]`); we override its fields, exactly as the
-    // synthetic fixture does.
-    let mut study = test_location(STUDY_ID.0, "Study");
-    study.code = CardCode("01111".into());
-    study.shroud = 2;
-    study.clues = 2;
-    study.revealed = true;
-    study.connections = Vec::new();
+    // (Act 1 is "trapped in the Study"). `Location::new` gives a
+    // revealed, unconnected location; the Study's connection graph is
+    // C1b's Door-on-the-Floor transition.
+    let study = Location::new(STUDY_ID, CardCode("01111".into()), "Study", 2, 2);
 
     // The Gathering's symbol effects are printed on reference card 01104
     // (board-dependent; evaluated in C2). Until then these flat NotZ
@@ -82,7 +76,7 @@ pub fn setup() -> GameState {
     token_modifiers.tablet = -3;
     token_modifiers.elder_thing = -4;
 
-    let mut state = TestGame::new()
+    let mut state = GameStateBuilder::new()
         .with_location(study)
         .with_chaos_bag(standard_chaos_bag())
         .with_scenario_id(ScenarioId::new(ID))

--- a/crates/scenarios/tests/hunter_movement.rs
+++ b/crates/scenarios/tests/hunter_movement.rs
@@ -7,7 +7,7 @@ use std::sync::Once;
 use game_core::action::{InputResponse, PlayerAction};
 use game_core::engine::{apply, EngineOutcome};
 use game_core::state::{EnemyId, InvestigatorId, LocationId, Phase};
-use game_core::test_support::{test_enemy, test_investigator, test_location, TestGame};
+use game_core::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
 use game_core::Action;
 use scenarios::test_fixtures::synth_cards::{SYNTH_ENEMY_CODE, TEST_REGISTRY};
 use scenarios::test_fixtures::synthetic;
@@ -84,7 +84,7 @@ fn hunter_movement_pick_location_replays_identically() {
         let mut hunter = test_enemy(1, "Hunter");
         hunter.hunter = true;
         hunter.current_location = Some(LocationId(1));
-        TestGame::new()
+        GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_location(loc_a)
             .with_location(loc_b)

--- a/crates/scenarios/tests/the_gathering.rs
+++ b/crates/scenarios/tests/the_gathering.rs
@@ -9,7 +9,9 @@ use game_core::action::RosterEntry;
 use game_core::engine::{apply, EngineOutcome};
 use game_core::scenario::Resolution;
 use game_core::state::{CardCode, InvestigatorId, LocationId};
-use game_core::test_support::{fire_forced_on_enter, test_investigator, test_location, TestGame};
+use game_core::test_support::{
+    fire_forced_on_enter, test_investigator, test_location, GameStateBuilder,
+};
 use game_core::{Action, PlayerAction};
 use scenarios::{the_gathering, REGISTRY};
 
@@ -106,7 +108,7 @@ fn attic_forced_enter_deals_one_horror() {
     // isn't reachable until C1b's Door-on-the-Floor transition).
     let mut attic = test_location(20, "Attic");
     attic.code = CardCode("01113".into());
-    let mut state = TestGame::new()
+    let mut state = GameStateBuilder::new()
         .with_investigator_at(test_investigator(1), LocationId(20))
         .with_location(attic)
         .build();
@@ -126,7 +128,7 @@ fn cellar_forced_enter_deals_one_damage() {
     install_registries();
     let mut cellar = test_location(21, "Cellar");
     cellar.code = CardCode("01114".into());
-    let mut state = TestGame::new()
+    let mut state = GameStateBuilder::new()
         .with_investigator_at(test_investigator(1), LocationId(21))
         .with_location(cellar)
         .build();

--- a/crates/server/tests/common/mod.rs
+++ b/crates/server/tests/common/mod.rs
@@ -7,8 +7,8 @@ use std::net::SocketAddr;
 
 use futures_util::{SinkExt, StreamExt};
 use game_core::scenario::{ScenarioId, ScenarioModule, ScenarioRegistry};
+use game_core::state::GameStateBuilder;
 use game_core::state::{ChaosBag, ChaosToken, GameState, InvestigatorId};
-use game_core::test_support::builder::TestGame;
 use game_core::test_support::fixtures::test_investigator;
 use game_core::{Event, Resolution};
 use protocol::{ClientMessage, ServerMessage};
@@ -24,7 +24,7 @@ fn test_setup() -> GameState {
     // rejected. The single-token chaos bag also makes the investigator
     // eligible for a `PerformSkillTest` (which pauses at a commit window
     // → `AwaitingInput`), exercised by the resume tests.
-    TestGame::new()
+    GameStateBuilder::new()
         .with_investigator(test_investigator(1))
         .with_turn_order([InvestigatorId(1)])
         .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))

--- a/crates/server/tests/game_session.rs
+++ b/crates/server/tests/game_session.rs
@@ -4,8 +4,8 @@
 //! `StartScenario` is accepted and `EndTurn` is rejected).
 
 use game_core::scenario::{ScenarioId, ScenarioModule, ScenarioRegistry};
+use game_core::state::GameStateBuilder;
 use game_core::state::{GameState, InvestigatorId};
-use game_core::test_support::builder::TestGame;
 use game_core::test_support::fixtures::test_investigator;
 use game_core::{EngineOutcome, Event, PlayerAction, Resolution};
 use server::session::GameSession;
@@ -16,7 +16,7 @@ use sqlx::SqlitePool;
 const TEST_SCENARIO_ID: &str = "test-scenario";
 
 fn test_setup() -> GameState {
-    TestGame::new()
+    GameStateBuilder::new()
         .with_investigator(test_investigator(1))
         .with_turn_order([InvestigatorId(1)])
         .with_scenario_id(ScenarioId::new(TEST_SCENARIO_ID))

--- a/crates/web/src/legality.rs
+++ b/crates/web/src/legality.rs
@@ -89,8 +89,8 @@ mod tests {
         AdvanceAct, Draw, EndTurn, Evade, Fight, Investigate, Move, PlayCard,
     };
     use super::{enabled_controls, ActionControl};
+    use game_core::state::GameStateBuilder;
     use game_core::state::{InvestigatorId, Phase};
-    use game_core::test_support::builder::TestGame;
     use game_core::test_support::fixtures::{awaiting_commit_input, test_investigator};
     use game_core::{EngineOutcome, Resolution};
     use std::collections::BTreeSet;
@@ -98,7 +98,7 @@ mod tests {
     fn investigation_game() -> game_core::state::GameState {
         // round 1: an in-progress game is never round 0 (the engine bumps
         // to 1 at StartScenario), and round 0 now gates to StartScenario.
-        TestGame::new()
+        GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_active_investigator(InvestigatorId(1))
             .with_phase(Phase::Investigation)
@@ -110,7 +110,7 @@ mod tests {
     fn round_zero_enables_only_start_scenario() {
         // The state straight from a scenario `setup()`: phase Mythos,
         // round 0, no cursors. The only legal action is StartScenario.
-        let game = TestGame::new()
+        let game = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_active_investigator(InvestigatorId(1))
             .build();

--- a/crates/web/src/store.rs
+++ b/crates/web/src/store.rs
@@ -66,11 +66,11 @@ pub fn use_store() -> StoreSignal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use game_core::test_support::builder::TestGame;
+    use game_core::state::GameStateBuilder;
     use game_core::test_support::fixtures::test_investigator;
 
     fn sample_state() -> GameState {
-        TestGame::new()
+        GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build()
     }

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -3,8 +3,8 @@
 //! wasm32-only (browser DOM); native jobs skip this file.
 #![cfg(target_arch = "wasm32")]
 
+use game_core::state::GameStateBuilder;
 use game_core::state::{Act, Agenda, CardCode, Phase};
-use game_core::test_support::builder::TestGame;
 use game_core::test_support::fixtures::{test_enemy, test_investigator, test_location};
 use game_core::EngineOutcome;
 use leptos::prelude::{provide_context, RwSignal, Update};
@@ -47,7 +47,7 @@ async fn render_state(state: game_core::state::GameState) -> String {
 
 #[wasm_bindgen_test]
 async fn phase_bar_renders_phase_round_act_agenda() {
-    let mut state = TestGame::new()
+    let mut state = GameStateBuilder::new()
         .with_investigator(test_investigator(1))
         .with_phase(Phase::Investigation)
         .with_round(3)
@@ -86,7 +86,7 @@ async fn locations_panel_renders_name_shroud_clues_revealed() {
     let mut loc = test_location(7, "Rivertown");
     loc.shroud = 3;
     loc.clues = 2;
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_investigator(test_investigator(1))
         .with_location(loc)
         .build();
@@ -118,7 +118,7 @@ async fn investigators_panel_renders_stats_and_hand() {
         CardCode::new("_synth_asset"),
         CardInstanceId(0),
     )];
-    let state = TestGame::new().with_investigator(inv).build();
+    let state = GameStateBuilder::new().with_investigator(inv).build();
 
     let html = render_state(state).await;
 
@@ -150,7 +150,7 @@ async fn enemies_panel_renders_name_stats_engagement() {
     let mut enemy = test_enemy(4, "Swarm of Rats");
     enemy.damage = 1; // 1/2
     enemy.engaged_with = Some(InvestigatorId(1));
-    let state = TestGame::new()
+    let state = GameStateBuilder::new()
         .with_investigator(test_investigator(1))
         .with_enemy(enemy)
         .build();
@@ -221,7 +221,7 @@ fn last_resolution_html() -> String {
 #[wasm_bindgen_test]
 async fn resolution_banner_renders_won() {
     use game_core::Resolution;
-    let mut state = TestGame::new()
+    let mut state = GameStateBuilder::new()
         .with_investigator(test_investigator(1))
         .build();
     state.resolution = Some(Resolution::Won { id: "demo".into() });
@@ -236,7 +236,7 @@ async fn resolution_banner_renders_won() {
 #[wasm_bindgen_test]
 async fn resolution_banner_renders_lost() {
     use game_core::Resolution;
-    let mut state = TestGame::new()
+    let mut state = GameStateBuilder::new()
         .with_investigator(test_investigator(1))
         .build();
     state.resolution = Some(Resolution::Lost {

--- a/crates/web/tests/controls.rs
+++ b/crates/web/tests/controls.rs
@@ -5,8 +5,8 @@
 #![cfg(target_arch = "wasm32")]
 
 use futures::channel::mpsc;
+use game_core::state::GameStateBuilder;
 use game_core::state::{CardCode, EnemyId, InvestigatorId, LocationId, Phase};
-use game_core::test_support::builder::TestGame;
 use game_core::test_support::fixtures::{test_enemy, test_investigator, test_location};
 use game_core::{EngineOutcome, PlayerAction};
 use leptos::prelude::*;
@@ -72,7 +72,7 @@ fn click_in(section: &web_sys::Element, selector: &str) {
 /// `round 1` because an in-progress game is never round 0 (round 0 is the
 /// pre-start state that gates to `StartScenario`).
 fn investigation_game() -> game_core::state::GameState {
-    TestGame::new()
+    GameStateBuilder::new()
         .with_investigator(test_investigator(1))
         .with_active_investigator(InvestigatorId(1))
         .with_phase(Phase::Investigation)
@@ -134,7 +134,7 @@ async fn draw_encounter_submits_draw_encounter_card() {
     // Mythos phase with this investigator on the draw cursor: only
     // DrawEncounter is legal. `mythos_draw_pending` has no builder setter,
     // so mutate the built state directly (legality.rs tests do the same).
-    let mut game = TestGame::new()
+    let mut game = GameStateBuilder::new()
         .with_investigator(test_investigator(1))
         .with_active_investigator(InvestigatorId(1))
         .with_phase(Phase::Mythos)
@@ -156,7 +156,7 @@ async fn draw_encounter_submits_draw_encounter_card() {
 async fn illegal_controls_are_disabled_and_do_not_submit() {
     // Mythos + draw cursor: only DrawEncounter is legal, so End turn is
     // disabled and DrawEncounter is not.
-    let mut game = TestGame::new()
+    let mut game = GameStateBuilder::new()
         .with_investigator(test_investigator(1))
         .with_active_investigator(InvestigatorId(1))
         .with_phase(Phase::Mythos)
@@ -195,7 +195,7 @@ async fn move_picker_submits_move_to_connected_destination() {
     let mut loc1 = test_location(1, "Study");
     loc1.connections = vec![LocationId(2)];
     let loc2 = test_location(2, "Hallway");
-    let game = TestGame::new()
+    let game = GameStateBuilder::new()
         .with_investigator_at(test_investigator(1), LocationId(1))
         .with_active_investigator(InvestigatorId(1))
         .with_location(loc1)
@@ -235,7 +235,7 @@ async fn play_picker_submits_play_card_by_hand_index() {
         CardCode::new("_synth_event_a"),
         CardCode::new("_synth_event_b"),
     ];
-    let game = TestGame::new()
+    let game = GameStateBuilder::new()
         .with_investigator(inv)
         .with_active_investigator(InvestigatorId(1))
         .with_phase(Phase::Investigation)
@@ -274,7 +274,7 @@ fn mulligan_game() -> game_core::state::GameState {
         CardCode::new("_synth_event_a"),
         CardCode::new("_synth_event_b"),
     ];
-    TestGame::new()
+    GameStateBuilder::new()
         .with_investigator(inv)
         .with_active_investigator(InvestigatorId(1))
         .with_phase(Phase::Investigation)
@@ -334,7 +334,7 @@ async fn mulligan_with_no_selection_keeps_hand() {
 fn investigation_game_with_engaged_enemy() -> game_core::state::GameState {
     let mut enemy = test_enemy(7, "Ghoul");
     enemy.engaged_with = Some(InvestigatorId(1));
-    TestGame::new()
+    GameStateBuilder::new()
         .with_investigator(test_investigator(1))
         .with_active_investigator(InvestigatorId(1))
         .with_phase(Phase::Investigation)
@@ -405,7 +405,7 @@ async fn start_scenario_is_the_only_control_at_round_zero() {
     // no cursors, no active investigator. The only legal action is
     // StartScenario — this is the state the server hands a freshly created
     // game, so the player must be able to start it.
-    let game = TestGame::new()
+    let game = GameStateBuilder::new()
         .with_investigator(test_investigator(1))
         .build();
     assert_eq!(game.round, 0, "precondition: pre-start state");

--- a/crates/web/tests/input.rs
+++ b/crates/web/tests/input.rs
@@ -5,8 +5,8 @@
 #![cfg(target_arch = "wasm32")]
 
 use futures::channel::mpsc;
+use game_core::state::GameStateBuilder;
 use game_core::state::{CardCode, InvestigatorId};
-use game_core::test_support::builder::TestGame;
 use game_core::test_support::fixtures::{awaiting_commit_input, test_investigator};
 use game_core::{InputResponse, PlayerAction};
 use leptos::prelude::*;
@@ -26,7 +26,7 @@ fn two_card_game() -> game_core::state::GameState {
         CardCode::new("_synth_event_a"),
         CardCode::new("_synth_event_b"),
     ];
-    TestGame::new()
+    GameStateBuilder::new()
         .with_investigator(inv)
         .with_active_investigator(InvestigatorId(1))
         .build()

--- a/crates/web/tests/store.rs
+++ b/crates/web/tests/store.rs
@@ -2,7 +2,7 @@
 //! the DOM rendered from it. wasm32-only (browser DOM); native jobs skip.
 #![cfg(target_arch = "wasm32")]
 
-use game_core::test_support::builder::TestGame;
+use game_core::state::GameStateBuilder;
 use game_core::test_support::fixtures::test_investigator;
 use game_core::EngineOutcome;
 use leptos::prelude::Update;
@@ -36,7 +36,7 @@ async fn hello_renders_state_present() {
         body_html()
     );
 
-    let game = TestGame::new()
+    let game = GameStateBuilder::new()
         .with_investigator(test_investigator(1))
         .build();
     store.update(|s| {


### PR DESCRIPTION
## Summary

Promotes the `TestGame` state builder to a first-class **`GameStateBuilder`**
and moves it out of `test_support` into `state` — so production scenario
`setup()` no longer constructs game state through a *test* builder. Fast-follow
cleanup on the C1a (#227) smell. Pure rename/move + a new constructor, **no
behavior change**.

## What changed

- **`TestGame` → `GameStateBuilder`**, relocated from
  `game_core::test_support::builder` to `game_core::state::builder` (canonical
  home: it builds production `GameState`s). `test_support` keeps a convenience
  `pub use` re-export, so test imports are unchanged beyond the identifier.
- **`Location::new(id, code, name, shroud, clues)`** — a real cross-crate
  constructor (the struct is `#[non_exhaustive]`). `connections`/`revealed` stay
  public for scenario-layout tweaks.
- **`the_gathering::setup()`** now builds the Study with `GameStateBuilder` +
  `Location::new` — no `test_location` fixture in production code.
- The resolver-driven **`.session()`** sugar moved to an `impl GameStateBuilder`
  block in `test_support::resolver`, so the production builder carries no
  dependency on test-only types.
- Mechanical rename across 47 files (every `TestGame::new()` call site).

## Why

`the_gathering::setup()` (production) was constructing state via a builder named
`TestGame` living under `test_support`, and faking a location with
`test_location(...)` then patching its fields. `GameState`/`Location` are
`#[non_exhaustive]`, so a cross-crate constructor is *required* — but it should
be a blessed, properly-named API, not test scaffolding. Surfaced in #250 review.

## Test notes

No behavior change; existing suite carried over under the new name, plus a
`Location::new` unit test. Full local gauntlet green
(test/clippy/fmt/doc/wasm-build/wasm-clippy); wasm-test left to CI.

## Linked issues

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)