### PR TITLE
Location reveal-on-entry + per-investigator clue placement (#257)

### DIFF
--- a/crates/card-data-pipeline/src/main.rs
+++ b/crates/card-data-pipeline/src/main.rs
@@ -165,6 +165,7 @@ struct RawCard {
     // Encounter-card stats (locations / acts / agendas / enemies).
     shroud: Option<u8>,
     clues: Option<u8>,
+    clues_fixed: Option<bool>,
     victory: Option<u8>,
     doom: Option<u8>,
     enemy_fight: Option<u8>,
@@ -201,6 +202,7 @@ struct NormalizedCard {
     // act's advance threshold (same JSON field); consumer interprets by kind.
     shroud: Option<u8>,
     clues: Option<u8>,
+    clues_fixed: bool,
     victory: Option<u8>,
     doom: Option<u8>,
     enemy_fight: Option<u8>,
@@ -248,6 +250,7 @@ fn normalize(raw: RawCard) -> Result<NormalizedCard, String> {
         is_fast,
         shroud: raw.shroud,
         clues: raw.clues,
+        clues_fixed: raw.clues_fixed.unwrap_or(false),
         victory: raw.victory,
         doom: raw.doom,
         enemy_fight: raw.enemy_fight,
@@ -341,7 +344,7 @@ fn render(all: &BTreeMap<String, NormalizedCard>) -> String {
     let mut out = String::new();
     out.push_str(GENERATED_HEADER);
     out.push_str(
-        "use card_dsl::card_data::{CardKind, CardMetadata, Class, SkillIcons, Skills, Slot};\n\n\
+        "use card_dsl::card_data::{CardKind, CardMetadata, Class, ClueValue, SkillIcons, Skills, Slot};\n\n\
          /// Every card from the pinned snapshot, sorted by code.\n\
          #[must_use]\n\
          pub fn all_cards() -> Vec<CardMetadata> {\n    vec![\n",
@@ -451,9 +454,9 @@ fn render_kind(c: &NormalizedCard) -> String {
             c.quantity,
         ),
         "Location" => format!(
-            "CardKind::Location {{ shroud: {}, clues: {}, victory: {} }}",
+            "CardKind::Location {{ shroud: {}, printed_clues: {}, victory: {} }}",
             c.shroud.unwrap_or(0),
-            c.clues.unwrap_or(0),
+            clue_value_lit(c.clues.unwrap_or(0), c.clues_fixed),
             opt_u8(c.victory),
         ),
         "Act" => format!(
@@ -500,6 +503,15 @@ fn opt_u8(v: Option<u8>) -> String {
     }
 }
 
+/// Emit the `ClueValue` literal for a location's clues.
+fn clue_value_lit(clues: u8, fixed: bool) -> String {
+    if fixed {
+        format!("ClueValue::Fixed({clues})")
+    } else {
+        format!("ClueValue::PerInvestigator({clues})")
+    }
+}
+
 fn string_vec(xs: &[String]) -> String {
     if xs.is_empty() {
         return "Vec::new()".into();
@@ -538,8 +550,8 @@ const GENERATED_HEADER: &str = "\
 #[cfg(test)]
 mod tests {
     use super::{
-        emit_card, map_card_type, map_class, normalize, parse_slots, parse_traits, process_raw,
-        NormalizedCard, RawCard,
+        clue_value_lit, emit_card, map_card_type, map_class, normalize, parse_slots, parse_traits,
+        process_raw, NormalizedCard, RawCard,
     };
     use std::collections::BTreeMap;
     use std::path::Path;
@@ -570,6 +582,7 @@ mod tests {
             skill_wild: None,
             shroud: None,
             clues: None,
+            clues_fixed: None,
             victory: None,
             doom: None,
             enemy_fight: None,
@@ -605,6 +618,7 @@ mod tests {
             is_fast: false,
             shroud: None,
             clues: None,
+            clues_fixed: false,
             victory: None,
             doom: None,
             enemy_fight: None,
@@ -941,6 +955,7 @@ mod tests {
             skill_wild: None,
             shroud: None,
             clues: None,
+            clues_fixed: None,
             victory: None,
             doom: None,
             enemy_fight: None,
@@ -980,9 +995,17 @@ mod tests {
         let mut buf = String::new();
         emit_card(&mut buf, &c);
         assert!(
-            buf.contains("CardKind::Location { shroud: 2, clues: 2"),
+            buf.contains(
+                "CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(2)"
+            ),
             "got:\n{buf}",
         );
+    }
+
+    #[test]
+    fn location_clue_value_reflects_clues_fixed() {
+        assert_eq!(clue_value_lit(2, false), "ClueValue::PerInvestigator(2)");
+        assert_eq!(clue_value_lit(2, true), "ClueValue::Fixed(2)");
     }
 
     #[test]
@@ -1035,6 +1058,7 @@ mod tests {
             skill_wild: None,
             shroud: None,
             clues: None,
+            clues_fixed: None,
             victory: None,
             doom: None,
             enemy_fight: None,

--- a/crates/card-dsl/src/card_data.rs
+++ b/crates/card-dsl/src/card_data.rs
@@ -209,6 +209,18 @@ pub struct CardMetadata {
     pub kind: CardKind,
 }
 
+/// A location's printed clue value. `PerInvestigator(n)` places
+/// `n × (number of investigators who started the scenario)` on reveal;
+/// `Fixed(n)` places exactly `n`. Distinguishes `ArkhamDB`'s `clues_fixed`
+/// (absent/false → per-investigator; `true` → fixed).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ClueValue {
+    /// `value × #investigators` at reveal time.
+    PerInvestigator(u8),
+    /// Exactly `value`, regardless of investigator count.
+    Fixed(u8),
+}
+
 /// Per-card-type data. The discriminant mirrors [`CardType`] — read it
 /// via [`CardMetadata::card_type`]. Player variants carry a [`Class`];
 /// encounter variants do not (encounter cards have no player class).
@@ -583,6 +595,20 @@ mod prey_tests {
         let json = serde_json::to_string(&original).expect("serialize");
         let back: Prey = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, original);
+    }
+}
+
+#[cfg(test)]
+mod clue_value_tests {
+    use super::*;
+
+    #[test]
+    fn clue_value_round_trips_through_serde() {
+        for cv in [ClueValue::PerInvestigator(2), ClueValue::Fixed(3)] {
+            let json = serde_json::to_string(&cv).expect("serialize");
+            let back: ClueValue = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(cv, back);
+        }
     }
 }
 

--- a/crates/card-dsl/src/card_data.rs
+++ b/crates/card-dsl/src/card_data.rs
@@ -326,8 +326,8 @@ pub enum CardKind {
     Location {
         /// Shroud (investigate difficulty).
         shroud: u8,
-        /// Clues placed on the location at scenario setup.
-        clues: u8,
+        /// Printed clue value (per-investigator or fixed).
+        printed_clues: ClueValue,
         /// Victory points when in the victory display.
         victory: Option<u8>,
     },
@@ -553,7 +553,7 @@ mod is_fast_tests {
             pack_code: "core".into(),
             kind: CardKind::Location {
                 shroud: 2,
-                clues: 2,
+                printed_clues: ClueValue::PerInvestigator(2),
                 victory: None,
             },
         };

--- a/crates/cards/src/generated/cards.rs
+++ b/crates/cards/src/generated/cards.rs
@@ -6,7 +6,7 @@
 
 #![allow(clippy::too_many_lines, clippy::needless_raw_string_hashes)]
 
-use card_dsl::card_data::{CardKind, CardMetadata, Class, SkillIcons, Skills, Slot};
+use card_dsl::card_data::{CardKind, CardMetadata, Class, ClueValue, SkillIcons, Skills, Slot};
 
 /// Every card from the pinned snapshot, sorted by code.
 #[must_use]
@@ -898,7 +898,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: Vec::new(),
             text: None,
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(2), victory: None },
         },
         CardMetadata {
             code: "01112".to_owned(),
@@ -906,7 +906,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: Vec::new(),
             text: None,
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 1, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 1, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "01113".to_owned(),
@@ -914,7 +914,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: Vec::new(),
             text: Some("<b>Forced</b> - After you enter the Attic: Take 1 horror.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 1, clues: 2, victory: Some(1) },
+            kind: CardKind::Location { shroud: 1, printed_clues: ClueValue::PerInvestigator(2), victory: Some(1) },
         },
         CardMetadata {
             code: "01114".to_owned(),
@@ -922,7 +922,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: Vec::new(),
             text: Some("<b>Forced</b> - After you enter the Cellar: Take 1 damage.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 4, clues: 2, victory: Some(1) },
+            kind: CardKind::Location { shroud: 4, printed_clues: ClueValue::PerInvestigator(2), victory: Some(1) },
         },
         CardMetadata {
             code: "01115".to_owned(),
@@ -930,7 +930,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: Vec::new(),
             text: Some("[action] <b>Resign.</b> \"This is too much for me!\" You run out the front door, fleeing in panic.\nWhile Lita Chantler is not controlled by a player, she gains: \"[action]: <b>Parley.</b> Test [intellect] (4). If you succeed, take control of Lita Chantler.\"".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "01116".to_owned(),
@@ -1002,7 +1002,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Arkham".to_owned()],
             text: Some("<b>Forced</b> - When the Ghoul Priest spawns: Spawn it here instead of at its normal location.\n[action]: Draw 1 card and gain 1 resource. (Limit once per turn.)".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "01125".to_owned(),
@@ -1010,7 +1010,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Arkham".to_owned(), "Central".to_owned()],
             text: None,
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 1, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 1, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "01126".to_owned(),
@@ -1018,7 +1018,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Arkham".to_owned()],
             text: Some("[action]: Draw 3 cards. (Limit once per game.)".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "01127".to_owned(),
@@ -1026,7 +1026,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Arkham".to_owned()],
             text: Some("[action]: Search your deck for an [[Ally]] asset and add it to your hand. Shuffle your deck. (Limit once per game.)".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "01128".to_owned(),
@@ -1034,7 +1034,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Arkham".to_owned()],
             text: Some("[action]: Heal 3 damage. (Limit once per game.)".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "01129".to_owned(),
@@ -1042,7 +1042,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Arkham".to_owned()],
             text: Some("[action]: Search the top 6 cards of your deck for a [[Tome]] or [[Spell]] card and add it to your hand. Shuffle your deck.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 4, clues: 2, victory: Some(1) },
+            kind: CardKind::Location { shroud: 4, printed_clues: ClueValue::PerInvestigator(2), victory: Some(1) },
         },
         CardMetadata {
             code: "01130".to_owned(),
@@ -1050,7 +1050,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Arkham".to_owned()],
             text: Some("[action]: Gain 3 resources. (Limit once per game.)".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "01131".to_owned(),
@@ -1058,7 +1058,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Arkham".to_owned()],
             text: Some("[action]: Heal 3 horror. (Limit once per game.)".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 4, clues: 2, victory: Some(1) },
+            kind: CardKind::Location { shroud: 4, printed_clues: ClueValue::PerInvestigator(2), victory: Some(1) },
         },
         CardMetadata {
             code: "01132".to_owned(),
@@ -1066,7 +1066,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Arkham".to_owned()],
             text: Some("While you are in Easttown, reduce the cost of each [[Ally]] asset you play by 2.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "01133".to_owned(),
@@ -1074,7 +1074,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Arkham".to_owned()],
             text: Some("<b>Forced</b> - After you enter the Graveyard: Test [willpower] (3). If you fail, you must either take 2 horror or move to Rivertown.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 1, clues: 2, victory: Some(1) },
+            kind: CardKind::Location { shroud: 1, printed_clues: ClueValue::PerInvestigator(2), victory: Some(1) },
         },
         CardMetadata {
             code: "01134".to_owned(),
@@ -1082,7 +1082,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Arkham".to_owned()],
             text: Some("[action] Spend 5 resources: Gain 2 clues from the token pool. (Group limit once per game.)".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 2, victory: Some(1) },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(2), victory: Some(1) },
         },
         CardMetadata {
             code: "01135".to_owned(),
@@ -1194,7 +1194,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Woods".to_owned()],
             text: Some("The Main Path is connected to each other [[Woods]] location.\n[action]: <b>Resign.</b> \"There's nothing we can do to stop them!\" You flee from the woods, leaving Arkham to its grisly fate.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "01150".to_owned(),
@@ -1202,7 +1202,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Woods".to_owned()],
             text: Some("<b>Forced</b> - After you enter this location: Test [willpower] (4). If you fail, take 1 horror and 1 damage.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 4, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 4, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "01151".to_owned(),
@@ -1210,7 +1210,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Woods".to_owned()],
             text: Some("<b>Forced</b> - When you move out of this location: Test [intellect] (3). If you fail, cancel the effects of the move.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "01152".to_owned(),
@@ -1218,7 +1218,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Woods".to_owned()],
             text: Some("This location is investigated using [willpower] instead of the skill indicated by the investigation attempt.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "01153".to_owned(),
@@ -1226,7 +1226,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Woods".to_owned()],
             text: Some("This location is investigated using [agility] instead of the skill indicated by the investigation attempt.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "01154".to_owned(),
@@ -1234,7 +1234,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Woods".to_owned()],
             text: Some("This location is investigated using [combat] instead of the skill indicated by the investigation attempt.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "01155".to_owned(),
@@ -1242,7 +1242,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Woods".to_owned()],
             text: Some("[action]: Heal 1 damage or heal 1 horror. (Limit once per turn.)".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 1, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 1, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "01156".to_owned(),
@@ -1250,7 +1250,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Cave".to_owned()],
             text: Some("<b>Forced</b> - At the end of the round, if there are fewer than 2 clues per investigator on Ritual Site: Add clues to it until it has 2 clues per investigator on it.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(2), victory: None },
         },
         CardMetadata {
             code: "01157".to_owned(),
@@ -1834,7 +1834,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned()],
             text: Some("[action]: <b>Resign.</b> \"We can't find Rice anywhere...\" You leave the campus, hoping Armitage will forgive you.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "02049".to_owned(),
@@ -1842,7 +1842,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned()],
             text: Some("<b>Forced</b> - At the end of your turn, if you are in the Humanities Building: Discard the top X cards of your deck, where X is the amount of horror on you.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(2), victory: None },
         },
         CardMetadata {
             code: "02050".to_owned(),
@@ -1850,7 +1850,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned()],
             text: Some("You must spend 1 additional action to investigate the Orne Library.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 1, victory: Some(1) },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(1), victory: Some(1) },
         },
         CardMetadata {
             code: "02051".to_owned(),
@@ -1858,7 +1858,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned()],
             text: Some("<b>Forced</b> - After Student Union is revealed: Put the set-aside Dormitories into play.\n[action] [action]: Heal 1 damage and 1 horror.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Location { shroud: 1, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 1, printed_clues: ClueValue::Fixed(2), victory: None },
         },
         CardMetadata {
             code: "02052".to_owned(),
@@ -1866,7 +1866,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned()],
             text: Some("<b>Objective</b> - If investigators in the Dormitories spend 3 [per_investigator] clues, as a group: <b>(→R2)</b>".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Location { shroud: 1, clues: 3, victory: Some(1) },
+            kind: CardKind::Location { shroud: 1, printed_clues: ClueValue::PerInvestigator(3), victory: Some(1) },
         },
         CardMetadata {
             code: "02053".to_owned(),
@@ -1874,7 +1874,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned()],
             text: Some("<b>Forced</b> - After Administration Building is revealed: Put the set-aside Faculty Offices into play.\n<b>Forced</b> - At the end of your turn, if you are in the Administration Building: Discard the top card of your deck.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Location { shroud: 4, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 4, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02054".to_owned(),
@@ -1882,7 +1882,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned()],
             text: Some("<b>Forced</b> - After Faculty Offices is revealed: Search the encounter deck and discard pile for a [[Humanoid]] enemy and spawn it here. Shuffle the encounter deck.\n<b>Objective</b> - If investigators in the Faculty Offices spend 2 [per_investigator] clues, as a group: <b>(→R1)</b>".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 2, victory: Some(1) },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(2), victory: Some(1) },
         },
         CardMetadata {
             code: "02055".to_owned(),
@@ -1890,7 +1890,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned()],
             text: None,
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "02056".to_owned(),
@@ -1898,7 +1898,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned()],
             text: Some("<b>Forced</b> - After Science Building is revealed: Put the set-aside Alchemy Labs into play.\n<b>Forced</b> - When you fail a [willpower] test in the Science Building: Take 1 damage.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02057".to_owned(),
@@ -1906,7 +1906,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned()],
             text: Some("[action]: <b>Investigate.</b> If you are successful, instead of discovering clues, take the Alchemical Concoction from underneath this location if able.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Location { shroud: 5, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 5, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "02058".to_owned(),
@@ -2002,7 +2002,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Arkham".to_owned()],
             text: Some("[action]: <b>Resign.</b> This was a bust.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02071".to_owned(),
@@ -2010,7 +2010,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Clover Club".to_owned()],
             text: Some("While it is Act 1, Clover Club Lounge gains:\n\"[action] Discard an [[Ally]] asset from your hand: Gain 2 clues from the token pool. (Limit once per game.)\"".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "02072".to_owned(),
@@ -2018,7 +2018,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Clover Club".to_owned()],
             text: Some("While it is Act 1, Clover Club Bar gains:\n\"[action] Spend 2 resources: Gain 2 clues from the token pool and draw 2 cards. Remember that you have 'had a drink.' (Limit once per game.)\"".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "02073".to_owned(),
@@ -2026,7 +2026,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Clover Club".to_owned()],
             text: Some("While it is Act 1, Clover Club Cardroom gains:\n\"[action] Spend 2 resources: Reveal a random chaos token.\nIf it is a [elder_sign] symbol, gain 2 clues and 2 resources from the token bank.\nIf it is an even number, gain 2 clues from the token bank.\nIf it is an odd number or a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol, nothing happens.\"".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "02074".to_owned(),
@@ -2034,7 +2034,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Clover Club".to_owned()],
             text: Some("<b>Forced</b> - When Darkened Hall is revealed: Put into play the 3 set-aside Back Hall Doorway locations.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Location { shroud: 4, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 4, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "02075".to_owned(),
@@ -2042,7 +2042,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Clover Club".to_owned()],
             text: Some("<b>Forced</b> - After you fail a skill test while investigating the Art Gallery: Lose 2 resources.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: Some(1) },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: Some(1) },
         },
         CardMetadata {
             code: "02076".to_owned(),
@@ -2050,7 +2050,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Clover Club".to_owned()],
             text: Some("While you are in the VIP Area, you cannot draw cards or gain resources during the upkeep phase.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 1, victory: Some(1) },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(1), victory: Some(1) },
         },
         CardMetadata {
             code: "02077".to_owned(),
@@ -2058,7 +2058,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Clover Club".to_owned()],
             text: Some("[action]: <b>Resign.</b> We can get out this way!".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Location { shroud: 1, clues: 1, victory: Some(1) },
+            kind: CardKind::Location { shroud: 1, printed_clues: ClueValue::PerInvestigator(1), victory: Some(1) },
         },
         CardMetadata {
             code: "02078".to_owned(),
@@ -2442,7 +2442,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned()],
             text: Some("Investigators at the Museum Entrance cannot gain resources.\n[action] <b>Resign.</b> \"Eh. How important can a book really be, anyway?\"".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::Fixed(2), victory: None },
         },
         CardMetadata {
             code: "02127".to_owned(),
@@ -2450,7 +2450,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned()],
             text: Some("Museum Halls is connected to each copy of Exhibit Hall.\n[action] Investigators in the Museum Halls spend 1 [per_investigator] clues, as a group: Put the top card of the Exhibit deck into play, unrevealed.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "02128".to_owned(),
@@ -2458,7 +2458,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned()],
             text: Some("[action] [action]: Search the top 6 cards of your deck for a card and add it to your hand. Shuffle the rest back into your deck. (Limit once per turn.)".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02129".to_owned(),
@@ -2466,7 +2466,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned()],
             text: Some("[action] [action]: Look at the revealed side of an Exhibit Hall in play, or the top card of the Exhibit deck. (Limit once per turn.)".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(2), victory: None },
         },
         CardMetadata {
             code: "02130".to_owned(),
@@ -2474,7 +2474,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned()],
             text: Some("You cannot investigate Administration Office while you have 4 or fewer resources.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Location { shroud: 1, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 1, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02131".to_owned(),
@@ -2482,7 +2482,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned()],
             text: Some("You cannot investigate Administration Office while you have 4 or fewer cards in your hand.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(2), victory: None },
         },
         CardMetadata {
             code: "02132".to_owned(),
@@ -2490,7 +2490,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned(), "Exhibit".to_owned()],
             text: Some("<b>Forced</b> - After you enter this location: Lose all of your remaining actions and immediately end your turn.\nWhile you are in this location, you get +2 [agility].".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Location { shroud: 1, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 1, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "02133".to_owned(),
@@ -2498,7 +2498,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned(), "Exhibit".to_owned()],
             text: Some("<b>Forced</b> - After you fail a skill test while investigating this location: Discard an asset you control.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: Some(1) },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: Some(1) },
         },
         CardMetadata {
             code: "02134".to_owned(),
@@ -2506,7 +2506,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned(), "Exhibit".to_owned()],
             text: Some("<b>Forced</b> - After you enter this location: Discard 2 cards from your hand at random.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Location { shroud: 4, clues: 1, victory: Some(1) },
+            kind: CardKind::Location { shroud: 4, printed_clues: ClueValue::PerInvestigator(1), victory: Some(1) },
         },
         CardMetadata {
             code: "02135".to_owned(),
@@ -2514,7 +2514,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned(), "Exhibit".to_owned()],
             text: Some("<b>Forced</b> - After you fail a skill test while investigating this location: Lose 1 action.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 2, victory: Some(1) },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(2), victory: Some(1) },
         },
         CardMetadata {
             code: "02136".to_owned(),
@@ -2522,7 +2522,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned(), "Exhibit".to_owned()],
             text: Some("<b>Forced</b> - After you fail a skill test while investigating this location: Take 1 horror.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 2, victory: Some(1) },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(2), victory: Some(1) },
         },
         CardMetadata {
             code: "02137".to_owned(),
@@ -2530,7 +2530,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Miskatonic".to_owned(), "Exhibit".to_owned()],
             text: Some("While Hunting Horror is at this location, this location cannot be investigated.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 2, victory: Some(1) },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(2), victory: Some(1) },
         },
         CardMetadata {
             code: "02138".to_owned(),
@@ -2762,7 +2762,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Train".to_owned()],
             text: Some("Passenger Car is connected to the locations to the left and right of it.\n<b>Forced</b> - After you enter Passenger Car: You must either discard cards from your hand with at least 2 total [agility] icons or take 2 damage.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Location { shroud: 1, clues: 3, victory: None },
+            kind: CardKind::Location { shroud: 1, printed_clues: ClueValue::PerInvestigator(3), victory: None },
         },
         CardMetadata {
             code: "02168".to_owned(),
@@ -2770,7 +2770,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Train".to_owned()],
             text: Some("Passenger Car is connected to the locations to the left and right of it.\n<b>Forced</b> - After you enter Passenger Car: You must either discard cards from your hand with at least 2 total [combat] icons or take 2 damage.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Location { shroud: 4, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 4, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02169".to_owned(),
@@ -2778,7 +2778,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Train".to_owned()],
             text: Some("Passenger Car is connected to the locations to the left and right of it.\n<b>Forced</b> - After you enter Passenger Car: You must either discard cards from your hand with at least 2 total [willpower] icons or take 2 horror.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(2), victory: None },
         },
         CardMetadata {
             code: "02170".to_owned(),
@@ -2786,7 +2786,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Train".to_owned()],
             text: Some("Passenger Car is connected to the locations to the left and right of it.\n<b>Forced</b> - After you enter Passenger Car: You must either discard cards from your hand with at least 2 total [intellect] icons or take 2 horror.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(2), victory: None },
         },
         CardMetadata {
             code: "02171".to_owned(),
@@ -2794,7 +2794,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Train".to_owned()],
             text: Some("Passenger Car is connected to the locations to the left and right of it.\n<b>Forced</b> - After you enter Passenger Car: You must either discard a card from your hand with at least 1 [wild] icon or take 1 damage and 1 horror.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Location { shroud: 1, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 1, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02172".to_owned(),
@@ -2802,7 +2802,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Train".to_owned()],
             text: Some("Sleeping Car is connected to the locations to the left and right of it.\n[action]: Gain 3 resources. Remember that you have \"stolen a passenger's luggage.\" (Group limit once per game).".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Location { shroud: 4, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 4, printed_clues: ClueValue::Fixed(1), victory: None },
         },
         CardMetadata {
             code: "02173".to_owned(),
@@ -2810,7 +2810,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Train".to_owned()],
             text: Some("Dining Car is connected to the locations to the left and right of it.\n<b>Forced</b> - After you reveal Dining Car: Search the encounter deck and discard pile for a Grappling Horror and draw it.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "02174".to_owned(),
@@ -2818,7 +2818,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Train".to_owned()],
             text: Some("Parlor Car is connected to the locations to the left and right of it.\nParlor Car cannot be investigated.\n[action] Spend 3 resources: Discover 1 clue in the Parlor Car.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 1, victory: Some(1) },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(1), victory: Some(1) },
         },
         CardMetadata {
             code: "02175".to_owned(),
@@ -2826,7 +2826,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Train".to_owned()],
             text: Some("Engine Car is connected to the location to the left of it.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Location { shroud: 4, clues: 2, victory: Some(1) },
+            kind: CardKind::Location { shroud: 4, printed_clues: ClueValue::PerInvestigator(2), victory: Some(1) },
         },
         CardMetadata {
             code: "02176".to_owned(),
@@ -2834,7 +2834,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Train".to_owned()],
             text: Some("Engine Car is connected to the location to the left of it.\n<b>Forced</b> - After you reveal Engine Car: Search the encounter deck and discard pile for a Grappling Horror and draw it. Shuffle the encounter deck.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 2, victory: Some(1) },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(2), victory: Some(1) },
         },
         CardMetadata {
             code: "02177".to_owned(),
@@ -2842,7 +2842,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Train".to_owned()],
             text: Some("Engine Car is connected to the location to the left of it.\n<b>Forced</b> - After you reveal Engine Car: Draw the top 3 cards of the encounter deck.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Location { shroud: 1, clues: 2, victory: Some(1) },
+            kind: CardKind::Location { shroud: 1, printed_clues: ClueValue::PerInvestigator(2), victory: Some(1) },
         },
         CardMetadata {
             code: "02178".to_owned(),
@@ -3026,7 +3026,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned(), "Central".to_owned()],
             text: Some("[action] <b>Resign.</b> \"This is suicide! We're better off hiding out the night.\"".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "02202".to_owned(),
@@ -3034,7 +3034,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("Each enemy at Bishop's Brook deals +1 horror while it is attacking.\n[fast] If there are no clues here: Draw the encounter card underneath Bishop's Brook. (Group limit once per game).".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::Fixed(2), victory: None },
         },
         CardMetadata {
             code: "02203".to_owned(),
@@ -3042,7 +3042,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("If there is an investigator at Bishop's Brook, other investigators cannot enter Bishop's Brook.\n[fast] If there are no clues here: Draw the encounter card underneath Bishop's Brook. (Group limit once per game).".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::Fixed(2), victory: None },
         },
         CardMetadata {
             code: "02204".to_owned(),
@@ -3050,7 +3050,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("Each enemy in the Burned Ruins gets +1 evade.\n[fast] If there are no clues here: Draw the encounter card underneath Burned Ruins. (Group limit once per game).".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 3, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::Fixed(3), victory: None },
         },
         CardMetadata {
             code: "02205".to_owned(),
@@ -3058,7 +3058,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("<b>Forced</b> - After you fail a skill test while investigating the Burned Ruins: Flip 1 clue token on the Burned Ruins to its doom side.\n[fast] If there are no clues here: Draw the encounter card underneath Burned Ruins. (Group limit once per game).".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 3, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::Fixed(3), victory: None },
         },
         CardMetadata {
             code: "02206".to_owned(),
@@ -3066,7 +3066,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("You cannot gain resources while you are in Osborn's General Store.\n[fast] If there are no clues here: Draw the encounter card underneath Osborn's General Store. (Group limit once per game).".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02207".to_owned(),
@@ -3074,7 +3074,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("[action]Spend 1 resource: Search the top 3 cards of your deck for an [[Item]] card and add it to your hand. Shuffle your deck.\n[fast] If there are no clues here: Draw the encounter card underneath Osborn's General Store. (Group limit once per game).".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02208".to_owned(),
@@ -3082,7 +3082,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("<b>Forced</b> - After Congregational Church is revealed: Search the encounter deck for a [[Humanoid]] enemy and spawn it at the Village Commons. Shuffle the encounter deck.\n[fast] If there are no clues here: Draw the encounter card underneath Congregational Church. (Group limit once per game).".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Location { shroud: 1, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 1, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02209".to_owned(),
@@ -3090,7 +3090,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("[action] Choose and discard a card from your hand: Gain 2 resources.\n[fast] If there are no clues here: Draw the encounter card underneath Congregational Church. (Group limit once per game).".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02210".to_owned(),
@@ -3098,7 +3098,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("While you are in the House in the Reeds, you cannot play events.\n[fast] If there are no clues here: Draw the encounter card underneath House in the Reeds. (Group limit once per game).".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02211".to_owned(),
@@ -3106,7 +3106,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("<b>Forced</b> - After House in the Reeds is revealed: Search the encounter deck for a [[Nightgaunt]] enemy and spawn it in the Village Commons. Shuffle the encounter deck.\n[fast] If there are no clues here: Draw the encounter card underneath House in the Reeds. (Group limit once per game).".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Location { shroud: 1, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 1, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02212".to_owned(),
@@ -3114,7 +3114,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("While you are in the Schoolhouse, you cannot commit skill cards to skill tests.\n[fast] If there are no clues here: Draw the encounter card underneath Schoolhouse. (Group limit once per game).".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Location { shroud: 4, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 4, printed_clues: ClueValue::Fixed(1), victory: None },
         },
         CardMetadata {
             code: "02213".to_owned(),
@@ -3122,7 +3122,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("You cannot discover clues here except by investigating.\n[fast] If there are no clues here: Draw the encounter card underneath Schoolhouse. (Group limit once per game).".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Location { shroud: 4, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 4, printed_clues: ClueValue::Fixed(1), victory: None },
         },
         CardMetadata {
             code: "02214".to_owned(),
@@ -3130,7 +3130,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("<b>Revelation</b> - Put The Hidden Chamber into play.\nThe Hidden Chamber and the location from which it was drawn are connected to one another.\nThe door to The Hidden Chamber is locked. You cannot enter The Hidden Chamber unless Key to the Chamber is attached to The Hidden Chamber.".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 0, victory: Some(2) },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(0), victory: Some(2) },
         },
         CardMetadata {
             code: "02215".to_owned(),
@@ -3346,7 +3346,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("[action]: <b>Resign.</b> You hide from the rampaging creatures.\n[fast]: You borrow some hounds to track the creatures by scent. An investigator in Dunwich Village may place 1 of his or her clues on any [[Abomination]] enemy in play. (Group limit once per game).".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::Fixed(1), victory: None },
         },
         CardMetadata {
             code: "02243".to_owned(),
@@ -3354,7 +3354,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("[action]: <b>Resign.</b> You hide from the rampaging creatures.\n[action]: Move a Brood of Yog-Sothoth enemy once toward Dunwich Village.".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 3, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::Fixed(3), victory: None },
         },
         CardMetadata {
             code: "02244".to_owned(),
@@ -3362,7 +3362,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("Each enemy in Cold Spring Glen gets -1 evade.\n[fast]: You lure the creature into the dense tree cover, and it becomes tangled. Investigators in Cold Spring Glen may, as a group, place up to 2 of their clues on an [[Abomination]] enemy in Cold Spring Glen. (Group limit once per game).".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::Fixed(2), victory: None },
         },
         CardMetadata {
             code: "02245".to_owned(),
@@ -3370,7 +3370,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("Each enemy in Cold Spring Glen gets -1 evade.\n[reaction] After Cold Spring Glen is chosen as a random location: An investigator in Cold Spring Glen tests [agility] (3). If successful, choose a different random location.".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "02246".to_owned(),
@@ -3378,7 +3378,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("[fast]: You lure the monster into the rain. Place 1 clue from the token bank on an [[Abomination]] enemy in Ten-Acre Meadow. At the end of the round, remove 1 clue from that enemy. (Group limit once per game).".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::Fixed(1), victory: None },
         },
         CardMetadata {
             code: "02247".to_owned(),
@@ -3386,7 +3386,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("[fast]: You set a bait using a live animal. Each investigator in Ten-Acre Meadow may place 1 of his or her clues on an [[Abomination]] enemy in Ten-Acre Meadow. (Group limit once per game).".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 3, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::Fixed(3), victory: None },
         },
         CardMetadata {
             code: "02248".to_owned(),
@@ -3394,7 +3394,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("[fast]: You lure the creature into a patch of sand. Investigators in Blasted Heath may, as a group, place up to 2 of their clues on an [[Abomination]] enemy in Blasted Heath. (Group limit once per game).".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Location { shroud: 4, clues: 3, victory: None },
+            kind: CardKind::Location { shroud: 4, printed_clues: ClueValue::Fixed(3), victory: None },
         },
         CardMetadata {
             code: "02249".to_owned(),
@@ -3402,7 +3402,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("<b>Forced</b> - At the end of your turn, if you are in Blasted Heath: Take 1 damage.".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::Fixed(2), victory: None },
         },
         CardMetadata {
             code: "02250".to_owned(),
@@ -3410,7 +3410,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("Each investigator in Whateley Ruins gets -1 [willpower].\n[fast]: You hurl a nearby canister of paint at the monster. An investigator in Whateley Ruins may place up to 3 of his or her clues on an [[Abomination]] enemy in Whateley Ruins. (Group limit once per game).".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(2), victory: None },
         },
         CardMetadata {
             code: "02251".to_owned(),
@@ -3418,7 +3418,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("Each investigator in Whateley Ruins gets -1 [willpower].\n[action]: Test [intellect] (4). If you are successful, move a Brood of Yog-Sothoth enemy 1 location in any direction.".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(2), victory: None },
         },
         CardMetadata {
             code: "02252".to_owned(),
@@ -3426,7 +3426,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("[fast]: You lure the creature into the thick fog. An investigator in Devil's Hop Yard may place up to 2 of his or her clues on an [[Abomination]] enemy in Devil's Hop Yard. (Group limit once per game).".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Location { shroud: 1, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 1, printed_clues: ClueValue::Fixed(2), victory: None },
         },
         CardMetadata {
             code: "02253".to_owned(),
@@ -3434,7 +3434,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned()],
             text: Some("[fast]: The creature follows you into the mud. Each investigator in Devil's Hop Yard may place 1 of his or her clues on an [[Abomination]] enemy in Devil's Hop Yard. (Group limit once per game).".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02254".to_owned(),
@@ -3658,7 +3658,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned(), "Sentinel Hill".to_owned()],
             text: Some("Base of the Hill is connected to each copy of Diverging Path.\n[action]: <b>Investigate.</b> If you succeed, instead of discovering clues, put a random set-aside Diverging Path into play. (Limit once per round.)\n[action]: <b>Resign.</b> \"This is more than I signed up for!\"".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "02283".to_owned(),
@@ -3666,7 +3666,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned(), "Sentinel Hill".to_owned()],
             text: Some("Ascending Path is connected to each copy of Altered Path.\n[action]: <b>Investigate.</b> If you succeed, instead of discovering clues, put a random set-aside Altered Path into play. (Limit once per round.)".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "02284".to_owned(),
@@ -3674,7 +3674,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned(), "Sentinel Hill".to_owned()],
             text: Some("<b>Forced</b> - When an investigator at this location draws a [[Hex]] card: That investigator takes 1 damage.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Location { shroud: 4, clues: 2, victory: Some(2) },
+            kind: CardKind::Location { shroud: 4, printed_clues: ClueValue::PerInvestigator(2), victory: Some(2) },
         },
         CardMetadata {
             code: "02285".to_owned(),
@@ -3682,7 +3682,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned(), "Woods".to_owned()],
             text: Some("<b>Forced</b> - After you reveal Slaughtered Woods: Take 2 horror if you have no actions remaining.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02286".to_owned(),
@@ -3690,7 +3690,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned(), "Woods".to_owned()],
             text: Some("<b>Forced</b> - After you reveal Eerie Glade: Discard the top 2 cards of your deck for each action you have remaining.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Location { shroud: 4, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 4, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02287".to_owned(),
@@ -3698,7 +3698,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned(), "Woods".to_owned()],
             text: Some("<b>Forced</b> - After you reveal Destroyed Path: Place 1 [per_investigator] doom on it.\n[action]: <b>Investigate.</b> If you succeed, instead of discovering clues, remove 1 doom from Destroyed Path.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "02288".to_owned(),
@@ -3706,7 +3706,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned(), "Woods".to_owned()],
             text: Some("<b>Forced</b> - After you reveal Frozen Spring: Lose the remainder of your actions and immediately end your turn.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02289".to_owned(),
@@ -3714,7 +3714,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned(), "Woods".to_owned(), "Altered".to_owned()],
             text: Some("<b>Forced</b> - After you reveal Dimensional Gap: Discard cards from the top of the encounter deck until an enemy is discarded. Spawn that enemy here (instead of its normal spawn location).".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02290".to_owned(),
@@ -3722,7 +3722,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned(), "Woods".to_owned(), "Altered".to_owned()],
             text: Some("<b>Forced</b> - After you reveal A Tear in the Path: Take 2 damage if you have no actions remaining.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02291".to_owned(),
@@ -3730,7 +3730,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned(), "Woods".to_owned(), "Altered".to_owned()],
             text: Some("<b>Forced</b> - After you reveal Uprooted Woods: Discard the top 5 cards of your deck if you have no actions remaining.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02292".to_owned(),
@@ -3738,7 +3738,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Dunwich".to_owned(), "Woods".to_owned(), "Altered".to_owned()],
             text: Some("<b>Forced</b> - After you reveal Lost Memories: Take 1 horror for each action you have remaining.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02293".to_owned(),
@@ -3954,7 +3954,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Otherworld".to_owned()],
             text: Some("<b>Forced</b> - When a location leaves play: Move each investigator and unengaged enemy at that location to Another Dimension. Cannot be canceled.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Location { shroud: 6, clues: 0, victory: None },
+            kind: CardKind::Location { shroud: 6, printed_clues: ClueValue::PerInvestigator(0), victory: None },
         },
         CardMetadata {
             code: "02321".to_owned(),
@@ -3962,7 +3962,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Otherworld".to_owned()],
             text: Some("You must have at least 2 clues in order to move to The Edge of the Universe.\nInvestigators at The Edge of the Universe cannot draw cards during the upkeep phase.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(2), victory: None },
         },
         CardMetadata {
             code: "02322".to_owned(),
@@ -3970,7 +3970,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Otherworld".to_owned()],
             text: Some("[action] Spend 2 clues: <b>Resign.</b> You find a new path and hope that it leads back to safety.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(2), victory: None },
         },
         CardMetadata {
             code: "02323".to_owned(),
@@ -3986,7 +3986,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Otherworld".to_owned(), "Extradimensional".to_owned()],
             text: Some("Surge.\n<b>Revelation</b> - Put Tear Through Space into play.\n<b>Forced</b> - At the end of the round: Either place 1 doom on Tear Through Space, or discard it.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Location { shroud: 1, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 1, printed_clues: ClueValue::Fixed(1), victory: None },
         },
         CardMetadata {
             code: "02325".to_owned(),
@@ -3994,7 +3994,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Otherworld".to_owned(), "Extradimensional".to_owned()],
             text: Some("<b>Revelation</b> - Put Prismatic Cascade into play and discard a random card from your hand.\n<b>Forced</b> - After the last clue on Prismatic Cascade is removed: Discard Prismatic Cascade.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 3, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::Fixed(3), victory: None },
         },
         CardMetadata {
             code: "02326".to_owned(),
@@ -4002,7 +4002,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Otherworld".to_owned(), "Extradimensional".to_owned()],
             text: Some("<b>Revelation</b> - Put Endless Bridge into play and lose 2 resources.\n<b>Forced</b> - After an investigator leaves Endless Bridge: Either place 1 doom on Endless Bridge, or discard it.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Location { shroud: 4, clues: 2, victory: None },
+            kind: CardKind::Location { shroud: 4, printed_clues: ClueValue::Fixed(2), victory: None },
         },
         CardMetadata {
             code: "02327".to_owned(),
@@ -4010,7 +4010,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Otherworld".to_owned(), "Extradimensional".to_owned()],
             text: Some("<b>Revelation</b> - Put Steps of Y'hagharl into play. Then, draw the topmost [[Madness]] card in your discard pile.\n<b>Forced</b> - When you would leave Steps of Y'hagharl: Test [willpower] (2). If you fail, shuffle Steps of Y'hagharl into the encounter deck instead of moving to your original destination.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Location { shroud: 3, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 3, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02328".to_owned(),
@@ -4018,7 +4018,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Otherworld".to_owned(), "Extradimensional".to_owned()],
             text: Some("<b>Revelation</b> - Put Dimensional Doorway into play. Then, draw the topmost [[Hex]] card in the encounter discard pile.\n<b>Forced</b> - At the end of your turn, if you are at Dimensional Doorway: You must either spend 2 resources or shuffle Dimensional Doorway into the encounter deck.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Location { shroud: 2, clues: 1, victory: None },
+            kind: CardKind::Location { shroud: 2, printed_clues: ClueValue::PerInvestigator(1), victory: None },
         },
         CardMetadata {
             code: "02329".to_owned(),

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -88,6 +88,11 @@ pub(super) fn investigate(cx: &mut Cx, investigator: InvestigatorId) -> EngineOu
              is not in the locations map; this is a state-corruption invariant violation"
         )
     });
+    if !location.revealed {
+        return EngineOutcome::Rejected {
+            reason: format!("Investigate: location {location_id:?} is not revealed").into(),
+        };
+    }
     // Shroud is u8 in state but skill-test difficulty is i8. Saturate
     // at i8::MAX for the absurd case; realistic shrouds are 0–6.
     let difficulty = i8::try_from(location.shroud).unwrap_or(i8::MAX);

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -273,6 +273,9 @@ pub(super) fn move_action(
         from,
         to: destination,
     });
+    // Reveal the destination if this is the first investigator entry
+    // (Rules Reference p.14). No-op if already revealed.
+    super::reveal::reveal_location(cx, destination);
     // Terminal step: the entered location's Forced on-enter abilities fire,
     // and their outcome becomes the move's outcome. This runs *after* the
     // move is applied, so if it returns Rejected (e.g. 2+ simultaneous

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -33,6 +33,7 @@ pub(super) mod forced_triggers;
 mod hunters;
 mod phases;
 mod reaction_windows;
+pub(crate) mod reveal;
 mod skill_test;
 
 /// Apply a [`PlayerAction`] to the state, pushing events.

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -119,6 +119,13 @@ pub(super) fn start_scenario(cx: &mut Cx, roster: &[RosterEntry]) -> EngineOutco
         );
         cx.state.turn_order.push(id);
     }
+    // Reveal the starting location on first entry (Rules Reference p.14).
+    // investigators.len() is now final (all roster entries seated), so
+    // per-investigator clue counts are correct. No-op when start is None
+    // (pre-seated test path) or already revealed.
+    if let Some(loc) = start {
+        super::reveal::reveal_location(cx, loc);
+    }
 
     // Round 1: scenario starts directly in Investigation phase —
     // Mythos is skipped entirely per Rules Reference p.24 "During

--- a/crates/game-core/src/engine/dispatch/reveal.rs
+++ b/crates/game-core/src/engine/dispatch/reveal.rs
@@ -1,0 +1,120 @@
+//! Location reveal-on-entry (Rules Reference p.14): the first time an
+//! investigator enters a location it is revealed and clues are placed
+//! (`PerInvestigator(n) → n × #investigators`, or `Fixed(n)`). Enemy
+//! movement does not reveal — only the investigator-entry call sites
+//! (seating, `move_action`, `RelocateAllInvestigators`) call this.
+
+use crate::card_data::ClueValue;
+use crate::event::Event;
+use crate::state::LocationId;
+
+use super::Cx;
+
+/// Reveal `location_id` if it is unrevealed, placing its printed clues.
+/// No-op if the location is absent or already revealed.
+pub(crate) fn reveal_location(cx: &mut Cx, location_id: LocationId) {
+    // "Number of investigators who started the scenario" — `len()` is
+    // faithful because eliminated investigators stay in the map (status
+    // flipped, never removed). If that invariant changes, per-investigator
+    // math here must switch to a stored started-count.
+    let count = u8::try_from(cx.state.investigators.len()).unwrap_or(u8::MAX);
+    let Some(loc) = cx.state.locations.get_mut(&location_id) else {
+        return;
+    };
+    if loc.revealed {
+        return;
+    }
+    loc.revealed = true;
+    let clues = match loc.printed_clues {
+        ClueValue::PerInvestigator(n) => n.saturating_mul(count),
+        ClueValue::Fixed(n) => n,
+    };
+    loc.clues = clues;
+    cx.events.push(Event::LocationRevealed {
+        location: location_id,
+        clues,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reveal_location;
+    use crate::card_data::ClueValue;
+    use crate::engine::Cx;
+    use crate::event::Event;
+    use crate::state::{CardCode, Location, LocationId};
+    use crate::test_support::{test_investigator, GameStateBuilder};
+
+    fn unrevealed(id: u32, code: &str, printed: ClueValue) -> Location {
+        let mut loc = Location::new(LocationId(id), CardCode(code.into()), "L", 1, 0);
+        loc.revealed = false;
+        loc.printed_clues = printed;
+        loc.clues = 0;
+        loc
+    }
+
+    #[test]
+    fn reveal_places_per_investigator_clues_times_count() {
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_investigator(test_investigator(2))
+            .with_location(unrevealed(5, "x", ClueValue::PerInvestigator(2)))
+            .build();
+        let mut events = Vec::new();
+        reveal_location(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            LocationId(5),
+        );
+        let loc = &state.locations[&LocationId(5)];
+        assert!(loc.revealed);
+        assert_eq!(loc.clues, 4, "2 per-investigator × 2 investigators");
+        assert!(events.iter().any(|e| matches!(e, Event::LocationRevealed { location, clues } if *location == LocationId(5) && *clues == 4)));
+    }
+
+    #[test]
+    fn reveal_places_fixed_clues_regardless_of_count() {
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_investigator(test_investigator(2))
+            .with_location(unrevealed(5, "x", ClueValue::Fixed(3)))
+            .build();
+        let mut events = Vec::new();
+        reveal_location(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            LocationId(5),
+        );
+        assert_eq!(state.locations[&LocationId(5)].clues, 3);
+    }
+
+    #[test]
+    fn reveal_is_idempotent_on_already_revealed() {
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_location(Location::new(
+                LocationId(5),
+                CardCode("x".into()),
+                "L",
+                1,
+                9,
+            ))
+            .build();
+        let mut events = Vec::new();
+        reveal_location(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            LocationId(5),
+        );
+        assert_eq!(state.locations[&LocationId(5)].clues, 9, "unchanged");
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, Event::LocationRevealed { .. })));
+    }
+}

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -176,6 +176,9 @@ pub(crate) fn apply_effect(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) 
                     }
                 }
             }
+            // Reveal the destination on first investigator entry
+            // (Rules Reference p.14). No-op if already revealed.
+            crate::engine::dispatch::reveal::reveal_location(cx, dest);
             EngineOutcome::Done
         }
         Effect::RemoveLocationFromGame { location } => {

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -1717,6 +1717,48 @@ mod tests {
     }
 
     #[test]
+    fn moving_to_an_unrevealed_location_reveals_it_and_places_clues() {
+        use crate::card_data::ClueValue;
+        // 1 investigator; destination `b` is in play but unrevealed with a
+        // per-investigator clue value. Entering reveals it and places clues.
+        let (inv_id, _a, b, mut state) = move_scenario();
+        let loc_b = state.locations.get_mut(&b).unwrap();
+        loc_b.revealed = false;
+        loc_b.clues = 0;
+        loc_b.printed_clues = ClueValue::PerInvestigator(2);
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: inv_id,
+                destination: b,
+            }),
+        );
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        let loc_b = &result.state.locations[&b];
+        assert!(loc_b.revealed, "entering an unrevealed location reveals it");
+        assert_eq!(loc_b.clues, 2, "1 investigator × 2 per-investigator");
+    }
+
+    #[test]
+    fn investigate_on_an_unrevealed_location_is_rejected() {
+        // An unrevealed location is not yet investigatable (Rules Reference
+        // p.14). In practice unreachable (entering reveals), but the gate
+        // makes the rule explicit.
+        let (inv_id, loc_id, mut state) = investigate_scenario(2, 2);
+        state.locations.get_mut(&loc_id).unwrap().revealed = false;
+        let result = apply_no_commits(
+            state,
+            Action::Player(PlayerAction::Investigate {
+                investigator: inv_id,
+            }),
+        );
+        assert!(
+            matches!(result.outcome, EngineOutcome::Rejected { .. }),
+            "unrevealed location cannot be investigated"
+        );
+    }
+
+    #[test]
     #[should_panic(expected = "state-corruption invariant violation")]
     fn investigate_with_active_investigator_missing_from_map_panics() {
         // Same corruption pattern as above, applied to Investigate.

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -1685,6 +1685,38 @@ mod tests {
     }
 
     #[test]
+    fn move_to_a_set_aside_location_is_rejected() {
+        use crate::state::{CardCode, Location, LocationId};
+        let (inv_id, a, _b, mut state) = move_scenario();
+        // A location that exists only in the set-aside zone is out of play.
+        state.set_aside_locations.push(Location::new(
+            LocationId(99),
+            CardCode("setaside".into()),
+            "Aside",
+            1,
+            0,
+        ));
+        // Illegally connect the current location to it; the move must STILL be rejected (not in play).
+        state
+            .locations
+            .get_mut(&a)
+            .unwrap()
+            .connections
+            .push(LocationId(99));
+        let r = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: inv_id,
+                destination: LocationId(99),
+            }),
+        );
+        assert!(
+            matches!(r.outcome, EngineOutcome::Rejected { .. }),
+            "set-aside location is out of play"
+        );
+    }
+
+    #[test]
     #[should_panic(expected = "state-corruption invariant violation")]
     fn investigate_with_active_investigator_missing_from_map_panics() {
         // Same corruption pattern as above, applied to Investigate.

--- a/crates/game-core/src/event.rs
+++ b/crates/game-core/src/event.rs
@@ -465,6 +465,14 @@ pub enum Event {
         /// moved).
         from: usize,
     },
+    /// A location was revealed (turned face-up) on first investigator
+    /// entry; `clues` were placed on it.
+    LocationRevealed {
+        /// The revealed location.
+        location: LocationId,
+        /// Clues placed at reveal.
+        clues: u8,
+    },
 }
 
 /// Why a skill test failed.

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -12,7 +12,7 @@ use super::{
     location::{Location, LocationId},
     phase::Phase,
 };
-use crate::card_data::{CardKind, CardMetadata, ClueValue};
+use crate::card_data::{CardKind, CardMetadata};
 use crate::dsl::{SkillTestKind, Stat};
 use crate::rng::RngState;
 use card_dsl::card_data::SkillKind;
@@ -873,17 +873,14 @@ impl GameState {
                 metadata.code
             ),
         };
-        let base = match printed_clues {
-            ClueValue::PerInvestigator(n) | ClueValue::Fixed(n) => n,
-        };
         let id = self.mint_location_id();
         Location {
             id,
             code: CardCode::new(metadata.code.clone()),
             name: metadata.name.clone(),
             shroud,
-            clues: base,
-            revealed: true,
+            clues: 0,
+            revealed: false,
             printed_clues,
             connections: Vec::new(),
         }
@@ -1229,9 +1226,14 @@ mod add_location_tests {
         let study = &state.locations[&a];
         assert_eq!(study.code.as_str(), "01111");
         assert_eq!(study.name, "Study");
-        assert_eq!((study.shroud, study.clues), (2, 2));
+        assert_eq!(study.shroud, 2);
+        assert_eq!(study.clues, 0, "enters unrevealed with no clues");
+        assert!(!study.revealed);
+        assert_eq!(
+            study.printed_clues,
+            crate::card_data::ClueValue::PerInvestigator(2)
+        );
         assert!(study.connections.is_empty());
-        assert!(study.revealed);
         assert_eq!(state.next_location_id, 2, "counter advanced twice");
     }
 

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -862,30 +862,31 @@ impl GameState {
     /// Panics if `metadata` is not a `Location` card (a build-time
     /// invariant — scenarios hand their own location cards).
     fn location_from_metadata(&mut self, metadata: &CardMetadata) -> Location {
-        let (shroud, clues) = match &metadata.kind {
+        let (shroud, printed_clues) = match &metadata.kind {
             CardKind::Location {
                 shroud,
                 printed_clues,
                 ..
-            } => {
-                let base = match printed_clues {
-                    ClueValue::PerInvestigator(n) | ClueValue::Fixed(n) => *n,
-                };
-                (*shroud, base)
-            }
+            } => (*shroud, *printed_clues),
             other => panic!(
                 "add_location: card {} is not a Location ({other:?})",
                 metadata.code
             ),
         };
+        let base = match printed_clues {
+            ClueValue::PerInvestigator(n) | ClueValue::Fixed(n) => n,
+        };
         let id = self.mint_location_id();
-        Location::new(
+        Location {
             id,
-            CardCode::new(metadata.code.clone()),
-            metadata.name.clone(),
+            code: CardCode::new(metadata.code.clone()),
+            name: metadata.name.clone(),
             shroud,
-            clues,
-        )
+            clues: base,
+            revealed: true,
+            printed_clues,
+            connections: Vec::new(),
+        }
     }
 
     /// Add a location **into play** from its card metadata, returning the

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -12,7 +12,7 @@ use super::{
     location::{Location, LocationId},
     phase::Phase,
 };
-use crate::card_data::{CardKind, CardMetadata};
+use crate::card_data::{CardKind, CardMetadata, ClueValue};
 use crate::dsl::{SkillTestKind, Stat};
 use crate::rng::RngState;
 use card_dsl::card_data::SkillKind;
@@ -863,7 +863,16 @@ impl GameState {
     /// invariant — scenarios hand their own location cards).
     fn location_from_metadata(&mut self, metadata: &CardMetadata) -> Location {
         let (shroud, clues) = match &metadata.kind {
-            CardKind::Location { shroud, clues, .. } => (*shroud, *clues),
+            CardKind::Location {
+                shroud,
+                printed_clues,
+                ..
+            } => {
+                let base = match printed_clues {
+                    ClueValue::PerInvestigator(n) | ClueValue::Fixed(n) => *n,
+                };
+                (*shroud, base)
+            }
             other => panic!(
                 "add_location: card {} is not a Location ({other:?})",
                 metadata.code
@@ -1192,7 +1201,7 @@ mod partial_eq_tests {
 
 #[cfg(test)]
 mod add_location_tests {
-    use crate::card_data::{CardKind, CardMetadata};
+    use crate::card_data::{CardKind, CardMetadata, ClueValue};
     use crate::test_support::GameStateBuilder;
 
     fn location_meta(code: &str, name: &str, shroud: u8, clues: u8) -> CardMetadata {
@@ -1204,7 +1213,7 @@ mod add_location_tests {
             pack_code: "core".to_string(),
             kind: CardKind::Location {
                 shroud,
-                clues,
+                printed_clues: ClueValue::PerInvestigator(clues),
                 victory: None,
             },
         }

--- a/crates/game-core/src/state/location.rs
+++ b/crates/game-core/src/state/location.rs
@@ -2,6 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use card_dsl::card_data::ClueValue;
+
 use super::card::CardCode;
 
 /// Stable identifier for a location within a scenario.
@@ -33,6 +35,10 @@ pub struct Location {
     pub shroud: u8,
     /// Clues currently on the location.
     pub clues: u8,
+    /// The printed clue value on the location card (used to place clues
+    /// at reveal time). `PerInvestigator(n)` means `n × investigator_count`
+    /// clues are placed; `Fixed(n)` places exactly `n` regardless of count.
+    pub printed_clues: ClueValue,
     /// Whether the location is face-up. Unrevealed locations show only
     /// their "back" name and aren't yet investigatable.
     pub revealed: bool,
@@ -64,6 +70,7 @@ impl Location {
             name: name.into(),
             shroud,
             clues,
+            printed_clues: ClueValue::Fixed(clues),
             revealed: true,
             connections: Vec::new(),
         }
@@ -83,6 +90,7 @@ mod location_code_tests {
             name: "Hallway".into(),
             shroud: 2,
             clues: 0,
+            printed_clues: ClueValue::Fixed(0),
             revealed: true,
             connections: Vec::new(),
         };
@@ -109,6 +117,7 @@ mod location_code_tests {
             name: "Demo Location".into(),
             shroud: 1,
             clues: 3,
+            printed_clues: ClueValue::Fixed(3),
             revealed: false,
             connections: vec![LocationId(1)],
         };

--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -17,7 +17,7 @@
 //! field's intent. Phase-2+ reviewers: flag missing fixture updates
 //! when a field addition lands.
 
-use crate::card_data::Prey;
+use crate::card_data::{ClueValue, Prey};
 use crate::engine::{EngineOutcome, InputRequest, ResumeToken};
 use crate::state::{
     CardCode, Enemy, EnemyId, Investigator, InvestigatorId, Location, LocationId, Skills, Status,
@@ -75,6 +75,7 @@ pub fn test_location(id: u32, name: impl Into<String>) -> Location {
         name: name.into(),
         shroud: 2,
         clues: 0,
+        printed_clues: ClueValue::Fixed(0),
         revealed: true,
         connections: Vec::new(),
     }

--- a/crates/scenarios/src/the_gathering.rs
+++ b/crates/scenarios/src/the_gathering.rs
@@ -181,6 +181,7 @@ pub const MODULE: ScenarioModule = ScenarioModule {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use game_core::card_data::ClueValue;
     use game_core::state::ChaosToken;
 
     #[test]
@@ -190,7 +191,14 @@ mod tests {
         // the reader helpers.
         let s = setup();
         let study = &s.locations[&s.starting_location.unwrap()];
-        assert_eq!((study.shroud, study.clues), (2, 2), "Study 01111 stats");
+        assert_eq!(study.shroud, 2, "Study 01111 shroud");
+        assert_eq!(study.clues, 0, "Study enters unrevealed with no clues");
+        assert!(!study.revealed, "Study enters unrevealed");
+        assert_eq!(
+            study.printed_clues,
+            ClueValue::PerInvestigator(2),
+            "Study 01111 printed_clues"
+        );
         assert_eq!(
             s.agenda_deck
                 .iter()

--- a/crates/scenarios/tests/the_gathering.rs
+++ b/crates/scenarios/tests/the_gathering.rs
@@ -72,6 +72,9 @@ fn roster_seating_places_investigator_at_study() {
         roland.current_location, study,
         "seating must place investigators at setup()'s starting_location",
     );
+    let study_loc = &state.locations[&state.starting_location.unwrap()];
+    assert!(study_loc.revealed, "seating reveals the starting location");
+    assert_eq!(study_loc.clues, 2, "1 investigator × 2 per-investigator");
 }
 
 #[test]
@@ -196,4 +199,13 @@ fn advancing_act_1_rebuilds_the_board() {
 
     // Act cursor moved to Act 2.
     assert_eq!(result.state.act_index, 1);
+
+    // Hallway (01112) was revealed when the investigator was relocated there.
+    let hallway = result
+        .state
+        .locations
+        .values()
+        .find(|l| l.code.as_str() == "01112")
+        .unwrap();
+    assert!(hallway.revealed, "relocate-to-Hallway reveals it");
 }

--- a/docs/superpowers/plans/2026-06-12-location-reveal.md
+++ b/docs/superpowers/plans/2026-06-12-location-reveal.md
@@ -1,0 +1,500 @@
+# Location reveal-on-entry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Model the Arkham location-reveal mechanic — locations enter play unrevealed, reveal on the first *investigator* entry, and at reveal place clues equal to the printed value (`PerInvestigator(n) → n × investigators.len()`, or `Fixed(n)`).
+
+**Architecture:** A shared `ClueValue` enum (`card-dsl`) reshapes `CardKind::Location` (`clues: u8` → `printed_clues: ClueValue`) and game-core's `Location`. The pipeline ingests `clues_fixed`. A `reveal_location(cx, id)` helper fires from the three investigator-entry sites (seating, `move_action`, `RelocateAllInvestigators`); enemy movement is untouched. Built green-at-each-step: the reveal machinery + call sites land while locations still enter *revealed* (so the wired sites are no-ops), then a final task flips `add_location` to enter unrevealed, activating them.
+
+**Tech Stack:** Rust workspace. `card-dsl` (`ClueValue`, `CardKind`), `card-data-pipeline` (ingest + regenerate `cards/src/generated/cards.rs`), `game-core` (`Location`, `Event`, dispatch), `scenarios` (`the_gathering`). Per-investigator multiplier = `state.investigators.len()` (faithful: eliminated investigators stay in the map).
+
+**Spec:** `docs/superpowers/specs/2026-06-12-location-reveal-design.md`
+
+**CI gauntlet (before each task-completing commit):**
+```sh
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+```
+
+---
+
+### Task 1: `ClueValue` enum (`card-dsl`)
+
+**Files:**
+- Modify: `crates/card-dsl/src/card_data.rs` (add the enum near `CardKind`)
+- Test: `crates/card-dsl/src/card_data.rs` (`#[cfg(test)]`)
+
+- [ ] **Step 1: Write the failing test:**
+
+```rust
+#[test]
+fn clue_value_round_trips_through_serde() {
+    for cv in [ClueValue::PerInvestigator(2), ClueValue::Fixed(3)] {
+        let json = serde_json::to_string(&cv).expect("serialize");
+        let back: ClueValue = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(cv, back);
+    }
+}
+```
+(Place it in `card_data.rs`'s existing `#[cfg(test)]` module, importing via `super::*` as the file's other tests do.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p card-dsl clue_value_round_trips`
+Expected: FAIL — `ClueValue` not found.
+
+- [ ] **Step 3: Add the enum** (near `CardKind`; match `CardKind`'s derives plus `Copy`, since both variants are `u8`):
+
+```rust
+/// A location's printed clue value. `PerInvestigator(n)` places
+/// `n × (number of investigators who started the scenario)` on reveal;
+/// `Fixed(n)` places exactly `n`. Distinguishes ArkhamDB's `clues_fixed`
+/// (absent/false → per-investigator; `true` → fixed).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ClueValue {
+    /// `value × #investigators` at reveal time.
+    PerInvestigator(u8),
+    /// Exactly `value`, regardless of investigator count.
+    Fixed(u8),
+}
+```
+(`Serialize`/`Deserialize` are already imported in this file — confirm.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p card-dsl clue_value_round_trips`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/card-dsl/src/card_data.rs
+git commit -m "card-dsl: add ClueValue enum (per-investigator / fixed) (#257)"
+```
+
+---
+
+### Task 2: Reshape `CardKind::Location` + ingest `clues_fixed` + regenerate corpus
+
+**Files:**
+- Modify: `crates/card-dsl/src/card_data.rs` (the `CardKind::Location` variant)
+- Modify: `crates/card-data-pipeline/src/main.rs` (`RawCard`, the `Location` emit, the generated-file `use` header, a `clue_value_lit` helper)
+- Regenerate: `crates/cards/src/generated/cards.rs` (via the pipeline)
+- Modify: `crates/game-core/src/state/game_state.rs` (`location_from_metadata` — read `printed_clues`'s base value; behavior unchanged)
+- Modify: the `add_location_tests` helper in `game_state.rs` (the `CardKind::Location` literal)
+
+This is an atomic type reshape: `CardKind::Location`'s `clues: u8` becomes `printed_clues: ClueValue`. **Behavior is unchanged** — `add_location` still builds revealed locations with the flat clue count (the reveal mechanic lands in Tasks 3–4).
+
+- [ ] **Step 1: Add a pipeline unit test** (in `card-data-pipeline/src/main.rs`'s `#[cfg(test)]`, mirroring the existing pipeline tests' style):
+
+```rust
+#[test]
+fn location_clue_value_reflects_clues_fixed() {
+    assert_eq!(clue_value_lit(2, false), "ClueValue::PerInvestigator(2)");
+    assert_eq!(clue_value_lit(2, true), "ClueValue::Fixed(2)");
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p card-data-pipeline location_clue_value`
+Expected: FAIL — `clue_value_lit` not found.
+
+- [ ] **Step 3: Reshape the type.** In `card_data.rs`, change the `Location` variant:
+
+```rust
+    /// Location — a place investigators move between and investigate.
+    Location {
+        /// Shroud (investigate difficulty).
+        shroud: u8,
+        /// Printed clue value (per-investigator or fixed).
+        printed_clues: ClueValue,
+        /// Victory points when in the victory display.
+        victory: Option<u8>,
+    },
+```
+
+- [ ] **Step 4: Update the pipeline.** In `card-data-pipeline/src/main.rs`:
+  - Add `clues_fixed: Option<bool>,` to the `RawCard` struct (next to `clues: Option<u8>`).
+  - Add the helper:
+    ```rust
+    /// Emit the `ClueValue` literal for a location's clues.
+    fn clue_value_lit(clues: u8, fixed: bool) -> String {
+        if fixed {
+            format!("ClueValue::Fixed({clues})")
+        } else {
+            format!("ClueValue::PerInvestigator({clues})")
+        }
+    }
+    ```
+  - Change the `"Location"` emit arm:
+    ```rust
+        "Location" => format!(
+            "CardKind::Location {{ shroud: {}, printed_clues: {}, victory: {} }}",
+            c.shroud.unwrap_or(0),
+            clue_value_lit(c.clues.unwrap_or(0), c.clues_fixed.unwrap_or(false)),
+            opt_u8(c.victory),
+        ),
+    ```
+  - Add `ClueValue` to the generated-file `use` header (the string at the `out.push_str` / `use card_dsl::card_data::{…}` site, ~main.rs:344): `use card_dsl::card_data::{CardKind, CardMetadata, ClueValue, Class, SkillIcons, Skills, Slot};`.
+  - The `CardMetadata` struct (the normalized intermediate, ~main.rs:203) carries `clues: Option<u8>` — keep it; also add `clues_fixed: bool` there and set it from `raw.clues_fixed.unwrap_or(false)` (~main.rs:250) so the emit can read it. (Check the actual intermediate struct's fields and thread `clues_fixed` through to the emit; the emit reads `c.clues` / `c.clues_fixed`.)
+
+- [ ] **Step 5: Run the pipeline test + regenerate the corpus**
+
+Run: `cargo test -p card-data-pipeline location_clue_value` → PASS.
+Run: `cargo run -p card-data-pipeline`
+Then verify the regenerated `crates/cards/src/generated/cards.rs` now emits `CardKind::Location { shroud: …, printed_clues: ClueValue::PerInvestigator(…)/Fixed(…), victory: … }` and imports `ClueValue`. Spot-check: `01111` (Study) → `PerInvestigator(2)`; a Dunwich location like `02242` (Dunwich Village) → `Fixed(…)`.
+
+- [ ] **Step 6: Fix the consumers** (compile-driven under the type change):
+  - `game_state.rs` `location_from_metadata` — the match now binds `printed_clues`. Keep behavior by extracting the base value:
+    ```rust
+        let (shroud, clues) = match &metadata.kind {
+            CardKind::Location { shroud, printed_clues, .. } => {
+                let base = match printed_clues {
+                    ClueValue::PerInvestigator(n) | ClueValue::Fixed(n) => *n,
+                };
+                (*shroud, base)
+            }
+            other => panic!("add_location: card {} is not a Location ({other:?})", metadata.code),
+        };
+    ```
+    Add `ClueValue` to the `use crate::card_data::{…}` line in `game_state.rs`.
+  - The `add_location_tests::location_meta` helper — change its `CardKind::Location { shroud, clues, victory: None }` literal to `CardKind::Location { shroud, printed_clues: ClueValue::PerInvestigator(clues), victory: None }` (import `ClueValue` in that test module). Its existing assertions (`study.clues == 2` etc.) still hold.
+  - Any other hand-written `CardKind::Location` literal the compiler flags (grep `CardKind::Location` across `crates/` — the generated file is already handled): update to `printed_clues`.
+
+- [ ] **Step 7: Full strict gauntlet, then commit**
+
+```sh
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+```
+All green, then:
+```bash
+git add crates/card-dsl/src/card_data.rs crates/card-data-pipeline/src/main.rs crates/cards/src/generated/cards.rs crates/game-core/src/state/game_state.rs
+git commit -m "card-data: CardKind::Location carries ClueValue; ingest clues_fixed (#257)"
+```
+
+---
+
+### Task 3: `Event::LocationRevealed` + `Location.printed_clues` + `reveal_location` helper (wired as no-ops)
+
+**Files:**
+- Modify: `crates/game-core/src/event.rs` (add `LocationRevealed`)
+- Modify: `crates/game-core/src/state/location.rs` (add `printed_clues` field; `Location::new` defaults it)
+- Modify: `crates/game-core/src/test_support/fixtures.rs` (`test_location` literal)
+- Modify: `crates/game-core/src/state/game_state.rs` (`location_from_metadata` stores the real `printed_clues`; still revealed)
+- Create: `crates/game-core/src/engine/dispatch/reveal.rs` (the helper) + declare it in `dispatch/mod.rs`
+- Modify: `crates/game-core/src/engine/dispatch/phases.rs` (seating), `actions.rs` (`move_action`), `crates/game-core/src/engine/evaluator.rs` (`RelocateAllInvestigators`) — call the helper
+- Test: `reveal.rs` (`#[cfg(test)]`)
+
+After this task locations still enter **revealed** (`add_location` unchanged in that respect), so every wired `reveal_location` call is a no-op — green, no behavior change. The helper's clue-placement is unit-tested directly with a manually-unrevealed location.
+
+- [ ] **Step 1: Add the event.** In `event.rs`'s `Event` enum (`LocationId` is already imported):
+
+```rust
+    /// A location was revealed (turned face-up) on first investigator
+    /// entry; `clues` were placed on it.
+    LocationRevealed {
+        /// The revealed location.
+        location: LocationId,
+        /// Clues placed at reveal.
+        clues: u8,
+    },
+```
+
+- [ ] **Step 2: Add the `printed_clues` field to `Location`.** In `location.rs`, add to the struct (after `clues`):
+
+```rust
+    /// Printed clue value, read at reveal time to place `clues`.
+    pub printed_clues: ClueValue,
+```
+Import `ClueValue` (`use card_dsl::card_data::ClueValue;` — confirm the crate path used in `location.rs`; it's re-exported at `game_core::card_data`). In `Location::new`, set `printed_clues: ClueValue::Fixed(clues)` (preserves today's behavior — a `new`-built location is revealed with its clues as a fixed count). Update the `test_location` fixture literal in `fixtures.rs` to include `printed_clues: ClueValue::Fixed(clues)` (it sets `clues` directly — mirror it). Fix any other `Location { … }` literal the compiler flags (e.g. `Location::new`'s own tests).
+
+- [ ] **Step 3: Store the real `printed_clues` in `add_location`.** In `game_state.rs` `location_from_metadata`, replace the body to build the `Location` carrying the metadata's `printed_clues` (still `revealed: true`, `clues = base` — behavior unchanged):
+
+```rust
+    fn location_from_metadata(&mut self, metadata: &CardMetadata) -> Location {
+        let (shroud, printed_clues) = match &metadata.kind {
+            CardKind::Location { shroud, printed_clues, .. } => (*shroud, *printed_clues),
+            other => panic!("add_location: card {} is not a Location ({other:?})", metadata.code),
+        };
+        let base = match printed_clues {
+            ClueValue::PerInvestigator(n) | ClueValue::Fixed(n) => n,
+        };
+        let id = self.mint_location_id();
+        Location {
+            id,
+            code: CardCode::new(metadata.code.clone()),
+            name: metadata.name.clone(),
+            shroud,
+            clues: base,
+            revealed: true,
+            printed_clues,
+            connections: Vec::new(),
+        }
+    }
+```
+(`Location` is `#[non_exhaustive]` but built within game-core, so the struct literal compiles. Keep `add_location`/`add_set_aside_location` themselves unchanged.)
+
+- [ ] **Step 4: Write the helper test** in the new `reveal.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::reveal_location;
+    use crate::card_data::ClueValue;
+    use crate::engine::Cx;
+    use crate::event::Event;
+    use crate::state::{CardCode, Location, LocationId};
+    use crate::test_support::{test_investigator, GameStateBuilder};
+
+    fn unrevealed(id: u32, code: &str, printed: ClueValue) -> Location {
+        let mut loc = Location::new(LocationId(id), CardCode(code.into()), "L", 1, 0);
+        loc.revealed = false;
+        loc.printed_clues = printed;
+        loc.clues = 0;
+        loc
+    }
+
+    #[test]
+    fn reveal_places_per_investigator_clues_times_count() {
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_investigator(test_investigator(2))
+            .with_location(unrevealed(5, "x", ClueValue::PerInvestigator(2)))
+            .build();
+        let mut events = Vec::new();
+        reveal_location(&mut Cx { state: &mut state, events: &mut events }, LocationId(5));
+        let loc = &state.locations[&LocationId(5)];
+        assert!(loc.revealed);
+        assert_eq!(loc.clues, 4, "2 per-investigator × 2 investigators");
+        assert!(events.iter().any(|e| matches!(e, Event::LocationRevealed { location, clues } if *location == LocationId(5) && *clues == 4)));
+    }
+
+    #[test]
+    fn reveal_places_fixed_clues_regardless_of_count() {
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_investigator(test_investigator(2))
+            .with_location(unrevealed(5, "x", ClueValue::Fixed(3)))
+            .build();
+        let mut events = Vec::new();
+        reveal_location(&mut Cx { state: &mut state, events: &mut events }, LocationId(5));
+        assert_eq!(state.locations[&LocationId(5)].clues, 3);
+    }
+
+    #[test]
+    fn reveal_is_idempotent_on_already_revealed() {
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_location(Location::new(LocationId(5), CardCode("x".into()), "L", 1, 9))
+            .build();
+        let mut events = Vec::new();
+        reveal_location(&mut Cx { state: &mut state, events: &mut events }, LocationId(5));
+        assert_eq!(state.locations[&LocationId(5)].clues, 9, "unchanged");
+        assert!(!events.iter().any(|e| matches!(e, Event::LocationRevealed { .. })));
+    }
+}
+```
+
+- [ ] **Step 5: Run to verify it fails**
+
+Run: `cargo test -p game-core reveal_` (the module isn't declared yet → fails to compile / not found).
+
+- [ ] **Step 6: Implement the helper.** Create `crates/game-core/src/engine/dispatch/reveal.rs`:
+
+```rust
+//! Location reveal-on-entry (Rules Reference p.14): the first time an
+//! investigator enters a location it is revealed and clues are placed
+//! (`PerInvestigator(n) → n × #investigators`, or `Fixed(n)`). Enemy
+//! movement does not reveal — only the investigator-entry call sites
+//! (seating, `move_action`, `RelocateAllInvestigators`) call this.
+
+use crate::card_data::ClueValue;
+use crate::event::Event;
+use crate::state::LocationId;
+
+use super::Cx;
+
+/// Reveal `location_id` if it is unrevealed, placing its printed clues.
+/// No-op if the location is absent or already revealed.
+pub(crate) fn reveal_location(cx: &mut Cx, location_id: LocationId) {
+    // "Number of investigators who started the scenario" — `len()` is
+    // faithful because eliminated investigators stay in the map (status
+    // flipped, never removed). If that invariant changes, per-investigator
+    // math here must switch to a stored started-count.
+    let count = u8::try_from(cx.state.investigators.len()).unwrap_or(u8::MAX);
+    let Some(loc) = cx.state.locations.get_mut(&location_id) else {
+        return;
+    };
+    if loc.revealed {
+        return;
+    }
+    loc.revealed = true;
+    let clues = match loc.printed_clues {
+        ClueValue::PerInvestigator(n) => n.saturating_mul(count),
+        ClueValue::Fixed(n) => n,
+    };
+    loc.clues = clues;
+    cx.events.push(Event::LocationRevealed {
+        location: location_id,
+        clues,
+    });
+}
+```
+Declare the module in `crates/game-core/src/engine/dispatch/mod.rs`: `pub(crate) mod reveal;` (it must be reachable from `evaluator.rs`, like `act_agenda` is).
+
+- [ ] **Step 7: Wire the three call sites** (no-ops while locations enter revealed):
+  - **Seating** (`phases.rs`, the roster step): after the `for` loop that inserts investigators (so `investigators.len()` is final), if `start` is `Some(loc)`, call `super::reveal::reveal_location(cx, loc)`. (`start` is the `starting_location` captured earlier.)
+  - **`move_action`** (`actions.rs`): right after the `cx.events.push(Event::InvestigatorMoved { … })` and **before** the forced-trigger fire, add `super::reveal::reveal_location(cx, destination);`.
+  - **`RelocateAllInvestigators`** (`evaluator.rs`): after the relocation `for` loop, add `crate::engine::dispatch::reveal::reveal_location(cx, dest);` (use the path that compiles from `evaluator.rs`, mirroring how it reaches `act_agenda`).
+
+- [ ] **Step 8: Run to verify the helper tests pass + nothing regressed**
+
+Run: `cargo test -p game-core reveal_` → PASS (3 tests).
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features` → all green (no behavior change — the wired calls are no-ops on revealed locations).
+
+- [ ] **Step 9: Full gauntlet + commit**
+
+```sh
+cargo clippy --all-targets --all-features -- -D warnings && cargo fmt --check && RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+```
+Then:
+```bash
+git add crates/game-core/src/event.rs crates/game-core/src/state/location.rs crates/game-core/src/test_support/fixtures.rs crates/game-core/src/state/game_state.rs crates/game-core/src/engine/dispatch/reveal.rs crates/game-core/src/engine/dispatch/mod.rs crates/game-core/src/engine/dispatch/phases.rs crates/game-core/src/engine/dispatch/actions.rs crates/game-core/src/engine/evaluator.rs
+git commit -m "engine: reveal_location helper + LocationRevealed; wire entry sites (no-op) (#257)"
+```
+
+---
+
+### Task 4: Enter unrevealed (activate reveal) + investigate gate + move regression + scenario tests
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (`location_from_metadata` — enter unrevealed)
+- Modify: `crates/game-core/src/engine/dispatch/actions.rs` (`investigate` revealed gate)
+- Modify: `crates/game-core/src/state/game_state.rs` `add_location_tests` (unrevealed expectations)
+- Modify: `crates/scenarios/src/the_gathering.rs` (`#[cfg(test)]` setup tests) + `crates/scenarios/tests/the_gathering.rs` (integration)
+- Test: `actions.rs` (`#[cfg(test)]` — move-to-set-aside regression + investigate-unrevealed)
+
+This flips `add_location` to enter locations **unrevealed** with `clues = 0`. The reveal sites wired in Task 3 now activate: seating reveals the Study, `move_action`/`RelocateAllInvestigators` reveal on entry.
+
+- [ ] **Step 1: Write the failing tests.**
+  - In `actions.rs`'s test module, a move-to-set-aside regression and an investigate-unrevealed rejection (adapt the harness to the file's existing move/investigate test scaffolding — find a helper like `move_scenario()`):
+    ```rust
+    #[test]
+    fn move_to_a_set_aside_location_is_rejected() {
+        // A location that exists only in the set-aside zone is out of play;
+        // moving to it must be rejected (not in state.locations).
+        use crate::state::{CardCode, Location, LocationId};
+        let (inv_id, a, _b, mut state) = move_scenario();
+        // Add a set-aside location and (illegally) connect `a` to it.
+        state.set_aside_locations.push(Location::new(LocationId(99), CardCode("setaside".into()), "Aside", 1, 0));
+        state.locations.get_mut(&a).unwrap().connections.push(LocationId(99));
+        let r = apply(state, Action::Player(PlayerAction::Move { investigator: inv_id, destination: LocationId(99) }));
+        assert!(matches!(r.outcome, EngineOutcome::Rejected { .. }), "set-aside is out of play");
+    }
+    ```
+    (Use the actual return shape of the file's `move_scenario()` — it yields `(inv_id, a, b, state)` per the existing tests; adjust names.)
+  - In the scenario setup tests, the post-setup expectation changes (Study now unrevealed, 0 clues) and a post-seating expectation is added. See Steps 3–4.
+
+- [ ] **Step 2: Flip `add_location` to enter unrevealed.** In `location_from_metadata` (`game_state.rs`), change the built `Location` to `revealed: false` and `clues: 0` (drop the `base` local — `printed_clues` carries the value for reveal):
+
+```rust
+    fn location_from_metadata(&mut self, metadata: &CardMetadata) -> Location {
+        let (shroud, printed_clues) = match &metadata.kind {
+            CardKind::Location { shroud, printed_clues, .. } => (*shroud, *printed_clues),
+            other => panic!("add_location: card {} is not a Location ({other:?})", metadata.code),
+        };
+        let id = self.mint_location_id();
+        Location {
+            id,
+            code: CardCode::new(metadata.code.clone()),
+            name: metadata.name.clone(),
+            shroud,
+            clues: 0,
+            revealed: false,
+            printed_clues,
+            connections: Vec::new(),
+        }
+    }
+```
+
+- [ ] **Step 3: Add the investigate gate.** In `investigate` (`actions.rs`), after the `location` is resolved (the `let location = cx.state.locations.get(&location_id)…` block) and before computing `difficulty`, add:
+
+```rust
+    if !location.revealed {
+        return EngineOutcome::Rejected {
+            reason: format!("Investigate: location {location_id:?} is not revealed").into(),
+        };
+    }
+```
+
+- [ ] **Step 4: Update `add_location_tests`** (`game_state.rs`): the existing `add_location_mints_sequential_ids_and_extracts_metadata` asserts `(study.shroud, study.clues) == (2, 2)`; change to assert the location enters unrevealed with `clues == 0` and the right `printed_clues`:
+```rust
+        assert_eq!(study.shroud, 2);
+        assert_eq!(study.clues, 0, "enters unrevealed with no clues");
+        assert!(!study.revealed);
+        assert_eq!(study.printed_clues, ClueValue::PerInvestigator(2));
+```
+
+- [ ] **Step 5: Update the Gathering scenario tests.**
+  - `the_gathering.rs` `#[cfg(test)] mod tests`: `setup_reads_card_stats_from_corpus` asserts `(study.shroud, study.clues) == (2, 2)` — change to `study.shroud == 2`, `study.clues == 0`, `!study.revealed`, `study.printed_clues == ClueValue::PerInvestigator(2)` (import `ClueValue`). Any set-aside-location clue assertions similarly become `clues == 0` / `!revealed`.
+  - `tests/the_gathering.rs` integration: in `roster_seating_places_investigator_at_study`, after seating, additionally assert the Study is now revealed with `2 × #seated` clues:
+    ```rust
+    let study = &state.locations[&state.starting_location.unwrap()];
+    assert!(study.revealed, "seating reveals the starting location");
+    assert_eq!(study.clues, 2, "1 investigator × 2 per-investigator");
+    ```
+    In `advancing_act_1_rebuilds_the_board`, after the act-1 advance, assert the Hallway (where investigators were relocated) is revealed:
+    ```rust
+    let hallway = result.state.locations.values().find(|l| l.code.as_str() == "01112").unwrap();
+    assert!(hallway.revealed, "relocate-to-Hallway reveals it");
+    ```
+    (The Attic/Cellar/Parlor remain unrevealed — they're in play but unentered.)
+
+- [ ] **Step 6: Run the suites.** Fix any other test that asserted location clues from the old flat placement (e.g. closing-demo / synthetic — those use `test_location`, which stays revealed with explicit clues, so they should be unaffected; if any scenario test investigated a location whose clues now require reveal, ensure the investigator entered it first).
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: all green.
+
+- [ ] **Step 7: Full gauntlet + commit**
+
+```sh
+cargo clippy --all-targets --all-features -- -D warnings && cargo fmt --check && RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+```
+Then:
+```bash
+git add -A
+git commit -m "engine: locations enter unrevealed; reveal on entry places clues (#257)"
+```
+(Review `git status` before `git add -A` — only the intended files.)
+
+---
+
+## Final: full CI gauntlet
+
+- [ ] Run the complete gauntlet (incl. wasm) on the final state:
+```sh
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+Expected: all green.
+
+- [ ] Phase-doc: #257 is cross-cutting (engine mechanic), not a phase-N deliverable — no `docs/phases` update. The PR closes #257.
+
+---
+
+## Self-Review notes (author)
+
+- **Spec coverage:** `ClueValue` → Task 1; corpus reshape + `clues_fixed` ingest → Task 2; `Location.printed_clues` + `reveal_location` + `LocationRevealed` + entry-site wiring → Task 3; enter-unrevealed activation + investigate gate + move-to-set-aside regression + scenario tests → Task 4. Per-investigator = `investigators.len()` (documented invariant in `reveal.rs`). Enemy/Hunter movement untouched (no site added there). Move-to-connected-in-play already enforced — Task 4 adds only the regression test.
+- **Green-at-each-step:** Tasks 1–2 are behavior-preserving (corpus type reshape only). Task 3 wires the reveal sites while locations still enter revealed → all calls are no-ops → no behavior change. Task 4 flips `add_location` to unrevealed, atomically activating the sites + updating the scenario expectations. The `reveal_location` helper is unit-tested in Task 3 via a manually-unrevealed location, independent of the flip.
+- **Type consistency:** `ClueValue { PerInvestigator(u8) | Fixed(u8) }` (Copy) used by `CardKind::Location.printed_clues` and `Location.printed_clues`; `Location::new` defaults `Fixed(clues)` (keeps `test_location`/synthetic/unit fixtures revealed-with-clues, unchanged); `add_location` builds via struct literal carrying the metadata's `printed_clues`. `Event::LocationRevealed { location: LocationId, clues: u8 }`. `reveal_location(cx, LocationId)` is `pub(crate)` in `dispatch::reveal`, called from `phases`/`actions`/`evaluator`.
+- **Scope-out confirmed untouched:** the `test_location(id,name)` fixture and the synthetic scenario keep explicit ids + revealed locations (they use `Location::new`/`test_location`, not `add_location`).

--- a/docs/superpowers/specs/2026-06-12-location-reveal-design.md
+++ b/docs/superpowers/specs/2026-06-12-location-reveal-design.md
@@ -1,0 +1,174 @@
+# Location reveal-on-entry + per-investigator clue placement
+
+Design for [#257](https://github.com/talelburg/eldritch/issues/257): model the
+Arkham location-reveal mechanic — locations enter play **unrevealed**, are
+**revealed** the first time an *investigator* enters them, and at reveal place
+clues equal to the printed clue value (per-investigator or fixed). Filed as a
+deferral from C1b (#228): the `revealed` field on `Location` is currently
+**dormant** (nothing reads it; `move_action` never reveals; clues are placed
+flat at construction).
+
+## Rules grounding
+
+Verified against the Rules Reference (`data/rules-reference/…`).
+
+**Reveal + clue placement** (p.14):
+> Locations enter play in an "unrevealed" state… The first time a location is
+> entered by an investigator, that location is revealed by turning it to its
+> other side **and placing a number of clues on it equal to its clue value**
+> (this may occur during setup). Most clue values are conveyed as a "per
+> investigator" value. If an **enemy** moves to an unrevealed location, that
+> location **remains unrevealed**.
+
+**Per-investigator multiplier** (p.16, *Per Investigator*):
+> That value is multiplied by **the number of investigators who started the
+> scenario**. … If investigators have been eliminated from the scenario, they
+> **still count** toward "per investigator" values.
+
+So a 2-per-investigator location with 3 starting investigators places **6**
+clues, even after one is eliminated. In this engine that count is
+`state.investigators.len()`: elimination flips `Investigator.status`
+(`Killed`/`Insane`/`Resigned`) and **never removes the entry** (the only
+`investigators.remove` calls are test-only corruption fixtures), and seating is
+the sole insertion point — so `len()` *is* the started-count, eliminated
+included. **Load-bearing invariant:** per-investigator math relies on eliminated
+investigators staying in the map; a future change that removes them must
+substitute a stored started-count.
+
+**`clues_fixed`** distinguishes the two: absent/false = per-investigator,
+`true` = fixed. The Gathering's locations are all per-investigator; ~20 Dunwich
+locations are fixed (already in the corpus). The pipeline currently drops the
+flag.
+
+**Move targets** (p.14): movement is to a *connecting* location. `move_action`
+already enforces both connectivity and in-play-ness (see Out of scope).
+
+## Design
+
+### `ClueValue` — a shared enum (`card-dsl`)
+
+```rust
+pub enum ClueValue {
+    /// `value × (number of investigators who started the scenario)`.
+    PerInvestigator(u8),
+    /// Exactly `value`, regardless of investigator count.
+    Fixed(u8),
+}
+```
+
+Used by **both** the corpus (`CardKind::Location`) and game-core's `Location`
+(one representation, no flat↔enum mapping). Lives in `card-dsl` (below both).
+
+### Pipeline + corpus
+
+`CardKind::Location { shroud, clues: u8, victory }` →
+`CardKind::Location { shroud, printed_clues: ClueValue, victory }`. The pipeline
+(`card-data-pipeline`) reads `clues_fixed` from the snapshot JSON and emits
+`ClueValue::Fixed(n)` when `clues_fixed == true`, else
+`ClueValue::PerInvestigator(n)` (where `n` is `clues`, defaulting 0). Regenerate
+`crates/cards/src/generated/cards.rs`. This remodels the `Location` variant (in
+the spirit of #254's `CardMetadata` remodel); the only readers are
+`GameState::add_location` and C2's future victory-point logic.
+
+### `Location` (game-core state)
+
+- Add `printed_clues: ClueValue` (the printed value + per-investigator/fixed).
+- `clues: u8` becomes **current** clues on the location (0 while unrevealed;
+  set at reveal).
+- `revealed: bool` — locations built by `add_location` enter **`false`**.
+- `add_location` / `add_set_aside_location` set `printed_clues` from the passed
+  metadata's `CardKind::Location`, `clues = 0`, `revealed = false`.
+- `Location::new(id, code, name, shroud, clues)` **keeps today's behavior**
+  (`revealed = true`, `clues` as given) by defaulting `printed_clues =
+  ClueValue::Fixed(clues)` — so the `test_location` fixture, the synthetic
+  scenario, and the game-core unit tests that build revealed locations with
+  explicit clues need no change.
+
+### `reveal_location` — the shared reveal step
+
+A helper in `game-core` (engine dispatch):
+
+```
+fn reveal_location(cx, location_id):
+    let loc = locations.get_mut(location_id)   // no-op if absent / already revealed
+    if loc.revealed: return
+    loc.revealed = true
+    loc.clues = match loc.printed_clues {
+        PerInvestigator(n) => n * investigators.len() (saturating, u8),
+        Fixed(n) => n,
+    }
+    emit Event::LocationRevealed { location, clues }
+```
+
+A new `Event::LocationRevealed { location, clues }` records the placement (for
+observers/replay clarity). Idempotent: revealing an already-revealed location is
+a no-op (no event, no extra clues).
+
+### Reveal fires on *investigator* entry — three call sites
+
+`reveal_location` is called wherever an investigator's `current_location` is set
+to a possibly-unrevealed location:
+
+1. **Seating** (`phases.rs` roster step) — after the investigators are inserted
+   at `starting_location`, reveal it (so `investigators.len()` reflects the full
+   seated count). The Study reveals here with `2 × len` clues.
+2. **`move_action`** (`actions.rs`) — when the investigator's destination is set
+   (after the existing AoO / move resolution), reveal the destination. Engaged
+   enemies move with the investigator but do **not** trigger reveal — only the
+   investigator's entry does.
+3. **`RelocateAllInvestigators`** (`evaluator.rs`, Act-1's reverse) — after
+   relocating everyone to the Hallway, reveal the Hallway.
+
+**Enemy / Hunter movement (`hunters.rs`, spawn) is untouched** — enemies entering
+an unrevealed location leave it unrevealed (per the rule).
+
+### `investigate` gate
+
+`investigate` gains an early rejection when the investigator's location is
+unrevealed. In practice this is unreachable (being at a location means you
+entered → revealed it), but it makes the "unrevealed isn't investigatable" rule
+explicit and guards against a future path that parks an investigator on an
+unrevealed location.
+
+## Out of scope (already handled / deferred)
+
+- **Move-to-connected-in-play:** already enforced by `move_action`
+  (`state.locations.contains_key(destination)` — the in-play gate, since
+  set-aside locations live in `set_aside_locations`, not `locations` — plus the
+  `from_loc.connections.contains(destination)` check). #257 adds only a
+  **regression test** asserting a move to a set-aside location is rejected,
+  since set-aside is now a real concept.
+- **Fixed-clue scenarios** (Dunwich) aren't *played* until Phase 10, but the
+  corpus now represents them correctly via `ClueValue::Fixed`.
+- **Per-investigator values elsewhere** (act/agenda thresholds, encounter
+  effects) — out of scope; this issue only places location clues. The
+  `investigators.len()` multiplier is reusable when those land.
+
+## Testing
+
+- **`card-dsl` unit:** `ClueValue` round-trips serde; `CardKind::Location`
+  carries `printed_clues`.
+- **Pipeline unit:** a `clues_fixed: true` location emits `Fixed(n)`; an absent
+  flag emits `PerInvestigator(n)`.
+- **Engine unit (`game_state.rs` / reveal helper):** `add_location` enters a
+  location unrevealed with `clues == 0` and the right `printed_clues`;
+  `reveal_location` places `n × len` (per-investigator, including a 2-investigator
+  case) and `n` (fixed), emits `LocationRevealed`, and is idempotent.
+- **Engine unit (`actions.rs`):** moving an investigator to an unrevealed in-play
+  location reveals it + places clues; **moving to a set-aside location is
+  rejected** (the regression test); `investigate` rejects on an unrevealed
+  location.
+- **Scenario (`the_gathering.rs` + `tests/`):** setup leaves the board
+  unrevealed (clues 0); after seating, the Study is revealed with
+  `2 × #investigators` clues; the act-1 board-rebuild test asserts the Hallway
+  reveals (clues placed) when investigators are relocated, and the set-aside
+  Attic/Cellar/Parlor enter unrevealed. Existing assertions that read the Study's
+  clue count update from the flat `2` to the per-investigator placement.
+
+## Open questions
+
+None. The shared `ClueValue` enum (over a `clues_fixed: bool` on the corpus +
+flat fields on `Location`) was chosen for a single clean representation across
+corpus and state. The per-investigator multiplier is `state.investigators.len()`,
+faithful because eliminated investigators remain in the map (documented as a
+load-bearing invariant).


### PR DESCRIPTION
## Summary

Models the Arkham location-reveal mechanic (Rules Reference p.14): locations enter play **unrevealed**, are **revealed on the first investigator entry**, and at reveal place clues equal to the printed value — `value × #investigators` (per-investigator) or a fixed amount. Closes the deferral filed from C1b (#228); the `revealed` field was previously dormant.

## What changed

- **`ClueValue` enum** (`card-dsl`: `PerInvestigator(u8)` | `Fixed(u8)`) reshapes `CardKind::Location` (`clues: u8` → `printed_clues: ClueValue`). The pipeline ingests ArkhamDB's `clues_fixed` (absent → per-investigator, `true` → fixed); the corpus is regenerated (110 locations: 90 per-investigator, 20 fixed Dunwich locations).
- **`Location`** gains `printed_clues`; `clues` becomes *current* clues (0 until revealed); `revealed` enters `false` via `add_location`. `Location::new` keeps today's behavior (revealed, `Fixed(clues)`) so the `test_location`/synthetic fixtures don't churn.
- **`reveal_location(cx, id)`** helper (`engine::dispatch::reveal`) — on first reveal, places clues and emits `Event::LocationRevealed`; idempotent. Fired from the **three investigator-entry sites**: seating, `move_action`, and `RelocateAllInvestigators` (Act-1's reverse). **Enemy/Hunter movement is untouched** — enemies entering an unrevealed location leave it unrevealed.
- **`investigate`** gains a `revealed` gate.

**Rules grounding (verified against the Rules Reference):**
- **Per-investigator = `state.investigators.len()`** (p.16): the multiplier is "investigators who *started* the scenario" — eliminated investigators *still count*. `len()` is faithful because elimination flips `status` and never removes from the map (documented as a load-bearing invariant in `reveal.rs`). So 3 started, 1 killed, reveal a 2-per-investigator location → 6 clues.
- **Move-to-connected-in-play** is already enforced by `move_action` (`state.locations.contains_key` is the in-play gate; set-aside lives in `set_aside_locations`). #257 adds only a **regression test** for the set-aside case.

Design: `docs/superpowers/specs/2026-06-12-location-reveal-design.md`.

## Test notes

- `card-dsl`: `ClueValue` serde. Pipeline: `clues_fixed` → `Fixed`/`PerInvestigator`.
- Engine: `reveal_location` (per-investigator ×count, fixed, idempotent); `add_location` enters unrevealed with `clues == 0`; **move-to-unrevealed reveals + places clues**; **investigate rejects on unrevealed**; **move-to-set-aside rejected**.
- Scenario (`the_gathering`): setup enters the board unrevealed (clues 0); seating reveals the Study with `2 × #investigators`; the act-1 board-rebuild test asserts the Hallway reveals on relocate.
- Full local gauntlet green: fmt, `-D warnings` test, clippy, doc, wasm-build, wasm-clippy.

Built green-at-each-step (the reveal machinery + sites land as no-ops while locations still enter revealed, then a final task flips `add_location` to unrevealed). Final Opus review: no critical/important issues; the two minor test-adequacy gaps it flagged are folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Linked issues

Closes #257