### PR TITLE
card: act 2 (01109) reverse — spawn set-aside Ghoul Priest + reveal Parlor

### DIFF
--- a/crates/cards/src/impls/act_01109.rs
+++ b/crates/cards/src/impls/act_01109.rs
@@ -1,0 +1,120 @@
+//! The Barrier (The Gathering Act 2, 01109).
+//!
+//! ```text
+//! Act 2 — The Barrier. Clues: 3.
+//! Objective - When the round ends, investigators in the hallway may, as
+//!   a group, spend the requisite number of clues to advance.
+//! (reverse) The barrier blocking passage into the parlor has vanished.
+//!   Reveal the Parlor.
+//!   Put the set-aside Lita Chantler into play in the Parlor.
+//!   Spawn the set-aside Ghoul Priest in the Hallway.
+//! ```
+//!
+//! The front objective (the round-end clue-spend window) is a kernel
+//! `Act.round_end_advance` field, set in `the_gathering::setup()` (C3d).
+//! This module implements the **reverse**: a Forced on-advance ability
+//! that fires via `ForcedTriggerPoint::ActAdvanced` when the act advances
+//! (Rules Reference p.3: flip the card, follow the reverse). It reveals
+//! the Parlor (01115) and spawns the set-aside Ghoul Priest (01116) in the
+//! Hallway (01112), making act 3's "If the Ghoul Priest is Defeated,
+//! advance" objective reachable in real play.
+//!
+//! "Put the set-aside Lita Chantler into play in the Parlor" is **out of
+//! scope** here — Lita / the Parlor barrier / Resign are tracked in #258.
+//!
+//! Like 01108's board build, the reverse is board-dependent, single-use
+//! scenario logic, so it lives card-locally as a [`card_dsl::dsl::Effect::Native`]
+//! handler (#276) rather than as shared `Effect` variants. The spawn reuses
+//! the engine's [`game_core::spawn_set_aside_enemy`], which mints the
+//! Priest's combat stats / keywords / per-investigator health from the
+//! corpus.
+//!
+//! Solo-scope note: with one investigator in the Hallway the Priest's
+//! `Prey - Highest [combat]` resolves to that lone investigator and the
+//! spawn engages inline (`Done`). A 2+-investigator Hallway with tied
+//! combat would suspend (`AwaitingInput`) — unreachable through the
+//! single-trigger forced-advance path until #213/#212; consistent with
+//! the rest of Slice 1's solo-first scope.
+
+use card_dsl::dsl::{native, on_event, Ability, EventPattern, EventTiming};
+use game_core::card_registry::NativeEffectFn;
+use game_core::{
+    location_id_by_code, reveal_location, spawn_set_aside_enemy, Cx, EngineOutcome, EvalContext,
+};
+
+/// `ArkhamDB` code for Act 2, "The Barrier".
+pub const CODE: &str = "01109";
+
+/// Native-effect tag for this act's reverse.
+const REVERSE: &str = "01109:reverse";
+
+/// Printed codes the reverse touches.
+const GHOUL_PRIEST: &str = "01116";
+const HALLWAY: &str = "01112";
+const PARLOR: &str = "01115";
+
+/// 01109's Forced on-advance reverse: reveal the Parlor + spawn the Priest.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![on_event(
+        EventPattern::ActAdvanced,
+        EventTiming::After,
+        native(REVERSE),
+    )]
+}
+
+/// Resolve [`REVERSE`] if `tag` matches. Wired into the crate registry's
+/// `native_effect_for`.
+pub(crate) fn native_effect_for(tag: &str) -> Option<NativeEffectFn> {
+    (tag == REVERSE).then_some(reverse as NativeEffectFn)
+}
+
+/// Reveal the Parlor (01115) and spawn the set-aside Ghoul Priest (01116)
+/// in the Hallway (01112). Validate-first: the Parlor must be in play
+/// before any mutation; the spawn ([`spawn_set_aside_enemy`]) validates
+/// the set-aside zone + Hallway internally and rejects without mutating.
+/// The Parlor is revealed only after a successful spawn, so a reject
+/// leaves the board untouched. (Reveal vs. spawn order is functionally
+/// independent — they touch disjoint state.)
+fn reverse(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
+    let Some(parlor) = location_id_by_code(cx.state, PARLOR) else {
+        return EngineOutcome::Rejected {
+            reason: "01109 reverse: Parlor (01115) not in play".into(),
+        };
+    };
+    let spawned = spawn_set_aside_enemy(cx, ctx.controller, GHOUL_PRIEST, HALLWAY);
+    if !matches!(spawned, EngineOutcome::Done) {
+        return spawned;
+    }
+    reveal_location(cx, parlor);
+    EngineOutcome::Done
+}
+
+#[cfg(test)]
+mod tests {
+    use card_dsl::dsl::{Effect, EventPattern, EventTiming, Trigger};
+
+    #[test]
+    fn abilities_are_one_forced_on_advance_native_reverse() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(
+            abilities[0].trigger,
+            Trigger::OnEvent {
+                pattern: EventPattern::ActAdvanced,
+                timing: EventTiming::After
+            }
+        );
+        assert!(
+            matches!(&abilities[0].effect, Effect::Native { tag } if tag == "01109:reverse"),
+            "the reverse is a card-local native effect, got {:?}",
+            abilities[0].effect
+        );
+    }
+
+    #[test]
+    fn native_effect_for_resolves_only_the_reverse_tag() {
+        assert!(super::native_effect_for("01109:reverse").is_some());
+        assert!(super::native_effect_for("01109:other").is_none());
+    }
+}

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -41,6 +41,7 @@
 //!   `UsageLimit { count: 1, period: Round }` for "Limit once per
 //!   round." Elder-sign half stubbed pending #118.
 //! - Trapped (01108) — Act 1; `Trigger::OnEvent` (`ActAdvanced`, `After`) on-advance board build.
