### PR TITLE
Location construction helper: GameState id allocation + add_location (#260)

### DIFF
--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -269,6 +269,7 @@ impl GameStateBuilder {
             mulligan_pending: self.mulligan_pending,
             next_card_instance_id: 0,
             next_enemy_id: 0,
+            next_location_id: 0,
             pending_skill_modifiers: Vec::new(),
             in_flight_skill_test: None,
             open_windows: self.open_windows,

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -106,6 +106,12 @@ pub struct GameState {
     /// because [`EnemyId`] and [`CardInstanceId`] are distinct types —
     /// enemies aren't tracked in the `CardInPlay` registry.
     pub next_enemy_id: u32,
+    /// Monotonic counter for assigning [`LocationId`]s when scenarios
+    /// build their board via `add_location` / `add_set_aside_location`
+    /// (added in a later task). Starts at 0 and increments after each
+    /// assignment; guarantees uniqueness within a scenario and
+    /// deterministic ids across replays.
+    pub next_location_id: u32,
     /// In-flight skill modifiers contributed by activated / triggered
     /// abilities with [`ModifierScope::ThisSkillTest`] scope.
     /// Accumulates between activation and skill-test resolution; the
@@ -915,6 +921,26 @@ mod fast_actor_scope_tests {
             let back: FastActorScope = serde_json::from_str(&json).expect("deserialize");
             assert_eq!(back, scope);
         }
+    }
+}
+
+#[cfg(test)]
+mod next_location_id_tests {
+    use crate::test_support::GameStateBuilder;
+
+    #[test]
+    fn game_state_starts_next_location_id_at_zero() {
+        let state = GameStateBuilder::new().build();
+        assert_eq!(state.next_location_id, 0);
+    }
+
+    #[test]
+    fn next_location_id_round_trips_through_serde() {
+        let mut state = GameStateBuilder::new().build();
+        state.next_location_id = 7;
+        let json = serde_json::to_string(&state).expect("serialize");
+        let back: crate::state::GameState = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.next_location_id, 7);
     }
 }
 

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -898,6 +898,29 @@ impl GameState {
         self.set_aside_locations.push(loc);
         id
     }
+
+    /// Find a location by id across both the in-play and set-aside zones.
+    fn location_mut(&mut self, id: LocationId) -> Option<&mut Location> {
+        if let Some(loc) = self.locations.get_mut(&id) {
+            return Some(loc);
+        }
+        self.set_aside_locations.iter_mut().find(|l| l.id == id)
+    }
+
+    /// Wire a **bidirectional** connection between two locations (each gains
+    /// the other in its `connections`). Resolves both ids across the in-play
+    /// and set-aside zones. `expect`s each to exist — a build-time invariant
+    /// (callers connect freshly-minted ids).
+    pub fn connect(&mut self, a: LocationId, b: LocationId) {
+        self.location_mut(a)
+            .unwrap_or_else(|| panic!("connect: location {a:?} not found"))
+            .connections
+            .push(b);
+        self.location_mut(b)
+            .unwrap_or_else(|| panic!("connect: location {b:?} not found"))
+            .connections
+            .push(a);
+    }
 }
 
 #[cfg(test)]
@@ -1228,6 +1251,75 @@ mod add_location_tests {
             },
         };
         state.add_location(&meta);
+    }
+}
+
+#[cfg(test)]
+mod connect_tests {
+    use crate::state::{CardCode, Location, LocationId};
+    use crate::test_support::GameStateBuilder;
+
+    #[test]
+    fn connect_wires_both_directions() {
+        let mut state = GameStateBuilder::new()
+            .with_location(Location::new(
+                LocationId(1),
+                CardCode("a".into()),
+                "A",
+                1,
+                0,
+            ))
+            .with_location(Location::new(
+                LocationId(2),
+                CardCode("b".into()),
+                "B",
+                1,
+                0,
+            ))
+            .build();
+        state.connect(LocationId(1), LocationId(2));
+        assert_eq!(
+            state.locations[&LocationId(1)].connections,
+            vec![LocationId(2)]
+        );
+        assert_eq!(
+            state.locations[&LocationId(2)].connections,
+            vec![LocationId(1)]
+        );
+    }
+
+    #[test]
+    fn connect_resolves_set_aside_locations() {
+        // Both endpoints live in the set-aside zone (The Gathering wires
+        // its board there before Act 1 brings it into play).
+        let mut state = GameStateBuilder::new().build();
+        state.set_aside_locations.push(Location::new(
+            LocationId(2),
+            CardCode("hub".into()),
+            "Hub",
+            1,
+            0,
+        ));
+        state.set_aside_locations.push(Location::new(
+            LocationId(3),
+            CardCode("spoke".into()),
+            "Spoke",
+            1,
+            0,
+        ));
+        state.connect(LocationId(2), LocationId(3));
+        let hub = state
+            .set_aside_locations
+            .iter()
+            .find(|l| l.id == LocationId(2))
+            .unwrap();
+        let spoke = state
+            .set_aside_locations
+            .iter()
+            .find(|l| l.id == LocationId(3))
+            .unwrap();
+        assert_eq!(hub.connections, vec![LocationId(3)]);
+        assert_eq!(spoke.connections, vec![LocationId(2)]);
     }
 }
 

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -12,6 +12,7 @@ use super::{
     location::{Location, LocationId},
     phase::Phase,
 };
+use crate::card_data::{CardKind, CardMetadata};
 use crate::dsl::{SkillTestKind, Stat};
 use crate::rng::RngState;
 use card_dsl::card_data::SkillKind;
@@ -848,6 +849,55 @@ impl GameState {
             .iter()
             .rposition(|w| !w.pending_triggers.is_empty())
     }
+
+    /// Mint a fresh, deterministic [`LocationId`] (sequential from
+    /// `next_location_id`).
+    fn mint_location_id(&mut self) -> LocationId {
+        let id = LocationId(self.next_location_id);
+        self.next_location_id = self.next_location_id.saturating_add(1);
+        id
+    }
+
+    /// Build a [`Location`] from its card `metadata`, minting a fresh id.
+    /// Panics if `metadata` is not a `Location` card (a build-time
+    /// invariant — scenarios hand their own location cards).
+    fn location_from_metadata(&mut self, metadata: &CardMetadata) -> Location {
+        let (shroud, clues) = match &metadata.kind {
+            CardKind::Location { shroud, clues, .. } => (*shroud, *clues),
+            other => panic!(
+                "add_location: card {} is not a Location ({other:?})",
+                metadata.code
+            ),
+        };
+        let id = self.mint_location_id();
+        Location::new(
+            id,
+            CardCode::new(metadata.code.clone()),
+            metadata.name.clone(),
+            shroud,
+            clues,
+        )
+    }
+
+    /// Add a location **into play** from its card metadata, returning the
+    /// minted [`LocationId`]. The id is deterministic (construction order),
+    /// so scenarios never hand-pick id literals.
+    pub fn add_location(&mut self, metadata: &CardMetadata) -> LocationId {
+        let loc = self.location_from_metadata(metadata);
+        let id = loc.id;
+        self.locations.insert(id, loc);
+        id
+    }
+
+    /// Add a location to the **set-aside** (out-of-play) zone from its card
+    /// metadata, returning the minted [`LocationId`]. Card effects (e.g. The
+    /// Gathering's Act-1 reverse) later move it into play.
+    pub fn add_set_aside_location(&mut self, metadata: &CardMetadata) -> LocationId {
+        let loc = self.location_from_metadata(metadata);
+        let id = loc.id;
+        self.set_aside_locations.push(loc);
+        id
+    }
 }
 
 #[cfg(test)]
