### PR TITLE
engine: prey ranking uses modified stat values (#270)

### DIFF
--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -1,6 +1,9 @@
 //! Hunter-movement and prey-resolution helpers (Enemy phase step 3.2).
 
-use crate::card_data::{Prey, PreyDirection, PreyMeasure};
+use crate::card_data::{Prey, PreyDirection, PreyMeasure, SkillKind};
+use crate::card_registry::{self, CardRegistry};
+use crate::dsl::Stat;
+use crate::engine::evaluator::unconditional_constant_stat_modifier;
 use crate::engine::pathfinding::{bfs_distance, shortest_first_steps};
 use crate::event::Event;
 use crate::state::{
@@ -29,16 +32,41 @@ pub(super) enum PreyResolution {
 /// underflow and so skills/health share one comparable type. Higher or
 /// lower is selected by the [`PreyDirection`] in [`Prey::Ranked`].
 ///
-/// TODO(#270): uses **base** skill / health only. Per RR p.18 (Modifiers)
-/// and p.12 (remaining health), prey comparisons should use the *modified*
-/// value (active constant modifiers folded in, as the skill-test path does
-/// via `constant_skill_modifier`). Deferred: only matters with 2+ tied
-/// candidates and a constant-modifier card (Beat Cop, C5d), neither in
-/// current scope.
-fn measure_value(measure: PreyMeasure, inv: &Investigator) -> i32 {
-    match measure {
-        PreyMeasure::Skill(kind) => i32::from(inv.skills.value(kind)),
-        PreyMeasure::RemainingHealth => i32::from(inv.max_health) - i32::from(inv.damage),
+/// The *modified* value (Rules Reference p.18 Modifiers, p.12 remaining
+/// health): the base value plus the investigator's always-on constant
+/// modifiers to that stat, floored at zero (RR p.15 — a stat cannot
+/// function below zero). Prey resolves outside any skill test, so only
+/// unconditional (`WhileInPlay`) modifiers apply — see
+/// [`unconditional_constant_stat_modifier`]. `registry` is `None` in
+/// engine-only tests with no card data installed (base values only).
+fn measure_value(
+    state: &GameState,
+    registry: Option<&CardRegistry>,
+    inv: &Investigator,
+    measure: PreyMeasure,
+) -> i32 {
+    let (base, stat) = match measure {
+        PreyMeasure::Skill(kind) => (i32::from(inv.skills.value(kind)), skill_to_stat(kind)),
+        PreyMeasure::RemainingHealth => (
+            i32::from(inv.max_health) - i32::from(inv.damage),
+            Stat::MaxHealth,
+        ),
+    };
+    let modifier = registry.map_or(0, |reg| {
+        i32::from(unconditional_constant_stat_modifier(
+            state, reg, inv.id, stat,
+        ))
+    });
+    (base + modifier).max(0)
+}
+
+/// Map a prey skill measure to its [`Stat`] for the modifier lookup.
+fn skill_to_stat(kind: SkillKind) -> Stat {
+    match kind {
+        SkillKind::Willpower => Stat::Willpower,
+        SkillKind::Intellect => Stat::Intellect,
+        SkillKind::Combat => Stat::Combat,
+        SkillKind::Agility => Stat::Agility,
     }
 }
 
@@ -56,6 +84,7 @@ pub(super) fn resolve_prey(
     if candidates.is_empty() {
         return PreyResolution::None;
     }
+    let registry = card_registry::current();
     let best: Vec<InvestigatorId> = match prey {
         Prey::Default => candidates.to_vec(),
         Prey::Ranked { direction, measure } => {
@@ -65,7 +94,7 @@ pub(super) fn resolve_prey(
                     state
                         .investigators
                         .get(id)
-                        .map(|inv| (*id, measure_value(measure, inv)))
+                        .map(|inv| (*id, measure_value(state, registry, inv, measure)))
                 })
                 .collect();
             let extreme = match direction {
@@ -595,6 +624,122 @@ mod resolve_prey_tests {
             &[InvestigatorId(1), InvestigatorId(2)],
         );
         assert!(matches!(r, PreyResolution::Tie(ref v) if v.len() == 2));
+    }
+}
+
+#[cfg(test)]
+mod measure_value_tests {
+    use super::*;
+    use crate::card_registry::CardRegistry;
+    use crate::dsl::{constant, modify, Ability, ModifierScope};
+    use crate::state::{CardCode, CardInPlay, CardInstanceId};
+    use crate::test_support::{test_investigator, GameStateBuilder};
+
+    fn no_metadata(_: &CardCode) -> Option<&'static crate::card_data::CardMetadata> {
+        None
+    }
+
+    fn fake_abilities(code: &CardCode) -> Option<Vec<Ability>> {
+        match code.as_str() {
+            "combat+1" => Some(vec![constant(modify(
+                Stat::Combat,
+                1,
+                ModifierScope::WhileInPlay,
+            ))]),
+            "combat-5" => Some(vec![constant(modify(
+                Stat::Combat,
+                -5,
+                ModifierScope::WhileInPlay,
+            ))]),
+            "maxhealth+2" => Some(vec![constant(modify(
+                Stat::MaxHealth,
+                2,
+                ModifierScope::WhileInPlay,
+            ))]),
+            _ => None,
+        }
+    }
+
+    fn fake_registry() -> CardRegistry {
+        CardRegistry {
+            metadata_for: no_metadata,
+            abilities_for: fake_abilities,
+        }
+    }
+
+    /// Build a state holding investigator 1 (the modifier lookup reads
+    /// `state.investigators[inv.id].cards_in_play`, so the investigator
+    /// must be in the state, not merely passed by reference).
+    fn state_with(cards: &[&str], damage: u8) -> GameState {
+        let mut inv = test_investigator(1); // combat 3, max_health 8
+        inv.damage = damage;
+        inv.cards_in_play = cards
+            .iter()
+            .enumerate()
+            .map(|(i, c)| {
+                CardInPlay::enter_play(
+                    CardCode::new(*c),
+                    #[allow(clippy::cast_possible_truncation)]
+                    CardInstanceId(i as u32),
+                )
+            })
+            .collect();
+        GameStateBuilder::new().with_investigator(inv).build()
+    }
+
+    #[test]
+    fn base_value_when_no_registry() {
+        let state = state_with(&[], 0);
+        let inv = &state.investigators[&InvestigatorId(1)];
+        assert_eq!(
+            measure_value(&state, None, inv, PreyMeasure::Skill(SkillKind::Combat)),
+            3
+        );
+    }
+
+    #[test]
+    fn folds_constant_skill_modifier() {
+        let state = state_with(&["combat+1"], 0);
+        let inv = &state.investigators[&InvestigatorId(1)];
+        let reg = fake_registry();
+        assert_eq!(
+            measure_value(
+                &state,
+                Some(&reg),
+                inv,
+                PreyMeasure::Skill(SkillKind::Combat)
+            ),
+            4
+        );
+    }
+
+    #[test]
+    fn folds_max_health_modifier_into_remaining_health() {
+        // max_health 8 − damage 1 + 2 = 9.
+        let state = state_with(&["maxhealth+2"], 1);
+        let inv = &state.investigators[&InvestigatorId(1)];
+        let reg = fake_registry();
+        assert_eq!(
+            measure_value(&state, Some(&reg), inv, PreyMeasure::RemainingHealth),
+            9
+        );
+    }
+
+    #[test]
+    fn clamps_at_zero() {
+        // combat 3 − 5 = −2, floored to 0 (RR p.15).
+        let state = state_with(&["combat-5"], 0);
+        let inv = &state.investigators[&InvestigatorId(1)];
+        let reg = fake_registry();
+        assert_eq!(
+            measure_value(
+                &state,
+                Some(&reg),
+                inv,
+                PreyMeasure::Skill(SkillKind::Combat)
+            ),
+            0
+        );
     }
 }
 

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -640,6 +640,57 @@ pub fn constant_skill_modifier(
     skill: SkillKind,
     kind: SkillTestKind,
 ) -> i8 {
+    sum_constant_modify(
+        state,
+        registry,
+        controller,
+        |scope| scope_applies(scope, kind),
+        |stat| stat_matches_skill(stat, skill),
+    )
+}
+
+/// Sum a controller's *unconditional* constant modifiers to `stat`: only
+/// [`ModifierScope::WhileInPlay`] `Trigger::Constant` `Effect::Modify`
+/// abilities matching that exact stat (Beat Cop's always-on
+/// `+1 [combat]`, or a future "+N max health"). Excludes
+/// [`WhileInPlayDuring`](ModifierScope::WhileInPlayDuring) (which need a
+/// skill-test context) and every non-constant scope.
+///
+/// Used by prey ranking ([#270]): a prey instruction like
+/// `Highest [combat]` or "Lowest remaining health" compares *modified*
+/// values (Rules Reference p.18 Modifiers, p.12 remaining health), but
+/// resolves outside any skill test, so only always-on modifiers apply.
+///
+/// [#270]: https://github.com/talelburg/eldritch/issues/270
+#[must_use]
+pub fn unconditional_constant_stat_modifier(
+    state: &GameState,
+    registry: &CardRegistry,
+    controller: InvestigatorId,
+    stat: Stat,
+) -> i8 {
+    sum_constant_modify(
+        state,
+        registry,
+        controller,
+        |scope| matches!(scope, ModifierScope::WhileInPlay),
+        |s| s == stat,
+    )
+}
+
+/// Shared core of [`constant_skill_modifier`] and
+/// [`unconditional_constant_stat_modifier`]: sum the `delta` of every
+/// `Trigger::Constant` `Effect::Modify` on `controller`'s cards in play
+/// whose scope and stat both satisfy the given predicates. Silently skips
+/// cards whose code the registry can't resolve (same policy as the
+/// callers — the deck-import gate keeps unimplemented codes out of play).
+fn sum_constant_modify(
+    state: &GameState,
+    registry: &CardRegistry,
+    controller: InvestigatorId,
+    scope_ok: impl Fn(ModifierScope) -> bool,
+    stat_ok: impl Fn(Stat) -> bool,
+) -> i8 {
     let Some(inv) = state.investigators.get(&controller) else {
         return 0;
     };
@@ -655,10 +706,7 @@ pub fn constant_skill_modifier(
             let Effect::Modify { stat, delta, scope } = &ability.effect else {
                 continue;
             };
-            if !scope_applies(*scope, kind) {
-                continue;
-            }
-            if stat_matches_skill(*stat, skill) {
+            if scope_ok(*scope) && stat_ok(*stat) {
                 total = total.saturating_add(*delta);
             }
         }
@@ -747,7 +795,10 @@ mod tests {
     use crate::test_support::{test_investigator, test_location, GameStateBuilder};
     use crate::{assert_event, assert_no_event};
 
-    use super::{apply_effect, constant_skill_modifier, EngineOutcome, EvalContext};
+    use super::{
+        apply_effect, constant_skill_modifier, unconditional_constant_stat_modifier, EngineOutcome,
+        EvalContext,
+    };
     use crate::engine::Cx;
 
     fn ctx(id: u32) -> EvalContext {
@@ -1489,6 +1540,42 @@ mod tests {
         let reg = fake_registry();
         assert_eq!(
             constant_skill_modifier(&state, &reg, id, SkillKind::Willpower, SkillTestKind::Plain),
+            0
+        );
+    }
+
+    #[test]
+    fn unconditional_modifier_counts_while_in_play_constant() {
+        let (state, id) = state_with_cards_in_play(&["willpower-plus-1"]);
+        let reg = fake_registry();
+        assert_eq!(
+            unconditional_constant_stat_modifier(&state, &reg, id, Stat::Willpower),
+            1
+        );
+    }
+
+    #[test]
+    fn unconditional_modifier_excludes_while_in_play_during() {
+        // WhileInPlayDuring needs a skill-test context; prey has none.
+        let (state, id) = state_with_cards_in_play(&["intellect-plus-1-while-investigating"]);
+        let reg = fake_registry();
+        assert_eq!(
+            unconditional_constant_stat_modifier(&state, &reg, id, Stat::Intellect),
+            0
+        );
+    }
+
+    #[test]
+    fn unconditional_modifier_matches_exact_stat_including_max_health() {
+        let (state, id) = state_with_cards_in_play(&["max-health-plus-1", "willpower-plus-1"]);
+        let reg = fake_registry();
+        assert_eq!(
+            unconditional_constant_stat_modifier(&state, &reg, id, Stat::MaxHealth),
+            1
+        );
+        // The willpower buff must not leak into a different stat's query.
+        assert_eq!(
+            unconditional_constant_stat_modifier(&state, &reg, id, Stat::Combat),
             0
         );
     }


### PR DESCRIPTION
## Summary

Prey comparisons (`Highest [combat]`, `Lowest remaining health`) now rank investigators by their **modified** value — base plus active always-on modifiers — instead of the printed base. Closes the gap noted in #270 / the C3a TODO.

## What changed

- New generic `unconditional_constant_stat_modifier(state, reg, controller, stat)` in `evaluator.rs`: sums only `WhileInPlay` `Constant` `Modify` abilities matching an exact `Stat`. Shares one private loop (`sum_constant_modify`, predicate-based) with the existing `constant_skill_modifier`, whose public signature and call-sites are untouched.
- `measure_value` (prey ranking) folds that modifier into **every** measure, keyed on the measure's `Stat` (`Skill(Combat)` → `Stat::Combat`; `RemainingHealth` → `Stat::MaxHealth`), and floors the result at 0.
- `measure_value` now takes the registry as a parameter (`resolve_prey` fetches `current()` once and passes it) so its folding/clamp logic is unit-testable without a global registry install.

## Rules basis (verbatim)

- **RR p.18 (Modifiers):** "Any time a new modifier is applied (or removed), the entire quantity is recalculated from the start, considering the unmodified base value and all active modifiers."
- **RR p.12 (remaining health):** "its base health minus the amount of damage on it, plus or minus any active health modifiers."
- **RR p.15:** "A quantity on a card (such as a stat …) cannot be reduced so that it functions with a value below zero … any resultant value below zero is treated as zero." → the clamp.

`WhileInPlayDuring(_)` modifiers are **excluded**: they require a skill-test context, and prey resolves outside any test.

## Why now / scope

The 2-investigator interaction goes live once stat-prey enemies (C3b) and a constant-modifier card (Beat Cop, +1 [combat], C5d) both land; the fix is generic so future `MaxHealth`-modifying cards work for `RemainingHealth` prey for free, with no current dead code.

## Test notes

- `evaluator.rs`: `unconditional_constant_stat_modifier` counts `WhileInPlay`, excludes `WhileInPlayDuring`, matches exact stat (incl. `MaxHealth`, no cross-stat leak) — reuses the existing mock-registry fixtures.
- `hunters.rs`: `measure_value` base-only (no registry), folds a skill modifier, folds a `MaxHealth` modifier into remaining health, clamps at 0.
- Full CI gauntlet green locally (test/clippy host+wasm/doc/fmt/wasm-build).

## Linked issues

Closes #270