+//! - The Barrier (01109) — Act 2; `Trigger::OnEvent` (`ActAdvanced`, `After`) on-advance reverse: reveal the Parlor + spawn the set-aside Ghoul Priest.
 //! - What Have You Done? (01110) — Act 3; `Trigger::OnEvent` (`EnemyDefeated` 01116, `After`) -> `AdvanceCurrentAct`.
 //!
 //! The remaining Phase-3 card (Study #56) blocks on the
@@ -49,6 +50,7 @@
 use card_dsl::dsl::Ability;
 
 pub mod act_01108;
+pub mod act_01109;
 pub mod act_01110;
 pub mod agenda_01107;
 pub mod attic;
@@ -66,6 +68,7 @@ pub mod working_a_hunch;
 pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
     match code {
         act_01108::CODE => Some(act_01108::abilities()),
+        act_01109::CODE => Some(act_01109::abilities()),
         act_01110::CODE => Some(act_01110::abilities()),
         agenda_01107::CODE => Some(agenda_01107::abilities()),
         attic::CODE => Some(attic::abilities()),
@@ -85,5 +88,7 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
 /// per-card delegation; returns `None` for unregistered tags.
 #[must_use]
 pub fn native_effect_for(tag: &str) -> Option<game_core::card_registry::NativeEffectFn> {
-    act_01108::native_effect_for(tag).or_else(|| agenda_01107::native_effect_for(tag))
+    act_01108::native_effect_for(tag)
+        .or_else(|| act_01109::native_effect_for(tag))
+        .or_else(|| agenda_01107::native_effect_for(tag))
 }

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -5,7 +5,8 @@ use crate::card_registry;
 use crate::dsl::Trigger;
 use crate::event::Event;
 use crate::state::{
-    CardCode, Enemy, EnemyId, InvestigatorId, Phase, PhaseStep, SpawnEngagePending, WindowKind,
+    CardCode, Enemy, EnemyId, InvestigatorId, LocationId, Phase, PhaseStep, SpawnEngagePending,
+    WindowKind,
 };
 
 use super::super::evaluator::{apply_effect, EvalContext};
@@ -241,48 +242,21 @@ fn resolve_encounter_card(
 /// resolves inline or suspends (`AwaitingInput`) with the enemy already
 /// minted into `state.enemies` and `Event::EnemySpawned` pushed (the
 /// pending choice carries the rest of the work to [`resume_spawn_engage`]).
-#[allow(clippy::too_many_lines)]
 fn spawn_enemy(
     cx: &mut Cx,
     investigator: InvestigatorId,
     code: CardCode,
     metadata: &CardMetadata,
 ) -> EngineOutcome {
-    // spawn_enemy is only reached for Enemy cards; pull the enemy-specific
-    // stats out of the kind.
-    let CardKind::Enemy {
-        spawn,
-        health,
-        fight,
-        evade,
-        damage,
-        horror,
-        hunter,
-        retaliate,
-        prey,
-        victory,
-        ..
-    } = &metadata.kind
-    else {
+    // Resolve the spawn location (validate-first). Only the card's `spawn`
+    // rule is read here; the full stat read + mint happens in
+    // [`spawn_enemy_at`]. A `Specific` spawn names an in-play location; the
+    // default rule (`None`) spawns at the drawing investigator's location.
+    let CardKind::Enemy { spawn, .. } = &metadata.kind else {
         return EngineOutcome::Rejected {
             reason: format!("spawn_enemy: card {code} is not an enemy").into(),
         };
     };
-    let prey = *prey;
-
-    // Resolve health. PerInvestigator scales by the number of investigators
-    // in the game (Rules Reference p.12); matches the per-investigator clue
-    // path in reveal.rs (its future started-count caveat applies here too).
-    let max_health = match health {
-        Some(HealthValue::Fixed(n)) => *n,
-        Some(HealthValue::PerInvestigator(n)) => {
-            let count = u8::try_from(cx.state.investigators.len()).unwrap_or(u8::MAX);
-            n.saturating_mul(count)
-        }
-        None => 1,
-    };
-
-    // 1. Resolve spawn location (validate-first).
     let location_id = match spawn {
         Some(Spawn {
             location: SpawnLocation::Specific(loc_code),
@@ -317,6 +291,57 @@ fn spawn_enemy(
                 };
             }
         },
+    };
+    spawn_enemy_at(cx, investigator, code, metadata, location_id)
+}
+
+/// Mint an enemy from `metadata` at an explicit `location_id`, resolving
+/// engagement-on-spawn (prey). The reusable spawn core: [`spawn_enemy`]
+/// supplies a location from the card's own spawn rule;
+/// [`spawn_set_aside_enemy`] supplies a location named by the bringing
+/// effect (The Gathering's Act-2 reverse spawns the Ghoul Priest in the
+/// Hallway). `investigator` is the drawing/controlling investigator —
+/// used only to carry the engagement-tie resume (`investigator_to_draw`);
+/// the engagement candidates come from `location_id` itself.
+#[allow(clippy::too_many_lines)]
+pub(super) fn spawn_enemy_at(
+    cx: &mut Cx,
+    investigator: InvestigatorId,
+    code: CardCode,
+    metadata: &CardMetadata,
+    location_id: LocationId,
+) -> EngineOutcome {
+    // spawn_enemy_at is only reached for Enemy cards; pull the
+    // enemy-specific stats out of the kind.
+    let CardKind::Enemy {
+        health,
+        fight,
+        evade,
+        damage,
+        horror,
+        hunter,
+        retaliate,
+        prey,
+        victory,
+        ..
+    } = &metadata.kind
+    else {
+        return EngineOutcome::Rejected {
+            reason: format!("spawn_enemy_at: card {code} is not an enemy").into(),
+        };
+    };
+    let prey = *prey;
+
+    // Resolve health. PerInvestigator scales by the number of investigators
+    // in the game (Rules Reference p.12); matches the per-investigator clue
+    // path in reveal.rs (its future started-count caveat applies here too).
+    let max_health = match health {
+        Some(HealthValue::Fixed(n)) => *n,
+        Some(HealthValue::PerInvestigator(n)) => {
+            let count = u8::try_from(cx.state.investigators.len()).unwrap_or(u8::MAX);
+            n.saturating_mul(count)
+        }
+        None => 1,
     };
 
     // 2. Resolve engagement-on-spawn (validate-first). The co-located
@@ -403,6 +428,61 @@ fn spawn_enemy(
             }
         }
     }
+}
+
+/// Bring a **set-aside enemy** into play at the location named by
+/// `location_code`, minting its stats from the corpus (so per-investigator
+/// health scales by the live investigator count). The set-aside-enemy
+/// path: [`GameState::add_set_aside_enemy`](crate::state::GameState::add_set_aside_enemy)
+/// records the code at `setup()`; a card effect calls this to spawn it
+/// (The Gathering's Act-2 reverse, `01109:reverse`).
+///
+/// Validate-first: rejects (mutating nothing) if `enemy_code` isn't in the
+/// set-aside zone, no card registry is installed, the code has no metadata,
+/// or `location_code` isn't in play. Only after every check passes does it
+/// remove the code from the zone and mint the enemy via `spawn_enemy_at`.
+/// `controller` is the lead investigator (carried into engagement-tie
+/// resume; the engagement candidates come from the spawn location).
+pub fn spawn_set_aside_enemy(
+    cx: &mut Cx,
+    controller: InvestigatorId,
+    enemy_code: &str,
+    location_code: &str,
+) -> EngineOutcome {
+    let Some(pos) = cx
+        .state
+        .set_aside_enemies
+        .iter()
+        .position(|c| c.as_str() == enemy_code)
+    else {
+        return EngineOutcome::Rejected {
+            reason: format!("spawn_set_aside_enemy: {enemy_code} is not set aside").into(),
+        };
+    };
+    let Some(registry) = card_registry::current() else {
+        return EngineOutcome::Rejected {
+            reason: "spawn_set_aside_enemy: no card registry installed".into(),
+        };
+    };
+    let Some(metadata) = (registry.metadata_for)(&CardCode::new(enemy_code)) else {
+        return EngineOutcome::Rejected {
+            reason: format!("spawn_set_aside_enemy: no metadata for {enemy_code}").into(),
+        };
+    };
+    let Some(location_id) = crate::engine::location_id_by_code(cx.state, location_code) else {
+        return EngineOutcome::Rejected {
+            reason: format!("spawn_set_aside_enemy: location {location_code} not in play").into(),
+        };
+    };
+    // All checks passed — mutate.
+    cx.state.set_aside_enemies.remove(pos);
+    spawn_enemy_at(
+        cx,
+        controller,
+        CardCode::new(enemy_code),
+        metadata,
+        location_id,
+    )
 }
 
 /// Fisher-Yates shuffle of the shared encounter deck using the
@@ -1035,6 +1115,110 @@ mod spawn_enemy_tests {
                 quantity: 1,
             },
         }