@@ -1114,6 +1164,70 @@ mod partial_eq_tests {
     fn game_state_is_partial_eq() {
         fn assert_partial_eq<T: PartialEq>() {}
         assert_partial_eq::<GameState>();
+    }
+}
+
+#[cfg(test)]
+mod add_location_tests {
+    use crate::card_data::{CardKind, CardMetadata};
+    use crate::test_support::GameStateBuilder;
+
+    fn location_meta(code: &str, name: &str, shroud: u8, clues: u8) -> CardMetadata {
+        CardMetadata {
+            code: code.to_string(),
+            name: name.to_string(),
+            traits: vec![],
+            text: None,
+            pack_code: "core".to_string(),
+            kind: CardKind::Location {
+                shroud,
+                clues,
+                victory: None,
+            },
+        }
+    }
+
+    #[test]
+    fn add_location_mints_sequential_ids_and_extracts_metadata() {
+        let mut state = GameStateBuilder::new().build();
+        let a = state.add_location(&location_meta("01111", "Study", 2, 2));
+        let b = state.add_location(&location_meta("01112", "Hallway", 1, 0));
+        assert_ne!(a, b, "ids are distinct");
+        let study = &state.locations[&a];
+        assert_eq!(study.code.as_str(), "01111");
+        assert_eq!(study.name, "Study");
+        assert_eq!((study.shroud, study.clues), (2, 2));
+        assert!(study.connections.is_empty());
+        assert!(study.revealed);
+        assert_eq!(state.next_location_id, 2, "counter advanced twice");
+    }
+
+    #[test]
+    fn add_set_aside_location_goes_to_the_set_aside_zone() {
+        let mut state = GameStateBuilder::new().build();
+        let id = state.add_set_aside_location(&location_meta("01113", "Attic", 1, 2));
+        assert!(!state.locations.contains_key(&id), "not in play");
+        assert_eq!(state.set_aside_locations.len(), 1);
+        assert_eq!(state.set_aside_locations[0].id, id);
+        assert_eq!(state.set_aside_locations[0].code.as_str(), "01113");
+    }
+
+    #[test]
+    #[should_panic(expected = "not a Location")]
+    fn add_location_panics_on_non_location_metadata() {
+        let mut state = GameStateBuilder::new().build();
+        let meta = CardMetadata {
+            code: "01108".to_string(),
+            name: "Trapped".to_string(),
+            traits: vec![],
+            text: None,
+            pack_code: "core".to_string(),
+            kind: CardKind::Act {
+                clue_threshold: Some(2),
+                victory: None,
+            },
+        };
+        state.add_location(&meta);
     }
 }
 

--- a/crates/scenarios/src/the_gathering.rs
+++ b/crates/scenarios/src/the_gathering.rs
@@ -5,7 +5,8 @@
 //! enter play via Act 1's (01108) Forced on-advance reverse, which also
 //! relocates investigators to the Hallway and removes the Study).
 //! `setup()` builds the world; the `StartScenario` roster step seats
-//! investigators at [`STUDY_ID`] via `GameState.starting_location`.
+//! investigators at the starting location (the Study, `01111`) via
+//! `GameState.starting_location`.
 //!
 //! Faithful where it can be (agenda doom 3/7/10; the verified Standard
 //! chaos bag; Study shroud/clues); structural stand-in where the rest of
@@ -19,18 +20,8 @@ use game_core::card_data::CardKind;
 use game_core::event::Event;
 use game_core::scenario::{Resolution, ScenarioId, ScenarioModule};
 use game_core::state::{
-    Act, Agenda, CardCode, ChaosBag, ChaosToken, GameState, GameStateBuilder, Location, LocationId,
-    TokenModifiers,
+    Act, Agenda, CardCode, ChaosBag, ChaosToken, GameState, GameStateBuilder, TokenModifiers,
 };
-
-/// Read a location's printed `(shroud, clues)` from the generated corpus.
-/// The code is a build-time invariant of the corpus, so a miss is a bug.
-fn location_stats(code: &str) -> (u8, u8) {
-    match cards::by_code(code).expect("location code in corpus").kind {
-        CardKind::Location { shroud, clues, .. } => (shroud, clues),
-        ref k => panic!("{code} is not a Location ({k:?})"),
-    }
-}
 
 /// Read an agenda's printed doom threshold from the corpus.
 fn agenda_doom(code: &str) -> u8 {
@@ -54,9 +45,6 @@ pub const ID: &str = "the-gathering";
 
 /// `ArkhamDB` reference-card code (chaos-symbol effects; evaluated in C2).
 pub const REFERENCE_CARD: &str = "01104";
-
-/// The Study's [`LocationId`] — the scenario's starting location.
-pub const STUDY_ID: LocationId = LocationId(1);
 
 /// The verified Standard-difficulty Night of the Zealot chaos bag (16
 /// tokens). Source: `data/campaign-guides/SOURCE.md` (campaign guide
@@ -83,50 +71,11 @@ fn standard_chaos_bag() -> ChaosBag {
     ])
 }
 
