### PR TITLE
card: C3b — The Gathering enemies (#231)

### DIFF
--- a/crates/card-data-pipeline/src/main.rs
+++ b/crates/card-data-pipeline/src/main.rs
@@ -512,6 +512,92 @@ fn clue_value_lit(clues: u8, fixed: bool) -> String {
     }
 }
 
+/// Strip ArkhamDB bold markup so keyword lines can be matched plainly.
+fn strip_html_bold(s: &str) -> String {
+    s.replace("<b>", "").replace("</b>", "")
+}
+
+/// True if `text` contains the standalone keyword token `"<kw>."`
+/// (e.g. `"Hunter."`). Bold tags are stripped first.
+fn has_keyword(text: &str, keyword: &str) -> bool {
+    strip_html_bold(text).contains(&format!("{keyword}."))
+}
+
+/// Parsed Prey line. `None` = no printed prey (emit `Prey::Default`);
+/// `Unrecognized` = a "Prey - …" form we don't model yet (emit
+/// `Prey::Default` + warn, matching `surge`/`peril`'s default-stub).
+#[derive(Debug, PartialEq, Eq)]
+enum PreyParse {
+    None,
+    /// `Prey - Highest [<skill>]`; payload is the `SkillKind` ident.
+    HighestSkill(&'static str),
+    /// `Prey - Lowest remaining health`.
+    LowestRemainingHealth,
+    /// A "Prey - …" clause not yet modeled (the clause text, trimmed).
+    Unrecognized(String),
+}
+
+/// Parse an enemy's Prey line out of `text`.
+fn parse_prey(text: &str) -> PreyParse {
+    let stripped = strip_html_bold(text);
+    let Some(rest) = stripped.split("Prey - ").nth(1) else {
+        return PreyParse::None;
+    };
+    // The clause runs to the next period.
+    let clause = rest.split('.').next().unwrap_or("").trim();
+    match clause {
+        "Highest [willpower]" => PreyParse::HighestSkill("Willpower"),
+        "Highest [intellect]" => PreyParse::HighestSkill("Intellect"),
+        "Highest [combat]" => PreyParse::HighestSkill("Combat"),
+        "Highest [agility]" => PreyParse::HighestSkill("Agility"),
+        "Lowest remaining health" => PreyParse::LowestRemainingHealth,
+        other => PreyParse::Unrecognized(other.to_owned()),
+    }
+}
+
+/// Emit the `Prey` literal for a parsed prey line.
+fn prey_lit(p: &PreyParse) -> String {
+    match p {
+        PreyParse::None | PreyParse::Unrecognized(_) => "Prey::Default".to_owned(),
+        PreyParse::HighestSkill(skill) => format!(
+            "Prey::Ranked {{ direction: PreyDirection::Highest, \
+             measure: PreyMeasure::Skill(SkillKind::{skill}) }}"
+        ),
+        PreyParse::LowestRemainingHealth => "Prey::Ranked { direction: PreyDirection::Lowest, \
+             measure: PreyMeasure::RemainingHealth }"
+            .to_owned(),
+    }
+}
+
+/// Parse the location name from a `Spawn - <name>.` line, if present.
+fn parse_spawn_name(text: &str) -> Option<String> {
+    let stripped = strip_html_bold(text);
+    let rest = stripped.split("Spawn - ").nth(1)?;
+    Some(rest.split('.').next().unwrap_or("").trim().to_owned())
+}
+
+/// Emit the `Option<Spawn>` literal for an enemy's resolved spawn code.
+fn spawn_lit(spawn_code: Option<&str>) -> String {
+    match spawn_code {
+        Some(code) => format!(
+            "Some(Spawn {{ location: SpawnLocation::Specific({}.to_owned()) }})",
+            str_lit(code)
+        ),
+        None => "None".to_owned(),
+    }
+}
+
+/// Emit the `Option<HealthValue>` literal for an enemy's health, mirroring
+/// `clue_value_lit`. Polarity is the opposite of clues: per-investigator
+/// only when ArkhamDB's `health_per_investigator` is set.
+fn health_value_opt_lit(health: Option<u8>, per_investigator: bool) -> String {
+    match health {
+        None => "None".to_owned(),
+        Some(n) if per_investigator => format!("Some(HealthValue::PerInvestigator({n}))"),
+        Some(n) => format!("Some(HealthValue::Fixed({n}))"),
+    }
+}
+
 fn string_vec(xs: &[String]) -> String {
     if xs.is_empty() {
         return "Vec::new()".into();
@@ -550,11 +636,99 @@ const GENERATED_HEADER: &str = "\
 #[cfg(test)]
 mod tests {
     use super::{
-        clue_value_lit, emit_card, map_card_type, map_class, normalize, parse_slots, parse_traits,
-        process_raw, NormalizedCard, RawCard,
+        clue_value_lit, emit_card, has_keyword, health_value_opt_lit, map_card_type, map_class,
+        normalize, parse_prey, parse_slots, parse_spawn_name, parse_traits, prey_lit, process_raw,
+        strip_html_bold, NormalizedCard, PreyParse, RawCard,
     };
     use std::collections::BTreeMap;
     use std::path::Path;
+
+    #[test]
+    fn strip_html_bold_removes_bold_tags() {
+        assert_eq!(
+            strip_html_bold("<b>Prey</b> - Highest [combat]."),
+            "Prey - Highest [combat]."
+        );
+    }
+
+    #[test]
+    fn has_keyword_matches_standalone_token() {
+        assert!(has_keyword("Hunter. Retaliate.", "Hunter"));
+        assert!(has_keyword("Hunter. Retaliate.", "Retaliate"));
+        assert!(!has_keyword("<b>Spawn</b> - Attic.", "Hunter"));
+    }
+
+    #[test]
+    fn parse_prey_recognizes_highest_combat() {
+        assert_eq!(
+            parse_prey("<b>Prey</b> - Highest [combat].\nHunter. Retaliate."),
+            PreyParse::HighestSkill("Combat"),
+        );
+    }
+
+    #[test]
+    fn parse_prey_recognizes_lowest_remaining_health() {
+        assert_eq!(
+            parse_prey("<b>Prey</b> - Lowest remaining health."),
+            PreyParse::LowestRemainingHealth,
+        );
+    }
+
+    #[test]
+    fn parse_prey_none_when_no_prey_line() {
+        assert_eq!(parse_prey("Hunter."), PreyParse::None);
+    }
+
+    #[test]
+    fn parse_prey_unrecognized_keeps_clause() {
+        assert_eq!(
+            parse_prey("<b>Prey</b> - Most clues."),
+            PreyParse::Unrecognized("Most clues".to_owned()),
+        );
+    }
+
+    #[test]
+    fn prey_lit_emits_expected_literals() {
+        assert_eq!(prey_lit(&PreyParse::None), "Prey::Default");
+        assert_eq!(
+            prey_lit(&PreyParse::Unrecognized("Most clues".to_owned())),
+            "Prey::Default"
+        );
+        assert_eq!(
+            prey_lit(&PreyParse::HighestSkill("Combat")),
+            "Prey::Ranked { direction: PreyDirection::Highest, measure: PreyMeasure::Skill(SkillKind::Combat) }",
+        );
+        assert_eq!(
+            prey_lit(&PreyParse::LowestRemainingHealth),
+            "Prey::Ranked { direction: PreyDirection::Lowest, measure: PreyMeasure::RemainingHealth }",
+        );
+    }
+
+    #[test]
+    fn parse_spawn_name_extracts_location_name() {
+        assert_eq!(
+            parse_spawn_name("<b>Spawn</b> - Attic."),
+            Some("Attic".to_owned())
+        );
+        assert_eq!(
+            parse_spawn_name("<b>Spawn</b> - Cellar."),
+            Some("Cellar".to_owned())
+        );
+        assert_eq!(parse_spawn_name("Hunter."), None);
+    }
+
+    #[test]
+    fn health_value_opt_lit_mirrors_clue_value() {
+        assert_eq!(health_value_opt_lit(None, false), "None");
+        assert_eq!(
+            health_value_opt_lit(Some(4), false),
+            "Some(HealthValue::Fixed(4))"
+        );
+        assert_eq!(
+            health_value_opt_lit(Some(5), true),
+            "Some(HealthValue::PerInvestigator(5))"
+        );
+    }
 
     /// Minimal `RawCard` fixture with the required fields populated and
     /// optional fields cleared. Tweak by mutating the returned value

--- a/crates/card-data-pipeline/src/main.rs
+++ b/crates/card-data-pipeline/src/main.rs
@@ -84,6 +84,46 @@ fn run() -> Result<(), String> {
         }
     }
 
+    // Resolve enemy Spawn-location names to location codes now that every
+    // card is loaded. Unresolved names (out-of-scope forms like
+    // "Engaged with Prey") stay None and warn — a loud stub, not silent.
+    let loc_index: BTreeMap<String, String> = all
+        .values()
+        .filter(|c| c.card_type == "Location")
+        .map(|c| (c.name.clone(), c.code.clone()))
+        .collect();
+    let mut resolutions: Vec<(String, Option<String>)> = Vec::new();
+    for c in all.values() {
+        if let Some(name) = &c.spawn_name {
+            match loc_index.get(name) {
+                Some(code) => resolutions.push((c.code.clone(), Some(code.clone()))),
+                None => {
+                    eprintln!(
+                        "card-data-pipeline: enemy {} ({}): unresolved Spawn location {name:?} \
+                         — emitting spawn: None",
+                        c.code, c.name
+                    );
+                    resolutions.push((c.code.clone(), None));
+                }
+            }
+        }
+    }
+    for (code, spawn_code) in resolutions {
+        if let Some(c) = all.get_mut(&code) {
+            c.spawn_code = spawn_code;
+        }
+    }
+    // Warn on Prey lines we parsed but do not model yet.
+    for c in all.values() {
+        if let PreyParse::Unrecognized(clause) = &c.prey {
+            eprintln!(
+                "card-data-pipeline: enemy {} ({}): unmodeled Prey clause {clause:?} \
+                 — emitting Prey::Default",
+                c.code, c.name
+            );
+        }
+    }
+
     let output = render(&all);
     let out_path = repo_root.join(OUTPUT_PATH);
     std::fs::write(&out_path, output)
@@ -172,6 +212,7 @@ struct RawCard {
     enemy_evade: Option<u8>,
     enemy_damage: Option<u8>,
     enemy_horror: Option<u8>,
+    health_per_investigator: Option<bool>,
 }
 
 // ---- normalized shape we emit -----------------------------------
@@ -209,6 +250,14 @@ struct NormalizedCard {
     enemy_evade: Option<u8>,
     enemy_damage: Option<u8>,
     enemy_horror: Option<u8>,
+    health_per_investigator: bool,
+    hunter: bool,
+    retaliate: bool,
+    prey: PreyParse,
+    /// Location name parsed from a `Spawn - <name>.` line (pre-resolution).
+    spawn_name: Option<String>,
+    /// Spawn location code, resolved from `spawn_name` after all cards load.
+    spawn_code: Option<String>,
 }
 
 fn normalize(raw: RawCard) -> Result<NormalizedCard, String> {
@@ -226,6 +275,16 @@ fn normalize(raw: RawCard) -> Result<NormalizedCard, String> {
         .text
         .as_deref()
         .is_some_and(|t| t.starts_with("Fast.") || t.starts_with("Fast "));
+
+    // Enemy keyword/prey/spawn data parsed from card text (read before
+    // `raw.text` is moved into the struct, mirroring `is_fast`).
+    let hunter = raw.text.as_deref().is_some_and(|t| has_keyword(t, "Hunter"));
+    let retaliate = raw
+        .text
+        .as_deref()
+        .is_some_and(|t| has_keyword(t, "Retaliate"));
+    let prey = raw.text.as_deref().map_or(PreyParse::None, parse_prey);
+    let spawn_name = raw.text.as_deref().and_then(parse_spawn_name);
 
     Ok(NormalizedCard {
         code: raw.code,
@@ -257,6 +316,12 @@ fn normalize(raw: RawCard) -> Result<NormalizedCard, String> {
         enemy_evade: raw.enemy_evade,
         enemy_damage: raw.enemy_damage,
         enemy_horror: raw.enemy_horror,
+        health_per_investigator: raw.health_per_investigator.unwrap_or(false),
+        hunter,
+        retaliate,
+        prey,
+        spawn_name,
+        spawn_code: None,
     })
 }
 
@@ -344,7 +409,7 @@ fn render(all: &BTreeMap<String, NormalizedCard>) -> String {
     let mut out = String::new();
     out.push_str(GENERATED_HEADER);
     out.push_str(
-        "use card_dsl::card_data::{CardKind, CardMetadata, Class, ClueValue, SkillIcons, Skills, Slot};\n\n\
+        "use card_dsl::card_data::{CardKind, CardMetadata, Class, ClueValue, HealthValue, Prey, PreyDirection, PreyMeasure, SkillIcons, SkillKind, Skills, Slot, Spawn, SpawnLocation};\n\n\
          /// Every card from the pinned snapshot, sorted by code.\n\
          #[must_use]\n\
          pub fn all_cards() -> Vec<CardMetadata> {\n    vec![\n",
@@ -387,9 +452,9 @@ fn render_card(out: &mut String, c: &NormalizedCard) {
 
 /// Render the `CardKind` literal for `c`, dispatched on its card type.
 ///
-/// `spawn`/`surge`/`peril` emit their not-yet-parsed defaults
-/// (`None`/`false`); enemy combat stats and the encounter variants
-/// (Location/Act/Agenda) land with encounter ingestion (#252).
+/// Enemy `hunter`/`retaliate`/`prey`/`spawn`/`health` are parsed from card
+/// text (C3b); `surge`/`peril` still emit their not-yet-parsed `false`
+/// default (#138).
 fn render_kind(c: &NormalizedCard) -> String {
     let icons = format!(
         "SkillIcons {{ willpower: {}, intellect: {}, combat: {}, agility: {}, wild: {} }}",
@@ -440,13 +505,18 @@ fn render_kind(c: &NormalizedCard) -> String {
         ),
         "Enemy" => format!(
             "CardKind::Enemy {{ fight: {}, evade: {}, damage: {}, horror: {}, \
-             health: {}, victory: {}, spawn: None, surge: false, peril: false, quantity: {} }}",
+             health: {}, victory: {}, spawn: {}, surge: false, peril: false, \
+             hunter: {}, retaliate: {}, prey: {}, quantity: {} }}",
             c.enemy_fight.unwrap_or(0),
             c.enemy_evade.unwrap_or(0),
             c.enemy_damage.unwrap_or(0),
             c.enemy_horror.unwrap_or(0),
-            opt_u8(c.health),
+            health_value_opt_lit(c.health, c.health_per_investigator),
             opt_u8(c.victory),
+            spawn_lit(c.spawn_code.as_deref()),
+            c.hunter,
+            c.retaliate,
+            prey_lit(&c.prey),
             c.quantity,
         ),
         "Treachery" => format!(
@@ -763,6 +833,7 @@ mod tests {
             enemy_evade: None,
             enemy_damage: None,
             enemy_horror: None,
+            health_per_investigator: None,
         }
     }
 
@@ -799,6 +870,12 @@ mod tests {
             enemy_evade: None,
             enemy_damage: None,
             enemy_horror: None,
+            health_per_investigator: false,
+            hunter: false,
+            retaliate: false,
+            prey: PreyParse::None,
+            spawn_name: None,
+            spawn_code: None,
         }
     }
 
@@ -1136,6 +1213,7 @@ mod tests {
             enemy_evade: None,
             enemy_damage: None,
             enemy_horror: None,
+            health_per_investigator: None,
         };
         let norm = normalize(raw).expect("normalize");
         assert!(
@@ -1239,6 +1317,7 @@ mod tests {
             enemy_evade: None,
             enemy_damage: None,
             enemy_horror: None,
+            health_per_investigator: None,
         };
         let norm = normalize(raw).expect("normalize");
         assert!(

--- a/crates/card-data-pipeline/src/main.rs
+++ b/crates/card-data-pipeline/src/main.rs
@@ -95,16 +95,15 @@ fn run() -> Result<(), String> {
     let mut resolutions: Vec<(String, Option<String>)> = Vec::new();
     for c in all.values() {
         if let Some(name) = &c.spawn_name {
-            match loc_index.get(name) {
-                Some(code) => resolutions.push((c.code.clone(), Some(code.clone()))),
-                None => {
-                    eprintln!(
-                        "card-data-pipeline: enemy {} ({}): unresolved Spawn location {name:?} \
-                         — emitting spawn: None",
-                        c.code, c.name
-                    );
-                    resolutions.push((c.code.clone(), None));
-                }
+            if let Some(code) = loc_index.get(name) {
+                resolutions.push((c.code.clone(), Some(code.clone())));
+            } else {
+                eprintln!(
+                    "card-data-pipeline: enemy {} ({}): unresolved Spawn location {name:?} \
+                     — emitting spawn: None",
+                    c.code, c.name
+                );
+                resolutions.push((c.code.clone(), None));
             }
         }
     }
@@ -218,6 +217,7 @@ struct RawCard {
 // ---- normalized shape we emit -----------------------------------
 
 #[derive(Debug)]
+#[allow(clippy::struct_excessive_bools)] // mirrors ArkhamDB's flag fields
 struct NormalizedCard {
     code: String,
     name: String,
@@ -278,7 +278,10 @@ fn normalize(raw: RawCard) -> Result<NormalizedCard, String> {
 
     // Enemy keyword/prey/spawn data parsed from card text (read before
     // `raw.text` is moved into the struct, mirroring `is_fast`).
-    let hunter = raw.text.as_deref().is_some_and(|t| has_keyword(t, "Hunter"));
+    let hunter = raw
+        .text
+        .as_deref()
+        .is_some_and(|t| has_keyword(t, "Hunter"));
     let retaliate = raw
         .text
         .as_deref()
@@ -409,7 +412,9 @@ fn render(all: &BTreeMap<String, NormalizedCard>) -> String {
     let mut out = String::new();
     out.push_str(GENERATED_HEADER);
     out.push_str(
-        "use card_dsl::card_data::{CardKind, CardMetadata, Class, ClueValue, HealthValue, Prey, PreyDirection, PreyMeasure, SkillIcons, SkillKind, Skills, Slot, Spawn, SpawnLocation};\n\n\
+        "use card_dsl::card_data::{\n    \
+         CardKind, CardMetadata, Class, ClueValue, HealthValue, Prey, PreyDirection, PreyMeasure,\n    \
+         SkillIcons, SkillKind, Skills, Slot, Spawn, SpawnLocation,\n};\n\n\
          /// Every card from the pinned snapshot, sorted by code.\n\
          #[must_use]\n\
          pub fn all_cards() -> Vec<CardMetadata> {\n    vec![\n",
@@ -582,7 +587,7 @@ fn clue_value_lit(clues: u8, fixed: bool) -> String {
     }
 }
 
-/// Strip ArkhamDB bold markup so keyword lines can be matched plainly.
+/// Strip `ArkhamDB` bold markup so keyword lines can be matched plainly.
 fn strip_html_bold(s: &str) -> String {
     s.replace("<b>", "").replace("</b>", "")
 }
@@ -659,7 +664,7 @@ fn spawn_lit(spawn_code: Option<&str>) -> String {
 
 /// Emit the `Option<HealthValue>` literal for an enemy's health, mirroring
 /// `clue_value_lit`. Polarity is the opposite of clues: per-investigator
-/// only when ArkhamDB's `health_per_investigator` is set.
+/// only when `ArkhamDB`'s `health_per_investigator` is set.
 fn health_value_opt_lit(health: Option<u8>, per_investigator: bool) -> String {
     match health {
         None => "None".to_owned(),

--- a/crates/card-dsl/src/card_data.rs
+++ b/crates/card-dsl/src/card_data.rs
@@ -253,6 +253,20 @@ pub enum ClueValue {
     Fixed(u8),
 }
 
+/// An enemy's printed health. Mirrors [`ClueValue`]: `PerInvestigator(n)`
+/// scales by the number of investigators in the game (Rules Reference
+/// p.12); `Fixed(n)` is a flat value. Distinguishes `ArkhamDB`'s
+/// `health_per_investigator` (absent/false → fixed; `true` →
+/// per-investigator). Note the polarity is the opposite of [`ClueValue`],
+/// whose clues default to per-investigator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HealthValue {
+    /// Exactly `value`, regardless of investigator count.
+    Fixed(u8),
+    /// `value × #investigators` at spawn time.
+    PerInvestigator(u8),
+}
+
 /// Per-card-type data. The discriminant mirrors [`CardType`] — read it
 /// via [`CardMetadata::card_type`]. Player variants carry a [`Class`];
 /// encounter variants do not (encounter cards have no player class).
@@ -331,8 +345,8 @@ pub enum CardKind {
         damage: u8,
         /// Horror dealt to an investigator on attack.
         horror: u8,
-        /// Maximum health.
-        health: Option<u8>,
+        /// Maximum health (per-investigator or fixed).
+        health: Option<HealthValue>,
         /// Victory points awarded when defeated (in the victory display).
         victory: Option<u8>,
         /// Spawn rule (`None` = default: engaged with the drawing
@@ -342,6 +356,13 @@ pub enum CardKind {
         surge: bool,
         /// Peril keyword (Rules Reference p.18).
         peril: bool,
+        /// Hunter keyword (Rules Reference p.12).
+        hunter: bool,
+        /// Retaliate keyword (Rules Reference p.18).
+        retaliate: bool,
+        /// Prey instruction (Rules Reference p.17); `Prey::Default` when
+        /// the card prints no prey line.
+        prey: Prey,
         /// Copies of this card in the encounter deck (build multiplicity).
         quantity: u8,
     },
@@ -673,6 +694,17 @@ mod spawn_tests {
     }
 
     #[test]
+    fn health_value_serde_roundtrip() {
+        for hv in [HealthValue::Fixed(4), HealthValue::PerInvestigator(5)] {
+            let json = serde_json::to_string(&hv).expect("serialize");
+            assert_eq!(
+                serde_json::from_str::<HealthValue>(&json).expect("deserialize"),
+                hv
+            );
+        }
+    }
+
+    #[test]
     fn card_metadata_serde_roundtrip_preserves_spawn_specific() {
         let original = CardMetadata {
             code: "_synth_enemy".into(),
@@ -685,13 +717,16 @@ mod spawn_tests {
                 evade: 2,
                 damage: 1,
                 horror: 1,
-                health: Some(1),
+                health: Some(HealthValue::Fixed(1)),
                 victory: None,
                 spawn: Some(Spawn {
                     location: SpawnLocation::Specific("_synth_loc".into()),
                 }),
                 surge: false,
                 peril: false,
+                hunter: false,
+                retaliate: false,
+                prey: Prey::Default,
                 quantity: 1,
             },
         };

--- a/crates/cards/src/generated/cards.rs
+++ b/crates/cards/src/generated/cards.rs
@@ -6,7 +6,10 @@
 
 #![allow(clippy::too_many_lines, clippy::needless_raw_string_hashes)]
 
-use card_dsl::card_data::{CardKind, CardMetadata, Class, ClueValue, HealthValue, Prey, PreyDirection, PreyMeasure, SkillIcons, SkillKind, Skills, Slot, Spawn, SpawnLocation};
+use card_dsl::card_data::{
+    CardKind, CardMetadata, Class, ClueValue, HealthValue, Prey, PreyDirection, PreyMeasure,
+    SkillIcons, SkillKind, Skills, Slot, Spawn, SpawnLocation,
+};
 
 /// Every card from the pinned snapshot, sorted by code.
 #[must_use]

--- a/crates/cards/src/generated/cards.rs
+++ b/crates/cards/src/generated/cards.rs
@@ -6,7 +6,7 @@
 
 #![allow(clippy::too_many_lines, clippy::needless_raw_string_hashes)]
 
-use card_dsl::card_data::{CardKind, CardMetadata, Class, ClueValue, SkillIcons, Skills, Slot};
+use card_dsl::card_data::{CardKind, CardMetadata, Class, ClueValue, HealthValue, Prey, PreyDirection, PreyMeasure, SkillIcons, SkillKind, Skills, Slot, Spawn, SpawnLocation};
 
 /// Every card from the pinned snapshot, sorted by code.
 #[must_use]
@@ -826,7 +826,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Criminal".to_owned()],
             text: Some("<b>Prey</b> - Bearer only.\nHunter.\n[action] Spend 4 resources: <b>Parley.</b> Discard Mob Enforcer.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 4, evade: 3, damage: 1, horror: 0, health: Some(3), victory: None, spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 4, evade: 3, damage: 1, horror: 0, health: Some(HealthValue::Fixed(3)), victory: None, spawn: None, surge: false, peril: false, hunter: true, retaliate: false, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "01102".to_owned(),
@@ -834,7 +834,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Cultist".to_owned(), "Silver Twilight".to_owned()],
             text: Some("<b>Prey</b> - Bearer only.\nHunter.\n<b>Forced</b> - After Silver Twilight Acolyte attacks: Place 1 doom on the current agenda.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 2, evade: 3, damage: 1, horror: 0, health: Some(3), victory: None, spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 2, evade: 3, damage: 1, horror: 0, health: Some(HealthValue::Fixed(3)), victory: None, spawn: None, surge: false, peril: false, hunter: true, retaliate: false, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "01103".to_owned(),
@@ -842,7 +842,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Detective".to_owned()],
             text: Some("<b>Prey</b> - Bearer only.\nHunter.\nWhile Stubborn Detective is at your location, treat your investigator as if his or her printed text box were blank (except for [[Traits]]).".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 3, evade: 2, damage: 1, horror: 0, health: Some(2), victory: None, spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 3, evade: 2, damage: 1, horror: 0, health: Some(HealthValue::Fixed(2)), victory: None, spawn: None, surge: false, peril: false, hunter: true, retaliate: false, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "01105".to_owned(),
@@ -938,7 +938,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Monster".to_owned(), "Ghoul".to_owned(), "Elite".to_owned()],
             text: Some("<b>Prey</b> - Highest [combat].\nHunter. Retaliate.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 4, evade: 4, damage: 2, horror: 2, health: Some(5), victory: Some(2), spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 4, evade: 4, damage: 2, horror: 2, health: Some(HealthValue::PerInvestigator(5)), victory: Some(2), spawn: None, surge: false, peril: false, hunter: true, retaliate: true, prey: Prey::Ranked { direction: PreyDirection::Highest, measure: PreyMeasure::Skill(SkillKind::Combat) }, quantity: 1 },
         },
         CardMetadata {
             code: "01117".to_owned(),
@@ -954,7 +954,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Monster".to_owned(), "Ghoul".to_owned()],
             text: Some("<b>Spawn</b> - Attic.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 4, evade: 1, damage: 1, horror: 2, health: Some(4), victory: Some(1), spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 4, evade: 1, damage: 1, horror: 2, health: Some(HealthValue::Fixed(4)), victory: Some(1), spawn: Some(Spawn { location: SpawnLocation::Specific("01113".to_owned()) }), surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "01119".to_owned(),
@@ -962,7 +962,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Monster".to_owned(), "Ghoul".to_owned()],
             text: Some("<b>Spawn</b> - Cellar.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 3, evade: 4, damage: 2, horror: 1, health: Some(4), victory: Some(1), spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 3, evade: 4, damage: 2, horror: 1, health: Some(HealthValue::Fixed(4)), victory: Some(1), spawn: Some(Spawn { location: SpawnLocation::Specific("01114".to_owned()) }), surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "01121a".to_owned(),
@@ -978,7 +978,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Cultist".to_owned(), "Elite".to_owned()],
             text: Some("<b>Spawn</b> - Engaged with Prey.\n<b>Prey</b> - Most clues.\nHunter.\nThe Masked Hunter gets +2 health per investigator.\nWhile you are engaged with The Masked Hunter, you cannot discover or spend clues.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 4, evade: 2, damage: 2, horror: 1, health: Some(4), victory: Some(2), spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 4, evade: 2, damage: 2, horror: 1, health: Some(HealthValue::Fixed(4)), victory: Some(2), spawn: None, surge: false, peril: false, hunter: true, retaliate: false, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "01122".to_owned(),
@@ -1106,7 +1106,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Cultist".to_owned()],
             text: Some("<b>Spawn</b> - Downtown.\n<b>Forced</b> - When \"Wolf-Man\" Drew attacks: Heal 1 damage from him.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 4, evade: 2, damage: 2, horror: 0, health: Some(4), victory: Some(1), spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 4, evade: 2, damage: 2, horror: 0, health: Some(HealthValue::Fixed(4)), victory: Some(1), spawn: Some(Spawn { location: SpawnLocation::Specific("01131".to_owned()) }), surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "01138".to_owned(),
@@ -1114,7 +1114,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Cultist".to_owned()],
             text: Some("<b>Spawn</b> - Graveyard.\n[action] Choose and discard 4 cards from your hand: <b>Parley.</b> Add Herman Collins to the victory display.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 3, evade: 4, damage: 1, horror: 1, health: Some(4), victory: Some(1), spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 3, evade: 4, damage: 1, horror: 1, health: Some(HealthValue::Fixed(4)), victory: Some(1), spawn: Some(Spawn { location: SpawnLocation::Specific("01133".to_owned()) }), surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "01139".to_owned(),
@@ -1122,7 +1122,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Cultist".to_owned()],
             text: Some("<b>Spawn</b> - Miskatonic University.\n[action] Spend 2 clues: <b>Parley.</b> Add Peter Warren to the victory display.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 2, evade: 3, damage: 1, horror: 0, health: Some(3), victory: Some(1), spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 2, evade: 3, damage: 1, horror: 0, health: Some(HealthValue::Fixed(3)), victory: Some(1), spawn: Some(Spawn { location: SpawnLocation::Specific("01129".to_owned()) }), surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "01140".to_owned(),
@@ -1130,7 +1130,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Cultist".to_owned()],
             text: Some("<b>Spawn</b> - Northside.\n[action] Spend 5 resources: <b>Parley.</b> Add Victoria Devereux to the victory display.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 3, evade: 2, damage: 1, horror: 0, health: Some(3), victory: Some(1), spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 3, evade: 2, damage: 1, horror: 0, health: Some(HealthValue::Fixed(3)), victory: Some(1), spawn: Some(Spawn { location: SpawnLocation::Specific("01134".to_owned()) }), surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "01141".to_owned(),
@@ -1138,7 +1138,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Cultist".to_owned()],
             text: Some("<b>Spawn</b> - St. Mary's Hospital.\n<b>Forced</b> - After Ruth Turner is evaded: Add her to the victory display.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 2, evade: 5, damage: 1, horror: 0, health: Some(4), victory: Some(1), spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 2, evade: 5, damage: 1, horror: 0, health: Some(HealthValue::Fixed(4)), victory: Some(1), spawn: None, surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "01143".to_owned(),
@@ -1258,7 +1258,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ancient One".to_owned(), "Elite".to_owned()],
             text: Some("Hunter. Massive.\nUmôrdhoth gets +4 health per investigator.\n<b>Forced</b> - At the end of each investigator's turn: Ready Umôrdhoth.\n[action] If you control Lita Chantler: \"It's only after her!\" You throw Lita to Umôrdhoth in order to spare your lives. <b>(→R3)</b>".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 5, evade: 6, damage: 3, horror: 3, health: Some(6), victory: None, spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 5, evade: 6, damage: 3, horror: 3, health: Some(HealthValue::Fixed(6)), victory: None, spawn: None, surge: false, peril: false, hunter: true, retaliate: false, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "01158".to_owned(),
@@ -1274,7 +1274,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Creature".to_owned()],
             text: Some("Hunter.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 1, evade: 3, damage: 1, horror: 0, health: Some(1), victory: None, spawn: None, surge: false, peril: false, quantity: 3 },
+            kind: CardKind::Enemy { fight: 1, evade: 3, damage: 1, horror: 0, health: Some(HealthValue::Fixed(1)), victory: None, spawn: None, surge: false, peril: false, hunter: true, retaliate: false, prey: Prey::Default, quantity: 3 },
         },
         CardMetadata {
             code: "01160".to_owned(),
@@ -1282,7 +1282,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Monster".to_owned(), "Ghoul".to_owned()],
             text: None,
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 2, evade: 2, damage: 1, horror: 1, health: Some(2), victory: None, spawn: None, surge: false, peril: false, quantity: 3 },
+            kind: CardKind::Enemy { fight: 2, evade: 2, damage: 1, horror: 1, health: Some(HealthValue::Fixed(2)), victory: None, spawn: None, surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Default, quantity: 3 },
         },
         CardMetadata {
             code: "01161".to_owned(),
@@ -1290,7 +1290,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Monster".to_owned(), "Ghoul".to_owned()],
             text: Some("<b>Prey</b> - Lowest remaining health.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 3, evade: 3, damage: 1, horror: 1, health: Some(3), victory: None, spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 3, evade: 3, damage: 1, horror: 1, health: Some(HealthValue::Fixed(3)), victory: None, spawn: None, surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Ranked { direction: PreyDirection::Lowest, measure: PreyMeasure::RemainingHealth }, quantity: 1 },
         },
         CardMetadata {
             code: "01162".to_owned(),
@@ -1354,7 +1354,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Cultist".to_owned()],
             text: Some("<b>Spawn</b> - Any empty location.\n<b>Forced</b> - After Acolyte enters play: Place 1 doom on it.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 3, evade: 2, damage: 1, horror: 0, health: Some(1), victory: None, spawn: None, surge: false, peril: false, quantity: 3 },
+            kind: CardKind::Enemy { fight: 3, evade: 2, damage: 1, horror: 0, health: Some(HealthValue::Fixed(1)), victory: None, spawn: None, surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Default, quantity: 3 },
         },
         CardMetadata {
             code: "01170".to_owned(),
@@ -1362,7 +1362,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Cultist".to_owned()],
             text: Some("<b>Spawn</b> - Any empty location.\nRetaliate.\n<b>Forced</b> - At the end of the mythos phase: Place 1 doom on Wizard of the Order.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 4, evade: 2, damage: 1, horror: 0, health: Some(2), victory: None, spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 4, evade: 2, damage: 1, horror: 0, health: Some(HealthValue::Fixed(2)), victory: None, spawn: None, surge: false, peril: false, hunter: false, retaliate: true, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "01171".to_owned(),
@@ -1378,7 +1378,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Monster".to_owned(), "Nightgaunt".to_owned()],
             text: Some("Hunter.\nWhile attempting to evade Hunting Nightgaunt, double the negative modifier of each revealed chaos token.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 3, evade: 1, damage: 1, horror: 1, health: Some(4), victory: None, spawn: None, surge: false, peril: false, quantity: 2 },
+            kind: CardKind::Enemy { fight: 3, evade: 1, damage: 1, horror: 1, health: Some(HealthValue::Fixed(4)), victory: None, spawn: None, surge: false, peril: false, hunter: true, retaliate: false, prey: Prey::Default, quantity: 2 },
         },
         CardMetadata {
             code: "01173".to_owned(),
@@ -1402,7 +1402,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Monster".to_owned(), "Byakhee".to_owned()],
             text: Some("<b>Prey</b> - Lowest remaining sanity.\nHunter.\nWhile engaged with an investigator with remaining sanity 4 or fewer, Screeching Byakhee gets +1 fight and +1 evade.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 3, evade: 3, damage: 1, horror: 2, health: Some(4), victory: Some(1), spawn: None, surge: false, peril: false, quantity: 2 },
+            kind: CardKind::Enemy { fight: 3, evade: 3, damage: 1, horror: 2, health: Some(HealthValue::Fixed(4)), victory: Some(1), spawn: None, surge: false, peril: false, hunter: true, retaliate: false, prey: Prey::Default, quantity: 2 },
         },
         CardMetadata {
             code: "01176".to_owned(),
@@ -1418,7 +1418,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Monster".to_owned(), "Yithian".to_owned()],
             text: Some("<b>Prey</b> - Fewest cards in hand.\n<b>Forced</b> - When Yithian Observer attacks you: Discard 1 card at random from your hand. If you cannot, Yithian Observer deals +1 damage and +1 horror for this attack.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 4, evade: 3, damage: 1, horror: 1, health: Some(4), victory: Some(1), spawn: None, surge: false, peril: false, quantity: 2 },
+            kind: CardKind::Enemy { fight: 4, evade: 3, damage: 1, horror: 1, health: Some(HealthValue::Fixed(4)), victory: Some(1), spawn: None, surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Default, quantity: 2 },
         },
         CardMetadata {
             code: "01178".to_owned(),
@@ -1434,7 +1434,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Monster".to_owned(), "Dark Young".to_owned()],
             text: Some("<b>Prey</b> - Lowest [agility].\n<b>Forced</b> - At the end of the round: Heal 2 damage from Relentless Dark Young.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 4, evade: 2, damage: 2, horror: 1, health: Some(5), victory: Some(1), spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 4, evade: 2, damage: 2, horror: 1, health: Some(HealthValue::Fixed(5)), victory: Some(1), spawn: None, surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "01180".to_owned(),
@@ -1442,7 +1442,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Monster".to_owned()],
             text: Some("Hunter. Retaliate.\n<b>Forced</b> - When Goat Spawn is defeated: Each investigator at this location takes 1 horror.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 3, evade: 2, damage: 1, horror: 0, health: Some(3), victory: None, spawn: None, surge: false, peril: false, quantity: 3 },
+            kind: CardKind::Enemy { fight: 3, evade: 2, damage: 1, horror: 0, health: Some(HealthValue::Fixed(3)), victory: None, spawn: None, surge: false, peril: false, hunter: true, retaliate: true, prey: Prey::Default, quantity: 3 },
         },
         CardMetadata {
             code: "01181".to_owned(),
@@ -1450,7 +1450,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Monster".to_owned(), "Deep One".to_owned()],
             text: Some("<b>Prey</b> - Lowest [combat].\nHunter.\n<b>Forced</b> - After Young Deep One engages you: Take 1 horror.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Enemy { fight: 3, evade: 3, damage: 1, horror: 1, health: Some(3), victory: None, spawn: None, surge: false, peril: false, quantity: 2 },
+            kind: CardKind::Enemy { fight: 3, evade: 3, damage: 1, horror: 1, health: Some(HealthValue::Fixed(3)), victory: None, spawn: None, surge: false, peril: false, hunter: true, retaliate: false, prey: Prey::Default, quantity: 2 },
         },
         CardMetadata {
             code: "01182".to_owned(),
@@ -1914,7 +1914,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Monster".to_owned(), "Abomination".to_owned(), "Elite".to_owned()],
             text: Some("Massive.\nThe Experiment gets +3 [per_investigator] health.\n<b>Forced</b> - When the enemy phase begins: Ready The Experiment.\n<b>Objective</b> - If The Experiment is defeated, advance to act 3b.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Enemy { fight: 4, evade: 2, damage: 2, horror: 2, health: Some(7), victory: Some(2), spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 4, evade: 2, damage: 2, horror: 2, health: Some(HealthValue::Fixed(7)), victory: Some(2), spawn: None, surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "02059".to_owned(),
@@ -2066,7 +2066,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Criminal".to_owned(), "Elite".to_owned()],
             text: Some("<b>Prey</b> - Highest [intellect].\nHunter.\n<b>Forced</b> - After an investigator at Clover Club Pit Boss's location gains any number of clues: Clover Club Pit Boss readies, engages that investigator, and makes an immediate attack.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Enemy { fight: 3, evade: 3, damage: 2, horror: 0, health: Some(4), victory: Some(1), spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 3, evade: 3, damage: 2, horror: 0, health: Some(HealthValue::Fixed(4)), victory: Some(1), spawn: None, surge: false, peril: false, hunter: true, retaliate: false, prey: Prey::Ranked { direction: PreyDirection::Highest, measure: PreyMeasure::Skill(SkillKind::Intellect) }, quantity: 1 },
         },
         CardMetadata {
             code: "02079".to_owned(),
@@ -2130,7 +2130,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Monster".to_owned(), "Abomination".to_owned()],
             text: Some("<b>Spawn</b> - Location with the most clues.\nRetaliate.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Enemy { fight: 2, evade: 2, damage: 1, horror: 1, health: Some(2), victory: None, spawn: None, surge: false, peril: false, quantity: 3 },
+            kind: CardKind::Enemy { fight: 2, evade: 2, damage: 1, horror: 1, health: Some(HealthValue::Fixed(2)), victory: None, spawn: None, surge: false, peril: false, hunter: false, retaliate: true, prey: Prey::Default, quantity: 3 },
         },
         CardMetadata {
             code: "02087".to_owned(),
@@ -2138,7 +2138,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Sorcerer".to_owned()],
             text: Some("<b>Prey</b> - Least cards in hand.\nHunter.\n<b>Forced</b> - When the engaged investigator draws a [[Hex]] or [[Pact]] card: Wizard of Yog-Sothoth attacks that investigator.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Enemy { fight: 4, evade: 3, damage: 1, horror: 2, health: Some(3), victory: Some(1), spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 4, evade: 3, damage: 1, horror: 2, health: Some(HealthValue::Fixed(3)), victory: Some(1), spawn: None, surge: false, peril: false, hunter: true, retaliate: false, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "02088".to_owned(),
@@ -2162,7 +2162,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Creature".to_owned()],
             text: Some("Aloof. Hunter.\nEach investigator at Whippoorwill's location gets -1 [willpower], -1 [intellect], -1 [combat], and -1 [agility].".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Enemy { fight: 2, evade: 4, damage: 0, horror: 1, health: Some(1), victory: None, spawn: None, surge: false, peril: false, quantity: 3 },
+            kind: CardKind::Enemy { fight: 2, evade: 4, damage: 0, horror: 1, health: Some(HealthValue::Fixed(1)), victory: None, spawn: None, surge: false, peril: false, hunter: true, retaliate: false, prey: Prey::Default, quantity: 3 },
         },
         CardMetadata {
             code: "02091".to_owned(),
@@ -2194,7 +2194,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Creature".to_owned(), "Monster".to_owned(), "Abomination".to_owned()],
             text: Some("<b>Prey</b> - Lowest [intellect].\nHunter.\nWhile Avian Thrall is being attacked using a [[Ranged]], [[Firearm]], or [[Spell]] asset, it gets -3 fight.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Enemy { fight: 5, evade: 3, damage: 1, horror: 1, health: Some(4), victory: None, spawn: None, surge: false, peril: false, quantity: 2 },
+            kind: CardKind::Enemy { fight: 5, evade: 3, damage: 1, horror: 1, health: Some(HealthValue::Fixed(4)), victory: None, spawn: None, surge: false, peril: false, hunter: true, retaliate: false, prey: Prey::Default, quantity: 2 },
         },
         CardMetadata {
             code: "02095".to_owned(),
@@ -2202,7 +2202,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Creature".to_owned(), "Monster".to_owned(), "Abomination".to_owned()],
             text: Some("<b>Spawn</b> - Farthest location from you.\n<b>Prey</b> - Lowest [agility].\nHunter. Retaliate.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Enemy { fight: 4, evade: 4, damage: 1, horror: 1, health: Some(3), victory: None, spawn: None, surge: false, peril: false, quantity: 2 },
+            kind: CardKind::Enemy { fight: 4, evade: 4, damage: 1, horror: 1, health: Some(HealthValue::Fixed(3)), victory: None, spawn: None, surge: false, peril: false, hunter: true, retaliate: true, prey: Prey::Default, quantity: 2 },
         },
         CardMetadata {
             code: "02096".to_owned(),
@@ -2218,7 +2218,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Criminal".to_owned(), "Syndicate".to_owned()],
             text: Some("While O'Bannion's Thug is engaged with you, you cannot gain resources.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Enemy { fight: 4, evade: 2, damage: 2, horror: 0, health: Some(2), victory: None, spawn: None, surge: false, peril: false, quantity: 2 },
+            kind: CardKind::Enemy { fight: 4, evade: 2, damage: 2, horror: 0, health: Some(HealthValue::Fixed(2)), victory: None, spawn: None, surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Default, quantity: 2 },
         },
         CardMetadata {
             code: "02098".to_owned(),
@@ -2226,7 +2226,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Criminal".to_owned(), "Syndicate".to_owned()],
             text: Some("Retaliate.\n<b>Forced</b> - After Mobster attacks you: Lose 1 resource.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Enemy { fight: 2, evade: 2, damage: 1, horror: 0, health: Some(2), victory: None, spawn: None, surge: false, peril: false, quantity: 2 },
+            kind: CardKind::Enemy { fight: 2, evade: 2, damage: 1, horror: 0, health: Some(HealthValue::Fixed(2)), victory: None, spawn: None, surge: false, peril: false, hunter: false, retaliate: true, prey: Prey::Default, quantity: 2 },
         },
         CardMetadata {
             code: "02099".to_owned(),
@@ -2266,7 +2266,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Monster".to_owned(), "Abomination".to_owned()],
             text: Some("<b>Prey</b> - Lowest [willpower].\nHunter.\n<b>Forced</b> - After you perform an attack against the Conglomeration of Spheres using a [[Melee]] card: Discard that card.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Enemy { fight: 1, evade: 4, damage: 1, horror: 1, health: Some(6), victory: None, spawn: None, surge: false, peril: false, quantity: 2 },
+            kind: CardKind::Enemy { fight: 1, evade: 4, damage: 1, horror: 1, health: Some(HealthValue::Fixed(6)), victory: None, spawn: None, surge: false, peril: false, hunter: true, retaliate: false, prey: Prey::Default, quantity: 2 },
         },
         CardMetadata {
             code: "02104".to_owned(),
@@ -2274,7 +2274,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Monster".to_owned(), "Abomination".to_owned()],
             text: Some("<b>Prey</b> - Lowest [agility].\nHunter.\n<b>Forced</b> - When Servant of the Lurker attacks you: Discard the top 2 cards of your deck.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Enemy { fight: 4, evade: 2, damage: 2, horror: 2, health: Some(5), victory: Some(1), spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 4, evade: 2, damage: 2, horror: 2, health: Some(HealthValue::Fixed(5)), victory: Some(1), spawn: None, surge: false, peril: false, hunter: true, retaliate: false, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "02105".to_owned(),
@@ -2562,7 +2562,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Monster".to_owned(), "Elite".to_owned()],
             text: Some("Hunter. Retaliate.\n<b>Forced</b> - At the start of the enemy phase: Reveal a random token from the chaos bag. If the revealed token has a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol, ready Hunting Horror.\n<b>Forced</b> - When Hunting Horror leaves play, place it in the void.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Enemy { fight: 2, evade: 2, damage: 1, horror: 1, health: Some(3), victory: None, spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 2, evade: 2, damage: 1, horror: 1, health: Some(HealthValue::Fixed(3)), victory: None, spawn: None, surge: false, peril: false, hunter: true, retaliate: true, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "02142".to_owned(),
@@ -2882,7 +2882,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Monster".to_owned(), "Abomination".to_owned()],
             text: Some("Hunter.\nWhile you are engaged with Grappling Horror, you cannot move.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Enemy { fight: 3, evade: 2, damage: 1, horror: 1, health: Some(3), victory: None, spawn: None, surge: false, peril: false, quantity: 2 },
+            kind: CardKind::Enemy { fight: 3, evade: 2, damage: 1, horror: 1, health: Some(HealthValue::Fixed(3)), victory: None, spawn: None, surge: false, peril: false, hunter: true, retaliate: false, prey: Prey::Default, quantity: 2 },
         },
         CardMetadata {
             code: "02183".to_owned(),
@@ -2890,7 +2890,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Monster".to_owned(), "Abomination".to_owned()],
             text: Some("<b>Spawn</b> - The location to your right (or your location if there is no location to your right).\nEmergent Monstrosity enters play exhausted.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Enemy { fight: 4, evade: 3, damage: 2, horror: 2, health: Some(5), victory: Some(1), spawn: None, surge: false, peril: false, quantity: 2 },
+            kind: CardKind::Enemy { fight: 4, evade: 3, damage: 2, horror: 2, health: Some(HealthValue::Fixed(5)), victory: Some(1), spawn: None, surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Default, quantity: 2 },
         },
         CardMetadata {
             code: "02184".to_owned(),
@@ -3146,7 +3146,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Monster".to_owned(), "Abomination".to_owned(), "Elite".to_owned()],
             text: Some("Massive.\nSilas Bishop cannot make attacks of opportunity.".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Enemy { fight: 3, evade: 7, damage: 2, horror: 2, health: Some(6), victory: Some(2), spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 3, evade: 7, damage: 2, horror: 2, health: Some(HealthValue::PerInvestigator(6)), victory: Some(2), spawn: None, surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "02217".to_owned(),
@@ -3210,7 +3210,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned()],
             text: Some("<b>Spawn</b> - Any empty location.\nRetaliate.\n[reaction] After you defeat Servant of Many Mouths: Discover 1 clue at any location.".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Enemy { fight: 3, evade: 1, damage: 2, horror: 0, health: Some(2), victory: None, spawn: None, surge: false, peril: false, quantity: 3 },
+            kind: CardKind::Enemy { fight: 3, evade: 1, damage: 2, horror: 0, health: Some(HealthValue::Fixed(2)), victory: None, spawn: None, surge: false, peril: false, hunter: false, retaliate: true, prey: Prey::Default, quantity: 3 },
         },
         CardMetadata {
             code: "02225".to_owned(),
@@ -3450,7 +3450,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Monster".to_owned(), "Abomination".to_owned()],
             text: Some("Massive.\nBrood of Yog-Sothoth gets +1 [per_investigator] health and cannot be damaged or attacked except using the ability on Esoteric Formula.".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Enemy { fight: 6, evade: 3, damage: 2, horror: 2, health: Some(1), victory: Some(1), spawn: None, surge: false, peril: false, quantity: 5 },
+            kind: CardKind::Enemy { fight: 6, evade: 3, damage: 2, horror: 2, health: Some(HealthValue::Fixed(1)), victory: Some(1), spawn: None, surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Default, quantity: 5 },
         },
         CardMetadata {
             code: "02256".to_owned(),
@@ -3746,7 +3746,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Sorcerer".to_owned(), "Elite".to_owned()],
             text: Some("Retaliate.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Enemy { fight: 5, evade: 5, damage: 1, horror: 1, health: Some(3), victory: Some(1), spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 5, evade: 5, damage: 1, horror: 1, health: Some(HealthValue::PerInvestigator(3)), victory: Some(1), spawn: None, surge: false, peril: false, hunter: false, retaliate: true, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "02294".to_owned(),
@@ -3754,7 +3754,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Sorcerer".to_owned()],
             text: Some("<b>Spawn</b> - Base of the Hill.\n<b>Forced</b> - At the end of the enemy phase, Devotee of the Key moves once toward Sentinel Peak. If Devotee of the Key is already at Sentinel Peak, discard it and add 2 doom to the current agenda, instead.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Enemy { fight: 3, evade: 3, damage: 1, horror: 1, health: Some(3), victory: None, spawn: None, surge: false, peril: false, quantity: 2 },
+            kind: CardKind::Enemy { fight: 3, evade: 3, damage: 1, horror: 1, health: Some(HealthValue::Fixed(3)), victory: None, spawn: Some(Spawn { location: SpawnLocation::Specific("02282".to_owned()) }), surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Default, quantity: 2 },
         },
         CardMetadata {
             code: "02295".to_owned(),
@@ -3762,7 +3762,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Monster".to_owned(), "Shoggoth".to_owned()],
             text: Some("<b>Spawn</b> - Nearest [[Altered]] location.\n<b>Forced</b> - When Crazed Shoggoth attacks: If this attack would defeat an investigator, that investigator is instead killed.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Enemy { fight: 3, evade: 4, damage: 2, horror: 2, health: Some(6), victory: Some(1), spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 3, evade: 4, damage: 2, horror: 2, health: Some(HealthValue::Fixed(6)), victory: Some(1), spawn: None, surge: false, peril: false, hunter: false, retaliate: false, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "02296".to_owned(),
@@ -3978,7 +3978,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ancient One".to_owned(), "Elite".to_owned()],
             text: Some("Massive. Hunter. Retaliate.\nYog-Sothoth gets +6 [per_investigator] health.\nYog-Sothoth cannot be evaded and cannot make attacks of opportunity.\n[reaction] When Yog-Sothoth attacks you: Instead of taking up to X horror, you may discard the top X cards from your deck. Then, if you have no cards in your deck, you are driven insane.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Enemy { fight: 4, evade: 0, damage: 1, horror: 5, health: Some(4), victory: None, spawn: None, surge: false, peril: false, quantity: 1 },
+            kind: CardKind::Enemy { fight: 4, evade: 0, damage: 1, horror: 5, health: Some(HealthValue::Fixed(4)), victory: None, spawn: None, surge: false, peril: false, hunter: true, retaliate: true, prey: Prey::Default, quantity: 1 },
         },
         CardMetadata {
             code: "02324".to_owned(),
@@ -4026,7 +4026,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Monster".to_owned(), "Yithian".to_owned()],
             text: Some("<b>Spawn</b> - Any [[Extradimensional]] location.\nHunter.\n<b>Forced</b> - When Interstellar Traveler enters a location: Flip 1 clue on that location to its doom side and place it on Interstellar Traveler, or place 1 doom on Interstellar Traveler if there are no clues on that location.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Enemy { fight: 4, evade: 2, damage: 1, horror: 2, health: Some(3), victory: None, spawn: None, surge: false, peril: false, quantity: 3 },
+            kind: CardKind::Enemy { fight: 4, evade: 2, damage: 1, horror: 2, health: Some(HealthValue::Fixed(3)), victory: None, spawn: None, surge: false, peril: false, hunter: true, retaliate: false, prey: Prey::Default, quantity: 3 },
         },
         CardMetadata {
             code: "02330".to_owned(),
@@ -4034,7 +4034,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Monster".to_owned(), "Yithian".to_owned()],
             text: Some("<b>Spawn</b> - Another Dimension.\nRetaliate.\n<b>Forced</b> - When Yithian Starseeker attacks an investigator with more than 10 cards in his or her discard pile: Place 1 doom on Yithian Starseeker.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Enemy { fight: 3, evade: 5, damage: 2, horror: 1, health: Some(4), victory: None, spawn: None, surge: false, peril: false, quantity: 2 },
+            kind: CardKind::Enemy { fight: 3, evade: 5, damage: 2, horror: 1, health: Some(HealthValue::Fixed(4)), victory: None, spawn: Some(Spawn { location: SpawnLocation::Specific("02320".to_owned()) }), surge: false, peril: false, hunter: false, retaliate: true, prey: Prey::Default, quantity: 2 },
         },
         CardMetadata {
             code: "02331".to_owned(),

--- a/crates/cards/tests/enemies.rs
+++ b/crates/cards/tests/enemies.rs
@@ -45,6 +45,25 @@ fn ghoul_priest_full_profile() {
 }
 
 #[test]
+fn ghoul_priest_carries_ghoul_and_elite_traits() {
+    // Traits flow through the pre-existing `parse_traits` onto the corpus
+    // (and onto spawned enemies via `traits.clone()`). "Elite" is modeled
+    // as a trait, not a keyword — the Rules Reference has no standalone
+    // Elite rule; card effects key off it as "non-Elite".
+    let meta = cards::by_code("01116").expect("Ghoul Priest in corpus");
+    assert!(
+        meta.traits.iter().any(|t| t == "Ghoul"),
+        "{:?}",
+        meta.traits
+    );
+    assert!(
+        meta.traits.iter().any(|t| t == "Elite"),
+        "{:?}",
+        meta.traits
+    );
+}
+
+#[test]
 fn flesh_eater_spawns_at_attic() {
     let CardKind::Enemy {
         fight,

--- a/crates/cards/tests/enemies.rs
+++ b/crates/cards/tests/enemies.rs
@@ -1,0 +1,158 @@
+//! C3b — the six Gathering encounter enemies carry their printed stats,
+//! keywords, and spawn-location in the corpus. Stats verified against
+//! `data/arkhamdb-snapshot/pack/core/core_encounter.json`.
+
+use card_dsl::card_data::{
+    CardKind, HealthValue, Prey, PreyDirection, PreyMeasure, SkillKind, Spawn, SpawnLocation,
+};
+
+fn enemy(code: &str) -> CardKind {
+    cards::by_code(code)
+        .unwrap_or_else(|| panic!("enemy {code} in corpus"))
+        .kind
+        .clone()
+}
+
+#[test]
+fn ghoul_priest_full_profile() {
+    let CardKind::Enemy {
+        fight,
+        evade,
+        damage,
+        horror,
+        health,
+        victory,
+        hunter,
+        retaliate,
+        prey,
+        ..
+    } = enemy("01116")
+    else {
+        panic!("01116 is an enemy")
+    };
+    assert_eq!((fight, evade, damage, horror), (4, 4, 2, 2));
+    assert_eq!(health, Some(HealthValue::PerInvestigator(5)));
+    assert_eq!(victory, Some(2));
+    assert!(hunter);
+    assert!(retaliate);
+    assert_eq!(
+        prey,
+        Prey::Ranked {
+            direction: PreyDirection::Highest,
+            measure: PreyMeasure::Skill(SkillKind::Combat),
+        },
+    );
+}
+
+#[test]
+fn flesh_eater_spawns_at_attic() {
+    let CardKind::Enemy {
+        fight,
+        evade,
+        damage,
+        horror,
+        health,
+        spawn,
+        ..
+    } = enemy("01118")
+    else {
+        panic!("enemy")
+    };
+    assert_eq!((fight, evade, damage, horror), (4, 1, 1, 2));
+    assert_eq!(health, Some(HealthValue::Fixed(4)));
+    assert_eq!(
+        spawn,
+        Some(Spawn {
+            location: SpawnLocation::Specific("01113".to_owned()),
+        }),
+    );
+}
+
+#[test]
+fn icy_ghoul_spawns_at_cellar() {
+    let CardKind::Enemy {
+        fight,
+        evade,
+        damage,
+        horror,
+        spawn,
+        ..
+    } = enemy("01119")
+    else {
+        panic!("enemy")
+    };
+    assert_eq!((fight, evade, damage, horror), (3, 4, 2, 1));
+    assert_eq!(
+        spawn,
+        Some(Spawn {
+            location: SpawnLocation::Specific("01114".to_owned()),
+        }),
+    );
+}
+
+#[test]
+fn ghoul_minion_is_plain() {
+    let CardKind::Enemy {
+        fight,
+        evade,
+        damage,
+        horror,
+        health,
+        hunter,
+        retaliate,
+        prey,
+        quantity,
+        ..
+    } = enemy("01160")
+    else {
+        panic!("enemy")
+    };
+    assert_eq!((fight, evade, damage, horror), (2, 2, 1, 1));
+    assert_eq!(health, Some(HealthValue::Fixed(2)));
+    assert!(!hunter);
+    assert!(!retaliate);
+    assert_eq!(prey, Prey::Default);
+    assert_eq!(quantity, 3);
+}
+
+#[test]
+fn ravenous_ghoul_prey_lowest_remaining_health() {
+    let CardKind::Enemy {
+        fight,
+        evade,
+        damage,
+        horror,
+        prey,
+        ..
+    } = enemy("01161")
+    else {
+        panic!("enemy")
+    };
+    assert_eq!((fight, evade, damage, horror), (3, 3, 1, 1));
+    assert_eq!(
+        prey,
+        Prey::Ranked {
+            direction: PreyDirection::Lowest,
+            measure: PreyMeasure::RemainingHealth,
+        },
+    );
+}
+
+#[test]
+fn swarm_of_rats_is_a_hunter() {
+    let CardKind::Enemy {
+        fight,
+        evade,
+        damage,
+        horror,
+        hunter,
+        quantity,
+        ..
+    } = enemy("01159")
+    else {
+        panic!("enemy")
+    };
+    assert_eq!((fight, evade, damage, horror), (1, 3, 1, 0));
+    assert!(hunter);
+    assert_eq!(quantity, 3);
+}

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -1,6 +1,6 @@
 //! Encounter-deck draw, spawn, and Mythos draw chain handlers.
 
-use crate::card_data::{CardKind, CardMetadata, CardType, Spawn, SpawnLocation};
+use crate::card_data::{CardKind, CardMetadata, CardType, HealthValue, Spawn, SpawnLocation};
 use crate::card_registry;
 use crate::dsl::Trigger;
 use crate::event::Event;
@@ -312,7 +312,12 @@ fn spawn_enemy(
         code: CardCode::new(metadata.code.clone()),
         fight: 1,
         evade: 1,
-        max_health: health.unwrap_or(1),
+        // Task 3 replaces this with per-investigator scaling + stat/keyword
+        // reads; here it only adapts to the new HealthValue type to compile.
+        max_health: match health {
+            Some(HealthValue::Fixed(n) | HealthValue::PerInvestigator(n)) => *n,
+            None => 1,
+        },
         damage: 0,
         attack_damage: 0,
         attack_horror: 0,
@@ -956,7 +961,7 @@ mod spawn_enemy_tests {
     use crate::state::{CardCode, InvestigatorId, LocationId, Phase};
     use crate::test_support::{test_investigator, test_location, GameStateBuilder};
     use crate::{assert_event, assert_event_sequence, assert_no_event};
-    use card_dsl::card_data::{CardKind, CardMetadata, Spawn, SpawnLocation};
+    use card_dsl::card_data::{CardKind, CardMetadata, HealthValue, Prey, Spawn, SpawnLocation};
 
     fn synth_enemy_metadata(spawn: Option<Spawn>) -> CardMetadata {
         CardMetadata {
@@ -970,11 +975,14 @@ mod spawn_enemy_tests {
                 evade: 1,
                 damage: 0,
                 horror: 0,
-                health: Some(1),
+                health: Some(HealthValue::Fixed(1)),
                 victory: None,
                 spawn,
                 surge: false,
                 peril: false,
+                hunter: false,
+                retaliate: false,
+                prey: Prey::Default,
                 quantity: 1,
             },
         }

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -984,7 +984,17 @@ mod spawn_enemy_tests {
     use card_dsl::card_data::{CardKind, CardMetadata, HealthValue, Prey, Spawn, SpawnLocation};
 
     fn synth_enemy_metadata(spawn: Option<Spawn>) -> CardMetadata {
-        enemy_metadata(spawn, HealthValue::Fixed(1), false, false, Prey::Default, 1, 1, 0, 0)
+        enemy_metadata(
+            spawn,
+            HealthValue::Fixed(1),
+            false,
+            false,
+            Prey::Default,
+            1,
+            1,
+            0,
+            0,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1038,10 +1048,23 @@ mod spawn_enemy_tests {
             .unwrap()
             .current_location = Some(LocationId(10));
 
-        let metadata = enemy_metadata(None, HealthValue::Fixed(5), true, true, Prey::Default, 4, 4, 2, 2);
+        let metadata = enemy_metadata(
+            None,
+            HealthValue::Fixed(5),
+            true,
+            true,
+            Prey::Default,
+            4,
+            4,
+            2,
+            2,
+        );
         let mut events = Vec::new();
         spawn_enemy(
-            &mut Cx { state: &mut state, events: &mut events },
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             InvestigatorId(1),
             CardCode("_synth_enemy".into()),
             &metadata,
@@ -1075,11 +1098,23 @@ mod spawn_enemy_tests {
                 .current_location = Some(LocationId(10));
         }
 
-        let metadata =
-            enemy_metadata(None, HealthValue::PerInvestigator(5), false, false, Prey::Default, 4, 4, 2, 2);
+        let metadata = enemy_metadata(
+            None,
+            HealthValue::PerInvestigator(5),
+            false,
+            false,
+            Prey::Default,
+            4,
+            4,
+            2,
+            2,
+        );
         let mut events = Vec::new();
         spawn_enemy(
-            &mut Cx { state: &mut state, events: &mut events },
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
             InvestigatorId(1),
             CardCode("_synth_enemy".into()),
             &metadata,

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -250,10 +250,35 @@ fn spawn_enemy(
 ) -> EngineOutcome {
     // spawn_enemy is only reached for Enemy cards; pull the enemy-specific
     // stats out of the kind.
-    let CardKind::Enemy { spawn, health, .. } = &metadata.kind else {
+    let CardKind::Enemy {
+        spawn,
+        health,
+        fight,
+        evade,
+        damage,
+        horror,
+        hunter,
+        retaliate,
+        prey,
+        ..
+    } = &metadata.kind
+    else {
         return EngineOutcome::Rejected {
             reason: format!("spawn_enemy: card {code} is not an enemy").into(),
         };
+    };
+    let prey = *prey;
+
+    // Resolve health. PerInvestigator scales by the number of investigators
+    // in the game (Rules Reference p.12); matches the per-investigator clue
+    // path in reveal.rs (its future started-count caveat applies here too).
+    let max_health = match health {
+        Some(HealthValue::Fixed(n)) => *n,
+        Some(HealthValue::PerInvestigator(n)) => {
+            let count = u8::try_from(cx.state.investigators.len()).unwrap_or(u8::MAX);
+            n.saturating_mul(count)
+        }
+        None => 1,
     };
 
     // 1. Resolve spawn location (validate-first).
@@ -294,9 +319,9 @@ fn spawn_enemy(
     };
 
     // 2. Resolve engagement-on-spawn (validate-first). The co-located
-    //    set is narrowed by the enemy's prey — every spawn uses
-    //    `Prey::Default` (Task 2), so a 2+ set always ties and suspends
-    //    for the lead investigator's `PickInvestigator` (option A).
+    //    set is narrowed by the enemy's `prey`; with `Prey::Default` a 2+
+    //    set ties and suspends for the lead investigator's
+    //    `PickInvestigator` (option A).
     let candidates = super::cursor::active_investigators_at(cx.state, location_id);
 
     // 3. Mint and place (mutate-second). The enemy is inserted unengaged;
@@ -310,28 +335,23 @@ fn spawn_enemy(
         id: enemy_id,
         name: metadata.name.clone(),
         code: CardCode::new(metadata.code.clone()),
-        fight: 1,
-        evade: 1,
-        // Task 3 replaces this with per-investigator scaling + stat/keyword
-        // reads; here it only adapts to the new HealthValue type to compile.
-        max_health: match health {
-            Some(HealthValue::Fixed(n) | HealthValue::PerInvestigator(n)) => *n,
-            None => 1,
-        },
+        fight: i8::try_from(*fight).unwrap_or(i8::MAX),
+        evade: i8::try_from(*evade).unwrap_or(i8::MAX),
+        max_health,
         damage: 0,
-        attack_damage: 0,
-        attack_horror: 0,
+        attack_damage: *damage,
+        attack_horror: *horror,
         current_location: Some(location_id),
         exhausted: false,
         traits: metadata.traits.clone(),
         engaged_with: None,
-        hunter: false,
-        prey: crate::card_data::Prey::Default,
-        retaliate: false,
+        hunter: *hunter,
+        prey,
+        retaliate: *retaliate,
     };
     cx.state.enemies.insert(enemy_id, enemy);
 
-    match super::hunters::resolve_prey(cx.state, crate::card_data::Prey::Default, &candidates) {
+    match super::hunters::resolve_prey(cx.state, prey, &candidates) {
         super::hunters::PreyResolution::None => {
             cx.events.push(Event::EnemySpawned {
                 enemy: enemy_id,
@@ -964,6 +984,21 @@ mod spawn_enemy_tests {
     use card_dsl::card_data::{CardKind, CardMetadata, HealthValue, Prey, Spawn, SpawnLocation};
 
     fn synth_enemy_metadata(spawn: Option<Spawn>) -> CardMetadata {
+        enemy_metadata(spawn, HealthValue::Fixed(1), false, false, Prey::Default, 1, 1, 0, 0)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn enemy_metadata(
+        spawn: Option<Spawn>,
+        health: HealthValue,
+        hunter: bool,
+        retaliate: bool,
+        prey: Prey,
+        fight: u8,
+        evade: u8,
+        damage: u8,
+        horror: u8,
+    ) -> CardMetadata {
         CardMetadata {
             code: "_synth_enemy".into(),
             name: "Synth Enemy".into(),
@@ -971,21 +1006,87 @@ mod spawn_enemy_tests {
             traits: Vec::new(),
             pack_code: "_synth".into(),
             kind: CardKind::Enemy {
-                fight: 1,
-                evade: 1,
-                damage: 0,
-                horror: 0,
-                health: Some(HealthValue::Fixed(1)),
+                fight,
+                evade,
+                damage,
+                horror,
+                health: Some(health),
                 victory: None,
                 spawn,
                 surge: false,
                 peril: false,
-                hunter: false,
-                retaliate: false,
-                prey: Prey::Default,
+                hunter,
+                retaliate,
+                prey,
                 quantity: 1,
             },
         }
+    }
+
+    #[test]
+    fn spawn_enemy_reads_combat_stats_and_keywords_from_metadata() {
+        let mut loc = test_location(10, "Loc");
+        loc.code = CardCode("_l".into());
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_location(loc)
+            .with_turn_order([InvestigatorId(1)])
+            .build();
+        state
+            .investigators
+            .get_mut(&InvestigatorId(1))
+            .unwrap()
+            .current_location = Some(LocationId(10));
+
+        let metadata = enemy_metadata(None, HealthValue::Fixed(5), true, true, Prey::Default, 4, 4, 2, 2);
+        let mut events = Vec::new();
+        spawn_enemy(
+            &mut Cx { state: &mut state, events: &mut events },
+            InvestigatorId(1),
+            CardCode("_synth_enemy".into()),
+            &metadata,
+        );
+
+        let enemy = state.enemies.values().next().expect("enemy spawned");
+        assert_eq!(enemy.fight, 4);
+        assert_eq!(enemy.evade, 4);
+        assert_eq!(enemy.attack_damage, 2);
+        assert_eq!(enemy.attack_horror, 2);
+        assert_eq!(enemy.max_health, 5);
+        assert!(enemy.hunter);
+        assert!(enemy.retaliate);
+    }
+
+    #[test]
+    fn spawn_enemy_scales_per_investigator_health_by_investigator_count() {
+        let mut loc = test_location(10, "Loc");
+        loc.code = CardCode("_l".into());
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_investigator(test_investigator(2))
+            .with_location(loc)
+            .with_turn_order([InvestigatorId(1), InvestigatorId(2)])
+            .build();
+        for id in [1, 2] {
+            state
+                .investigators
+                .get_mut(&InvestigatorId(id))
+                .unwrap()
+                .current_location = Some(LocationId(10));
+        }
+
+        let metadata =
+            enemy_metadata(None, HealthValue::PerInvestigator(5), false, false, Prey::Default, 4, 4, 2, 2);
+        let mut events = Vec::new();
+        spawn_enemy(
+            &mut Cx { state: &mut state, events: &mut events },
+            InvestigatorId(1),
+            CardCode("_synth_enemy".into()),
+            &metadata,
+        );
+
+        let enemy = state.enemies.values().next().expect("enemy spawned");
+        assert_eq!(enemy.max_health, 10, "5 health × 2 investigators");
     }
 
     #[test]

--- a/crates/scenarios/src/test_fixtures/synth_cards.rs
+++ b/crates/scenarios/src/test_fixtures/synth_cards.rs
@@ -15,7 +15,9 @@
 
 use std::sync::OnceLock;
 
-use game_core::card_data::{CardKind, CardMetadata, Class, SkillIcons, Spawn, SpawnLocation};
+use game_core::card_data::{
+    CardKind, CardMetadata, Class, HealthValue, Prey, SkillIcons, Spawn, SpawnLocation,
+};
 use game_core::card_registry::CardRegistry;
 use game_core::dsl::{gain_resources, on_play, revelation, Ability, InvestigatorTarget};
 use game_core::state::CardCode;
@@ -94,13 +96,16 @@ fn synth_enemy_metadata() -> CardMetadata {
             evade: 1,
             damage: 0,
             horror: 0,
-            health: Some(1),
+            health: Some(HealthValue::Fixed(1)),
             victory: None,
             spawn: Some(Spawn {
                 location: SpawnLocation::Specific(SYNTH_LOC_CODE.to_owned()),
             }),
             surge: false,
             peril: false,
+            hunter: false,
+            retaliate: false,
+            prey: Prey::Default,
             quantity: 1,
         },
     }

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -9,7 +9,8 @@ Engine spine (A1/A2) and scenario plumbing (B1/B2) shipped; **Group C**
 kickoff [#246](https://github.com/talelburg/eldritch/issues/246)). Shipped:
 C1a (board skeleton), C1b (Act-1 board build + Act-3 forced advance-on-defeat),
 C2 (01104 symbol-token effects + location victory points),
-C3a (Prey – Lowest remaining health + Retaliate keyword).
+C3a (Prey – Lowest remaining health + Retaliate keyword),
+C3b (the six encounter enemies + pipeline keyword/spawn/health parsing).
 Design specs:
 [Gathering design](../superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md),
 [Group C decomposition](../superpowers/specs/2026-06-11-phase-7-slice-1-group-c-decomposition-design.md).
@@ -54,7 +55,7 @@ root dependency; C7 is the playable Won/Lost gate; #212 lands after C.
 | C1b | [#228](https://github.com/talelburg/eldritch/issues/228) | Act-1 (01108) reverse board-build + Act-3 (01110) forced advance-on-defeat (act-2 01109 objective → C3c) | ✅ PR #259 |
 | C2 | [#229](https://github.com/talelburg/eldritch/issues/229) | 01104 symbol-token effects + victory points | ✅ PR #263 |
 | C3a | [#230](https://github.com/talelburg/eldritch/issues/230) | Prey variants + Retaliate | ✅ PR #269 |
-| C3b | [#231](https://github.com/talelburg/eldritch/issues/231) | the six encounter enemies | — |
+| C3b | [#231](https://github.com/talelburg/eldritch/issues/231) | the six encounter enemies | ✅ PR #272 |
 | C3c | [#232](https://github.com/talelburg/eldritch/issues/232) | agenda 01107 forced (movement + doom; +`RoundEnded`) **+ act-2 (01109) round-end objective (moved from C1b)** | — |
 | C4a | [#233](https://github.com/talelburg/eldritch/issues/233) | threat-area zone + shared scan source (in-C consolidation seam) | — |
 | C4b | [#234](https://github.com/talelburg/eldritch/issues/234) | one-shot Revelation treacheries (×4) | — |
@@ -123,6 +124,8 @@ Devourer Below, campaign log + `Fact` enum) is **Phase 9**, not Phase 7.
 - **Scenario chaos-symbol effects live on `ScenarioModule.resolve_symbol`, not card `abilities()` (C2, [#229](https://github.com/talelburg/eldritch/issues/229), PR #263).** A reference card is one-per-scenario, never a card-object (never played/revealed/moved), and board-dependent, so it doesn't fit the `abilities()` model; the scenario module — already the context-taking home for `setup`/`apply_resolution` — owns it via a plain-Rust `fn(ChaosToken, &SymbolCtx) -> SymbolOutcome` hook returning a `modifier` (applied to the total before pass/fail) plus `immediate`/`on_fail` `TokenEffect`s (applied after, routed through the existing `DealDamage`/`DealHorror` paths). **No new DSL primitives** — 01104's Ghoul-count is inline Rust in `the_gathering.rs`. **Future scenarios' reference cards add a `resolve_symbol` hook, not card impls.** This removed B1's dead `reference_card` field + `active_reference_card` lookup ([#223](https://github.com/talelburg/eldritch/issues/223)) in the same PR; the static `TokenModifiers` path remains for hook-less fixtures.
 
 - **Location victory points are placed at scenario resolution, not on clear (C2, [#229](https://github.com/talelburg/eldritch/issues/229), PR #263).** Per RR p.21 ("at the end of a scenario, place each victory point location that is in play, revealed, and with no clues on it in the victory display"), the engine generically scans `state.locations` at the `fire_scenario_resolution` chokepoint and places qualifying victory-bearing locations (reading `CardKind::Location { victory }` from the corpus) into a new `GameState.victory_display: Vec<CardCode>`. The victory-point **enemy** path (place as defeated) plugs into the same zone in **C3**; Phase 9 sums the zone for XP.
+
+- **Enemy keywords / spawn-location / per-investigator health are parsed in the pipeline into the corpus, not hand-written per-enemy (C3b, [#231](https://github.com/talelburg/eldritch/issues/231), PR #272).** `CardKind::Enemy` gained `hunter`/`retaliate`/`prey`, and `health: Option<u8>` became `Option<HealthValue>` (a new enum mirroring `ClueValue`; polarity flipped — ArkhamDB `health_per_investigator` defaults false → `Fixed`). The pipeline parses these from card text (incl. resolving `Spawn - <name>` to a location code via a name→code index over Location cards); `spawn_enemy` reads all stats/keywords from the corpus and scales `PerInvestigator` health by the in-game investigator count (same source as the per-investigator clue path in `reveal.rs`). **Future enemies need no hand-written impl** — they land via the snapshot + a regen. Out-of-scope keyword forms not yet modeled (e.g. `Prey - Most clues`, `Spawn - Engaged with Prey`) default + emit a build warning rather than failing or silently approximating. `surge`/`peril` remain unparsed (#138).
 
 ## Open questions
 

--- a/docs/superpowers/plans/2026-06-13-phase-7-slice-1-c3b-enemies.md
+++ b/docs/superpowers/plans/2026-06-13-phase-7-slice-1-c3b-enemies.md
@@ -1,0 +1,814 @@
+# C3b — The Gathering enemies Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the six Gathering encounter enemies spawn with their correct printed stats and keywords by parsing keyword/spawn/per-investigator-health data into the corpus and wiring `spawn_enemy` to read it.
+
+**Architecture:** Combat stats already live in `CardKind::Enemy`. Add three keyword fields (`hunter`, `retaliate`, `prey`) and replace `health: Option<u8>` with `Option<HealthValue>` (mirroring the location `ClueValue` pattern). The pipeline parses these from card `text` and regenerates the corpus; `spawn_enemy` reads all of it, scaling per-investigator health by the in-game investigator count.
+
+**Tech Stack:** Rust workspace — `card-dsl` (types), `card-data-pipeline` (codegen), `game-core` (engine), `cards` (corpus + integration tests).
+
+**Spec:** `docs/superpowers/specs/2026-06-13-phase-7-slice-1-c3b-enemies-design.md`
+
+**Verified stats** (from `data/arkhamdb-snapshot/pack/core/core_encounter.json`):
+
+| Enemy | code | fight | evade | dmg | horror | health | victory | qty | keywords |
+|---|---|---|---|---|---|---|---|---|---|
+| Ghoul Priest | 01116 | 4 | 4 | 2 | 2 | 5 *(per-inv)* | 2 | 1 | Prey-Highest [combat], Hunter, Retaliate |
+| Flesh-Eater | 01118 | 4 | 1 | 1 | 2 | 4 | 1 | 1 | Spawn-Attic |
+| Icy Ghoul | 01119 | 3 | 4 | 2 | 1 | 4 | 1 | 1 | Spawn-Cellar |
+| Ghoul Minion | 01160 | 2 | 2 | 1 | 1 | 2 | — | 3 | — |
+| Ravenous Ghoul | 01161 | 3 | 3 | 1 | 1 | 3 | — | 1 | Prey-Lowest remaining health |
+| Swarm of Rats | 01159 | 1 | 3 | 1 | 0 | 1 | — | 3 | Hunter |
+
+Attic = `01113`, Cellar = `01114`.
+
+**Pre-flight (run once before Task 1):**
+```bash
+git checkout -b card/c3b-gathering-enemies
+```
+
+---
+
+## Task 1: Pipeline keyword/spawn parsers (pure helpers)
+
+Pure functions + a pipeline-local `PreyParse` enum, TDD'd in isolation. They compile and pass before any struct change because they only produce `String`s / enums.
+
+**Files:**
+- Modify: `crates/card-data-pipeline/src/main.rs` (add helpers near `clue_value_lit` ~line 506; add tests in the existing `#[cfg(test)] mod tests` ~line 553)
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the `#[cfg(test)] mod tests` block (the one importing `clue_value_lit, emit_card, …`). First extend its `use super::{…}` line to also import `health_value_opt_lit, parse_prey, parse_spawn_name, prey_lit, strip_html_bold, has_keyword, PreyParse`.
+
+```rust
+#[test]
+fn strip_html_bold_removes_bold_tags() {
+    assert_eq!(strip_html_bold("<b>Prey</b> - Highest [combat]."), "Prey - Highest [combat].");
+}
+
+#[test]
+fn has_keyword_matches_standalone_token() {
+    assert!(has_keyword("Hunter. Retaliate.", "Hunter"));
+    assert!(has_keyword("Hunter. Retaliate.", "Retaliate"));
+    assert!(!has_keyword("<b>Spawn</b> - Attic.", "Hunter"));
+}
+
+#[test]
+fn parse_prey_recognizes_highest_combat() {
+    assert_eq!(
+        parse_prey("<b>Prey</b> - Highest [combat].\nHunter. Retaliate."),
+        PreyParse::HighestSkill("Combat"),
+    );
+}
+
+#[test]
+fn parse_prey_recognizes_lowest_remaining_health() {
+    assert_eq!(
+        parse_prey("<b>Prey</b> - Lowest remaining health."),
+        PreyParse::LowestRemainingHealth,
+    );
+}
+
+#[test]
+fn parse_prey_none_when_no_prey_line() {
+    assert_eq!(parse_prey("Hunter."), PreyParse::None);
+}
+
+#[test]
+fn parse_prey_unrecognized_keeps_clause() {
+    assert_eq!(
+        parse_prey("<b>Prey</b> - Most clues."),
+        PreyParse::Unrecognized("Most clues".to_owned()),
+    );
+}
+
+#[test]
+fn prey_lit_emits_expected_literals() {
+    assert_eq!(prey_lit(&PreyParse::None), "Prey::Default");
+    assert_eq!(prey_lit(&PreyParse::Unrecognized("Most clues".to_owned())), "Prey::Default");
+    assert_eq!(
+        prey_lit(&PreyParse::HighestSkill("Combat")),
+        "Prey::Ranked { direction: PreyDirection::Highest, measure: PreyMeasure::Skill(SkillKind::Combat) }",
+    );
+    assert_eq!(
+        prey_lit(&PreyParse::LowestRemainingHealth),
+        "Prey::Ranked { direction: PreyDirection::Lowest, measure: PreyMeasure::RemainingHealth }",
+    );
+}
+
+#[test]
+fn parse_spawn_name_extracts_location_name() {
+    assert_eq!(parse_spawn_name("<b>Spawn</b> - Attic."), Some("Attic".to_owned()));
+    assert_eq!(parse_spawn_name("<b>Spawn</b> - Cellar."), Some("Cellar".to_owned()));
+    assert_eq!(parse_spawn_name("Hunter."), None);
+}
+
+#[test]
+fn health_value_opt_lit_mirrors_clue_value() {
+    assert_eq!(health_value_opt_lit(None, false), "None");
+    assert_eq!(health_value_opt_lit(Some(4), false), "Some(HealthValue::Fixed(4))");
+    assert_eq!(health_value_opt_lit(Some(5), true), "Some(HealthValue::PerInvestigator(5))");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p card-data-pipeline`
+Expected: FAIL — `cannot find function/type` for the new helpers.
+
+- [ ] **Step 3: Implement the helpers**
+
+Add near `clue_value_lit` (~line 506):
+
+```rust
+/// Strip ArkhamDB bold markup so keyword lines can be matched plainly.
+fn strip_html_bold(s: &str) -> String {
+    s.replace("<b>", "").replace("</b>", "")
+}
+
+/// True if `text` contains the standalone keyword token `"<kw>."`
+/// (e.g. `"Hunter."`). Bold tags are stripped first.
+fn has_keyword(text: &str, keyword: &str) -> bool {
+    strip_html_bold(text).contains(&format!("{keyword}."))
+}
+
+/// Parsed Prey line. `None` = no printed prey (emit `Prey::Default`);
+/// `Unrecognized` = a "Prey - …" form we don't model yet (emit
+/// `Prey::Default` + warn, matching `surge`/`peril`'s default-stub).
+#[derive(Debug, PartialEq, Eq)]
+enum PreyParse {
+    None,
+    /// `Prey - Highest [<skill>]`; payload is the `SkillKind` ident.
+    HighestSkill(&'static str),
+    /// `Prey - Lowest remaining health`.
+    LowestRemainingHealth,
+    /// A "Prey - …" clause not yet modeled (the clause text, trimmed).
+    Unrecognized(String),
+}
+
+/// Parse an enemy's Prey line out of `text`.
+fn parse_prey(text: &str) -> PreyParse {
+    let stripped = strip_html_bold(text);
+    let Some(rest) = stripped.split("Prey - ").nth(1) else {
+        return PreyParse::None;
+    };
+    // The clause runs to the next period.
+    let clause = rest.split('.').next().unwrap_or("").trim();
+    match clause {
+        "Highest [willpower]" => PreyParse::HighestSkill("Willpower"),
+        "Highest [intellect]" => PreyParse::HighestSkill("Intellect"),
+        "Highest [combat]" => PreyParse::HighestSkill("Combat"),
+        "Highest [agility]" => PreyParse::HighestSkill("Agility"),
+        "Lowest remaining health" => PreyParse::LowestRemainingHealth,
+        other => PreyParse::Unrecognized(other.to_owned()),
+    }
+}
+
+/// Emit the `Prey` literal for a parsed prey line.
+fn prey_lit(p: &PreyParse) -> String {
+    match p {
+        PreyParse::None | PreyParse::Unrecognized(_) => "Prey::Default".to_owned(),
+        PreyParse::HighestSkill(skill) => format!(
+            "Prey::Ranked {{ direction: PreyDirection::Highest, \
+             measure: PreyMeasure::Skill(SkillKind::{skill}) }}"
+        ),
+        PreyParse::LowestRemainingHealth => "Prey::Ranked { direction: PreyDirection::Lowest, \
+             measure: PreyMeasure::RemainingHealth }"
+            .to_owned(),
+    }
+}
+
+/// Parse the location name from a `Spawn - <name>.` line, if present.
+fn parse_spawn_name(text: &str) -> Option<String> {
+    let stripped = strip_html_bold(text);
+    let rest = stripped.split("Spawn - ").nth(1)?;
+    Some(rest.split('.').next().unwrap_or("").trim().to_owned())
+}
+
+/// Emit the `Option<HealthValue>` literal for an enemy's health, mirroring
+/// `clue_value_lit`. Polarity is the opposite of clues: per-investigator
+/// only when ArkhamDB's `health_per_investigator` is set.
+fn health_value_opt_lit(health: Option<u8>, per_investigator: bool) -> String {
+    match health {
+        None => "None".to_owned(),
+        Some(n) if per_investigator => format!("Some(HealthValue::PerInvestigator({n}))"),
+        Some(n) => format!("Some(HealthValue::Fixed({n}))"),
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p card-data-pipeline`
+Expected: PASS (new tests green; helpers are dead-code until Task 2 — that is fine, `cargo test` does not deny warnings).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/card-data-pipeline/src/main.rs
+git commit -m "$(cat <<'EOF'
+pipeline: enemy keyword/spawn/health parse helpers (C3b)
+
+Pure parsers for Hunter/Retaliate/Prey/Spawn-location and a
+health_value_opt_lit mirroring clue_value_lit. Wired into the corpus
+in the next commit.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Extend `CardKind::Enemy`, wire the pipeline, regenerate the corpus
+
+Atomic by necessity: adding fields to `CardKind::Enemy` breaks the generated corpus, so the struct change, the pipeline emit change, the corpus regen, and the hand-written literal fixes all land together.
+
+**Files:**
+- Modify: `crates/card-dsl/src/card_data.rs` (add `HealthValue` enum ~after `ClueValue` line 254; extend `CardKind::Enemy` ~line 325; fix serde test literal ~line 683)
+- Modify: `crates/card-dsl/src/lib.rs` (export `HealthValue` alongside `ClueValue` ~line 34)
+- Modify: `crates/card-data-pipeline/src/main.rs` (raw + normalized `health_per_investigator`; new `PreyParse`/spawn fields on `NormalizedCard`; wire `normalize`; spawn-name→code resolution pass in `run`; extend `render_kind` Enemy arm + generated `use` line; fix the `CardKind::Enemy { fight: 4, evade: 4,` assertion ~line 1020)
+- Modify: `crates/scenarios/src/test_fixtures/synth_cards.rs:92` (literal)
+- Modify: `crates/game-core/src/engine/dispatch/encounter.rs:968` (test-mock literal)
+- Regenerate: `crates/cards/src/generated/cards.rs`
+
+- [ ] **Step 1: Add the `HealthValue` enum**
+
+In `crates/card-dsl/src/card_data.rs`, after the `ClueValue` enum (~line 254):
+
+```rust
+/// An enemy's printed health. Mirrors [`ClueValue`]: `PerInvestigator(n)`
+/// scales by the number of investigators in the game (Rules Reference
+/// p.12); `Fixed(n)` is a flat value. Distinguishes ArkhamDB's
+/// `health_per_investigator` (absent/false → fixed; `true` →
+/// per-investigator). Note the polarity is the opposite of `ClueValue`,
+/// whose clues default to per-investigator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HealthValue {
+    /// Exactly `value`, regardless of investigator count.
+    Fixed(u8),
+    /// `value × #investigators` at spawn time.
+    PerInvestigator(u8),
+}
+```
+
+- [ ] **Step 2: Extend `CardKind::Enemy`**
+
+In the same file, in the `Enemy { … }` variant (~line 325): change the `health` field type and add three keyword fields (place the keyword cluster after `peril`, before `quantity`):
+
+```rust
+        /// Maximum health (per-investigator or fixed).
+        health: Option<HealthValue>,
+```
+and after the `peril: bool,` field:
+```rust
+        /// Hunter keyword (Rules Reference p.12).
+        hunter: bool,
+        /// Retaliate keyword (Rules Reference p.18).
+        retaliate: bool,
+        /// Prey instruction (Rules Reference p.17); `Prey::Default` when
+        /// the card prints no prey line.
+        prey: Prey,
+```
+
+- [ ] **Step 3: Export `HealthValue`**
+
+In `crates/card-dsl/src/lib.rs`, add `HealthValue` to the `pub use card_data::{…}` re-export list (alphabetically near `ClueValue`).
+
+- [ ] **Step 4: Fix the `card-dsl` serde-test literal**
+
+In `crates/card-dsl/src/card_data.rs` ~line 683 (`card_metadata_serde_roundtrip_preserves_spawn_specific`), update the enemy literal to the new shape:
+
+```rust
+            kind: CardKind::Enemy {
+                fight: 3,
+                evade: 2,
+                damage: 1,
+                horror: 1,
+                health: Some(HealthValue::Fixed(1)),
+                victory: None,
+                spawn: Some(Spawn {
+                    location: SpawnLocation::Specific("_synth_loc".into()),
+                }),
+                surge: false,
+                peril: false,
+                hunter: false,
+                retaliate: false,
+                prey: Prey::Default,
+                quantity: 1,
+            },
+```
+Ensure `Prey` and `HealthValue` are in scope in that test module (add to its `use` if needed).
+
+- [ ] **Step 5: Add a `HealthValue` serde roundtrip assertion**
+
+In the card-dsl tests, add:
+
+```rust
+#[test]
+fn health_value_serde_roundtrip() {
+    for hv in [HealthValue::Fixed(4), HealthValue::PerInvestigator(5)] {
+        let json = serde_json::to_string(&hv).expect("serialize");
+        assert_eq!(serde_json::from_str::<HealthValue>(&json).expect("deserialize"), hv);
+    }
+}
+```
+
+- [ ] **Step 6: Add pipeline raw + normalized `health_per_investigator` and the parsed fields**
+
+In `crates/card-data-pipeline/src/main.rs`:
+
+In `RawCard` (~line 174, next to `enemy_horror`):
+```rust
+    health_per_investigator: Option<bool>,
+```
+In `NormalizedCard` (~line 211, next to `enemy_horror`):
+```rust
+    enemy_horror: Option<u8>,
+    health_per_investigator: bool,
+    hunter: bool,
+    retaliate: bool,
+    prey: PreyParse,
+    /// Location name parsed from a `Spawn - <name>.` line (pre-resolution).
+    spawn_name: Option<String>,
+    /// Spawn location code, resolved from `spawn_name` after all cards load.
+    spawn_code: Option<String>,
+```
+
+- [ ] **Step 7: Populate the new fields in `normalize`**
+
+In `normalize` (~line 230, in the `Ok(NormalizedCard { … })`), after `enemy_horror: raw.enemy_horror,`:
+```rust
+        health_per_investigator: raw.health_per_investigator.unwrap_or(false),
+        hunter: raw.text.as_deref().is_some_and(|t| has_keyword(t, "Hunter")),
+        retaliate: raw.text.as_deref().is_some_and(|t| has_keyword(t, "Retaliate")),
+        prey: raw.text.as_deref().map_or(PreyParse::None, parse_prey),
+        spawn_name: raw.text.as_deref().and_then(parse_spawn_name),
+        spawn_code: None,
+```
+Note: `raw.text` is moved into the struct's `text` field — read these *before* that move, or clone. Simplest: compute them into `let` bindings at the top of `normalize` (alongside `is_fast`, which already reads `raw.text.as_deref()`), then move the bindings in. Mirror the existing `is_fast` pattern.
+
+- [ ] **Step 8: Resolve `spawn_name` → `spawn_code` after all cards load**
+
+In `run()` (~line 86, after the `for rel in PACK_FILES` loop, before `render(&all)`):
+```rust
+    // Resolve enemy Spawn-location names to location codes now that every
+    // card is loaded. Unresolved names (out-of-scope forms like
+    // "Engaged with Prey") stay None and warn — a loud stub, not silent.
+    let loc_index: BTreeMap<String, String> = all
+        .values()
+        .filter(|c| c.card_type == "Location")
+        .map(|c| (c.name.clone(), c.code.clone()))
+        .collect();
+    let mut resolutions: Vec<(String, Option<String>)> = Vec::new();
+    for c in all.values() {
+        if let Some(name) = &c.spawn_name {
+            match loc_index.get(name) {
+                Some(code) => resolutions.push((c.code.clone(), Some(code.clone()))),
+                None => {
+                    eprintln!(
+                        "card-data-pipeline: enemy {} ({}): unresolved Spawn location {name:?} \
+                         — emitting spawn: None",
+                        c.code, c.name
+                    );
+                    resolutions.push((c.code.clone(), None));
+                }
+            }
+        }
+    }
+    for (code, spawn_code) in resolutions {
+        if let Some(c) = all.get_mut(&code) {
+            c.spawn_code = spawn_code;
+        }
+    }
+    // Warn on Prey lines we parsed but do not model yet.
+    for c in all.values() {
+        if let PreyParse::Unrecognized(clause) = &c.prey {
+            eprintln!(
+                "card-data-pipeline: enemy {} ({}): unmodeled Prey clause {clause:?} \
+                 — emitting Prey::Default",
+                c.code, c.name
+            );
+        }
+    }
+```
+(The two-pass collect-then-set avoids a simultaneous `&` + `&mut` borrow of `all`.)
+
+- [ ] **Step 9: Emit the new fields in `render_kind` + extend the generated `use` line**
+
+In `render_kind`, replace the `"Enemy" =>` arm:
+```rust
+        "Enemy" => format!(
+            "CardKind::Enemy {{ fight: {}, evade: {}, damage: {}, horror: {}, \
+             health: {}, victory: {}, spawn: {}, surge: false, peril: false, \
+             hunter: {}, retaliate: {}, prey: {}, quantity: {} }}",
+            c.enemy_fight.unwrap_or(0),
+            c.enemy_evade.unwrap_or(0),
+            c.enemy_damage.unwrap_or(0),
+            c.enemy_horror.unwrap_or(0),
+            health_value_opt_lit(c.health, c.health_per_investigator),
+            opt_u8(c.victory),
+            spawn_lit(c.spawn_code.as_deref()),
+            c.hunter,
+            c.retaliate,
+            prey_lit(&c.prey),
+            c.quantity,
+        ),
+```
+Add the `spawn_lit` helper near `health_value_opt_lit`:
+```rust
+/// Emit the `Option<Spawn>` literal for an enemy's resolved spawn code.
+fn spawn_lit(spawn_code: Option<&str>) -> String {
+    match spawn_code {
+        Some(code) => format!(
+            "Some(Spawn {{ location: SpawnLocation::Specific({}.to_owned()) }})",
+            str_lit(code)
+        ),
+        None => "None".to_owned(),
+    }
+}
+```
+Extend the generated `use` line in `render` (~line 347) to:
+```rust
+        "use card_dsl::card_data::{CardKind, CardMetadata, Class, ClueValue, HealthValue, Prey, PreyDirection, PreyMeasure, SkillIcons, SkillKind, Skills, Slot, Spawn, SpawnLocation};\n\n\
+```
+Update the doc-comment on `render_kind` (~line 388) to drop the now-stale "`spawn`… emit not-yet-parsed defaults" sentence for enemies (keep the note for `surge`/`peril`).
+
+- [ ] **Step 10: Fix the pipeline test assertion that pins the Enemy literal prefix**
+
+In `crates/card-data-pipeline/src/main.rs` ~line 1020, the test mock sets `c.enemy_fight = Some(4)` and asserts `buf.contains("CardKind::Enemy { fight: 4, evade: 4,")`. That prefix is unchanged by our edits, so it still holds — but that mock `NormalizedCard` now needs the new fields to construct. Update every `NormalizedCard { … }` test literal in this file (there are several skeleton mocks ~lines 585, 621, 958, 1061) to add:
+```rust
+            health_per_investigator: false,
+            hunter: false,
+            retaliate: false,
+            prey: PreyParse::None,
+            spawn_name: None,
+            spawn_code: None,
+```
+and add `health_per_investigator: None,` to any `RawCard { … }` test literal.
+
+- [ ] **Step 11: Fix remaining hand-written `CardKind::Enemy` literals**
+
+`crates/scenarios/src/test_fixtures/synth_cards.rs:92` and `crates/game-core/src/engine/dispatch/encounter.rs:968` (`synth_enemy_metadata`): change `health: Some(1)` → `health: Some(HealthValue::Fixed(1))` and add `hunter: false, retaliate: false, prey: Prey::Default,`. Add `HealthValue` / `Prey` to each file's imports (`encounter.rs` test module already imports from `card_dsl::card_data` at line 959 — extend it; `synth_cards.rs` imports near its top).
+
+- [ ] **Step 12: Regenerate the corpus**
+
+Run: `cargo run -p card-data-pipeline`
+Expected: prints `wrote N cards`, plus warnings for out-of-scope unmodeled forms (e.g. Masked Hunter `Most clues` / `Engaged with Prey`). Confirm the six in-scope enemies look right:
+
+Run: `grep -E 'code: "011(16|18|19|59|60|61)"' -A2 crates/cards/src/generated/cards.rs | grep -E 'CardKind::Enemy'`
+Expected (spot-check): Ghoul Priest has `health: Some(HealthValue::PerInvestigator(5))`, `hunter: true`, `retaliate: true`, `prey: Prey::Ranked { direction: PreyDirection::Highest, measure: PreyMeasure::Skill(SkillKind::Combat) }`; Flesh-Eater has `spawn: Some(Spawn { location: SpawnLocation::Specific("01113".to_owned()) })`; Ravenous Ghoul has the `Lowest`/`RemainingHealth` prey.
+
+- [ ] **Step 13: Build the workspace**
+
+Run: `RUSTFLAGS="-D warnings" cargo build --all --all-features`
+Expected: clean build (generated corpus + all literal sites compile against the new struct).
+
+- [ ] **Step 14: Run the affected test suites**
+
+Run: `cargo test -p card-dsl -p card-data-pipeline`
+Expected: PASS.
+
+- [ ] **Step 15: Commit**
+
+```bash
+git add crates/card-dsl crates/card-data-pipeline crates/scenarios crates/game-core/src/engine/dispatch/encounter.rs crates/cards/src/generated/cards.rs
+git commit -m "$(cat <<'EOF'
+card: enemy keywords + per-investigator health in the corpus (C3b)
+
+Add hunter/retaliate/prey to CardKind::Enemy and replace
+health: Option<u8> with Option<HealthValue> (mirrors ClueValue). The
+pipeline parses these from card text and resolves Spawn-location names
+to codes; regenerated corpus carries them for the six Gathering enemies.
+Out-of-scope keyword forms default + warn.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `spawn_enemy` reads stats + keywords from the corpus
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/encounter.rs` (`spawn_enemy` ~line 245; `synth_enemy_metadata` + tests in `mod spawn_enemy_tests` ~line 954)
+
+- [ ] **Step 1: Write failing tests**
+
+In `mod spawn_enemy_tests`, first give the mock helper parameters for the new data. Replace `synth_enemy_metadata` with:
+
+```rust
+fn synth_enemy_metadata(spawn: Option<Spawn>) -> CardMetadata {
+    enemy_metadata(spawn, HealthValue::Fixed(1), false, false, Prey::Default, 1, 1, 0, 0)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn enemy_metadata(
+    spawn: Option<Spawn>,
+    health: HealthValue,
+    hunter: bool,
+    retaliate: bool,
+    prey: Prey,
+    fight: u8,
+    evade: u8,
+    damage: u8,
+    horror: u8,
+) -> CardMetadata {
+    CardMetadata {
+        code: "_synth_enemy".into(),
+        name: "Synth Enemy".into(),
+        text: None,
+        traits: Vec::new(),
+        pack_code: "_synth".into(),
+        kind: CardKind::Enemy {
+            fight, evade, damage, horror,
+            health: Some(health),
+            victory: None,
+            spawn,
+            surge: false,
+            peril: false,
+            hunter,
+            retaliate,
+            prey,
+            quantity: 1,
+        },
+    }
+}
+```
+Extend the module's imports (line 959) to `use card_dsl::card_data::{CardKind, CardMetadata, HealthValue, Prey, Spawn, SpawnLocation};`.
+
+Then add tests:
+
+```rust
+#[test]
+fn spawn_enemy_reads_combat_stats_and_keywords_from_metadata() {
+    let mut state = GameStateBuilder::new()
+        .with_investigator(test_investigator(1))
+        .with_location({ let mut l = test_location(10, "Loc"); l.code = CardCode("_l".into()); l })
+        .with_turn_order([InvestigatorId(1)])
+        .build();
+    state.investigators.get_mut(&InvestigatorId(1)).unwrap().current_location = Some(LocationId(10));
+
+    let metadata = enemy_metadata(None, HealthValue::Fixed(5), true, true, Prey::Default, 4, 4, 2, 2);
+    let mut events = Vec::new();
+    spawn_enemy(&mut Cx { state: &mut state, events: &mut events }, InvestigatorId(1), CardCode("_synth_enemy".into()), &metadata);
+
+    let enemy = state.enemies.values().next().expect("enemy spawned");
+    assert_eq!(enemy.fight, 4);
+    assert_eq!(enemy.evade, 4);
+    assert_eq!(enemy.attack_damage, 2);
+    assert_eq!(enemy.attack_horror, 2);
+    assert_eq!(enemy.max_health, 5);
+    assert!(enemy.hunter);
+    assert!(enemy.retaliate);
+}
+
+#[test]
+fn spawn_enemy_scales_per_investigator_health_by_investigator_count() {
+    let mut state = GameStateBuilder::new()
+        .with_investigator(test_investigator(1))
+        .with_investigator(test_investigator(2))
+        .with_location({ let mut l = test_location(10, "Loc"); l.code = CardCode("_l".into()); l })
+        .with_turn_order([InvestigatorId(1), InvestigatorId(2)])
+        .build();
+    for id in [1, 2] {
+        state.investigators.get_mut(&InvestigatorId(id)).unwrap().current_location = Some(LocationId(10));
+    }
+
+    let metadata = enemy_metadata(None, HealthValue::PerInvestigator(5), false, false, Prey::Default, 4, 4, 2, 2);
+    let mut events = Vec::new();
+    spawn_enemy(&mut Cx { state: &mut state, events: &mut events }, InvestigatorId(1), CardCode("_synth_enemy".into()), &metadata);
+
+    let enemy = state.enemies.values().next().expect("enemy spawned");
+    assert_eq!(enemy.max_health, 10, "5 health × 2 investigators");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p game-core spawn_enemy`
+Expected: FAIL — `enemy.fight` is `1` (hardcoded), `max_health` is `5` not `10`, `hunter`/`retaliate` are `false`.
+
+- [ ] **Step 3: Implement — read stats from metadata in `spawn_enemy`**
+
+In `spawn_enemy` (~line 253), widen the destructure and compute health:
+```rust
+    let CardKind::Enemy {
+        spawn, health, fight, evade, damage, horror, hunter, retaliate, prey, ..
+    } = &metadata.kind
+    else {
+        return EngineOutcome::Rejected {
+            reason: format!("spawn_enemy: card {code} is not an enemy").into(),
+        };
+    };
+```
+Compute `max_health` from `HealthValue` using the same investigator-count source as per-investigator clues (`reveal.rs:20`):
+```rust
+    // Resolve health. PerInvestigator scales by the number of
+    // investigators in the game (Rules Reference p.12); matches the
+    // per-investigator clue path in reveal.rs (its future
+    // started-count caveat applies equally here).
+    let max_health = match health {
+        Some(HealthValue::Fixed(n)) => *n,
+        Some(HealthValue::PerInvestigator(n)) => {
+            let count = u8::try_from(cx.state.investigators.len()).unwrap_or(u8::MAX);
+            n.saturating_mul(count)
+        }
+        None => 1,
+    };
+    let prey = *prey;
+```
+Then in the `Enemy { … }` literal (~line 309) replace the hardcoded fields:
+```rust
+        fight: i8::try_from(*fight).unwrap_or(i8::MAX),
+        evade: i8::try_from(*evade).unwrap_or(i8::MAX),
+        max_health,
+        damage: 0,
+        attack_damage: *damage,
+        attack_horror: *horror,
+        ...
+        hunter: *hunter,
+        prey,
+        retaliate: *retaliate,
+```
+(`fight`/`evade` on `Enemy` are `i8`; metadata is `u8` — convert. `damage` here is the *current* damage suffered, stays `0`; the printed attack damage goes to `attack_damage`.)
+
+- [ ] **Step 4: Use the enemy's prey for spawn-engagement narrowing**
+
+The `resolve_prey` call (~line 329) currently passes `crate::card_data::Prey::Default`. Change it to the enemy's `prey`:
+```rust
+    match super::hunters::resolve_prey(cx.state, prey, &candidates) {
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p game-core spawn_enemy`
+Expected: PASS (new tests + the pre-existing spawn tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/encounter.rs
+git commit -m "$(cat <<'EOF'
+engine: spawn_enemy reads stats + keywords from the corpus (C3b)
+
+Replace the hardcoded fight/evade/attack/health/keyword placeholders
+with the CardKind::Enemy values; scale PerInvestigator health by the
+in-game investigator count; engage on spawn using the enemy's prey.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Integration test — the six enemies against the real corpus
+
+Realizes the issue's "card test per enemy" acceptance: with `cards::REGISTRY` installed, assert each enemy's parsed corpus metadata. (Full in-engine spawn-to-defeat is the C7b end-to-end test, #245.)
+
+**Files:**
+- Create: `crates/cards/tests/enemies.rs`
+
+- [ ] **Step 1: Write the test**
+
+```rust
+//! C3b — the six Gathering encounter enemies carry their printed stats,
+//! keywords, and spawn-location in the corpus.
+
+use card_dsl::card_data::{
+    CardKind, HealthValue, Prey, PreyDirection, PreyMeasure, SkillKind, Spawn, SpawnLocation,
+};
+
+fn enemy(code: &str) -> CardKind {
+    cards::by_code(code)
+        .unwrap_or_else(|| panic!("enemy {code} in corpus"))
+        .kind
+        .clone()
+}
+
+#[test]
+fn ghoul_priest_full_profile() {
+    let CardKind::Enemy { fight, evade, damage, horror, health, victory, hunter, retaliate, prey, .. } = enemy("01116")
+    else { panic!("01116 is an enemy") };
+    assert_eq!((fight, evade, damage, horror), (4, 4, 2, 2));
+    assert_eq!(health, Some(HealthValue::PerInvestigator(5)));
+    assert_eq!(victory, Some(2));
+    assert!(hunter);
+    assert!(retaliate);
+    assert_eq!(prey, Prey::Ranked { direction: PreyDirection::Highest, measure: PreyMeasure::Skill(SkillKind::Combat) });
+}
+
+#[test]
+fn flesh_eater_spawns_at_attic() {
+    let CardKind::Enemy { fight, evade, damage, horror, health, spawn, .. } = enemy("01118")
+    else { panic!("enemy") };
+    assert_eq!((fight, evade, damage, horror), (4, 1, 1, 2));
+    assert_eq!(health, Some(HealthValue::Fixed(4)));
+    assert_eq!(spawn, Some(Spawn { location: SpawnLocation::Specific("01113".to_owned()) }));
+}
+
+#[test]
+fn icy_ghoul_spawns_at_cellar() {
+    let CardKind::Enemy { fight, evade, damage, horror, spawn, .. } = enemy("01119")
+    else { panic!("enemy") };
+    assert_eq!((fight, evade, damage, horror), (3, 4, 2, 1));
+    assert_eq!(spawn, Some(Spawn { location: SpawnLocation::Specific("01114".to_owned()) }));
+}
+
+#[test]
+fn ghoul_minion_is_plain() {
+    let CardKind::Enemy { fight, evade, damage, horror, health, hunter, retaliate, prey, quantity, .. } = enemy("01160")
+    else { panic!("enemy") };
+    assert_eq!((fight, evade, damage, horror), (2, 2, 1, 1));
+    assert_eq!(health, Some(HealthValue::Fixed(2)));
+    assert!(!hunter);
+    assert!(!retaliate);
+    assert_eq!(prey, Prey::Default);
+    assert_eq!(quantity, 3);
+}
+
+#[test]
+fn ravenous_ghoul_prey_lowest_remaining_health() {
+    let CardKind::Enemy { fight, evade, damage, horror, prey, .. } = enemy("01161")
+    else { panic!("enemy") };
+    assert_eq!((fight, evade, damage, horror), (3, 3, 1, 1));
+    assert_eq!(prey, Prey::Ranked { direction: PreyDirection::Lowest, measure: PreyMeasure::RemainingHealth });
+}
+
+#[test]
+fn swarm_of_rats_is_a_hunter() {
+    let CardKind::Enemy { fight, evade, damage, horror, hunter, quantity, .. } = enemy("01159")
+    else { panic!("enemy") };
+    assert_eq!((fight, evade, damage, horror), (1, 3, 1, 0));
+    assert!(hunter);
+    assert_eq!(quantity, 3);
+}
+```
+
+Note: confirm the corpus accessor name — if `cards::by_code` does not exist, use the one the other integration tests use (check `crates/cards/tests/play_card.rs` for the metadata accessor and `REGISTRY` install pattern, and mirror it). If a `REGISTRY` install is required for the accessor, add it; if `by_code` reads the static corpus directly, no install is needed.
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `cargo test -p cards --test enemies`
+Expected: PASS (the corpus was regenerated in Task 2).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cards/tests/enemies.rs
+git commit -m "$(cat <<'EOF'
+test: corpus profile checks for the six Gathering enemies (C3b)
+
+Assert stats, keywords, per-investigator health, and spawn-location for
+Ghoul Priest, Flesh-Eater, Icy Ghoul, Ghoul Minion, Ravenous Ghoul, and
+Swarm of Rats against the regenerated corpus.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Full CI gauntlet + PR
+
+- [ ] **Step 1: Run the full local gauntlet** (from CLAUDE.md)
+
+```bash
+RUSTFLAGS="-D warnings"     cargo test --all --all-features
+                            cargo clippy --all-targets --all-features -- -D warnings
+                            cargo fmt --check
+RUSTDOCFLAGS="-D warnings"  cargo doc --workspace --no-deps --all-features
+                            cargo build -p web --target wasm32-unknown-unknown
+                            cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+Expected: all green. Fix any clippy/doc issues before pushing (e.g. `too_many_arguments` on the test helper is already `#[allow]`'d; check the generated corpus has no unused imports — every added `use` type must appear in an emitted literal).
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+git push -u origin card/c3b-gathering-enemies
+gh pr create --fill
+```
+PR body: design-decisions paragraph (keyword/spawn/health now parsed in the pipeline into the corpus; `HealthValue` mirrors `ClueValue`; out-of-scope forms default + warn), and `Closes #231.`
+
+- [ ] **Step 3: Watch CI**
+
+Run: `gh pr checks <PR#> --watch`
+Fix failures with follow-up commits to the same branch.
+
+- [ ] **Step 4: Update the phase doc — ONLY after CI is green**
+
+Per `docs/phases/README.md`: in `docs/phases/phase-7-the-gathering.md`, flip the C3b row (#231) to `✅ PR #<n>`, update the Status "Shipped:" line, and add a **Decisions made** entry only if load-bearing for future PRs (e.g. "enemy keywords/spawn/per-inv-health are parsed in the pipeline into `CardKind::Enemy`; `HealthValue` mirrors `ClueValue`; future enemies need no hand-written impl"). Commit as the final commit on the branch. Do **not** merge — stop for user approval.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** card-dsl fields (T2) · pipeline parsing + corpus regen (T1, T2) · per-investigator `HealthValue` mirroring `ClueValue` (T1, T2) · `spawn_enemy` reads stats/keywords + scales health + uses prey (T3) · out-of-scope default+warn (T2 step 8) · pipeline/spawn/integration tests (T1, T3, T4) · all six enemies verified (T4). Covered.
+- **i8/u8:** `Enemy.fight/evade` are `i8`; metadata `u8` — converted in T3 step 3.
+- **Atomicity:** the `CardKind::Enemy` change forces a corpus regen; T2 bundles struct + pipeline + regen + literal fixes so every commit compiles.
+- **Accessor name (`cards::by_code`)** is verified against `crates/cards/tests/play_card.rs` in T4 step 1 before relying on it.

--- a/docs/superpowers/specs/2026-06-13-phase-7-slice-1-c3b-enemies-design.md
+++ b/docs/superpowers/specs/2026-06-13-phase-7-slice-1-c3b-enemies-design.md
@@ -1,0 +1,153 @@
+# Phase 7 Slice 1 — C3b: The Gathering enemies (design)
+
+**Issue:** [#231](https://github.com/talelburg/eldritch/issues/231) · **Date:** 2026-06-13
+**Depends on:** C3a (#230 — `Prey`/`Retaliate` machinery), C1a (#227 — locations for spawn).
+
+## Goal
+
+Make the six Gathering encounter enemies spawn with their correct printed
+stats and keywords, by reading them from the corpus instead of the
+hardcoded placeholders in `spawn_enemy`. The combat stats already live in
+the corpus (`CardKind::Enemy`); this PR adds the missing keyword/scaling
+data (Hunter, Retaliate, Prey, per-investigator health, spawn-location),
+parses it in the pipeline, and wires `spawn_enemy` to use all of it.
+
+## The six enemies (stats verified against `data/arkhamdb-snapshot/pack/core/core_encounter.json`)
+
+| Enemy | code | fight | evade | dmg | horror | health | victory | qty | keywords |
+|---|---|---|---|---|---|---|---|---|---|
+| Ghoul Priest | 01116 | 4 | 4 | 2 | 2 | 5 *(per-investigator)* | 2 | 1 | Prey-Highest [combat], Hunter, Retaliate, Elite |
+| Flesh-Eater | 01118 | 4 | 1 | 1 | 2 | 4 | 1 | 1 | Spawn-Attic |
+| Icy Ghoul | 01119 | 3 | 4 | 2 | 1 | 4 | 1 | 1 | Spawn-Cellar |
+| Ghoul Minion | 01160 | 2 | 2 | 1 | 1 | 2 | — | 3 | (none) |
+| Ravenous Ghoul | 01161 | 3 | 3 | 1 | 1 | 3 | — | 1 | Prey-Lowest remaining health |
+| Swarm of Rats | 01159 | 1 | 3 | 1 | 0 | 1 | — | 3 | Hunter |
+
+Attic = `01113`, Cellar = `01114` (from `crates/cards/src/impls/{attic,cellar}.rs`).
+
+## Current state
+
+- **Combat stats already in the corpus** (`CardKind::Enemy { fight, evade,
+  damage, horror, health, victory, spawn, surge, peril, quantity }`), but
+  `spawn_enemy` (`crates/game-core/src/engine/dispatch/encounter.rs:309`)
+  **ignores them** and hardcodes `fight: 1, evade: 1, attack_damage: 0,
+  attack_horror: 0`, `max_health = health.unwrap_or(1)`, `prey:
+  Prey::Default`, `hunter: false`, `retaliate: false`.
+- **C3a's keyword machinery exists** (`Prey::Ranked`, `resolve_prey`,
+  hunter movement, retaliate in skill-test) but is only exercised by tests
+  that mutate the `Enemy` struct directly — there is no production path
+  that sets `hunter`/`retaliate`/`prey` on a spawned enemy.
+- **Keywords + spawn-location are not in the corpus** — they live only in
+  card `text`; the pipeline emits `spawn: None, surge: false, peril:
+  false` as documented "not-yet-parsed defaults" (`main.rs:390`).
+
+## Design
+
+### 1. `card-dsl` — extend `CardKind::Enemy`
+
+Three genuinely new fields (everything else already exists):
+
+- `hunter: bool`
+- `retaliate: bool`
+- `prey: Prey` (the enum already lives in `card-dsl`)
+
+And change `health: Option<u8>` → `health: Option<HealthValue>`, mirroring
+the location `ClueValue` pattern:
+
+```rust
+/// An enemy's printed health. Mirrors `ClueValue`: `PerInvestigator(n)`
+/// scales by the number of investigators in the game; `Fixed(n)` is a flat
+/// value. Distinguishes ArkhamDB's `health_per_investigator` (absent/false
+/// → fixed; `true` → per-investigator). Note the polarity is the opposite
+/// of `ClueValue` (clues default to per-investigator).
+pub enum HealthValue {
+    Fixed(u8),
+    PerInvestigator(u8),
+}
+```
+
+`health` stays `Option<_>` to preserve the existing "enemy may have no
+health" semantics (unlike location clues, which are always present).
+
+Update the hand-written construction sites: the `01112` literal at
+`card_data.rs:683`, synth fixtures, and mocks.
+
+### 2. `card-data-pipeline` — parse keywords + spawn + per-investigator health
+
+Parse from enemy `text`:
+
+- `Hunter.` → `hunter: true`; `Retaliate.` → `retaliate: true` (substring).
+- `Prey - Highest [combat].` → `Prey::Ranked { direction: Highest,
+  measure: Skill(Combat) }`; `Prey - Lowest remaining health.` →
+  `{ Lowest, RemainingHealth }`. (The four skill brackets map to
+  `SkillKind`; `remaining health` → `RemainingHealth`.)
+- `Spawn - <LocationName>.` → resolve name → code over the snapshot's
+  Location cards → `SpawnLocation::Specific(code)` (Attic→01113,
+  Cellar→01114).
+
+Read JSON `health_per_investigator: Option<bool>` (normalized to `bool`,
+default false), and emit health via a `health_value_lit(health,
+health_per_investigator)` helper mirroring the existing
+`clue_value_lit(clues, clues_fixed)`:
+`PerInvestigator(n)` when `health_per_investigator`, else `Fixed(n)`.
+
+Extend the Enemy arm of `render_kind` to emit the new fields, then
+regenerate the corpus (`cargo run -p card-data-pipeline`).
+
+**Totality over the whole pack.** The corpus ingests the *entire* core
+encounter set, which includes out-of-scope keyword forms the model can't
+yet represent — Masked Hunter's `Prey - Most clues` (no
+`PreyMeasure::Clues`) and `Spawn - Engaged with Prey` (no such
+`SpawnLocation`). Those fall back to the existing documented defaults
+(`Prey::Default`, `spawn: None`) **plus an `eprintln` warning** naming each
+enemy + unparsed line, so it's a loud stub rather than a silent
+approximation — matching how `surge`/`peril` already default. The six
+in-scope enemies use only modeled forms.
+
+### 3. `game-core` — `spawn_enemy` reads the corpus
+
+In `crates/game-core/src/engine/dispatch/encounter.rs`:
+
+- Read `fight`/`evade`/`damage`/`horror` from `CardKind::Enemy` (replace
+  the hardcoded `1`/`1`/`0`/`0`).
+- Resolve `max_health` from `HealthValue`: `Fixed(n) => n`,
+  `PerInvestigator(n) => n * count`, where `count =
+  state.investigators.len()` — the **same source** the per-investigator
+  clue path uses (`reveal.rs:20`), carrying the same future caveat about
+  switching to a stored started-count.
+- Set `hunter`/`retaliate`/`prey` from metadata.
+- Use the enemy's actual `prey` (not the hardcoded `Prey::Default`) for
+  the spawn-engagement narrowing (`resolve_prey` call).
+
+### 4. Tests (TDD)
+
+- **Pipeline unit tests** — each parse function on representative text,
+  including the unparsed-form fallback (assert default + warning path).
+  Mirror the existing `clue_value_lit` tests for `health_value_lit`.
+- **`game-core` unit tests** — extend `spawn_enemy_tests` with mock
+  metadata carrying keywords + `HealthValue::PerInvestigator` → assert the
+  minted `Enemy` fields (incl. health scaling by investigator count).
+- **Integration test** (`crates/cards/tests/enemies.rs`) — install
+  `cards::REGISTRY`, spawn each of the six real enemies through the engine,
+  and assert stats / keywords / spawn-location against the corpus. Under
+  this approach there is no per-enemy `impls/` module, so the issue's
+  "card test per enemy" acceptance is realized here.
+
+## Out of scope / noted
+
+- `surge`/`peril` stay unparsed (`false`) — tracked by #138; none of the
+  six in-scope enemies carry them.
+- Agenda-driven Ghoul movement and the Act-3 advance-on-Priest-defeat are
+  **C3c (#232)** / already-shipped **C1b (#259)**, not this PR.
+- Out-of-scope enemies' un-modeled Prey/Spawn forms (Masked Hunter, etc.)
+  default + warn; modeling them is future work as those cards land.
+
+## Success criteria
+
+- `RUSTFLAGS="-D warnings" cargo test --all --all-features` green, plus the
+  full CI gauntlet (fmt, clippy, doc, wasm-build, wasm-test, wasm-clippy).
+- Regenerated corpus carries the parsed keyword/health/spawn fields for the
+  six enemies (and sane defaults + warnings for un-modeled forms).
+- The integration test demonstrates each enemy spawning with its verified
+  stats, keywords, and (for Flesh-Eater/Icy Ghoul) spawn-location;
+  Ghoul Priest's health scales per investigator.


### PR DESCRIPTION
## Summary

Wire the six Gathering encounter enemies to spawn with their correct printed stats and keywords, by parsing keyword/spawn/per-investigator-health data into the corpus and having `spawn_enemy` read it (it previously hardcoded `fight: 1, evade: 1, attack: 0`).

## What changed

- **`card-dsl`** — `CardKind::Enemy` gains `hunter`/`retaliate`/`prey`; `health: Option<u8>` → `Option<HealthValue>`. New `HealthValue { Fixed, PerInvestigator }` enum mirrors `ClueValue`.
- **`card-data-pipeline`** — parses Hunter/Retaliate, Prey (Highest [skill] / Lowest remaining health), Spawn-location (name → location code), and per-investigator health from card text; regenerated corpus carries them. Out-of-scope keyword forms (e.g. Masked Hunter "Most clues", "Spawn - Engaged with Prey") fall back to defaults **with a loud `eprintln` warning** rather than failing or silently approximating.
- **`game-core`** — `spawn_enemy` reads fight/evade/attack-damage/attack-horror/keywords from the corpus and scales `PerInvestigator` health by the in-game investigator count (same source as the per-investigator clue path in `reveal.rs`); engages on spawn using the enemy's `prey`.

## Design decisions

- **Keywords/spawn/per-investigator-health are parsed in the pipeline into the corpus**, not hand-written per-enemy. The corpus is the single source of truth for printed enemy data; future enemies need no hand-written impl. `surge`/`peril` remain unparsed (`#138`).
- **`HealthValue` mirrors the location `ClueValue` pattern** (polarity flipped: ArkhamDB `health_per_investigator` defaults false → `Fixed`). Ghoul Priest now scales correctly (5 solo, 10 at two).
- The generated `use` import is emitted pre-wrapped so a fresh `cargo run -p card-data-pipeline` stays rustfmt-clean.

## Test notes

- Pipeline parser unit tests (`parse_prey`/`parse_spawn_name`/`health_value_opt_lit`/keyword detection, incl. unrecognized-form fallback).
- `spawn_enemy` unit tests: reads stats/keywords from metadata; scales per-investigator health by investigator count.
- `crates/cards/tests/enemies.rs`: corpus profile checks for all six enemies (stats/keywords/per-inv health/spawn-location), verified against `data/arkhamdb-snapshot`.
- Full local gauntlet green: test, clippy, fmt, doc, wasm-build, wasm-clippy.

## Linked issues

Closes #231