### PR TITLE
engine: agenda reverses (01105, 01106) + AgendaAdvanced forced point

### DIFF
--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -261,6 +261,14 @@ pub enum EventPattern {
     /// binds controller = the lead investigator (board-wide reverse
     /// effects ignore it).
     ActAdvanced,
+    /// The agenda this ability is printed on advanced (its reverse side
+    /// resolves on doom). Fired forced via
+    /// `ForcedTriggerPoint::AgendaAdvanced` from `advance_agenda` (the
+    /// mirror of the act path — `advance_act` fires `ActAdvanced`); binds
+    /// controller = the lead investigator. The Gathering's agenda reverses
+    /// listen here: 01105 (lead's discard/horror choice) and 01106
+    /// (dig the encounter deck until a `Ghoul` enemy, lead draws it).
+    AgendaAdvanced,
     /// The round ended (Rules Reference p.24: the round ends at the close
     /// of the upkeep phase). Forced agenda/act effects keyed to "at the
     /// end of the round" listen here — agenda `01107` places doom. Fired

--- a/crates/cards/src/impls/agenda_01105.rs
+++ b/crates/cards/src/impls/agenda_01105.rs
@@ -1,0 +1,80 @@
+//! What's Going On?! (The Gathering Agenda 1, 01105).
+//!
+//! ```text
+//! Agenda 1 — What's Going On?! Doom: 3.
+//! (reverse) The lead investigator must decide (choose one): Either each
+//!   investigator discards 1 card at random from his or her hand, or the
+//!   lead investigator takes 2 horror.
+//! ```
+//!
+//! Forced on-advance reverse, fired via `ForcedTriggerPoint::AgendaAdvanced`
+//! from `advance_agenda` (the mirror of the act path).
+//!
+//! **Deferred-choice scope (TODO #212).** The card is a *lead-investigator
+//! choice* between two legal outcomes. Presenting that choice needs a
+//! suspendable `AwaitingInput` mid-forced-dispatch, which the engine does
+//! not have yet: `Effect::ChooseOne` is a stub (#19 shipped only the
+//! test-side resolver), and the Mythos step-1.3 doom-check path
+//! (`mythos_phase → check_doom_threshold → advance_agenda`) resolves
+//! inline and cannot suspend. That suspendable-dispatch machinery is the
+//! `emit_event` unification ([#212]) — which explicitly owns "mid-emit
+//! `AwaitingInput` suspension" and will absorb `fire_forced_triggers`. A
+//! bespoke suspension threaded through Mythos now would be throwaway work
+//! #212 removes.
+//!
+//! So this ships **one of the two legal branches deterministically — the
+//! lead takes 2 horror** — as a plain DSL [`deal_horror`] effect, not a
+//! silent approximation: it applies an outcome the card actually offers
+//! (mirroring act-3's R1/R2 choice deferred to a single latch). The horror
+//! branch is chosen over the random-discard branch deliberately: "discards
+//! 1 card **at random**" needs *recorded* randomness (an `EngineRecord`)
+//! for replay determinism — more throwaway infra for a branch becoming
+//! interactive under #212 anyway. Revisit when #212 lands.
+//!
+//! [#212]: https://github.com/talelburg/eldritch/issues/212
+
+use card_dsl::dsl::{
+    deal_horror, on_event, Ability, EventPattern, EventTiming, InvestigatorTarget,
+};
+
+/// `ArkhamDB` code for Agenda 1, "What's Going On?!".
+pub const CODE: &str = "01105";
+
+/// 01105's Forced on-advance reverse (deferred to the deterministic
+/// 2-horror-to-the-lead branch; see the module docs / TODO #212).
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![on_event(
+        EventPattern::AgendaAdvanced,
+        EventTiming::After,
+        // `You` binds to the controller, which `AgendaAdvanced` sets to the
+        // lead investigator.
+        deal_horror(InvestigatorTarget::You, 2),
+    )]
+}
+
+#[cfg(test)]
+mod tests {
+    use card_dsl::dsl::{Effect, EventPattern, EventTiming, InvestigatorTarget, Trigger};
+
+    #[test]
+    fn abilities_are_one_forced_on_advance_lead_two_horror() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(
+            abilities[0].trigger,
+            Trigger::OnEvent {
+                pattern: EventPattern::AgendaAdvanced,
+                timing: EventTiming::After,
+            }
+        );
+        assert_eq!(
+            abilities[0].effect,
+            Effect::DealHorror {
+                target: InvestigatorTarget::You,
+                amount: 2,
+            },
+            "deferred branch: the lead takes 2 horror (TODO #212 for the real choice)",
+        );
+    }
+}