-/// The Hallway's [`LocationId`] — the hub of the Act-2 board.
-const HALLWAY_ID: LocationId = LocationId(2);
-/// The Attic's [`LocationId`].
-const ATTIC_ID: LocationId = LocationId(3);
-/// The Cellar's [`LocationId`].
-const CELLAR_ID: LocationId = LocationId(4);
-/// The Parlor's [`LocationId`].
-const PARLOR_ID: LocationId = LocationId(5);
-
 /// Build the initial [`GameState`]: the Study in play (isolated), the
 /// four set-aside locations (Hallway/Attic/Cellar/Parlor, pre-connected),
 /// the act/agenda decks, the Standard chaos bag, and `starting_location`.
 /// No investigators — the `StartScenario` roster step seats them.
 pub fn setup() -> GameState {
-    // The Study (01111): shroud/clues read from the corpus. `Location::new`
-    // gives a revealed, unconnected location (Act 1 is "trapped in the Study").
-    let (study_shroud, study_clues) = location_stats("01111");
-    let study = Location::new(
-        STUDY_ID,
-        CardCode("01111".into()),
-        "Study",
-        study_shroud,
-        study_clues,
-    );
-
-    // LocationIds 2–5: the four set-aside locations. Connections are wired
-    // here (scenario map knowledge — the corpus carries none) so they enter
-    // play already connected when Act 1's (01108) Forced on-advance reverse
-    // fires. The Hallway is the hub; Attic/Cellar/Parlor are the spokes.
-    // TODO(#260): replace the hand-assigned LocationIds + manual connection
-    // wiring with a location-construction/id-allocation helper.
-    let make = |id: LocationId, code: &str, name: &str| {
-        let (shroud, clues) = location_stats(code);
-        Location::new(id, CardCode(code.into()), name, shroud, clues)
-    };
-    let mut hallway = make(HALLWAY_ID, "01112", "Hallway");
-    hallway.connections = vec![ATTIC_ID, CELLAR_ID, PARLOR_ID];
-    let mut attic = make(ATTIC_ID, "01113", "Attic");
-    attic.connections = vec![HALLWAY_ID];
-    let mut cellar = make(CELLAR_ID, "01114", "Cellar");
-    cellar.connections = vec![HALLWAY_ID];
-    let mut parlor = make(PARLOR_ID, "01115", "Parlor");
-    parlor.connections = vec![HALLWAY_ID];
-
     // The Gathering's symbol effects are printed on reference card 01104
     // (board-dependent; evaluated in C2). Until then these flat NotZ
     // fallbacks stand in; they are off the C1a structural test path.
@@ -139,14 +88,29 @@ pub fn setup() -> GameState {
     token_modifiers.elder_thing = -4;
 
     let mut state = GameStateBuilder::new()
-        .with_location(study)
         .with_chaos_bag(standard_chaos_bag())
         .with_scenario_id(ScenarioId::new(ID))
         .with_token_modifiers(token_modifiers)
         .build();
 
-    state.starting_location = Some(STUDY_ID);
-    state.set_aside_locations = vec![hallway, attic, cellar, parlor];
+    // The Gathering board. Ids are minted by `add_location` /
+    // `add_set_aside_location` (deterministic, construction order), so no
+    // hand-assigned LocationId literals. The scenario looks up each
+    // location's metadata in the corpus and hands it to the engine; stats
+    // (shroud/clues) come from the metadata. The Study starts in play
+    // (isolated — Act 1 is "trapped in the Study"); the Hallway hub +
+    // Attic/Cellar/Parlor spokes are set aside until Act 1's (01108)
+    // Forced on-advance reverse brings them into play.
+    let meta = |code: &str| cards::by_code(code).expect("Gathering location in corpus");
+    let study = state.add_location(meta("01111"));
+    let hallway = state.add_set_aside_location(meta("01112"));
+    let attic = state.add_set_aside_location(meta("01113"));
+    let cellar = state.add_set_aside_location(meta("01114"));
+    let parlor = state.add_set_aside_location(meta("01115"));
+    state.connect(hallway, attic);
+    state.connect(hallway, cellar);
+    state.connect(hallway, parlor);
+    state.starting_location = Some(study);
 
     // Act deck 01108 -> 01109 -> 01110. Clue thresholds read from the
     // corpus. 01110 advances via its Forced EnemyDefeated objective
@@ -225,7 +189,7 @@ mod tests {
         // cards::by_code. Pinning them guards both the corpus data and
         // the reader helpers.
         let s = setup();
-        let study = s.locations.get(&STUDY_ID).unwrap();
+        let study = &s.locations[&s.starting_location.unwrap()];
         assert_eq!((study.shroud, study.clues), (2, 2), "Study 01111 stats");
         assert_eq!(
             s.agenda_deck
@@ -244,7 +208,7 @@ mod tests {
         let s = setup();
         // In play: only the Study (Act-1 board).
         assert_eq!(s.locations.len(), 1);
-        let study = s.locations.get(&STUDY_ID).expect("Study present");
+        let study = &s.locations[&s.starting_location.unwrap()];
         assert_eq!(study.code, CardCode("01111".into()));
         assert!(study.connections.is_empty(), "Study is isolated");
         // Set aside: Hallway, Attic, Cellar, Parlor, each pre-connected.
@@ -283,7 +247,10 @@ mod tests {
                 "spokes connect back to the Hallway"
             );
         }
-        assert_eq!(s.starting_location, Some(STUDY_ID));
+        assert_eq!(
+            s.locations[&s.starting_location.unwrap()].code.as_str(),
+            "01111"
+        );
         assert!(s.investigators.is_empty(), "setup() seats no one");
     }
 

--- a/crates/scenarios/tests/the_gathering.rs
+++ b/crates/scenarios/tests/the_gathering.rs
@@ -67,9 +67,9 @@ fn roster_seating_places_investigator_at_study() {
         .investigators
         .get(&InvestigatorId(1))
         .expect("Roland seated");
+    let study = state.starting_location;
     assert_eq!(
-        roland.current_location,
-        Some(the_gathering::STUDY_ID),
+        roland.current_location, study,
         "seating must place investigators at setup()'s starting_location",
     );
 }
@@ -152,7 +152,7 @@ fn advancing_act_1_rebuilds_the_board() {
     // Seat one investigator at the Study with the 2 clues Act 1 needs.
     let inv = InvestigatorId(1);
     let mut investigator = test_investigator(1);
-    investigator.current_location = Some(the_gathering::STUDY_ID);
+    investigator.current_location = state.starting_location;
     investigator.clues = 2;
     state.investigators.insert(inv, investigator);
     state.turn_order = vec![inv];

--- a/docs/superpowers/plans/2026-06-12-location-construction-helper.md
+++ b/docs/superpowers/plans/2026-06-12-location-construction-helper.md
@@ -1,0 +1,417 @@
+# Location construction helper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hand-assigned `LocationId` literals + manual connection wiring in `the_gathering::setup()` with `GameState`-owned, deterministic location id allocation + metadata-driven construction methods, mirroring the existing `next_enemy_id` allocator.
+
+**Architecture:** `GameState` gains a `next_location_id` counter and three registry-free methods: `add_location(&CardMetadata)` and `add_set_aside_location(&CardMetadata)` (mint a deterministic id, build a `Location` from the passed card metadata, insert into `locations` / `set_aside_locations`), and `connect(a, b)` (bidirectional, resolving ids across both zones). The scenario does its own `cards::by_code` corpus lookup and passes the `&CardMetadata` in — so game-core stays registry-free and the methods are directly unit-testable. `STUDY_ID` is removed in favour of `GameState.starting_location`.
+
+**Tech Stack:** Rust workspace. `game-core` (state), `scenarios` (`the_gathering`). `CardMetadata`/`CardKind` live in `card-dsl`, re-exported at `game_core::card_data`. Codes are `String` in card-dsl; `CardCode` is game-core's newtype.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-location-construction-helper-design.md`
+
+**CI gauntlet (run before every task-completing commit):**
+```sh
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+```
+
+---
+
+### Task 1: `next_location_id` counter on `GameState`
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (struct `GameState`, after the `next_enemy_id` field ~line 108)
+- Modify: `crates/game-core/src/state/builder.rs` (`build()`, alongside `next_enemy_id: 0`)
+- Test: `crates/game-core/src/state/game_state.rs` (`#[cfg(test)]`)
+
+- [ ] **Step 1: Write the failing test** (add to / create a test module in `game_state.rs`):
+
+```rust
+#[cfg(test)]
+mod next_location_id_tests {
+    use crate::test_support::GameStateBuilder;
+
+    #[test]
+    fn game_state_starts_next_location_id_at_zero() {
+        let state = GameStateBuilder::new().build();
+        assert_eq!(state.next_location_id, 0);
+    }
+
+    #[test]
+    fn next_location_id_round_trips_through_serde() {
+        let mut state = GameStateBuilder::new().build();
+        state.next_location_id = 7;
+        let json = serde_json::to_string(&state).expect("serialize");
+        let back: crate::state::GameState = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.next_location_id, 7);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p game-core next_location_id`
+Expected: FAIL — `no field next_location_id on type GameState`.
+
+- [ ] **Step 3: Add the field** to `GameState`, immediately after `pub next_enemy_id: u32,` (mirror its doc):
+
+```rust
+    /// Monotonic counter for assigning [`LocationId`]s when scenarios
+    /// build their board via [`add_location`](Self::add_location) /
+    /// [`add_set_aside_location`](Self::add_set_aside_location). Starts
+    /// at 0 and increments after each assignment; guarantees uniqueness
+    /// within a scenario and deterministic ids across replays.
+    pub next_location_id: u32,
+```
+
+Initialize it in `builder.rs`'s `build()` literal, next to `next_enemy_id: 0,`:
+
+```rust
+            next_location_id: 0,
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p game-core next_location_id`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/game-core/src/state/game_state.rs crates/game-core/src/state/builder.rs
+git commit -m "engine: add next_location_id counter to GameState (#260)"
+```
+
+---
+
+### Task 2: `add_location` / `add_set_aside_location` (metadata-driven)
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (an `impl GameState` block + imports)
+- Test: `crates/game-core/src/state/game_state.rs` (`#[cfg(test)]`)
+
+Registry-free: the caller passes the `&CardMetadata`. `CardMetadata`/`CardKind` come from `crate::card_data`; `CardKind::Location { shroud: u8, clues: u8, victory: Option<u8> }`.
+
+- [ ] **Step 1: Write the failing tests:**
+
+```rust
+#[cfg(test)]
+mod add_location_tests {
+    use crate::card_data::{CardKind, CardMetadata};
+    use crate::test_support::GameStateBuilder;
+
+    fn location_meta(code: &str, name: &str, shroud: u8, clues: u8) -> CardMetadata {
+        CardMetadata {
+            code: code.to_string(),
+            name: name.to_string(),
+            traits: vec![],
+            text: None,
+            pack_code: "core".to_string(),
+            kind: CardKind::Location { shroud, clues, victory: None },
+        }
+    }
+
+    #[test]
+    fn add_location_mints_sequential_ids_and_extracts_metadata() {
+        let mut state = GameStateBuilder::new().build();
+        let a = state.add_location(&location_meta("01111", "Study", 2, 2));
+        let b = state.add_location(&location_meta("01112", "Hallway", 1, 0));
+        assert_ne!(a, b, "ids are distinct");
+        let study = &state.locations[&a];
+        assert_eq!(study.code.as_str(), "01111");
+        assert_eq!(study.name, "Study");
+        assert_eq!((study.shroud, study.clues), (2, 2));
+        assert!(study.connections.is_empty());
+        assert!(study.revealed);
+        assert_eq!(state.next_location_id, 2, "counter advanced twice");
+    }
+
+    #[test]
+    fn add_set_aside_location_goes_to_the_set_aside_zone() {
+        let mut state = GameStateBuilder::new().build();
+        let id = state.add_set_aside_location(&location_meta("01113", "Attic", 1, 2));
+        assert!(!state.locations.contains_key(&id), "not in play");
+        assert_eq!(state.set_aside_locations.len(), 1);
+        assert_eq!(state.set_aside_locations[0].id, id);
+        assert_eq!(state.set_aside_locations[0].code.as_str(), "01113");
+    }
+
+    #[test]
+    #[should_panic(expected = "not a Location")]
+    fn add_location_panics_on_non_location_metadata() {
+        let mut state = GameStateBuilder::new().build();
+        let meta = CardMetadata {
+            code: "01108".to_string(),
+            name: "Trapped".to_string(),
+            traits: vec![],
+            text: None,
+            pack_code: "core".to_string(),
+            kind: CardKind::Act { clue_threshold: Some(2), victory: None },
+        };
+        state.add_location(&meta);
+    }
+}
+```
+
+Note: confirm `CardKind::Act`'s exact fields against `crates/card-dsl/src/card_data.rs` and adjust the panic-test literal if they differ (the point is "any non-`Location` kind").
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p game-core add_location`
+Expected: FAIL — `add_location` not found.
+
+- [ ] **Step 3: Implement.** Add (or extend) an `impl GameState` block in `game_state.rs`. Ensure the imports `use crate::card_data::{CardKind, CardMetadata};` are present at the top of the file (add if missing). `CardCode`, `Location`, `LocationId` are already in scope in this module.
+
+```rust
+impl GameState {
+    /// Mint a fresh, deterministic [`LocationId`] (sequential from
+    /// `next_location_id`).
+    fn mint_location_id(&mut self) -> LocationId {
+        let id = LocationId(self.next_location_id);
+        self.next_location_id = self.next_location_id.saturating_add(1);
+        id
+    }
+
+    /// Build a [`Location`] from its card `metadata`, minting a fresh id.
+    /// Panics if `metadata` is not a `Location` card (a build-time
+    /// invariant — scenarios hand their own location cards).
+    fn location_from_metadata(&mut self, metadata: &CardMetadata) -> Location {
+        let (shroud, clues) = match &metadata.kind {
+            CardKind::Location { shroud, clues, .. } => (*shroud, *clues),
+            other => panic!(
+                "add_location: card {} is not a Location ({other:?})",
+                metadata.code
+            ),
+        };
+        let id = self.mint_location_id();
+        Location::new(
+            id,
+            CardCode::new(metadata.code.clone()),
+            metadata.name.clone(),
+            shroud,
+            clues,
+        )
+    }
+
+    /// Add a location **into play** from its card metadata, returning the
+    /// minted [`LocationId`]. The id is deterministic (construction order),
+    /// so scenarios never hand-pick id literals.
+    pub fn add_location(&mut self, metadata: &CardMetadata) -> LocationId {
+        let loc = self.location_from_metadata(metadata);
+        let id = loc.id;
+        self.locations.insert(id, loc);
+        id
+    }
+
+    /// Add a location to the **set-aside** (out-of-play) zone from its card
+    /// metadata, returning the minted [`LocationId`]. Card effects (e.g.
+    /// The Gathering's Act-1 reverse) later move it into play.
+    pub fn add_set_aside_location(&mut self, metadata: &CardMetadata) -> LocationId {
+        let loc = self.location_from_metadata(metadata);
+        let id = loc.id;
+        self.set_aside_locations.push(loc);
+        id
+    }
+}
+```
+
+If an `impl GameState` block already exists in this file, add the methods there rather than opening a second block (keep it tidy; match the file's structure).
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo test -p game-core add_location`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/game-core/src/state/game_state.rs
+git commit -m "engine: GameState::add_location/add_set_aside_location from metadata (#260)"
+```
+
+---
+
+### Task 3: `connect` — bidirectional, cross-zone
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (the `impl GameState` block)
+- Test: `crates/game-core/src/state/game_state.rs` (`#[cfg(test)]`)
+
+- [ ] **Step 1: Write the failing tests:**
+
+```rust
+#[cfg(test)]
+mod connect_tests {
+    use crate::state::{CardCode, Location, LocationId};
+    use crate::test_support::GameStateBuilder;
+
+    #[test]
+    fn connect_wires_both_directions() {
+        let mut state = GameStateBuilder::new()
+            .with_location(Location::new(LocationId(1), CardCode("a".into()), "A", 1, 0))
+            .with_location(Location::new(LocationId(2), CardCode("b".into()), "B", 1, 0))
+            .build();
+        state.connect(LocationId(1), LocationId(2));
+        assert_eq!(state.locations[&LocationId(1)].connections, vec![LocationId(2)]);
+        assert_eq!(state.locations[&LocationId(2)].connections, vec![LocationId(1)]);
+    }
+
+    #[test]
+    fn connect_resolves_set_aside_locations() {
+        // Both endpoints live in the set-aside zone (The Gathering wires
+        // its board there before Act 1 brings it into play).
+        let mut state = GameStateBuilder::new().build();
+        state.set_aside_locations.push(Location::new(LocationId(2), CardCode("hub".into()), "Hub", 1, 0));
+        state.set_aside_locations.push(Location::new(LocationId(3), CardCode("spoke".into()), "Spoke", 1, 0));
+        state.connect(LocationId(2), LocationId(3));
+        let hub = state.set_aside_locations.iter().find(|l| l.id == LocationId(2)).unwrap();
+        let spoke = state.set_aside_locations.iter().find(|l| l.id == LocationId(3)).unwrap();
+        assert_eq!(hub.connections, vec![LocationId(3)]);
+        assert_eq!(spoke.connections, vec![LocationId(2)]);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p game-core connect_`
+Expected: FAIL — `connect` not found.
+
+- [ ] **Step 3: Implement** — add to the `impl GameState` block:
+
+```rust
+    /// Find a location by id across both the in-play and set-aside zones.
+    fn location_mut(&mut self, id: LocationId) -> Option<&mut Location> {
+        if let Some(loc) = self.locations.get_mut(&id) {
+            return Some(loc);
+        }
+        self.set_aside_locations.iter_mut().find(|l| l.id == id)
+    }
+
+    /// Wire a **bidirectional** connection between two locations (each gains
+    /// the other in its `connections`). Resolves both ids across the in-play
+    /// and set-aside zones. `expect`s each to exist — a build-time invariant
+    /// (callers connect freshly-minted ids).
+    pub fn connect(&mut self, a: LocationId, b: LocationId) {
+        self.location_mut(a)
+            .unwrap_or_else(|| panic!("connect: location {a:?} not found"))
+            .connections
+            .push(b);
+        self.location_mut(b)
+            .unwrap_or_else(|| panic!("connect: location {b:?} not found"))
+            .connections
+            .push(a);
+    }
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo test -p game-core connect_`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/game-core/src/state/game_state.rs
+git commit -m "engine: GameState::connect (bidirectional, cross-zone) (#260)"
+```
+
+---
+
+### Task 4: Migrate `the_gathering::setup()` + remove `STUDY_ID`
+
+**Files:**
+- Modify: `crates/scenarios/src/the_gathering.rs` (`setup()`, `location_stats` deletion, the `HALLWAY_ID..PARLOR_ID` + `STUDY_ID` const deletions, module doc, the `#[cfg(test)]` setup tests)
+- Modify: `crates/scenarios/tests/the_gathering.rs` (integration tests referencing `STUDY_ID`)
+
+This is an atomic refactor: removing the `pub const STUDY_ID` breaks every reference, so `setup()`, its unit tests, and the integration tests must all change in one commit. The existing tests are the safety net — they must stay green (run them before and after). **There is no new behavior** — the board is byte-for-byte the same except location ids are now minted (deterministically, starting at 0) instead of hand-assigned `1..=5`.
+
+- [ ] **Step 1: Confirm the green baseline**
+
+Run: `cargo test -p scenarios`
+Expected: PASS (record this — it's the before state).
+
+- [ ] **Step 2: Rewrite `setup()`'s board construction.** Delete: the `location_stats` helper (lines ~26–32), the `STUDY_ID` const (line ~59), the `HALLWAY_ID..PARLOR_ID` consts (lines ~86–93), the Study `Location::new` construction (lines ~100–109), and the `make`-closure block (lines ~111–128). Drop the `.with_location(study)` call from the `GameStateBuilder` chain (the chain keeps `.with_chaos_bag(...)`, `.with_scenario_id(...)`, `.with_token_modifiers(...)`, `.build()`). Also delete the old `state.starting_location = Some(STUDY_ID);` and `state.set_aside_locations = vec![…];` lines.
+
+Then, **after** `let mut state = …build();`, build the board with the new methods:
+
+```rust
+    // The Gathering board. Ids are minted by `add_location` /
+    // `add_set_aside_location` (deterministic, construction order), so no
+    // hand-assigned LocationId literals. The scenario looks up each
+    // location's metadata in the corpus and hands it to the engine; stats
+    // (shroud/clues) come from the metadata. The Study starts in play
+    // (isolated — Act 1 is "trapped in the Study"); the Hallway hub +
+    // Attic/Cellar/Parlor spokes are set aside until Act 1's (01108)
+    // Forced on-advance reverse brings them into play.
+    let meta = |code: &str| cards::by_code(code).expect("Gathering location in corpus");
+    let study = state.add_location(meta("01111"));
+    let hallway = state.add_set_aside_location(meta("01112"));
+    let attic = state.add_set_aside_location(meta("01113"));
+    let cellar = state.add_set_aside_location(meta("01114"));
+    let parlor = state.add_set_aside_location(meta("01115"));
+    state.connect(hallway, attic);
+    state.connect(hallway, cellar);
+    state.connect(hallway, parlor);
+    state.starting_location = Some(study);
+```
+
+Update the `STUDY_ID` doc reference in the module-level doc-comment (line ~8) — replace "seats investigators at [`STUDY_ID`]" with "seats investigators at the starting location (the Study, `01111`)".
+
+- [ ] **Step 3: Update `setup()`'s unit tests** (`#[cfg(test)] mod tests`). They reference `STUDY_ID`; switch to `starting_location`. Concretely:
+  - `setup_reads_card_stats_from_corpus` (~line 228): `let study = s.locations.get(&STUDY_ID).unwrap();` → `let study = &s.locations[&s.starting_location.unwrap()];`
+  - `setup_places_study_in_play_and_four_set_aside` (~line 247): `let study = s.locations.get(&STUDY_ID).expect("Study present");` → `let study = &s.locations[&s.starting_location.unwrap()];`. The `assert_eq!(s.starting_location, Some(STUDY_ID));` (~line 286) → assert the starting location's code instead: `assert_eq!(s.locations[&s.starting_location.unwrap()].code.as_str(), "01111");`
+  - Any other `STUDY_ID` use in this module: replace via `s.starting_location`.
+
+Keep all the other assertions (set-aside codes in order, Hallway connections, spokes → Hallway, Study isolated) — they still hold.
+
+- [ ] **Step 4: Update the integration tests** in `crates/scenarios/tests/the_gathering.rs`. Two references (~line 72 seating assertion, ~line 155 board-rebuild seating):
+  - `Some(the_gathering::STUDY_ID)` → `the_gathering::setup().starting_location` is awkward; instead read it from the state under test. For the seating assertion (`roster_seating_places_investigator_at_study`): assert `roland.current_location == state.starting_location` (the state already in scope) and that it's `Some`. For the board-rebuild test (`advancing_act_1_rebuilds_the_board`, ~line 155): `investigator.current_location = Some(the_gathering::STUDY_ID);` → `investigator.current_location = state.starting_location;` (the `state` from `the_gathering::setup()` is in scope there).
+
+- [ ] **Step 5: Run the scenario suite + confirm the board is unchanged**
+
+Run: `cargo test -p scenarios`
+Expected: PASS — every setup + integration test green (same board, minted ids). If a test fails because it asserted a specific `LocationId` value, fix it to use `starting_location` / look-up-by-code (do not re-introduce id literals).
+
+- [ ] **Step 6: Full strict gauntlet, then commit**
+
+```sh
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+```
+All green, then:
+```bash
+git add crates/scenarios/src/the_gathering.rs crates/scenarios/tests/the_gathering.rs
+git commit -m "scenario: build the Gathering board via add_location; drop STUDY_ID (#260)"
+```
+
+---
+
+## Final: full CI gauntlet
+
+- [ ] Run the complete gauntlet (incl. wasm) on the final state:
+```sh
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+Expected: all green.
+
+- [ ] No phase-doc update needed (#260 is cross-cutting engine ergonomics, not a phase-N deliverable). The PR closes #260; the `TODO(#260)` comment added in PR #259 is removed by Task 4's `setup()` rewrite.
+
+---
+
+## Self-Review notes (author)
+
+- **Spec coverage:** `next_location_id` → Task 1; `add_location`/`add_set_aside_location` (metadata-driven, registry-free) → Task 2; `connect` → Task 3; `setup()` migration + `STUDY_ID` removal + test updates → Task 4. Scope-out (synthetic fixture, `test_location`) untouched — confirmed no task changes them.
+- **Type consistency:** methods take `&CardMetadata` (from `crate::card_data`); `CardKind::Location { shroud: u8, clues: u8, victory: Option<u8> }`; `Location::new(id, CardCode, name: impl Into<String>, shroud, clues)`; ids minted from `next_location_id` (start 0). `connect` is bidirectional and resolves both zones via `location_mut`.
+- **Atomicity:** Task 4 is deliberately one commit — removing `pub const STUDY_ID` forces simultaneous updates across `setup()`, its unit tests, and the integration tests; the existing tests guard that the board is unchanged (only ids are now minted).
+- **Determinism:** minted ids are sequential from 0 — deterministic across replays (the property the event-sourced engine needs), just not written as literals.

--- a/docs/superpowers/specs/2026-06-12-location-construction-helper-design.md
+++ b/docs/superpowers/specs/2026-06-12-location-construction-helper-design.md
@@ -1,0 +1,144 @@
+# Location construction helper / id allocation
+
+Design for [#260](https://github.com/talelburg/eldritch/issues/260): replace
+the hand-assigned `LocationId` literals + manual connection wiring in scenario
+`setup()` with a `GameState`-owned location-construction API, mirroring the
+existing `next_enemy_id` / `next_card_instance_id` allocators.
+
+## Problem
+
+`crates/scenarios/src/the_gathering.rs::setup()` builds its board by
+hand-picking `LocationId` literals and wiring connections by raw id:
+
+```rust
+pub const STUDY_ID: LocationId = LocationId(1);
+const HALLWAY_ID: LocationId = LocationId(2);
+const ATTIC_ID: LocationId = LocationId(3);
+// … CELLAR_ID(4), PARLOR_ID(5)
+let make = |id, code, name| { let (shroud, clues) = location_stats(code); Location::new(id, …) };
+let mut hallway = make(HALLWAY_ID, "01112", "Hallway");
+hallway.connections = vec![ATTIC_ID, CELLAR_ID, PARLOR_ID];
+// … each spoke connects back to HALLWAY_ID; then state.set_aside_locations = vec![…]
+```
+
+This is verbatim and error-prone (ids must be unique and not collide), wires
+connections by raw id, and is inconsistent with the rest of the engine —
+enemies and card instances mint ids via auto-increment counters
+(`GameState.next_enemy_id`, `next_card_instance_id`), but locations have no
+equivalent; `GameStateBuilder::with_location` takes a caller-built `Location`
+with a caller-chosen id. The pattern will be copy-pasted into every future
+scenario.
+
+## Design
+
+### `GameState` gains location id allocation + construction methods
+
+New field:
+
+- `next_location_id: u32` — auto-increment counter (serde-roundtripped; builder
+  initialises to 0), mirroring `next_enemy_id`. Ids are minted **sequentially
+  and deterministically** in construction order, so callers never write
+  `LocationId(N)` literals while replay/serialization determinism is preserved.
+
+New methods:
+
+- `add_location(&mut self, code: &str) -> LocationId` — mint the next id, read
+  `name`/`shroud`/`clues` from the card metadata, insert into `locations`,
+  return the id.
+- `add_set_aside_location(&mut self, code: &str) -> LocationId` — identical, but
+  insert into the `set_aside_locations` zone instead.
+- `connect(&mut self, a: LocationId, b: LocationId)` — add a **bidirectional**
+  connection (push `b` onto `a`'s `connections` and `a` onto `b`'s). It resolves
+  each id across **both** `locations` and `set_aside_locations` (The Gathering's
+  connections are wired among set-aside locations before they enter play).
+
+The Gathering's `setup()` becomes:
+
+```rust
+let study   = state.add_location("01111");
+let hallway = state.add_set_aside_location("01112");
+let attic   = state.add_set_aside_location("01113");
+let cellar  = state.add_set_aside_location("01114");
+let parlor  = state.add_set_aside_location("01115");
+state.connect(hallway, attic);
+state.connect(hallway, cellar);
+state.connect(hallway, parlor);
+state.starting_location = Some(study);
+```
+
+`location_stats` is deleted (the metadata read moves into `add_location`).
+
+### Corpus read goes through the card registry
+
+`game-core` cannot call `cards::by_code` (that crate is a layer above it); it
+reaches card metadata only through the installed **`card_registry`** — the same
+path `PlayCard` and forced-trigger dispatch already use. So `add_location` /
+`add_set_aside_location` read via `card_registry::current()` →
+`(metadata_for)(code)` → `CardKind::Location { shroud, clues, .. }` + the
+metadata's `name`.
+
+A missing registry, a code absent from the corpus, or a non-`Location` card is
+a **build-time invariant violation** (a scenario knows its own location codes),
+so these panic with a clear message — matching what `location_stats` does today
+(`.expect("location code in corpus")` + a kind mismatch `panic!`). The methods
+return `LocationId` (not `Result`) to keep `setup()` ergonomic.
+
+**Consequence:** `setup()`'s in-crate unit tests (`setup_reads_card_stats_from_corpus`,
+`setup_places_study_in_play_and_four_set_aside`, etc.) currently rely on the
+direct `cards::by_code` path and do **not** install the registry. They must now
+install it (`let _ = game_core::card_registry::install(cards::REGISTRY);` — a
+shared test helper or one line each). The integration tests in
+`crates/scenarios/tests/the_gathering.rs` already install it. This is arguably
+more honest: a scenario's `setup()` genuinely depends on card data being
+available.
+
+### `STUDY_ID` is removed
+
+The `pub const STUDY_ID: LocationId = LocationId(1)` is dropped. With minted
+ids, keeping it would just re-encode "the Study is added first" — the implicit
+coupling this change removes. Its role (naming the starting location) is already
+served by `GameState.starting_location`, which `setup()` sets from the minted
+Study id. The ~8 references migrate:
+
+- `the_gathering.rs` `setup()` + its unit tests: read the Study via
+  `state.starting_location` (e.g. `s.locations[&s.starting_location.unwrap()]`).
+  The `s.starting_location == Some(STUDY_ID)` assertion becomes "the starting
+  location's code is `01111`" (asserting identity, not a magic id).
+- `crates/scenarios/tests/the_gathering.rs`: the seating assertion and the
+  board-rebuild test's `current_location = Some(STUDY_ID)` switch to
+  `state.starting_location`.
+
+## Scope
+
+- **In:** the new `GameState` field + three methods; migrating
+  `the_gathering::setup()` and its tests (incl. the registry install + `STUDY_ID`
+  removal).
+- **Out:** the synthetic fixture (`test_fixtures/synthetic.rs`) and the
+  `test_support::test_location(id, name)` fixture keep explicit ids — unit-test
+  fixtures pin ids deliberately, which is legitimate, not the pain point. No new
+  scenarios exist to migrate (the rest of Group C is Gathering *content*, not new
+  boards).
+
+## Testing
+
+- **Engine unit (`game_state.rs` / `builder.rs`):** `next_location_id` starts at
+  0 and round-trips through serde; `add_location` mints sequential ids, inserts
+  into `locations`, and reads stats from the metadata (with a test registry, as
+  `card_registry`'s existing tests do); `add_set_aside_location` inserts into the
+  set-aside zone; `connect` makes both locations reference each other and works
+  across the in-play/set-aside split.
+- **Scenario (`the_gathering.rs`):** the existing setup tests, updated for the
+  registry install + `STUDY_ID` → `starting_location` migration, still pin the
+  board shape (Study in play with code `01111` + shroud/clues `(2,2)`; four
+  set-aside locations in order; Hallway ↔ Attic/Cellar/Parlor; Study isolated).
+- **Integration (`tests/the_gathering.rs`):** unchanged behavior — the seating
+  and act-1 board-rebuild tests still pass via `starting_location`.
+
+## Open questions
+
+None. The single design fork (registry-based `GameState` method vs. a
+`scenarios`-layer helper using `cards::by_code`) is settled in favour of the
+`GameState` method: it matches the "on game state" intent, keeps the API
+reusable from any registry-having host, and uses the engine's sanctioned
+card-data path — at the cost of one registry-install line in `setup()`'s unit
+tests.

--- a/docs/superpowers/specs/2026-06-12-location-construction-helper-design.md
+++ b/docs/superpowers/specs/2026-06-12-location-construction-helper-design.md
@@ -40,57 +40,58 @@ New field:
   and deterministically** in construction order, so callers never write
   `LocationId(N)` literals while replay/serialization determinism is preserved.
 
-New methods:
+New methods (all **registry-free** — they take the card metadata as a parameter;
+see below):
 
-- `add_location(&mut self, code: &str) -> LocationId` — mint the next id, read
-  `name`/`shroud`/`clues` from the card metadata, insert into `locations`,
-  return the id.
-- `add_set_aside_location(&mut self, code: &str) -> LocationId` — identical, but
-  insert into the `set_aside_locations` zone instead.
+- `add_location(&mut self, metadata: &CardMetadata) -> LocationId` — mint the
+  next id; build a `Location` from `metadata` (`code`, `name`, and
+  `shroud`/`clues` out of `CardKind::Location`); insert into `locations`; return
+  the id.
+- `add_set_aside_location(&mut self, metadata: &CardMetadata) -> LocationId` —
+  identical, but insert into the `set_aside_locations` zone instead.
 - `connect(&mut self, a: LocationId, b: LocationId)` — add a **bidirectional**
   connection (push `b` onto `a`'s `connections` and `a` onto `b`'s). It resolves
   each id across **both** `locations` and `set_aside_locations` (The Gathering's
-  connections are wired among set-aside locations before they enter play).
+  connections are wired among set-aside locations before they enter play), and
+  `expect`s each id to resolve (a build-time invariant — `connect` is called with
+  freshly-minted ids).
 
-The Gathering's `setup()` becomes:
+A non-`Location` `metadata.kind` is a build-time invariant violation (a scenario
+hands its own location cards), so the extraction `panic!`s with a clear message —
+matching what `location_stats` does today on a kind mismatch. The methods return
+`LocationId` (not `Result`) to keep `setup()` ergonomic.
+
+### The corpus read stays in the scenario layer (metadata passed in)
+
+`game-core` cannot call `cards::by_code` (that crate is a layer above it), and we
+deliberately **don't** make these methods read the process-global
+`card_registry` either — doing so makes them un-unit-testable inside game-core
+(its lib test binary already pins a `TEST1`-only global fake; `install` is
+first-wins). Instead the **scenario** does the corpus lookup (it already depends
+on `cards`) and passes the `&CardMetadata` in. game-core stays registry-free for
+construction and the methods are trivially unit-testable with a constructed
+`CardMetadata` (which is deliberately not `#[non_exhaustive]`, expressly for
+mocks).
+
+The Gathering's `setup()` becomes (a small local closure keeps the corpus lookup
+terse):
 
 ```rust
-let study   = state.add_location("01111");
-let hallway = state.add_set_aside_location("01112");
-let attic   = state.add_set_aside_location("01113");
-let cellar  = state.add_set_aside_location("01114");
-let parlor  = state.add_set_aside_location("01115");
+let meta = |code| cards::by_code(code).expect("Gathering location in corpus");
+let study   = state.add_location(meta("01111"));
+let hallway  = state.add_set_aside_location(meta("01112"));
+let attic   = state.add_set_aside_location(meta("01113"));
+let cellar  = state.add_set_aside_location(meta("01114"));
+let parlor  = state.add_set_aside_location(meta("01115"));
 state.connect(hallway, attic);
 state.connect(hallway, cellar);
 state.connect(hallway, parlor);
 state.starting_location = Some(study);
 ```
 
-`location_stats` is deleted (the metadata read moves into `add_location`).
-
-### Corpus read goes through the card registry
-
-`game-core` cannot call `cards::by_code` (that crate is a layer above it); it
-reaches card metadata only through the installed **`card_registry`** — the same
-path `PlayCard` and forced-trigger dispatch already use. So `add_location` /
-`add_set_aside_location` read via `card_registry::current()` →
-`(metadata_for)(code)` → `CardKind::Location { shroud, clues, .. }` + the
-metadata's `name`.
-
-A missing registry, a code absent from the corpus, or a non-`Location` card is
-a **build-time invariant violation** (a scenario knows its own location codes),
-so these panic with a clear message — matching what `location_stats` does today
-(`.expect("location code in corpus")` + a kind mismatch `panic!`). The methods
-return `LocationId` (not `Result`) to keep `setup()` ergonomic.
-
-**Consequence:** `setup()`'s in-crate unit tests (`setup_reads_card_stats_from_corpus`,
-`setup_places_study_in_play_and_four_set_aside`, etc.) currently rely on the
-direct `cards::by_code` path and do **not** install the registry. They must now
-install it (`let _ = game_core::card_registry::install(cards::REGISTRY);` — a
-shared test helper or one line each). The integration tests in
-`crates/scenarios/tests/the_gathering.rs` already install it. This is arguably
-more honest: a scenario's `setup()` genuinely depends on card data being
-available.
+`location_stats` and the `make` closure are deleted (their work moves into
+`add_location`). `setup()`'s unit tests keep using the direct `cards::by_code`
+path — **no registry install needed** (only the `STUDY_ID` migration below).
 
 ### `STUDY_ID` is removed
 
@@ -119,41 +120,33 @@ Study id. The ~8 references migrate:
   scenarios exist to migrate (the rest of Group C is Gathering *content*, not new
   boards).
 
-### Where the registry-reading methods are tested
-
-`add_location` / `add_set_aside_location` read `card_registry::current()`. The
-game-core lib test binary can't supply real location metadata (it can't depend
-on `cards`, and its existing `card_registry` test already pins a `TEST1`-only
-global fake — `install` is first-wins, so a competing global install is
-unreliable). So these two methods are **not** unit-tested inside game-core;
-they're covered where the real corpus is reachable — the `scenarios` crate,
-which installs `cards::REGISTRY` and exercises them against the **actual**
-Study/Hallway/Attic/Cellar/Parlor metadata. This mirrors how the engine's
-`encounter.rs` spawn handlers (which also read `current()`) are integration-
-tested rather than unit-tested with fakes. `connect` and the `next_location_id`
-counter are registry-free, so they keep direct game-core unit tests.
+Because the methods are registry-free (metadata passed in), everything is
+directly testable in its own layer with no fakes-fighting-the-global.
 
 - **Engine unit (`game_state.rs` / `builder.rs`):** `next_location_id` starts at
-  0 and round-trips through serde; `connect` makes both locations reference each
-  other and works across the in-play / set-aside split (build the two locations
-  via direct insertion of `Location::new` fixtures — no registry needed).
-- **Scenario unit (`the_gathering.rs` `#[cfg(test)]`):** install `cards::REGISTRY`,
-  then the setup tests (updated for the `STUDY_ID` → `starting_location`
-  migration) pin the board built by the real `add_location` calls: Study in play
-  with code `01111` + shroud/clues `(2,2)`; four set-aside locations in order
-  with distinct ids; Hallway ↔ Attic/Cellar/Parlor; Study isolated; the four
-  minted ids are distinct from the Study's. This is the coverage for
-  `add_location` / `add_set_aside_location` against actual locations.
+  0 and round-trips through serde. `add_location` mints a sequential id, inserts
+  into `locations`, and extracts `code`/`name`/`shroud`/`clues` — tested with a
+  constructed `CardMetadata { kind: CardKind::Location { shroud, clues, victory } }`
+  (no registry; `CardMetadata` is non-`#[non_exhaustive]` for exactly this). A
+  second metadata with a non-`Location` kind asserts the panic. `add_set_aside_location`
+  inserts into the set-aside zone. `connect` makes both locations reference each
+  other and works across the in-play / set-aside split (insert two `Location::new`
+  fixtures, call `connect`, assert both `connections`).
+- **Scenario unit (`the_gathering.rs` `#[cfg(test)]`):** the existing setup tests,
+  updated only for the `STUDY_ID` → `starting_location` migration (no registry
+  install needed — `cards::by_code` is direct), still pin the board built by the
+  real metadata: Study in play with code `01111` + shroud/clues `(2,2)`; four
+  set-aside locations in order with distinct ids; Hallway ↔ Attic/Cellar/Parlor;
+  Study isolated.
 - **Integration (`tests/the_gathering.rs`):** unchanged behavior — the seating
   and act-1 board-rebuild tests still pass via `starting_location`.
 
 ## Open questions
 
-None. The registry-based `GameState` method (over a `scenarios`-layer helper
-using `cards::by_code`) was chosen for the "on game state" intent + the engine's
-sanctioned card-data path. The one concern it raised — unit-testing a method
-that reads the process-global registry inside game-core — is resolved by testing
-`add_location` / `add_set_aside_location` at the `scenarios` layer against the
-**actual** location corpus (see Testing), rather than with game-core fakes; the
-methods need no in-game-core unit test, exactly like the `encounter.rs` spawn
-handlers that also read `current()`.
+None. The design fork over how the corpus stats reach `add_location` is settled:
+the **scenario passes `&CardMetadata` in** (it already has `cards::by_code`),
+keeping the id-allocation + construction on `GameState` while leaving game-core
+registry-free and directly unit-testable. This is simpler than reading the
+process-global `card_registry` from a `GameState` method (which the game-core
+lib test binary can't reliably supply, given its first-wins `TEST1` global fake)
+and avoids putting the corpus read in a separate `scenarios`-layer helper.

--- a/docs/superpowers/specs/2026-06-12-location-construction-helper-design.md
+++ b/docs/superpowers/specs/2026-06-12-location-construction-helper-design.md
@@ -119,26 +119,41 @@ Study id. The ~8 references migrate:
   scenarios exist to migrate (the rest of Group C is Gathering *content*, not new
   boards).
 
-## Testing
+### Where the registry-reading methods are tested
+
+`add_location` / `add_set_aside_location` read `card_registry::current()`. The
+game-core lib test binary can't supply real location metadata (it can't depend
+on `cards`, and its existing `card_registry` test already pins a `TEST1`-only
+global fake — `install` is first-wins, so a competing global install is
+unreliable). So these two methods are **not** unit-tested inside game-core;
+they're covered where the real corpus is reachable — the `scenarios` crate,
+which installs `cards::REGISTRY` and exercises them against the **actual**
+Study/Hallway/Attic/Cellar/Parlor metadata. This mirrors how the engine's
+`encounter.rs` spawn handlers (which also read `current()`) are integration-
+tested rather than unit-tested with fakes. `connect` and the `next_location_id`
+counter are registry-free, so they keep direct game-core unit tests.
 
 - **Engine unit (`game_state.rs` / `builder.rs`):** `next_location_id` starts at
-  0 and round-trips through serde; `add_location` mints sequential ids, inserts
-  into `locations`, and reads stats from the metadata (with a test registry, as
-  `card_registry`'s existing tests do); `add_set_aside_location` inserts into the
-  set-aside zone; `connect` makes both locations reference each other and works
-  across the in-play/set-aside split.
-- **Scenario (`the_gathering.rs`):** the existing setup tests, updated for the
-  registry install + `STUDY_ID` → `starting_location` migration, still pin the
-  board shape (Study in play with code `01111` + shroud/clues `(2,2)`; four
-  set-aside locations in order; Hallway ↔ Attic/Cellar/Parlor; Study isolated).
+  0 and round-trips through serde; `connect` makes both locations reference each
+  other and works across the in-play / set-aside split (build the two locations
+  via direct insertion of `Location::new` fixtures — no registry needed).
+- **Scenario unit (`the_gathering.rs` `#[cfg(test)]`):** install `cards::REGISTRY`,
+  then the setup tests (updated for the `STUDY_ID` → `starting_location`
+  migration) pin the board built by the real `add_location` calls: Study in play
+  with code `01111` + shroud/clues `(2,2)`; four set-aside locations in order
+  with distinct ids; Hallway ↔ Attic/Cellar/Parlor; Study isolated; the four
+  minted ids are distinct from the Study's. This is the coverage for
+  `add_location` / `add_set_aside_location` against actual locations.
 - **Integration (`tests/the_gathering.rs`):** unchanged behavior — the seating
   and act-1 board-rebuild tests still pass via `starting_location`.
 
 ## Open questions
 
-None. The single design fork (registry-based `GameState` method vs. a
-`scenarios`-layer helper using `cards::by_code`) is settled in favour of the
-`GameState` method: it matches the "on game state" intent, keeps the API
-reusable from any registry-having host, and uses the engine's sanctioned
-card-data path — at the cost of one registry-install line in `setup()`'s unit
-tests.
+None. The registry-based `GameState` method (over a `scenarios`-layer helper
+using `cards::by_code`) was chosen for the "on game state" intent + the engine's
+sanctioned card-data path. The one concern it raised — unit-testing a method
+that reads the process-global registry inside game-core — is resolved by testing
+`add_location` / `add_set_aside_location` at the `scenarios` layer against the
+**actual** location corpus (see Testing), rather than with game-core fakes; the
+methods need no in-game-core unit test, exactly like the `encounter.rs` spawn
+handlers that also read `current()`.


### PR DESCRIPTION
## Summary

Replaces the hand-assigned `LocationId` literals + manual connection wiring in `the_gathering::setup()` with `GameState`-owned, deterministic location id allocation + metadata-driven construction methods — mirroring the existing `next_enemy_id` allocator. Closes the follow-up filed from the C1b review (#259).

## What changed

- **`GameState.next_location_id`** — monotonic counter (serde-roundtripped, builder-init 0), the location analogue of `next_enemy_id` / `next_card_instance_id`.
- **`GameState::add_location(&CardMetadata) -> LocationId`** and **`add_set_aside_location(&CardMetadata) -> LocationId`** — mint a deterministic sequential id, build the `Location` from the passed card metadata (code/name/shroud/clues), insert into `locations` / `set_aside_locations`. **Registry-free** — the scenario does its own `cards::by_code` lookup and passes the metadata in, so game-core stays registry-free and the methods are directly unit-testable. Non-`Location` metadata panics (build-time invariant).
- **`GameState::connect(a, b)`** — bidirectional connection, resolving each id across both the in-play and set-aside zones.
- **`the_gathering::setup()`** migrated to the new methods; **`location_stats` helper + the `make` closure + the `STUDY_ID`/`HALLWAY_ID`/… consts deleted.** `STUDY_ID` (the one named id) is dropped — minted ids would make it stale — and its role (naming the starting location) is served by `GameState.starting_location`; the ~8 references migrated.

**Design note:** an earlier draft had `add_location(code)` read the process-global `card_registry`, but that isn't cleanly unit-testable inside game-core (its lib test binary already pins a `TEST1`-only global fake, `install` is first-wins). Passing `&CardMetadata` in keeps the methods registry-free and trivially testable (`CardMetadata` is non-`#[non_exhaustive]` for exactly this), with the corpus lookup where it belongs — the scenario layer. Design: `docs/superpowers/specs/2026-06-12-location-construction-helper-design.md`.

## Test notes

- Engine unit (`game_state.rs`): `next_location_id` zero+serde; `add_location` mints sequential ids + extracts metadata (constructed `CardMetadata`, no registry); `add_set_aside_location` targets the set-aside zone; non-`Location` panic; `connect` wires both directions across both zones.
- Scenario (`the_gathering.rs` + `tests/`): existing setup + integration tests unchanged in behavior (same board, ids now minted) — they're the safety net proving the refactor preserves the board; `STUDY_ID` references migrated to `starting_location`.
- Full local gauntlet green: fmt, `-D warnings` test (all crates), clippy, doc, wasm-build, wasm-clippy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Linked issues

Closes #260