+    }
+
+    #[test]
+    fn spawn_enemy_at_places_enemy_at_the_given_location_not_the_drawers() {
+        // The investigator is at loc 10; spawn_enemy_at is told loc 11. The
+        // enemy must land at 11 (the explicit location wins), unlike
+        // spawn_enemy's investigator-location fallback.
+        let mut here = test_location(10, "Here");
+        here.code = CardCode("_here".into());
+        let mut there = test_location(11, "There");
+        there.code = CardCode("_there".into());
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_location(here)
+            .with_location(there)
+            .with_turn_order([InvestigatorId(1)])
+            .build();
+        state
+            .investigators
+            .get_mut(&InvestigatorId(1))
+            .unwrap()
+            .current_location = Some(LocationId(10));
+
+        let metadata = synth_enemy_metadata(None);
+        let mut events = Vec::new();
+        let outcome = spawn_enemy_at(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            InvestigatorId(1),
+            CardCode("_synth_enemy".into()),
+            &metadata,
+            LocationId(11),
+        );
+        assert_eq!(outcome, EngineOutcome::Done);
+        let enemy = state.enemies.values().next().expect("enemy spawned");
+        assert_eq!(
+            enemy.current_location,
+            Some(LocationId(11)),
+            "the explicit location wins over the drawer's location",
+        );
+        assert_event!(
+            events,
+            Event::EnemySpawned { location, .. } if *location == LocationId(11)
+        );
+    }
+
+    #[test]
+    fn spawn_set_aside_enemy_rejects_when_not_set_aside() {
+        // Empty set-aside zone — the spawn must reject before touching the
+        // registry or location, and mint nothing.
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_turn_order([InvestigatorId(1)])
+            .build();
+        let mut events = Vec::new();
+        let outcome = spawn_set_aside_enemy(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            InvestigatorId(1),
+            "01116",
+            "01112",
+        );
+        assert!(
+            matches!(outcome, EngineOutcome::Rejected { .. }),
+            "spawning an enemy that isn't set aside must reject, got {outcome:?}",
+        );
+        assert!(state.enemies.is_empty(), "no enemy minted on reject");
+    }
+
+    #[test]
+    fn spawn_set_aside_enemy_keeps_the_code_aside_on_a_failed_spawn() {
+        // The enemy is set aside, but the target location isn't in play (and
+        // no usable metadata is guaranteed in a bare unit test) — the spawn
+        // must reject without removing the code from the set-aside zone
+        // (validate-first: no mutation on reject).
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_turn_order([InvestigatorId(1)])
+            .build();
+        state.set_aside_enemies.push(CardCode::new("01116"));
+        let mut events = Vec::new();
+        let outcome = spawn_set_aside_enemy(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            InvestigatorId(1),
+            "01116",
+            "01112", // not in play
+        );
+        assert!(
+            matches!(outcome, EngineOutcome::Rejected { .. }),
+            "missing target location must reject, got {outcome:?}",
+        );
+        assert_eq!(
+            state.set_aside_enemies,
+            vec![CardCode::new("01116")],
+            "the code stays set aside when the spawn rejects",
+        );
+        assert!(state.enemies.is_empty(), "no enemy minted on reject");
     }
 
     #[test]

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -26,7 +26,9 @@ mod cursor;
 // pub(super): evaluator reaches take_damage/take_horror via the full path
 // crate::engine::dispatch::elimination (a sibling of dispatch).
 pub(super) mod elimination;