--- a/crates/cards/src/impls/agenda_01106.rs
+++ b/crates/cards/src/impls/agenda_01106.rs
@@ -1,0 +1,129 @@
+//! Rise of the Ghouls (The Gathering Agenda 2, 01106).
+//!
+//! ```text
+//! Agenda 2 — Rise of the Ghouls. Doom: 7.
+//! (reverse) Shuffle the encounter discard pile into the encounter deck.
+//!   Discard cards from the top of the encounter deck until a [[Ghoul]]
+//!   enemy is discarded. The lead investigator draws that enemy.
+//! ```
+//!
+//! Forced on-advance reverse, fired via `ForcedTriggerPoint::AgendaAdvanced`
+//! from `advance_agenda` (the mirror of the act path). Board-dependent,
+//! single-use scenario logic, so it lives card-locally as an
+//! `Effect::Native` handler (#276), orchestrating engine primitives
+//! ([`reshuffle_encounter_discard`], [`resolve_encounter_card`]) over the
+//! encounter deck.
+//!
+//! The dug-up enemy is a *generic* `Ghoul` from the encounter deck —
+//! distinct from act-2's set-aside Ghoul Priest (01116, #280). "Draws that
+//! enemy" resolves it through the normal encounter-draw path
+//! ([`resolve_encounter_card`]): `CardRevealed`, any Revelation, then spawn.
+//!
+//! Empty-deck note: The Gathering's encounter deck isn't assembled yet, so
+//! today the reshuffle finds an empty discard and the dig an empty deck —
+//! the reverse is a faithful no-op (RR: "discard … until a `Ghoul` …";
+//! a deck with no Ghoul yields none). The algorithm is exercised against a
+//! seeded deck in `cards/tests/agenda_reverses.rs`.
+//!
+//! Solo-scope note: spawning the drawn Ghoul engages inline (`Done`) with
+//! one investigator; a tied-prey multi-investigator spawn would suspend
+//! (`AwaitingInput`) — unreachable through the single-trigger
+//! forced-advance path until #212/#213, consistent with Slice 1.
+
+use card_dsl::card_data::CardType;
+use card_dsl::dsl::{native, on_event, Ability, EventPattern, EventTiming};
+use game_core::card_registry::NativeEffectFn;
+use game_core::{
+    reshuffle_encounter_discard, resolve_encounter_card, Cx, EngineOutcome, EvalContext,
+};
+
+/// `ArkhamDB` code for Agenda 2, "Rise of the Ghouls".
+pub const CODE: &str = "01106";
+
+/// Native-effect tag for this agenda's reverse.
+const REVERSE: &str = "01106:reverse";
+
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![on_event(
+        EventPattern::AgendaAdvanced,
+        EventTiming::After,
+        native(REVERSE),
+    )]
+}
+
+/// Resolve [`REVERSE`] if `tag` matches. Wired into the crate registry's
+/// `native_effect_for`.
+pub(crate) fn native_effect_for(tag: &str) -> Option<NativeEffectFn> {
+    (tag == REVERSE).then_some(reverse as NativeEffectFn)
+}
+
+/// `true` if `code` is an encounter **enemy** carrying the `Ghoul` trait.
+fn is_ghoul_enemy(code: &str) -> bool {
+    crate::by_code(code)
+        .is_some_and(|m| m.card_type() == CardType::Enemy && m.traits.iter().any(|t| t == "Ghoul"))
+}
+
+/// Shuffle the encounter discard into the deck, then dig from the top —
+/// discarding each non-`Ghoul`-enemy — until a `Ghoul` enemy is found, and
+/// have the lead investigator draw it. A deck exhausted without a Ghoul is
+/// a no-op (nothing to draw).
+fn reverse(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
+    reshuffle_encounter_discard(cx);
+    // Pop directly from the deck (not `draw_encounter_top`, which would
+    // reshuffle the just-discarded cards back in and loop). The deck is
+    // finite and shrinks by one each iteration, so this terminates.
+    while let Some(code) = cx.state.encounter_deck.pop_front() {
+        if is_ghoul_enemy(code.as_str()) {
+            let metadata = crate::by_code(code.as_str()).expect("is_ghoul_enemy looked it up");
+            return resolve_encounter_card(cx, ctx.controller, code, metadata);
+        }
+        cx.state.encounter_discard.push(code);
+    }
+    EngineOutcome::Done
+}
+
+#[cfg(test)]
+mod tests {
+    use card_dsl::dsl::{Effect, EventPattern, EventTiming, Trigger};
+
+    #[test]
+    fn abilities_are_one_forced_on_advance_native_reverse() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(
+            abilities[0].trigger,
+            Trigger::OnEvent {
+                pattern: EventPattern::AgendaAdvanced,
+                timing: EventTiming::After,
+            }
+        );
+        assert!(
+            matches!(&abilities[0].effect, Effect::Native { tag } if tag == "01106:reverse"),
+            "the reverse is a card-local native effect, got {:?}",
+            abilities[0].effect
+        );
+    }
+
+    #[test]
+    fn native_effect_for_resolves_only_the_reverse_tag() {
+        assert!(super::native_effect_for("01106:reverse").is_some());
+        assert!(super::native_effect_for("01106:other").is_none());
+    }
+
+    #[test]
+    fn is_ghoul_enemy_recognises_ghoul_enemies_only() {
+        assert!(
+            super::is_ghoul_enemy("01160"),
+            "Ghoul Minion is a Ghoul enemy"
+        );
+        assert!(
+            super::is_ghoul_enemy("01116"),
+            "Ghoul Priest is a Ghoul enemy",
+        );
+        assert!(
+            !super::is_ghoul_enemy("01105"),
+            "an agenda is not a Ghoul enemy",
+        );
+    }
+}

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -43,6 +43,8 @@
 //! - Trapped (01108) — Act 1; `Trigger::OnEvent` (`ActAdvanced`, `After`) on-advance board build.
 //! - The Barrier (01109) — Act 2; `Trigger::OnEvent` (`ActAdvanced`, `After`) on-advance reverse: reveal the Parlor + spawn the set-aside Ghoul Priest.
 //! - What Have You Done? (01110) — Act 3; `Trigger::OnEvent` (`EnemyDefeated` 01116, `After`) -> `AdvanceCurrentAct`.
