### PR TITLE
C1b: act advancement — Act-1 board build + Act-3 forced advance-on-defeat (#228)

### DIFF
--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -252,6 +252,11 @@ pub enum EventPattern {
     /// wired for Enemy and Upkeep phase-ends only; Mythos and
     /// Investigation are not wired (see #212).
     PhaseEnded { phase: Phase },
+    /// The act this ability is printed on advanced (its reverse side
+    /// resolves). Fired forced via `ForcedTriggerPoint::ActAdvanced`;
+    /// binds controller = the lead investigator (board-wide reverse
+    /// effects ignore it).
+    ActAdvanced,
 }
 
 /// The four game phases, mirrored in `card-dsl` so [`EventPattern`] can
@@ -459,6 +464,16 @@ pub enum Effect {
     /// branch's effect. Requires an `AwaitingInput` round-trip; the
     /// evaluator stub for this lands in Phase 3 alongside skill tests.
     ChooseOne(Vec<Effect>),
+    /// Put every location in `set_aside_locations` into play (Rules
+    /// Reference p.3 "set aside" -> in play). Board-wide; ignores the
+    /// controller.
+    PutSetAsideLocationsIntoPlay,
+    /// Move every investigator to the in-play location with this
+    /// printed `code`. Rejects if no such location is in play.
+    RelocateAllInvestigators { to: String },
+    /// Remove the in-play location with this printed `code` from the
+    /// game. Rejects if no such location is in play.
+    RemoveLocationFromGame { location: String },
 }
 
 // ---- stats and modifier scopes --------------------------------
@@ -799,6 +814,28 @@ pub fn for_each(targets: InvestigatorTargetSet, body: Effect) -> Effect {
 #[must_use]
 pub fn choose_one(effects: impl IntoIterator<Item = Effect>) -> Effect {
     Effect::ChooseOne(effects.into_iter().collect())
+}
+
+/// Build an [`Effect::PutSetAsideLocationsIntoPlay`].
+#[must_use]
+pub fn put_set_aside_locations_into_play() -> Effect {
+    Effect::PutSetAsideLocationsIntoPlay
+}
+
+/// Build an [`Effect::RelocateAllInvestigators`] targeting `to` (a
+/// printed location code).
+#[must_use]
+pub fn relocate_all_investigators(to: impl Into<String>) -> Effect {
+    Effect::RelocateAllInvestigators { to: to.into() }
+}
+
+/// Build an [`Effect::RemoveLocationFromGame`] targeting `location` (a
+/// printed location code).
+#[must_use]
+pub fn remove_location_from_game(location: impl Into<String>) -> Effect {
+    Effect::RemoveLocationFromGame {
+        location: location.into(),
+    }
 }
 
 // ---- tests ----------------------------------------------------
@@ -1200,6 +1237,22 @@ mod tests {
         let json = serde_json::to_string(&p).unwrap();
         let back: EventPattern = serde_json::from_str(&json).unwrap();
         assert_eq!(p, back);
+    }
+
+    #[test]
+    fn world_build_effect_builders_have_expected_shape() {
+        assert!(matches!(
+            put_set_aside_locations_into_play(),
+            Effect::PutSetAsideLocationsIntoPlay
+        ));
+        assert!(matches!(
+            relocate_all_investigators("01112"),
+            Effect::RelocateAllInvestigators { to } if to == "01112"
+        ));
+        assert!(matches!(
+            remove_location_from_game("01111"),
+            Effect::RemoveLocationFromGame { location } if location == "01111"
+        ));
     }
 
     /// Effects clone deeply (the recursive Box doesn't break Clone).

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -65,7 +65,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Phase-3 set. Later phases add `AtPhaseStart`/`AtPhaseEnd`,
 /// `OnLeavePlay`, and additional reactive patterns as cards demand.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Trigger {
     /// Always-on while the card is in play. The ability's `effect`
     /// describes a passive contribution to engine queries (most
@@ -186,7 +186,7 @@ pub enum Trigger {
 /// movement, clue placement, …); the engine evaluator exhaustively
 /// matches on this enum so adding a variant is a deliberate change
 /// rather than a silent broadening.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum EventPattern {
     /// An enemy was defeated. `by_controller` narrows the match to
     /// defeats credited to the ability's controller — Roland Banks's
@@ -198,6 +198,10 @@ pub enum EventPattern {
         /// `game_core::Event::EnemyDefeated`). If `false`, any defeat
         /// matches.
         by_controller: bool,
+        /// Narrow the match to a specific defeated enemy printed code
+        /// (e.g. the Ghoul Priest's `"01116"` for Act 3's objective).
+        /// `None` matches any enemy's defeat (e.g. Roland's reaction).
+        code: Option<String>,
     },
     /// An encounter card was revealed (drawn from the encounter deck
     /// and announced via the engine's on-draw path). `card_type`
@@ -1060,6 +1064,7 @@ mod tests {
         let ability = on_event(
             EventPattern::EnemyDefeated {
                 by_controller: true,
+                code: None,
             },
             EventTiming::After,
             discover_clue(LocationTarget::YourLocation, 1),
@@ -1069,6 +1074,7 @@ mod tests {
             Trigger::OnEvent {
                 pattern: EventPattern::EnemyDefeated {
                     by_controller: true,
+                    code: None,
                 },
                 timing: EventTiming::After,
             },
@@ -1094,18 +1100,21 @@ mod tests {
         let after_any = Trigger::OnEvent {
             pattern: EventPattern::EnemyDefeated {
                 by_controller: false,
+                code: None,
             },
             timing: EventTiming::After,
         };
         let after_controller = Trigger::OnEvent {
             pattern: EventPattern::EnemyDefeated {
                 by_controller: true,
+                code: None,
             },
             timing: EventTiming::After,
         };
         let before_controller = Trigger::OnEvent {
             pattern: EventPattern::EnemyDefeated {
                 by_controller: true,
+                code: None,
             },
             timing: EventTiming::Before,
         };
@@ -1129,6 +1138,7 @@ mod tests {
             let original = on_event(
                 EventPattern::EnemyDefeated {
                     by_controller: true,
+                    code: None,
                 },
                 timing,
                 discover_clue(LocationTarget::YourLocation, 1),
@@ -1198,6 +1208,7 @@ mod tests {
         };
         let enemy_defeated = EventPattern::EnemyDefeated {
             by_controller: true,
+            code: None,
         };
         assert_ne!(revealed_treachery, enemy_defeated);
     }
@@ -1215,6 +1226,7 @@ mod tests {
         let spawned = EventPattern::EnemySpawned;
         let defeated = EventPattern::EnemyDefeated {
             by_controller: true,
+            code: None,
         };
         let revealed = EventPattern::CardRevealed { card_type: None };
         assert_ne!(spawned, defeated);
@@ -1253,6 +1265,19 @@ mod tests {
             remove_location_from_game("01111"),
             Effect::RemoveLocationFromGame { location } if location == "01111"
         ));
+    }
+
+    #[test]
+    fn enemy_defeated_carries_optional_code_narrow() {
+        let any = EventPattern::EnemyDefeated {
+            by_controller: false,
+            code: None,
+        };
+        let narrowed = EventPattern::EnemyDefeated {
+            by_controller: false,
+            code: Some("01116".into()),
+        };
+        assert_ne!(any, narrowed);
     }
 
     /// Effects clone deeply (the recursive Box doesn't break Clone).

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -478,6 +478,11 @@ pub enum Effect {
     /// Remove the in-play location with this printed `code` from the
     /// game. Rejects if no such location is in play.
     RemoveLocationFromGame { location: String },
+    /// Advance the current act one step. If the act is terminal (carries
+    /// a resolution) the scenario resolves; otherwise the cursor moves
+    /// and the act's on-advance reverse fires. Used by act objectives
+    /// like 01110 ("If the Ghoul Priest is Defeated, advance.").
+    AdvanceCurrentAct,
 }
 
 // ---- stats and modifier scopes --------------------------------
@@ -840,6 +845,12 @@ pub fn remove_location_from_game(location: impl Into<String>) -> Effect {
     Effect::RemoveLocationFromGame {
         location: location.into(),
     }
+}
+
+/// Build an [`Effect::AdvanceCurrentAct`].
+#[must_use]
+pub fn advance_current_act() -> Effect {
+    Effect::AdvanceCurrentAct
 }
 
 // ---- tests ----------------------------------------------------

--- a/crates/cards/src/impls/act_01108.rs
+++ b/crates/cards/src/impls/act_01108.rs
@@ -1,0 +1,66 @@
+//! Trapped (The Gathering Act 1, 01108).
+//!
+//! ```text
+//! Act 1 — Trapped. Clues: 2.
+//! (reverse) Put into play the set-aside Hallway, Cellar, Attic, and
+//! Parlor. Discard each enemy in the Study. Place each investigator in
+//! the Hallway. Remove the Study from the game.
+//! ```
+//!
+//! The reverse side is a Forced on-advance ability: it fires via
+//! `ForcedTriggerPoint::ActAdvanced` when the act advances, before the
+//! next act becomes current. "Discard each enemy in the Study" is a
+//! faithful **no-op** — nothing can spawn into the isolated Act-1 Study
+//! in Slice-1 scope (location reveal-on-entry is TODO(#257); no encounter
+//! path targets the Study). The set-aside locations + their connections
+//! are built by the scenario's `setup()`; this ability just moves them
+//! into play, relocates investigators to the Hallway (01112), and removes
+//! the Study (01111).
+
+use card_dsl::dsl::{
+    on_event, put_set_aside_locations_into_play, relocate_all_investigators,
+    remove_location_from_game, Ability, Effect, EventPattern, EventTiming,
+};
+
+/// `ArkhamDB` code for Act 1, "Trapped".
+pub const CODE: &str = "01108";
+
+/// 01108's Forced on-advance reverse: build the Act-1 board.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![on_event(
+        EventPattern::ActAdvanced,
+        EventTiming::After,
+        Effect::Seq(vec![
+            put_set_aside_locations_into_play(),
+            relocate_all_investigators("01112"), // the Hallway
+            remove_location_from_game("01111"),  // the Study
+        ]),
+    )]
+}
+
+#[cfg(test)]
+mod tests {
+    use card_dsl::dsl::{Effect, EventPattern, EventTiming, Trigger};
+
+    #[test]
+    fn abilities_are_one_forced_on_advance_world_build() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(
+            abilities[0].trigger,
+            Trigger::OnEvent {
+                pattern: EventPattern::ActAdvanced,
+                timing: EventTiming::After
+            }
+        );
+        let Effect::Seq(steps) = &abilities[0].effect else {
+            panic!("expected a Seq, got {:?}", abilities[0].effect);
+        };
+        assert!(matches!(steps[0], Effect::PutSetAsideLocationsIntoPlay));
+        assert!(matches!(&steps[1], Effect::RelocateAllInvestigators { to } if to == "01112"));
+        assert!(
+            matches!(&steps[2], Effect::RemoveLocationFromGame { location } if location == "01111")
+        );
+    }
+}

--- a/crates/cards/src/impls/act_01110.rs
+++ b/crates/cards/src/impls/act_01110.rs
@@ -1,0 +1,58 @@
+//! What Have You Done? (The Gathering Act 3, 01110).
+//!
+//! ```text
+//! Act 3 — What Have You Done?
+//! Objective – If the Ghoul Priest is Defeated, advance.
+//! ```
+//!
+//! Forced (no "may" — Rules Reference p.3; the bare "advance" with no
+//! clue threshold cannot be the optional clue-spend ability): the act
+//! advances the instant the Ghoul Priest (01116) is defeated, firing its
+//! terminal Won/R1 resolution. Wired via `ForcedTriggerPoint::EnemyDefeated`
+//! from the defeat path; narrowed to 01116 so other ghouls' defeats don't
+//! advance it.
+//!
+//! Act-3's *reverse* (the R1/R2 resolution choice) is deferred to Phase 9
+//! (campaign log gives the branch meaning); the scenario keeps a single
+//! Won/R1 latch. The Ghoul Priest enemy + its spawn land in C3 (#231);
+//! this objective is unit-tested here and proven end-to-end in C7b (#245).
+
+use card_dsl::dsl::{advance_current_act, on_event, Ability, EventPattern, EventTiming};
+
+/// `ArkhamDB` code for Act 3, "What Have You Done?".
+pub const CODE: &str = "01110";
+
+/// 01110's Forced objective: advance when the Ghoul Priest is defeated.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![on_event(
+        EventPattern::EnemyDefeated {
+            by_controller: false,
+            code: Some("01116".to_owned()),
+        },
+        EventTiming::After,
+        advance_current_act(),
+    )]
+}
+
+#[cfg(test)]
+mod tests {
+    use card_dsl::dsl::{Effect, EventPattern, EventTiming, Trigger};
+
+    #[test]
+    fn abilities_advance_on_ghoul_priest_defeat() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(
+            abilities[0].trigger,
+            Trigger::OnEvent {
+                pattern: EventPattern::EnemyDefeated {
+                    by_controller: false,
+                    code: Some("01116".into()),
+                },
+                timing: EventTiming::After,
+            }
+        );
+        assert!(matches!(abilities[0].effect, Effect::AdvanceCurrentAct));
+    }
+}

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -41,6 +41,7 @@
 //!   `UsageLimit { count: 1, period: Round }` for "Limit once per
 //!   round." Elder-sign half stubbed pending #118.
 //! - Trapped (01108) — Act 1; `Trigger::OnEvent` (`ActAdvanced`, `After`) on-advance board build.
+//! - What Have You Done? (01110) — Act 3; `Trigger::OnEvent` (`EnemyDefeated` 01116, `After`) -> `AdvanceCurrentAct`.
 //!
 //! The remaining Phase-3 card (Study #56) blocks on the
 //! location-state shape.
@@ -48,6 +49,7 @@
 use card_dsl::dsl::Ability;
 
 pub mod act_01108;
+pub mod act_01110;
 pub mod attic;
 pub mod cellar;
 pub mod deduction;