-mod encounter;
+// pub(crate): engine/mod.rs re-exports `spawn_set_aside_enemy` for the
+// `cards` crate (The Gathering's Act-2 reverse).
+pub(crate) mod encounter;
 // pub(super): engine/mod.rs re-exports ForcedTriggerPoint + fire_forced_triggers
 // via pub(crate) for test_support::fire_forced_at (Task 2 of #215).
 pub(super) mod forced_triggers;

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -17,6 +17,7 @@ pub mod evaluator;
 mod outcome;
 pub(crate) mod pathfinding;
 
+pub use dispatch::encounter::spawn_set_aside_enemy;
 pub use dispatch::reveal::reveal_location;
 pub use evaluator::{location_id_by_code, EvalContext};
 pub use outcome::{EngineOutcome, InputRequest, ResumeToken};

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -43,8 +43,8 @@ pub use action::{Action, EngineRecord, InputResponse, PlayerAction};
 pub use card_data::{CardMetadata, CardType, Class, SkillIcons, Slot};
 pub use card_registry::CardRegistry;
 pub use engine::{
-    apply, location_id_by_code, reveal_location, shortest_first_steps, ApplyResult, Cx,
-    EngineOutcome, EvalContext, InputRequest, ResumeToken,
+    apply, location_id_by_code, reveal_location, shortest_first_steps, spawn_set_aside_enemy,
+    ApplyResult, Cx, EngineOutcome, EvalContext, InputRequest, ResumeToken,
 };
 pub use event::{Event, FailureReason};
 pub use rng::RngState;

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -257,6 +257,7 @@ impl GameStateBuilder {
             investigators: self.investigators,
             locations: self.locations,
             set_aside_locations: Vec::new(),
+            set_aside_enemies: Vec::new(),
             starting_location: None,
             enemies: self.enemies,
             chaos_bag: self.chaos_bag,

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -44,6 +44,15 @@ pub struct GameState {
     /// Act-1 reverse drains these into play (the `01108:board-build`
     /// native effect).
     pub set_aside_locations: Vec<Location>,
+    /// Enemies set aside, out of play (Rules Reference p.3, "set aside"),
+    /// recorded by printed code only — their stats (per-investigator
+    /// health, combat) are minted from the corpus at spawn time, when the
+    /// investigator count is known. Brought into play by card effects —
+    /// The Gathering's Act-2 reverse spawns the Ghoul Priest (01116) from
+    /// here (the `01109:reverse` native effect, via [`spawn_set_aside_enemy`]).
+    ///
+    /// [`spawn_set_aside_enemy`]: crate::engine::spawn_set_aside_enemy
+    pub set_aside_enemies: Vec<CardCode>,
     /// Where roster-seated investigators are placed at scenario start.
     /// `setup()` sets it (e.g. The Gathering -> the Study); the
     /// `StartScenario` seating step reads it. `None` leaves seated
@@ -956,6 +965,24 @@ impl GameState {
         id
     }
 
+    /// Add an enemy to the **set-aside** (out-of-play) zone, recording its
+    /// printed code only. Unlike set-aside locations (fully built here),
+    /// an enemy's stats — notably per-investigator health — depend on the
+    /// in-game investigator count, which isn't known at `setup()`; so the
+    /// `Enemy` is minted from the corpus when a card effect brings it into
+    /// play (see [`spawn_set_aside_enemy`](crate::engine::spawn_set_aside_enemy)).
+    /// Panics on non-Enemy metadata — a setup-time invariant.
+    pub fn add_set_aside_enemy(&mut self, metadata: &CardMetadata) {
+        assert!(
+            matches!(metadata.kind, CardKind::Enemy { .. }),
+            "add_set_aside_enemy: card {} is not an Enemy ({:?})",
+            metadata.code,
+            metadata.kind,
+        );
+        self.set_aside_enemies
+            .push(CardCode::new(metadata.code.clone()));
+    }
+
     /// Find a location by id across both the in-play and set-aside zones.
     fn location_mut(&mut self, id: LocationId) -> Option<&mut Location> {
         if let Some(loc) = self.locations.get_mut(&id) {
@@ -1296,6 +1323,50 @@ mod add_location_tests {
         assert_eq!(state.set_aside_locations.len(), 1);
         assert_eq!(state.set_aside_locations[0].id, id);
         assert_eq!(state.set_aside_locations[0].code.as_str(), "01113");
+    }
+
+    fn enemy_meta(code: &str, name: &str) -> CardMetadata {
+        use crate::card_data::Prey;
+        CardMetadata {
+            code: code.to_string(),
+            name: name.to_string(),
+            traits: vec![],
+            text: None,
+            pack_code: "core".to_string(),
+            kind: CardKind::Enemy {
+                fight: 1,
+                evade: 1,
+                damage: 0,
+                horror: 0,
+                health: None,
+                victory: None,
+                spawn: None,
+                surge: false,
+                peril: false,
+                hunter: false,
+                retaliate: false,
+                prey: Prey::Default,
+                quantity: 1,
+            },
+        }
+    }
+
+    #[test]
+    fn add_set_aside_enemy_records_the_code() {
+        let mut state = GameStateBuilder::new().build();
+        state.add_set_aside_enemy(&enemy_meta("01116", "Ghoul Priest"));
+        assert_eq!(
+            state.set_aside_enemies,
+            vec![crate::state::CardCode::new("01116")],
+            "set-aside enemies record only the code (stats minted at spawn)",
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "not an Enemy")]
+    fn add_set_aside_enemy_panics_on_non_enemy_metadata() {
+        let mut state = GameStateBuilder::new().build();
+        state.add_set_aside_enemy(&location_meta("01113", "Attic", 1, 2));
     }
 
     #[test]

--- a/crates/scenarios/src/the_gathering.rs
+++ b/crates/scenarios/src/the_gathering.rs
@@ -142,13 +142,19 @@ pub fn setup() -> GameState {
     state.connect(hallway, parlor);
     state.starting_location = Some(study);
 
+    // The Ghoul Priest (01116) starts set aside; Act 2's (01109) reverse
+    // spawns it in the Hallway when the act advances (cards::act_01109).
+    // Recorded by code only — its per-investigator health is minted from
+    // the corpus at spawn, when the investigator count is known.
+    state.add_set_aside_enemy(meta("01116"));
+
     // Act deck 01108 -> 01109 -> 01110. Clue thresholds read from the
     // corpus. 01110 advances via its Forced EnemyDefeated objective
     // (01116; in cards::act_01110), not a clue spend — its printed clue
     // threshold is null, which the reader maps to 0.
-    // TODO(#280): Act-2 (01109) reverse — reveal the Parlor and spawn the
-    // set-aside Ghoul Priest (01116) in the Hallway (needs set-aside-enemy
-    // support). Lita Chantler -> #258. (Not C3b/#231, which was enemy stats.)
+    // Act-2 (01109) reverse — reveals the Parlor and spawns the set-aside
+    // Ghoul Priest (01116) in the Hallway — ships in cards::act_01109 (#280).
+    // Lita Chantler / the Parlor barrier -> #258.
     // TODO(#281): agenda reverses (01105 discard/horror, 01106 dig-until-Ghoul)
     // + an `AgendaAdvanced` forced point — `advance_agenda` fires no reverse today.
     // TODO(#phase-9): act-3 (01110) reverse is the lead's R1/R2 resolution choice.

--- a/crates/scenarios/tests/the_gathering.rs
+++ b/crates/scenarios/tests/the_gathering.rs
@@ -130,6 +130,40 @@ fn drives_act_1_then_act_2_via_round_end_window() {
         Some(Resolution::Won { id: "R1".into() }),
         "the terminal act carries the Won resolution (latched on Ghoul-Priest defeat)",
     );
+
+    // Act 2's reverse (#280) fired on advance: the set-aside Ghoul Priest
+    // (01116) is now in play in the Hallway (01112), and the Parlor (01115)
+    // is revealed. This makes act 3's "Ghoul Priest defeated" objective
+    // reachable in real play.
+    assert!(
+        r.state.set_aside_enemies.is_empty(),
+        "the Ghoul Priest left the set-aside zone",
+    );
+    let priest = r
+        .state
+        .enemies
+        .values()
+        .find(|e| e.code.as_str() == "01116")
+        .expect("Ghoul Priest (01116) spawned");
+    let hallway_id = r
+        .state
+        .locations
+        .values()
+        .find(|l| l.code.as_str() == "01112")
+        .unwrap()
+        .id;
+    assert_eq!(
+        priest.current_location,
+        Some(hallway_id),
+        "the Ghoul Priest spawns in the Hallway",
+    );
+    let parlor = r
+        .state
+        .locations
+        .values()
+        .find(|l| l.code.as_str() == "01115")
+        .expect("Parlor (01115) in play");
+    assert!(parlor.revealed, "act 2's reverse reveals the Parlor");
 }
 
 #[test]

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -14,8 +14,8 @@ C3b (the six encounter enemies + pipeline keyword/spawn/health parsing),
 C3c (agenda 01107 forced abilities), C3d (act-2 round-end window).
 
 > **Next (directive — do before C4):** [#280](https://github.com/talelburg/eldritch/issues/280)
-> (act-2 reverse: spawn the set-aside Ghoul Priest + reveal the Parlor) then
-> [#281](https://github.com/talelburg/eldritch/issues/281) (agenda reverses 01105/01106 +
+> (act-2 reverse: spawn the set-aside Ghoul Priest + reveal the Parlor) ✅ PR #282;
+> then [#281](https://github.com/talelburg/eldritch/issues/281) (agenda reverses 01105/01106 +
 > `AgendaAdvanced` forced point). These close the act/agenda **reverse-coverage**
 > gap (see the table below) that blocks the real win/lose path, so they take
 > priority over C4. Then resume C4 → C7.
@@ -93,7 +93,7 @@ breakdown rows; this is reverses only.
 | Card | Reverse | Status |
 |---|---|---|
 | Act 1 (01108) | board build | ✅ `act_01108.rs` (C1b) |
-| Act 2 (01109) | reveal Parlor, put Lita, spawn Ghoul Priest | ⛔ [#280](https://github.com/talelburg/eldritch/issues/280) (Lita → [#258](https://github.com/talelburg/eldritch/issues/258)) |
+| Act 2 (01109) | reveal Parlor, put Lita, spawn Ghoul Priest | ✅ `act_01109.rs` (PR #282); Lita → [#258](https://github.com/talelburg/eldritch/issues/258) |
 | Act 3 (01110) | R1/R2 resolution choice | ⚠️ R1 Won latch (C1b); R2 + choice → Phase 9 |
 | Agenda 1 (01105) | lead: each discards 1 random, or lead takes 2 horror | ⛔ [#281](https://github.com/talelburg/eldritch/issues/281) |
 | Agenda 2 (01106) | dig encounter deck until a [[Ghoul]], lead draws it | ⛔ [#281](https://github.com/talelburg/eldritch/issues/281) |
@@ -165,6 +165,8 @@ Devourer Below, campaign log + `Fact` enum) is **Phase 9**, not Phase 7.
 - **`upkeep_phase_end` is now suspendable; act round-end objectives are a kernel `Act.round_end_advance` field (C3d, [#275](https://github.com/talelburg/eldritch/issues/275), PR #279).** `upkeep_phase_end` returns `EngineOutcome` (both callers propagate) and, after the round-end forced dispatch, opens a Confirm/Skip window when the current act carries `round_end_advance: Some(RoundEndAdvance { contributor_location })` **and** the investigators at that location can afford the act's `clue_threshold`. Suspension uses `act_round_end_pending` + an action-gate guard + `resolve_input` routing + `resume_act_round_end_advance`, mirroring hand-size discard; Confirm spends from the contributor-location investigators and `advance_act`s, Skip continues, either way Upkeep→Mythos. `AdvanceAct` is re-gated to reject for round-end-advance acts (act-1 still uses it; act-3 uses its forced `EnemyDefeated`). **Modeling:** the threshold stays corpus-sourced (`CardKind::Act`), but the objective shape is **content-set** in `the_gathering.rs` — ArkhamDB has no structured field for it, it's a single consumer, and sibling act objectives (01108/01110) are likewise hand-authored. A card-local native effect was rejected: the window lifecycle + Upkeep→Mythos continuation are inherently kernel, and suspendable forced/native dispatch is the #212/#213 north-star. **Future round-end act objectives reuse this field + window**; multi-investigator clue *allocation* stays the deterministic spend (#153).
 
 - **`RoundEnded` is a distinct framework timing point, separate from `PhaseEnded { Upkeep }` (C3c, [#232](https://github.com/talelburg/eldritch/issues/232), PR #278).** `EventPattern::RoundEnded` + `ForcedTriggerPoint::RoundEnded` fire in `upkeep_phase_end` *after* the upkeep-phase-end forced dispatch ("Upkeep phase ends. Round ends.", RR p.24). Kept separate so an end-of-upkeep-phase and an end-of-round card can coexist without conflation. Agenda 01107's two abilities are card-local native fns (per the #276 decision): `01107:move-ghouls` (enemy-phase-end, unengaged Ghouls step toward the Parlor — deterministic lowest-`LocationId` tie-break, unreachable on this star map; engagement-on-arrival unmodeled) and `01107:round-end-doom` (1 doom per Ghoul in Hallway/Parlor, no threshold check — RR checks doom at Mythos 1.3). **C3d ([#275](https://github.com/talelburg/eldritch/issues/275)) reuses this `RoundEnded` point** for act-2's round-end window. `shortest_first_steps` is now `pub`.
+
+- **Set-aside *enemies* record a code only; the `Enemy` is minted at spawn (#280, PR #282).** Set-aside *locations* are fully built in `setup()` (`set_aside_locations: Vec<Location>`), but an enemy's per-investigator health (Ghoul Priest 01116 = 5×N) depends on the investigator count, unknown at `setup()` — so `set_aside_enemies: Vec<CardCode>` stores codes and `spawn_set_aside_enemy` mints stats from the corpus when a card effect brings the enemy into play. The shared spawn core is `spawn_enemy_at(cx, controller, code, metadata, location)`, factored out of `spawn_enemy` and reused by both the encounter-draw path (location from the card's spawn rule) and the set-aside path (location named by the bringing effect). **Future set-aside enemies reuse this field + helper, not a new mechanism.** Act-2's reverse (`act_01109`) is the first consumer; "put Lita into play" stays deferred to #258.
 
 ## Open questions
 


### PR DESCRIPTION
## Summary

Closes #280. Implements The Gathering Act 2's (**01109**) reverse, closing the win-path gap from C3d (#275, PR #279): act 2 advanced via its round-end window, but its reverse was unimplemented, so the Ghoul Priest never spawned and act 3 ("If the Ghoul Priest is Defeated, advance → Won") was unreachable in real play.

**Verified reverse (`back_text`, snapshot):**
> The barrier blocking passage into the parlor has vanished. Reveal the Parlor. Put the set-aside Lita Chantler into play in the Parlor. **Spawn the set-aside Ghoul Priest in the Hallway.**

## What's here

- **Set-aside-*enemy* path** — `GameState.set_aside_enemies: Vec<CardCode>` + `add_set_aside_enemy`. Records the code only (unlike fully-built set-aside *locations*): the Ghoul Priest's health is per-investigator, so the count-dependent `Enemy` is minted from the corpus **at spawn**, not at `setup()`. `the_gathering::setup()` sets 01116 aside.
- **Reusable spawn core** — factored `spawn_enemy_at(cx, controller, code, metadata, location)` out of `spawn_enemy` (its location-resolution wrapper is unchanged), plus a public `spawn_set_aside_enemy(cx, controller, enemy_code, location_code)` that **validates first** (set-aside zone, registry, metadata, target location) and only then removes the code and mints — state untouched on reject.
- **`cards::act_01109`** — the act's Forced on-advance reverse (`OnEvent(ActAdvanced, After)` → `Effect::Native "01109:reverse"`, per #276): reveal the Parlor (01115) + spawn the Priest in the Hallway (01112) via the engine helper (combat stats / keywords / per-investigator health from the corpus).

## Out of scope
"Put the set-aside Lita Chantler into play" → **#258** (Lita / Parlor barrier / Resign), as the issue specifies.

## Design notes
- **Why code-only set-aside enemies:** per-investigator health (5×N for the Priest) can't be minted before investigators exist; locations carry no count-dependent stat, so they stay fully-built.
- **Reveal-after-spawn ordering:** the native reveals the Parlor only after a successful spawn so a reject leaves the board untouched (the two touch disjoint state, so order is functionally irrelevant).
- **Solo scope:** with one Hallway investigator the Priest's `Prey - Highest [combat]` resolves inline (`Done`); a 2+ tied-combat Hallway would suspend — unreachable through the single-trigger forced-advance path until #212/#213, consistent with the rest of Slice 1.

## Testing
- Unit: `add_set_aside_enemy` (records code / panics on non-enemy); `spawn_enemy_at` (explicit location wins); `spawn_set_aside_enemy` reject paths (not set aside / missing location keeps the code aside, no mint).
- Card: `act_01109` ability shape + native-tag resolution.
- End-to-end (`tests/the_gathering.rs`): act 1 → act 2 round-end window → Confirm leaves the Ghoul Priest in play in the Hallway with the Parlor revealed.
- Full strict gauntlet green locally (all 7 CI jobs incl. headless wasm-test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)