+//! - What's Going On?! (01105) — Agenda 1; `Trigger::OnEvent` (`AgendaAdvanced`, `After`) reverse: lead takes 2 horror (deferred branch, TODO #212).
+//! - Rise of the Ghouls (01106) — Agenda 2; `Trigger::OnEvent` (`AgendaAdvanced`, `After`) reverse: dig the encounter deck until a Ghoul, lead draws it.
 //!
 //! The remaining Phase-3 card (Study #56) blocks on the
 //! location-state shape.
@@ -52,6 +54,8 @@ use card_dsl::dsl::Ability;
 pub mod act_01108;
 pub mod act_01109;
 pub mod act_01110;
+pub mod agenda_01105;
+pub mod agenda_01106;
 pub mod agenda_01107;
 pub mod attic;
 pub mod cellar;
@@ -70,6 +74,8 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
         act_01108::CODE => Some(act_01108::abilities()),
         act_01109::CODE => Some(act_01109::abilities()),
         act_01110::CODE => Some(act_01110::abilities()),
+        agenda_01105::CODE => Some(agenda_01105::abilities()),
+        agenda_01106::CODE => Some(agenda_01106::abilities()),
         agenda_01107::CODE => Some(agenda_01107::abilities()),
         attic::CODE => Some(attic::abilities()),
         cellar::CODE => Some(cellar::abilities()),
@@ -90,5 +96,6 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
 pub fn native_effect_for(tag: &str) -> Option<game_core::card_registry::NativeEffectFn> {
     act_01108::native_effect_for(tag)
         .or_else(|| act_01109::native_effect_for(tag))
+        .or_else(|| agenda_01106::native_effect_for(tag))
         .or_else(|| agenda_01107::native_effect_for(tag))
 }