@@ -63,6 +65,7 @@ pub mod working_a_hunch;
 pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
     match code {
         act_01108::CODE => Some(act_01108::abilities()),
+        act_01110::CODE => Some(act_01110::abilities()),
         attic::CODE => Some(attic::abilities()),
         cellar::CODE => Some(cellar::abilities()),
         deduction::CODE => Some(deduction::abilities()),

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -40,12 +40,14 @@
 //!   reaction (`EnemyDefeated { by_controller: true }`, `After`) +
 //!   `UsageLimit { count: 1, period: Round }` for "Limit once per
 //!   round." Elder-sign half stubbed pending #118.
+//! - Trapped (01108) — Act 1; `Trigger::OnEvent` (`ActAdvanced`, `After`) on-advance board build.
 //!
 //! The remaining Phase-3 card (Study #56) blocks on the
 //! location-state shape.
 
 use card_dsl::dsl::Ability;
 
+pub mod act_01108;
 pub mod attic;
 pub mod cellar;
 pub mod deduction;
@@ -60,6 +62,7 @@ pub mod working_a_hunch;
 #[must_use]
 pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
     match code {
+        act_01108::CODE => Some(act_01108::abilities()),
         attic::CODE => Some(attic::abilities()),
         cellar::CODE => Some(cellar::abilities()),
         deduction::CODE => Some(deduction::abilities()),

--- a/crates/cards/src/impls/roland_banks.rs
+++ b/crates/cards/src/impls/roland_banks.rs
@@ -48,6 +48,7 @@ pub fn abilities() -> Vec<Ability> {
     vec![on_event(
         EventPattern::EnemyDefeated {
             by_controller: true,
+            code: None,
         },
         EventTiming::After,
         discover_clue(LocationTarget::YourLocation, 1),
@@ -73,6 +74,7 @@ mod tests {
             Trigger::OnEvent {
                 pattern: EventPattern::EnemyDefeated {
                     by_controller: true,
+                    code: None,
                 },
                 timing: EventTiming::After,
             },

--- a/crates/cards/tests/act_advancement.rs
+++ b/crates/cards/tests/act_advancement.rs
@@ -1,0 +1,55 @@
+//! Act-3 objective: defeating the Ghoul Priest (01116) advances Act 3
+//! (01110) to its terminal Won resolution. The Ghoul Priest enemy + its
+//! spawn land in C3 (#231); here we drive the forced dispatch directly
+//! with the real registry. End-to-end defeat->Won via a real Fight is
+//! C7b (#245).
+
+use game_core::engine::EngineOutcome;
+use game_core::scenario::Resolution;
+use game_core::state::{Act, CardCode, InvestigatorId};
+use game_core::test_support::GameStateBuilder;
+
+fn act3_state() -> game_core::state::GameState {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+    let inv = InvestigatorId(1);
+    let mut state = GameStateBuilder::new().with_turn_order([inv]).build();
+    // Act 3 is current and terminal-Won (mirrors the_gathering setup()).
+    state.act_deck = vec![Act {
+        code: CardCode("01110".into()),
+        clue_threshold: 0,
+        resolution: Some(Resolution::Won { id: "R1".into() }),
+    }];
+    state
+}
+
+#[test]
+fn defeating_ghoul_priest_advances_act_3_to_won() {
+    let mut state = act3_state();
+    let mut events = Vec::new();
+    let out = game_core::test_support::fire_forced_on_enemy_defeat(
+        &mut state,
+        &mut events,
+        CardCode("01116".into()), // the Ghoul Priest
+    );
+    assert_eq!(out, EngineOutcome::Done);
+    assert!(
+        matches!(state.resolution, Some(Resolution::Won { .. })),
+        "Ghoul Priest defeat should set resolution to Won"
+    );
+}
+
+#[test]
+fn defeating_other_enemy_does_not_advance_act_3() {
+    let mut state = act3_state();
+    let mut events = Vec::new();
+    let out = game_core::test_support::fire_forced_on_enemy_defeat(
+        &mut state,
+        &mut events,
+        CardCode("01103".into()), // some other enemy, not the Ghoul Priest
+    );
+    assert_eq!(out, EngineOutcome::Done);
+    assert!(
+        state.resolution.is_none(),
+        "only the Ghoul Priest's defeat advances Act 3"
+    );
+}

--- a/crates/game-core/src/engine/dispatch/act_agenda.rs
+++ b/crates/game-core/src/engine/dispatch/act_agenda.rs
@@ -150,13 +150,29 @@ fn spend_clues(state: &mut GameState, acting: InvestigatorId, amount: u8) {
     );
 }
 
-/// Advance the act deck one step: emit [`Event::ActAdvanced`] and move the
-/// cursor. Only called for a non-terminal act; the missing-successor case
-/// is `unreachable!()` (a terminal act must carry a resolution point —
-/// malformed scenario data otherwise). Mirrors [`advance_agenda`].
-fn advance_act(cx: &mut Cx) {
+/// Advance the act deck one step: emit [`Event::ActAdvanced`], fire the
+/// leaving act's Forced on-advance reverse effect via the registry, then
+/// move the cursor. Only called for a non-terminal act; the
+/// missing-successor case is `unreachable!()` (a terminal act must carry a
+/// resolution point — malformed scenario data otherwise). Mirrors
+/// [`advance_agenda`].
+pub(crate) fn advance_act(cx: &mut Cx) {
     let from = cx.state.act_index;
+    let leaving_code = cx.state.act_deck[from].code.clone();
     cx.events.push(crate::event::Event::ActAdvanced { from });
+    // Resolve the leaving act's Forced on-advance reverse effect (the
+    // board world-build) before the next act becomes current — Rules
+    // Reference p.3: flip the card, follow the reverse, then the next
+    // card becomes current. `()` return can't propagate a 2+-trigger
+    // reject; `debug_assert!` guards it (mirror of `upkeep_phase_end`).
+    let forced = super::forced_triggers::fire_forced_triggers(
+        cx,
+        &super::forced_triggers::ForcedTriggerPoint::ActAdvanced { code: leaving_code },
+    );
+    debug_assert!(
+        matches!(forced, EngineOutcome::Done),
+        "advance_act on-advance forced did not resolve to Done: {forced:?} (2+ needs #213)"
+    );
     cx.state.act_index += 1;
     if cx.state.act_index >= cx.state.act_deck.len() {
         unreachable!(
@@ -177,7 +193,7 @@ fn advance_act(cx: &mut Cx) {
 /// outcome `apply` clears events but does not roll back `state`, so a
 /// latch set on a doomed path would persist. All current callers latch
 /// only on their success branches.
-pub(super) fn request_resolution(state: &mut GameState, resolution: crate::scenario::Resolution) {
+pub(crate) fn request_resolution(state: &mut GameState, resolution: crate::scenario::Resolution) {
     if state.resolution.is_none() {
         state.resolution = Some(resolution);
     }
@@ -427,6 +443,43 @@ mod advance_act_tests {
         ));
         assert_no_event!(result.events, Event::ActAdvanced { .. });
         assert_eq!(result.state.investigators[&inv].clues, 0);
+    }
+
+    #[test]
+    fn advance_act_without_registry_still_advances() {
+        use crate::scenario::Resolution;
+        use crate::state::{Act, CardCode, InvestigatorId, Phase};
+        use crate::test_support::{test_investigator, GameStateBuilder};
+        let inv = InvestigatorId(1);
+        let mut investigator = test_investigator(1);
+        investigator.clues = 2;
+        let mut state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .with_investigator(investigator)
+            .with_active_investigator(inv)
+            .with_turn_order([inv])
+            .build();
+        state.act_deck = vec![
+            Act {
+                code: CardCode("01108".into()),
+                clue_threshold: 2,
+                resolution: None,
+            },
+            Act {
+                code: CardCode("01109".into()),
+                clue_threshold: 3,
+                resolution: Some(Resolution::Won { id: "R1".into() }),
+            },
+        ];
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::AdvanceAct { investigator: inv }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_eq!(
+            result.state.act_index, 1,
+            "cursor advances even with no forced ability"
+        );
     }
 
     #[test]

--- a/crates/game-core/src/engine/dispatch/act_agenda.rs
+++ b/crates/game-core/src/engine/dispatch/act_agenda.rs
@@ -156,6 +156,10 @@ fn spend_clues(state: &mut GameState, acting: InvestigatorId, amount: u8) {
 /// missing-successor case is `unreachable!()` (a terminal act must carry a
 /// resolution point — malformed scenario data otherwise). Mirrors
 /// [`advance_agenda`].
+///
+/// Invariant: the leaving act's on-advance Forced effect must not itself
+/// re-advance the act (no in-scope card does; a re-advance from that
+/// effect would recurse here). Revisit if such an ability lands.
 pub(crate) fn advance_act(cx: &mut Cx) {
     let from = cx.state.act_index;
     let leaving_code = cx.state.act_deck[from].code.clone();

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -281,7 +281,7 @@ pub(super) fn move_action(
     // the apply-loop snapshot that `play_card` documents).
     super::forced_triggers::fire_forced_triggers(
         cx,
-        super::forced_triggers::ForcedTriggerPoint::EnteredLocation {
+        &super::forced_triggers::ForcedTriggerPoint::EnteredLocation {
             investigator,
             location: destination,
         },

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -25,6 +25,7 @@ pub(super) fn damage_enemy(cx: &mut Cx, enemy_id: EnemyId, amount: u8, by: Optio
         new_damage,
     });
     if new_damage >= enemy.max_health {
+        let defeated_code = enemy.code.clone(); // capture before the enemy is removed
         cx.events.push(Event::EnemyDefeated {
             enemy: enemy_id,
             by,
@@ -42,6 +43,22 @@ pub(super) fn damage_enemy(cx: &mut Cx, enemy_id: EnemyId, amount: u8, by: Optio
                 enemy: enemy_id,
                 by,
             },
+        );
+        // Forced act objectives keyed to this defeat (Act 3's "If the
+        // Ghoul Priest is Defeated, advance."). `()` return can't
+        // propagate a 2+-trigger reject; debug_assert guards it (mirror of
+        // upkeep_phase_end / advance_act). Ordering vs. the
+        // AfterEnemyDefeated reaction window is fixed-deterministic for
+        // now; #212/#213 revisit.
+        let forced = super::forced_triggers::fire_forced_triggers(
+            cx,
+            &super::forced_triggers::ForcedTriggerPoint::EnemyDefeated {
+                code: defeated_code,
+            },
+        );
+        debug_assert!(
+            matches!(forced, crate::engine::EngineOutcome::Done),
+            "EnemyDefeated forced did not resolve to Done: {forced:?} (2+ needs #213)"
         );
     }
 }
@@ -285,5 +302,28 @@ pub(super) fn resolve_attacks_for_investigator(cx: &mut Cx, investigator: Invest
         });
         enemy.exhausted = true;
         cx.events.push(Event::EnemyExhausted { enemy: enemy_id });
+    }
+}
+
+#[cfg(test)]
+mod combat_tests {
+    use super::super::Cx;
+    use crate::state::{EnemyId, InvestigatorId};
+    use crate::test_support::{test_enemy, GameStateBuilder};
+
+    #[test]
+    fn defeating_enemy_without_registry_still_removes_it() {
+        let eid = EnemyId(1);
+        let mut enemy = test_enemy(1, "Ghoul");
+        enemy.max_health = 1;
+        let mut state = GameStateBuilder::new().build();
+        state.enemies.insert(eid, enemy);
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+        super::damage_enemy(&mut cx, eid, 1, Some(InvestigatorId(1)));
+        assert!(!state.enemies.contains_key(&eid), "defeated enemy removed");
     }
 }

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -309,6 +309,7 @@ fn spawn_enemy(
     let enemy = Enemy {
         id: enemy_id,
         name: metadata.name.clone(),
+        code: CardCode::new(metadata.code.clone()),
         fight: 1,
         evade: 1,
         max_health: health.unwrap_or(1),

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -22,7 +22,7 @@ use super::Cx;
 /// helper), so integration tests never need to name this type directly.
 /// Wired into `move_action` (`EnteredLocation`) and
 /// `enemy_phase_end`/`upkeep_phase_end` (`PhaseEnded`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ForcedTriggerPoint {
     /// An investigator entered a location. Scans that location's card
     /// for `EventPattern::EnteredLocation` forced abilities; binds
@@ -37,6 +37,13 @@ pub(crate) enum ForcedTriggerPoint {
     /// `EventPattern::PhaseEnded { phase }` forced abilities; binds
     /// controller = the lead investigator (board-wide effects ignore it).
     PhaseEnded { phase: Phase },
+    /// An act advanced (its reverse side resolves). Scans the *leaving*
+    /// act's card for `EventPattern::ActAdvanced` forced abilities; binds
+    /// controller = the lead investigator.
+    ActAdvanced {
+        /// Printed code of the act that advanced.
+        code: CardCode,
+    },
 }
 
 struct ForcedHit {
@@ -48,7 +55,7 @@ struct ForcedHit {
 /// Fire Forced abilities matching `point`. Single-trigger path: 0 → Done;
 /// 1 → resolve via `apply_effect`; 2+ → reject loudly (no silently-chosen
 /// order — #213 adds the ordering loop).
-pub(crate) fn fire_forced_triggers(cx: &mut Cx, point: ForcedTriggerPoint) -> EngineOutcome {
+pub(crate) fn fire_forced_triggers(cx: &mut Cx, point: &ForcedTriggerPoint) -> EngineOutcome {
     let hits = collect_forced_hits(cx.state, point);
     match hits.len() {
         0 => EngineOutcome::Done,
@@ -66,7 +73,7 @@ pub(crate) fn fire_forced_triggers(cx: &mut Cx, point: ForcedTriggerPoint) -> En
 
 fn collect_forced_hits(
     state: &crate::state::GameState,
-    point: ForcedTriggerPoint,
+    point: &ForcedTriggerPoint,
 ) -> Vec<ForcedHit> {
     let Some(reg) = card_registry::current() else {
         return Vec::new();
@@ -77,15 +84,15 @@ fn collect_forced_hits(
             investigator,
             location,
         } => {
-            let Some(loc) = state.locations.get(&location) else {
+            let Some(loc) = state.locations.get(location) else {
                 return hits;
             };
-            push_matching(reg, &loc.code, investigator, &mut hits, |p| {
+            push_matching(reg, &loc.code, *investigator, &mut hits, |p| {
                 matches!(p, EventPattern::EnteredLocation)
             });
         }
         ForcedTriggerPoint::PhaseEnded { phase } => {
-            let want_phase = dsl_phase(phase);
+            let want_phase = dsl_phase(*phase);
             // Lead investigator binds the controller for board-wide effects
             // (which ignore it). First of turn_order is the lead.
             let Some(lead) = state.turn_order.first().copied() else {
@@ -109,6 +116,14 @@ fn collect_forced_hits(
                     |p| matches!(p, EventPattern::PhaseEnded { phase } if phase == want_phase),
                 );
             }
+        }
+        ForcedTriggerPoint::ActAdvanced { code } => {
+            let Some(lead) = state.turn_order.first().copied() else {
+                return hits;
+            };
+            push_matching(reg, code, lead, &mut hits, |p| {
+                matches!(p, EventPattern::ActAdvanced)
+            });
         }
     }
     hits

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -44,6 +44,15 @@ pub(crate) enum ForcedTriggerPoint {
         /// Printed code of the act that advanced.
         code: CardCode,
     },
+    /// An enemy was defeated. Scans the *current act* for
+    /// `EventPattern::EnemyDefeated` forced abilities whose `code` narrow
+    /// matches (or is `None`); binds controller = the lead investigator.
+    /// The act-3 objective (01110) advances on the Ghoul Priest's defeat
+    /// through this point.
+    EnemyDefeated {
+        /// Printed code of the defeated enemy (for `code`-narrow matching).
+        code: CardCode,
+    },
 }
 
 struct ForcedHit {
@@ -124,6 +133,20 @@ fn collect_forced_hits(
             push_matching(reg, code, lead, &mut hits, |p| {
                 matches!(p, EventPattern::ActAdvanced)
             });
+        }
+        ForcedTriggerPoint::EnemyDefeated { code } => {
+            let Some(lead) = state.turn_order.first().copied() else {
+                return hits;
+            };
+            if let Some(act) = state.act_deck.get(state.act_index) {
+                push_matching(reg, &act.code, lead, &mut hits, |p| {
+                    matches!(
+                        p,
+                        EventPattern::EnemyDefeated { code: narrow, .. }
+                            if narrow.as_deref().is_none_or(|c| c == code.as_str())
+                    )
+                });
+            }
         }
     }
     hits

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -104,7 +104,7 @@ fn collect_forced_hits(
                     &act.code,
                     lead,
                     &mut hits,
-                    |p| matches!(p, EventPattern::PhaseEnded { phase } if phase == want_phase),
+                    |p| matches!(p, EventPattern::PhaseEnded { phase } if *phase == want_phase),
                 );
             }
             if let Some(agenda) = state.agenda_deck.get(state.agenda_index) {
@@ -113,7 +113,7 @@ fn collect_forced_hits(
                     &agenda.code,
                     lead,
                     &mut hits,
-                    |p| matches!(p, EventPattern::PhaseEnded { phase } if phase == want_phase),
+                    |p| matches!(p, EventPattern::PhaseEnded { phase } if *phase == want_phase),
                 );
             }
         }
@@ -145,17 +145,17 @@ fn push_matching(
     code: &CardCode,
     controller: InvestigatorId,
     out: &mut Vec<ForcedHit>,
-    want: impl Fn(EventPattern) -> bool,
+    want: impl Fn(&EventPattern) -> bool,
 ) {
     let Some(abilities) = (reg.abilities_for)(code) else {
         return;
     };
     for (idx, ability) in abilities.iter().enumerate() {
-        if let Trigger::OnEvent { pattern, timing } = ability.trigger {
+        if let Trigger::OnEvent { pattern, timing } = &ability.trigger {
             // Only `After` timing is handled in this slice; no in-scope
             // Forced card uses `Before` ("when X would Y") timing.
             // Revisit when such a card lands.
-            if timing == EventTiming::After && want(pattern) {
+            if *timing == EventTiming::After && want(pattern) {
                 out.push(ForcedHit {
                     code: code.clone(),
                     ability_index: idx,

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -16,7 +16,7 @@ use super::outcome::EngineOutcome;
 use super::Cx;
 
 mod abilities;
-mod act_agenda;
+pub(crate) mod act_agenda;
 mod actions;
 // pub(super): evaluator reaches grant_resources via the full path
 // crate::engine::dispatch::cards::grant_resources (a sibling of dispatch).

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -493,7 +493,7 @@ pub(super) fn enemy_phase_end(cx: &mut Cx) -> EngineOutcome {
     // 2+ → rejects loudly (#213 adds the ordering loop).
     let forced = super::forced_triggers::fire_forced_triggers(
         cx,
-        super::forced_triggers::ForcedTriggerPoint::PhaseEnded {
+        &super::forced_triggers::ForcedTriggerPoint::PhaseEnded {
             phase: Phase::Enemy,
         },
     );
@@ -586,7 +586,7 @@ fn upkeep_phase_end(cx: &mut Cx) {
     // limitation.
     let forced = super::forced_triggers::fire_forced_triggers(
         cx,
-        super::forced_triggers::ForcedTriggerPoint::PhaseEnded {
+        &super::forced_triggers::ForcedTriggerPoint::PhaseEnded {
             phase: Phase::Upkeep,
         },
     );

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -175,13 +175,33 @@ fn trigger_matches(
         // PhaseEnded is matched only by the forced dispatch path
         // (`engine::dispatch::forced_triggers`), never by player reaction
         // windows.
+        // PlayerWindow steps open for timing reasons; no
+        // Trigger::OnEvent pattern matches them — those windows gate
+        // Fast actions, not after-event reactions. AfterEnemyDefeated
+        // windows only match EnemyDefeated patterns (handled above);
+        // encounter-reveal patterns return false.
+        //
+        // EnemySpawned: no WindowKind opens specifically for "enemy
+        // spawned" in Phase 4. A future PR (likely Phase-7+) that wants
+        // to react to spawns will add the corresponding WindowKind
+        // variant and update this arm.
+        // EnteredLocation is matched by the forced auto-fire path in
+        // `engine::dispatch::forced_triggers` (fired from `move_action`),
+        // not by reaction windows.
+        // PhaseEnded is matched only by the forced dispatch path
+        // (`engine::dispatch::forced_triggers`), never by player reaction
+        // windows.
+        // ActAdvanced is matched only by the forced dispatch path
+        // (`ForcedTriggerPoint::ActAdvanced`), never by player reaction
+        // windows.
         (
             WindowKind::PlayerWindow(_) | WindowKind::AfterEnemyDefeated { .. },
             EventPattern::EnemyDefeated { .. }
             | EventPattern::CardRevealed { .. }
             | EventPattern::EnemySpawned
             | EventPattern::EnteredLocation
-            | EventPattern::PhaseEnded { .. },
+            | EventPattern::PhaseEnded { .. }
+            | EventPattern::ActAdvanced,
         ) => false,
     }
 }

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -175,22 +175,6 @@ fn trigger_matches(
         // PhaseEnded is matched only by the forced dispatch path
         // (`engine::dispatch::forced_triggers`), never by player reaction
         // windows.
-        // PlayerWindow steps open for timing reasons; no
-        // Trigger::OnEvent pattern matches them — those windows gate
-        // Fast actions, not after-event reactions. AfterEnemyDefeated
-        // windows only match EnemyDefeated patterns (handled above);
-        // encounter-reveal patterns return false.
-        //
-        // EnemySpawned: no WindowKind opens specifically for "enemy
-        // spawned" in Phase 4. A future PR (likely Phase-7+) that wants
-        // to react to spawns will add the corresponding WindowKind
-        // variant and update this arm.
-        // EnteredLocation is matched by the forced auto-fire path in
-        // `engine::dispatch::forced_triggers` (fired from `move_action`),
-        // not by reaction windows.
-        // PhaseEnded is matched only by the forced dispatch path
-        // (`engine::dispatch::forced_triggers`), never by player reaction
-        // windows.
         // ActAdvanced is matched only by the forced dispatch path
         // (`ForcedTriggerPoint::ActAdvanced`), never by player reaction
         // windows.

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -98,10 +98,10 @@ fn scan_pending_triggers(state: &GameState, kind: WindowKind) -> Vec<PendingTrig
                 continue;
             };
             for (idx, ability) in abilities.iter().enumerate() {
-                let Trigger::OnEvent { pattern, timing } = ability.trigger else {
+                let Trigger::OnEvent { pattern, timing } = &ability.trigger else {
                     continue;
                 };
-                if !trigger_matches(kind, pattern, timing, id) {
+                if !trigger_matches(kind, pattern, *timing, id) {
                     continue;
                 }
                 let ability_index = u8::try_from(idx)
@@ -141,7 +141,7 @@ fn scan_pending_triggers(state: &GameState, kind: WindowKind) -> Vec<PendingTrig
 /// scanning hook when the first such card lands.
 fn trigger_matches(
     kind: WindowKind,
-    pattern: EventPattern,
+    pattern: &EventPattern,
     timing: EventTiming,
     controller: InvestigatorId,
 ) -> bool {
@@ -151,9 +151,12 @@ fn trigger_matches(
     match (kind, pattern) {
         (
             WindowKind::AfterEnemyDefeated { by, .. },
-            EventPattern::EnemyDefeated { by_controller },
+            EventPattern::EnemyDefeated {
+                by_controller,
+                code: _,
+            },
         ) => {
-            if by_controller {
+            if *by_controller {
                 by == Some(controller)
             } else {
                 true

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -190,6 +190,19 @@ pub(crate) fn apply_effect(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) 
             cx.state.locations.remove(&target);
             EngineOutcome::Done
         }
+        Effect::AdvanceCurrentAct => {
+            use crate::engine::dispatch::act_agenda::{advance_act, request_resolution};
+            if cx.state.act_deck.is_empty() {
+                return EngineOutcome::Rejected {
+                    reason: "AdvanceCurrentAct: no act deck is modeled".into(),
+                };
+            }
+            match cx.state.act_deck[cx.state.act_index].resolution.clone() {
+                Some(resolution) => request_resolution(cx.state, resolution),
+                None => advance_act(cx),
+            }
+            EngineOutcome::Done
+        }
     }
 }
 
@@ -1926,5 +1939,68 @@ mod tests {
             events,
             Event::InvestigatorDefeated { investigator, .. } if *investigator == id
         );
+    }
+
+    #[test]
+    fn advance_current_act_non_terminal_bumps_cursor() {
+        use crate::scenario::Resolution;
+        use crate::state::{Act, CardCode, InvestigatorId};
+        use crate::test_support::GameStateBuilder;
+        let mut state = GameStateBuilder::new()
+            .with_turn_order([InvestigatorId(1)])
+            .build();
+        state.act_deck = vec![
+            Act {
+                code: CardCode("a1".into()),
+                clue_threshold: 0,
+                resolution: None,
+            },
+            Act {
+                code: CardCode("a2".into()),
+                clue_threshold: 0,
+                resolution: Some(Resolution::Won { id: "R1".into() }),
+            },
+        ];
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+        let out = apply_effect(
+            &mut cx,
+            &Effect::AdvanceCurrentAct,
+            EvalContext::for_controller(InvestigatorId(1)),
+        );
+        assert_eq!(out, EngineOutcome::Done);
+        assert_eq!(state.act_index, 1);
+        assert!(state.resolution.is_none());
+    }
+
+    #[test]
+    fn advance_current_act_terminal_latches_resolution() {
+        use crate::scenario::Resolution;
+        use crate::state::{Act, CardCode, InvestigatorId};
+        use crate::test_support::GameStateBuilder;
+        let mut state = GameStateBuilder::new()
+            .with_turn_order([InvestigatorId(1)])
+            .build();
+        state.act_deck = vec![Act {
+            code: CardCode("a1".into()),
+            clue_threshold: 0,
+            resolution: Some(Resolution::Won { id: "R1".into() }),
+        }];
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+        let out = apply_effect(
+            &mut cx,
+            &Effect::AdvanceCurrentAct,
+            EvalContext::for_controller(InvestigatorId(1)),
+        );
+        assert_eq!(out, EngineOutcome::Done);
+        assert_eq!(state.act_index, 0, "terminal act does not move the cursor");
+        assert!(matches!(state.resolution, Some(Resolution::Won { .. })));
     }
 }

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -143,9 +143,53 @@ pub(crate) fn apply_effect(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) 
         } => apply_if(cx, eval_ctx, condition, then, else_.as_deref()),
         Effect::ForEach { .. } => awaiting_input_stub("ForEach"),
         Effect::ChooseOne(_) => awaiting_input_stub("ChooseOne"),
-        Effect::PutSetAsideLocationsIntoPlay => world_build_stub("PutSetAsideLocationsIntoPlay"),
-        Effect::RelocateAllInvestigators { .. } => world_build_stub("RelocateAllInvestigators"),
-        Effect::RemoveLocationFromGame { .. } => world_build_stub("RemoveLocationFromGame"),
+        Effect::PutSetAsideLocationsIntoPlay => {
+            let drained = std::mem::take(&mut cx.state.set_aside_locations);
+            for loc in drained {
+                cx.state.locations.insert(loc.id, loc);
+            }
+            EngineOutcome::Done
+        }
+        Effect::RelocateAllInvestigators { to } => {
+            let Some(dest) = location_id_by_code(cx.state, to) else {
+                return EngineOutcome::Rejected {
+                    reason: format!("RelocateAllInvestigators: no in-play location with code {to}")
+                        .into(),
+                };
+            };
+            let ids: Vec<_> = cx.state.investigators.keys().copied().collect();
+            for id in ids {
+                let inv = cx
+                    .state
+                    .investigators
+                    .get_mut(&id)
+                    .expect("id sourced from keys()");
+                let from = inv.current_location;
+                inv.current_location = Some(dest);
+                if let Some(from_id) = from {
+                    if from_id != dest {
+                        cx.events.push(Event::InvestigatorMoved {
+                            investigator: id,
+                            from: from_id,
+                            to: dest,
+                        });
+                    }
+                }
+            }
+            EngineOutcome::Done
+        }
+        Effect::RemoveLocationFromGame { location } => {
+            let Some(target) = location_id_by_code(cx.state, location) else {
+                return EngineOutcome::Rejected {
+                    reason: format!(
+                        "RemoveLocationFromGame: no in-play location with code {location}"
+                    )
+                    .into(),
+                };
+            };
+            cx.state.locations.remove(&target);
+            EngineOutcome::Done
+        }
     }
 }
 
@@ -277,20 +321,6 @@ fn awaiting_input_stub(name: &'static str) -> EngineOutcome {
         reason: format!(
             "TODO: {name} evaluator needs AwaitingInput + ResolveInput resume; \
              no engine consumer has landed yet."
-        )
-        .into(),
-    }
-}
-
-/// Standard rejection message for world-build effect variants whose
-/// evaluator behavior lands in a later task (Task 3 / #228). The DSL
-/// variants exist now so card declarations compile; the state mutations
-/// are not yet wired.
-fn world_build_stub(name: &'static str) -> EngineOutcome {
-    EngineOutcome::Rejected {
-        reason: format!(
-            "TODO(#228): {name} evaluator not yet implemented; \
-             world-build effect behavior lands in Task 3."
         )
         .into(),
     }
@@ -676,6 +706,15 @@ fn stat_matches_skill(stat: Stat, skill: SkillKind) -> bool {
             | (Stat::Combat, SkillKind::Combat)
             | (Stat::Agility, SkillKind::Agility)
     )
+}
+
+/// Find the in-play location whose printed code equals `code`.
+fn location_id_by_code(state: &GameState, code: &str) -> Option<crate::state::LocationId> {
+    state
+        .locations
+        .iter()
+        .find(|(_, loc)| loc.code.as_str() == code)
+        .map(|(id, _)| *id)
 }
 
 #[cfg(test)]
@@ -1742,6 +1781,124 @@ mod tests {
             events,
             Event::HorrorTaken { investigator, amount: 1 } if *investigator == InvestigatorId(1)
         );
+    }
+
+    // ---- world-build effect tests --------------------------------
+
+    #[test]
+    fn put_set_aside_drains_into_locations() {
+        use crate::state::{CardCode, Location, LocationId};
+        let mut state = crate::test_support::GameStateBuilder::new().build();
+        state.set_aside_locations = vec![Location::new(
+            LocationId(2),
+            CardCode("01112".into()),
+            "Hallway",
+            1,
+            0,
+        )];
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+        let out = apply_effect(
+            &mut cx,
+            &Effect::PutSetAsideLocationsIntoPlay,
+            EvalContext::for_controller(crate::state::InvestigatorId(1)),
+        );
+        assert_eq!(out, EngineOutcome::Done);
+        assert!(state.set_aside_locations.is_empty());
+        assert!(state.locations.contains_key(&LocationId(2)));
+    }
+
+    #[test]
+    fn relocate_all_moves_everyone_to_named_code() {
+        use crate::state::{CardCode, InvestigatorId, Location, LocationId};
+        use crate::test_support::{test_investigator, GameStateBuilder};
+        let mut inv = test_investigator(1);
+        inv.current_location = Some(LocationId(1));
+        let mut state = GameStateBuilder::new()
+            .with_location(Location::new(
+                LocationId(1),
+                CardCode("01111".into()),
+                "Study",
+                2,
+                2,
+            ))
+            .with_location(Location::new(
+                LocationId(2),
+                CardCode("01112".into()),
+                "Hallway",
+                1,
+                0,
+            ))
+            .with_investigator(inv)
+            .build();
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+        let out = apply_effect(
+            &mut cx,
+            &Effect::RelocateAllInvestigators { to: "01112".into() },
+            EvalContext::for_controller(InvestigatorId(1)),
+        );
+        assert_eq!(out, EngineOutcome::Done);
+        assert_eq!(
+            state.investigators[&InvestigatorId(1)].current_location,
+            Some(LocationId(2))
+        );
+        assert!(events.iter().any(|e| matches!(e,
+            Event::InvestigatorMoved { investigator, from, to }
+                if *investigator == InvestigatorId(1) && *from == LocationId(1) && *to == LocationId(2))));
+    }
+
+    #[test]
+    fn remove_location_drops_it_from_play() {
+        use crate::state::{CardCode, Location, LocationId};
+        use crate::test_support::GameStateBuilder;
+        let mut state = GameStateBuilder::new()
+            .with_location(Location::new(
+                LocationId(1),
+                CardCode("01111".into()),
+                "Study",
+                2,
+                2,
+            ))
+            .build();
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+        let out = apply_effect(
+            &mut cx,
+            &Effect::RemoveLocationFromGame {
+                location: "01111".into(),
+            },
+            EvalContext::for_controller(crate::state::InvestigatorId(1)),
+        );
+        assert_eq!(out, EngineOutcome::Done);
+        assert!(state.locations.is_empty());
+    }
+
+    #[test]
+    fn relocate_to_missing_code_rejects() {
+        use crate::state::InvestigatorId;
+        use crate::test_support::GameStateBuilder;
+        let mut state = GameStateBuilder::new().build();
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+        let out = apply_effect(
+            &mut cx,
+            &Effect::RelocateAllInvestigators { to: "09999".into() },
+            EvalContext::for_controller(InvestigatorId(1)),
+        );
+        assert!(matches!(out, EngineOutcome::Rejected { .. }));
     }
 
     #[test]

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -143,6 +143,9 @@ pub(crate) fn apply_effect(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) 
         } => apply_if(cx, eval_ctx, condition, then, else_.as_deref()),
         Effect::ForEach { .. } => awaiting_input_stub("ForEach"),
         Effect::ChooseOne(_) => awaiting_input_stub("ChooseOne"),
+        Effect::PutSetAsideLocationsIntoPlay => world_build_stub("PutSetAsideLocationsIntoPlay"),
+        Effect::RelocateAllInvestigators { .. } => world_build_stub("RelocateAllInvestigators"),
+        Effect::RemoveLocationFromGame { .. } => world_build_stub("RemoveLocationFromGame"),
     }
 }
 
@@ -274,6 +277,20 @@ fn awaiting_input_stub(name: &'static str) -> EngineOutcome {
         reason: format!(
             "TODO: {name} evaluator needs AwaitingInput + ResolveInput resume; \
              no engine consumer has landed yet."
+        )
+        .into(),
+    }
+}
+
+/// Standard rejection message for world-build effect variants whose
+/// evaluator behavior lands in a later task (Task 3 / #228). The DSL
+/// variants exist now so card declarations compile; the state mutations
+/// are not yet wired.
+fn world_build_stub(name: &'static str) -> EngineOutcome {
+    EngineOutcome::Rejected {
+        reason: format!(
+            "TODO(#228): {name} evaluator not yet implemented; \
+             world-build effect behavior lands in Task 3."
         )
         .into(),
     }

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -256,6 +256,7 @@ impl GameStateBuilder {
         GameState {
             investigators: self.investigators,
             locations: self.locations,
+            set_aside_locations: Vec::new(),
             starting_location: None,
             enemies: self.enemies,
             chaos_bag: self.chaos_bag,
@@ -292,6 +293,17 @@ impl GameStateBuilder {
 impl Default for GameStateBuilder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod set_aside_locations_tests {
+    use super::*;
+
+    #[test]
+    fn build_starts_with_empty_set_aside_locations() {
+        let state = GameStateBuilder::new().build();
+        assert!(state.set_aside_locations.is_empty());
     }
 }
 

--- a/crates/game-core/src/state/enemy.rs
+++ b/crates/game-core/src/state/enemy.rs
@@ -107,6 +107,9 @@ mod hunter_prey_field_tests {
     #[test]
     fn test_enemy_fixture_carries_a_code() {
         let e = crate::test_support::test_enemy(7, "Ghoul");
-        assert!(!e.code.as_str().is_empty(), "every enemy carries its printed code");
+        assert!(
+            !e.code.as_str().is_empty(),
+            "every enemy carries its printed code"
+        );
     }
 }

--- a/crates/game-core/src/state/enemy.rs
+++ b/crates/game-core/src/state/enemy.rs
@@ -3,7 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::{investigator::InvestigatorId, location::LocationId};
+use super::{card::CardCode, investigator::InvestigatorId, location::LocationId};
 use crate::card_data::Prey;
 
 /// Stable identifier for an enemy within a scenario.
@@ -31,6 +31,11 @@ pub struct Enemy {
     pub id: EnemyId,
     /// Display name.
     pub name: String,
+    /// Printed `ArkhamDB` code (e.g. `"01116"` for the Ghoul Priest).
+    /// Carried so framework effects keyed on a specific enemy — Act 3's
+    /// "If the Ghoul Priest is Defeated, advance." — can match after the
+    /// enemy leaves `state.enemies`.
+    pub code: CardCode,
     /// Difficulty for Fight tests against this enemy.
     pub fight: i8,
     /// Difficulty for Evade tests against this enemy.
@@ -93,8 +98,15 @@ mod hunter_prey_field_tests {
             engaged_with: None,
             hunter: true,
             prey: Prey::Default,
+            code: crate::CardCode::new("01116"),
         };
         assert!(e.hunter);
         assert_eq!(e.prey, Prey::Default);
+    }
+
+    #[test]
+    fn test_enemy_fixture_carries_a_code() {
+        let e = crate::test_support::test_enemy(7, "Ghoul");
+        assert!(!e.code.as_str().is_empty(), "every enemy carries its printed code");
     }
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -38,6 +38,11 @@ pub struct GameState {
     pub investigators: BTreeMap<InvestigatorId, Investigator>,
     /// All locations laid out (revealed and unrevealed alike), keyed by ID.
     pub locations: BTreeMap<LocationId, Location>,
+    /// Locations set aside, out of play (Rules Reference p.3, "set
+    /// aside"). Brought into play by card effects — The Gathering's
+    /// Act-1 reverse drains these via the `PutSetAsideLocationsIntoPlay`
+    /// DSL effect (added in a later task).
+    pub set_aside_locations: Vec<Location>,
     /// Where roster-seated investigators are placed at scenario start.
     /// `setup()` sets it (e.g. The Gathering -> the Study); the
     /// `StartScenario` seating step reads it. `None` leaves seated

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -41,7 +41,7 @@ pub struct GameState {
     /// Locations set aside, out of play (Rules Reference p.3, "set
     /// aside"). Brought into play by card effects — The Gathering's
     /// Act-1 reverse drains these via the `PutSetAsideLocationsIntoPlay`
-    /// DSL effect (added in a later task).
+    /// DSL effect.
     pub set_aside_locations: Vec<Location>,
     /// Where roster-seated investigators are placed at scenario start.
     /// `setup()` sets it (e.g. The Gathering -> the Study); the

--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -96,6 +96,7 @@ pub fn test_enemy(id: u32, name: impl Into<String>) -> Enemy {
     Enemy {
         id: EnemyId(id),
         name: name.into(),
+        code: CardCode::new(format!("_test_enemy_{id}")),
         fight: 2,
         evade: 2,
         max_health: 2,

--- a/crates/game-core/src/test_support/mod.rs
+++ b/crates/game-core/src/test_support/mod.rs
@@ -36,7 +36,7 @@ pub fn fire_forced_on_enter(
     let mut cx = crate::engine::Cx { state, events };
     crate::engine::fire_forced_triggers(
         &mut cx,
-        crate::engine::ForcedTriggerPoint::EnteredLocation {
+        &crate::engine::ForcedTriggerPoint::EnteredLocation {
             investigator,
             location,
         },
@@ -54,6 +54,20 @@ pub fn fire_forced_on_phase_end(
     let mut cx = crate::engine::Cx { state, events };
     crate::engine::fire_forced_triggers(
         &mut cx,
-        crate::engine::ForcedTriggerPoint::PhaseEnded { phase },
+        &crate::engine::ForcedTriggerPoint::PhaseEnded { phase },
+    )
+}
+
+/// Test helper: fire forced triggers for an act advancing, returning the
+/// `EngineOutcome`. See `fire_forced_on_enter`.
+pub fn fire_forced_on_act_advance(
+    state: &mut crate::state::GameState,
+    events: &mut Vec<crate::event::Event>,
+    code: crate::state::CardCode,
+) -> crate::engine::EngineOutcome {
+    let mut cx = crate::engine::Cx { state, events };
+    crate::engine::fire_forced_triggers(
+        &mut cx,
+        &crate::engine::ForcedTriggerPoint::ActAdvanced { code },
     )
 }

--- a/crates/game-core/src/test_support/mod.rs
+++ b/crates/game-core/src/test_support/mod.rs
@@ -71,3 +71,17 @@ pub fn fire_forced_on_act_advance(
         &crate::engine::ForcedTriggerPoint::ActAdvanced { code },
     )
 }
+
+/// Test helper: fire forced triggers for an enemy defeat, returning the
+/// `EngineOutcome`. See `fire_forced_on_enter`.
+pub fn fire_forced_on_enemy_defeat(
+    state: &mut crate::state::GameState,
+    events: &mut Vec<crate::event::Event>,
+    code: crate::state::CardCode,
+) -> crate::engine::EngineOutcome {
+    let mut cx = crate::engine::Cx { state, events };
+    crate::engine::fire_forced_triggers(
+        &mut cx,
+        &crate::engine::ForcedTriggerPoint::EnemyDefeated { code },
+    )
+}

--- a/crates/game-core/tests/reaction_windows.rs
+++ b/crates/game-core/tests/reaction_windows.rs
@@ -56,6 +56,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
         ROLAND_REACTION => Some(vec![on_event(
             EventPattern::EnemyDefeated {
                 by_controller: true,
+                code: None,
             },
             EventTiming::After,
             discover_clue(LocationTarget::YourLocation, 1),
@@ -63,6 +64,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
         BYSTANDER_REACTION => Some(vec![on_event(
             EventPattern::EnemyDefeated {
                 by_controller: false,
+                code: None,
             },
             EventTiming::After,
             gain_resources(InvestigatorTarget::You, 1),
@@ -71,6 +73,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
             on_event(
                 EventPattern::EnemyDefeated {
                     by_controller: true,
+                    code: None,
                 },
                 EventTiming::After,
                 discover_clue(LocationTarget::YourLocation, 1),
@@ -78,6 +81,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
             on_event(
                 EventPattern::EnemyDefeated {
                     by_controller: true,
+                    code: None,
                 },
                 EventTiming::After,
                 gain_resources(InvestigatorTarget::You, 1),

--- a/crates/scenarios/src/the_gathering.rs
+++ b/crates/scenarios/src/the_gathering.rs
@@ -9,11 +9,11 @@
 //!
 //! Faithful where it can be (agenda doom 3/7/10; the verified Standard
 //! chaos bag; Study shroud/clues); structural stand-in where the rest of
-//! Group C owns fidelity (act 01110's clue threshold is a placeholder —
-//! its real "Ghoul Priest defeated" objective is C1b; symbol-token
-//! effects on reference card 01104 are C2). C1a does not claim faithful
-//! win/lose semantics — only structural reachability, proven by
-//! `tests/the_gathering.rs`.
+//! Group C owns fidelity (act 01110 advances via its Forced `EnemyDefeated`
+//! objective (01116; in `cards`) — its R1/R2 resolution choice is Phase-9
+//! — TODO; symbol-token effects on reference card 01104 are C2). C1a does
+//! not claim faithful win/lose semantics — only structural reachability,
+//! proven by `tests/the_gathering.rs`.
 
 use game_core::card_data::CardKind;
 use game_core::event::Event;
@@ -40,12 +40,11 @@ fn agenda_doom(code: &str) -> u8 {
     }
 }
 
-/// Read an act's printed clue threshold from the corpus, falling back to
-/// `placeholder` for acts that advance on a non-clue objective (`01110`,
-/// "Ghoul Priest defeated" — C1b owns that).
-fn act_clue_threshold(code: &str, placeholder: u8) -> u8 {
+/// Read an act's printed clue threshold from the corpus. Acts that
+/// advance on a non-clue objective (01110) carry `null` clues -> 0.
+fn act_clue_threshold(code: &str) -> u8 {
     match cards::by_code(code).expect("act code in corpus").kind {
-        CardKind::Act { clue_threshold, .. } => clue_threshold.unwrap_or(placeholder),
+        CardKind::Act { clue_threshold, .. } => clue_threshold.unwrap_or(0),
         ref k => panic!("{code} is not an Act ({k:?})"),
     }
 }
@@ -148,23 +147,26 @@ pub fn setup() -> GameState {
     state.set_aside_locations = vec![hallway, attic, cellar, parlor];
 
     // Act deck 01108 -> 01109 -> 01110. Clue thresholds read from the
-    // corpus; 01110's printed threshold is null (it advances on "Ghoul
-    // Priest defeated" — C1b), so it falls back to a placeholder. The
-    // terminal act carries the Won latch.
+    // corpus. 01110 advances via its Forced EnemyDefeated objective
+    // (01116; in cards::act_01110), not a clue spend — its printed clue
+    // threshold is null, which the reader maps to 0.
+    // TODO(#231): the Ghoul Priest (01116) spawns at Act-2 (01109) advance — C3b.
+    // TODO(#phase-9): the reverse is the lead investigator's R1/R2 resolution choice (campaign log).
     state.act_deck = vec![
         Act {
             code: CardCode("01108".into()),
-            clue_threshold: act_clue_threshold("01108", 0),
+            clue_threshold: act_clue_threshold("01108"),
             resolution: None,
         },
         Act {
             code: CardCode("01109".into()),
-            clue_threshold: act_clue_threshold("01109", 0),
+            clue_threshold: act_clue_threshold("01109"),
             resolution: None,
         },
         Act {
+            // 01110 advances via its Forced EnemyDefeated objective (01116; in cards::act_01110), not a clue spend.
             code: CardCode("01110".into()),
-            clue_threshold: act_clue_threshold("01110", 2), // 2 = C1b placeholder
+            clue_threshold: act_clue_threshold("01110"),
             resolution: Some(Resolution::Won { id: "R1".into() }),
         },
     ];
@@ -281,6 +283,20 @@ mod tests {
         }
         assert_eq!(s.starting_location, Some(STUDY_ID));
         assert!(s.investigators.is_empty(), "setup() seats no one");
+    }
+
+    #[test]
+    fn act_three_advances_on_objective_not_clues() {
+        let s = setup();
+        assert_eq!(s.act_deck[2].code.as_str(), "01110");
+        assert_eq!(
+            s.act_deck[2].clue_threshold, 0,
+            "01110 advances on Ghoul-Priest-defeat, not clues"
+        );
+        assert!(matches!(
+            s.act_deck[2].resolution,
+            Some(Resolution::Won { .. })
+        ));
     }
 
     #[test]

--- a/crates/scenarios/src/the_gathering.rs
+++ b/crates/scenarios/src/the_gathering.rs
@@ -1,10 +1,11 @@
 //! The Gathering (Night of the Zealot, scenario 1) — Slice 1 C1a skeleton.
 //!
 //! Builds the faithful **Act-1 board**: only the Study is in play (the
-//! Hallway/Attic/Cellar/Parlor are set aside and enter via the Act-1
-//! "Door on the Floor" transition — C1b). `setup()` builds the world;
-//! the `StartScenario` roster step seats investigators at
-//! [`STUDY_ID`] via `GameState.starting_location`.
+//! Hallway/Attic/Cellar/Parlor are set aside (`set_aside_locations`) and
+//! enter play via Act 1's (01108) Forced on-advance reverse, which also
+//! relocates investigators to the Hallway and removes the Study).
+//! `setup()` builds the world; the `StartScenario` roster step seats
+//! investigators at [`STUDY_ID`] via `GameState.starting_location`.
 //!
 //! Faithful where it can be (agenda doom 3/7/10; the verified Standard
 //! chaos bag; Study shroud/clues); structural stand-in where the rest of
@@ -83,13 +84,22 @@ fn standard_chaos_bag() -> ChaosBag {
     ])
 }
 
+/// The Hallway's [`LocationId`] — the hub of the Act-2 board.
+const HALLWAY_ID: LocationId = LocationId(2);
+/// The Attic's [`LocationId`].
+const ATTIC_ID: LocationId = LocationId(3);
+/// The Cellar's [`LocationId`].
+const CELLAR_ID: LocationId = LocationId(4);
+/// The Parlor's [`LocationId`].
+const PARLOR_ID: LocationId = LocationId(5);
+
 /// Build the initial [`GameState`]: the Study in play (isolated), the
-/// act/agenda decks, the Standard chaos bag, and `starting_location`.
+/// four set-aside locations (Hallway/Attic/Cellar/Parlor, pre-connected),
+/// the act/agenda decks, the Standard chaos bag, and `starting_location`.
 /// No investigators — the `StartScenario` roster step seats them.
 pub fn setup() -> GameState {
     // The Study (01111): shroud/clues read from the corpus. `Location::new`
-    // gives a revealed, unconnected location (Act 1 is "trapped in the
-    // Study"); the connection graph is C1b's Door-on-the-Floor transition.
+    // gives a revealed, unconnected location (Act 1 is "trapped in the Study").
     let (study_shroud, study_clues) = location_stats("01111");
     let study = Location::new(
         STUDY_ID,
@@ -98,6 +108,23 @@ pub fn setup() -> GameState {
         study_shroud,
         study_clues,
     );
+
+    // LocationIds 2–5: the four set-aside locations. Connections are wired
+    // here (scenario map knowledge — the corpus carries none) so they enter
+    // play already connected when Act 1's (01108) Forced on-advance reverse
+    // fires. The Hallway is the hub; Attic/Cellar/Parlor are the spokes.
+    let make = |id: LocationId, code: &str, name: &str| {
+        let (shroud, clues) = location_stats(code);
+        Location::new(id, CardCode(code.into()), name, shroud, clues)
+    };
+    let mut hallway = make(HALLWAY_ID, "01112", "Hallway");
+    hallway.connections = vec![ATTIC_ID, CELLAR_ID, PARLOR_ID];
+    let mut attic = make(ATTIC_ID, "01113", "Attic");
+    attic.connections = vec![HALLWAY_ID];
+    let mut cellar = make(CELLAR_ID, "01114", "Cellar");
+    cellar.connections = vec![HALLWAY_ID];
+    let mut parlor = make(PARLOR_ID, "01115", "Parlor");
+    parlor.connections = vec![HALLWAY_ID];
 
     // The Gathering's symbol effects are printed on reference card 01104
     // (board-dependent; evaluated in C2). Until then these flat NotZ
@@ -118,6 +145,7 @@ pub fn setup() -> GameState {
         .build();
 
     state.starting_location = Some(STUDY_ID);
+    state.set_aside_locations = vec![hallway, attic, cellar, parlor];
 
     // Act deck 01108 -> 01109 -> 01110. Clue thresholds read from the
     // corpus; 01110's printed threshold is null (it advances on "Ghoul
@@ -208,17 +236,50 @@ mod tests {
     }
 
     #[test]
-    fn setup_places_only_the_isolated_study() {
+    fn setup_places_study_in_play_and_four_set_aside() {
         let s = setup();
-        assert_eq!(s.locations.len(), 1, "Act-1 board is the Study only");
+        // In play: only the Study (Act-1 board).
+        assert_eq!(s.locations.len(), 1);
         let study = s.locations.get(&STUDY_ID).expect("Study present");
         assert_eq!(study.code, CardCode("01111".into()));
-        assert_eq!(study.shroud, 2);
-        assert_eq!(study.clues, 2);
-        assert!(study.revealed);
-        assert!(study.connections.is_empty(), "Study is isolated in Act 1");
+        assert!(study.connections.is_empty(), "Study is isolated");
+        // Set aside: Hallway, Attic, Cellar, Parlor, each pre-connected.
+        let codes: Vec<_> = s
+            .set_aside_locations
+            .iter()
+            .map(|l| l.code.as_str().to_owned())
+            .collect();
+        assert_eq!(codes, ["01112", "01113", "01114", "01115"]);
+        let hallway = s
+            .set_aside_locations
+            .iter()
+            .find(|l| l.code.as_str() == "01112")
+            .unwrap();
+        let mut hall_conns: Vec<_> = hallway.connections.clone();
+        hall_conns.sort();
+        let mut others: Vec<_> = s
+            .set_aside_locations
+            .iter()
+            .filter(|l| l.code.as_str() != "01112")
+            .map(|l| l.id)
+            .collect();
+        others.sort();
+        assert_eq!(
+            hall_conns, others,
+            "Hallway connects to Attic/Cellar/Parlor"
+        );
+        for l in s
+            .set_aside_locations
+            .iter()
+            .filter(|l| l.code.as_str() != "01112")
+        {
+            assert_eq!(
+                l.connections,
+                vec![hallway.id],
+                "spokes connect back to the Hallway"
+            );
+        }
         assert_eq!(s.starting_location, Some(STUDY_ID));
-        assert_eq!(s.scenario_id, Some(ScenarioId::new(ID)));
         assert!(s.investigators.is_empty(), "setup() seats no one");
     }
 

--- a/crates/scenarios/src/the_gathering.rs
+++ b/crates/scenarios/src/the_gathering.rs
@@ -112,6 +112,8 @@ pub fn setup() -> GameState {
     // here (scenario map knowledge — the corpus carries none) so they enter
     // play already connected when Act 1's (01108) Forced on-advance reverse
     // fires. The Hallway is the hub; Attic/Cellar/Parlor are the spokes.
+    // TODO(#260): replace the hand-assigned LocationIds + manual connection
+    // wiring with a location-construction/id-allocation helper.
     let make = |id: LocationId, code: &str, name: &str| {
         let (shroud, clues) = location_stats(code);
         Location::new(id, CardCode(code.into()), name, shroud, clues)

--- a/crates/scenarios/tests/the_gathering.rs
+++ b/crates/scenarios/tests/the_gathering.rs
@@ -8,7 +8,7 @@ use std::sync::Once;
 use game_core::action::RosterEntry;
 use game_core::engine::{apply, EngineOutcome};
 use game_core::scenario::Resolution;
-use game_core::state::{CardCode, InvestigatorId, LocationId};
+use game_core::state::{CardCode, InvestigatorId, LocationId, Phase};
 use game_core::test_support::{
     fire_forced_on_enter, test_investigator, test_location, GameStateBuilder,
 };
@@ -141,4 +141,58 @@ fn cellar_forced_enter_deals_one_damage() {
         1,
         "entering the Cellar deals 1 damage to the entering investigator",
     );
+}
+
+#[test]
+fn advancing_act_1_rebuilds_the_board() {
+    install_registries();
+    let mut state = the_gathering::setup();
+
+    // Seat one investigator at the Study with the 2 clues Act 1 needs.
+    let inv = InvestigatorId(1);
+    let mut investigator = test_investigator(1);
+    investigator.current_location = Some(the_gathering::STUDY_ID);
+    investigator.clues = 2;
+    state.investigators.insert(inv, investigator);
+    state.turn_order = vec![inv];
+    state.active_investigator = Some(inv);
+    state.phase = Phase::Investigation;
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::AdvanceAct { investigator: inv }),
+    );
+    assert_eq!(result.outcome, EngineOutcome::Done);
+
+    // Board rebuilt: four locations in play, Study gone, set-aside empty.
+    let codes: std::collections::BTreeSet<String> = result
+        .state
+        .locations
+        .values()
+        .map(|l| l.code.as_str().to_owned())
+        .collect();
+    assert_eq!(
+        codes,
+        ["01112", "01113", "01114", "01115"]
+            .into_iter()
+            .map(String::from)
+            .collect()
+    );
+    assert!(result.state.set_aside_locations.is_empty());
+
+    // Investigator relocated to the Hallway (01112).
+    let hallway_id = result
+        .state
+        .locations
+        .values()
+        .find(|l| l.code.as_str() == "01112")
+        .unwrap()
+        .id;
+    assert_eq!(
+        result.state.investigators[&inv].current_location,
+        Some(hallway_id)
+    );
+
+    // Act cursor moved to Act 2.
+    assert_eq!(result.state.act_index, 1);
 }

--- a/crates/scenarios/tests/the_gathering.rs
+++ b/crates/scenarios/tests/the_gathering.rs
@@ -80,10 +80,11 @@ fn drives_to_a_won_resolution() {
     let inv = InvestigatorId(1);
     let mut state = setup_and_seat();
 
-    // Hand the investigator enough clues to clear all three act
-    // thresholds (2 + 3 + 2 = 7); AdvanceAct spends from group clues,
-    // no chaos draw involved. Proves the resolution latch fires for the
-    // real act deck, deterministically.
+    // Hand the investigator enough clues to clear acts 1 and 2 (2 + 3 = 5
+    // needed); act 3 (01110) has threshold 0 — it advances on Ghoul-Priest-
+    // defeat, not a clue spend. 7 is comfortably enough. AdvanceAct spends
+    // from group clues, no chaos draw involved. Proves the resolution latch
+    // fires for the real act deck, deterministically.
     state.investigators.get_mut(&inv).unwrap().clues = 7;
 
     for _ in 0..3 {

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -6,7 +6,8 @@
 Engine spine (A1/A2) and scenario plumbing (B1/B2) shipped; **Group C**
 (the Gathering content) is decomposed into sub-slices C1–C7
 ([#227](https://github.com/talelburg/eldritch/issues/227)–[#245](https://github.com/talelburg/eldritch/issues/245),
-kickoff [#246](https://github.com/talelburg/eldritch/issues/246)).
+kickoff [#246](https://github.com/talelburg/eldritch/issues/246)). Shipped:
+C1a (board skeleton), C1b (Act-1 board build + Act-3 forced advance-on-defeat).
 Design specs:
 [Gathering design](../superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md),
 [Group C decomposition](../superpowers/specs/2026-06-11-phase-7-slice-1-group-c-decomposition-design.md).
@@ -48,11 +49,11 @@ root dependency; C7 is the playable Won/Lost gate; #212 lands after C.
 | Sub | Issue | What | State |
 |---|---|---|---|
 | C1a | [#227](https://github.com/talelburg/eldritch/issues/227) | `setup()` world-build + forced location effects | ✅ PR #250 |
-| C1b | [#228](https://github.com/talelburg/eldritch/issues/228) | act-advancement objective types (01109 / 01110) | — |
+| C1b | [#228](https://github.com/talelburg/eldritch/issues/228) | Act-1 (01108) reverse board-build + Act-3 (01110) forced advance-on-defeat (act-2 01109 objective → C3c) | ✅ PR #259 |
 | C2 | [#229](https://github.com/talelburg/eldritch/issues/229) | 01104 symbol-token effects + victory points | — |
 | C3a | [#230](https://github.com/talelburg/eldritch/issues/230) | Prey variants + Retaliate | — |
 | C3b | [#231](https://github.com/talelburg/eldritch/issues/231) | the six encounter enemies | — |
-| C3c | [#232](https://github.com/talelburg/eldritch/issues/232) | agenda 01107 forced (movement + doom; +`RoundEnded`) | — |
+| C3c | [#232](https://github.com/talelburg/eldritch/issues/232) | agenda 01107 forced (movement + doom; +`RoundEnded`) **+ act-2 (01109) round-end objective (moved from C1b)** | — |
 | C4a | [#233](https://github.com/talelburg/eldritch/issues/233) | threat-area zone + shared scan source (in-C consolidation seam) | — |
 | C4b | [#234](https://github.com/talelburg/eldritch/issues/234) | one-shot Revelation treacheries (×4) | — |
 | C4c | [#235](https://github.com/talelburg/eldritch/issues/235) | persistent threat-area treacheries (×3) | — |
@@ -114,6 +115,8 @@ Devourer Below, campaign log + `Fact` enum) is **Phase 9**, not Phase 7.
 - **Card metadata is a `CardKind` enum, and encounter cards + their stats are in the corpus** ([#254](https://github.com/talelburg/eldritch/issues/254) remodel, [#252](https://github.com/talelburg/eldritch/issues/252) ingestion — both infra PRs, not phase-7 issues, but load-bearing for all of Group C). `CardMetadata` is now an identity core + a `kind: CardKind` enum (`Investigator`/`Asset`/`Event`/`Skill`/`Enemy`/`Location`/`Act`/`Agenda`/`Treachery`); read `card_type()`/`class()` via accessors and match on `kind` for type-specific stats. The 8 in-scope encounter files are ingested, so **locations/acts/agendas/enemies/treacheries carry their printed stats in the corpus** (`CardKind::Location { shroud, clues, victory }`, `Act { clue_threshold, victory }`, `Agenda { doom_threshold }`, `Enemy { fight, evade, damage, horror, health, victory, quantity, … }`). Consequences for Group C: read stats via `cards::by_code`/`metadata_for` instead of hand-typing (C1b set-aside locations, C2 victory points, C3 enemy stats, C4 treachery `quantity`); `scenario`-type cards (e.g. ref card `01104`) are **not** in the corpus — their effects live in `abilities()` impls; and C3b (#231) must wire `spawn_enemy` to read combat stats from `CardKind::Enemy` (it still hardcodes `fight: 1, evade: 1`).
 
 - **`emit_event` unification (#212) lands *after* Group C, not before it.** C is built on the existing `ForcedTriggerPoint` enum-dispatcher + reaction-window pipeline, extended with new timing points (`RoundEnded`, `EndOfTurn`, `AfterLocationInvestigated`, `GameEnd`, damage/investigate windows) as content demands them; #212 then consolidates those into one emit-driven chokepoint, validated against all of C's real content. The dispatch surface C adds is a handful of points through already-generic machinery (the 7 treacheries share one Revelation hook; locations and Beat Cop reuse existing paths), so front-loading #212 would design its event taxonomy before the cards defining its requirements exist. **#213** (player-choice simultaneous-trigger ordering) is deferred further still — until then simultaneous triggers resolve in a fixed **deterministic** order. C4a (#233) lands the one in-C consolidation seam (shared scan source over `cards_in_play` + threat area) that #212 later absorbs.
+
+- **Act-2 (01109)'s round-end objective moved from C1b to C3c ([#232](https://github.com/talelburg/eldritch/issues/232)); C1b (#228, PR #259) shipped Pillars 1+3 only.** A faithful "when the round ends, investigators in the hallway *may*, as a group, spend clues to advance" requires the engine to *pause at round end* — a suspendable round-end **player window** (threading `upkeep_phase_end`, which returns `()` today, plus `AdvanceAct` re-gating + a Hallway contributor filter). That lands on the same round-end point C3c is already adding (`RoundEnded`, for the agenda's forced doom), so C3c builds the window once and act-2's optional advance rides it. **C3c's scope therefore includes the act-2 round-end clue gate** (threshold 3, Hallway-restricted); C1b left act 2 on the interim action-driven `AdvanceAct`. C1b's two pillars (Act-1 reverse board-build via a Forced `OnEvent(ActAdvanced)` ability on the act card; Act-3 forced advance on the Ghoul Priest's defeat via `ForcedTriggerPoint::EnemyDefeated` → `Effect::AdvanceCurrentAct`) both ride the existing forced-trigger rails — adding `EventPattern::EnemyDefeated`'s code narrow dropped `Copy` from `EventPattern`/`Trigger`, and `Enemy` gained a `code` field. New deferral issues filed: **#257** (location reveal-on-entry + per-investigator clues — currently the `revealed` field is dormant) and **#258** (Lita Chantler / Parlor barrier / Resign).
 
 ## Open questions
 

--- a/docs/superpowers/plans/2026-06-12-c1b-act-advancement.md
+++ b/docs/superpowers/plans/2026-06-12-c1b-act-advancement.md
@@ -1,0 +1,1392 @@
+# C1b — Act advancement (reverse effects + objective types) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make The Gathering's act spine real — advancing Act 1 (01108) rebuilds the board (set-aside locations enter play, investigators move to the Hallway, the Study is removed), and Act 3 (01110) advances — forced — when the Ghoul Priest (01116) is defeated.
+
+**Architecture:** Both behaviors ride the existing single-trigger forced path (`fire_forced_triggers` / `ForcedTriggerPoint`, `crates/game-core/src/engine/dispatch/forced_triggers.rs`). Reverse effects and objectives live as `Trigger::OnEvent` abilities *on the act cards* (Option C), looked up by code through `cards::REGISTRY` — exactly like the existing Attic/Cellar forced location abilities. Four new DSL `Effect`s + two new `ForcedTriggerPoint` variants; no new window/suspend machinery. Act 2's round-end objective is **out of scope** (moved to C3c/#232).
+
+**Tech Stack:** Rust workspace. Crates: `card-dsl` (DSL types/builders), `game-core` (engine/state/evaluator/dispatch), `cards` (per-card `abilities()` impls + registry), `scenarios` (`the_gathering.rs`). Tests: per-crate `#[cfg(test)]` + integration tests in `crates/cards/tests/` and `crates/scenarios/tests/` (each its own process, installs `cards::REGISTRY`).
+
+**Spec:** `docs/superpowers/specs/2026-06-12-phase-7-slice-1-c1b-act-advancement-design.md`
+
+**CI gauntlet (run before every commit that finishes a task):**
+```sh
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+```
+
+---
+
+## Pillar 1 — Act-1 reverse board-build (Tasks 1–7)
+
+### Task 1: `set_aside_locations` zone on `GameState`
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (struct `GameState`, ~line 40 after `locations`)
+- Modify: `crates/game-core/src/state/builder.rs` (`build()`, ~line 255)
+- Test: `crates/game-core/src/state/builder.rs` (`#[cfg(test)]`)
+
+- [ ] **Step 1: Write the failing test** in `builder.rs`'s test module:
+
+```rust
+#[test]
+fn build_starts_with_empty_set_aside_locations() {
+    let state = GameStateBuilder::new().build();
+    assert!(state.set_aside_locations.is_empty());
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p game-core build_starts_with_empty_set_aside_locations`
+Expected: FAIL — `no field set_aside_locations on type GameState`.
+
+- [ ] **Step 3: Add the field** to `GameState` (after the `locations` field):
+
+```rust
+    /// Locations set aside, out of play (Rules Reference p.3, "set
+    /// aside"). Brought into play by card effects — The Gathering's
+    /// Act-1 reverse drains these via
+    /// [`Effect::PutSetAsideLocationsIntoPlay`](crate::dsl::Effect::PutSetAsideLocationsIntoPlay).
+    pub set_aside_locations: Vec<Location>,
+```
+
+And initialize it in `builder.rs`'s `build()` (in the `GameState { … }` literal):
+
+```rust
+            set_aside_locations: Vec::new(),
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p game-core build_starts_with_empty_set_aside_locations`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/game-core/src/state/game_state.rs crates/game-core/src/state/builder.rs
+git commit -m "engine: add set_aside_locations zone to GameState (#228)"
+```
+
+---
+
+### Task 2: DSL — `EventPattern::ActAdvanced` + three world-build `Effect`s
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs` (enum `EventPattern` ~line 190; enum `Effect` ~line 409; builders ~line 720)
+- Test: `crates/card-dsl/src/dsl.rs` (`#[cfg(test)]`)
+
+These are bare/`String`-typed data types (card-dsl has no `game-core` `CardCode`; it uses `String` codes, mirroring `SpawnLocation::Specific(String)`).
+
+- [ ] **Step 1: Write the failing test:**
+
+```rust
+#[test]
+fn world_build_effect_builders_have_expected_shape() {
+    assert!(matches!(
+        put_set_aside_locations_into_play(),
+        Effect::PutSetAsideLocationsIntoPlay
+    ));
+    assert!(matches!(
+        relocate_all_investigators("01112"),
+        Effect::RelocateAllInvestigators { to } if to == "01112"
+    ));
+    assert!(matches!(
+        remove_location_from_game("01111"),
+        Effect::RemoveLocationFromGame { location } if location == "01111"
+    ));
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p card-dsl world_build_effect_builders_have_expected_shape`
+Expected: FAIL — builders/variants not found.
+
+- [ ] **Step 3: Add the variants and builders.**
+
+Add to `enum EventPattern` (a bare variant, like `EnemySpawned`):
+
+```rust
+    /// The act this ability is printed on advanced (its reverse side
+    /// resolves). Fired forced via
+    /// `ForcedTriggerPoint::ActAdvanced`; binds controller = the lead
+    /// investigator (board-wide reverse effects ignore it).
+    ActAdvanced,
+```
+
+Add to `enum Effect`:
+
+```rust
+    /// Put every location in `set_aside_locations` into play (Rules
+    /// Reference p.3 "set aside" → in play). Board-wide; ignores the
+    /// controller.
+    PutSetAsideLocationsIntoPlay,
+    /// Move every investigator to the in-play location with this
+    /// printed `code`. Rejects if no such location is in play.
+    RelocateAllInvestigators { to: String },
+    /// Remove the in-play location with this printed `code` from the
+    /// game. Rejects if no such location is in play.
+    RemoveLocationFromGame { location: String },
+```
+
+Add builders near the other `pub fn` builders (~line 720), each `#[must_use]`:
+
+```rust
+/// Build an [`Effect::PutSetAsideLocationsIntoPlay`].
+#[must_use]
+pub fn put_set_aside_locations_into_play() -> Effect {
+    Effect::PutSetAsideLocationsIntoPlay
+}
+
+/// Build an [`Effect::RelocateAllInvestigators`] targeting `to` (a
+/// printed location code).
+#[must_use]
+pub fn relocate_all_investigators(to: impl Into<String>) -> Effect {
+    Effect::RelocateAllInvestigators { to: to.into() }
+}
+
+/// Build an [`Effect::RemoveLocationFromGame`] targeting `location` (a
+/// printed location code).
+#[must_use]
+pub fn remove_location_from_game(location: impl Into<String>) -> Effect {
+    Effect::RemoveLocationFromGame {
+        location: location.into(),
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p card-dsl world_build_effect_builders_have_expected_shape`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/card-dsl/src/dsl.rs
+git commit -m "card-dsl: ActAdvanced pattern + world-build effects (#228)"
+```
+
+---
+
+### Task 3: Evaluator arms for the three world-build effects
+
+**Files:**
+- Modify: `crates/game-core/src/engine/evaluator.rs` (the `apply_effect` match ~line 130; add a `location_id_by_code` helper)
+- Test: `crates/game-core/src/engine/evaluator.rs` (`#[cfg(test)]`)
+
+No registry needed — these are pure state mutations through `apply_effect`.
+
+- [ ] **Step 1: Write the failing tests:**
+
+```rust
+#[test]
+fn put_set_aside_drains_into_locations() {
+    use crate::state::{CardCode, Location, LocationId};
+    let mut state = crate::test_support::GameStateBuilder::new().build();
+    state.set_aside_locations = vec![Location::new(
+        LocationId(2),
+        CardCode("01112".into()),
+        "Hallway",
+        1,
+        0,
+    )];
+    let mut events = Vec::new();
+    let mut cx = Cx { state: &mut state, events: &mut events };
+    let out = apply_effect(
+        &mut cx,
+        &Effect::PutSetAsideLocationsIntoPlay,
+        EvalContext::for_controller(crate::state::InvestigatorId(1)),
+    );
+    assert_eq!(out, EngineOutcome::Done);
+    assert!(state.set_aside_locations.is_empty());
+    assert!(state.locations.contains_key(&LocationId(2)));
+}
+
+#[test]
+fn relocate_all_moves_everyone_to_named_code() {
+    use crate::state::{CardCode, InvestigatorId, Location, LocationId};
+    use crate::test_support::{test_investigator, GameStateBuilder};
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(LocationId(1));
+    let mut state = GameStateBuilder::new()
+        .with_location(Location::new(LocationId(1), CardCode("01111".into()), "Study", 2, 2))
+        .with_location(Location::new(LocationId(2), CardCode("01112".into()), "Hallway", 1, 0))
+        .with_investigator(inv)
+        .build();
+    let mut events = Vec::new();
+    let mut cx = Cx { state: &mut state, events: &mut events };
+    let out = apply_effect(
+        &mut cx,
+        &Effect::RelocateAllInvestigators { to: "01112".into() },
+        EvalContext::for_controller(InvestigatorId(1)),
+    );
+    assert_eq!(out, EngineOutcome::Done);
+    assert_eq!(state.investigators[&InvestigatorId(1)].current_location, Some(LocationId(2)));
+    assert!(events.iter().any(|e| matches!(
+        e,
+        Event::InvestigatorMoved { investigator, from, to }
+            if *investigator == InvestigatorId(1) && *from == LocationId(1) && *to == LocationId(2)
+    )));
+}
+
+#[test]
+fn remove_location_drops_it_from_play() {
+    use crate::state::{CardCode, Location, LocationId};
+    use crate::test_support::GameStateBuilder;
+    let mut state = GameStateBuilder::new()
+        .with_location(Location::new(LocationId(1), CardCode("01111".into()), "Study", 2, 2))
+        .build();
+    let mut events = Vec::new();
+    let mut cx = Cx { state: &mut state, events: &mut events };
+    let out = apply_effect(
+        &mut cx,
+        &Effect::RemoveLocationFromGame { location: "01111".into() },
+        EvalContext::for_controller(crate::state::InvestigatorId(1)),
+    );
+    assert_eq!(out, EngineOutcome::Done);
+    assert!(state.locations.is_empty());
+}
+
+#[test]
+fn relocate_to_missing_code_rejects() {
+    use crate::state::InvestigatorId;
+    use crate::test_support::GameStateBuilder;
+    let mut state = GameStateBuilder::new().build();
+    let mut events = Vec::new();
+    let mut cx = Cx { state: &mut state, events: &mut events };
+    let out = apply_effect(
+        &mut cx,
+        &Effect::RelocateAllInvestigators { to: "09999".into() },
+        EvalContext::for_controller(InvestigatorId(1)),
+    );
+    assert!(matches!(out, EngineOutcome::Rejected { .. }));
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p game-core -- put_set_aside relocate_all remove_location relocate_to_missing`
+Expected: FAIL — non-exhaustive match / arms unimplemented.
+
+- [ ] **Step 3: Implement the arms.** Add a private helper at the bottom of `evaluator.rs`:
+
+```rust
+/// Find the in-play location whose printed code equals `code`.
+fn location_id_by_code(state: &GameState, code: &str) -> Option<crate::state::LocationId> {
+    state
+        .locations
+        .iter()
+        .find(|(_, loc)| loc.code.as_str() == code)
+        .map(|(id, _)| *id)
+}
+```
+
+Add the match arms in `apply_effect` (alongside the existing `Effect::` arms):
+
+```rust
+        Effect::PutSetAsideLocationsIntoPlay => {
+            let drained = std::mem::take(&mut cx.state.set_aside_locations);
+            for loc in drained {
+                cx.state.locations.insert(loc.id, loc);
+            }
+            EngineOutcome::Done
+        }
+        Effect::RelocateAllInvestigators { to } => {
+            let Some(dest) = location_id_by_code(cx.state, to) else {
+                return EngineOutcome::Rejected {
+                    reason: format!(
+                        "RelocateAllInvestigators: no in-play location with code {to}"
+                    )
+                    .into(),
+                };
+            };
+            let ids: Vec<_> = cx.state.investigators.keys().copied().collect();
+            for id in ids {
+                let inv = cx
+                    .state
+                    .investigators
+                    .get_mut(&id)
+                    .expect("id sourced from keys()");
+                let from = inv.current_location;
+                inv.current_location = Some(dest);
+                if let Some(from_id) = from {
+                    if from_id != dest {
+                        cx.events.push(Event::InvestigatorMoved {
+                            investigator: id,
+                            from: from_id,
+                            to: dest,
+                        });
+                    }
+                }
+            }
+            EngineOutcome::Done
+        }
+        Effect::RemoveLocationFromGame { location } => {
+            let Some(target) = location_id_by_code(cx.state, location) else {
+                return EngineOutcome::Rejected {
+                    reason: format!(
+                        "RemoveLocationFromGame: no in-play location with code {location}"
+                    )
+                    .into(),
+                };
+            };
+            cx.state.locations.remove(&target);
+            EngineOutcome::Done
+        }
+```
+
+Ensure `Event` and `GameState` are in scope (the module already imports `crate::event::Event` and `crate::state::GameState`).
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo test -p game-core -- put_set_aside relocate_all remove_location relocate_to_missing`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/game-core/src/engine/evaluator.rs
+git commit -m "engine: evaluator arms for world-build effects (#228)"
+```
+
+---
+
+### Task 4: `ForcedTriggerPoint::ActAdvanced` + fire from `advance_act`
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/forced_triggers.rs` (`ForcedTriggerPoint` enum ~line 26; `collect_forced_hits` ~line 67)
+- Modify: `crates/game-core/src/engine/dispatch/act_agenda.rs` (`advance_act` ~line 157)
+- Modify: `crates/game-core/src/test_support/mod.rs` (add `fire_forced_on_act_advance` helper)
+- Test: `crates/game-core/src/engine/dispatch/act_agenda.rs` (`#[cfg(test)]`)
+
+- [ ] **Step 1: Write the failing test** in `act_agenda.rs`'s `advance_act_tests` — without a registry, advancing must still bump the cursor (the forced fire is a no-op):
+
+```rust
+#[test]
+fn advance_act_without_registry_still_advances() {
+    use crate::scenario::Resolution;
+    use crate::state::{Act, CardCode, InvestigatorId, Phase};
+    use crate::test_support::{test_investigator, GameStateBuilder};
+    let inv = InvestigatorId(1);
+    let mut investigator = test_investigator(1);
+    investigator.clues = 2;
+    let mut state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(investigator)
+        .with_active_investigator(inv)
+        .with_turn_order([inv])
+        .build();
+    state.act_deck = vec![
+        Act { code: CardCode("01108".into()), clue_threshold: 2, resolution: None },
+        Act { code: CardCode("01109".into()), clue_threshold: 3,
+              resolution: Some(Resolution::Won { id: "R1".into() }) },
+    ];
+    let result = apply(state, Action::Player(PlayerAction::AdvanceAct { investigator: inv }));
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_eq!(result.state.act_index, 1, "cursor advances even with no forced ability");
+}
+```
+
+- [ ] **Step 2: Run to verify it passes already** (regression guard — `advance_act` already advances; this pins behavior before the wiring):
+
+Run: `cargo test -p game-core advance_act_without_registry_still_advances`
+Expected: PASS (existing behavior).
+
+- [ ] **Step 3: Add the `ForcedTriggerPoint` variant** in `forced_triggers.rs`:
+
+```rust
+    /// An act advanced (its reverse side resolves). Scans the
+    /// *leaving* act's card for `EventPattern::ActAdvanced` forced
+    /// abilities; binds controller = the lead investigator.
+    ActAdvanced {
+        /// Printed code of the act that advanced.
+        code: CardCode,
+    },
+```
+
+Add a match arm in `collect_forced_hits` (mirrors the `PhaseEnded` act-scan, but uses the carried `code` directly):
+
+```rust
+        ForcedTriggerPoint::ActAdvanced { code } => {
+            let Some(lead) = state.turn_order.first().copied() else {
+                return hits;
+            };
+            push_matching(reg, &code, lead, &mut hits, |p| {
+                matches!(p, EventPattern::ActAdvanced)
+            });
+        }
+```
+
+(Note: this match arm consumes `code` by value; `point` is taken by value in `collect_forced_hits`. Since `CardCode` is not `Copy`, bind with `ForcedTriggerPoint::ActAdvanced { code }` and pass `&code`.)
+
+- [ ] **Step 4: Fire it from `advance_act`** in `act_agenda.rs`. Replace the body of `advance_act`:
+
+```rust
+pub(crate) fn advance_act(cx: &mut Cx) {
+    let from = cx.state.act_index;
+    let leaving_code = cx.state.act_deck[from].code.clone();
+    cx.events.push(crate::event::Event::ActAdvanced { from });
+    // Resolve the leaving act's Forced on-advance reverse effect (the
+    // board world-build) before the next act becomes current — Rules
+    // Reference p.3: flip the card, follow the reverse, then the next
+    // card becomes current. `()` return can't propagate a 2+-trigger
+    // reject; `debug_assert!` guards it (mirror of `upkeep_phase_end`).
+    let forced = super::forced_triggers::fire_forced_triggers(
+        cx,
+        super::forced_triggers::ForcedTriggerPoint::ActAdvanced { code: leaving_code },
+    );
+    debug_assert!(
+        matches!(forced, EngineOutcome::Done),
+        "advance_act on-advance forced did not resolve to Done: {forced:?} (2+ needs #213)"
+    );
+    cx.state.act_index += 1;
+    if cx.state.act_index >= cx.state.act_deck.len() {
+        unreachable!(
+            "advance_act: act {from} advanced past the end of the deck without a resolution \
+             firing — a terminal act must carry a resolution point; this is malformed \
+             scenario data"
+        );
+    }
+}
+```
+
+Note the visibility bump: `fn advance_act` → `pub(crate) fn advance_act` (Task 9's `AdvanceCurrentAct` evaluator arm reuses it). Also bump `request_resolution` to `pub(crate)` while here (same reason).
+
+- [ ] **Step 5: Add the `fire_forced_on_act_advance` test helper** in `test_support/mod.rs` (mirror `fire_forced_on_phase_end`):
+
+```rust
+/// Test helper: fire forced triggers for an act advancing, returning
+/// the `EngineOutcome`. See `fire_forced_on_enter`.
+pub fn fire_forced_on_act_advance(
+    state: &mut crate::state::GameState,
+    events: &mut Vec<crate::event::Event>,
+    code: crate::state::CardCode,
+) -> crate::engine::EngineOutcome {
+    let mut cx = crate::engine::Cx { state, events };
+    crate::engine::fire_forced_triggers(
+        &mut cx,
+        crate::engine::ForcedTriggerPoint::ActAdvanced { code },
+    )
+}
+```
+
+- [ ] **Step 6: Run the regression test + fmt/clippy**
+
+Run: `cargo test -p game-core advance_act_without_registry_still_advances && cargo clippy -p game-core --all-targets -- -D warnings`
+Expected: PASS, no warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/forced_triggers.rs crates/game-core/src/engine/dispatch/act_agenda.rs crates/game-core/src/test_support/mod.rs
+git commit -m "engine: fire on-advance forced trigger from advance_act (#228)"
+```
+
+---
+
+### Task 5: `01108` abilities impl + registry registration
+
+**Files:**
+- Create: `crates/cards/src/impls/act_01108.rs`
+- Modify: `crates/cards/src/impls/mod.rs` (`pub mod` + `abilities_for` arm + doc list)
+- Test: in `act_01108.rs` (`#[cfg(test)]`)
+
+Mirror `attic.rs`. 01108 back (verbatim, `core_encounter.json`): *"Put into play the set-aside Hallway, Cellar, Attic, and Parlor. Discard each enemy in the Study. Place each investigator in the Hallway. Remove the Study from the game."*
+
+- [ ] **Step 1: Write the failing test** (in the new file's test module):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use card_dsl::dsl::{Effect, EventPattern, EventTiming, Trigger};
+
+    #[test]
+    fn abilities_are_one_forced_on_advance_world_build() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(
+            abilities[0].trigger,
+            Trigger::OnEvent { pattern: EventPattern::ActAdvanced, timing: EventTiming::After }
+        );
+        let Effect::Seq(steps) = &abilities[0].effect else {
+            panic!("expected a Seq, got {:?}", abilities[0].effect);
+        };
+        assert!(matches!(steps[0], Effect::PutSetAsideLocationsIntoPlay));
+        assert!(matches!(&steps[1], Effect::RelocateAllInvestigators { to } if to == "01112"));
+        assert!(matches!(&steps[2], Effect::RemoveLocationFromGame { location } if location == "01111"));
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p cards abilities_are_one_forced_on_advance_world_build`
+Expected: FAIL — module not declared.
+
+- [ ] **Step 3: Write the impl** (`act_01108.rs` body, above the test module):
+
+```rust
+//! Trapped (The Gathering Act 1, 01108).
+//!
+//! ```text
+//! Act 1 — Trapped. Clues: 2.
+//! (reverse) Put into play the set-aside Hallway, Cellar, Attic, and
+//! Parlor. Discard each enemy in the Study. Place each investigator in
+//! the Hallway. Remove the Study from the game.
+//! ```
+//!
+//! The reverse side is a Forced on-advance ability (Option C): it fires
+//! via `ForcedTriggerPoint::ActAdvanced` when the act advances, before
+//! the next act becomes current. "Discard each enemy in the Study" is a
+//! faithful **no-op** — nothing can spawn into the isolated Act-1 Study
+//! in Slice-1 scope (location reveal-on-entry is TODO(#257); no encounter
+//! path targets the Study). The set-aside locations + their connections
+//! are built by the scenario's `setup()`; this ability just moves them
+//! into play.
+
+use card_dsl::dsl::{
+    on_event, put_set_aside_locations_into_play, relocate_all_investigators,
+    remove_location_from_game, Ability, Effect, EventPattern, EventTiming,
+};
+
+/// `ArkhamDB` code for Act 1, "Trapped".
+pub const CODE: &str = "01108";
+
+/// 01108's Forced on-advance reverse: build the Act-1 board.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![on_event(
+        EventPattern::ActAdvanced,
+        EventTiming::After,
+        Effect::Seq(vec![
+            put_set_aside_locations_into_play(),
+            relocate_all_investigators("01112"), // the Hallway
+            remove_location_from_game("01111"),  // the Study
+        ]),
+    )]
+}
+```
+
+- [ ] **Step 4: Register it** in `impls/mod.rs` — add `pub mod act_01108;`, add the match arm `act_01108::CODE => Some(act_01108::abilities()),`, and a bullet in the `# Implemented so far` doc list.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cargo test -p cards abilities_are_one_forced_on_advance_world_build`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cards/src/impls/act_01108.rs crates/cards/src/impls/mod.rs
+git commit -m "cards: 01108 Trapped on-advance reverse ability (#228)"
+```
+
+---
+
+### Task 6: `the_gathering.rs` setup — five-location board + set-aside split
+
+**Files:**
+- Modify: `crates/scenarios/src/the_gathering.rs` (`setup()` ~line 89; module doc; setup tests)
+- Test: `crates/scenarios/src/the_gathering.rs` (`#[cfg(test)]`)
+
+The board graph (scenario knowledge — no connection data in the corpus): the **Hallway (01112)** is the hub, connected to **Attic (01113)**, **Cellar (01114)**, **Parlor (01115)**. The **Study (01111)** is isolated. The Study starts in play; the other four are set aside.
+
+- [ ] **Step 1: Update the failing setup tests.** Replace `setup_places_only_the_isolated_study` and extend the pinning so they assert the new split:
+
+```rust
+#[test]
+fn setup_places_study_in_play_and_four_set_aside() {
+    let s = setup();
+    // In play: only the Study (Act-1 board).
+    assert_eq!(s.locations.len(), 1);
+    let study = s.locations.get(&STUDY_ID).expect("Study present");
+    assert_eq!(study.code, CardCode("01111".into()));
+    assert!(study.connections.is_empty(), "Study is isolated");
+    // Set aside: Hallway, Attic, Cellar, Parlor, each pre-connected.
+    let codes: Vec<_> = s.set_aside_locations.iter().map(|l| l.code.as_str().to_owned()).collect();
+    assert_eq!(codes, ["01112", "01113", "01114", "01115"]);
+    let hallway = s.set_aside_locations.iter().find(|l| l.code.as_str() == "01112").unwrap();
+    let mut hall_conns: Vec<_> = hallway.connections.clone();
+    hall_conns.sort();
+    let mut others: Vec<_> = s.set_aside_locations.iter()
+        .filter(|l| l.code.as_str() != "01112").map(|l| l.id).collect();
+    others.sort();
+    assert_eq!(hall_conns, others, "Hallway connects to Attic/Cellar/Parlor");
+    for l in s.set_aside_locations.iter().filter(|l| l.code.as_str() != "01112") {
+        assert_eq!(l.connections, vec![hallway.id], "spokes connect back to the Hallway");
+    }
+    assert_eq!(s.starting_location, Some(STUDY_ID));
+    assert!(s.investigators.is_empty(), "setup() seats no one");
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p scenarios setup_places_study_in_play_and_four_set_aside`
+Expected: FAIL — `set_aside_locations` is empty.
+
+- [ ] **Step 3: Build the five locations** in `setup()`. Assign stable `LocationId`s, wire connections, split into in-play / set-aside. Insert after the existing Study construction (which can be reused) and before the `GameStateBuilder`:
+
+```rust
+    // LocationIds for the Gathering board. Study is STUDY_ID (1); the
+    // four set-aside locations get 2..=5. Connections are wired here
+    // (scenario map knowledge — the corpus carries none) so they enter
+    // play already connected when Act 1 advances.
+    const HALLWAY_ID: LocationId = LocationId(2);
+    const ATTIC_ID: LocationId = LocationId(3);
+    const CELLAR_ID: LocationId = LocationId(4);
+    const PARLOR_ID: LocationId = LocationId(5);
+
+    let mut make = |id: LocationId, code: &str, name: &str| {
+        let (shroud, clues) = location_stats(code);
+        Location::new(id, CardCode(code.into()), name, shroud, clues)
+    };
+    let mut hallway = make(HALLWAY_ID, "01112", "Hallway");
+    hallway.connections = vec![ATTIC_ID, CELLAR_ID, PARLOR_ID];
+    let mut attic = make(ATTIC_ID, "01113", "Attic");
+    attic.connections = vec![HALLWAY_ID];
+    let mut cellar = make(CELLAR_ID, "01114", "Cellar");
+    cellar.connections = vec![HALLWAY_ID];
+    let mut parlor = make(PARLOR_ID, "01115", "Parlor");
+    parlor.connections = vec![HALLWAY_ID];
+```
+
+After `state` is built and `starting_location` is set, attach the set-aside zone (matching how `act_deck` is assigned directly):
+
+```rust
+    state.set_aside_locations = vec![hallway, attic, cellar, parlor];
+```
+
+(Keep the Study built via `Location::new` and passed to `.with_location(study)` as today.)
+
+- [ ] **Step 4: Update the module doc** — replace the "the Hallway/Attic/Cellar/Parlor are set aside and enter via the Act-1 'Door on the Floor' transition — C1b" sentence with: *"the Hallway/Attic/Cellar/Parlor are set aside (`set_aside_locations`) and enter play via Act 1's (01108) Forced on-advance reverse, which also moves investigators to the Hallway and removes the Study."*
+
+- [ ] **Step 5: Run to verify it passes** (and the other setup tests still pass)
+
+Run: `cargo test -p scenarios the_gathering`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/scenarios/src/the_gathering.rs
+git commit -m "scenario: build the five-location Gathering board + set-aside split (#228)"
+```
+
+---
+
+### Task 7: Integration test — Act-1 advance rebuilds the board
+
+**Files:**
+- Modify: `crates/scenarios/tests/the_gathering.rs` (real `cards::REGISTRY` installed)
+
+Drive the real `AdvanceAct` action so `advance_act` fires 01108's on-advance reverse through the registry.
+
+- [ ] **Step 1: Write the failing test.** Add to `crates/scenarios/tests/the_gathering.rs` (follow the file's existing setup + registry-install pattern; seat one investigator at the Study with 2 clues, set Investigation phase, then advance Act 1):
+
+```rust
+#[test]
+fn advancing_act_1_rebuilds_the_board() {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+    let mut state = scenarios::the_gathering::setup();
+
+    // Seat one investigator at the Study with the 2 clues Act 1 needs.
+    let inv = game_core::state::InvestigatorId(1);
+    let mut investigator = game_core::test_support::test_investigator(1);
+    investigator.current_location = Some(scenarios::the_gathering::STUDY_ID);
+    investigator.clues = 2;
+    state.investigators.insert(inv, investigator);
+    state.turn_order = vec![inv];
+    state.active_investigator = Some(inv);
+    state.phase = game_core::state::Phase::Investigation;
+
+    let result = game_core::engine::apply(
+        state,
+        game_core::action::Action::Player(
+            game_core::action::PlayerAction::AdvanceAct { investigator: inv },
+        ),
+    );
+    assert_eq!(result.outcome, game_core::engine::EngineOutcome::Done);
+
+    // Board rebuilt: four locations in play, Study gone, set-aside empty.
+    let codes: std::collections::BTreeSet<_> = result.state.locations.values()
+        .map(|l| l.code.as_str().to_owned()).collect();
+    assert_eq!(codes, ["01112", "01113", "01114", "01115"].into_iter().map(String::from).collect());
+    assert!(result.state.set_aside_locations.is_empty());
+    // Investigator relocated to the Hallway (01112).
+    let hallway_id = result.state.locations.values().find(|l| l.code.as_str() == "01112").unwrap().id;
+    assert_eq!(result.state.investigators[&inv].current_location, Some(hallway_id));
+    // Act cursor moved to Act 2.
+    assert_eq!(result.state.act_index, 1);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails** (then passes once the chain is wired):
+
+Run: `cargo test -p scenarios --test the_gathering advancing_act_1_rebuilds_the_board`
+Expected: PASS (all upstream tasks done). If FAIL, inspect which link (registry install, ability lookup, evaluator arm).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/scenarios/tests/the_gathering.rs
+git commit -m "test: act-1 advance rebuilds the Gathering board end-to-end (#228)"
+```
+
+---
+
+## Pillar 3 — Act-3 forced advance-on-defeat (Tasks 8–13)
+
+### Task 8: `EventPattern::EnemyDefeated` enemy-code narrow (`Copy` → `Clone`)
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs` (`EventPattern::EnemyDefeated` ~line 195; remove `Copy` from `EventPattern` and `Trigger` derives)
+- Modify: `crates/game-core/src/engine/dispatch/forced_triggers.rs` (`push_matching` ~line 128–152)
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (~line 101, 154)
+- Modify: `crates/game-core/src/engine/dispatch/abilities.rs` (~line 191)
+- Modify: `crates/game-core/src/engine/dispatch/skill_test.rs` (~line 576)
+- Modify: `crates/cards/src/impls/roland_banks.rs` (the `EnemyDefeated { by_controller: true }` constructor)
+- Test: `crates/card-dsl/src/dsl.rs`
+
+- [ ] **Step 1: Write the failing test** in `card-dsl`:
+
+```rust
+#[test]
+fn enemy_defeated_carries_optional_code_narrow() {
+    let any = EventPattern::EnemyDefeated { by_controller: false, code: None };
+    let narrowed = EventPattern::EnemyDefeated { by_controller: false, code: Some("01116".into()) };
+    assert_ne!(any, narrowed);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p card-dsl enemy_defeated_carries_optional_code_narrow`
+Expected: FAIL — `EnemyDefeated` has no field `code`.
+
+- [ ] **Step 3: Add the field + drop `Copy`.** Change the `EnemyDefeated` variant:
+
+```rust
+    EnemyDefeated {
+        /// If `true`, only fires when the controller of this ability is
+        /// credited with the defeat. If `false`, any defeat matches.
+        by_controller: bool,
+        /// Narrow the match to a specific defeated enemy printed code
+        /// (e.g. the Ghoul Priest's `"01116"` for Act 3's objective).
+        /// `None` matches any enemy's defeat (e.g. Roland's reaction).
+        code: Option<String>,
+    },
+```
+
+Remove `Copy` from the derives on **`enum EventPattern`** (line ~189) and **`enum Trigger`** (line ~68) — keep `Clone`. (`String` is not `Copy`, so the enums can no longer be `Copy`. `Ability` was already non-`Copy`.)
+
+- [ ] **Step 4: Fix the by-value match sites** to take `&ability.trigger` references:
+
+In `forced_triggers.rs` `push_matching` — change the signature and loop:
+
+```rust
+fn push_matching(
+    reg: &card_registry::CardRegistry,
+    code: &CardCode,
+    controller: InvestigatorId,
+    out: &mut Vec<ForcedHit>,
+    want: impl Fn(&EventPattern) -> bool,
+) {
+    let Some(abilities) = (reg.abilities_for)(code) else {
+        return;
+    };
+    for (idx, ability) in abilities.iter().enumerate() {
+        if let Trigger::OnEvent { pattern, timing } = &ability.trigger {
+            if *timing == EventTiming::After && want(pattern) {
+                out.push(ForcedHit { code: code.clone(), ability_index: idx, controller });
+            }
+        }
+    }
+}
+```
+
+Update the two `collect_forced_hits` closures to take `&p` references (they become `|p| matches!(p, EventPattern::EnteredLocation)` where `p: &EventPattern` — `matches!` on a reference works as-is; for the `ActAdvanced` arm from Task 4, same).
+
+In `reaction_windows.rs:101`, `abilities.rs:191`, `skill_test.rs:576` — change `= ability.trigger` to `= &ability.trigger` and adjust the bound sub-fields to deref where they were copied (e.g. `action_cost` becomes `&u8` → use `*action_cost`; `outcome` similarly). Compile-driven: fix each `cannot move out of` error by referencing/deref.
+
+In `reaction_windows.rs:154`, update the `EnemyDefeated { by_controller }` match to `EnemyDefeated { by_controller, code: _ }` (or `..`) so it still compiles; the reaction-window matcher ignores the act-only `code` narrow.
+
+- [ ] **Step 5: Fix the Roland constructor** in `roland_banks.rs`:
+
+```rust
+        EventPattern::EnemyDefeated { by_controller: true, code: None },
+```
+
+- [ ] **Step 6: Run the full suite** (compile-driven fixups until green):
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all && cargo clippy --all-targets --all-features -- -D warnings`
+Expected: PASS, no warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/card-dsl/src/dsl.rs crates/game-core/src/engine/dispatch/ crates/cards/src/impls/roland_banks.rs
+git commit -m "card-dsl: EnemyDefeated enemy-code narrow; EventPattern Copy->Clone (#228)"
+```
+
+---
+
+### Task 9: `Effect::AdvanceCurrentAct` + builder + evaluator arm
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs` (`Effect` enum + builder)
+- Modify: `crates/game-core/src/engine/evaluator.rs` (`apply_effect` arm)
+- Test: `crates/game-core/src/engine/evaluator.rs`
+
+- [ ] **Step 1: Write the failing tests** in `evaluator.rs` (no registry needed — `AdvanceCurrentAct` reuses `advance_act`/`request_resolution`):
+
+```rust
+#[test]
+fn advance_current_act_non_terminal_bumps_cursor() {
+    use crate::scenario::Resolution;
+    use crate::state::{Act, CardCode, InvestigatorId};
+    use crate::test_support::GameStateBuilder;
+    let mut state = GameStateBuilder::new().with_turn_order([InvestigatorId(1)]).build();
+    state.act_deck = vec![
+        Act { code: CardCode("a1".into()), clue_threshold: 0, resolution: None },
+        Act { code: CardCode("a2".into()), clue_threshold: 0,
+              resolution: Some(Resolution::Won { id: "R1".into() }) },
+    ];
+    let mut events = Vec::new();
+    let mut cx = Cx { state: &mut state, events: &mut events };
+    let out = apply_effect(&mut cx, &Effect::AdvanceCurrentAct,
+        EvalContext::for_controller(InvestigatorId(1)));
+    assert_eq!(out, EngineOutcome::Done);
+    assert_eq!(state.act_index, 1);
+    assert!(state.resolution.is_none());
+}
+
+#[test]
+fn advance_current_act_terminal_latches_resolution() {
+    use crate::scenario::Resolution;
+    use crate::state::{Act, CardCode, InvestigatorId};
+    use crate::test_support::GameStateBuilder;
+    let mut state = GameStateBuilder::new().with_turn_order([InvestigatorId(1)]).build();
+    state.act_deck = vec![Act { code: CardCode("a1".into()), clue_threshold: 0,
+        resolution: Some(Resolution::Won { id: "R1".into() }) }];
+    let mut events = Vec::new();
+    let mut cx = Cx { state: &mut state, events: &mut events };
+    let out = apply_effect(&mut cx, &Effect::AdvanceCurrentAct,
+        EvalContext::for_controller(InvestigatorId(1)));
+    assert_eq!(out, EngineOutcome::Done);
+    assert_eq!(state.act_index, 0, "terminal act does not move the cursor");
+    assert!(matches!(state.resolution, Some(Resolution::Won { .. })));
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p game-core -- advance_current_act_non_terminal advance_current_act_terminal`
+Expected: FAIL — `AdvanceCurrentAct` not found.
+
+- [ ] **Step 3: Add the DSL variant + builder** in `dsl.rs`:
+
+```rust
+    /// Advance the current act one step. If the act is terminal (carries
+    /// a resolution) the scenario resolves; otherwise the cursor moves
+    /// and the act's on-advance reverse fires. Used by act objectives
+    /// like 01110 ("If the Ghoul Priest is Defeated, advance.").
+    AdvanceCurrentAct,
+```
+
+```rust
+/// Build an [`Effect::AdvanceCurrentAct`].
+#[must_use]
+pub fn advance_current_act() -> Effect {
+    Effect::AdvanceCurrentAct
+}
+```
+
+- [ ] **Step 4: Add the evaluator arm** in `apply_effect` (reusing the now-`pub(crate)` `advance_act` / `request_resolution` from Task 4):
+
+```rust
+        Effect::AdvanceCurrentAct => {
+            use crate::engine::dispatch::act_agenda::{advance_act, request_resolution};
+            if cx.state.act_deck.is_empty() {
+                return EngineOutcome::Rejected {
+                    reason: "AdvanceCurrentAct: no act deck is modeled".into(),
+                };
+            }
+            match cx.state.act_deck[cx.state.act_index].resolution.clone() {
+                Some(resolution) => request_resolution(cx.state, resolution),
+                None => advance_act(cx),
+            }
+            EngineOutcome::Done
+        }
+```
+
+(If `crate::engine::dispatch::act_agenda` is not importable at that path, add a `pub(crate) use` re-export in `engine/dispatch/mod.rs` or call via the existing `super::dispatch` path — match the crate's module conventions.)
+
+- [ ] **Step 5: Run to verify they pass**
+
+Run: `cargo test -p game-core -- advance_current_act_non_terminal advance_current_act_terminal`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/card-dsl/src/dsl.rs crates/game-core/src/engine/evaluator.rs crates/game-core/src/engine/dispatch/
+git commit -m "engine: Effect::AdvanceCurrentAct (#228)"
+```
+
+---
+
+### Task 10: `Enemy.code` + `ForcedTriggerPoint::EnemyDefeated` + fire from the defeat path
+
+The `Enemy` struct does **not** carry its printed code today (only `id`, `name`, stats, location, traits). The act-3 objective routes on the *defeated enemy's code*, and `Event::EnemyDefeated` carries only the `EnemyId` — so the enemy must carry its code, captured before removal. Part A adds it; Part B wires the dispatch.
+
+**Files:**
+- Modify: `crates/game-core/src/state/enemy.rs` (struct `Enemy` + the `#[cfg(test)]` if present)
+- Modify: `crates/game-core/src/test_support/fixtures.rs` (`test_enemy` sets a default code)
+- Modify: `crates/game-core/src/engine/dispatch/encounter.rs` (`spawn_enemy` sets `code` from `metadata.code` ~line 308)
+- Modify: `crates/game-core/src/engine/dispatch/forced_triggers.rs` (variant + `collect_forced_hits` arm)
+- Modify: `crates/game-core/src/engine/dispatch/combat.rs` (`damage_enemy` defeat branch ~line 28)
+- Modify: `crates/game-core/src/test_support/mod.rs` (`fire_forced_on_enemy_defeat` helper)
+- Test: `crates/game-core/src/state/enemy.rs`, `crates/game-core/src/engine/dispatch/combat.rs`
+
+**Part A — add `code` to `Enemy`:**
+
+- [ ] **Step A1: Write the failing test** in `enemy.rs`'s test module:
+
+```rust
+#[test]
+fn test_enemy_fixture_carries_a_code() {
+    let e = crate::test_support::test_enemy(7, "Ghoul");
+    assert!(!e.code.as_str().is_empty(), "every enemy carries its printed code");
+}
+```
+
+- [ ] **Step A2: Run to verify it fails**
+
+Run: `cargo test -p game-core test_enemy_fixture_carries_a_code`
+Expected: FAIL — `no field code on Enemy`.
+
+- [ ] **Step A3: Add the field + set it at the two construction sites.** In `enemy.rs`, add to `struct Enemy` (after `name`):
+
+```rust
+    /// Printed `ArkhamDB` code (e.g. `"01116"` for the Ghoul Priest).
+    /// Carried so framework effects keyed on a specific enemy — Act 3's
+    /// "If the Ghoul Priest is Defeated, advance." — can match after the
+    /// enemy leaves `state.enemies`.
+    pub code: CardCode,
+```
+
+(Add `use crate::state::CardCode;` / `super::CardCode` as the module needs.)
+
+In `test_support/fixtures.rs` `test_enemy`, set a synthetic default so existing callers don't change:
+
+```rust
+        code: CardCode::new(format!("_test_enemy_{id}")),
+```
+
+In `encounter.rs` `spawn_enemy`'s `Enemy { … }` literal, set the real code from metadata:
+
+```rust
+        code: CardCode::new(metadata.code.clone()),
+```
+
+- [ ] **Step A4: Run to verify it passes** (and nothing else broke)
+
+Run: `cargo test -p game-core test_enemy_fixture_carries_a_code && RUSTFLAGS="-D warnings" cargo test -p game-core`
+Expected: PASS.
+
+- [ ] **Step A5: Commit**
+
+```bash
+git add crates/game-core/src/state/enemy.rs crates/game-core/src/test_support/fixtures.rs crates/game-core/src/engine/dispatch/encounter.rs
+git commit -m "engine: Enemy carries its printed code (#228)"
+```
+
+**Part B — EnemyDefeated forced dispatch:**
+
+- [ ] **Step 1: Write the failing regression test** in `combat.rs` — defeating an enemy with no registry still works (forced fire is a no-op):
+
+```rust
+#[test]
+fn defeating_enemy_without_registry_still_removes_it() {
+    use crate::state::{EnemyId, InvestigatorId};
+    use crate::test_support::{test_enemy, GameStateBuilder};
+    let eid = EnemyId(1);
+    let mut enemy = test_enemy(1, "Ghoul"); // max_health small; see fixtures
+    enemy.max_health = 1;
+    let mut state = GameStateBuilder::new().build();
+    state.enemies.insert(eid, enemy);
+    let mut events = Vec::new();
+    let mut cx = Cx { state: &mut state, events: &mut events };
+    super::combat::damage_enemy(&mut cx, eid, 1, Some(InvestigatorId(1)));
+    assert!(!state.enemies.contains_key(&eid), "defeated enemy removed");
+}
+```
+
+(Adjust `test_enemy` usage to the fixture's actual signature — see `crates/game-core/src/test_support/fixtures.rs`.)
+
+- [ ] **Step 2: Run to verify it passes** (regression — current behavior):
+
+Run: `cargo test -p game-core defeating_enemy_without_registry_still_removes_it`
+Expected: PASS.
+
+- [ ] **Step 3: Add the `ForcedTriggerPoint` variant** in `forced_triggers.rs`:
+
+```rust
+    /// An enemy was defeated. Scans the *current act* for
+    /// `EventPattern::EnemyDefeated` forced abilities whose `code`
+    /// narrow matches (or is `None`); binds controller = the lead
+    /// investigator. The act-3 objective (01110) advances on the Ghoul
+    /// Priest's defeat through this point.
+    EnemyDefeated {
+        /// Printed code of the defeated enemy (for `code`-narrow matching).
+        code: CardCode,
+    },
+```
+
+Add the `collect_forced_hits` arm (scan the current act only — no agenda consumes this yet):
+
+```rust
+        ForcedTriggerPoint::EnemyDefeated { code } => {
+            let Some(lead) = state.turn_order.first().copied() else {
+                return hits;
+            };
+            if let Some(act) = state.act_deck.get(state.act_index) {
+                let defeated = code.as_str().to_owned();
+                push_matching(reg, &act.code, lead, &mut hits, move |p| {
+                    matches!(
+                        p,
+                        EventPattern::EnemyDefeated { code: narrow, .. }
+                            if narrow.as_deref().is_none_or(|c| c == defeated)
+                    )
+                });
+            }
+        }
+```
+
+(If the toolchain predates `Option::is_none_or`, use `narrow.as_deref().map_or(true, |c| c == defeated)`.)
+
+- [ ] **Step 4: Fire it from `damage_enemy`** — rewrite the defeat branch (`if new_damage >= enemy.max_health`) to capture the enemy's `code` *before* removal (the `Enemy` is dropped from `state.enemies` in this branch), then fire after queueing the reaction window:
+
+```rust
+    if new_damage >= enemy.max_health {
+        let defeated_code = enemy.code.clone(); // capture before the enemy is removed
+        cx.events.push(Event::EnemyDefeated { enemy: enemy_id, by });
+        cx.state.enemies.remove(&enemy_id);
+        super::reaction_windows::queue_reaction_window(
+            cx,
+            WindowKind::AfterEnemyDefeated { enemy: enemy_id, by },
+        );
+        // Forced act objectives keyed to this defeat (Act 3's "If the
+        // Ghoul Priest is Defeated, advance."). `()` return can't
+        // propagate a 2+-trigger reject; debug_assert guards it (mirror of
+        // upkeep_phase_end / advance_act). Ordering vs. the
+        // AfterEnemyDefeated reaction window is fixed-deterministic for
+        // now; #212/#213 revisit.
+        let forced = super::forced_triggers::fire_forced_triggers(
+            cx,
+            super::forced_triggers::ForcedTriggerPoint::EnemyDefeated { code: defeated_code },
+        );
+        debug_assert!(
+            matches!(forced, crate::engine::EngineOutcome::Done),
+            "EnemyDefeated forced did not resolve to Done: {forced:?} (2+ needs #213)"
+        );
+    }
+```
+
+- [ ] **Step 5: Add the test helper** in `test_support/mod.rs`:
+
+```rust
+/// Test helper: fire forced triggers for an enemy defeat, returning the
+/// `EngineOutcome`. See `fire_forced_on_enter`.
+pub fn fire_forced_on_enemy_defeat(
+    state: &mut crate::state::GameState,
+    events: &mut Vec<crate::event::Event>,
+    code: crate::state::CardCode,
+) -> crate::engine::EngineOutcome {
+    let mut cx = crate::engine::Cx { state, events };
+    crate::engine::fire_forced_triggers(
+        &mut cx,
+        crate::engine::ForcedTriggerPoint::EnemyDefeated { code },
+    )
+}
+```
+
+- [ ] **Step 6: Run the regression + clippy**
+
+Run: `cargo test -p game-core defeating_enemy_without_registry_still_removes_it && cargo clippy -p game-core --all-targets -- -D warnings`
+Expected: PASS, no warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/forced_triggers.rs crates/game-core/src/engine/dispatch/combat.rs crates/game-core/src/test_support/mod.rs
+git commit -m "engine: fire EnemyDefeated forced trigger from the defeat path (#228)"
+```
+
+---
+
+### Task 11: `01110` abilities impl + registry registration
+
+**Files:**
+- Create: `crates/cards/src/impls/act_01110.rs`
+- Modify: `crates/cards/src/impls/mod.rs`
+- Test: in `act_01110.rs`
+
+01110 front (verbatim): *"**Objective** – If the Ghoul Priest is Defeated, advance."* — forced (no "may"); the Ghoul Priest is **01116**.
+
+- [ ] **Step 1: Write the failing test:**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use card_dsl::dsl::{Effect, EventPattern, EventTiming, Trigger};
+
+    #[test]
+    fn abilities_advance_on_ghoul_priest_defeat() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(
+            abilities[0].trigger,
+            Trigger::OnEvent {
+                pattern: EventPattern::EnemyDefeated { by_controller: false, code: Some("01116".into()) },
+                timing: EventTiming::After,
+            }
+        );
+        assert!(matches!(abilities[0].effect, Effect::AdvanceCurrentAct));
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p cards abilities_advance_on_ghoul_priest_defeat`
+Expected: FAIL — module not declared.
+
+- [ ] **Step 3: Write the impl:**
+
+```rust
+//! What Have You Done? (The Gathering Act 3, 01110).
+//!
+//! ```text
+//! Act 3 — What Have You Done?
+//! Objective – If the Ghoul Priest is Defeated, advance.
+//! ```
+//!
+//! Forced (no "may" — Rules Reference p.3; the bare "advance" with no
+//! clue threshold cannot be the optional clue-spend ability): the act
+//! advances the instant the Ghoul Priest (01116) is defeated, firing
+//! its terminal Won/R1 resolution. Wired via `ForcedTriggerPoint::
+//! EnemyDefeated` from the defeat path; narrowed to 01116 so other
+//! ghouls' defeats don't advance it.
+//!
+//! Act-3's *reverse* (the R1/R2 resolution choice) is deferred to
+//! Phase 9 (campaign log gives the branch meaning); the scenario keeps
+//! a single Won/R1 latch. The Ghoul Priest enemy + its spawn land in
+//! C3 (#231); this objective is unit-tested here and proven end-to-end
+//! in C7b (#245).
+
+use card_dsl::dsl::{advance_current_act, on_event, Ability, EventPattern, EventTiming};
+
+/// `ArkhamDB` code for Act 3, "What Have You Done?".
+pub const CODE: &str = "01110";
+
+/// 01110's Forced objective: advance when the Ghoul Priest is defeated.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![on_event(
+        EventPattern::EnemyDefeated { by_controller: false, code: Some("01116".to_owned()) },
+        EventTiming::After,
+        advance_current_act(),
+    )]
+}
+```
+
+- [ ] **Step 4: Register it** in `impls/mod.rs` (`pub mod act_01110;`, match arm, doc bullet).
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cargo test -p cards abilities_advance_on_ghoul_priest_defeat`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cards/src/impls/act_01110.rs crates/cards/src/impls/mod.rs
+git commit -m "cards: 01110 What Have You Done? advance-on-defeat objective (#228)"
+```
+
+---
+
+### Task 12: `the_gathering.rs` — real 01110 objective (drop the placeholder)
+
+**Files:**
+- Modify: `crates/scenarios/src/the_gathering.rs` (`setup()` act_deck ~line 137; `act_clue_threshold` helper; module doc; setup tests)
+
+- [ ] **Step 1: Update the failing setup test** — 01110 no longer has a placeholder threshold; pin its terminal Won + threshold 0:
+
+```rust
+#[test]
+fn act_three_advances_on_objective_not_clues() {
+    let s = setup();
+    assert_eq!(s.act_deck[2].code.as_str(), "01110");
+    assert_eq!(s.act_deck[2].clue_threshold, 0, "01110 advances on Ghoul-Priest-defeat, not clues");
+    assert!(matches!(s.act_deck[2].resolution, Some(Resolution::Won { .. })));
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p scenarios act_three_advances_on_objective_not_clues`
+Expected: FAIL — placeholder threshold is 2.
+
+- [ ] **Step 3: Drop the placeholder.** In `setup()`'s `act_deck`, change the 01110 entry to `clue_threshold: 0` (objective-driven, no clue cost):
+
+```rust
+        Act {
+            code: CardCode("01110".into()),
+            clue_threshold: 0, // advances via 01110's EnemyDefeated objective (cards), not clues
+            resolution: Some(Resolution::Won { id: "R1".into() }),
+        },
+```
+
+Remove the now-unused `placeholder` path: simplify `act_clue_threshold` to drop its `placeholder` parameter (every act now reads a real value — 01108→2, 01109→3, 01110 has `clues: null` so map `None`→`0`). Update its two other call sites (01108, 01109) accordingly:
+
+```rust
+/// Read an act's printed clue threshold from the corpus. Acts that
+/// advance on a non-clue objective (01110) carry `null` clues → 0.
+fn act_clue_threshold(code: &str) -> u8 {
+    match cards::by_code(code).expect("act code in corpus").kind {
+        CardKind::Act { clue_threshold, .. } => clue_threshold.unwrap_or(0),
+        ref k => panic!("{code} is not an Act ({k:?})"),
+    }
+}
+```
+
+Update the module doc: remove the "act 01110's clue threshold is a placeholder" sentence; replace with "act 01110 advances via its Forced EnemyDefeated objective (01116; in `cards`). Its R1/R2 resolution choice is Phase-9 — `TODO`."
+
+Add a `// TODO(#phase-9): 01110's reverse is the lead investigator's R1/R2 choice…` comment at the 01110 act entry, and a `// TODO(#231): the Ghoul Priest (01116) spawns at Act-2 advance` near the act_deck.
+
+- [ ] **Step 4: Run the scenario tests** (the existing `setup_reads_card_stats_from_corpus` etc. — update any that asserted the old placeholder/`act_clue_threshold` signature):
+
+Run: `cargo test -p scenarios the_gathering`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/scenarios/src/the_gathering.rs
+git commit -m "scenario: real 01110 objective; drop placeholder threshold (#228)"
+```
+
+---
+
+### Task 13: Integration test — defeating the Ghoul Priest advances Act 3 to Won
+
+**Files:**
+- Create: `crates/cards/tests/act_advancement.rs` (own process; installs `cards::REGISTRY`)
+
+Uses the `fire_forced_on_enemy_defeat` helper + the real 01110 ability + a real corpus 01116 (it carries metadata since #252), proving dispatch → ability → `AdvanceCurrentAct` → Won.
+
+- [ ] **Step 1: Write the test:**
+
+```rust
+//! Act-3 objective: defeating the Ghoul Priest (01116) advances Act 3
+//! (01110) to its terminal Won resolution. The Ghoul Priest enemy +
+//! spawn land in C3 (#231); here we drive the forced dispatch directly
+//! with the real registry. End-to-end defeat→Won via a real Fight is
+//! C7b (#245).
+
+use game_core::scenario::Resolution;
+use game_core::state::{Act, CardCode, InvestigatorId};
+
+#[test]
+fn defeating_ghoul_priest_advances_act_3_to_won() {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+
+    let inv = InvestigatorId(1);
+    let mut state = game_core::test_support::GameStateBuilder::new()
+        .with_turn_order([inv])
+        .build();
+    // Act 3 is current and terminal-Won (mirrors the_gathering setup()).
+    state.act_deck = vec![Act {
+        code: CardCode("01110".into()),
+        clue_threshold: 0,
+        resolution: Some(Resolution::Won { id: "R1".into() }),
+    }];
+
+    let mut events = Vec::new();
+    let out = game_core::test_support::fire_forced_on_enemy_defeat(
+        &mut state,
+        &mut events,
+        CardCode("01116".into()), // the Ghoul Priest
+    );
+    assert_eq!(out, game_core::engine::EngineOutcome::Done);
+    assert!(matches!(state.resolution, Some(Resolution::Won { .. })));
+}
+
+#[test]
+fn defeating_other_enemy_does_not_advance_act_3() {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+    let inv = InvestigatorId(1);
+    let mut state = game_core::test_support::GameStateBuilder::new()
+        .with_turn_order([inv])
+        .build();
+    state.act_deck = vec![Act {
+        code: CardCode("01110".into()),
+        clue_threshold: 0,
+        resolution: Some(Resolution::Won { id: "R1".into() }),
+    }];
+    let mut events = Vec::new();
+    let out = game_core::test_support::fire_forced_on_enemy_defeat(
+        &mut state,
+        &mut events,
+        CardCode("01103".into()), // some other enemy, not the Ghoul Priest
+    );
+    assert_eq!(out, game_core::engine::EngineOutcome::Done);
+    assert!(state.resolution.is_none(), "only the Ghoul Priest's defeat advances Act 3");
+}
+```
+
+- [ ] **Step 2: Run to verify they pass**
+
+Run: `cargo test -p cards --test act_advancement`
+Expected: PASS (2 tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cards/tests/act_advancement.rs
+git commit -m "test: defeating the Ghoul Priest advances Act 3 to Won (#228)"
+```
+
+---
+
+## Final: full CI gauntlet + phase doc
+
+- [ ] **Run the complete gauntlet** (all jobs, strict flags):
+
+```sh
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+```
+Expected: all green.
+
+- [ ] **Phase doc** (`docs/phases/phase-7-the-gathering.md`) is updated **as the final commit, only once the PR is green** (per the repo's PR procedure — not now): move C1b (#228) to the Closed table / flip its Arc row to `✅ PR #N`; add a **Decisions made** entry for the Pillar-2→C3c re-scope (#232) and the act-objective forced-vs-optional split; note new follow-ups #257, #258. Do **not** make this edit in an earlier task.
+
+---
+
+## Self-Review notes (author)
+
+- **Spec coverage:** Pillar 1 → Tasks 1–7; Pillar 3 → Tasks 8–13. Act-2 (Pillar 2) is explicitly out of scope (C3c/#232) — no task, by design. Deferral TODOs (#231, #257, #258, Phase 9) land in Tasks 5/6/11/12 doc-comments.
+- **Type consistency:** card-dsl codes are `String` (not `CardCode`); `Event::InvestigatorMoved.from` is a non-optional `LocationId` (Task 3 emits only when `from` is `Some`); `EventPattern`/`Trigger` lose `Copy` in Task 8 (match sites switch to `&ability.trigger`). `advance_act`/`request_resolution` bumped to `pub(crate)` in Task 4 for reuse in Task 9. **`Enemy` gains a `code: CardCode` field** in Task 10 Part A (it had none) — set in `test_enemy` (synthetic) and `spawn_enemy` (`metadata.code`); the defeat branch captures it before removal.
+- **Ordering:** Task 8 (drop `Copy`) precedes Task 11 (01110 uses the `code` field). Task 4's visibility bump precedes Task 9's reuse. Task 6 (set-aside build) precedes Task 7 (integration). All forced-dispatch behavior is exercised through `test_support` helpers + real-registry integration tests, mirroring the existing `fire_forced_on_enter` convention.

--- a/docs/superpowers/specs/2026-06-12-phase-7-slice-1-c1b-act-advancement-design.md
+++ b/docs/superpowers/specs/2026-06-12-phase-7-slice-1-c1b-act-advancement-design.md
@@ -185,7 +185,9 @@ single Won/R1 latch is retained; the R1-vs-R2 choice (01110 back) is Phase-9.
 
 ## State & DSL surface added
 
-- `GameState.set_aside_locations: Vec<Location>`.
+- `GameState.set_aside_locations: Vec<Location>`; `Enemy.code: CardCode` (the
+  `Enemy` struct carries no printed code today — needed so Act 3 can route on
+  the *defeated* enemy's code after it leaves `state.enemies`).
 - `card-dsl`: `EventPattern::ActAdvanced`; `EventPattern::EnemyDefeated.code:
   Option<CardCode>` (drops `Copy` from `EventPattern`/`Trigger` — see note);
   `Effect::{PutSetAsideLocationsIntoPlay, RelocateAllInvestigators,

--- a/docs/superpowers/specs/2026-06-12-phase-7-slice-1-c1b-act-advancement-design.md
+++ b/docs/superpowers/specs/2026-06-12-phase-7-slice-1-c1b-act-advancement-design.md
@@ -1,0 +1,227 @@
+# Phase 7 Slice 1 — C1b: Act advancement (reverse effects + objective types)
+
+Design for **C1b** ([#228](https://github.com/talelburg/eldritch/issues/228)) of
+Phase 7 Slice 1. Companion to the Group C decomposition
+(`2026-06-11-phase-7-slice-1-group-c-decomposition-design.md`) and the C1a
+skeleton it builds on (`crates/scenarios/src/the_gathering.rs`, PR #250).
+
+## Goal
+
+Make The Gathering's three-act spine real: the Act-1 board transition (the
+isolated Study expands into the four-location map) and the act-2 / act-3
+**objective types** that govern how those acts advance. After C1b, advancing
+act 1 rebuilds the board; act 2 advances by an optional round-end clue spend
+from the Hallway; act 3 advances — forced — when the Ghoul Priest is defeated.
+
+## Scope
+
+**In scope**
+
+- **Pillar 1** — Act-1 (01108) reverse effect: the board world-build, modeled
+  as a forced `OnEvent` ability *on the act card* (Option C below).
+- **Pillar 2** — Act-2 (01109) objective: a round-end, Hallway-restricted,
+  optional ("may") group clue-spend advance.
+- **Pillar 3** — Act-3 (01110) objective: a **forced** advance when the Ghoul
+  Priest (01116) is defeated, replacing C1a's placeholder clue threshold.
+
+**Out of scope (deferred, tracked — see Deferrals & follow-ups)**
+
+- Location reveal-on-entry + per-investigator clue placement → **#257**.
+- Act-2 back content: Ghoul Priest spawn → **#231** (C3b); Lita / Parlor
+  barrier → **#258**.
+- Act-3 back content: the R1/R2 resolution choice and its campaign-log
+  consequences → **Phase 9**.
+- End-to-end defeat→Won fidelity → **C7b** (#245); C1b proves act 3 with a
+  synthetic enemy.
+
+## Rules grounding
+
+Verified against the Rules Reference (`data/rules-reference/…`) and the card
+text (`data/arkhamdb-snapshot/pack/core/core_encounter.json`).
+
+**Forced vs. optional advancement — the card text draws the line.** Rules
+Reference p.3 (*Act Deck and Agenda Deck*): the act deck advances when the
+group spends the requisite clues, "normally done as a [Free] player ability …
+If the act has an 'Objective –' instruction, that instruction overrides or adds
+additional requirements." The two Gathering objectives are phrased
+deliberately differently:
+
+- 01109: "**Objective** – When the round ends, investigators in the hallway
+  **may**, as a group, spend the requisite number of clues to advance." → the
+  "may" makes it an **optional** player choice, timed to round end, restricted
+  to the Hallway.
+- 01110: "**Objective** – If the Ghoul Priest is Defeated, advance." → no
+  "may", and the act carries **no clue threshold** (`clues: null`), so the
+  optional clue-spend path does not exist. The bare conditional "advance" is
+  **forced**: the moment the Ghoul Priest is defeated, act 3 advances. Players
+  cannot choose to delay.
+
+**Reveal mechanic deferred.** Rules Reference p.14: locations enter play
+unrevealed and reveal (placing clues = clue value × #investigators) on first
+*investigator* entry. This is unmodeled today (`Location.revealed` is a dormant
+field; clues are flat). C1a already shipped the Study revealed with flat clues;
+C1b enters the set-aside locations the same way. The real mechanic is **#257**.
+
+## Design
+
+All three pillars build on the **existing forced-trigger + card-registry
+rails** (`engine/dispatch/forced_triggers.rs`): forced abilities are
+`Trigger::OnEvent { pattern, timing: After }` printed on scenario-structure
+cards, fired via `fire_forced_triggers(ForcedTriggerPoint)`. Single-trigger
+path (2+ simultaneous hits reject loudly, #213); each Gathering act back is one
+ability, so this holds.
+
+### Reverse effects live on the act cards (Option C)
+
+The `Act` struct's `code` field already exists specifically to "resolve the
+act's `Trigger::OnEvent` abilities through the card registry" — the
+architecture already anticipates registry-resolved act abilities. So an act's
+reverse effect is an `OnEvent` ability in `cards`, looked up by code, exactly
+like a playable card's abilities. New DSL primitives are scoped to **only what
+01108's back needs now** (act-2's spawn is C3-coupled; act-3's back is
+Phase-9), keeping the world-build vocabulary honest until a second scenario's
+acts inform it.
+
+### Pillar 1 — Act-1 (01108) reverse effect
+
+01108 back (verbatim): *"Put into play the set-aside Hallway, Cellar, Attic,
+and Parlor. Discard each enemy in the Study. Place each investigator in the
+Hallway. Remove the Study from the game."*
+
+**Dispatch.** Add `EventPattern::ActAdvanced` and
+`ForcedTriggerPoint::ActAdvanced { code }`. In `advance_act`, fire the
+**leaving** act's forced ability *before* moving the cursor (the reverse side
+resolves, then the next act becomes current — Rules Reference p.3 step order).
+
+**Ability.** `cards/src/impls/act_01108.rs` (or equivalent) exposes
+`abilities() -> [Ability { trigger: OnEvent { pattern: ActAdvanced, timing:
+After }, effect: Seq([...]) }]`.
+
+**New `Effect` primitives** (each addressing locations by card code, resolved
+to `LocationId` by the evaluator):
+
+- `PutSetAsideLocationsIntoPlay` — drains `state.set_aside_locations` into
+  `state.locations`.
+- `RelocateAllInvestigators { to: CardCode }` — moves every investigator to the
+  named location (here `"01112"`, the Hallway).
+- `RemoveLocationFromGame { location: CardCode }` — removes the named location
+  (here `"01111"`, the Study).
+- *"Discard each enemy in the Study"* → **deliberately omitted** as a faithful
+  no-op: nothing can spawn into the isolated Study in Slice-1 scope. Noted in
+  the ability's doc comment, not silently dropped.
+
+So 01108's effect is `Seq([PutSetAsideLocationsIntoPlay,
+RelocateAllInvestigators { to: "01112" }, RemoveLocationFromGame { location:
+"01111" }])`.
+
+**Set-aside representation.** Add `set_aside_locations: Vec<Location>` to
+`GameState` — an explicit Arkham "set aside, out of play" zone that later
+scenarios reuse (chosen over a `revealed`/`in_play` flag on `Location`).
+`setup()`:
+
+- Builds all five Location structs with the full Gathering connection graph
+  (scenario knowledge — no connection data exists in the corpus):
+  **Hallway (01112)** ↔ Attic (01113), Cellar (01114), Parlor (01115); the
+  **Study (01111)** isolated.
+- Puts the Study in `state.locations`; the other four in
+  `state.set_aside_locations`. All enter **revealed** with corpus clue counts
+  (reveal mechanic deferred to #257).
+
+The connections are wired at setup time against the LocationIds assigned to all
+five up front, so the four enter play already connected when act 1 advances.
+
+### Pillar 2 — Act-2 (01109) round-end objective
+
+01109 front (verbatim): *"When the round ends, investigators in the hallway
+may, as a group, spend the requisite number of clues to advance."* Clue
+threshold 3 (from the corpus).
+
+**Round-end hook.** "The round ends" = end of Upkeep (the Upkeep→Mythos
+boundary). Open the act-2 advancement window there.
+
+**Optional window.** It is a "may", so an optional `AwaitingInput` window: at
+round end, **iff** the current act is 01109 and investigators *at the Hallway*
+collectively hold ≥3 clues, offer "advance act 2?". Accept → spend 3 clues
+(Hallway-filtered contributors, reusing `spend_clues` + `advance_act` so the
+act-1-style reverse-effect path also fires for any future act-2 ability) →
+advance. Decline → proceed to Mythos. The Hallway filter is a Hallway-restricted
+variant of the existing `clue_contributors`.
+
+**Act-2 back** (Parlor reveal / Lita / Ghoul Priest spawn) is entirely
+deferred (see follow-ups); 01109 has no `abilities()` impl in C1b, so the
+forced on-advance dispatch finds nothing and returns `Done`.
+
+### Pillar 3 — Act-3 (01110) forced objective
+
+01110 front (verbatim): *"If the Ghoul Priest is Defeated, advance."* No clue
+threshold.
+
+**Dispatch.** Add `ForcedTriggerPoint::EnemyDefeated { code }`, fired from the
+enemy-defeat path in `combat.rs` (which already emits `Event::EnemyDefeated`).
+It scans the **current act** for a matching ability.
+
+**Pattern narrowing.** Extend `EventPattern::EnemyDefeated` with an optional
+`code: Option<CardCode>` narrow (so the act fires only on the Ghoul Priest's
+defeat, not any enemy's). `None` preserves today's any-defeat behavior.
+
+**Effect.** Add `Effect::AdvanceCurrentAct` — advances the current act (firing
+its terminal resolution if any). 01110's ability: `OnEvent { pattern:
+EnemyDefeated { code: Some("01116") }, timing: After } → AdvanceCurrentAct`.
+Advancing 01110 hits its terminal `Resolution::Won { id: "R1" }` — replacing
+C1a's placeholder clue threshold of 2.
+
+**Dormant until C3, tested now.** The Ghoul Priest (01116) does not exist until
+C3b (#231), so this path is **unit-tested in C1b with a synthetic enemy bearing
+code 01116**; the real defeat→Won is proven end-to-end in C7b (#245). The
+single Won/R1 latch is retained; the R1-vs-R2 choice (01110 back) is Phase-9.
+
+## State & DSL surface added
+
+- `GameState.set_aside_locations: Vec<Location>`.
+- `card-dsl`: `EventPattern::ActAdvanced`; `EventPattern::EnemyDefeated.code:
+  Option<CardCode>`; `Effect::{PutSetAsideLocationsIntoPlay,
+  RelocateAllInvestigators, RemoveLocationFromGame, AdvanceCurrentAct}`.
+- `engine`: `ForcedTriggerPoint::{ActAdvanced, EnemyDefeated}` + their dispatch
+  + evaluator arms for the new effects; round-end act-2 window at Upkeep end.
+- `cards`: `01108` abilities (reverse), `01110` abilities (objective).
+- `scenarios`: `setup()` builds five locations + graph + set-aside split; drops
+  the 01110 placeholder threshold.
+
+## Deferrals & follow-ups
+
+Every deferral gets a `TODO(#NN)` at the code site and a note in the phase doc.
+
+| Deferred | Surfaces at | Tracking |
+|---|---|---|
+| Ghoul Priest spawn in Hallway | act-2 back | `TODO(#231)` (C3b) |
+| Lita Chantler / Parlor barrier / Resign | act-2 back, 01115, R1 | `TODO(#258)` |
+| R1/R2 resolution choice + consequences | act-3 back | `TODO` → Phase 9 |
+| Location reveal-on-entry + per-inv clues | set-aside locations, Study | `TODO(#257)` |
+| End-to-end defeat→Won | act-3 objective | C7b (#245) |
+
+## Testing
+
+Per the test-layering convention (cards → engine unit → integration):
+
+- **Engine unit** (`act_agenda.rs`, `forced_triggers.rs`):
+  - Act-1 advance fires the world-build: set-aside locations move into play with
+    connections, all investigators relocate to the Hallway, the Study is
+    removed.
+  - Act-2 round-end window: offered only when current act is 01109 and Hallway
+    investigators hold ≥3 clues; accept spends 3 + advances; decline leaves
+    state unchanged; non-Hallway clues don't count.
+  - Act-3: a synthetic 01116 defeat advances 01110 → Won/R1 latch; an unrelated
+    enemy's defeat does not.
+- **Card tests** — 01108 and 01110 abilities (per the per-card convention).
+- **`the_gathering.rs` setup tests** — updated for the set-aside split and the
+  real 01110 objective (drop the placeholder-threshold assertions).
+- **Scenario integration** (`scenarios/tests/the_gathering.rs`) — drive setup →
+  advance act 1 → assert the four-location board, investigators in the Hallway,
+  Study gone, connections correct.
+
+## Open questions
+
+None blocking. The act-2 round-end window is the most novel surface; if the
+optional-input plumbing proves heavier than expected during planning, the
+fallback is to gate the existing action-driven `AdvanceAct` to round end — but
+the optional window is the faithful model and the current target.

--- a/docs/superpowers/specs/2026-06-12-phase-7-slice-1-c1b-act-advancement-design.md
+++ b/docs/superpowers/specs/2026-06-12-phase-7-slice-1-c1b-act-advancement-design.md
@@ -7,11 +7,11 @@ skeleton it builds on (`crates/scenarios/src/the_gathering.rs`, PR #250).
 
 ## Goal
 
-Make The Gathering's three-act spine real: the Act-1 board transition (the
-isolated Study expands into the four-location map) and the act-2 / act-3
-**objective types** that govern how those acts advance. After C1b, advancing
-act 1 rebuilds the board; act 2 advances by an optional round-end clue spend
-from the Hallway; act 3 advances — forced — when the Ghoul Priest is defeated.
+Make The Gathering's act spine real on the existing forced-trigger rails:
+the **Act-1 board transition** (the isolated Study expands into the four-
+location map) and the **Act-3 forced objective** (advance when the Ghoul Priest
+is defeated). Act 2's round-end objective is built later, in C3c (#232),
+alongside that slice's round-end dispatch — see Scope.
 
 ## Scope
 
@@ -19,13 +19,25 @@ from the Hallway; act 3 advances — forced — when the Ghoul Priest is defeate
 
 - **Pillar 1** — Act-1 (01108) reverse effect: the board world-build, modeled
   as a forced `OnEvent` ability *on the act card* (Option C below).
-- **Pillar 2** — Act-2 (01109) objective: a round-end, Hallway-restricted,
-  optional ("may") group clue-spend advance.
 - **Pillar 3** — Act-3 (01110) objective: a **forced** advance when the Ghoul
   Priest (01116) is defeated, replacing C1a's placeholder clue threshold.
 
+Both ride the existing forced-trigger rails (`fire_forced_triggers` /
+`ForcedTriggerPoint`) with **no new window/suspend machinery**.
+
 **Out of scope (deferred, tracked — see Deferrals & follow-ups)**
 
+- **Pillar 2 — Act-2 (01109) round-end objective → moved to C3c (#232).**
+  Planning found that a faithful "may, as a group, spend clues *when the round
+  ends*" needs a suspendable round-end **player window** (the engine must pause
+  at round end to offer the choice) — substantial new suspend machinery that
+  directly overlaps C3c, which is *already* adding the round-end dispatch point
+  (`ForcedTriggerPoint::RoundEnded`) for the agenda's forced doom. Building the
+  round-end window once, in C3c, shared by act-2's optional advance and the
+  agenda doom, avoids building it twice and avoids rework against #212's
+  emit_event restructure. Act 2 keeps its current functional clue-spend
+  (action-driven `AdvanceAct`, threshold 3) in the interim — playable, not yet
+  round-end-faithful.
 - Location reveal-on-entry + per-investigator clue placement → **#257**.
 - Act-2 back content: Ghoul Priest spawn → **#231** (C3b); Lita / Parlor
   barrier → **#258**.
@@ -130,26 +142,22 @@ scenarios reuse (chosen over a `revealed`/`in_play` flag on `Location`).
 The connections are wired at setup time against the LocationIds assigned to all
 five up front, so the four enter play already connected when act 1 advances.
 
-### Pillar 2 — Act-2 (01109) round-end objective
+### Pillar 2 — Act-2 (01109) round-end objective → C3c (#232)
 
 01109 front (verbatim): *"When the round ends, investigators in the hallway
-may, as a group, spend the requisite number of clues to advance."* Clue
-threshold 3 (from the corpus).
+may, as a group, spend the requisite number of clues to advance."*
 
-**Round-end hook.** "The round ends" = end of Upkeep (the Upkeep→Mythos
-boundary). Open the act-2 advancement window there.
-
-**Optional window.** It is a "may", so an optional `AwaitingInput` window: at
-round end, **iff** the current act is 01109 and investigators *at the Hallway*
-collectively hold ≥3 clues, offer "advance act 2?". Accept → spend 3 clues
-(Hallway-filtered contributors, reusing `spend_clues` + `advance_act` so the
-act-1-style reverse-effect path also fires for any future act-2 ability) →
-advance. Decline → proceed to Mythos. The Hallway filter is a Hallway-restricted
-variant of the existing `clue_contributors`.
-
-**Act-2 back** (Parlor reveal / Lita / Ghoul Priest spawn) is entirely
-deferred (see follow-ups); 01109 has no `abilities()` impl in C1b, so the
-forced on-advance dispatch finds nothing and returns `Done`.
+**Moved out of C1b during planning.** Faithfully, the engine must *pause at
+round end* to offer the optional "may" choice — i.e. a suspendable round-end
+**player window** threaded through `upkeep_phase_end` (today a `()`-returning,
+non-suspending step) plus `AdvanceAct` re-gating and a Hallway-restricted
+contributor filter. That is substantial new suspend/window machinery, and it
+lands on the **same round-end point** C3c (#232) is already adding
+(`ForcedTriggerPoint::RoundEnded`, for the agenda's forced doom). Building the
+window once in C3c — shared by act-2's optional advance and the agenda doom —
+avoids duplicate machinery and rework against #212. C1b leaves act 2 on its
+current action-driven `AdvanceAct` (threshold 3): functional, not yet
+round-end-faithful.
 
 ### Pillar 3 — Act-3 (01110) forced objective
 
@@ -179,11 +187,22 @@ single Won/R1 latch is retained; the R1-vs-R2 choice (01110 back) is Phase-9.
 
 - `GameState.set_aside_locations: Vec<Location>`.
 - `card-dsl`: `EventPattern::ActAdvanced`; `EventPattern::EnemyDefeated.code:
-  Option<CardCode>`; `Effect::{PutSetAsideLocationsIntoPlay,
-  RelocateAllInvestigators, RemoveLocationFromGame, AdvanceCurrentAct}`.
-- `engine`: `ForcedTriggerPoint::{ActAdvanced, EnemyDefeated}` + their dispatch
-  + evaluator arms for the new effects; round-end act-2 window at Upkeep end.
+  Option<CardCode>` (drops `Copy` from `EventPattern`/`Trigger` — see note);
+  `Effect::{PutSetAsideLocationsIntoPlay, RelocateAllInvestigators,
+  RemoveLocationFromGame, AdvanceCurrentAct}`.
+- `engine`: `ForcedTriggerPoint::{ActAdvanced, EnemyDefeated}` + their
+  `collect_forced_hits` arms; evaluator arms for the new effects; `advance_act`
+  and the `damage_enemy` defeat path fire their forced points (the `()`-return
+  sites use the established `debug_assert!(matches!(_, Done))` guard).
 - `cards`: `01108` abilities (reverse), `01110` abilities (objective).
+
+**`Copy` note:** adding a `CardCode` (`String`-backed) field to
+`EventPattern::EnemyDefeated` removes the `Copy` derive from `EventPattern` and
+`Trigger`. The ~4 sites that move out of `ability.trigger` by `Copy`
+(`forced_triggers`, `reaction_windows`, `abilities`, `skill_test`) switch to
+`&ability.trigger` with reference patterns; `push_matching`'s `want:
+impl Fn(EventPattern)` becomes `Fn(&EventPattern)`. Bounded, and honest DSL
+growth (string-bearing patterns are inevitable).
 - `scenarios`: `setup()` builds five locations + graph + set-aside split; drops
   the 01110 placeholder threshold.
 
@@ -193,6 +212,7 @@ Every deferral gets a `TODO(#NN)` at the code site and a note in the phase doc.
 
 | Deferred | Surfaces at | Tracking |
 |---|---|---|
+| Act-2 round-end objective (the window) | act 2 front | C3c (**#232**) |
 | Ghoul Priest spawn in Hallway | act-2 back | `TODO(#231)` (C3b) |
 | Lita Chantler / Parlor barrier / Resign | act-2 back, 01115, R1 | `TODO(#258)` |
 | R1/R2 resolution choice + consequences | act-3 back | `TODO` → Phase 9 |
@@ -203,16 +223,16 @@ Every deferral gets a `TODO(#NN)` at the code site and a note in the phase doc.
 
 Per the test-layering convention (cards → engine unit → integration):
 
-- **Engine unit** (`act_agenda.rs`, `forced_triggers.rs`):
+- **Engine unit** (`act_agenda.rs`, `forced_triggers.rs`, `evaluator.rs`):
   - Act-1 advance fires the world-build: set-aside locations move into play with
     connections, all investigators relocate to the Hallway, the Study is
     removed.
-  - Act-2 round-end window: offered only when current act is 01109 and Hallway
-    investigators hold ≥3 clues; accept spends 3 + advances; decline leaves
-    state unchanged; non-Hallway clues don't count.
   - Act-3: a synthetic 01116 defeat advances 01110 → Won/R1 latch; an unrelated
-    enemy's defeat does not.
+    enemy's defeat does not (code narrowing).
 - **Card tests** — 01108 and 01110 abilities (per the per-card convention).
+- **Integration** (`crates/cards/tests/`, real registry): act-1 reverse fires
+  through `fire_forced_triggers` end-to-end; defeating a real corpus 01116
+  enemy advances act 3 to Won.
 - **`the_gathering.rs` setup tests** — updated for the set-aside split and the
   real 01110 objective (drop the placeholder-threshold assertions).
 - **Scenario integration** (`scenarios/tests/the_gathering.rs`) — drive setup →
@@ -221,7 +241,7 @@ Per the test-layering convention (cards → engine unit → integration):
 
 ## Open questions
 
-None blocking. The act-2 round-end window is the most novel surface; if the
-optional-input plumbing proves heavier than expected during planning, the
-fallback is to gate the existing action-driven `AdvanceAct` to round end — but
-the optional window is the faithful model and the current target.
+None blocking. Act 2's round-end objective is the deferred surface (→ C3c
+#232); C1b's two pillars both extend the existing single-trigger forced path,
+so the only genuinely new engine surface is the four DSL effects and the
+`EventPattern` `Copy`→`Clone` adjustment.


### PR DESCRIPTION
## Summary

Phase-7 Slice-1 **C1b** ([#228](https://github.com/talelburg/eldritch/issues/228)): makes The Gathering's act spine real. Advancing **Act 1 (01108)** rebuilds the board (the four set-aside locations enter play, investigators move to the Hallway, the Study is removed); **Act 3 (01110)** advances — forced — when the Ghoul Priest (01116) is defeated, latching the Won resolution. Both ride the existing forced-trigger rails; no new window/suspend machinery.

## What changed

**Pillar 1 — Act-1 reverse board build**
- New DSL: `EventPattern::ActAdvanced`; effects `PutSetAsideLocationsIntoPlay`, `RelocateAllInvestigators { to }`, `RemoveLocationFromGame { location }` (+ builders, evaluator arms).
- New `GameState.set_aside_locations` zone. `the_gathering::setup()` now builds all five locations + the connection graph (Hallway hub ↔ Attic/Cellar/Parlor; Study isolated), Study in play + the four others set aside.
- `ForcedTriggerPoint::ActAdvanced` fired from `advance_act` (before the cursor moves). 01108 gets a Forced `OnEvent(ActAdvanced)` ability = `Seq[PutSetAside, Relocate("01112"), Remove("01111")]`.

**Pillar 3 — Act-3 forced advance-on-defeat**
- `EventPattern::EnemyDefeated` gains an `Option<String>` enemy-code narrow (this dropped `Copy` from `EventPattern`/`Trigger`; by-value match sites switched to references).
- New `Effect::AdvanceCurrentAct`; `Enemy` gains a `code: CardCode` field (set in `spawn_enemy` from metadata + the `test_enemy` fixture).
- `ForcedTriggerPoint::EnemyDefeated { code }` fired from `damage_enemy` (code captured before removal), scanning the current act. 01110's ability = `OnEvent(EnemyDefeated{code:Some("01116")}) -> AdvanceCurrentAct`; `setup()` drops 01110's placeholder clue threshold (→ 0, advances via the objective).

**Design decisions** (full detail in `docs/superpowers/specs/2026-06-12-phase-7-slice-1-c1b-act-advancement-design.md`):
- *Reverse effects live on the act cards* (registry-resolved `OnEvent` abilities), not engine-side — the `Act.code` field already anticipated this. New DSL primitives scoped to just 01108's back.
- *Forced vs. optional is drawn from the card text*: 01110 has no "may" and no clue threshold → forced (verified against Rules Reference p.3 + the snapshot); 01109's "may … when the round ends" is optional.
- **Act-2 (01109) round-end objective is out of scope** — its faithful "may, as a group, at round end" needs a suspendable round-end window that overlaps C3c ([#232](https://github.com/talelburg/eldritch/issues/232))'s round-end dispatch, so it's built once there. Noted on #232. Act 2 keeps the interim action-driven `AdvanceAct`.

**Deferrals tracked:** Ghoul Priest spawn → #231; location reveal-on-entry + per-investigator clues → #257 (filed); Lita/Parlor barrier/Resign → #258 (filed); R1/R2 resolution choice → Phase 9.

## Test notes

- Engine unit tests: evaluator arms (set-aside drain, relocate, remove + missing-code reject); `AdvanceCurrentAct` (terminal latch / non-terminal bump); no-registry no-op regressions for both new fire sites.
- Card tests: 01108 and 01110 ability shapes.
- Integration: `crates/scenarios/tests/the_gathering.rs::advancing_act_1_rebuilds_the_board` (full board rebuild via public `AdvanceAct`); `crates/cards/tests/act_advancement.rs` (defeat 01116 → Won, and the negative case — a different enemy does not advance).
- Full local gauntlet green: fmt, `RUSTFLAGS="-D warnings"` test (all crates), clippy, doc, wasm-build, wasm-clippy. (wasm-test needs headless Firefox; web crate logic untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Linked issues

Closes #228