### PR TITLE
engine: C3a — prey LowestRemainingHealth + Retaliate keyword (#230)

### DIFF
--- a/crates/card-dsl/src/card_data.rs
+++ b/crates/card-dsl/src/card_data.rs
@@ -183,6 +183,13 @@ pub enum Prey {
     /// Pursue / engage the investigator with the highest value of the
     /// given stat; ties fall to the lead investigator.
     HighestStat(Stat),
+    /// Pursue / engage the investigator with the lowest remaining
+    /// health (base health − damage; Rules Reference p.12). Ties fall to
+    /// the lead investigator. Ravenous Ghoul (`01161`).
+    // TODO: generalize to a `{ measure, direction }` shape (covering
+    // stats *and* derived measures) when a 2nd derived-measure prey
+    // lands — Lowest remaining sanity, Most clues, Fewest cards in hand.
+    LowestRemainingHealth,
 }
 
 /// Static metadata for one card as printed: an identity core shared by

--- a/crates/card-dsl/src/card_data.rs
+++ b/crates/card-dsl/src/card_data.rs
@@ -14,7 +14,6 @@
 //! looked up through the registry too but lives in
 //! [`crate::dsl::Ability`].
 
-use crate::dsl::Stat;
 use serde::{Deserialize, Serialize};
 
 /// Investigator class. Translation of upstream's `faction_code` field
@@ -166,13 +165,14 @@ pub struct Spawn {
 /// An enemy's prey instruction (Rules Reference p.17): which
 /// investigator it pursues / engages when it has a choice.
 ///
-/// Phase-4 ships `Default` + `HighestStat`. `Default` covers "no prey
-/// instruction" and "Prey – nearest" — among equidistant / co-located
-/// investigators all are equal, so the lead investigator breaks the tie
-/// (p.12 / p.17). `HighestStat(Stat::Combat)` is Ghoul Priest's
-/// `Prey – Highest [combat]`. Other printed variants (`Lowest`,
-/// `Bearer only`, `Most clues`, …) land with their first card consumer;
-/// `#[non_exhaustive]` keeps that additive.
+/// `Default` covers "no prey instruction" and "Prey – nearest" — among
+/// equidistant / co-located investigators all are equal, so the lead
+/// investigator breaks the tie (p.12 / p.17). [`Ranked`](Self::Ranked)
+/// covers every *comparative* prey line as a `{ direction, measure }`
+/// pair: Ghoul Priest's `Highest [combat]` (`Highest` +
+/// `Skill(Combat)`) and Ravenous Ghoul's "Lowest remaining health"
+/// (`Lowest` + `RemainingHealth`). `#[non_exhaustive]` leaves room for
+/// genuinely non-comparative future shapes (e.g. "Bearer only").
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Prey {
@@ -180,16 +180,41 @@ pub enum Prey {
     /// lead investigator breaks ties.
     #[default]
     Default,
-    /// Pursue / engage the investigator with the highest value of the
-    /// given stat; ties fall to the lead investigator.
-    HighestStat(Stat),
-    /// Pursue / engage the investigator with the lowest remaining
-    /// health (base health − damage; Rules Reference p.12). Ties fall to
-    /// the lead investigator. Ravenous Ghoul (`01161`).
-    // TODO: generalize to a `{ measure, direction }` shape (covering
-    // stats *and* derived measures) when a 2nd derived-measure prey
-    // lands — Lowest remaining sanity, Most clues, Fewest cards in hand.
-    LowestRemainingHealth,
+    /// Pursue / engage the investigator with the highest or lowest value
+    /// of `measure`; ties fall to the lead investigator.
+    Ranked {
+        /// Whether the highest or lowest measure value is preferred.
+        direction: PreyDirection,
+        /// The quantity investigators are ranked by.
+        measure: PreyMeasure,
+    },
+}
+
+/// Whether a [`Prey::Ranked`] instruction prefers the highest or lowest
+/// value of its [`PreyMeasure`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum PreyDirection {
+    /// Prefer the investigator with the greatest measure value.
+    Highest,
+    /// Prefer the investigator with the least measure value.
+    Lowest,
+}
+
+/// The quantity a [`Prey::Ranked`] instruction ranks investigators by.
+///
+/// Exhaustive (unlike [`Prey`]): adding a measure must force the engine's
+/// `resolve_prey` to wire it, so the compiler flags the site. New printed
+/// measures land here with their first card consumer — `RemainingSanity`
+/// (Lowest remaining sanity), `Clues` (Most clues), `CardsInHand` (Fewest
+/// cards in hand), ….
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum PreyMeasure {
+    /// One of the four skills (Rules Reference p.17). Ghoul Priest's
+    /// `Highest [combat]` is `Skill(SkillKind::Combat)`.
+    Skill(SkillKind),
+    /// Remaining health = base health − damage (Rules Reference p.12).
+    /// Ravenous Ghoul's "Lowest remaining health".
+    RemainingHealth,
 }
 
 /// Static metadata for one card as printed: an identity core shared by
@@ -589,8 +614,22 @@ mod prey_tests {
     }
 
     #[test]
-    fn prey_serde_roundtrip_highest_stat() {
-        let original = Prey::HighestStat(Stat::Combat);
+    fn prey_serde_roundtrip_ranked_skill() {
+        let original = Prey::Ranked {
+            direction: PreyDirection::Highest,
+            measure: PreyMeasure::Skill(SkillKind::Combat),
+        };
+        let json = serde_json::to_string(&original).expect("serialize");
+        let back: Prey = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn prey_serde_roundtrip_ranked_remaining_health() {
+        let original = Prey::Ranked {
+            direction: PreyDirection::Lowest,
+            measure: PreyMeasure::RemainingHealth,
+        };
         let json = serde_json::to_string(&original).expect("serialize");
         let back: Prey = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, original);

--- a/crates/game-core/src/engine/dispatch/cursor.rs
+++ b/crates/game-core/src/engine/dispatch/cursor.rs
@@ -3,24 +3,7 @@
 //! These are pure lookup functions with no side effects; they call only into
 //! `crate::state` / `crate::dsl` and are called by multiple dispatch handlers.
 
-use crate::dsl::Stat;
-use crate::state::{GameState, InvestigatorId, LocationId, SkillKind, Status};
-
-/// Map a prey `Stat` to the `SkillKind` used for investigator lookup.
-/// Only the four base skills are valid prey stats in Phase-4 scope; a
-/// `MaxHealth`/`MaxSanity` prey would be a card-impl bug.
-pub(super) fn stat_to_skill_kind(stat: Stat) -> SkillKind {
-    match stat {
-        Stat::Willpower => SkillKind::Willpower,
-        Stat::Intellect => SkillKind::Intellect,
-        Stat::Combat => SkillKind::Combat,
-        Stat::Agility => SkillKind::Agility,
-        Stat::MaxHealth | Stat::MaxSanity => unreachable!(
-            "resolve_prey: prey stat {stat:?} is not a base skill; no in-scope \
-             prey instruction uses MaxHealth/MaxSanity — card-impl bug"
-        ),
-    }
-}
+use crate::state::{GameState, InvestigatorId, LocationId, Status};
 
 /// Investigators (Active, on the map) at `loc`, in `turn_order` order
 /// so prey ties carry a deterministic, lead-first candidate list.

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -322,6 +322,7 @@ fn spawn_enemy(
         engaged_with: None,
         hunter: false,
         prey: crate::card_data::Prey::Default,
+        retaliate: false,
     };
     cx.state.enemies.insert(enemy_id, enemy);
 

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -1,9 +1,11 @@
 //! Hunter-movement and prey-resolution helpers (Enemy phase step 3.2).
 
-use crate::card_data::Prey;
+use crate::card_data::{Prey, PreyDirection, PreyMeasure};
 use crate::engine::pathfinding::{bfs_distance, shortest_first_steps};
 use crate::event::Event;
-use crate::state::{Enemy, EnemyId, GameState, HunterChoice, InvestigatorId, LocationId};
+use crate::state::{
+    Enemy, EnemyId, GameState, HunterChoice, Investigator, InvestigatorId, LocationId,
+};
 
 use super::cursor;
 use super::Cx;
@@ -22,12 +24,23 @@ pub(super) enum PreyResolution {
     None,
 }
 
+/// The value an investigator scores for a comparative prey
+/// [`PreyMeasure`]. Widened to `i32` so `base_health − damage` can't
+/// underflow and so skills/health share one comparable type. Higher or
+/// lower is selected by the [`PreyDirection`] in [`Prey::Ranked`].
+fn measure_value(measure: PreyMeasure, inv: &Investigator) -> i32 {
+    match measure {
+        PreyMeasure::Skill(kind) => i32::from(inv.skills.value(kind)),
+        PreyMeasure::RemainingHealth => i32::from(inv.max_health) - i32::from(inv.damage),
+    }
+}
+
 /// Narrow `candidates` by `prey`. `Default` treats all candidates as
-/// equal; `HighestStat` keeps those with the maximum value of the
-/// stat. Returns `One` (single best), `Tie` (2+ best — lead decides),
-/// or `None` (empty candidate set). Caller supplies the candidate set
-/// (equidistant-nearest investigators for movement; co-located
-/// investigators for engagement).
+/// equal; `Ranked` keeps those with the most extreme measure value (max
+/// for `Highest`, min for `Lowest`). Returns `One` (single best), `Tie`
+/// (2+ best — lead decides), or `None` (empty candidate set). Caller
+/// supplies the candidate set (equidistant-nearest investigators for
+/// movement; co-located investigators for engagement).
 pub(super) fn resolve_prey(
     state: &GameState,
     prey: Prey,
@@ -38,51 +51,33 @@ pub(super) fn resolve_prey(
     }
     let best: Vec<InvestigatorId> = match prey {
         Prey::Default => candidates.to_vec(),
-        Prey::HighestStat(stat) => {
-            let skill = cursor::stat_to_skill_kind(stat);
-            let max = candidates
+        Prey::Ranked { direction, measure } => {
+            let scored: Vec<(InvestigatorId, i32)> = candidates
                 .iter()
                 .filter_map(|id| {
                     state
                         .investigators
                         .get(id)
-                        .map(|inv| inv.skills.value(skill))
+                        .map(|inv| (*id, measure_value(measure, inv)))
                 })
-                .max();
-            match max {
-                Some(m) => candidates
-                    .iter()
-                    .copied()
-                    .filter(|id| {
-                        state
-                            .investigators
-                            .get(id)
-                            .is_some_and(|inv| inv.skills.value(skill) == m)
-                    })
-                    .collect(),
-                None => Vec::new(),
-            }
-        }
-        Prey::LowestRemainingHealth => {
-            let remaining = |id: &InvestigatorId| -> Option<u8> {
-                state
-                    .investigators
-                    .get(id)
-                    .map(|inv| inv.max_health.saturating_sub(inv.damage))
+                .collect();
+            let extreme = match direction {
+                PreyDirection::Highest => scored.iter().map(|(_, v)| *v).max(),
+                PreyDirection::Lowest => scored.iter().map(|(_, v)| *v).min(),
             };
-            let min = candidates.iter().filter_map(remaining).min();
-            match min {
-                Some(m) => candidates
+            match extreme {
+                Some(target) => scored
                     .iter()
-                    .copied()
-                    .filter(|id| remaining(id) == Some(m))
+                    .filter(|(_, v)| *v == target)
+                    .map(|(id, _)| *id)
                     .collect(),
                 None => Vec::new(),
             }
         }
-        // `Prey` is #[non_exhaustive]; new variants (Lowest, Most Clues, etc.)
-        // must be wired here when their first card consumer lands — an
-        // unrecognised variant at runtime is a card-impl bug.
+        // `Prey` is #[non_exhaustive]; new *comparative* measures are
+        // added to `PreyMeasure` (compile-forced — exhaustive), so this
+        // arm only guards genuinely new non-`Ranked` shapes (e.g.
+        // "Bearer only"), which must be wired here when they land.
         _ => unreachable!(
             "resolve_prey: unrecognised Prey variant {prey:?} — \
              card-impl bug or new variant needs engine wiring"
@@ -516,7 +511,10 @@ mod resolve_prey_tests {
             .build();
         let r = resolve_prey(
             &state,
-            crate::card_data::Prey::HighestStat(crate::dsl::Stat::Combat),
+            crate::card_data::Prey::Ranked {
+                direction: crate::card_data::PreyDirection::Highest,
+                measure: crate::card_data::PreyMeasure::Skill(crate::card_data::SkillKind::Combat),
+            },
             &[InvestigatorId(1), InvestigatorId(2)],
         );
         assert!(matches!(r, PreyResolution::One(id) if id == InvestigatorId(1)));
@@ -534,7 +532,10 @@ mod resolve_prey_tests {
             .build();
         let r = resolve_prey(
             &state,
-            crate::card_data::Prey::HighestStat(crate::dsl::Stat::Combat),
+            crate::card_data::Prey::Ranked {
+                direction: crate::card_data::PreyDirection::Highest,
+                measure: crate::card_data::PreyMeasure::Skill(crate::card_data::SkillKind::Combat),
+            },
             &[InvestigatorId(1), InvestigatorId(2)],
         );
         assert!(matches!(r, PreyResolution::Tie(ref v) if v.len() == 2));
@@ -556,7 +557,10 @@ mod resolve_prey_tests {
             .build();
         let r = resolve_prey(
             &state,
-            crate::card_data::Prey::LowestRemainingHealth,
+            crate::card_data::Prey::Ranked {
+                direction: crate::card_data::PreyDirection::Lowest,
+                measure: crate::card_data::PreyMeasure::RemainingHealth,
+            },
             &[InvestigatorId(1), InvestigatorId(2)],
         );
         assert!(matches!(r, PreyResolution::One(id) if id == InvestigatorId(1)));
@@ -577,7 +581,10 @@ mod resolve_prey_tests {
             .build();
         let r = resolve_prey(
             &state,
-            crate::card_data::Prey::LowestRemainingHealth,
+            crate::card_data::Prey::Ranked {
+                direction: crate::card_data::PreyDirection::Lowest,
+                measure: crate::card_data::PreyMeasure::RemainingHealth,
+            },
             &[InvestigatorId(1), InvestigatorId(2)],
         );
         assert!(matches!(r, PreyResolution::Tie(ref v) if v.len() == 2));
@@ -961,7 +968,7 @@ mod hunter_resume_tests {
     #[test]
     fn highest_combat_prey_breaks_move_tie_without_prompt() {
         // Fan A(1)-{B(2),C(3)}. inv1 at B combat 5; inv2 at C combat 2.
-        // hunter at A with HighestStat(Combat) prey. resolve_prey picks
+        // hunter at A with Ranked Highest-combat prey. resolve_prey picks
         // inv1 unambiguously -> moves A->B, engages, no prompt.
         let mut loc_a = test_location(1, "A");
         let mut loc_b = test_location(2, "B");
@@ -977,7 +984,10 @@ mod hunter_resume_tests {
         inv2.skills.combat = 2;
         let mut hunter = test_enemy(1, "Ghoul Priest");
         hunter.hunter = true;
-        hunter.prey = crate::card_data::Prey::HighestStat(crate::dsl::Stat::Combat);
+        hunter.prey = crate::card_data::Prey::Ranked {
+            direction: crate::card_data::PreyDirection::Highest,
+            measure: crate::card_data::PreyMeasure::Skill(crate::card_data::SkillKind::Combat),
+        };
         hunter.current_location = Some(LocationId(1));
         let mut state = GameStateBuilder::new()
             .with_phase(Phase::Enemy)

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -28,6 +28,13 @@ pub(super) enum PreyResolution {
 /// [`PreyMeasure`]. Widened to `i32` so `base_health − damage` can't
 /// underflow and so skills/health share one comparable type. Higher or
 /// lower is selected by the [`PreyDirection`] in [`Prey::Ranked`].
+///
+/// TODO(#270): uses **base** skill / health only. Per RR p.18 (Modifiers)
+/// and p.12 (remaining health), prey comparisons should use the *modified*
+/// value (active constant modifiers folded in, as the skill-test path does
+/// via `constant_skill_modifier`). Deferred: only matters with 2+ tied
+/// candidates and a constant-modifier card (Beat Cop, C5d), neither in
+/// current scope.
 fn measure_value(measure: PreyMeasure, inv: &Investigator) -> i32 {
     match measure {
         PreyMeasure::Skill(kind) => i32::from(inv.skills.value(kind)),

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -63,6 +63,23 @@ pub(super) fn resolve_prey(
                 None => Vec::new(),
             }
         }
+        Prey::LowestRemainingHealth => {
+            let remaining = |id: &InvestigatorId| -> Option<u8> {
+                state
+                    .investigators
+                    .get(id)
+                    .map(|inv| inv.max_health.saturating_sub(inv.damage))
+            };
+            let min = candidates.iter().filter_map(remaining).min();
+            match min {
+                Some(m) => candidates
+                    .iter()
+                    .copied()
+                    .filter(|id| remaining(id) == Some(m))
+                    .collect(),
+                None => Vec::new(),
+            }
+        }
         // `Prey` is #[non_exhaustive]; new variants (Lowest, Most Clues, etc.)
         // must be wired here when their first card consumer lands — an
         // unrecognised variant at runtime is a card-impl bug.
@@ -518,6 +535,49 @@ mod resolve_prey_tests {
         let r = resolve_prey(
             &state,
             crate::card_data::Prey::HighestStat(crate::dsl::Stat::Combat),
+            &[InvestigatorId(1), InvestigatorId(2)],
+        );
+        assert!(matches!(r, PreyResolution::Tie(ref v) if v.len() == 2));
+    }
+
+    #[test]
+    fn resolve_prey_lowest_remaining_health_picks_min() {
+        // inv1: max_health 5, damage 4 → remaining 1.
+        // inv2: max_health 5, damage 0 → remaining 5. inv1 is lowest.
+        let mut hurt = test_investigator(1);
+        hurt.max_health = 5;
+        hurt.damage = 4;
+        let mut healthy = test_investigator(2);
+        healthy.max_health = 5;
+        healthy.damage = 0;
+        let state = GameStateBuilder::new()
+            .with_investigator(hurt)
+            .with_investigator(healthy)
+            .build();
+        let r = resolve_prey(
+            &state,
+            crate::card_data::Prey::LowestRemainingHealth,
+            &[InvestigatorId(1), InvestigatorId(2)],
+        );
+        assert!(matches!(r, PreyResolution::One(id) if id == InvestigatorId(1)));
+    }
+
+    #[test]
+    fn resolve_prey_lowest_remaining_health_tie_is_tie() {
+        // inv1: 5 − 2 = 3 remaining. inv2: 4 − 1 = 3 remaining. Tie.
+        let mut a = test_investigator(1);
+        a.max_health = 5;
+        a.damage = 2;
+        let mut b = test_investigator(2);
+        b.max_health = 4;
+        b.damage = 1;
+        let state = GameStateBuilder::new()
+            .with_investigator(a)
+            .with_investigator(b)
+            .build();
+        let r = resolve_prey(
+            &state,
+            crate::card_data::Prey::LowestRemainingHealth,
             &[InvestigatorId(1), InvestigatorId(2)],
         );
         assert!(matches!(r, PreyResolution::Tie(ref v) if v.len() == 2));

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -250,6 +250,14 @@ pub(super) fn drive_skill_test(cx: &mut Cx) -> EngineOutcome {
                     .in_flight_skill_test
                     .as_mut()
                     .expect("in_flight_skill_test must persist across driver steps")
+                    .continuation = FinishContinuation::PostRetaliate { succeeded };
+            }
+            FinishContinuation::PostRetaliate { succeeded } => {
+                fire_retaliate_if_any(cx, investigator, succeeded);
+                cx.state
+                    .in_flight_skill_test
+                    .as_mut()
+                    .expect("in_flight_skill_test must persist across driver steps")
                     .continuation = FinishContinuation::PostOnResolution { succeeded };
             }
             FinishContinuation::PostOnResolution { succeeded: _ } => {
@@ -528,6 +536,46 @@ fn apply_skill_test_follow_up(
             });
             cx.events.push(Event::EnemyExhausted { enemy });
         }
+    }
+}
+
+/// Fire a Retaliate attack if the just-resolved test was a *failed Fight*
+/// against a ready enemy with the retaliate keyword.
+///
+/// Rules Reference p.18: *"Each time an investigator fails a skill test
+/// while attacking a ready enemy with the retaliate keyword, after
+/// applying all results for that skill test, that enemy performs an
+/// attack against the attacking investigator. An enemy does not exhaust
+/// after performing a retaliate attack."*
+///
+/// Runs at the `PostRetaliate` step — after `fire_on_skill_test_resolution`
+/// (the rest of ST.7) and before the `PostOnResolution` teardown (ST.8) —
+/// matching "after applying all results." The attack routes through
+/// [`super::combat::enemy_attack`], which does not exhaust the attacker,
+/// satisfying the no-exhaust clause for free.
+///
+/// No-op unless every condition holds: the test failed; its follow-up was
+/// `Fight`; the enemy is still in play, ready (`!exhausted`), and has
+/// `retaliate`. A missing enemy is skipped quietly — a failed fight deals
+/// no damage, so the target can't have been defeated mid-test; this only
+/// guards against future enemy-removing commit effects. This step is also
+/// the future home of the "after an enemy attacks" reaction window (Guard
+/// Dog C5b, Roland's reaction).
+fn fire_retaliate_if_any(cx: &mut Cx, investigator: InvestigatorId, succeeded: bool) {
+    if succeeded {
+        return;
+    }
+    let follow_up = cx.state.in_flight_skill_test.as_ref().map(|t| t.follow_up);
+    let Some(SkillTestFollowUp::Fight { enemy }) = follow_up else {
+        return;
+    };
+    let retaliates = cx
+        .state
+        .enemies
+        .get(&enemy)
+        .is_some_and(|e| e.retaliate && !e.exhausted);
+    if retaliates {
+        super::combat::enemy_attack(cx, enemy, investigator);
     }
 }
 

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -1891,6 +1891,127 @@ mod tests {
     }
 
     #[test]
+    fn failed_fight_against_ready_retaliate_enemy_triggers_attack() {
+        // Combat 1 vs fight 3 → fail. Enemy retaliates 1 dmg + 1 horror.
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.investigators.get_mut(&inv_id).unwrap().skills.combat = 1;
+        let e = state.enemies.get_mut(&enemy_id).unwrap();
+        e.retaliate = true;
+        e.attack_damage = 1;
+        e.attack_horror = 1;
+        let result = apply_no_commits(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(result.events, Event::SkillTestFailed { .. });
+        // Retaliate attack lands (damage + horror, simultaneously).
+        assert_event!(result.events, Event::DamageTaken { investigator, amount: 1 } if *investigator == inv_id);
+        assert_event!(result.events, Event::HorrorTaken { investigator, amount: 1 } if *investigator == inv_id);
+        assert_eq!(result.state.investigators[&inv_id].damage, 1);
+        assert_eq!(result.state.investigators[&inv_id].horror, 1);
+        // Enemy does NOT exhaust after a retaliate attack (RR p.18).
+        assert!(!result.state.enemies[&enemy_id].exhausted);
+        // Failed fight dealt no damage to the enemy.
+        assert_no_event!(result.events, Event::EnemyDamaged { .. });
+        // Skill test still tears down.
+        assert_event!(result.events, Event::SkillTestEnded { .. });
+    }
+
+    #[test]
+    fn successful_fight_against_retaliate_enemy_does_not_trigger_attack() {
+        // Combat 3 vs fight 3 → success; retaliate must NOT fire.
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.investigators.get_mut(&inv_id).unwrap().skills.combat = 3;
+        let e = state.enemies.get_mut(&enemy_id).unwrap();
+        e.retaliate = true;
+        e.attack_damage = 1;
+        e.attack_horror = 1;
+        let result = apply_no_commits(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+
+        assert_event!(result.events, Event::SkillTestSucceeded { .. });
+        assert_no_event!(result.events, Event::DamageTaken { .. });
+        assert_no_event!(result.events, Event::HorrorTaken { .. });
+        assert_eq!(result.state.investigators[&inv_id].damage, 0);
+    }
+
+    #[test]
+    fn failed_fight_against_exhausted_retaliate_enemy_does_not_trigger_attack() {
+        // Retaliate requires a READY enemy (RR p.18). Exhausted → no attack.
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.investigators.get_mut(&inv_id).unwrap().skills.combat = 1;
+        let e = state.enemies.get_mut(&enemy_id).unwrap();
+        e.retaliate = true;
+        e.exhausted = true;
+        e.attack_damage = 1;
+        e.attack_horror = 1;
+        let result = apply_no_commits(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+
+        assert_event!(result.events, Event::SkillTestFailed { .. });
+        assert_no_event!(result.events, Event::DamageTaken { .. });
+        assert_eq!(result.state.investigators[&inv_id].damage, 0);
+    }
+
+    #[test]
+    fn failed_fight_against_non_retaliate_enemy_does_not_trigger_attack() {
+        // No retaliate flag → no attack on failure.
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.investigators.get_mut(&inv_id).unwrap().skills.combat = 1;
+        let e = state.enemies.get_mut(&enemy_id).unwrap();
+        e.attack_damage = 1;
+        e.attack_horror = 1;
+        let result = apply_no_commits(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+
+        assert_event!(result.events, Event::SkillTestFailed { .. });
+        assert_no_event!(result.events, Event::DamageTaken { .. });
+        assert_eq!(result.state.investigators[&inv_id].damage, 0);
+    }
+
+    #[test]
+    fn failed_evade_against_retaliate_enemy_does_not_trigger_attack() {
+        // Retaliate is "while attacking" — a failed Evade must NOT fire it.
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.investigators.get_mut(&inv_id).unwrap().skills.agility = 1; // vs evade 3 → fail
+        let e = state.enemies.get_mut(&enemy_id).unwrap();
+        e.retaliate = true;
+        e.attack_damage = 1;
+        e.attack_horror = 1;
+        let result = apply_no_commits(
+            state,
+            Action::Player(PlayerAction::Evade {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+
+        assert_event!(result.events, Event::SkillTestFailed { .. });
+        assert_no_event!(result.events, Event::DamageTaken { .. });
+        assert_eq!(result.state.investigators[&inv_id].damage, 0);
+    }
+
+    #[test]
     fn fight_defeats_enemy_when_damage_reaches_max_health() {
         // Enemy at 1/2 already; Fight success → damage 2, defeated,
         // removed from state, engagement cleared.

--- a/crates/game-core/src/state/enemy.rs
+++ b/crates/game-core/src/state/enemy.rs
@@ -75,6 +75,12 @@ pub struct Enemy {
     /// enemy pursues / engages when it has a choice. `Prey::Default`
     /// for enemies with no printed prey line.
     pub prey: Prey,
+    /// Whether this enemy has the Retaliate keyword (Rules Reference
+    /// p.18): after an investigator fails a Fight test against this
+    /// enemy while it is ready, it performs an attack against that
+    /// investigator (without exhausting). `false` for enemies with no
+    /// printed Retaliate line.
+    pub retaliate: bool,
 }
 
 #[cfg(test)]
@@ -98,10 +104,12 @@ mod hunter_prey_field_tests {
             engaged_with: None,
             hunter: true,
             prey: Prey::Default,
+            retaliate: true,
             code: crate::CardCode::new("01116"),
         };
         assert!(e.hunter);
         assert_eq!(e.prey, Prey::Default);
+        assert!(e.retaliate);
     }
 
     #[test]

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -433,6 +433,16 @@ pub enum FinishContinuation {
         succeeded: bool,
     },
     /// Step 3 (`OnSkillTestResolution`) is complete. The next driver
+    /// iteration fires a Retaliate attack if the test was a failed Fight
+    /// against a ready retaliate enemy (Rules Reference p.18 — "after
+    /// applying all results for that skill test"), then advances to
+    /// teardown.
+    PostRetaliate {
+        /// The chaos-token resolution's success determination — Retaliate
+        /// fires only on failure.
+        succeeded: bool,
+    },
+    /// Step 3 (`OnSkillTestResolution`) is complete. The next driver
     /// iteration discards committed cards, emits
     /// [`SkillTestEnded`](crate::Event::SkillTestEnded), and clears
     /// the in-flight record.

--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -110,6 +110,7 @@ pub fn test_enemy(id: u32, name: impl Into<String>) -> Enemy {
         engaged_with: None,
         hunter: false,
         prey: Prey::Default,
+        retaliate: false,
     }
 }
 

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -8,7 +8,8 @@ Engine spine (A1/A2) and scenario plumbing (B1/B2) shipped; **Group C**
 ([#227](https://github.com/talelburg/eldritch/issues/227)–[#245](https://github.com/talelburg/eldritch/issues/245),
 kickoff [#246](https://github.com/talelburg/eldritch/issues/246)). Shipped:
 C1a (board skeleton), C1b (Act-1 board build + Act-3 forced advance-on-defeat),
-C2 (01104 symbol-token effects + location victory points).
+C2 (01104 symbol-token effects + location victory points),
+C3a (Prey – Lowest remaining health + Retaliate keyword).
 Design specs:
 [Gathering design](../superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md),
 [Group C decomposition](../superpowers/specs/2026-06-11-phase-7-slice-1-group-c-decomposition-design.md).
@@ -52,7 +53,7 @@ root dependency; C7 is the playable Won/Lost gate; #212 lands after C.
 | C1a | [#227](https://github.com/talelburg/eldritch/issues/227) | `setup()` world-build + forced location effects | ✅ PR #250 |
 | C1b | [#228](https://github.com/talelburg/eldritch/issues/228) | Act-1 (01108) reverse board-build + Act-3 (01110) forced advance-on-defeat (act-2 01109 objective → C3c) | ✅ PR #259 |
 | C2 | [#229](https://github.com/talelburg/eldritch/issues/229) | 01104 symbol-token effects + victory points | ✅ PR #263 |
-| C3a | [#230](https://github.com/talelburg/eldritch/issues/230) | Prey variants + Retaliate | — |
+| C3a | [#230](https://github.com/talelburg/eldritch/issues/230) | Prey variants + Retaliate | ✅ PR #269 |
 | C3b | [#231](https://github.com/talelburg/eldritch/issues/231) | the six encounter enemies | — |
 | C3c | [#232](https://github.com/talelburg/eldritch/issues/232) | agenda 01107 forced (movement + doom; +`RoundEnded`) **+ act-2 (01109) round-end objective (moved from C1b)** | — |
 | C4a | [#233](https://github.com/talelburg/eldritch/issues/233) | threat-area zone + shared scan source (in-C consolidation seam) | — |

--- a/docs/superpowers/plans/2026-06-13-phase-7-c3a-prey-retaliate.md
+++ b/docs/superpowers/plans/2026-06-13-phase-7-c3a-prey-retaliate.md
@@ -1,0 +1,518 @@
+# C3a — Prey variants + Retaliate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two engine primitives The Gathering's encounter enemies need — the `Prey::LowestRemainingHealth` instruction (Ravenous Ghoul 01161) and the Retaliate keyword (Ghoul Priest 01116).
+
+**Architecture:** `Prey::LowestRemainingHealth` is a new variant on the existing `#[non_exhaustive]` `Prey` enum, wired into `resolve_prey` as a min-over-remaining-health branch mirroring the existing `HighestStat` max branch. Retaliate adds a `retaliate: bool` flag to the `Enemy` state struct and a new `FinishContinuation::PostRetaliate` step in the skill-test driver that fires an enemy attack after a failed Fight test (after ST.7's OnSkillTestResolution triggers, before ST.8 teardown — RR p.26 "after applying all results"). C3a is engine-only: `spawn_enemy` keeps its hardcoded defaults; C3b ([#231](https://github.com/talelburg/eldritch/issues/231)) populates the keywords onto real enemies.
+
+**Tech Stack:** Rust, the `game-core` kernel crate + the `card-dsl` data crate. No async, no I/O. Tests via `cargo test` with `RUSTFLAGS="-D warnings"`.
+
+**Spec:** `docs/superpowers/specs/2026-06-13-phase-7-c3a-prey-retaliate-design.md`
+
+---
+
+## Background the implementer needs
+
+- **`resolve_prey`** (`crates/game-core/src/engine/dispatch/hunters.rs:31`) narrows a candidate investigator set by a `Prey` instruction, returning `PreyResolution::One` / `Tie` / `None`. The `HighestStat` branch (lines 41-65) is the template: compute the max of a per-investigator value, then keep every candidate matching it.
+- **`Prey`** enum lives in `crates/card-dsl/src/card_data.rs:178`, re-exported as `crate::card_data::Prey` inside `game-core`. It is `#[non_exhaustive]`; `resolve_prey` has a catch-all `_ => unreachable!(...)` arm (lines 66-72) — a new variant **must** be wired before that arm or it panics at runtime.
+- **`Enemy`** state struct: `crates/game-core/src/state/enemy.rs:29`. The runtime enemy (distinct from `CardKind::Enemy` *metadata*). Three literal-construction sites exist in-crate and all must gain the new field: `test_enemy` fixture (`crates/game-core/src/test_support/fixtures.rs:97`), the `enemy_carries_hunter_and_prey` test (`crates/game-core/src/state/enemy.rs:86`), and `spawn_enemy` (`crates/game-core/src/engine/dispatch/encounter.rs:309`).
+- **Investigator** state (`crates/game-core/src/state/investigator.rs`) has `max_health: u8` and `damage: u8`. Remaining health = `max_health − damage` (saturating).
+- **Skill-test driver**: `finish_skill_test` (`crates/game-core/src/engine/dispatch/skill_test.rs:132`) resolves the chaos token, runs the success-only `apply_skill_test_follow_up`, then sets continuation `PostFollowUp { succeeded }` and calls `drive_skill_test` (line 220). `drive_skill_test`'s loop maps: `PostFollowUp` → `fire_on_skill_test_resolution` then advance; `PostOnResolution` → discard committed cards + `SkillTestEnded` + clear in-flight, return `Done`. `FinishContinuation` is defined at `crates/game-core/src/state/game_state.rs:423` (`#[non_exhaustive]`, `Copy`, serde).
+- **`SkillTestFollowUp`** (`crates/game-core/src/state/game_state.rs:456`): `None | Investigate | Fight { enemy } | Evade { enemy }`. The in-flight record carries `follow_up` (`game_state.rs:357`); it persists until teardown, so later driver steps can re-read it.
+- **`enemy_attack`** (`crates/game-core/src/engine/dispatch/combat.rs:175`, `pub(super) fn enemy_attack(cx, enemy_id, investigator)`) places the enemy's `attack_damage` + `attack_horror` on the investigator (simultaneously per RR p.7) and handles investigator defeat. It does **not** exhaust the attacker — exactly the Retaliate no-exhaust clause. Call it as `super::combat::enemy_attack(...)` from `skill_test.rs`.
+- **Test helpers** (in `crates/game-core/src/engine/mod.rs` test module): `fight_evade_scenario()` (`:1814`) returns `(InvestigatorId(1), EnemyId(100), GameState)` with the enemy engaged, `fight=evade=3`, `max_health=2`, chaos bag `bag_only_zero()` (always draws `Numeric(0)`), phase Investigation, active investigator set. `apply_no_commits(state, action)` (`crates/game-core/src/test_support/resolver.rs:238`) drives a skill-test-initiating action through the commit window with zero commits and aggregates all events into `ApplyResult { state, events, outcome }`. `test_investigator` defaults: all skills 3, `max_health` 8, `max_sanity` 8, `damage`/`horror` 0.
+
+### CI gauntlet (run before declaring any task done)
+
+```sh
+RUSTFLAGS="-D warnings" cargo test -p game-core --all-features
+RUSTFLAGS="-D warnings" cargo test -p card-dsl --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+```
+
+Single test: `cargo test -p game-core <test_fn_name>`.
+
+---
+
+## Task 1: `Prey::LowestRemainingHealth`
+
+**Files:**
+- Modify: `crates/card-dsl/src/card_data.rs:178` (add enum variant)
+- Modify: `crates/game-core/src/engine/dispatch/hunters.rs:39` (add `resolve_prey` branch)
+- Test: `crates/game-core/src/engine/dispatch/hunters.rs` (`resolve_prey_tests` module, ~line 451)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `resolve_prey_tests` module in `crates/game-core/src/engine/dispatch/hunters.rs` (alongside the existing `resolve_prey_highest_stat_*` tests):
+
+```rust
+    #[test]
+    fn resolve_prey_lowest_remaining_health_picks_min() {
+        // inv1: max_health 5, damage 4 → remaining 1.
+        // inv2: max_health 5, damage 0 → remaining 5. inv1 is lowest.
+        let mut hurt = test_investigator(1);
+        hurt.max_health = 5;
+        hurt.damage = 4;
+        let mut healthy = test_investigator(2);
+        healthy.max_health = 5;
+        healthy.damage = 0;
+        let state = GameStateBuilder::new()
+            .with_investigator(hurt)
+            .with_investigator(healthy)
+            .build();
+        let r = resolve_prey(
+            &state,
+            crate::card_data::Prey::LowestRemainingHealth,
+            &[InvestigatorId(1), InvestigatorId(2)],
+        );
+        assert!(matches!(r, PreyResolution::One(id) if id == InvestigatorId(1)));
+    }
+
+    #[test]
+    fn resolve_prey_lowest_remaining_health_tie_is_tie() {
+        // inv1: 5 − 2 = 3 remaining. inv2: 4 − 1 = 3 remaining. Tie.
+        let mut a = test_investigator(1);
+        a.max_health = 5;
+        a.damage = 2;
+        let mut b = test_investigator(2);
+        b.max_health = 4;
+        b.damage = 1;
+        let state = GameStateBuilder::new()
+            .with_investigator(a)
+            .with_investigator(b)
+            .build();
+        let r = resolve_prey(
+            &state,
+            crate::card_data::Prey::LowestRemainingHealth,
+            &[InvestigatorId(1), InvestigatorId(2)],
+        );
+        assert!(matches!(r, PreyResolution::Tie(ref v) if v.len() == 2));
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p game-core resolve_prey_lowest_remaining_health 2>&1 | tail -20`
+Expected: compile error — `no variant named LowestRemainingHealth found for enum ... Prey`.
+
+- [ ] **Step 3a: Add the enum variant**
+
+In `crates/card-dsl/src/card_data.rs`, inside the `Prey` enum (after the `HighestStat(Stat)` variant, before the closing brace at ~line 186):
+
+```rust
+    /// Pursue / engage the investigator with the lowest remaining
+    /// health (base health − damage; Rules Reference p.12). Ties fall to
+    /// the lead investigator. Ravenous Ghoul (`01161`).
+    // TODO: generalize to a `{ measure, direction }` shape (covering
+    // stats *and* derived measures) when a 2nd derived-measure prey
+    // lands — Lowest remaining sanity, Most clues, Fewest cards in hand.
+    LowestRemainingHealth,
+```
+
+- [ ] **Step 3b: Wire the `resolve_prey` branch**
+
+In `crates/game-core/src/engine/dispatch/hunters.rs`, inside `resolve_prey`'s `match prey` (after the `Prey::HighestStat(stat) => { ... }` arm at line 65, before the `_ => unreachable!` catch-all at line 66):
+
+```rust
+        Prey::LowestRemainingHealth => {
+            let remaining = |id: &InvestigatorId| -> Option<u8> {
+                state
+                    .investigators
+                    .get(id)
+                    .map(|inv| inv.max_health.saturating_sub(inv.damage))
+            };
+            let min = candidates.iter().filter_map(remaining).min();
+            match min {
+                Some(m) => candidates
+                    .iter()
+                    .copied()
+                    .filter(|id| remaining(id) == Some(m))
+                    .collect(),
+                None => Vec::new(),
+            }
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p game-core resolve_prey 2>&1 | tail -20`
+Expected: PASS (all `resolve_prey_*` tests, including the two new ones).
+
+- [ ] **Step 5: Run the gauntlet + commit**
+
+```sh
+RUSTFLAGS="-D warnings" cargo test -p game-core --all-features
+RUSTFLAGS="-D warnings" cargo test -p card-dsl --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+```
+
+```bash
+git add crates/card-dsl/src/card_data.rs crates/game-core/src/engine/dispatch/hunters.rs
+git commit -m "engine: Prey::LowestRemainingHealth (Ravenous Ghoul 01161)
+
+Adds the lowest-remaining-health prey instruction (RR p.12) as a specific
+Prey variant, wired into resolve_prey as a min-over-(max_health-damage)
+branch mirroring HighestStat. Generalize to a measure/direction shape on
+the 2nd derived-measure consumer (TODO noted in the enum).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `Enemy.retaliate` field
+
+Pure state plumbing — adds the flag and fills it on every `Enemy` literal. No behavior yet (Task 3 consumes it). `spawn_enemy` keeps `retaliate: false` (C3b populates it from card data).
+
+**Files:**
+- Modify: `crates/game-core/src/state/enemy.rs:77` (field) and `:86` (test literal + assertion)
+- Modify: `crates/game-core/src/test_support/fixtures.rs:97` (`test_enemy` literal)
+- Modify: `crates/game-core/src/engine/dispatch/encounter.rs:309` (`spawn_enemy` literal)
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/game-core/src/state/enemy.rs`, edit the existing `enemy_carries_hunter_and_prey` test (line 85): add `retaliate: true,` to the `Enemy { ... }` literal (after the `prey:` field) and add an assertion at the end of the test body:
+
+```rust
+        assert!(e.retaliate);
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p game-core enemy_carries_hunter_and_prey 2>&1 | tail -20`
+Expected: compile error — `struct Enemy has no field named retaliate`.
+
+- [ ] **Step 3a: Add the struct field**
+
+In `crates/game-core/src/state/enemy.rs`, add to the `Enemy` struct after the `prey` field (line 77):
+
+```rust
+    /// Whether this enemy has the Retaliate keyword (Rules Reference
+    /// p.18): after an investigator fails a Fight test against this
+    /// enemy while it is ready, it performs an attack against that
+    /// investigator (without exhausting). `false` for enemies with no
+    /// printed Retaliate line.
+    pub retaliate: bool,
+```
+
+- [ ] **Step 3b: Fill the two remaining literals**
+
+In `crates/game-core/src/test_support/fixtures.rs`, in `test_enemy` (line 97), add after `prey: Prey::Default,`:
+
+```rust
+        retaliate: false,
+```
+
+In `crates/game-core/src/engine/dispatch/encounter.rs`, in `spawn_enemy`'s `Enemy { ... }` (line 309), add after `prey: crate::card_data::Prey::Default,`:
+
+```rust
+        retaliate: false,
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p game-core enemy_carries_hunter_and_prey 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 5: Run the gauntlet + commit**
+
+```sh
+RUSTFLAGS="-D warnings" cargo test -p game-core --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+```
+
+```bash
+git add crates/game-core/src/state/enemy.rs crates/game-core/src/test_support/fixtures.rs crates/game-core/src/engine/dispatch/encounter.rs
+git commit -m "engine: add Enemy.retaliate flag (state plumbing)
+
+Adds the retaliate keyword flag to the runtime Enemy struct, defaulted
+false on every construction site (fixture, spawn_enemy). Consumed by the
+retaliate-firing step in the next commit; populated from card data in C3b.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Retaliate firing (`FinishContinuation::PostRetaliate`)
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs:434` (new `FinishContinuation` variant)
+- Modify: `crates/game-core/src/engine/dispatch/skill_test.rs:247` (driver wiring) + new helper
+- Test: `crates/game-core/src/engine/mod.rs` (test module, near the fight tests ~line 1890)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `crates/game-core/src/engine/mod.rs`, in the test module containing `fight_evade_scenario`, add:
+
+```rust
+    #[test]
+    fn failed_fight_against_ready_retaliate_enemy_triggers_attack() {
+        // Combat 1 vs fight 3 → fail. Enemy retaliates 1 dmg + 1 horror.
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.investigators.get_mut(&inv_id).unwrap().skills.combat = 1;
+        let e = state.enemies.get_mut(&enemy_id).unwrap();
+        e.retaliate = true;
+        e.attack_damage = 1;
+        e.attack_horror = 1;
+        let result = apply_no_commits(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(result.events, Event::SkillTestFailed { .. });
+        // Retaliate attack lands (damage + horror, simultaneously).
+        assert_event!(result.events, Event::DamageTaken { investigator, amount: 1 } if *investigator == inv_id);
+        assert_event!(result.events, Event::HorrorTaken { investigator, amount: 1 } if *investigator == inv_id);
+        assert_eq!(result.state.investigators[&inv_id].damage, 1);
+        assert_eq!(result.state.investigators[&inv_id].horror, 1);
+        // Enemy does NOT exhaust after a retaliate attack (RR p.18).
+        assert!(!result.state.enemies[&enemy_id].exhausted);
+        // Failed fight dealt no damage to the enemy.
+        assert_no_event!(result.events, Event::EnemyDamaged { .. });
+        // Skill test still tears down.
+        assert_event!(result.events, Event::SkillTestEnded { .. });
+    }
+
+    #[test]
+    fn successful_fight_against_retaliate_enemy_does_not_trigger_attack() {
+        // Combat 3 vs fight 3 → success; retaliate must NOT fire.
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.investigators.get_mut(&inv_id).unwrap().skills.combat = 3;
+        let e = state.enemies.get_mut(&enemy_id).unwrap();
+        e.retaliate = true;
+        e.attack_damage = 1;
+        e.attack_horror = 1;
+        let result = apply_no_commits(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+
+        assert_event!(result.events, Event::SkillTestSucceeded { .. });
+        assert_no_event!(result.events, Event::DamageTaken { .. });
+        assert_no_event!(result.events, Event::HorrorTaken { .. });
+        assert_eq!(result.state.investigators[&inv_id].damage, 0);
+    }
+
+    #[test]
+    fn failed_fight_against_exhausted_retaliate_enemy_does_not_trigger_attack() {
+        // Retaliate requires a READY enemy (RR p.18). Exhausted → no attack.
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.investigators.get_mut(&inv_id).unwrap().skills.combat = 1;
+        let e = state.enemies.get_mut(&enemy_id).unwrap();
+        e.retaliate = true;
+        e.exhausted = true;
+        e.attack_damage = 1;
+        e.attack_horror = 1;
+        let result = apply_no_commits(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+
+        assert_event!(result.events, Event::SkillTestFailed { .. });
+        assert_no_event!(result.events, Event::DamageTaken { .. });
+        assert_eq!(result.state.investigators[&inv_id].damage, 0);
+    }
+
+    #[test]
+    fn failed_fight_against_non_retaliate_enemy_does_not_trigger_attack() {
+        // No retaliate flag → no attack on failure.
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.investigators.get_mut(&inv_id).unwrap().skills.combat = 1;
+        let e = state.enemies.get_mut(&enemy_id).unwrap();
+        e.attack_damage = 1;
+        e.attack_horror = 1;
+        let result = apply_no_commits(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+
+        assert_event!(result.events, Event::SkillTestFailed { .. });
+        assert_no_event!(result.events, Event::DamageTaken { .. });
+        assert_eq!(result.state.investigators[&inv_id].damage, 0);
+    }
+
+    #[test]
+    fn failed_evade_against_retaliate_enemy_does_not_trigger_attack() {
+        // Retaliate is "while attacking" — a failed Evade must NOT fire it.
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.investigators.get_mut(&inv_id).unwrap().skills.agility = 1; // vs evade 3 → fail
+        let e = state.enemies.get_mut(&enemy_id).unwrap();
+        e.retaliate = true;
+        e.attack_damage = 1;
+        e.attack_horror = 1;
+        let result = apply_no_commits(
+            state,
+            Action::Player(PlayerAction::Evade {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+
+        assert_event!(result.events, Event::SkillTestFailed { .. });
+        assert_no_event!(result.events, Event::DamageTaken { .. });
+        assert_eq!(result.state.investigators[&inv_id].damage, 0);
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p game-core retaliate 2>&1 | tail -25`
+Expected: `failed_fight_against_ready_retaliate_enemy_triggers_attack` FAILS (no `DamageTaken`/`HorrorTaken` event; `damage == 0`). The four negative tests may already pass (no retaliate path exists yet) — that's fine; the positive test is the red.
+
+- [ ] **Step 3a: Add the `FinishContinuation::PostRetaliate` variant**
+
+In `crates/game-core/src/state/game_state.rs`, in the `FinishContinuation` enum, **between** `PostFollowUp { .. }` (ends line 434) and `PostOnResolution { .. }` (starts line 439):
+
+```rust
+    /// Step 3 (`OnSkillTestResolution`) is complete. The next driver
+    /// iteration fires a Retaliate attack if the test was a failed Fight
+    /// against a ready retaliate enemy (Rules Reference p.18 — "after
+    /// applying all results for that skill test"), then advances to
+    /// teardown.
+    PostRetaliate {
+        /// The chaos-token resolution's success determination — Retaliate
+        /// fires only on failure.
+        succeeded: bool,
+    },
+```
+
+- [ ] **Step 3b: Wire the driver + add the helper**
+
+In `crates/game-core/src/engine/dispatch/skill_test.rs`, in `drive_skill_test`'s `match continuation`:
+
+Change the `PostFollowUp` arm's next continuation from `PostOnResolution` to `PostRetaliate` (line ~253), and add a new `PostRetaliate` arm immediately after it. The result:
+
+```rust
+            FinishContinuation::PostFollowUp { succeeded } => {
+                fire_on_skill_test_resolution(cx, investigator, &indices_u8, succeeded);
+                cx.state
+                    .in_flight_skill_test
+                    .as_mut()
+                    .expect("in_flight_skill_test must persist across driver steps")
+                    .continuation = FinishContinuation::PostRetaliate { succeeded };
+            }
+            FinishContinuation::PostRetaliate { succeeded } => {
+                fire_retaliate_if_any(cx, investigator, succeeded);
+                cx.state
+                    .in_flight_skill_test
+                    .as_mut()
+                    .expect("in_flight_skill_test must persist across driver steps")
+                    .continuation = FinishContinuation::PostOnResolution { succeeded };
+            }
+```
+
+(The `PostOnResolution` arm is unchanged.)
+
+Then add this helper near `apply_skill_test_follow_up` (e.g. after it, ~line 532):
+
+```rust
+/// Fire a Retaliate attack if the just-resolved test was a *failed Fight*
+/// against a ready enemy with the retaliate keyword.
+///
+/// Rules Reference p.18: *"Each time an investigator fails a skill test
+/// while attacking a ready enemy with the retaliate keyword, after
+/// applying all results for that skill test, that enemy performs an
+/// attack against the attacking investigator. An enemy does not exhaust
+/// after performing a retaliate attack."*
+///
+/// Runs at the `PostRetaliate` step — after `fire_on_skill_test_resolution`
+/// (the rest of ST.7) and before the `PostOnResolution` teardown (ST.8) —
+/// matching "after applying all results." The attack routes through
+/// [`super::combat::enemy_attack`], which does not exhaust the attacker,
+/// satisfying the no-exhaust clause for free.
+///
+/// No-op unless every condition holds: the test failed; its follow-up was
+/// `Fight`; the enemy is still in play, ready (`!exhausted`), and has
+/// `retaliate`. A missing enemy is skipped quietly — a failed fight deals
+/// no damage, so the target can't have been defeated mid-test; this only
+/// guards against future enemy-removing commit effects. This step is also
+/// the future home of the "after an enemy attacks" reaction window (Guard
+/// Dog C5b, Roland's reaction).
+fn fire_retaliate_if_any(cx: &mut Cx, investigator: InvestigatorId, succeeded: bool) {
+    if succeeded {
+        return;
+    }
+    let follow_up = cx.state.in_flight_skill_test.as_ref().map(|t| t.follow_up);
+    let Some(SkillTestFollowUp::Fight { enemy }) = follow_up else {
+        return;
+    };
+    let retaliates = cx
+        .state
+        .enemies
+        .get(&enemy)
+        .is_some_and(|e| e.retaliate && !e.exhausted);
+    if retaliates {
+        super::combat::enemy_attack(cx, enemy, investigator);
+    }
+}
+```
+
+`SkillTestFollowUp` is already imported in `skill_test.rs` (used by `apply_skill_test_follow_up`); `InvestigatorId` likewise. No new `use` needed.
+
+- [ ] **Step 4: Run to verify all pass**
+
+Run: `cargo test -p game-core retaliate 2>&1 | tail -25`
+Expected: all five `*_retaliate_*` tests PASS.
+
+- [ ] **Step 5: Run the gauntlet + commit**
+
+```sh
+RUSTFLAGS="-D warnings" cargo test -p game-core --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+```
+
+```bash
+git add crates/game-core/src/state/game_state.rs crates/game-core/src/engine/dispatch/skill_test.rs crates/game-core/src/engine/mod.rs
+git commit -m "engine: Retaliate keyword (Ghoul Priest 01116)
+
+After a failed Fight test against a ready retaliate enemy, the enemy
+attacks the investigator without exhausting (RR p.18). Fires in a new
+FinishContinuation::PostRetaliate step, after ST.7's OnSkillTestResolution
+triggers and before ST.8 teardown (RR p.26 'after applying all results').
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification (whole-workspace gauntlet)
+
+After all three tasks, run the full CI gauntlet from the repo root before opening the PR:
+
+```sh
+RUSTFLAGS="-D warnings"    cargo test --all --all-features
+                           cargo clippy --all-targets --all-features -- -D warnings
+                           cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+                           cargo build -p web --target wasm32-unknown-unknown
+                           cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+
+(`wasm-pack test` for `crates/web` is unaffected by this engine change but is part of CI.)
+
+## Self-review notes (coverage vs. spec)
+
+- Spec §1 `Prey::LowestRemainingHealth` → Task 1 (variant + branch + One/Tie tests).
+- Spec §2 state `retaliate: bool` → Task 2 (field + all three literals).
+- Spec §2 firing (Option B, `PostRetaliate` after ST.7) → Task 3 (continuation + driver + helper).
+- Spec §2 edge cases (success / exhausted / non-retaliate / non-Fight follow-up) → Task 3 negative tests (success, exhausted, non-retaliate, failed-Evade). Enemy-absent graceful-skip is covered by the `.is_some_and(...)` guard (asserted indirectly — no enemy-removing path exists to test directly in C3a; documented in the helper).
+- Out-of-scope (spawn_enemy population, six enemy impls) correctly left untouched: `spawn_enemy` keeps `retaliate: false`.

--- a/docs/superpowers/specs/2026-06-13-phase-7-c3a-prey-retaliate-design.md
+++ b/docs/superpowers/specs/2026-06-13-phase-7-c3a-prey-retaliate-design.md
@@ -1,0 +1,144 @@
+# Phase 7 Slice 1 — C3a: Prey variants + Retaliate
+
+Engine primitives for two enemy keywords The Gathering's encounter enemies
+need. Sub-slice C3a of Group C ([#230](https://github.com/talelburg/eldritch/issues/230)),
+the root of the C3 enemy chain (`C3a → C3b → C3c`). Companion to the
+[Group C decomposition](2026-06-11-phase-7-slice-1-group-c-decomposition-design.md).
+
+## Scope
+
+C3a is the **engine** half of the seam: it adds two reusable engine
+capabilities and exercises them with synthetic enemies + engine unit tests.
+It does **not** wire the real enemies. The two consumers are:
+
+- **Ravenous Ghoul (01161)** — "Prey – Lowest remaining health."
+- **Ghoul Priest (01116)** — "Hunter. Retaliate." (Hunter + highest-combat
+  prey already exist; Retaliate is the new piece.)
+
+### Out of scope (C3b, [#231](https://github.com/talelburg/eldritch/issues/231))
+
+- Populating `hunter` / `prey` / `retaliate` onto spawned enemies. `spawn_enemy`
+  keeps its hardcoded `hunter: false`, `prey: Prey::Default`, `retaliate: false`
+  (the keywords live only in printed text today; mapping text → structured
+  `Enemy` state is C3b's job, alongside reading `fight`/`evade`/`damage`/`horror`
+  from `CardKind::Enemy`). C3a's only `spawn_enemy` touch is adding
+  `retaliate: false` to the struct literal so it keeps compiling.
+- The six enemy card impls and their tests.
+
+## Card text & rules (verified against snapshot + Rules Reference)
+
+- Ravenous Ghoul `01161`: `<b>Prey</b> - Lowest remaining health.`
+- Ghoul Priest `01116`: `<b>Prey</b> - Highest [combat].\nHunter. Retaliate.`
+- **Remaining health** (RR p.12): *"A card's 'remaining health' is its base
+  health minus the amount of damage on it, plus or minus any active health
+  modifiers."* No health modifiers are modeled yet, so for an investigator this
+  is `max_health − damage`.
+- **Retaliate** (RR p.18): *"Retaliate is a keyword ability. Each time an
+  investigator fails a skill test while attacking a ready enemy with the
+  retaliate keyword, after applying all results for that skill test, that enemy
+  performs an attack against the attacking investigator. An enemy does not
+  exhaust after performing a retaliate attack. ==This attack occurs whether the
+  enemy is engaged with the attacking investigator or not."*
+- **Skill-test steps** (RR p.26): ST.7 *Apply skill test results* ("the card
+  ability or game rule that initiated the test … plus some other card abilities
+  may contribute additional consequences … at this time"); ST.8 *Skill test
+  ends* (discard committed cards, return tokens). "After applying all results"
+  = after the whole of ST.7, before ST.8.
+
+## 1. `Prey::LowestRemainingHealth`
+
+- Add a variant to the `#[non_exhaustive]` `Prey` enum
+  (`crates/card-dsl/src/card_data.rs`). **Specific, not generic** — "lowest
+  remaining health" is a derived measure, *not* a `Stat`, so it can't be a
+  symmetric `LowestStat(Stat)`; the honest general form is a `{ measure,
+  direction }` shape spanning stats and derived quantities (remaining
+  health/sanity, clues, cards-in-hand), which is speculative with one consumer.
+  Per CLAUDE.md (no speculative DSL primitives; wait for 2+ consumers) and the
+  enum's own doc convention ("other printed variants … land with their first
+  card consumer"), ship the specific variant with a doc-note:
+  `// TODO: generalize to { measure, direction } when a 2nd derived-measure
+  prey lands (Lowest remaining sanity, Most clues, …).`
+- Wire it in `resolve_prey` (`crates/game-core/src/engine/dispatch/hunters.rs`)
+  as a new branch mirroring `HighestStat`, keeping candidates that **minimize**
+  `inv.max_health − inv.damage` (saturating). Returns `One` / `Tie` / `None` via
+  the existing post-narrowing match.
+- Tests (mirror the `HighestStat` set in `resolve_prey_tests`): single clear
+  minimum → `One`; two-way tie at the minimum → `Tie`; all-equal → `Tie`.
+
+## 2. Retaliate
+
+### State
+
+Add `retaliate: bool` to `Enemy` (`crates/game-core/src/state/enemy.rs`),
+beside `hunter`, with a doc-comment citing RR p.18. Additive updates:
+`test_enemy` fixture (`test_support/fixtures.rs`, `retaliate: false`) and the
+`spawn_enemy` struct literal (`retaliate: false`).
+
+### Firing — Option B (faithful placement)
+
+Retaliate fires *after all of ST.7*, before ST.8 teardown. In the engine, ST.7
+spans `apply_skill_test_follow_up` (the Fight consequence) **and**
+`fire_on_skill_test_resolution` (OnSkillTestResolution triggers). So the
+retaliate attack lands at the boundary between `fire_on_skill_test_resolution`
+and the `PostOnResolution` teardown.
+
+- Add `FinishContinuation::PostRetaliate { succeeded }`
+  (`crates/game-core/src/state/game_state.rs`, `#[non_exhaustive]` Copy serde
+  enum) between `PostFollowUp` and `PostOnResolution`.
+- In `drive_skill_test` (`skill_test.rs`): the `PostFollowUp` arm, after running
+  `fire_on_skill_test_resolution`, advances to `PostRetaliate { succeeded }`
+  (instead of jumping to `PostOnResolution`).
+- New `PostRetaliate` arm: fire the retaliate attack iff **all** hold —
+  `!succeeded`; the in-flight record's `follow_up` is `Fight { enemy }`; the
+  enemy is still in `state.enemies`; the enemy is ready (`!exhausted`); the
+  enemy has `retaliate`. If so, `combat::enemy_attack(cx, enemy, investigator)`
+  (places damage + horror, handles investigator defeat) **without exhausting the
+  enemy** (RR p.18). Then advance to `PostOnResolution`. The `follow_up` field
+  lives on the in-flight record until teardown, so the step re-reads it.
+
+### Edge cases
+
+- Non-Fight follow-up (Investigate/Evade/None), success, exhausted enemy, or
+  non-retaliate enemy → no retaliate (rule is "fails a skill test **while
+  attacking** a **ready** enemy").
+- Enemy absent from `state.enemies` → graceful skip. (Can't happen on a *failed*
+  fight — no damage was dealt — but the step degrades quietly rather than
+  panicking, since retaliate is a bonus attack, not a load-bearing mutation.)
+- Retaliate attack defeats the investigator → `enemy_attack` →
+  `apply_investigator_defeat` handles elimination; ST.8 teardown (commit-card
+  discard, `SkillTestEnded`) still runs in the following `PostOnResolution` step.
+- The new step is also the natural future home for the "after an enemy attacks"
+  reaction window (Guard Dog C5b, Roland's reaction) — forward-compatible, not
+  built now.
+
+### Tests (engine unit, `skill_test.rs`)
+
+- Failed Fight vs. ready retaliate enemy → investigator takes the enemy's
+  `attack_damage` + `attack_horror`; enemy stays ready (`!exhausted`);
+  `SkillTestEnded` still emitted.
+- Successful Fight vs. retaliate enemy → no retaliate attack (enemy takes the
+  fight damage as usual).
+- Failed Fight vs. **exhausted** retaliate enemy → no retaliate.
+- Failed Fight vs. **non-retaliate** enemy → no retaliate.
+- Failed **Evade**/**Investigate** test → no retaliate (only "while attacking").
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `crates/card-dsl/src/card_data.rs` | `Prey::LowestRemainingHealth` variant + generalize-later note |
+| `crates/game-core/src/engine/dispatch/hunters.rs` | `resolve_prey` branch + tests |
+| `crates/game-core/src/state/enemy.rs` | `retaliate: bool` field + fixture-shape test update |
+| `crates/game-core/src/test_support/fixtures.rs` | `test_enemy` → `retaliate: false` |
+| `crates/game-core/src/engine/dispatch/encounter.rs` | `spawn_enemy` literal → `retaliate: false` |
+| `crates/game-core/src/state/game_state.rs` | `FinishContinuation::PostRetaliate` variant + doc |
+| `crates/game-core/src/engine/dispatch/skill_test.rs` | driver wiring + `PostRetaliate` logic + tests |
+
+## Decisions for the phase doc (on merge)
+
+- `Prey::LowestRemainingHealth` is a **specific** variant (not a generic
+  measure/direction shape) — generalize on the second derived-measure consumer.
+- Retaliate fires in a dedicated `FinishContinuation::PostRetaliate` step after
+  ST.7's OnSkillTestResolution triggers and before ST.8 teardown (RR p.26
+  "after applying all results") — also the future home of after-enemy-attacks
+  reaction windows.

--- a/docs/superpowers/specs/2026-06-13-phase-7-c3a-prey-retaliate-design.md
+++ b/docs/superpowers/specs/2026-06-13-phase-7-c3a-prey-retaliate-design.md
@@ -45,25 +45,41 @@ It does **not** wire the real enemies. The two consumers are:
   ends* (discard committed cards, return tokens). "After applying all results"
   = after the whole of ST.7, before ST.8.
 
-## 1. `Prey::LowestRemainingHealth`
+## 1. Prey — unified `Ranked { direction, measure }`
 
-- Add a variant to the `#[non_exhaustive]` `Prey` enum
-  (`crates/card-dsl/src/card_data.rs`). **Specific, not generic** — "lowest
-  remaining health" is a derived measure, *not* a `Stat`, so it can't be a
-  symmetric `LowestStat(Stat)`; the honest general form is a `{ measure,
-  direction }` shape spanning stats and derived quantities (remaining
-  health/sanity, clues, cards-in-hand), which is speculative with one consumer.
-  Per CLAUDE.md (no speculative DSL primitives; wait for 2+ consumers) and the
-  enum's own doc convention ("other printed variants … land with their first
-  card consumer"), ship the specific variant with a doc-note:
-  `// TODO: generalize to { measure, direction } when a 2nd derived-measure
-  prey lands (Lowest remaining sanity, Most clues, …).`
-- Wire it in `resolve_prey` (`crates/game-core/src/engine/dispatch/hunters.rs`)
-  as a new branch mirroring `HighestStat`, keeping candidates that **minimize**
-  `inv.max_health − inv.damage` (saturating). Returns `One` / `Tie` / `None` via
-  the existing post-narrowing match.
-- Tests (mirror the `HighestStat` set in `resolve_prey_tests`): single clear
-  minimum → `One`; two-way tie at the minimum → `Tie`; all-equal → `Tie`.
+> **Revised after first review.** Originally shipped as a specific
+> `Prey::LowestRemainingHealth` variant (deferring generalization). On a second
+> look we unified instead: the "wait for 2+ consumers" rule was *already* met —
+> `Prey::HighestStat(Combat)` and lowest-remaining-health are two consumers of
+> the same ranked-measure pattern. So both collapse into one `{ direction,
+> measure }` shape now, while we have full information about the axis.
+
+- Replace `Prey::HighestStat(Stat)` **and** the would-be `LowestRemainingHealth`
+  with one variant on the `#[non_exhaustive]` `Prey` enum
+  (`crates/card-dsl/src/card_data.rs`):
+  `Prey::Ranked { direction: PreyDirection, measure: PreyMeasure }`.
+  - `PreyDirection { Highest, Lowest }` — exhaustive.
+  - `PreyMeasure { Skill(SkillKind), RemainingHealth }` — **exhaustive** (not
+    `#[non_exhaustive]`): adding a measure must force `resolve_prey` to wire it
+    at compile time. Uses `SkillKind` (the four skills), *not* `Stat` — `Stat`
+    also has `MaxHealth`/`MaxSanity`, nonsensical as a prey measure alongside a
+    dedicated `RemainingHealth`; `SkillKind` makes illegal states
+    unrepresentable and lets `Skills::value` be called directly (dropping the
+    `cursor::stat_to_skill_kind` hop, which this change removes as dead code).
+  - Ghoul Priest's "Highest [combat]" = `Highest` + `Skill(Combat)`; Ravenous
+    Ghoul's "Lowest remaining health" = `Lowest` + `RemainingHealth`.
+  - Future printed measures (`RemainingSanity`, `Clues`, `CardsInHand`, …) add a
+    `PreyMeasure` variant + one `measure_value` arm. `Prey` stays
+    `#[non_exhaustive]` for genuinely non-comparative future shapes ("Bearer
+    only").
+- `resolve_prey` (`crates/game-core/src/engine/dispatch/hunters.rs`) gets one
+  `Ranked` branch: score each candidate via a `measure_value(measure, inv) ->
+  i32` helper (`i32` so `base_health − damage` can't underflow and skills/health
+  share a comparable type), take `max`/`min` per `direction`, keep the matchers.
+  Returns `One` / `Tie` / `None` via the existing post-narrowing match.
+- Tests in `resolve_prey_tests`: highest-skill single → `One` and tie → `Tie`;
+  lowest-remaining-health single → `One` and tie → `Tie`; serde round-trips for
+  both `Ranked` forms in `card_data.rs`.
 
 ## 2. Retaliate
 
@@ -136,8 +152,11 @@ and the `PostOnResolution` teardown.
 
 ## Decisions for the phase doc (on merge)
 
-- `Prey::LowestRemainingHealth` is a **specific** variant (not a generic
-  measure/direction shape) — generalize on the second derived-measure consumer.
+- Prey comparative instructions are one unified `Prey::Ranked { direction,
+  measure }` shape (`PreyDirection` × `PreyMeasure`), replacing the old
+  `HighestStat(Stat)`. `PreyMeasure` is exhaustive + uses `SkillKind`, so a new
+  measure is compile-forced to wire `resolve_prey`. New measures
+  (`RemainingSanity`, `Clues`, `CardsInHand`) land with their first consumer.
 - Retaliate fires in a dedicated `FinishContinuation::PostRetaliate` step after
   ST.7's OnSkillTestResolution triggers and before ST.8 teardown (RR p.26
   "after applying all results") — also the future home of after-enemy-attacks


### PR DESCRIPTION
## Summary

C3a (engine half of Group C): two encounter-enemy primitives The Gathering needs — the `Prey – Lowest remaining health` instruction (Ravenous Ghoul 01161) and the **Retaliate** keyword (Ghoul Priest 01116). Engine-only; C3b (#231) wires the real enemies and populates these from card data.

## What changed

- **`Prey::LowestRemainingHealth`** — a new `#[non_exhaustive]` `Prey` variant, wired into `resolve_prey` as a min-over-(`max_health − damage`) branch mirroring `HighestStat`. Specific (not a generic measure/direction shape) per the enum's "one variant per first consumer" convention; carries a TODO to generalize on the 2nd derived-measure prey. Remaining health per RR p.12.
- **`Enemy.retaliate: bool`** — state flag beside `hunter`, defaulted `false` at every construction site (`test_enemy`, `spawn_enemy`). `spawn_enemy` stays hardcoded — populating it from card data is C3b.
- **Retaliate firing** — a new `FinishContinuation::PostRetaliate` step in the skill-test driver. After a **failed Fight** test against a still-in-play, **ready** retaliate enemy, the enemy attacks the investigator via `enemy_attack` **without exhausting** (RR p.18). It fires after ST.7's `OnSkillTestResolution` triggers and before ST.8 teardown, matching RR p.26 "after applying all results for that skill test" — also the natural future home for the after-an-enemy-attacks reaction window (Guard Dog C5b, Roland's reaction).

### Design note

Retaliate placement (Option B — dedicated `PostRetaliate` step) was chosen over firing it inside the success/failure follow-up because the latter would land *inside* ST.7, one sub-step before the `OnSkillTestResolution` triggers. Unobservable for The Gathering (Ghoul Priest is the only retaliate enemy; no failed-fight on-resolution trigger interacts), but the dedicated step is both more faithful to RR p.26 and forward-compatible.

## Test notes

- `resolve_prey` unit tests: lowest-remaining-health single-min → `One`, tie → `Tie`.
- `Enemy.retaliate` field-presence test.
- 5 engine integration tests via `apply_no_commits`: failed fight vs ready-retaliate fires the attack (damage + horror, enemy stays ready, `SkillTestEnded` still emitted); success / exhausted-enemy / non-retaliate / failed-**Evade** all do **not** fire.
- Full CI gauntlet green locally: `test`, `clippy` (host + wasm), `doc`, `fmt`, `wasm-build`.

All card text and rules quoted verbatim from `data/arkhamdb-snapshot` and `data/rules-reference`.

## Linked issues

Closes #230