--- a/crates/cards/tests/agenda_reverses.rs
+++ b/crates/cards/tests/agenda_reverses.rs
@@ -1,0 +1,127 @@
+//! Integration: The Gathering's agenda reverses fire on advance, through
+//! the real card registry (#281). Own process so it can install the
+//! process-global registry against the real `cards` corpus.
+//!
+//! Drives the reverses via `fire_forced_on_agenda_advance` (the
+//! `ForcedTriggerPoint::AgendaAdvanced` path) rather than a full Mythos
+//! doom-to-threshold cascade — the firing wiring lives in `advance_agenda`
+//! and is unit-tested there; here we prove the *card effects* resolve.
+
+use std::sync::Once;
+
+use game_core::state::{CardCode, EnemyId, InvestigatorId, LocationId};
+use game_core::test_support::{
+    fire_forced_on_agenda_advance, test_investigator, test_location, GameStateBuilder,
+};
+use game_core::EngineOutcome;
+
+static INSTALL: Once = Once::new();
+
+fn install_registry() {
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// 01105's deferred reverse: the lead investigator takes 2 horror (the
+/// real card is a lead choice — TODO #212; see `impls::agenda_01105`).
+#[test]
+fn agenda_01105_reverse_deals_two_horror_to_the_lead() {
+    install_registry();
+    let lead = InvestigatorId(1);
+    let mut state = GameStateBuilder::new()
+        .with_investigator(test_investigator(1))
+        .with_turn_order([lead])
+        .build();
+    assert_eq!(state.investigators[&lead].horror, 0);
+
+    let mut events = Vec::new();
+    let outcome = fire_forced_on_agenda_advance(&mut state, &mut events, CardCode::new("01105"));
+    assert_eq!(outcome, EngineOutcome::Done);
+    assert_eq!(
+        state.investigators[&lead].horror, 2,
+        "01105's reverse deals 2 horror to the lead investigator",
+    );
+}
+
+/// 01106's reverse digs past non-Ghoul cards to the Ghoul enemy and the
+/// lead draws (spawns) it. The "shuffle the discard into the deck" step
+/// randomizes order, so the order-independent invariant is: the Ghoul is
+/// always reached and drawn, and exactly the one non-Ghoul card remains
+/// (still in the deck if the Ghoul sat above it, or in the discard if it
+/// was dug through). Seeded deck = [Hunting Shadow (01135, treachery),
+/// Ghoul Minion (01160, the Ghoul enemy)].
+#[test]
+fn agenda_01106_reverse_digs_until_a_ghoul_and_the_lead_draws_it() {
+    install_registry();
+    let lead = InvestigatorId(1);
+    let loc = test_location(20, "Here");
+    let mut state = GameStateBuilder::new()
+        .with_investigator_at(test_investigator(1), LocationId(20))
+        .with_location(loc)
+        .with_turn_order([lead])
+        .build();
+    state.encounter_deck.push_back(CardCode::new("01135")); // treachery (non-Ghoul)
+    state.encounter_deck.push_back(CardCode::new("01160")); // Ghoul Minion
+
+    let mut events = Vec::new();
+    let outcome = fire_forced_on_agenda_advance(&mut state, &mut events, CardCode::new("01106"));
+    assert_eq!(outcome, EngineOutcome::Done);
+
+    // The Ghoul Minion was drawn → spawned into play (always reached,
+    // whatever the shuffle order).
+    let ghoul = state
+        .enemies
+        .values()
+        .find(|e| e.code.as_str() == "01160")
+        .expect("the dug-up Ghoul enemy (01160) spawned");
+    assert_eq!(
+        ghoul.current_location,
+        Some(LocationId(20)),
+        "Ghoul Minion (no spawn rule) spawns at the lead's location",
+    );
+    assert!(state
+        .enemies
+        .contains_key(&EnemyId(state.next_enemy_id - 1)));
+    // The Ghoul left both deck and discard (it was drawn into play).
+    assert!(!state.encounter_deck.contains(&CardCode::new("01160")));
+    assert!(!state.encounter_discard.contains(&CardCode::new("01160")));
+    // Exactly the one non-Ghoul card remains somewhere (deck if the Ghoul
+    // was above it, discard if it was dug through).
+    assert_eq!(
+        state.encounter_deck.len() + state.encounter_discard.len(),
+        1,
+        "deck={:?} discard={:?}",
+        state.encounter_deck,
+        state.encounter_discard,
+    );
+}
+
+/// 01106's dig discards non-Ghoul cards. A one-card deck (no shuffle, since
+/// `len < 2`) with a single non-Ghoul card: it is discarded, nothing is
+/// drawn, and the reverse resolves to `Done` (deck exhausted with no Ghoul
+/// — a faithful no-op draw).
+#[test]
+fn agenda_01106_reverse_discards_non_ghoul_cards() {
+    install_registry();
+    let lead = InvestigatorId(1);
+    let mut state = GameStateBuilder::new()
+        .with_investigator(test_investigator(1))
+        .with_turn_order([lead])
+        .build();
+    state.encounter_deck.push_back(CardCode::new("01135")); // treachery, no Ghoul
+
+    let mut events = Vec::new();
+    let outcome = fire_forced_on_agenda_advance(&mut state, &mut events, CardCode::new("01106"));
+    assert_eq!(outcome, EngineOutcome::Done);
+    assert_eq!(
+        state.encounter_discard,
+        vec![CardCode::new("01135")],
+        "the non-Ghoul card is discarded",
+    );
+    assert!(state.encounter_deck.is_empty());
+    assert!(
+        state.enemies.is_empty(),
+        "no Ghoul to draw → nothing spawns"
+    );
+}

--- a/crates/game-core/src/engine/dispatch/act_agenda.rs
+++ b/crates/game-core/src/engine/dispatch/act_agenda.rs
@@ -54,7 +54,22 @@ pub(super) fn check_doom_threshold(cx: &mut Cx) {
 /// malformation guards from #69.
 pub(super) fn advance_agenda(cx: &mut Cx) {
     let from = cx.state.agenda_index;
+    let leaving_code = cx.state.agenda_deck[from].code.clone();
     cx.events.push(crate::event::Event::AgendaAdvanced { from });
+    // Resolve the leaving agenda's Forced on-advance reverse effect before
+    // the next agenda becomes current — the mirror of `advance_act`'s
+    // `ActAdvanced` firing (`advance_agenda` fired nothing before #281).
+    // The Gathering's reverses (01105 lead discard/horror, 01106
+    // dig-until-Ghoul) resolve here. `()` return can't propagate a
+    // 2+-trigger reject; `debug_assert!` guards it (mirror of `advance_act`).
+    let forced = super::forced_triggers::fire_forced_triggers(
+        cx,
+        &super::forced_triggers::ForcedTriggerPoint::AgendaAdvanced { code: leaving_code },
+    );
+    debug_assert!(
+        matches!(forced, EngineOutcome::Done),
+        "advance_agenda on-advance forced did not resolve to Done: {forced:?} (2+ needs #213)"
+    );
     cx.state.agenda_doom = 0;
     cx.state.agenda_index += 1;
     if cx.state.agenda_index >= cx.state.agenda_deck.len() {

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -88,21 +88,25 @@ pub(super) fn encounter_card_revealed(cx: &mut Cx, investigator: InvestigatorId)
 
 /// Shared post-draw resolution helper. Resolves the per-card 5-step
 /// sub-sequence's steps 3 (Revelation) and 4 (enemy spawn) for an
-/// already-drawn encounter card. Called by [`encounter_card_revealed`]
+/// already-drawn encounter card. Called by `encounter_card_revealed`
 /// (the `EngineRecord::EncounterCardRevealed` path) and by
-/// `mythos_draw_for` (Mythos 1.4 player-driven draws, lands in T11).
+/// `mythos_draw_for` (Mythos 1.4 player-driven draws).
 ///
 /// Body: emits [`Event::CardRevealed`], then dispatches on
 /// `metadata.card_type` — treachery → run Revelation abilities →
-/// push card to `encounter_discard`;
-/// enemy → run Revelation abilities → call [`spawn_enemy`];
-/// any other type → return `Rejected`.
+/// push card to `encounter_discard`; enemy → run Revelation abilities →
+/// spawn it; any other type → return `Rejected`.
 ///
 /// **Mid-resolution caveat:** [`Event::CardRevealed`] emits before
 /// Revelation runs (Before-timing reactions need that ordering,
 /// per #126's design decision). The apply loop's `events.clear()`
 /// on Rejected still wipes the event stream on rejection.
-fn resolve_encounter_card(
+///
+/// Public so card effects that "draw"/"discard until" cards from the
+/// encounter deck can resolve the drawn card faithfully — agenda 01106's
+/// reverse draws the dug-up `Ghoul` enemy through here. Requires an
+/// installed card registry (rejects otherwise).
+pub fn resolve_encounter_card(
     cx: &mut Cx,
     investigator: InvestigatorId,
     code: CardCode,
@@ -513,8 +517,9 @@ pub(super) fn shuffle_encounter_deck(cx: &mut Cx) {
 }
 
 /// Drain `state.encounter_discard` into `state.encounter_deck` and
-/// shuffle the resulting deck. Called by
-/// [`draw_encounter_top`] when the deck runs empty.
+/// shuffle the resulting deck. Called by `draw_encounter_top` when the
+/// deck runs empty, and by card effects that "shuffle the discard into
+/// the encounter deck" (agenda 01106's reverse).
 ///
 /// Does NOT push an `EngineRecord::EncounterDeckShuffled` to the
 /// action log — mid-handler reshuffles rely on RNG determinism for
@@ -522,7 +527,7 @@ pub(super) fn shuffle_encounter_deck(cx: &mut Cx) {
 /// player-deck pattern. The `EngineRecord` variant is reserved for
 /// explicit shuffle actions (future "shuffle X into the encounter
 /// deck" effects).
-pub(super) fn reshuffle_encounter_discard(cx: &mut Cx) {
+pub fn reshuffle_encounter_discard(cx: &mut Cx) {
     cx.state
         .encounter_deck
         .extend(cx.state.encounter_discard.drain(..));

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -44,6 +44,14 @@ pub(crate) enum ForcedTriggerPoint {
         /// Printed code of the act that advanced.
         code: CardCode,
     },
+    /// An agenda advanced (its reverse side resolves on doom). Scans the
+    /// *leaving* agenda's card for `EventPattern::AgendaAdvanced` forced
+    /// abilities; binds controller = the lead investigator. The mirror of
+    /// [`ActAdvanced`](Self::ActAdvanced) — fired from `advance_agenda`.
+    AgendaAdvanced {
+        /// Printed code of the agenda that advanced.
+        code: CardCode,
+    },
     /// An enemy was defeated. Scans the *current act* for
     /// `EventPattern::EnemyDefeated` forced abilities whose `code` narrow
     /// matches (or is `None`); binds controller = the lead investigator.
@@ -136,6 +144,14 @@ fn collect_forced_hits(
             };
             push_matching(reg, code, lead, &mut hits, |p| {
                 matches!(p, EventPattern::ActAdvanced)
+            });
+        }
+        ForcedTriggerPoint::AgendaAdvanced { code } => {
+            let Some(lead) = state.turn_order.first().copied() else {
+                return hits;
+            };
+            push_matching(reg, code, lead, &mut hits, |p| {
+                matches!(p, EventPattern::AgendaAdvanced)
             });
         }
         ForcedTriggerPoint::EnemyDefeated { code } => {

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -189,6 +189,7 @@ fn trigger_matches(
             | EventPattern::EnteredLocation
             | EventPattern::PhaseEnded { .. }
             | EventPattern::ActAdvanced
+            | EventPattern::AgendaAdvanced
             | EventPattern::RoundEnded,
         ) => false,
     }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -17,7 +17,9 @@ pub mod evaluator;
 mod outcome;
 pub(crate) mod pathfinding;
 
-pub use dispatch::encounter::spawn_set_aside_enemy;
+pub use dispatch::encounter::{
+    reshuffle_encounter_discard, resolve_encounter_card, spawn_set_aside_enemy,
+};
 pub use dispatch::reveal::reveal_location;
 pub use evaluator::{location_id_by_code, EvalContext};
 pub use outcome::{EngineOutcome, InputRequest, ResumeToken};

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -43,8 +43,9 @@ pub use action::{Action, EngineRecord, InputResponse, PlayerAction};
 pub use card_data::{CardMetadata, CardType, Class, SkillIcons, Slot};
 pub use card_registry::CardRegistry;
 pub use engine::{
-    apply, location_id_by_code, reveal_location, shortest_first_steps, spawn_set_aside_enemy,
-    ApplyResult, Cx, EngineOutcome, EvalContext, InputRequest, ResumeToken,
+    apply, location_id_by_code, reshuffle_encounter_discard, resolve_encounter_card,
+    reveal_location, shortest_first_steps, spawn_set_aside_enemy, ApplyResult, Cx, EngineOutcome,
+    EvalContext, InputRequest, ResumeToken,
 };
 pub use event::{Event, FailureReason};
 pub use rng::RngState;

--- a/crates/game-core/src/test_support/mod.rs
+++ b/crates/game-core/src/test_support/mod.rs
@@ -83,6 +83,21 @@ pub fn fire_forced_on_act_advance(
     )
 }
 
+/// Test helper: fire forced triggers for an agenda advancing, returning
+/// the `EngineOutcome`. See `fire_forced_on_enter`. Exercises the agenda
+/// reverses (01105 discard/horror, 01106 dig-until-Ghoul).
+pub fn fire_forced_on_agenda_advance(
+    state: &mut crate::state::GameState,
+    events: &mut Vec<crate::event::Event>,
+    code: crate::state::CardCode,
+) -> crate::engine::EngineOutcome {
+    let mut cx = crate::engine::Cx { state, events };
+    crate::engine::fire_forced_triggers(
+        &mut cx,
+        &crate::engine::ForcedTriggerPoint::AgendaAdvanced { code },
+    )
+}
+
 /// Test helper: fire forced triggers for an enemy defeat, returning the
 /// `EngineOutcome`. See `fire_forced_on_enter`.
 pub fn fire_forced_on_enemy_defeat(

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -13,12 +13,13 @@ C3a (Prey – Lowest remaining health + Retaliate keyword),
 C3b (the six encounter enemies + pipeline keyword/spawn/health parsing),
 C3c (agenda 01107 forced abilities), C3d (act-2 round-end window).
 
-> **Next (directive — do before C4):** [#280](https://github.com/talelburg/eldritch/issues/280)
-> (act-2 reverse: spawn the set-aside Ghoul Priest + reveal the Parlor) ✅ PR #282;
-> then [#281](https://github.com/talelburg/eldritch/issues/281) (agenda reverses 01105/01106 +
-> `AgendaAdvanced` forced point). These close the act/agenda **reverse-coverage**
-> gap (see the table below) that blocks the real win/lose path, so they take
-> priority over C4. Then resume C4 → C7.
+> **Reverse-coverage gap closed; resume C4 → C7.**
+> [#280](https://github.com/talelburg/eldritch/issues/280) (act-2 reverse:
+> spawn the set-aside Ghoul Priest + reveal the Parlor) ✅ PR #282 and
+> [#281](https://github.com/talelburg/eldritch/issues/281) (agenda reverses
+> 01105/01106 + `AgendaAdvanced` forced point) ✅ PR #283 are done — the
+> act/agenda **reverse-coverage** gap (see the table below) that blocked the
+> real win/lose path is closed. Next: C4 → C7.
 
 Design specs:
 [Gathering design](../superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md),
@@ -95,14 +96,14 @@ breakdown rows; this is reverses only.
 | Act 1 (01108) | board build | ✅ `act_01108.rs` (C1b) |
 | Act 2 (01109) | reveal Parlor, put Lita, spawn Ghoul Priest | ✅ `act_01109.rs` (PR #282); Lita → [#258](https://github.com/talelburg/eldritch/issues/258) |
 | Act 3 (01110) | R1/R2 resolution choice | ⚠️ R1 Won latch (C1b); R2 + choice → Phase 9 |
-| Agenda 1 (01105) | lead: each discards 1 random, or lead takes 2 horror | ⛔ [#281](https://github.com/talelburg/eldritch/issues/281) |
-| Agenda 2 (01106) | dig encounter deck until a [[Ghoul]], lead draws it | ⛔ [#281](https://github.com/talelburg/eldritch/issues/281) |
+| Agenda 1 (01105) | lead: each discards 1 random, or lead takes 2 horror | ⚠️ `agenda_01105.rs` (PR #283): deterministic 2-horror branch; interactive choice → [#212](https://github.com/talelburg/eldritch/issues/212) |
+| Agenda 2 (01106) | dig encounter deck until a [[Ghoul]], lead draws it | ✅ `agenda_01106.rs` (PR #283) |
 | Agenda 3 (01107) | (→R3) Lost | ✅ terminal Lost latch |
 
 Infra note: acts fire their reverse via `ForcedTriggerPoint::ActAdvanced`
-(from `advance_act`); **agendas have no equivalent** — `advance_agenda`
-fires nothing, so the agenda reverses need an `AgendaAdvanced` forced point
-first ([#281](https://github.com/talelburg/eldritch/issues/281)).
+(from `advance_act`); agendas now have the **mirror** `AgendaAdvanced`
+forced point, fired from `advance_agenda` (added in [#281](https://github.com/talelburg/eldritch/issues/281),
+PR #283 — `advance_agenda` previously fired nothing).
 
 ## Future slices (after Slice 1)
 
@@ -167,6 +168,8 @@ Devourer Below, campaign log + `Fact` enum) is **Phase 9**, not Phase 7.
 - **`RoundEnded` is a distinct framework timing point, separate from `PhaseEnded { Upkeep }` (C3c, [#232](https://github.com/talelburg/eldritch/issues/232), PR #278).** `EventPattern::RoundEnded` + `ForcedTriggerPoint::RoundEnded` fire in `upkeep_phase_end` *after* the upkeep-phase-end forced dispatch ("Upkeep phase ends. Round ends.", RR p.24). Kept separate so an end-of-upkeep-phase and an end-of-round card can coexist without conflation. Agenda 01107's two abilities are card-local native fns (per the #276 decision): `01107:move-ghouls` (enemy-phase-end, unengaged Ghouls step toward the Parlor — deterministic lowest-`LocationId` tie-break, unreachable on this star map; engagement-on-arrival unmodeled) and `01107:round-end-doom` (1 doom per Ghoul in Hallway/Parlor, no threshold check — RR checks doom at Mythos 1.3). **C3d ([#275](https://github.com/talelburg/eldritch/issues/275)) reuses this `RoundEnded` point** for act-2's round-end window. `shortest_first_steps` is now `pub`.
 
 - **Set-aside *enemies* record a code only; the `Enemy` is minted at spawn (#280, PR #282).** Set-aside *locations* are fully built in `setup()` (`set_aside_locations: Vec<Location>`), but an enemy's per-investigator health (Ghoul Priest 01116 = 5×N) depends on the investigator count, unknown at `setup()` — so `set_aside_enemies: Vec<CardCode>` stores codes and `spawn_set_aside_enemy` mints stats from the corpus when a card effect brings the enemy into play. The shared spawn core is `spawn_enemy_at(cx, controller, code, metadata, location)`, factored out of `spawn_enemy` and reused by both the encounter-draw path (location from the card's spawn rule) and the set-aside path (location named by the bringing effect). **Future set-aside enemies reuse this field + helper, not a new mechanism.** Act-2's reverse (`act_01109`) is the first consumer; "put Lita into play" stays deferred to #258.
+
+- **Agenda reverses fire via an `AgendaAdvanced` forced point mirroring `ActAdvanced`; 01105's interactive choice is deferred to #212 (#281, PR #283).** `advance_agenda` now fires `ForcedTriggerPoint::AgendaAdvanced { code }` (lead-bound) the way `advance_act` fires `ActAdvanced` — the forward-compatible subset #212 will absorb. **01106** is fully deterministic (reshuffle discard → dig the encounter deck discarding non-Ghoul cards → lead draws the Ghoul via the now-public `resolve_encounter_card`/`reshuffle_encounter_discard`); it is a faithful no-op until the encounter deck is assembled (a later C-sub), and is tested against a seeded deck. **01105 is a lead *choice*** (each discards 1 random / lead takes 2 horror) that needs suspendable mid-forced-dispatch `AwaitingInput` — which the engine lacks (`ChooseOne` is a stub; the Mythos 1.3 doom-check resolves inline) and which **#212** ("mid-emit `AwaitingInput` suspension"; absorbs `fire_forced_triggers`) owns. So 01105 ships the deterministic 2-horror branch (a legal outcome, like act-3's R1/R2 single-latch deferral), `TODO(#212)`; the random-discard branch was rejected as the default because it needs *recorded* randomness for replay. **Pattern for future forced "choose one" reverses: defer the interactive choice to #212 with a deterministic legal branch rather than building bespoke suspension now.**
 
 ## Open questions
 

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -76,8 +76,9 @@ root dependency; C7 is the playable Won/Lost gate; #212 lands after C.
 | C6a | [#241](https://github.com/talelburg/eldritch/issues/241) | Dr. Milan after-investigate window | — |
 | C6b | [#242](https://github.com/talelburg/eldritch/issues/242) | Seeker deck cards | — |
 | C6c | [#243](https://github.com/talelburg/eldritch/issues/243) | Neutral deck cards | — |
+| C6d | [#284](https://github.com/talelburg/eldritch/issues/284) | encounter-deck assembly in `setup()` (quantity-aware, excludes set-aside) — gates C7b; makes Mythos draws + 01106's dig operate live | — |
 | C7a | [#244](https://github.com/talelburg/eldritch/issues/244) | registry swap + web `SCENARIO_ID` repoint (B3) | — |
-| C7b | [#245](https://github.com/talelburg/eldritch/issues/245) | end-to-end Won/Lost integration test | — |
+| C7b | [#245](https://github.com/talelburg/eldritch/issues/245) | end-to-end Won/Lost integration test (needs C6d) | — |
 
 ## Future slices (after Slice 1)
 

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -11,15 +11,11 @@ C1a (board skeleton), C1b (Act-1 board build + Act-3 forced advance-on-defeat),
 C2 (01104 symbol-token effects + location victory points),
 C3a (Prey – Lowest remaining health + Retaliate keyword),
 C3b (the six encounter enemies + pipeline keyword/spawn/health parsing),
-C3c (agenda 01107 forced abilities), C3d (act-2 round-end window).
-
-> **Reverse-coverage gap closed; resume C4 → C7.**
-> [#280](https://github.com/talelburg/eldritch/issues/280) (act-2 reverse:
-> spawn the set-aside Ghoul Priest + reveal the Parlor) ✅ PR #282 and
-> [#281](https://github.com/talelburg/eldritch/issues/281) (agenda reverses
-> 01105/01106 + `AgendaAdvanced` forced point) ✅ PR #283 are done — the
-> act/agenda **reverse-coverage** gap (see the table below) that blocked the
-> real win/lose path is closed. Next: C4 → C7.
+C3c (agenda 01107 forced abilities), C3d (act-2 round-end window),
+the act-2 reverse ([#280](https://github.com/talelburg/eldritch/issues/280):
+spawn the set-aside Ghoul Priest + reveal the Parlor), and the agenda
+reverses ([#281](https://github.com/talelburg/eldritch/issues/281):
+01105/01106 + the `AgendaAdvanced` forced point). **Next: C4 → C7.**
 
 Design specs:
 [Gathering design](../superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md),
@@ -82,28 +78,6 @@ root dependency; C7 is the playable Won/Lost gate; #212 lands after C.
 | C6c | [#243](https://github.com/talelburg/eldritch/issues/243) | Neutral deck cards | — |
 | C7a | [#244](https://github.com/talelburg/eldritch/issues/244) | registry swap + web `SCENARIO_ID` repoint (B3) | — |
 | C7b | [#245](https://github.com/talelburg/eldritch/issues/245) | end-to-end Won/Lost integration test | — |
-
-### Act/agenda reverse coverage
-
-Every act and agenda **reverse** (its `back_text` — what happens when it
-advances) must be implemented for a faithful slice; the Group C rows above
-covered some piecemeal (fronts + a couple of reverses), so this table is
-the explicit coverage check. Fronts (objectives/forced) are tracked in the
-breakdown rows; this is reverses only.
-
-| Card | Reverse | Status |
-|---|---|---|
-| Act 1 (01108) | board build | ✅ `act_01108.rs` (C1b) |
-| Act 2 (01109) | reveal Parlor, put Lita, spawn Ghoul Priest | ✅ `act_01109.rs` (PR #282); Lita → [#258](https://github.com/talelburg/eldritch/issues/258) |
-| Act 3 (01110) | R1/R2 resolution choice | ⚠️ R1 Won latch (C1b); R2 + choice → Phase 9 |
-| Agenda 1 (01105) | lead: each discards 1 random, or lead takes 2 horror | ⚠️ `agenda_01105.rs` (PR #283): deterministic 2-horror branch; interactive choice → [#212](https://github.com/talelburg/eldritch/issues/212) |
-| Agenda 2 (01106) | dig encounter deck until a [[Ghoul]], lead draws it | ✅ `agenda_01106.rs` (PR #283) |
-| Agenda 3 (01107) | (→R3) Lost | ✅ terminal Lost latch |
-
-Infra note: acts fire their reverse via `ForcedTriggerPoint::ActAdvanced`
-(from `advance_act`); agendas now have the **mirror** `AgendaAdvanced`
-forced point, fired from `advance_agenda` (added in [#281](https://github.com/talelburg/eldritch/issues/281),
-PR #283 — `advance_agenda` previously fired nothing).
 
 ## Future slices (after Slice 1)
 


### PR DESCRIPTION
## Summary

Closes #281. Agenda **reverses** were unimplemented and — unlike acts — had no firing mechanism: `advance_act` fires `ForcedTriggerPoint::ActAdvanced`, but `advance_agenda` fired nothing. This adds the infra *and* both reverses, closing the agenda half of the act/agenda reverse-coverage gap.

**Verified reverses (`back_text`, snapshot):**
- **01105 "What's Going On?!":** "The lead investigator must decide (choose one): Either each investigator discards 1 card at random from his or her hand, or the lead investigator takes 2 horror."
- **01106 "Rise of the Ghouls":** "Shuffle the encounter discard pile into the encounter deck. Discard cards from the top of the encounter deck until a [[Ghoul]] enemy is discarded. The lead investigator draws that enemy."

## Infra (forward-compatible subset, mirrors `ActAdvanced`)
- `EventPattern::AgendaAdvanced` + `ForcedTriggerPoint::AgendaAdvanced { code }`, bound to the lead investigator and fired from `advance_agenda` (debug-asserts `Done`, like `advance_act`).
- `test_support::fire_forced_on_agenda_advance`.

## 01106 — full deterministic reverse
Card-local `Effect::Native` (#276): shuffle the encounter discard into the deck, dig from the top discarding non-Ghoul cards until a Ghoul **enemy**, and the lead draws it via the normal encounter-draw path. Exposes `reshuffle_encounter_discard` + `resolve_encounter_card` as engine primitives.

> **Empty-deck note:** The Gathering's encounter deck isn't assembled yet, so the live reverse is a faithful no-op on the empty deck (RR: "discard … until a Ghoul …"; a deck with no Ghoul yields none). The algorithm is exercised against a **seeded** deck in `cards/tests/agenda_reverses.rs`.

## 01105 — deferred-choice branch (TODO #212)
The card is a lead-investigator **choice**. Presenting it needs suspendable mid-forced-dispatch `AwaitingInput`, which the engine lacks today:
- `Effect::ChooseOne` is a stub (#19 shipped only the *test-side* resolver), and
- the Mythos step-1.3 doom-check path (`mythos_phase → check_doom_threshold → advance_agenda`) resolves inline and can't suspend.

That suspendable-dispatch machinery is exactly the `emit_event` unification (**#212**), whose deferred scope explicitly names *"mid-emit `AwaitingInput` suspension"* and *absorbing `fire_forced_triggers`*. A bespoke C3d-style suspension threaded through Mythos now would be throwaway work #212 removes.

So 01105 ships **one of the two legal branches deterministically — the lead takes 2 horror** — as a plain DSL `DealHorror` (not a silent approximation: it applies an outcome the card actually offers, mirroring act-3's R1/R2 single-latch deferral). The horror branch is chosen over random-discard, which would need *recorded* randomness (`EngineRecord`) for replay determinism — more throwaway infra for a branch becoming interactive under #212 anyway. `TODO(#212)`.

## Testing
- Unit: 01105/01106 ability shapes + native-tag resolution; `is_ghoul_enemy`; doom-advance regression (advance_agenda's new firing is a no-op without a registry).
- Integration (`cards/tests/agenda_reverses.rs`, real corpus): 01105 deals 2 horror to the lead; 01106 digs to the Ghoul (order-independent invariant: the Ghoul is always drawn) + discards non-Ghoul cards.
- Full strict gauntlet green locally (all 7 CI jobs incl. headless wasm-test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)