### PR TITLE
card: C4c — persistent threat-area / attachment treacheries (01164/01165/01168)

### DIFF
--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -545,6 +545,9 @@ pub enum Stat {
     Agility,
     MaxHealth,
     MaxSanity,
+    /// A location's shroud (investigate difficulty), adjusted by
+    /// location attachments such as Obscuring Fog 01168's `+2`.
+    Shroud,
 }
 
 /// How long an [`Effect::Modify`] applies.

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -549,6 +549,16 @@ pub enum Effect {
     /// 01165) — the card names its own `CODE`. (Attaching to a *location*
     /// stays card-local because of per-card rules like Obscuring Fog's
     /// "Limit 1 per location".)
+    ///
+    /// The `code` is carried because at Revelation the card isn't in play
+    /// yet, so the evaluator context has no instance handle for "self"
+    /// (unlike [`DiscardSelf`](Self::DiscardSelf), which reads the
+    /// already-in-play `EvalContext.source`). TODO: once encounter cards
+    /// are minted as in-play instances *at reveal* (so the source instance
+    /// exists before the Revelation runs), this can drop the `code` and
+    /// place "self" uniformly with `DiscardSelf` — an encounter-resolution
+    /// change, not worth threading the code through a now-`Copy`
+    /// `EvalContext` on its own.
     PutIntoThreatArea {
         /// Printed `ArkhamDB` code of the card to place.
         code: String,

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -520,6 +520,11 @@ pub enum Effect {
     SkillTest {
         skill: crate::card_data::SkillKind,
         difficulty: u8,
+        /// Effect to run **on success** after the test resolves (the
+        /// success-side mirror of `on_fail`). `None` for tests that only
+        /// branch on failure. Frozen in Fear 01164 discards itself on a
+        /// successful end-of-turn willpower test.
+        on_success: Option<Box<Effect>>,
         on_fail: Box<Effect>,
     },
     /// Run `body` once per point the just-resolved skill test was failed
@@ -973,12 +978,32 @@ pub fn restrict(restriction: Restriction) -> Effect {
 }
 
 /// Build an [`Effect::SkillTest`] initiating a `skill` test against
-/// `difficulty`, running `on_fail` after the test resolves on failure.
+/// `difficulty`, running `on_fail` after the test resolves on failure
+/// (no success-side effect).
 #[must_use]
 pub fn skill_test(skill: crate::card_data::SkillKind, difficulty: u8, on_fail: Effect) -> Effect {
     Effect::SkillTest {
         skill,
         difficulty,
+        on_success: None,
+        on_fail: Box::new(on_fail),
+    }
+}
+
+/// Build an [`Effect::SkillTest`] with both success- and failure-side
+/// follow-ups. Frozen in Fear 01164 discards itself on success and does
+/// nothing on failure (pass `Effect::Seq(vec![])` for the latter).
+#[must_use]
+pub fn skill_test_with_success(
+    skill: crate::card_data::SkillKind,
+    difficulty: u8,
+    on_success: Effect,
+    on_fail: Effect,
+) -> Effect {
+    Effect::SkillTest {
+        skill,
+        difficulty,
+        on_success: Some(Box::new(on_success)),
         on_fail: Box::new(on_fail),
     }
 }

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -528,6 +528,13 @@ pub enum Effect {
     /// runs `body` zero times. Only meaningful inside an
     /// [`Effect::SkillTest`]'s `on_fail`.
     ForEachPointFailed(Box<Effect>),
+    /// Discard the firing card instance (the evaluator context's
+    /// `source`). Locates the instance in a threat area or location
+    /// attachment, removes it, and discards it to the encounter discard.
+    /// Used by persistent treacheries' `Forced` self-discard abilities
+    /// (Frozen in Fear 01164, Dissonant Voices 01165, Obscuring Fog
+    /// 01168). Rejects if there is no source or the instance isn't found.
+    DiscardSelf,
 }
 
 // ---- stats and modifier scopes --------------------------------
@@ -884,6 +891,12 @@ pub fn advance_current_act() -> Effect {
 #[must_use]
 pub fn native(tag: impl Into<String>) -> Effect {
     Effect::Native { tag: tag.into() }
+}
+
+/// Build an [`Effect::DiscardSelf`].
+#[must_use]
+pub fn discard_self() -> Effect {
+    Effect::DiscardSelf
 }
 
 /// Build an [`Effect::SkillTest`] initiating a `skill` test against

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -553,12 +553,10 @@ pub enum Effect {
     /// The `code` is carried because at Revelation the card isn't in play
     /// yet, so the evaluator context has no instance handle for "self"
     /// (unlike [`DiscardSelf`](Self::DiscardSelf), which reads the
-    /// already-in-play `EvalContext.source`). TODO: once encounter cards
-    /// are minted as in-play instances *at reveal* (so the source instance
-    /// exists before the Revelation runs), this can drop the `code` and
-    /// place "self" uniformly with `DiscardSelf` — an encounter-resolution
-    /// change, not worth threading the code through a now-`Copy`
-    /// `EvalContext` on its own.
+    /// already-in-play `EvalContext.source`). `TODO(#290)`: once encounter
+    /// cards are minted as in-play instances *at reveal* (so the source
+    /// instance exists before the Revelation runs), this can drop the
+    /// `code` and place "self" uniformly with `DiscardSelf`.
     PutIntoThreatArea {
         /// Printed `ArkhamDB` code of the card to place.
         code: String,

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -975,31 +975,22 @@ pub fn restrict(restriction: Restriction) -> Effect {
 }
 
 /// Build an [`Effect::SkillTest`] initiating a `skill` test against
-/// `difficulty`, running `on_fail` after the test resolves on failure
-/// (no success-side effect).
+/// `difficulty`. `on_success` runs after a passing draw, `on_fail` after a
+/// failing one (with the margin in the evaluator context's `failed_by`);
+/// either may be `None`. Most cards branch on exactly one side — failure
+/// (the one-shot Revelation treacheries) or success (Frozen in Fear 01164).
 #[must_use]
-pub fn skill_test(skill: crate::card_data::SkillKind, difficulty: u8, on_fail: Effect) -> Effect {
-    Effect::SkillTest {
-        skill,
-        difficulty,
-        on_success: None,
-        on_fail: Some(Box::new(on_fail)),
-    }
-}
-
-/// Build an [`Effect::SkillTest`] that runs `on_success` on a passing draw
-/// and nothing on failure (Frozen in Fear 01164's end-of-turn test).
-#[must_use]
-pub fn skill_test_with_success(
+pub fn skill_test(
     skill: crate::card_data::SkillKind,
     difficulty: u8,
-    on_success: Effect,
+    on_success: Option<Effect>,
+    on_fail: Option<Effect>,
 ) -> Effect {
     Effect::SkillTest {
         skill,
         difficulty,
-        on_success: Some(Box::new(on_success)),
-        on_fail: None,
+        on_success: on_success.map(Box::new),
+        on_fail: on_fail.map(Box::new),
     }
 }
 
@@ -1239,7 +1230,11 @@ mod tests {
         let effect = skill_test(
             SkillKind::Agility,
             3,
-            for_each_point_failed(deal_damage(InvestigatorTarget::You, 1)),
+            None,
+            Some(for_each_point_failed(deal_damage(
+                InvestigatorTarget::You,
+                1,
+            ))),
         );
         let json = serde_json::to_string(&effect).expect("serialize");
         let back: Effect = serde_json::from_str(&json).expect("deserialize");

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -520,12 +520,15 @@ pub enum Effect {
     SkillTest {
         skill: crate::card_data::SkillKind,
         difficulty: u8,
-        /// Effect to run **on success** after the test resolves (the
-        /// success-side mirror of `on_fail`). `None` for tests that only
-        /// branch on failure. Frozen in Fear 01164 discards itself on a
-        /// successful end-of-turn willpower test.
+        /// Effect to run **on success** after the test resolves. Frozen in
+        /// Fear 01164 discards itself on a successful end-of-turn willpower
+        /// test. `None` for tests with no success-side effect.
         on_success: Option<Box<Effect>>,
-        on_fail: Box<Effect>,
+        /// Effect to run **on failure** after the test resolves, with the
+        /// failure margin available via the evaluator context's `failed_by`.
+        /// `None` for tests with no failure-side effect. Symmetric with
+        /// `on_success` — success and margin-keyed-failure are separate axes.
+        on_fail: Option<Box<Effect>>,
     },
     /// Run `body` once per point the just-resolved skill test was failed
     /// by ("for each point you fail by, …"). Reads the failure margin
@@ -540,6 +543,16 @@ pub enum Effect {
     /// (Frozen in Fear 01164, Dissonant Voices 01165, Obscuring Fog
     /// 01168). Rejects if there is no source or the instance isn't found.
     DiscardSelf,
+    /// Put the card with this printed `code` into the controller's threat
+    /// area as a fresh in-play instance. The Revelation of persistent
+    /// threat-area treacheries (Frozen in Fear 01164, Dissonant Voices
+    /// 01165) — the card names its own `CODE`. (Attaching to a *location*
+    /// stays card-local because of per-card rules like Obscuring Fog's
+    /// "Limit 1 per location".)
+    PutIntoThreatArea {
+        /// Printed `ArkhamDB` code of the card to place.
+        code: String,
+    },
     /// A constant restriction the source card imposes while in play
     /// (under [`Trigger::Constant`]). **Inspected, not executed** — the
     /// engine reads it at the relevant decision point (`play_is_prohibited`
@@ -612,26 +625,16 @@ pub enum Restriction {
     /// once a second mechanism needs the same gate — not while action cost
     /// is its only consumer.
     ExtraActionCost {
-        /// Which action kinds are surcharged.
-        actions: ActionClassSet,
+        /// Which action kinds are surcharged (Frozen in Fear 01164: move,
+        /// fight, evade).
+        actions: Vec<ActionClass>,
         /// Gate the surcharge to the first matching action each round.
         first_each_round: bool,
     },
 }
 
-/// The set of action kinds an [`Restriction::ExtraActionCost`] surcharges.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-pub struct ActionClassSet {
-    /// Surcharge the Move action.
-    pub move_: bool,
-    /// Surcharge the Fight action.
-    pub fight: bool,
-    /// Surcharge the Evade action.
-    pub evade: bool,
-}
-
-/// One action kind, for querying an [`ActionClassSet`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// One action kind an [`Restriction::ExtraActionCost`] can surcharge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ActionClass {
     /// The Move action.
     Move,
@@ -639,18 +642,6 @@ pub enum ActionClass {
     Fight,
     /// The Evade action.
     Evade,
-}
-
-impl ActionClassSet {
-    /// Whether this set includes `class`.
-    #[must_use]
-    pub fn contains(self, class: ActionClass) -> bool {
-        match class {
-            ActionClass::Move => self.move_,
-            ActionClass::Fight => self.fight,
-            ActionClass::Evade => self.evade,
-        }
-    }
 }
 
 /// Which kind of skill test is running.
@@ -971,6 +962,12 @@ pub fn discard_self() -> Effect {
     Effect::DiscardSelf
 }
 
+/// Build an [`Effect::PutIntoThreatArea`] for the card with printed `code`.
+#[must_use]
+pub fn put_into_threat_area(code: impl Into<String>) -> Effect {
+    Effect::PutIntoThreatArea { code: code.into() }
+}
+
 /// Build an [`Effect::Restrict`] carrying a constant [`Restriction`].
 #[must_use]
 pub fn restrict(restriction: Restriction) -> Effect {
@@ -986,25 +983,23 @@ pub fn skill_test(skill: crate::card_data::SkillKind, difficulty: u8, on_fail: E
         skill,
         difficulty,
         on_success: None,
-        on_fail: Box::new(on_fail),
+        on_fail: Some(Box::new(on_fail)),
     }
 }
 
-/// Build an [`Effect::SkillTest`] with both success- and failure-side
-/// follow-ups. Frozen in Fear 01164 discards itself on success and does
-/// nothing on failure (pass `Effect::Seq(vec![])` for the latter).
+/// Build an [`Effect::SkillTest`] that runs `on_success` on a passing draw
+/// and nothing on failure (Frozen in Fear 01164's end-of-turn test).
 #[must_use]
 pub fn skill_test_with_success(
     skill: crate::card_data::SkillKind,
     difficulty: u8,
     on_success: Effect,
-    on_fail: Effect,
 ) -> Effect {
     Effect::SkillTest {
         skill,
         difficulty,
         on_success: Some(Box::new(on_success)),
-        on_fail: Box::new(on_fail),
+        on_fail: None,
     }
 }
 

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -535,6 +535,12 @@ pub enum Effect {
     /// (Frozen in Fear 01164, Dissonant Voices 01165, Obscuring Fog
     /// 01168). Rejects if there is no source or the instance isn't found.
     DiscardSelf,
+    /// A constant restriction the source card imposes while in play
+    /// (under [`Trigger::Constant`]). **Inspected, not executed** — the
+    /// engine reads it at the relevant decision point (`play_is_prohibited`
+    /// for `CannotPlay`, `pending_action_surcharge` for `ExtraActionCost`);
+    /// resolving it as an effect is a misuse and rejects.
+    Restrict(Restriction),
 }
 
 // ---- stats and modifier scopes --------------------------------
@@ -579,6 +585,67 @@ pub enum ModifierScope {
     ThisSkillTest,
     /// Active until the end of the current investigator turn.
     ThisTurn,
+}
+
+/// A constant restriction a card imposes while in play, carried by a
+/// [`Trigger::Constant`] [`Effect::Restrict`]. The engine inspects these
+/// at decision points rather than executing them.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Restriction {
+    /// The controller cannot play cards of this type (Dissonant Voices
+    /// 01165 declares one per forbidden type — assets and events).
+    CannotPlay(crate::card_data::CardType),
+    /// Performing one of `actions` costs 1 additional action. When
+    /// `first_each_round` is set, only the first matching action each
+    /// round is surcharged (Frozen in Fear 01164).
+    ///
+    /// TODO: the `first_each_round` gate also applies to non-cost
+    /// mechanisms (a constant ability that suppresses attacks of
+    /// opportunity on the first action each round; a forced trigger on the
+    /// first move each turn). Promote it to a shared "first-applicable each
+    /// round/turn" scope spanning constant modifiers and forced triggers
+    /// once a second mechanism needs the same gate — not while action cost
+    /// is its only consumer.
+    ExtraActionCost {
+        /// Which action kinds are surcharged.
+        actions: ActionClassSet,
+        /// Gate the surcharge to the first matching action each round.
+        first_each_round: bool,
+    },
+}
+
+/// The set of action kinds an [`Restriction::ExtraActionCost`] surcharges.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ActionClassSet {
+    /// Surcharge the Move action.
+    pub move_: bool,
+    /// Surcharge the Fight action.
+    pub fight: bool,
+    /// Surcharge the Evade action.
+    pub evade: bool,
+}
+
+/// One action kind, for querying an [`ActionClassSet`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActionClass {
+    /// The Move action.
+    Move,
+    /// The Fight action.
+    Fight,
+    /// The Evade action.
+    Evade,
+}
+
+impl ActionClassSet {
+    /// Whether this set includes `class`.
+    #[must_use]
+    pub fn contains(self, class: ActionClass) -> bool {
+        match class {
+            ActionClass::Move => self.move_,
+            ActionClass::Fight => self.fight,
+            ActionClass::Evade => self.evade,
+        }
+    }
 }
 
 /// Which kind of skill test is running.
@@ -897,6 +964,12 @@ pub fn native(tag: impl Into<String>) -> Effect {
 #[must_use]
 pub fn discard_self() -> Effect {
     Effect::DiscardSelf
+}
+
+/// Build an [`Effect::Restrict`] carrying a constant [`Restriction`].
+#[must_use]
+pub fn restrict(restriction: Restriction) -> Effect {
+    Effect::Restrict(restriction)
 }
 
 /// Build an [`Effect::SkillTest`] initiating a `skill` test against

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -68,6 +68,7 @@ pub mod treachery_01162;
 pub mod treachery_01163;
 pub mod treachery_01166;
 pub mod treachery_01167;
+pub mod treachery_01168;
 pub mod working_a_hunch;
 
 /// Look up a card's hand-implemented abilities by code. Returns
@@ -92,6 +93,7 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
         treachery_01163::CODE => Some(treachery_01163::abilities()),
         treachery_01166::CODE => Some(treachery_01166::abilities()),
         treachery_01167::CODE => Some(treachery_01167::abilities()),
+        treachery_01168::CODE => Some(treachery_01168::abilities()),
         working_a_hunch::CODE => Some(working_a_hunch::abilities()),
         _ => None,
     }
@@ -108,4 +110,5 @@ pub fn native_effect_for(tag: &str) -> Option<game_core::card_registry::NativeEf
         .or_else(|| agenda_01107::native_effect_for(tag))
         .or_else(|| treachery_01166::native_effect_for(tag))
         .or_else(|| treachery_01167::native_effect_for(tag))
+        .or_else(|| treachery_01168::native_effect_for(tag))
 }

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -66,6 +66,7 @@ pub mod magnifying_glass;
 pub mod roland_banks;
 pub mod treachery_01162;
 pub mod treachery_01163;
+pub mod treachery_01165;
 pub mod treachery_01166;
 pub mod treachery_01167;
 pub mod treachery_01168;
@@ -91,6 +92,7 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
         roland_banks::CODE => Some(roland_banks::abilities()),
         treachery_01162::CODE => Some(treachery_01162::abilities()),
         treachery_01163::CODE => Some(treachery_01163::abilities()),
+        treachery_01165::CODE => Some(treachery_01165::abilities()),
         treachery_01166::CODE => Some(treachery_01166::abilities()),
         treachery_01167::CODE => Some(treachery_01167::abilities()),
         treachery_01168::CODE => Some(treachery_01168::abilities()),
@@ -108,6 +110,7 @@ pub fn native_effect_for(tag: &str) -> Option<game_core::card_registry::NativeEf
         .or_else(|| act_01109::native_effect_for(tag))
         .or_else(|| agenda_01106::native_effect_for(tag))
         .or_else(|| agenda_01107::native_effect_for(tag))
+        .or_else(|| treachery_01165::native_effect_for(tag))
         .or_else(|| treachery_01166::native_effect_for(tag))
         .or_else(|| treachery_01167::native_effect_for(tag))
         .or_else(|| treachery_01168::native_effect_for(tag))

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -112,8 +112,6 @@ pub fn native_effect_for(tag: &str) -> Option<game_core::card_registry::NativeEf
         .or_else(|| act_01109::native_effect_for(tag))
         .or_else(|| agenda_01106::native_effect_for(tag))
         .or_else(|| agenda_01107::native_effect_for(tag))
-        .or_else(|| treachery_01164::native_effect_for(tag))
-        .or_else(|| treachery_01165::native_effect_for(tag))
         .or_else(|| treachery_01166::native_effect_for(tag))
         .or_else(|| treachery_01167::native_effect_for(tag))
         .or_else(|| treachery_01168::native_effect_for(tag))

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -66,6 +66,7 @@ pub mod magnifying_glass;
 pub mod roland_banks;
 pub mod treachery_01162;
 pub mod treachery_01163;
+pub mod treachery_01164;
 pub mod treachery_01165;
 pub mod treachery_01166;
 pub mod treachery_01167;
@@ -92,6 +93,7 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
         roland_banks::CODE => Some(roland_banks::abilities()),
         treachery_01162::CODE => Some(treachery_01162::abilities()),
         treachery_01163::CODE => Some(treachery_01163::abilities()),
+        treachery_01164::CODE => Some(treachery_01164::abilities()),
         treachery_01165::CODE => Some(treachery_01165::abilities()),
         treachery_01166::CODE => Some(treachery_01166::abilities()),
         treachery_01167::CODE => Some(treachery_01167::abilities()),
@@ -110,6 +112,7 @@ pub fn native_effect_for(tag: &str) -> Option<game_core::card_registry::NativeEf
         .or_else(|| act_01109::native_effect_for(tag))
         .or_else(|| agenda_01106::native_effect_for(tag))
         .or_else(|| agenda_01107::native_effect_for(tag))
+        .or_else(|| treachery_01164::native_effect_for(tag))
         .or_else(|| treachery_01165::native_effect_for(tag))
         .or_else(|| treachery_01166::native_effect_for(tag))
         .or_else(|| treachery_01167::native_effect_for(tag))

--- a/crates/cards/src/impls/treachery_01162.rs
+++ b/crates/cards/src/impls/treachery_01162.rs
@@ -20,7 +20,11 @@ pub fn abilities() -> Vec<Ability> {
     vec![revelation(skill_test(
         SkillKind::Agility,
         3,
-        for_each_point_failed(deal_damage(InvestigatorTarget::You, 1)),
+        None,
+        Some(for_each_point_failed(deal_damage(
+            InvestigatorTarget::You,
+            1,
+        ))),
     ))]
 }
 

--- a/crates/cards/src/impls/treachery_01162.rs
+++ b/crates/cards/src/impls/treachery_01162.rs
@@ -46,8 +46,8 @@ mod tests {
         assert_eq!(*difficulty, 3);
         assert!(on_success.is_none(), "no success-side effect");
         assert!(matches!(
-            **on_fail,
-            Effect::ForEachPointFailed(ref b)
+            on_fail.as_deref(),
+            Some(Effect::ForEachPointFailed(b))
                 if matches!(**b, Effect::DealDamage { amount: 1, .. })
         ));
     }

--- a/crates/cards/src/impls/treachery_01162.rs
+++ b/crates/cards/src/impls/treachery_01162.rs
@@ -36,6 +36,7 @@ mod tests {
         let Effect::SkillTest {
             skill,
             difficulty,
+            on_success,
             on_fail,
         } = &abilities[0].effect
         else {
@@ -43,6 +44,7 @@ mod tests {
         };
         assert_eq!(*skill, SkillKind::Agility);
         assert_eq!(*difficulty, 3);
+        assert!(on_success.is_none(), "no success-side effect");
         assert!(matches!(
             **on_fail,
             Effect::ForEachPointFailed(ref b)

--- a/crates/cards/src/impls/treachery_01163.rs
+++ b/crates/cards/src/impls/treachery_01163.rs
@@ -36,6 +36,7 @@ mod tests {
         let Effect::SkillTest {
             skill,
             difficulty,
+            on_success,
             on_fail,
         } = &abilities[0].effect
         else {
@@ -43,6 +44,7 @@ mod tests {
         };
         assert_eq!(*skill, SkillKind::Willpower);
         assert_eq!(*difficulty, 3);
+        assert!(on_success.is_none(), "no success-side effect");
         assert!(matches!(
             **on_fail,
             Effect::ForEachPointFailed(ref b)

--- a/crates/cards/src/impls/treachery_01163.rs
+++ b/crates/cards/src/impls/treachery_01163.rs
@@ -46,8 +46,8 @@ mod tests {
         assert_eq!(*difficulty, 3);
         assert!(on_success.is_none(), "no success-side effect");
         assert!(matches!(
-            **on_fail,
-            Effect::ForEachPointFailed(ref b)
+            on_fail.as_deref(),
+            Some(Effect::ForEachPointFailed(b))
                 if matches!(**b, Effect::DealHorror { amount: 1, .. })
         ));
     }

--- a/crates/cards/src/impls/treachery_01163.rs
+++ b/crates/cards/src/impls/treachery_01163.rs
@@ -20,7 +20,11 @@ pub fn abilities() -> Vec<Ability> {
     vec![revelation(skill_test(
         SkillKind::Willpower,
         3,
-        for_each_point_failed(deal_horror(InvestigatorTarget::You, 1)),
+        None,
+        Some(for_each_point_failed(deal_horror(
+            InvestigatorTarget::You,
+            1,
+        ))),
     ))]
 }
 

--- a/crates/cards/src/impls/treachery_01164.rs
+++ b/crates/cards/src/impls/treachery_01164.rs
@@ -21,7 +21,7 @@
 use card_dsl::card_data::SkillKind;
 use card_dsl::dsl::{
     constant, discard_self, native, on_event, restrict, revelation, skill_test_with_success,
-    ActionClassSet, Ability, Effect, EventPattern, EventTiming, Restriction,
+    Ability, ActionClassSet, Effect, EventPattern, EventTiming, Restriction,
 };
 use game_core::card_registry::NativeEffectFn;
 use game_core::state::CardCode;
@@ -83,7 +83,11 @@ mod tests {
         assert!(matches!(
             &abilities[1].effect,
             Effect::Restrict(Restriction::ExtraActionCost {
-                actions: ActionClassSet { move_: true, fight: true, evade: true },
+                actions: ActionClassSet {
+                    move_: true,
+                    fight: true,
+                    evade: true
+                },
                 first_each_round: true,
             })
         ));

--- a/crates/cards/src/impls/treachery_01164.rs
+++ b/crates/cards/src/impls/treachery_01164.rs
@@ -20,8 +20,8 @@
 
 use card_dsl::card_data::SkillKind;
 use card_dsl::dsl::{
-    constant, discard_self, on_event, put_into_threat_area, restrict, revelation,
-    skill_test_with_success, Ability, ActionClass, EventPattern, EventTiming, Restriction,
+    constant, discard_self, on_event, put_into_threat_area, restrict, revelation, skill_test,
+    Ability, ActionClass, EventPattern, EventTiming, Restriction,
 };
 
 /// `ArkhamDB` code for Frozen in Fear.
@@ -39,7 +39,7 @@ pub fn abilities() -> Vec<Ability> {
             EventPattern::EndOfTurn,
             EventTiming::After,
             // Test willpower(3): on success discard Frozen in Fear.
-            skill_test_with_success(SkillKind::Willpower, 3, discard_self()),
+            skill_test(SkillKind::Willpower, 3, Some(discard_self()), None),
         ),
     ]
 }

--- a/crates/cards/src/impls/treachery_01164.rs
+++ b/crates/cards/src/impls/treachery_01164.rs
@@ -1,0 +1,115 @@
+//! Frozen in Fear (The Gathering treachery, 01164).
+//!
+//! ```text
+//! Revelation - Put Frozen in Fear into play in your threat area.
+//! The first time you perform one of the following actions (move, fight,
+//!   or evade) each round, it costs 1 additional action.
+//! Forced - At the end of your turn: Test [willpower] (3). If you succeed,
+//!   discard Frozen in Fear.
+//! ```
+//!
+//! Persistent treachery: it has non-Revelation abilities (a constant
+//! action surcharge and a forced end-of-turn test), so
+//! `resolve_encounter_card` does not auto-discard it. The Revelation
+//! native places it in the controller's threat area. The surcharge is
+//! `Restriction::ExtraActionCost { first_each_round: true }` over
+//! move/fight/evade, read by those handlers via `pending_action_surcharge`.
+//! The forced ability runs a willpower(3) [`Effect::SkillTest`] that
+//! discards the card on **success** (`on_success = DiscardSelf`) and does
+//! nothing on failure (`Effect::Seq(vec![])`).
+
+use card_dsl::card_data::SkillKind;
+use card_dsl::dsl::{
+    constant, discard_self, native, on_event, restrict, revelation, skill_test_with_success,
+    ActionClassSet, Ability, Effect, EventPattern, EventTiming, Restriction,
+};
+use game_core::card_registry::NativeEffectFn;
+use game_core::state::CardCode;
+use game_core::{place_in_threat_area, Cx, EngineOutcome, EvalContext};
+
+/// `ArkhamDB` code for Frozen in Fear.
+pub const CODE: &str = "01164";
+
+const TO_THREAT_AREA: &str = "01164:to-threat-area";
+
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![
+        revelation(native(TO_THREAT_AREA)),
+        constant(restrict(Restriction::ExtraActionCost {
+            actions: ActionClassSet {
+                move_: true,
+                fight: true,
+                evade: true,
+            },
+            first_each_round: true,
+        })),
+        on_event(
+            EventPattern::EndOfTurn,
+            EventTiming::After,
+            // Test willpower(3): on success discard Frozen in Fear; on
+            // failure do nothing.
+            skill_test_with_success(SkillKind::Willpower, 3, discard_self(), Effect::Seq(vec![])),
+        ),
+    ]
+}
+
+/// Resolve this treachery's native-effect tag. Wired into the crate
+/// registry's `native_effect_for`.
+pub(crate) fn native_effect_for(tag: &str) -> Option<NativeEffectFn> {
+    (tag == TO_THREAT_AREA).then_some(to_threat_area as NativeEffectFn)
+}
+
+/// Revelation: put Frozen in Fear into the controller's threat area.
+fn to_threat_area(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
+    place_in_threat_area(cx, ctx.controller, CardCode::new(CODE));
+    EngineOutcome::Done
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use card_dsl::dsl::Trigger;
+
+    #[test]
+    fn abilities_are_threat_area_surcharge_and_end_of_turn_test() {
+        let abilities = abilities();
+        assert_eq!(abilities.len(), 3);
+
+        assert_eq!(abilities[0].trigger, Trigger::Revelation);
+        assert!(matches!(&abilities[0].effect, Effect::Native { tag } if tag == TO_THREAT_AREA));
+
+        assert_eq!(abilities[1].trigger, Trigger::Constant);
+        assert!(matches!(
+            &abilities[1].effect,
+            Effect::Restrict(Restriction::ExtraActionCost {
+                actions: ActionClassSet { move_: true, fight: true, evade: true },
+                first_each_round: true,
+            })
+        ));
+
+        assert!(matches!(
+            &abilities[2].trigger,
+            Trigger::OnEvent {
+                pattern: EventPattern::EndOfTurn,
+                timing: EventTiming::After,
+            }
+        ));
+        let Effect::SkillTest {
+            skill,
+            difficulty,
+            on_success,
+            on_fail,
+        } = &abilities[2].effect
+        else {
+            panic!("expected SkillTest, got {:?}", abilities[2].effect);
+        };
+        assert_eq!(*skill, SkillKind::Willpower);
+        assert_eq!(*difficulty, 3);
+        assert!(matches!(on_success.as_deref(), Some(Effect::DiscardSelf)));
+        assert!(matches!(**on_fail, Effect::Seq(ref v) if v.is_empty()));
+
+        assert!(native_effect_for(TO_THREAT_AREA).is_some());
+        assert!(native_effect_for("nope").is_none());
+    }
+}

--- a/crates/cards/src/impls/treachery_01164.rs
+++ b/crates/cards/src/impls/treachery_01164.rs
@@ -10,66 +10,44 @@
 //!
 //! Persistent treachery: it has non-Revelation abilities (a constant
 //! action surcharge and a forced end-of-turn test), so
-//! `resolve_encounter_card` does not auto-discard it. The Revelation
-//! native places it in the controller's threat area. The surcharge is
+//! `resolve_encounter_card` does not auto-discard it. The Revelation uses
+//! the shared `Effect::PutIntoThreatArea`. The surcharge is
 //! `Restriction::ExtraActionCost { first_each_round: true }` over
 //! move/fight/evade, read by those handlers via `pending_action_surcharge`.
-//! The forced ability runs a willpower(3) [`Effect::SkillTest`] that
-//! discards the card on **success** (`on_success = DiscardSelf`) and does
-//! nothing on failure (`Effect::Seq(vec![])`).
+//! The forced ability runs a willpower(3) `Effect::SkillTest` that
+//! discards the card on **success** (`on_success = DiscardSelf`) and has no
+//! failure-side effect.
 
 use card_dsl::card_data::SkillKind;
 use card_dsl::dsl::{
-    constant, discard_self, native, on_event, restrict, revelation, skill_test_with_success,
-    Ability, ActionClassSet, Effect, EventPattern, EventTiming, Restriction,
+    constant, discard_self, on_event, put_into_threat_area, restrict, revelation,
+    skill_test_with_success, Ability, ActionClass, EventPattern, EventTiming, Restriction,
 };
-use game_core::card_registry::NativeEffectFn;
-use game_core::state::CardCode;
-use game_core::{place_in_threat_area, Cx, EngineOutcome, EvalContext};
 
 /// `ArkhamDB` code for Frozen in Fear.
 pub const CODE: &str = "01164";
 
-const TO_THREAT_AREA: &str = "01164:to-threat-area";
-
 #[must_use]
 pub fn abilities() -> Vec<Ability> {
     vec![
-        revelation(native(TO_THREAT_AREA)),
+        revelation(put_into_threat_area(CODE)),
         constant(restrict(Restriction::ExtraActionCost {
-            actions: ActionClassSet {
-                move_: true,
-                fight: true,
-                evade: true,
-            },
+            actions: vec![ActionClass::Move, ActionClass::Fight, ActionClass::Evade],
             first_each_round: true,
         })),
         on_event(
             EventPattern::EndOfTurn,
             EventTiming::After,
-            // Test willpower(3): on success discard Frozen in Fear; on
-            // failure do nothing.
-            skill_test_with_success(SkillKind::Willpower, 3, discard_self(), Effect::Seq(vec![])),
+            // Test willpower(3): on success discard Frozen in Fear.
+            skill_test_with_success(SkillKind::Willpower, 3, discard_self()),
         ),
     ]
-}
-
-/// Resolve this treachery's native-effect tag. Wired into the crate
-/// registry's `native_effect_for`.
-pub(crate) fn native_effect_for(tag: &str) -> Option<NativeEffectFn> {
-    (tag == TO_THREAT_AREA).then_some(to_threat_area as NativeEffectFn)
-}
-
-/// Revelation: put Frozen in Fear into the controller's threat area.
-fn to_threat_area(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
-    place_in_threat_area(cx, ctx.controller, CardCode::new(CODE));
-    EngineOutcome::Done
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use card_dsl::dsl::Trigger;
+    use card_dsl::dsl::{Effect, Trigger};
 
     #[test]
     fn abilities_are_threat_area_surcharge_and_end_of_turn_test() {
@@ -77,20 +55,21 @@ mod tests {
         assert_eq!(abilities.len(), 3);
 
         assert_eq!(abilities[0].trigger, Trigger::Revelation);
-        assert!(matches!(&abilities[0].effect, Effect::Native { tag } if tag == TO_THREAT_AREA));
+        assert!(matches!(&abilities[0].effect, Effect::PutIntoThreatArea { code } if code == CODE));
 
         assert_eq!(abilities[1].trigger, Trigger::Constant);
-        assert!(matches!(
-            &abilities[1].effect,
-            Effect::Restrict(Restriction::ExtraActionCost {
-                actions: ActionClassSet {
-                    move_: true,
-                    fight: true,
-                    evade: true
-                },
-                first_each_round: true,
-            })
-        ));
+        let Effect::Restrict(Restriction::ExtraActionCost {
+            actions,
+            first_each_round,
+        }) = &abilities[1].effect
+        else {
+            panic!("expected ExtraActionCost, got {:?}", abilities[1].effect);
+        };
+        assert_eq!(
+            actions,
+            &[ActionClass::Move, ActionClass::Fight, ActionClass::Evade]
+        );
+        assert!(first_each_round);
 
         assert!(matches!(
             &abilities[2].trigger,
@@ -111,9 +90,6 @@ mod tests {
         assert_eq!(*skill, SkillKind::Willpower);
         assert_eq!(*difficulty, 3);
         assert!(matches!(on_success.as_deref(), Some(Effect::DiscardSelf)));
-        assert!(matches!(**on_fail, Effect::Seq(ref v) if v.is_empty()));
-
-        assert!(native_effect_for(TO_THREAT_AREA).is_some());
-        assert!(native_effect_for("nope").is_none());
+        assert!(on_fail.is_none(), "no failure-side effect");
     }
 }

--- a/crates/cards/src/impls/treachery_01165.rs
+++ b/crates/cards/src/impls/treachery_01165.rs
@@ -8,47 +8,30 @@
 //!
 //! Persistent treachery: it has non-Revelation abilities (two constant
 //! `CannotPlay` restrictions and a forced self-discard), so
-//! `resolve_encounter_card` does not auto-discard it. The Revelation
-//! native places it in the controller's threat area; the `CannotPlay`
-//! restrictions are read by `play_card` via `play_is_prohibited`; the
-//! forced `Effect::DiscardSelf` fires on `RoundEnded` (resolving
-//! alongside the agenda's round-end forced effect via the dispatcher's
-//! deterministic multi-resolve).
+//! `resolve_encounter_card` does not auto-discard it. The Revelation uses
+//! the shared `Effect::PutIntoThreatArea`; the `CannotPlay` restrictions
+//! are read by `play_card` via `play_is_prohibited`; the forced
+//! `Effect::DiscardSelf` fires on `RoundEnded` (resolving alongside the
+//! agenda's round-end forced effect via the dispatcher's deterministic
+//! multi-resolve).
 
 use card_dsl::card_data::CardType;
 use card_dsl::dsl::{
-    constant, discard_self, native, on_event, restrict, revelation, Ability, EventPattern,
-    EventTiming, Restriction,
+    constant, discard_self, on_event, put_into_threat_area, restrict, revelation, Ability,
+    EventPattern, EventTiming, Restriction,
 };
-use game_core::card_registry::NativeEffectFn;
-use game_core::state::CardCode;
-use game_core::{place_in_threat_area, Cx, EngineOutcome, EvalContext};
 
 /// `ArkhamDB` code for Dissonant Voices.
 pub const CODE: &str = "01165";
 
-const TO_THREAT_AREA: &str = "01165:to-threat-area";
-
 #[must_use]
 pub fn abilities() -> Vec<Ability> {
     vec![
-        revelation(native(TO_THREAT_AREA)),
+        revelation(put_into_threat_area(CODE)),
         constant(restrict(Restriction::CannotPlay(CardType::Asset))),
         constant(restrict(Restriction::CannotPlay(CardType::Event))),
         on_event(EventPattern::RoundEnded, EventTiming::After, discard_self()),
     ]
-}
-
-/// Resolve this treachery's native-effect tag. Wired into the crate
-/// registry's `native_effect_for`.
-pub(crate) fn native_effect_for(tag: &str) -> Option<NativeEffectFn> {
-    (tag == TO_THREAT_AREA).then_some(to_threat_area as NativeEffectFn)
-}
-
-/// Revelation: put Dissonant Voices into the controller's threat area.
-fn to_threat_area(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
-    place_in_threat_area(cx, ctx.controller, CardCode::new(CODE));
-    EngineOutcome::Done
 }
 
 #[cfg(test)]
@@ -62,7 +45,7 @@ mod tests {
         assert_eq!(abilities.len(), 4);
 
         assert_eq!(abilities[0].trigger, Trigger::Revelation);
-        assert!(matches!(&abilities[0].effect, Effect::Native { tag } if tag == TO_THREAT_AREA));
+        assert!(matches!(&abilities[0].effect, Effect::PutIntoThreatArea { code } if code == CODE));
 
         assert_eq!(abilities[1].trigger, Trigger::Constant);
         assert!(matches!(
@@ -82,8 +65,5 @@ mod tests {
             }
         ));
         assert!(matches!(&abilities[3].effect, Effect::DiscardSelf));
-
-        assert!(native_effect_for(TO_THREAT_AREA).is_some());
-        assert!(native_effect_for("nope").is_none());
     }
 }

--- a/crates/cards/src/impls/treachery_01165.rs
+++ b/crates/cards/src/impls/treachery_01165.rs
@@ -1,0 +1,89 @@
+//! Dissonant Voices (The Gathering treachery, 01165).
+//!
+//! ```text
+//! Revelation - Put Dissonant Voices into play in your threat area.
+//! You cannot play assets or events.
+//! Forced - At the end of the round: Discard Dissonant Voices.
+//! ```
+//!
+//! Persistent treachery: it has non-Revelation abilities (two constant
+//! `CannotPlay` restrictions and a forced self-discard), so
+//! `resolve_encounter_card` does not auto-discard it. The Revelation
+//! native places it in the controller's threat area; the `CannotPlay`
+//! restrictions are read by `play_card` via `play_is_prohibited`; the
+//! forced `Effect::DiscardSelf` fires on `RoundEnded` (resolving
+//! alongside the agenda's round-end forced effect via the dispatcher's
+//! deterministic multi-resolve).
+
+use card_dsl::card_data::CardType;
+use card_dsl::dsl::{
+    constant, discard_self, native, on_event, restrict, revelation, Ability, EventPattern,
+    EventTiming, Restriction,
+};
+use game_core::card_registry::NativeEffectFn;
+use game_core::state::CardCode;
+use game_core::{place_in_threat_area, Cx, EngineOutcome, EvalContext};
+
+/// `ArkhamDB` code for Dissonant Voices.
+pub const CODE: &str = "01165";
+
+const TO_THREAT_AREA: &str = "01165:to-threat-area";
+
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![
+        revelation(native(TO_THREAT_AREA)),
+        constant(restrict(Restriction::CannotPlay(CardType::Asset))),
+        constant(restrict(Restriction::CannotPlay(CardType::Event))),
+        on_event(EventPattern::RoundEnded, EventTiming::After, discard_self()),
+    ]
+}
+
+/// Resolve this treachery's native-effect tag. Wired into the crate
+/// registry's `native_effect_for`.
+pub(crate) fn native_effect_for(tag: &str) -> Option<NativeEffectFn> {
+    (tag == TO_THREAT_AREA).then_some(to_threat_area as NativeEffectFn)
+}
+
+/// Revelation: put Dissonant Voices into the controller's threat area.
+fn to_threat_area(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
+    place_in_threat_area(cx, ctx.controller, CardCode::new(CODE));
+    EngineOutcome::Done
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use card_dsl::dsl::{Effect, Trigger};
+
+    #[test]
+    fn abilities_are_threat_area_two_play_bans_and_forced_discard() {
+        let abilities = abilities();
+        assert_eq!(abilities.len(), 4);
+
+        assert_eq!(abilities[0].trigger, Trigger::Revelation);
+        assert!(matches!(&abilities[0].effect, Effect::Native { tag } if tag == TO_THREAT_AREA));
+
+        assert_eq!(abilities[1].trigger, Trigger::Constant);
+        assert!(matches!(
+            &abilities[1].effect,
+            Effect::Restrict(Restriction::CannotPlay(CardType::Asset))
+        ));
+        assert!(matches!(
+            &abilities[2].effect,
+            Effect::Restrict(Restriction::CannotPlay(CardType::Event))
+        ));
+
+        assert!(matches!(
+            &abilities[3].trigger,
+            Trigger::OnEvent {
+                pattern: EventPattern::RoundEnded,
+                timing: EventTiming::After,
+            }
+        ));
+        assert!(matches!(&abilities[3].effect, Effect::DiscardSelf));
+
+        assert!(native_effect_for(TO_THREAT_AREA).is_some());
+        assert!(native_effect_for("nope").is_none());
+    }
+}

--- a/crates/cards/src/impls/treachery_01167.rs
+++ b/crates/cards/src/impls/treachery_01167.rs
@@ -83,6 +83,7 @@ mod tests {
         let Effect::SkillTest {
             skill,
             difficulty,
+            on_success,
             on_fail,
         } = &abilities[0].effect
         else {
@@ -90,6 +91,7 @@ mod tests {
         };
         assert_eq!(*skill, SkillKind::Willpower);
         assert_eq!(*difficulty, 4);
+        assert!(on_success.is_none(), "no success-side effect");
         assert!(matches!(**on_fail, Effect::Native { ref tag } if tag == CRYPT_CHILL_FAIL));
         assert!(native_effect_for(CRYPT_CHILL_FAIL).is_some());
         assert!(native_effect_for("nope").is_none());

--- a/crates/cards/src/impls/treachery_01167.rs
+++ b/crates/cards/src/impls/treachery_01167.rs
@@ -30,7 +30,8 @@ pub fn abilities() -> Vec<Ability> {
     vec![revelation(skill_test(
         SkillKind::Willpower,
         4,
-        native(CRYPT_CHILL_FAIL),
+        None,
+        Some(native(CRYPT_CHILL_FAIL)),
     ))]
 }
 

--- a/crates/cards/src/impls/treachery_01167.rs
+++ b/crates/cards/src/impls/treachery_01167.rs
@@ -92,7 +92,9 @@ mod tests {
         assert_eq!(*skill, SkillKind::Willpower);
         assert_eq!(*difficulty, 4);
         assert!(on_success.is_none(), "no success-side effect");
-        assert!(matches!(**on_fail, Effect::Native { ref tag } if tag == CRYPT_CHILL_FAIL));
+        assert!(
+            matches!(on_fail.as_deref(), Some(Effect::Native { tag }) if tag == CRYPT_CHILL_FAIL)
+        );
         assert!(native_effect_for(CRYPT_CHILL_FAIL).is_some());
         assert!(native_effect_for("nope").is_none());
     }

--- a/crates/cards/src/impls/treachery_01168.rs
+++ b/crates/cards/src/impls/treachery_01168.rs
@@ -1,0 +1,123 @@
+//! Obscuring Fog (The Gathering treachery, 01168).
+//!
+//! ```text
+//! Revelation - Attach to your location. Limit 1 per location.
+//! Attached location gets +2 shroud.
+//! Forced - After attached location is successfully investigated:
+//!   Discard Obscuring Fog.
+//! ```
+//!
+//! Persistent treachery: it has non-Revelation abilities (a constant
+//! `+2` shroud modifier and a forced self-discard), so
+//! `resolve_encounter_card` does not auto-discard it — the card owns its
+//! own disposition. The Revelation native enforces the printed "Limit 1
+//! per location": a second copy is discarded to the encounter discard
+//! instead of attaching (a treachery that cannot enter play is
+//! discarded). The `+2` shroud is read by `investigate` via
+//! `effective_shroud`; the forced discard runs `Effect::DiscardSelf`,
+//! which finds this attachment by the firing instance.
+
+use card_dsl::dsl::{
+    constant, discard_self, modify, native, on_event, revelation, Ability, EventPattern,
+    EventTiming, ModifierScope, Stat,
+};
+use game_core::card_registry::NativeEffectFn;
+use game_core::state::{CardCode, Zone};
+use game_core::{attach_to_location, Cx, EngineOutcome, EvalContext, Event};
+
+/// `ArkhamDB` code for Obscuring Fog.
+pub const CODE: &str = "01168";
+
+const LIMIT1_ATTACH: &str = "01168:limit1-attach";
+
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![
+        revelation(native(LIMIT1_ATTACH)),
+        constant(modify(Stat::Shroud, 2, ModifierScope::WhileInPlay)),
+        on_event(
+            EventPattern::AfterLocationInvestigated,
+            EventTiming::After,
+            discard_self(),
+        ),
+    ]
+}
+
+/// Resolve this treachery's native-effect tag. Wired into the crate
+/// registry's `native_effect_for`.
+pub(crate) fn native_effect_for(tag: &str) -> Option<NativeEffectFn> {
+    (tag == LIMIT1_ATTACH).then_some(limit1_attach as NativeEffectFn)
+}
+
+/// Revelation: attach to the controller's location, enforcing "Limit 1
+/// per location". A second copy on the same location is discarded to the
+/// encounter discard instead.
+fn limit1_attach(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
+    let Some(loc_id) = cx
+        .state
+        .investigators
+        .get(&ctx.controller)
+        .and_then(|inv| inv.current_location)
+    else {
+        return EngineOutcome::Rejected {
+            reason: "01168 limit1-attach: controller has no location".into(),
+        };
+    };
+    let already = cx
+        .state
+        .locations
+        .get(&loc_id)
+        .is_some_and(|loc| loc.attachments.iter().any(|c| c.code.as_str() == CODE));
+    if already {
+        // Limit 1 per location: this copy can't enter play, so discard it.
+        cx.state.encounter_discard.push(CardCode::new(CODE));
+        cx.events.push(Event::CardDiscarded {
+            investigator: ctx.controller,
+            code: CardCode::new(CODE),
+            from: Zone::LocationAttachment,
+        });
+        return EngineOutcome::Done;
+    }
+    attach_to_location(cx, loc_id, CardCode::new(CODE));
+    EngineOutcome::Done
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use card_dsl::dsl::{Effect, Trigger};
+
+    #[test]
+    fn abilities_are_attach_shroud_and_forced_discard() {
+        let abilities = abilities();
+        assert_eq!(abilities.len(), 3);
+
+        // Revelation = limit-1 attach native.
+        assert_eq!(abilities[0].trigger, Trigger::Revelation);
+        assert!(matches!(&abilities[0].effect, Effect::Native { tag } if tag == LIMIT1_ATTACH));
+
+        // Constant +2 shroud.
+        assert_eq!(abilities[1].trigger, Trigger::Constant);
+        assert!(matches!(
+            &abilities[1].effect,
+            Effect::Modify {
+                stat: Stat::Shroud,
+                delta: 2,
+                scope: ModifierScope::WhileInPlay
+            }
+        ));
+
+        // Forced: after attached location investigated -> discard self.
+        assert!(matches!(
+            &abilities[2].trigger,
+            Trigger::OnEvent {
+                pattern: EventPattern::AfterLocationInvestigated,
+                timing: EventTiming::After,
+            }
+        ));
+        assert!(matches!(&abilities[2].effect, Effect::DiscardSelf));
+
+        assert!(native_effect_for(LIMIT1_ATTACH).is_some());
+        assert!(native_effect_for("nope").is_none());
+    }
+}

--- a/crates/cards/tests/persistent_treachery.rs
+++ b/crates/cards/tests/persistent_treachery.rs
@@ -6,13 +6,16 @@
 
 use std::sync::Once;
 
-use game_core::action::EngineRecord;
-use game_core::state::{CardCode, InvestigatorId, LocationId};
-use game_core::test_support::{
-    drive, fire_forced_after_location_investigated, test_investigator, test_location,
-    GameStateBuilder, ScriptedResolver,
+use game_core::action::{EngineRecord, PlayerAction};
+use game_core::state::{
+    Agenda, CardCode, CardInPlay, CardInstanceId, EnemyId, InvestigatorId, Location, LocationId,
+    Phase,
 };
-use game_core::{Action, EngineOutcome};
+use game_core::test_support::{
+    drive, fire_forced_after_location_investigated, fire_forced_on_round_end, test_enemy,
+    test_investigator, test_location, GameStateBuilder, ScriptedResolver,
+};
+use game_core::{apply, Action, EngineOutcome};
 
 static INSTALL: Once = Once::new();
 
@@ -86,6 +89,117 @@ fn obscuring_fog_attaches_raises_shroud_and_discards_on_investigate() {
         "Obscuring Fog discards after its location is investigated",
     );
     assert!(state.encounter_discard.contains(&CardCode::new("01168")));
+}
+
+// ---- Dissonant Voices (01165) --------------------------------------
+
+#[test]
+fn dissonant_voices_enters_threat_area_and_discards_on_round_end() {
+    install_registry();
+
+    let result = reveal_top(board_with("01165"));
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    let inv = &result.state.investigators[&InvestigatorId(1)];
+    assert_eq!(inv.threat_area.len(), 1, "Dissonant Voices in threat area");
+    assert_eq!(inv.threat_area[0].code.as_str(), "01165");
+    assert!(!result.state.encounter_discard.contains(&CardCode::new("01165")));
+
+    // Forced — at the end of the round, discard Dissonant Voices.
+    let mut state = result.state;
+    let mut events = Vec::new();
+    let outcome = fire_forced_on_round_end(&mut state, &mut events);
+    assert_eq!(outcome, EngineOutcome::Done);
+    assert!(
+        state.investigators[&InvestigatorId(1)].threat_area.is_empty(),
+        "Dissonant Voices discards at end of round",
+    );
+    assert!(state.encounter_discard.contains(&CardCode::new("01165")));
+}
+
+#[test]
+fn dissonant_voices_forbids_playing_an_asset() {
+    install_registry();
+    // Investigator mid-investigation with a playable asset (Holy Rosary,
+    // 01059) in hand and Dissonant Voices in their threat area.
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(LocationId(101));
+    inv.hand = vec![CardCode::new("01059")];
+    inv.threat_area
+        .push(CardInPlay::enter_play(CardCode::new("01165"), CardInstanceId(0)));
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(inv)
+        .with_active_investigator(InvestigatorId(1))
+        .with_location(test_location(101, "Study"))
+        .build();
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: InvestigatorId(1),
+            hand_index: 0,
+        }),
+    );
+    assert!(
+        matches!(result.outcome, EngineOutcome::Rejected { .. }),
+        "Dissonant Voices forbids playing assets; got {:?}",
+        result.outcome,
+    );
+    // Validate-first: the asset stays in hand, nothing entered play.
+    let inv = &result.state.investigators[&InvestigatorId(1)];
+    assert_eq!(inv.hand, vec![CardCode::new("01059")]);
+    assert!(inv.cards_in_play.is_empty());
+}
+
+#[test]
+fn dissonant_voices_round_end_coexists_with_agenda_01107_doom() {
+    install_registry();
+    // Both Dissonant Voices (threat area) and agenda 01107 carry a
+    // RoundEnded forced ability. They must resolve together (deterministic
+    // multi-resolve), not reject: the agenda places doom per ghoul in the
+    // Hallway/Parlor, and Dissonant Voices discards itself.
+    let loc =
+        |id, code: &str, name| Location::new(LocationId(id), CardCode::new(code), name, 1, 0);
+    let mut inv = test_investigator(1);
+    inv.threat_area
+        .push(CardInPlay::enter_play(CardCode::new("01165"), CardInstanceId(0)));
+    let mut state = GameStateBuilder::new()
+        .with_investigator(inv)
+        .with_turn_order([InvestigatorId(1)])
+        .with_location(loc(2, "01112", "Hallway"))
+        .with_location(loc(5, "01115", "Parlor"))
+        .build();
+    let mut ghoul = test_enemy(1, "Ghoul");
+    ghoul.traits = vec!["Monster".into(), "Ghoul".into()];
+    ghoul.current_location = Some(LocationId(2)); // Hallway
+    state.enemies.insert(EnemyId(1), ghoul);
+    state.agenda_deck = vec![Agenda {
+        code: CardCode::new("01107"),
+        doom_threshold: 10,
+        resolution: None,
+    }];
+    state.agenda_index = 0;
+
+    let mut events = Vec::new();
+    let outcome = fire_forced_on_round_end(&mut state, &mut events);
+    assert_eq!(
+        outcome,
+        EngineOutcome::Done,
+        "two simultaneous RoundEnded forced triggers resolve in order, not reject",
+    );
+    assert_eq!(
+        state.agenda_deck[0_usize].doom_threshold, 10,
+        "doom_threshold unchanged (sanity)",
+    );
+    assert!(
+        state.agenda_doom >= 1,
+        "agenda 01107 placed doom for the Ghoul in the Hallway; agenda_doom = {}",
+        state.agenda_doom,
+    );
+    assert!(
+        state.investigators[&InvestigatorId(1)].threat_area.is_empty(),
+        "Dissonant Voices also discarded in the same round-end resolution",
+    );
 }
 
 #[test]

--- a/crates/cards/tests/persistent_treachery.rs
+++ b/crates/cards/tests/persistent_treachery.rs
@@ -8,8 +8,8 @@ use std::sync::Once;
 
 use game_core::action::{EngineRecord, PlayerAction};
 use game_core::state::{
-    Agenda, CardCode, CardInPlay, CardInstanceId, EnemyId, InvestigatorId, Location, LocationId,
-    Phase,
+    Agenda, CardCode, CardInPlay, CardInstanceId, ChaosToken, EnemyId, InvestigatorId, Location,
+    LocationId, Phase,
 };
 use game_core::test_support::{
     drive, fire_forced_after_location_investigated, fire_forced_on_round_end, test_enemy,
@@ -200,6 +200,114 @@ fn dissonant_voices_round_end_coexists_with_agenda_01107_doom() {
         state.investigators[&InvestigatorId(1)].threat_area.is_empty(),
         "Dissonant Voices also discarded in the same round-end resolution",
     );
+}
+
+// ---- Frozen in Fear (01164) ----------------------------------------
+
+#[test]
+fn frozen_in_fear_surcharges_first_move_each_round_only() {
+    install_registry();
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(LocationId(1));
+    inv.threat_area
+        .push(CardInPlay::enter_play(CardCode::new("01164"), CardInstanceId(0)));
+    let mut state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(inv)
+        .with_active_investigator(InvestigatorId(1))
+        .with_location(test_location(1, "A"))
+        .with_location(test_location(2, "B"))
+        .build();
+    state.connect(LocationId(1), LocationId(2));
+    assert_eq!(state.investigators[&InvestigatorId(1)].actions_remaining, 3);
+
+    // First move this round costs 2 (base 1 + surcharge 1): 3 → 1.
+    let r = apply(
+        state,
+        Action::Player(PlayerAction::Move {
+            investigator: InvestigatorId(1),
+            destination: LocationId(2),
+        }),
+    );
+    assert_eq!(r.outcome, EngineOutcome::Done);
+    assert_eq!(
+        r.state.investigators[&InvestigatorId(1)].actions_remaining, 1,
+        "first move/fight/evade each round costs +1 action",
+    );
+
+    // Second move this round costs 1 (surcharge already spent): 1 → 0.
+    let r = apply(
+        r.state,
+        Action::Player(PlayerAction::Move {
+            investigator: InvestigatorId(1),
+            destination: LocationId(1),
+        }),
+    );
+    assert_eq!(r.outcome, EngineOutcome::Done);
+    assert_eq!(
+        r.state.investigators[&InvestigatorId(1)].actions_remaining, 0,
+        "subsequent actions that round cost the normal 1",
+    );
+}
+
+/// Build a two-investigator Investigation-phase board with Frozen in Fear
+/// in investigator 1's threat area and a single rigged chaos token.
+fn frozen_in_fear_board(token: ChaosToken) -> game_core::GameState {
+    let mut inv1 = test_investigator(1);
+    inv1.threat_area
+        .push(CardInPlay::enter_play(CardCode::new("01164"), CardInstanceId(0)));
+    let mut state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(inv1)
+        .with_investigator(test_investigator(2))
+        .with_active_investigator(InvestigatorId(1))
+        .with_turn_order([InvestigatorId(1), InvestigatorId(2)])
+        .build();
+    state.chaos_bag.tokens = vec![token];
+    state
+}
+
+fn end_turn_committing_nothing(state: game_core::GameState) -> game_core::ApplyResult {
+    let mut resolver = ScriptedResolver::new();
+    resolver.commit_cards(&[]);
+    drive(state, Action::Player(PlayerAction::EndTurn), resolver)
+}
+
+#[test]
+fn frozen_in_fear_end_of_turn_success_discards_and_turn_resumes() {
+    install_registry();
+    // Willpower 3 + Numeric(0) = 3 vs difficulty 3 → success.
+    let r = end_turn_committing_nothing(frozen_in_fear_board(ChaosToken::Numeric(0)));
+    assert_eq!(r.outcome, EngineOutcome::Done);
+    assert!(
+        r.state.investigators[&InvestigatorId(1)].threat_area.is_empty(),
+        "succeeded willpower(3) test discards Frozen in Fear",
+    );
+    assert!(r.state.encounter_discard.contains(&CardCode::new("01164")));
+    // The suspending end-of-turn test did not strand the turn: rotation ran.
+    assert_eq!(
+        r.state.active_investigator,
+        Some(InvestigatorId(2)),
+        "end_turn resumed after the test and rotated to investigator 2",
+    );
+    assert!(r.state.pending_end_turn.is_none());
+}
+
+#[test]
+fn frozen_in_fear_end_of_turn_failure_keeps_card_but_turn_still_resumes() {
+    install_registry();
+    // Willpower 3 + Numeric(-1) = 2 vs difficulty 3 → fail.
+    let r = end_turn_committing_nothing(frozen_in_fear_board(ChaosToken::Numeric(-1)));
+    assert_eq!(r.outcome, EngineOutcome::Done);
+    assert_eq!(
+        r.state.investigators[&InvestigatorId(1)].threat_area.len(),
+        1,
+        "failed test leaves Frozen in Fear in the threat area",
+    );
+    assert!(!r.state.encounter_discard.contains(&CardCode::new("01164")));
+    // Turn still progresses regardless of the test outcome.
+    assert_eq!(r.state.active_investigator, Some(InvestigatorId(2)));
+    assert!(r.state.pending_end_turn.is_none());
 }
 
 #[test]

--- a/crates/cards/tests/persistent_treachery.rs
+++ b/crates/cards/tests/persistent_treachery.rs
@@ -1,0 +1,114 @@
+//! Integration: The Gathering's three persistent treacheries (C4c, #235)
+//! resolved through the real `cards` registry — they stay in play, enforce
+//! their constant restriction, and discard at a forced timing point. Own
+//! process so it can install the process-global registry against the real
+//! corpus.
+
+use std::sync::Once;
+
+use game_core::action::EngineRecord;
+use game_core::state::{CardCode, InvestigatorId, LocationId};
+use game_core::test_support::{
+    drive, fire_forced_after_location_investigated, test_investigator, test_location,
+    GameStateBuilder, ScriptedResolver,
+};
+use game_core::{Action, EngineOutcome};
+
+static INSTALL: Once = Once::new();
+
+fn install_registry() {
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// Reveal the top encounter card for investigator 1, committing no cards
+/// at any skill-test commit window that opens.
+fn reveal_top(state: game_core::GameState) -> game_core::ApplyResult {
+    let mut resolver = ScriptedResolver::new();
+    resolver.commit_cards(&[]);
+    drive(
+        state,
+        Action::Engine(EngineRecord::EncounterCardRevealed {
+            investigator: InvestigatorId(1),
+        }),
+        resolver,
+    )
+}
+
+/// One investigator at location 20 (printed shroud 2), with `treachery`
+/// on top of the encounter deck.
+fn board_with(treachery: &str) -> game_core::GameState {
+    let mut state = GameStateBuilder::new()
+        .with_investigator_at(test_investigator(1), LocationId(20))
+        .with_location(test_location(20, "Here"))
+        .with_turn_order([InvestigatorId(1)])
+        .build();
+    state.encounter_deck.push_back(CardCode::new(treachery));
+    state
+}
+
+#[test]
+fn obscuring_fog_attaches_raises_shroud_and_discards_on_investigate() {
+    install_registry();
+
+    // Reveal: attaches to the investigator's location, not discarded.
+    let result = reveal_top(board_with("01168"));
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    let loc = &result.state.locations[&LocationId(20)];
+    assert_eq!(loc.attachments.len(), 1, "Obscuring Fog attached");
+    assert_eq!(loc.attachments[0].code.as_str(), "01168");
+    assert!(
+        !result.state.encounter_discard.contains(&CardCode::new("01168")),
+        "a persistent treachery is not auto-discarded after its Revelation",
+    );
+
+    // +2 shroud: printed 2 → effective 4.
+    assert_eq!(
+        game_core::effective_shroud(&cards::REGISTRY, loc),
+        4,
+        "attached Obscuring Fog grants +2 shroud (printed 2)",
+    );
+
+    // Forced — after the attached location is successfully investigated,
+    // discard Obscuring Fog.
+    let mut state = result.state;
+    let mut events = Vec::new();
+    let outcome = fire_forced_after_location_investigated(
+        &mut state,
+        &mut events,
+        InvestigatorId(1),
+        LocationId(20),
+    );
+    assert_eq!(outcome, EngineOutcome::Done);
+    assert!(
+        state.locations[&LocationId(20)].attachments.is_empty(),
+        "Obscuring Fog discards after its location is investigated",
+    );
+    assert!(state.encounter_discard.contains(&CardCode::new("01168")));
+}
+
+#[test]
+fn obscuring_fog_limit_one_per_location_discards_the_second_copy() {
+    install_registry();
+
+    // First copy attaches.
+    let result = reveal_top(board_with("01168"));
+    let mut state = result.state;
+    assert_eq!(state.locations[&LocationId(20)].attachments.len(), 1);
+
+    // Second copy revealed at the same location: limit 1 → discarded, not
+    // attached.
+    state.encounter_deck.push_back(CardCode::new("01168"));
+    let result = reveal_top(state);
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_eq!(
+        result.state.locations[&LocationId(20)].attachments.len(),
+        1,
+        "limit 1 per location: the second copy does not attach",
+    );
+    assert!(
+        result.state.encounter_discard.contains(&CardCode::new("01168")),
+        "the over-limit copy is discarded",
+    );
+}

--- a/crates/cards/tests/persistent_treachery.rs
+++ b/crates/cards/tests/persistent_treachery.rs
@@ -62,7 +62,10 @@ fn obscuring_fog_attaches_raises_shroud_and_discards_on_investigate() {
     assert_eq!(loc.attachments.len(), 1, "Obscuring Fog attached");
     assert_eq!(loc.attachments[0].code.as_str(), "01168");
     assert!(
-        !result.state.encounter_discard.contains(&CardCode::new("01168")),
+        !result
+            .state
+            .encounter_discard
+            .contains(&CardCode::new("01168")),
         "a persistent treachery is not auto-discarded after its Revelation",
     );
 
@@ -102,7 +105,10 @@ fn dissonant_voices_enters_threat_area_and_discards_on_round_end() {
     let inv = &result.state.investigators[&InvestigatorId(1)];
     assert_eq!(inv.threat_area.len(), 1, "Dissonant Voices in threat area");
     assert_eq!(inv.threat_area[0].code.as_str(), "01165");
-    assert!(!result.state.encounter_discard.contains(&CardCode::new("01165")));
+    assert!(!result
+        .state
+        .encounter_discard
+        .contains(&CardCode::new("01165")));
 
     // Forced — at the end of the round, discard Dissonant Voices.
     let mut state = result.state;
@@ -110,7 +116,9 @@ fn dissonant_voices_enters_threat_area_and_discards_on_round_end() {
     let outcome = fire_forced_on_round_end(&mut state, &mut events);
     assert_eq!(outcome, EngineOutcome::Done);
     assert!(
-        state.investigators[&InvestigatorId(1)].threat_area.is_empty(),
+        state.investigators[&InvestigatorId(1)]
+            .threat_area
+            .is_empty(),
         "Dissonant Voices discards at end of round",
     );
     assert!(state.encounter_discard.contains(&CardCode::new("01165")));
@@ -124,8 +132,10 @@ fn dissonant_voices_forbids_playing_an_asset() {
     let mut inv = test_investigator(1);
     inv.current_location = Some(LocationId(101));
     inv.hand = vec![CardCode::new("01059")];
-    inv.threat_area
-        .push(CardInPlay::enter_play(CardCode::new("01165"), CardInstanceId(0)));
+    inv.threat_area.push(CardInPlay::enter_play(
+        CardCode::new("01165"),
+        CardInstanceId(0),
+    ));
     let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_investigator(inv)
@@ -158,11 +168,12 @@ fn dissonant_voices_round_end_coexists_with_agenda_01107_doom() {
     // RoundEnded forced ability. They must resolve together (deterministic
     // multi-resolve), not reject: the agenda places doom per ghoul in the
     // Hallway/Parlor, and Dissonant Voices discards itself.
-    let loc =
-        |id, code: &str, name| Location::new(LocationId(id), CardCode::new(code), name, 1, 0);
+    let loc = |id, code: &str, name| Location::new(LocationId(id), CardCode::new(code), name, 1, 0);
     let mut inv = test_investigator(1);
-    inv.threat_area
-        .push(CardInPlay::enter_play(CardCode::new("01165"), CardInstanceId(0)));
+    inv.threat_area.push(CardInPlay::enter_play(
+        CardCode::new("01165"),
+        CardInstanceId(0),
+    ));
     let mut state = GameStateBuilder::new()
         .with_investigator(inv)
         .with_turn_order([InvestigatorId(1)])
@@ -197,7 +208,9 @@ fn dissonant_voices_round_end_coexists_with_agenda_01107_doom() {
         state.agenda_doom,
     );
     assert!(
-        state.investigators[&InvestigatorId(1)].threat_area.is_empty(),
+        state.investigators[&InvestigatorId(1)]
+            .threat_area
+            .is_empty(),
         "Dissonant Voices also discarded in the same round-end resolution",
     );
 }
@@ -209,8 +222,10 @@ fn frozen_in_fear_surcharges_first_move_each_round_only() {
     install_registry();
     let mut inv = test_investigator(1);
     inv.current_location = Some(LocationId(1));
-    inv.threat_area
-        .push(CardInPlay::enter_play(CardCode::new("01164"), CardInstanceId(0)));
+    inv.threat_area.push(CardInPlay::enter_play(
+        CardCode::new("01164"),
+        CardInstanceId(0),
+    ));
     let mut state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_investigator(inv)
@@ -231,7 +246,8 @@ fn frozen_in_fear_surcharges_first_move_each_round_only() {
     );
     assert_eq!(r.outcome, EngineOutcome::Done);
     assert_eq!(
-        r.state.investigators[&InvestigatorId(1)].actions_remaining, 1,
+        r.state.investigators[&InvestigatorId(1)].actions_remaining,
+        1,
         "first move/fight/evade each round costs +1 action",
     );
 
@@ -245,7 +261,8 @@ fn frozen_in_fear_surcharges_first_move_each_round_only() {
     );
     assert_eq!(r.outcome, EngineOutcome::Done);
     assert_eq!(
-        r.state.investigators[&InvestigatorId(1)].actions_remaining, 0,
+        r.state.investigators[&InvestigatorId(1)].actions_remaining,
+        0,
         "subsequent actions that round cost the normal 1",
     );
 }
@@ -254,8 +271,10 @@ fn frozen_in_fear_surcharges_first_move_each_round_only() {
 /// in investigator 1's threat area and a single rigged chaos token.
 fn frozen_in_fear_board(token: ChaosToken) -> game_core::GameState {
     let mut inv1 = test_investigator(1);
-    inv1.threat_area
-        .push(CardInPlay::enter_play(CardCode::new("01164"), CardInstanceId(0)));
+    inv1.threat_area.push(CardInPlay::enter_play(
+        CardCode::new("01164"),
+        CardInstanceId(0),
+    ));
     let mut state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_investigator(inv1)
@@ -280,7 +299,9 @@ fn frozen_in_fear_end_of_turn_success_discards_and_turn_resumes() {
     let r = end_turn_committing_nothing(frozen_in_fear_board(ChaosToken::Numeric(0)));
     assert_eq!(r.outcome, EngineOutcome::Done);
     assert!(
-        r.state.investigators[&InvestigatorId(1)].threat_area.is_empty(),
+        r.state.investigators[&InvestigatorId(1)]
+            .threat_area
+            .is_empty(),
         "succeeded willpower(3) test discards Frozen in Fear",
     );
     assert!(r.state.encounter_discard.contains(&CardCode::new("01164")));
@@ -330,7 +351,10 @@ fn obscuring_fog_limit_one_per_location_discards_the_second_copy() {
         "limit 1 per location: the second copy does not attach",
     );
     assert!(
-        result.state.encounter_discard.contains(&CardCode::new("01168")),
+        result
+            .state
+            .encounter_discard
+            .contains(&CardCode::new("01168")),
         "the over-limit copy is discarded",
     );
 }

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -199,13 +199,6 @@ pub(super) fn move_action(
             .into(),
         };
     }
-    let (cost, surcharge_sources) =
-        action_cost_with_surcharge(cx, investigator, crate::dsl::ActionClass::Move);
-    if inv.actions_remaining < cost {
-        return EngineOutcome::Rejected {
-            reason: format!("Move requires {cost} action point(s)").into(),
-        };
-    }
     let Some(from) = inv.current_location else {
         return EngineOutcome::Rejected {
             reason: format!("Move: {investigator:?} has no current_location to move from").into(),
@@ -239,9 +232,11 @@ pub(super) fn move_action(
         };
     }
 
-    // Mutate-second.
-    spend_actions(cx, investigator, cost);
-    mark_surcharge_spent(cx, investigator, surcharge_sources);
+    // Mutate-second. Charge the action (base 1 + surcharge) last — after
+    // every move precondition has passed — so a rejected move spends nothing.
+    if let Err(rejected) = charge_action(cx, investigator, crate::dsl::ActionClass::Move, "Move") {
+        return rejected;
+    }
 
     // Move triggers attacks of opportunity from each ready engaged
     // enemy. Per the Rules Reference, this happens BEFORE the move
@@ -409,16 +404,19 @@ pub(super) fn spend_actions(cx: &mut Cx, investigator: InvestigatorId, n: u8) {
     });
 }
 
-/// Compute the total action cost (base 1 + surcharge) for `investigator`
-/// performing `action_class`, returning the cost and the surcharge source
-/// instances to mark spent on commit. Read-only — the marking happens in
-/// the handler's mutate phase. Falls back to cost 1 with nothing to mark
-/// when no registry is installed (bare unit tests).
-fn action_cost_with_surcharge(
-    cx: &Cx,
+/// Charge the action cost for `action_class` (base 1 + any Frozen-in-Fear
+/// `ExtraActionCost` surcharge): validate-first, returning `Err(Rejected)`
+/// without mutating if the investigator lacks the points. On `Ok` the
+/// actions are spent and the surcharge sources are marked spent for the
+/// round. **Mutates on success**, so call it after every other precondition
+/// for the action has passed. Falls back to cost 1 with no surcharge when
+/// no registry is installed (bare unit tests). Shared by move/fight/evade.
+fn charge_action(
+    cx: &mut Cx,
     investigator: InvestigatorId,
     action_class: crate::dsl::ActionClass,
-) -> (u8, Vec<crate::state::CardInstanceId>) {
+    action_name: &str,
+) -> Result<(), EngineOutcome> {
     let (extra, to_mark) = match crate::card_registry::current() {
         Some(reg) => crate::engine::evaluator::pending_action_surcharge(
             cx.state,
@@ -428,22 +426,22 @@ fn action_cost_with_surcharge(
         ),
         None => (0, Vec::new()),
     };
-    (1u8.saturating_add(extra), to_mark)
-}
-
-/// Mark surcharge source instances spent for this round (called in the
-/// mutate phase after the action commits).
-fn mark_surcharge_spent(
-    cx: &mut Cx,
-    investigator: InvestigatorId,
-    to_mark: Vec<crate::state::CardInstanceId>,
-) {
-    if to_mark.is_empty() {
-        return;
+    let cost = 1u8.saturating_add(extra);
+    let remaining = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .map_or(0, |inv| inv.actions_remaining);
+    if remaining < cost {
+        return Err(EngineOutcome::Rejected {
+            reason: format!("{action_name} requires {cost} action point(s)").into(),
+        });
     }
+    spend_actions(cx, investigator, cost);
     if let Some(inv) = cx.state.investigators.get_mut(&investigator) {
         inv.action_surcharge_spent_this_round.extend(to_mark);
     }
+    Ok(())
 }
 
 /// Handler for [`PlayerAction::Fight`].
@@ -473,15 +471,10 @@ pub(super) fn fight(cx: &mut Cx, investigator: InvestigatorId, enemy_id: EnemyId
         }
         Err(rejected) => return rejected,
     };
-    let (cost, surcharge_sources) =
-        action_cost_with_surcharge(cx, investigator, crate::dsl::ActionClass::Fight);
-    if cx.state.investigators[&investigator].actions_remaining < cost {
-        return EngineOutcome::Rejected {
-            reason: format!("Fight requires {cost} action point(s)").into(),
-        };
+    if let Err(rejected) = charge_action(cx, investigator, crate::dsl::ActionClass::Fight, "Fight")
+    {
+        return rejected;
     }
-    spend_actions(cx, investigator, cost);
-    mark_surcharge_spent(cx, investigator, surcharge_sources);
     super::skill_test::start_skill_test(
         cx,
         investigator,
@@ -516,15 +509,10 @@ pub(super) fn evade(cx: &mut Cx, investigator: InvestigatorId, enemy_id: EnemyId
         }
         Err(rejected) => return rejected,
     };
-    let (cost, surcharge_sources) =
-        action_cost_with_surcharge(cx, investigator, crate::dsl::ActionClass::Evade);
-    if cx.state.investigators[&investigator].actions_remaining < cost {
-        return EngineOutcome::Rejected {
-            reason: format!("Evade requires {cost} action point(s)").into(),
-        };
+    if let Err(rejected) = charge_action(cx, investigator, crate::dsl::ActionClass::Evade, "Evade")
+    {
+        return rejected;
     }
-    spend_actions(cx, investigator, cost);
-    mark_surcharge_spent(cx, investigator, surcharge_sources);
     super::skill_test::start_skill_test(
         cx,
         investigator,

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -137,6 +137,8 @@ pub(super) fn investigate(cx: &mut Cx, investigator: InvestigatorId) -> EngineOu
         difficulty,
         SkillTestFollowUp::Investigate,
         None,
+        None,
+        None,
     )
 }
 
@@ -197,9 +199,11 @@ pub(super) fn move_action(
             .into(),
         };
     }
-    if inv.actions_remaining < 1 {
+    let (cost, surcharge_sources) =
+        action_cost_with_surcharge(cx, investigator, crate::dsl::ActionClass::Move);
+    if inv.actions_remaining < cost {
         return EngineOutcome::Rejected {
-            reason: "Move requires at least 1 action point".into(),
+            reason: format!("Move requires {cost} action point(s)").into(),
         };
     }
     let Some(from) = inv.current_location else {
@@ -236,7 +240,8 @@ pub(super) fn move_action(
     }
 
     // Mutate-second.
-    spend_one_action(cx, investigator);
+    spend_actions(cx, investigator, cost);
+    mark_surcharge_spent(cx, investigator, surcharge_sources);
 
     // Move triggers attacks of opportunity from each ready engaged
     // enemy. Per the Rules Reference, this happens BEFORE the move
@@ -384,17 +389,61 @@ fn validate_engaged_action<'a>(
 /// `ActionsRemainingChanged`. Caller has already validated that
 /// `actions_remaining >= 1`.
 pub(super) fn spend_one_action(cx: &mut Cx, investigator: InvestigatorId) {
+    spend_actions(cx, investigator, 1);
+}
+
+/// Spend `n` action points from the active investigator and emit a single
+/// `ActionsRemainingChanged`. Caller has already validated that
+/// `actions_remaining >= n`.
+pub(super) fn spend_actions(cx: &mut Cx, investigator: InvestigatorId, n: u8) {
     let inv = cx
         .state
         .investigators
         .get_mut(&investigator)
-        .expect("investigator existence checked before spend_one_action");
-    let new_count = inv.actions_remaining - 1;
+        .expect("investigator existence checked before spend_actions");
+    let new_count = inv.actions_remaining - n;
     inv.actions_remaining = new_count;
     cx.events.push(Event::ActionsRemainingChanged {
         investigator,
         new_count,
     });
+}
+
+/// Compute the total action cost (base 1 + surcharge) for `investigator`
+/// performing `action_class`, returning the cost and the surcharge source
+/// instances to mark spent on commit. Read-only — the marking happens in
+/// the handler's mutate phase. Falls back to cost 1 with nothing to mark
+/// when no registry is installed (bare unit tests).
+fn action_cost_with_surcharge(
+    cx: &Cx,
+    investigator: InvestigatorId,
+    action_class: crate::dsl::ActionClass,
+) -> (u8, Vec<crate::state::CardInstanceId>) {
+    let (extra, to_mark) = match crate::card_registry::current() {
+        Some(reg) => crate::engine::evaluator::pending_action_surcharge(
+            cx.state,
+            reg,
+            investigator,
+            action_class,
+        ),
+        None => (0, Vec::new()),
+    };
+    (1u8.saturating_add(extra), to_mark)
+}
+
+/// Mark surcharge source instances spent for this round (called in the
+/// mutate phase after the action commits).
+fn mark_surcharge_spent(
+    cx: &mut Cx,
+    investigator: InvestigatorId,
+    to_mark: Vec<crate::state::CardInstanceId>,
+) {
+    if to_mark.is_empty() {
+        return;
+    }
+    if let Some(inv) = cx.state.investigators.get_mut(&investigator) {
+        inv.action_surcharge_spent_this_round.extend(to_mark);
+    }
 }
 
 /// Handler for [`PlayerAction::Fight`].
@@ -424,7 +473,15 @@ pub(super) fn fight(cx: &mut Cx, investigator: InvestigatorId, enemy_id: EnemyId
         }
         Err(rejected) => return rejected,
     };
-    spend_one_action(cx, investigator);
+    let (cost, surcharge_sources) =
+        action_cost_with_surcharge(cx, investigator, crate::dsl::ActionClass::Fight);
+    if cx.state.investigators[&investigator].actions_remaining < cost {
+        return EngineOutcome::Rejected {
+            reason: format!("Fight requires {cost} action point(s)").into(),
+        };
+    }
+    spend_actions(cx, investigator, cost);
+    mark_surcharge_spent(cx, investigator, surcharge_sources);
     super::skill_test::start_skill_test(
         cx,
         investigator,
@@ -432,6 +489,8 @@ pub(super) fn fight(cx: &mut Cx, investigator: InvestigatorId, enemy_id: EnemyId
         SkillTestKind::Fight,
         fight_difficulty,
         SkillTestFollowUp::Fight { enemy: enemy_id },
+        None,
+        None,
         None,
     )
 }
@@ -457,7 +516,15 @@ pub(super) fn evade(cx: &mut Cx, investigator: InvestigatorId, enemy_id: EnemyId
         }
         Err(rejected) => return rejected,
     };
-    spend_one_action(cx, investigator);
+    let (cost, surcharge_sources) =
+        action_cost_with_surcharge(cx, investigator, crate::dsl::ActionClass::Evade);
+    if cx.state.investigators[&investigator].actions_remaining < cost {
+        return EngineOutcome::Rejected {
+            reason: format!("Evade requires {cost} action point(s)").into(),
+        };
+    }
+    spend_actions(cx, investigator, cost);
+    mark_surcharge_spent(cx, investigator, surcharge_sources);
     super::skill_test::start_skill_test(
         cx,
         investigator,
@@ -465,6 +532,8 @@ pub(super) fn evade(cx: &mut Cx, investigator: InvestigatorId, enemy_id: EnemyId
         SkillTestKind::Evade,
         evade_difficulty,
         SkillTestFollowUp::Evade { enemy: enemy_id },
+        None,
+        None,
         None,
     )
 }

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -94,8 +94,15 @@ pub(super) fn investigate(cx: &mut Cx, investigator: InvestigatorId) -> EngineOu
         };
     }
     // Shroud is u8 in state but skill-test difficulty is i8. Saturate
-    // at i8::MAX for the absurd case; realistic shrouds are 0–6.
-    let difficulty = i8::try_from(location.shroud).unwrap_or(i8::MAX);
+    // at i8::MAX for the absurd case; realistic shrouds are 0–6. The
+    // *effective* shroud folds in location-attachment modifiers (Obscuring
+    // Fog 01168's +2); fall back to the printed value when no registry is
+    // installed (bare unit tests).
+    let shroud = match crate::card_registry::current() {
+        Some(reg) => crate::engine::evaluator::effective_shroud(reg, location),
+        None => location.shroud,
+    };
+    let difficulty = i8::try_from(shroud).unwrap_or(i8::MAX);
 
     // Mutate-second: spend the action, fire AoO, then resolve the
     // test. Investigate is NOT on the AoO-exempt list (only Fight,

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -469,11 +469,24 @@ pub(super) fn play_card(
         destination,
         abilities,
         is_fast: _,
-        card_type: _,
+        card_type,
     } = match super::reaction_windows::check_play_card(cx.state, investigator, hand_index) {
         Ok(r) => r,
         Err(reason) => return EngineOutcome::Rejected { reason },
     };
+    // Validate-first: a constant restriction may forbid playing this card
+    // type (Dissonant Voices 01165: "You cannot play assets or events").
+    if let Some(reg) = crate::card_registry::current() {
+        if crate::engine::evaluator::play_is_prohibited(cx.state, reg, investigator, card_type) {
+            return EngineOutcome::Rejected {
+                reason: format!(
+                    "PlayCard: {investigator:?} cannot play a {card_type:?} \
+                     (a constant restriction forbids it)"
+                )
+                .into(),
+            };
+        }
+    }
     // The code is re-read from state here so we don't pass it through
     // the result (avoiding the lifetime question). The validator already
     // confirmed the hand_index is in bounds and the investigator exists.

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -106,6 +106,39 @@ pub(super) fn encounter_card_revealed(cx: &mut Cx, investigator: InvestigatorId)
 /// encounter deck can resolve the drawn card faithfully — agenda 01106's
 /// reverse draws the dug-up `Ghoul` enemy through here. Requires an
 /// installed card registry (rejects otherwise).
+/// A treachery is **persistent** (stays in play after its Revelation,
+/// owning its own disposition) iff it has at least one ability whose
+/// trigger is not [`Trigger::Revelation`] — the ongoing `Constant`
+/// restriction / `OnEvent` forced-discard abilities the three C4c
+/// treacheries carry. One-shot treacheries have only a `Revelation`, so
+/// they auto-discard after it resolves.
+///
+/// TODO: assumes every persistent treachery carries an ongoing ability
+/// and every one-shot carries none (holds for all Core+Dunwich
+/// treacheries). Revisit with an explicit persistence marker only if a
+/// treachery must persist with no ongoing ability, or auto-discard
+/// despite carrying one.
+fn treachery_is_persistent(abilities: &[crate::dsl::Ability]) -> bool {
+    abilities.iter().any(|a| a.trigger != Trigger::Revelation)
+}
+
+#[cfg(test)]
+mod persistence_tests {
+    use card_dsl::dsl::{constant, modify, native, revelation, Ability, ModifierScope, Stat};
+
+    #[test]
+    fn persistence_is_derived_from_non_revelation_abilities() {
+        let one_shot: Vec<Ability> = vec![revelation(native("x:rev"))];
+        assert!(!super::treachery_is_persistent(&one_shot));
+
+        let persistent: Vec<Ability> = vec![
+            revelation(native("y:rev")),
+            constant(modify(Stat::Willpower, 1, ModifierScope::WhileInPlay)),
+        ];
+        assert!(super::treachery_is_persistent(&persistent));
+    }
+}
+
 pub fn resolve_encounter_card(
     cx: &mut Cx,
     investigator: InvestigatorId,
@@ -148,8 +181,16 @@ pub fn resolve_encounter_card(
                     outcome @ EngineOutcome::Rejected { .. } => return outcome,
                 }
             }
-            cx.state.encounter_discard.push(code);
-            EngineOutcome::Done
+            if treachery_is_persistent(&abilities) {
+                // Persistent: the card placed itself (threat area /
+                // attachment) during its Revelation and owns its own
+                // disposition (including Obscuring Fog's limit-1
+                // discard). Do not auto-discard.
+                EngineOutcome::Done
+            } else {
+                cx.state.encounter_discard.push(code);
+                EngineOutcome::Done
+            }
         }
         CardType::Enemy => {
             // Revelation effects on enemies (rare, but printed on

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -181,16 +181,14 @@ pub fn resolve_encounter_card(
                     outcome @ EngineOutcome::Rejected { .. } => return outcome,
                 }
             }
-            if treachery_is_persistent(&abilities) {
-                // Persistent: the card placed itself (threat area /
-                // attachment) during its Revelation and owns its own
-                // disposition (including Obscuring Fog's limit-1
-                // discard). Do not auto-discard.
-                EngineOutcome::Done
-            } else {
+            // A persistent treachery (one with an ongoing ability) placed
+            // itself during its Revelation and owns its own disposition
+            // (including Obscuring Fog's limit-1 discard); only a one-shot
+            // is auto-discarded here.
+            if !treachery_is_persistent(&abilities) {
                 cx.state.encounter_discard.push(code);
-                EngineOutcome::Done
             }
+            EngineOutcome::Done
         }
         CardType::Enemy => {
             // Revelation effects on enemies (rare, but printed on

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -86,26 +86,6 @@ pub(super) fn encounter_card_revealed(cx: &mut Cx, investigator: InvestigatorId)
     resolve_encounter_card(cx, investigator, code, metadata)
 }
 
-/// Shared post-draw resolution helper. Resolves the per-card 5-step
-/// sub-sequence's steps 3 (Revelation) and 4 (enemy spawn) for an
-/// already-drawn encounter card. Called by `encounter_card_revealed`
-/// (the `EngineRecord::EncounterCardRevealed` path) and by
-/// `mythos_draw_for` (Mythos 1.4 player-driven draws).
-///
-/// Body: emits [`Event::CardRevealed`], then dispatches on
-/// `metadata.card_type` — treachery → run Revelation abilities →
-/// push card to `encounter_discard`; enemy → run Revelation abilities →
-/// spawn it; any other type → return `Rejected`.
-///
-/// **Mid-resolution caveat:** [`Event::CardRevealed`] emits before
-/// Revelation runs (Before-timing reactions need that ordering,
-/// per #126's design decision). The apply loop's `events.clear()`
-/// on Rejected still wipes the event stream on rejection.
-///
-/// Public so card effects that "draw"/"discard until" cards from the
-/// encounter deck can resolve the drawn card faithfully — agenda 01106's
-/// reverse draws the dug-up `Ghoul` enemy through here. Requires an
-/// installed card registry (rejects otherwise).
 /// A treachery is **persistent** (stays in play after its Revelation,
 /// owning its own disposition) iff it has at least one ability whose
 /// trigger is not [`Trigger::Revelation`] — the ongoing `Constant`
@@ -139,6 +119,26 @@ mod persistence_tests {
     }
 }
 
+/// Shared post-draw resolution helper. Resolves the per-card 5-step
+/// sub-sequence's steps 3 (Revelation) and 4 (enemy spawn) for an
+/// already-drawn encounter card. Called by `encounter_card_revealed`
+/// (the `EngineRecord::EncounterCardRevealed` path) and by
+/// `mythos_draw_for` (Mythos 1.4 player-driven draws).
+///
+/// Body: emits [`Event::CardRevealed`], then dispatches on
+/// `metadata.card_type` — treachery → run Revelation abilities →
+/// push card to `encounter_discard`; enemy → run Revelation abilities →
+/// spawn it; any other type → return `Rejected`.
+///
+/// **Mid-resolution caveat:** [`Event::CardRevealed`] emits before
+/// Revelation runs (Before-timing reactions need that ordering,
+/// per #126's design decision). The apply loop's `events.clear()`
+/// on Rejected still wipes the event stream on rejection.
+///
+/// Public so card effects that "draw"/"discard until" cards from the
+/// encounter deck can resolve the drawn card faithfully — agenda 01106's
+/// reverse draws the dug-up `Ghoul` enemy through here. Requires an
+/// installed card registry (rejects otherwise).
 pub fn resolve_encounter_card(
     cx: &mut Cx,
     investigator: InvestigatorId,

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -112,11 +112,14 @@ struct ForcedHit {
 ///
 /// **Suspension caveat (#212 reentrancy).** A hit that suspends
 /// (`AwaitingInput`) or rejects is surfaced immediately, abandoning any
-/// later hits — re-entry mid-sequence isn't modeled yet. Safe in current
-/// scope: the only multi-hit point is `RoundEnded` (agenda 01107 doom +
-/// Dissonant Voices 01165 discard), whose effects are all synchronous;
-/// the one suspending forced effect (Frozen in Fear 01164's `EndOfTurn`
-/// skill test) is always the sole hit at its point.
+/// later hits — re-entry mid-sequence isn't modeled yet. This is correct
+/// as long as no point produces 2+ simultaneous *suspending* hits;
+/// synchronous multi-hit points (`RoundEnded`: agenda 01107 doom +
+/// Dissonant Voices 01165 discard) all resolve fully. The only suspending
+/// forced effect today is Frozen in Fear 01164's `EndOfTurn` skill test;
+/// since it carries no "Limit 1", two copies on one investigator would
+/// drop the second copy's test at end of turn — a known #212/#213
+/// limitation, not a single-hit guarantee.
 pub(crate) fn fire_forced_triggers(cx: &mut Cx, point: &ForcedTriggerPoint) -> EngineOutcome {
     let hits = collect_forced_hits(cx.state, point);
     for hit in &hits {

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -7,7 +7,7 @@
 
 use crate::card_registry;
 use crate::dsl::{EventPattern, EventTiming, Trigger};
-use crate::state::{CardCode, InvestigatorId, LocationId, Phase};
+use crate::state::{CardCode, CardInstanceId, InvestigatorId, LocationId, Phase};
 
 use super::super::evaluator::{apply_effect, EvalContext};
 use super::super::outcome::EngineOutcome;
@@ -93,6 +93,11 @@ struct ForcedHit {
     code: CardCode,
     ability_index: usize,
     controller: InvestigatorId,
+    /// The firing card instance, when the hit came from scanning an
+    /// investigator's controlled instances or a location's attachments
+    /// (so `Effect::DiscardSelf` can find itself). `None` for board-card
+    /// hits (act / agenda).
+    source: Option<CardInstanceId>,
 }
 
 /// Fire Forced abilities matching `point`. Single-trigger path: 0 → Done;
@@ -132,7 +137,7 @@ fn collect_forced_hits(
             let Some(loc) = state.locations.get(location) else {
                 return hits;
             };
-            push_matching(reg, &loc.code, *investigator, &mut hits, |p| {
+            push_matching(reg, &loc.code, *investigator, None, &mut hits, |p| {
                 matches!(p, EventPattern::EnteredLocation)
             });
         }
@@ -148,6 +153,7 @@ fn collect_forced_hits(
                     reg,
                     &act.code,
                     lead,
+                    None,
                     &mut hits,
                     |p| matches!(p, EventPattern::PhaseEnded { phase } if *phase == want_phase),
                 );
@@ -157,6 +163,7 @@ fn collect_forced_hits(
                     reg,
                     &agenda.code,
                     lead,
+                    None,
                     &mut hits,
                     |p| matches!(p, EventPattern::PhaseEnded { phase } if *phase == want_phase),
                 );
@@ -166,7 +173,7 @@ fn collect_forced_hits(
             let Some(lead) = state.turn_order.first().copied() else {
                 return hits;
             };
-            push_matching(reg, code, lead, &mut hits, |p| {
+            push_matching(reg, code, lead, None, &mut hits, |p| {
                 matches!(p, EventPattern::ActAdvanced)
             });
         }
@@ -174,7 +181,7 @@ fn collect_forced_hits(
             let Some(lead) = state.turn_order.first().copied() else {
                 return hits;
             };
-            push_matching(reg, code, lead, &mut hits, |p| {
+            push_matching(reg, code, lead, None, &mut hits, |p| {
                 matches!(p, EventPattern::AgendaAdvanced)
             });
         }
@@ -183,7 +190,7 @@ fn collect_forced_hits(
                 return hits;
             };
             if let Some(act) = state.act_deck.get(state.act_index) {
-                push_matching(reg, &act.code, lead, &mut hits, |p| {
+                push_matching(reg, &act.code, lead, None, &mut hits, |p| {
                     matches!(
                         p,
                         EventPattern::EnemyDefeated { code: narrow, .. }
@@ -197,14 +204,25 @@ fn collect_forced_hits(
                 return hits;
             };
             if let Some(act) = state.act_deck.get(state.act_index) {
-                push_matching(reg, &act.code, lead, &mut hits, |p| {
+                push_matching(reg, &act.code, lead, None, &mut hits, |p| {
                     matches!(p, EventPattern::RoundEnded)
                 });
             }
             if let Some(agenda) = state.agenda_deck.get(state.agenda_index) {
-                push_matching(reg, &agenda.code, lead, &mut hits, |p| {
+                push_matching(reg, &agenda.code, lead, None, &mut hits, |p| {
                     matches!(p, EventPattern::RoundEnded)
                 });
+            }
+            // Persistent threat-area treacheries discard on RoundEnded
+            // (Dissonant Voices 01165). Scan every investigator's
+            // controlled instances; bind source = the instance so
+            // `Effect::DiscardSelf` finds itself.
+            for (inv_id, inv) in &state.investigators {
+                for card in inv.controlled_card_instances() {
+                    push_matching(reg, &card.code, *inv_id, Some(card.instance_id), &mut hits, |p| {
+                        matches!(p, EventPattern::RoundEnded)
+                    });
+                }
             }
         }
         ForcedTriggerPoint::EndOfTurn { investigator } => {
@@ -216,24 +234,34 @@ fn collect_forced_hits(
             // fine — abilities are static per code; C4c threads the
             // source instance when an effect needs to discard itself.
             for card in inv.controlled_card_instances() {
-                push_matching(reg, &card.code, *investigator, &mut hits, |p| {
+                push_matching(reg, &card.code, *investigator, Some(card.instance_id), &mut hits, |p| {
                     matches!(p, EventPattern::EndOfTurn)
                 });
             }
         }
         ForcedTriggerPoint::AfterLocationInvestigated {
             investigator,
-            location: _location,
+            location,
         } => {
             let Some(inv) = state.investigators.get(investigator) else {
                 return hits;
             };
-            // C4a scans the investigator's controlled instances; C4c
-            // extends to `_location`'s attachment zone (Obscuring Fog).
+            // Scan the investigator's controlled instances (C4a) and the
+            // investigated location's attachment zone (C4c — Obscuring Fog
+            // 01168 attaches to the location, not the threat area). Bind
+            // source = the firing instance so `Effect::DiscardSelf` finds
+            // itself.
             for card in inv.controlled_card_instances() {
-                push_matching(reg, &card.code, *investigator, &mut hits, |p| {
+                push_matching(reg, &card.code, *investigator, Some(card.instance_id), &mut hits, |p| {
                     matches!(p, EventPattern::AfterLocationInvestigated)
                 });
+            }
+            if let Some(loc) = state.locations.get(location) {
+                for att in &loc.attachments {
+                    push_matching(reg, &att.code, *investigator, Some(att.instance_id), &mut hits, |p| {
+                        matches!(p, EventPattern::AfterLocationInvestigated)
+                    });
+                }
             }
         }
     }
@@ -255,6 +283,7 @@ fn push_matching(
     reg: &card_registry::CardRegistry,
     code: &CardCode,
     controller: InvestigatorId,
+    source: Option<CardInstanceId>,
     out: &mut Vec<ForcedHit>,
     want: impl Fn(&EventPattern) -> bool,
 ) {
@@ -271,6 +300,7 @@ fn push_matching(
                     code: code.clone(),
                     ability_index: idx,
                     controller,
+                    source,
                 });
             }
         }
@@ -293,5 +323,9 @@ fn resolve_one(cx: &mut Cx, hit: &ForcedHit) -> EngineOutcome {
         };
     };
     let effect = abilities[hit.ability_index].effect.clone();
-    apply_effect(cx, &effect, EvalContext::for_controller(hit.controller))
+    let ctx = match hit.source {
+        Some(src) => EvalContext::for_controller_with_source(hit.controller, src),
+        None => EvalContext::for_controller(hit.controller),
+    };
+    apply_effect(cx, &effect, ctx)
 }

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -1,9 +1,9 @@
 //! Forced-trigger dispatch: fires `Trigger::OnEvent` abilities printed
 //! on scenario-structure cards (locations, acts, agendas) at framework
 //! timing points, via an immediate path separate from the player
-//! reaction-window machinery. Single-trigger only in this slice; 2+
-//! simultaneous pending triggers reject loudly (#213 adds the ordering
-//! loop, #212 the universal `emit_event` chokepoint).
+//! reaction-window machinery. Multiple simultaneous triggers resolve in
+//! a fixed deterministic order (see [`fire_forced_triggers`]); #213 adds
+//! player-chosen ordering, #212 the universal `emit_event` chokepoint.
 
 use crate::card_registry;
 use crate::dsl::{EventPattern, EventTiming, Trigger};
@@ -100,23 +100,32 @@ struct ForcedHit {
     source: Option<CardInstanceId>,
 }
 
-/// Fire Forced abilities matching `point`. Single-trigger path: 0 → Done;
-/// 1 → resolve via `apply_effect`; 2+ → reject loudly (no silently-chosen
-/// order — #213 adds the ordering loop).
+/// Fire Forced abilities matching `point`, resolving each hit in a fixed
+/// deterministic order.
+///
+/// The order is the collection order of [`collect_forced_hits`]: board
+/// cards (act before agenda) before threat-area / attachment instances,
+/// investigators by id (`BTreeMap`), instances in zone order. #213 will
+/// replace this with player-chosen ordering (Rules Reference p.17: the
+/// player orders simultaneous triggers, even in solo); a fixed order is a
+/// rules-acceptable stand-in until then.
+///
+/// **Suspension caveat (#212 reentrancy).** A hit that suspends
+/// (`AwaitingInput`) or rejects is surfaced immediately, abandoning any
+/// later hits — re-entry mid-sequence isn't modeled yet. Safe in current
+/// scope: the only multi-hit point is `RoundEnded` (agenda 01107 doom +
+/// Dissonant Voices 01165 discard), whose effects are all synchronous;
+/// the one suspending forced effect (Frozen in Fear 01164's `EndOfTurn`
+/// skill test) is always the sole hit at its point.
 pub(crate) fn fire_forced_triggers(cx: &mut Cx, point: &ForcedTriggerPoint) -> EngineOutcome {
     let hits = collect_forced_hits(cx.state, point);
-    match hits.len() {
-        0 => EngineOutcome::Done,
-        1 => resolve_one(cx, &hits[0]),
-        n => EngineOutcome::Rejected {
-            reason: format!(
-                "fire_forced_triggers: {n} simultaneous forced triggers at {point:?}; \
-                 ordering not yet implemented (see #213). Slice-1 content never produces \
-                 this — investigate the source."
-            )
-            .into(),
-        },
+    for hit in &hits {
+        match resolve_one(cx, hit) {
+            EngineOutcome::Done => {}
+            other => return other,
+        }
     }
+    EngineOutcome::Done
 }
 
 // dispatcher: one match arm per ForcedTriggerPoint.

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -228,9 +228,14 @@ fn collect_forced_hits(
             // `Effect::DiscardSelf` finds itself.
             for (inv_id, inv) in &state.investigators {
                 for card in inv.controlled_card_instances() {
-                    push_matching(reg, &card.code, *inv_id, Some(card.instance_id), &mut hits, |p| {
-                        matches!(p, EventPattern::RoundEnded)
-                    });
+                    push_matching(
+                        reg,
+                        &card.code,
+                        *inv_id,
+                        Some(card.instance_id),
+                        &mut hits,
+                        |p| matches!(p, EventPattern::RoundEnded),
+                    );
                 }
             }
         }
@@ -243,9 +248,14 @@ fn collect_forced_hits(
             // fine — abilities are static per code; C4c threads the
             // source instance when an effect needs to discard itself.
             for card in inv.controlled_card_instances() {
-                push_matching(reg, &card.code, *investigator, Some(card.instance_id), &mut hits, |p| {
-                    matches!(p, EventPattern::EndOfTurn)
-                });
+                push_matching(
+                    reg,
+                    &card.code,
+                    *investigator,
+                    Some(card.instance_id),
+                    &mut hits,
+                    |p| matches!(p, EventPattern::EndOfTurn),
+                );
             }
         }
         ForcedTriggerPoint::AfterLocationInvestigated {
@@ -261,15 +271,25 @@ fn collect_forced_hits(
             // source = the firing instance so `Effect::DiscardSelf` finds
             // itself.
             for card in inv.controlled_card_instances() {
-                push_matching(reg, &card.code, *investigator, Some(card.instance_id), &mut hits, |p| {
-                    matches!(p, EventPattern::AfterLocationInvestigated)
-                });
+                push_matching(
+                    reg,
+                    &card.code,
+                    *investigator,
+                    Some(card.instance_id),
+                    &mut hits,
+                    |p| matches!(p, EventPattern::AfterLocationInvestigated),
+                );
             }
             if let Some(loc) = state.locations.get(location) {
                 for att in &loc.attachments {
-                    push_matching(reg, &att.code, *investigator, Some(att.instance_id), &mut hits, |p| {
-                        matches!(p, EventPattern::AfterLocationInvestigated)
-                    });
+                    push_matching(
+                        reg,
+                        &att.code,
+                        *investigator,
+                        Some(att.instance_id),
+                        &mut hits,
+                        |p| matches!(p, EventPattern::AfterLocationInvestigated),
+                    );
                 }
             }
         }

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -38,7 +38,7 @@ mod reaction_windows;
 pub(crate) mod reveal;
 // pub(super): engine::evaluator reaches start_skill_test for Effect::SkillTest.
 pub(super) mod skill_test;
-mod threat_area;
+pub(crate) mod threat_area;
 
 /// Apply a [`PlayerAction`] to the state, pushing events.
 ///

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -402,7 +402,20 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
         };
     }
     match response {
-        InputResponse::CommitCards { indices } => skill_test::finish_skill_test(cx, indices),
+        InputResponse::CommitCards { indices } => {
+            let outcome = skill_test::finish_skill_test(cx, indices);
+            // If the resolved test was a suspending `EndOfTurn` forced
+            // effect (Frozen in Fear 01164), `end_turn` was stranded before
+            // rotation; resume it now that the test is fully done (C4c,
+            // #235). Only on `Done` — an `AwaitingInput` mid-teardown leaves
+            // `pending_end_turn` set for the next resume.
+            if matches!(outcome, EngineOutcome::Done) {
+                if let Some(active_id) = cx.state.pending_end_turn.take() {
+                    return phases::resume_end_turn(cx, active_id);
+                }
+            }
+            outcome
+        }
         other => EngineOutcome::Rejected {
             reason: format!(
                 "ResolveInput: skill-test commit window expects InputResponse::CommitCards, \

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -116,6 +116,7 @@ pub(super) fn start_scenario(cx: &mut Cx, roster: &[RosterEntry]) -> EngineOutco
                 cards_in_play: Vec::new(),
                 threat_area: Vec::new(),
                 removed_from_game: Vec::new(),
+                action_surcharge_spent_this_round: std::collections::BTreeSet::new(),
             },
         );
         cx.state.turn_order.push(id);
@@ -328,6 +329,11 @@ fn mythos_phase(cx: &mut Cx) {
     //     skipped). This is also the future home for a RoundStarted
     //     event when a consumer lands.
     cx.state.round = cx.state.round.saturating_add(1);
+    // New round: clear each investigator's per-round "first-applicable
+    // action surcharge already spent" set (Frozen in Fear 01164).
+    for inv in cx.state.investigators.values_mut() {
+        inv.action_surcharge_spent_this_round.clear();
+    }
     cx.events.push(Event::PhaseStarted {
         phase: Phase::Mythos,
     });

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -208,22 +208,41 @@ pub(super) fn end_turn(cx: &mut Cx) -> EngineOutcome {
     // turn just ended, before the turn passes on. No real card
     // consumes this in C4a; C4c (#235) is the first consumer.
     //
-    // Suspension caveat: a forced effect that itself initiates a skill
-    // test would return AwaitingInput here, suspending end_turn before
-    // rotation — which end_turn has no resume plumbing for. No C4c
-    // consumer suspends at this point; a suspending one is #212
-    // reentrancy work. We propagate the outcome rather than swallow it
-    // so the gap is loud if it ever arises.
+    // Forced "at the end of your turn" abilities (Frozen in Fear 01164's
+    // willpower test) fire for the investigator whose turn just ended,
+    // before the turn passes on.
+    //
+    // A forced effect that initiates a skill test suspends here
+    // (`AwaitingInput`), stranding `end_turn` before rotation. Record the
+    // active investigator in `pending_end_turn` so the skill-test
+    // commit-resume path re-enters [`resume_end_turn`] once the test
+    // resolves (C4c, #235 — mirrors `spawn_engage_pending`). A single
+    // suspending hit is handled; 2+ simultaneous suspends are #212/#213
+    // reentrancy work. A `Rejected` propagates as-is.
     let end_of_turn = super::forced_triggers::fire_forced_triggers(
         cx,
         &super::forced_triggers::ForcedTriggerPoint::EndOfTurn {
             investigator: active_id,
         },
     );
-    if !matches!(end_of_turn, EngineOutcome::Done) {
-        return end_of_turn;
+    match end_of_turn {
+        EngineOutcome::Done => resume_end_turn(cx, active_id),
+        EngineOutcome::AwaitingInput { .. } => {
+            cx.state.pending_end_turn = Some(active_id);
+            end_of_turn
+        }
+        EngineOutcome::Rejected { .. } => end_of_turn,
     }
+}
 
+/// Run the post-`EndOfTurn`-forced portion of [`end_turn`] (Rules
+/// Reference p.24 step 2.2.2): rotate to the next active investigator, or
+/// end the Investigation phase. Called inline by `end_turn` when the
+/// `EndOfTurn` forced effects resolved synchronously, and by the
+/// skill-test commit-resume path (via `pending_end_turn`) when a
+/// suspending `EndOfTurn` forced effect (Frozen in Fear 01164) stranded
+/// `end_turn` before rotation.
+pub(super) fn resume_end_turn(cx: &mut Cx, active_id: InvestigatorId) -> EngineOutcome {
     // 2.2.2 decision: "return to 2.2" for the next investigator, or
     // proceed to 2.3. next_active_investigator_after skips eliminated
     // investigators (Rules Reference p.10) — the same shared helper the

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -21,6 +21,10 @@ use super::super::evaluator::{
 use super::super::outcome::{EngineOutcome, InputRequest, ResumeToken};
 use super::Cx;
 
+// Nine args: the skill-test parameters are genuinely independent axes
+// (skill, kind, difficulty, success/fail follow-ups, source). A params
+// struct would add indirection without grouping anything cohesive.
+#[allow(clippy::too_many_arguments)]
 pub(in crate::engine) fn start_skill_test(
     cx: &mut Cx,
     investigator: InvestigatorId,

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -28,7 +28,9 @@ pub(in crate::engine) fn start_skill_test(
     kind: SkillTestKind,
     difficulty: i8,
     follow_up: SkillTestFollowUp,
+    on_success: Option<card_dsl::dsl::Effect>,
     on_fail: Option<card_dsl::dsl::Effect>,
+    source: Option<crate::state::CardInstanceId>,
 ) -> EngineOutcome {
     // Validate-first: investigator must exist and be Active; chaos
     // bag must be non-empty so we can draw; difficulty must be non-
@@ -83,6 +85,8 @@ pub(in crate::engine) fn start_skill_test(
         tested_location,
         follow_up,
         on_fail,
+        on_success,
+        source,
         continuation: FinishContinuation::AwaitingCommit,
     });
     cx.events.push(Event::SkillTestStarted {
@@ -155,6 +159,8 @@ pub(super) fn finish_skill_test(cx: &mut Cx, indices: &[u32]) -> EngineOutcome {
     let difficulty = in_flight.difficulty;
     let follow_up = in_flight.follow_up;
     let on_fail = in_flight.on_fail.clone();
+    let on_success = in_flight.on_success.clone();
+    let source = in_flight.source;
 
     // Validate the commit indices against the resolving
     // investigator's hand. On Err, state is untouched and the engine
@@ -179,15 +185,34 @@ pub(super) fn finish_skill_test(cx: &mut Cx, indices: &[u32]) -> EngineOutcome {
     let (succeeded, failed_by) =
         resolve_chaos_token_and_emit(cx, investigator, skill, difficulty, skill_value);
 
+    // Build the eval context for the success/failure card effects,
+    // threading the firing instance (`source`) so `Effect::DiscardSelf`
+    // can find itself across the suspend/resume boundary.
+    let card_ctx = |investigator: InvestigatorId| match source {
+        Some(src) => EvalContext::for_controller_with_source(investigator, src),
+        None => EvalContext::for_controller(investigator),
+    };
+
     if succeeded {
         apply_skill_test_follow_up(cx, investigator, follow_up);
+        if let Some(effect) = &on_success {
+            // Success-side card effect (Frozen in Fear 01164 discards
+            // itself on a successful end-of-turn willpower test). In-scope
+            // effects run to completion; a future suspending on_success is
+            // #212 reentrancy work.
+            let outcome = apply_effect(cx, effect, card_ctx(investigator));
+            debug_assert!(
+                matches!(outcome, EngineOutcome::Done),
+                "skill-test on_success must resolve to Done in scope: {outcome:?}"
+            );
+        }
     } else if let Some(effect) = &on_fail {
         // Margin-keyed failure branch of a treachery-Revelation test
         // (`Effect::SkillTest`). The failure margin is threaded so
         // `Effect::ForEachPointFailed` can scale. In-scope on_fail
         // effects (DealDamage / DealHorror / Native) run to completion;
         // a future suspending on_fail is #212 reentrancy work.
-        let mut ctx = EvalContext::for_controller(investigator);
+        let mut ctx = card_ctx(investigator);
         ctx.failed_by = Some(failed_by);
         let outcome = apply_effect(cx, effect, ctx);
         debug_assert!(
@@ -752,6 +777,8 @@ pub(super) fn perform_skill_test(
         difficulty,
         SkillTestFollowUp::None,
         None,
+        None,
+        None,
     )
 }
 
@@ -887,10 +914,12 @@ mod tests {
             SkillTestKind::Plain,
             2,
             SkillTestFollowUp::None,
+            None,
             Some(for_each_point_failed(deal_damage(
                 InvestigatorTarget::You,
                 1,
             ))),
+            None,
         );
         assert!(matches!(out, EngineOutcome::AwaitingInput { .. }));
         // What resolve_encounter_card does on a suspended revelation:
@@ -937,5 +966,44 @@ mod tests {
             "plain test must not set or flush the revelation-discard slot"
         );
         assert!(state.encounter_discard.is_empty());
+    }
+
+    /// A skill test with an `on_success` effect runs it on a successful
+    /// draw (the success-side mirror of the `on_fail` path).
+    #[test]
+    fn skill_test_runs_on_success_effect_on_a_passing_draw() {
+        use crate::dsl::{deal_horror, InvestigatorTarget};
+        use crate::state::ChaosToken;
+
+        let inv = InvestigatorId(1);
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_active_investigator(inv)
+            .build();
+        // Willpower 3 + Numeric(0) = 3 vs difficulty 2 → success.
+        state.chaos_bag.tokens = vec![ChaosToken::Numeric(0)];
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+        let out = start_skill_test(
+            &mut cx,
+            inv,
+            SkillKind::Willpower,
+            SkillTestKind::Plain,
+            2,
+            SkillTestFollowUp::None,
+            Some(deal_horror(InvestigatorTarget::You, 1)),
+            None,
+            None,
+        );
+        assert!(matches!(out, EngineOutcome::AwaitingInput { .. }));
+        let out = finish_skill_test(&mut cx, &[]);
+        assert_eq!(out, EngineOutcome::Done);
+        assert_eq!(
+            state.investigators[&inv].horror, 1,
+            "on_success effect ran on the passing draw",
+        );
     }
 }

--- a/crates/game-core/src/engine/dispatch/threat_area.rs
+++ b/crates/game-core/src/engine/dispatch/threat_area.rs
@@ -16,8 +16,7 @@ use super::Cx;
 /// No-op (returns `None`) if the investigator isn't in state — callers
 /// in dispatch have already validated the investigator exists, but the
 /// helper stays total so a misuse can't panic.
-#[cfg_attr(not(test), allow(dead_code))] // C4c (#235) is the first production caller
-pub(super) fn place_in_threat_area(
+pub fn place_in_threat_area(
     cx: &mut Cx,
     investigator: InvestigatorId,
     code: CardCode,
@@ -50,8 +49,7 @@ pub(super) fn place_in_threat_area(
 /// **No limit enforcement** — "Limit 1 per location" is printed on
 /// specific cards (Obscuring Fog 01168), not a property of all
 /// attachments, so the limit lives in the card's Revelation, not here.
-#[cfg_attr(not(test), allow(dead_code))] // Obscuring Fog (01168, C4c) is the first production caller
-pub(super) fn attach_to_location(
+pub fn attach_to_location(
     cx: &mut Cx,
     location: LocationId,
     code: CardCode,

--- a/crates/game-core/src/engine/dispatch/threat_area.rs
+++ b/crates/game-core/src/engine/dispatch/threat_area.rs
@@ -5,7 +5,7 @@
 //! (#235).
 
 use crate::event::Event;
-use crate::state::{CardCode, CardInPlay, CardInstanceId, InvestigatorId, Zone};
+use crate::state::{CardCode, CardInPlay, CardInstanceId, InvestigatorId, LocationId, Zone};
 
 use super::Cx;
 
@@ -36,6 +36,40 @@ pub(super) fn place_in_threat_area(
         .push(CardInPlay::enter_play(code.clone(), instance_id));
     cx.events.push(Event::CardEnteredThreatArea {
         investigator,
+        code,
+        instance_id,
+    });
+    Some(instance_id)
+}
+
+/// Attach `code` to `location` as a fresh in-play instance, minting an
+/// instance id from the per-state counter, and emit
+/// [`Event::CardAttachedToLocation`]. Returns the minted id, or `None`
+/// if the location isn't in state.
+///
+/// **No limit enforcement** — "Limit 1 per location" is printed on
+/// specific cards (Obscuring Fog 01168), not a property of all
+/// attachments, so the limit lives in the card's Revelation, not here.
+#[cfg_attr(not(test), allow(dead_code))] // Obscuring Fog (01168, C4c) is the first production caller
+pub(super) fn attach_to_location(
+    cx: &mut Cx,
+    location: LocationId,
+    code: CardCode,
+) -> Option<CardInstanceId> {
+    if !cx.state.locations.contains_key(&location) {
+        return None;
+    }
+    let instance_id = CardInstanceId(cx.state.next_card_instance_id);
+    cx.state.next_card_instance_id = cx.state.next_card_instance_id.saturating_add(1);
+    let loc = cx
+        .state
+        .locations
+        .get_mut(&location)
+        .expect("existence checked above");
+    loc.attachments
+        .push(CardInPlay::enter_play(code.clone(), instance_id));
+    cx.events.push(Event::CardAttachedToLocation {
+        location,
         code,
         instance_id,
     });
@@ -75,7 +109,31 @@ pub(super) fn discard_from_threat_area(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::{test_investigator, GameStateBuilder};
+    use crate::test_support::{test_investigator, test_location, GameStateBuilder};
+
+    #[test]
+    fn attach_mints_id_pushes_to_location_and_emits_event() {
+        let mut state = GameStateBuilder::new()
+            .with_location(test_location(7, "Study"))
+            .build();
+        let mut events = Vec::new();
+        let id = {
+            let mut cx = Cx {
+                state: &mut state,
+                events: &mut events,
+            };
+            attach_to_location(&mut cx, LocationId(7), CardCode::new("01168"))
+        };
+        assert_eq!(id, Some(CardInstanceId(0)));
+        let loc = &state.locations[&LocationId(7)];
+        assert_eq!(loc.attachments.len(), 1);
+        assert_eq!(loc.attachments[0].code.as_str(), "01168");
+        assert!(events.iter().any(|e| matches!(
+            e,
+            Event::CardAttachedToLocation { code, location, .. }
+                if code.as_str() == "01168" && *location == LocationId(7)
+        )));
+    }
 
     #[test]
     fn place_mints_id_pushes_instance_and_emits_event() {

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -198,10 +198,18 @@ pub(crate) fn apply_effect(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) 
             i8::try_from(*difficulty).unwrap_or(i8::MAX),
             crate::state::SkillTestFollowUp::None,
             on_success.as_ref().map(|b| (**b).clone()),
-            Some((**on_fail).clone()),
+            on_fail.as_ref().map(|b| (**b).clone()),
             eval_ctx.source,
         ),
         Effect::DiscardSelf => discard_self(cx, &eval_ctx),
+        Effect::PutIntoThreatArea { code } => {
+            crate::engine::dispatch::threat_area::place_in_threat_area(
+                cx,
+                eval_ctx.controller,
+                crate::state::CardCode::new(code.clone()),
+            );
+            EngineOutcome::Done
+        }
         Effect::Restrict(_) => EngineOutcome::Rejected {
             reason: "Effect::Restrict is a constant marker — inspected at decision points, \
                      never executed"
@@ -853,7 +861,7 @@ pub fn pending_action_surcharge(
             else {
                 continue;
             };
-            if !actions.contains(action_class) {
+            if !actions.contains(&action_class) {
                 continue;
             }
             if *first_each_round {
@@ -1721,11 +1729,11 @@ mod tests {
             ))]),
             "frozen-surcharge" => Some(vec![constant(crate::dsl::restrict(
                 crate::dsl::Restriction::ExtraActionCost {
-                    actions: crate::dsl::ActionClassSet {
-                        move_: true,
-                        fight: true,
-                        evade: true,
-                    },
+                    actions: vec![
+                        crate::dsl::ActionClass::Move,
+                        crate::dsl::ActionClass::Fight,
+                        crate::dsl::ActionClass::Evade,
+                    ],
                     first_each_round: true,
                 },
             ))]),

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -1800,8 +1800,10 @@ mod tests {
         use crate::state::Zone;
         use crate::test_support::test_location;
         let mut loc = test_location(3, "Study");
-        loc.attachments
-            .push(CardInPlay::enter_play(CardCode::new("01168"), CardInstanceId(9)));
+        loc.attachments.push(CardInPlay::enter_play(
+            CardCode::new("01168"),
+            CardInstanceId(9),
+        ));
         let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_location(loc)
@@ -1896,7 +1898,10 @@ mod tests {
         let (state, id) = state_with_cards_in_play(&["frozen-surcharge", "frozen-surcharge"]);
         let reg = fake_registry();
         let (extra, to_mark) = pending_action_surcharge(&state, &reg, id, ActionClass::Move);
-        assert_eq!(extra, 2, "two Frozen in Fear each surcharge the first action");
+        assert_eq!(
+            extra, 2,
+            "two Frozen in Fear each surcharge the first action"
+        );
         assert_eq!(to_mark, vec![CardInstanceId(0), CardInstanceId(1)]);
     }
 

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -188,6 +188,7 @@ pub(crate) fn apply_effect(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) 
         Effect::SkillTest {
             skill,
             difficulty,
+            on_success,
             on_fail,
         } => crate::engine::dispatch::skill_test::start_skill_test(
             cx,
@@ -196,7 +197,9 @@ pub(crate) fn apply_effect(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) 
             crate::dsl::SkillTestKind::Plain,
             i8::try_from(*difficulty).unwrap_or(i8::MAX),
             crate::state::SkillTestFollowUp::None,
+            on_success.as_ref().map(|b| (**b).clone()),
             Some((**on_fail).clone()),
+            eval_ctx.source,
         ),
         Effect::DiscardSelf => discard_self(cx, &eval_ctx),
         Effect::Restrict(_) => EngineOutcome::Rejected {
@@ -810,6 +813,64 @@ pub fn play_is_prohibited(
     })
 }
 
+/// The extra action cost `investigator` pays to perform `action_class`,
+/// plus the `first_each_round` source instances to mark spent on commit.
+///
+/// Sums `Restriction::ExtraActionCost` deltas (1 each) from active
+/// `Trigger::Constant` abilities on the investigator's controlled
+/// instances whose `actions` include `action_class` (Frozen in Fear
+/// 01164: move / fight / evade). A `first_each_round` source already in
+/// `action_surcharge_spent_this_round` contributes 0; the returned
+/// instance list is the set the caller marks spent **after** the action
+/// commits (so cost-peek stays read-only for validate-first). Always-on
+/// (`first_each_round == false`) surcharges always contribute and are not
+/// returned for marking.
+#[must_use]
+pub fn pending_action_surcharge(
+    state: &GameState,
+    registry: &CardRegistry,
+    investigator: InvestigatorId,
+    action_class: crate::dsl::ActionClass,
+) -> (u8, Vec<crate::state::CardInstanceId>) {
+    use crate::dsl::Restriction;
+    let Some(inv) = state.investigators.get(&investigator) else {
+        return (0, Vec::new());
+    };
+    let mut extra: u8 = 0;
+    let mut to_mark = Vec::new();
+    for card in inv.controlled_card_instances() {
+        let Some(abilities) = (registry.abilities_for)(&card.code) else {
+            continue;
+        };
+        for a in &abilities {
+            if a.trigger != Trigger::Constant {
+                continue;
+            }
+            let Effect::Restrict(Restriction::ExtraActionCost {
+                actions,
+                first_each_round,
+            }) = &a.effect
+            else {
+                continue;
+            };
+            if !actions.contains(action_class) {
+                continue;
+            }
+            if *first_each_round {
+                if inv
+                    .action_surcharge_spent_this_round
+                    .contains(&card.instance_id)
+                {
+                    continue;
+                }
+                to_mark.push(card.instance_id);
+            }
+            extra = extra.saturating_add(1);
+        }
+    }
+    (extra, to_mark)
+}
+
 /// Shared core of [`constant_skill_modifier`] and
 /// [`unconditional_constant_stat_modifier`]: sum the `delta` of every
 /// `Trigger::Constant` `Effect::Modify` on `controller`'s cards in play
@@ -1170,6 +1231,8 @@ mod tests {
             tested_location: Some(tested),
             follow_up: crate::state::SkillTestFollowUp::Investigate,
             on_fail: None,
+            on_success: None,
+            source: None,
             continuation: crate::state::FinishContinuation::AwaitingCommit,
         });
         let mut events = Vec::new();
@@ -1241,6 +1304,8 @@ mod tests {
             tested_location: Some(LocationId(10)),
             follow_up: crate::state::SkillTestFollowUp::None,
             on_fail: None,
+            on_success: None,
+            source: None,
             continuation: crate::state::FinishContinuation::AwaitingCommit,
         });
         state
@@ -1403,6 +1468,8 @@ mod tests {
             tested_location: None,
             follow_up: crate::state::SkillTestFollowUp::None,
             on_fail: None,
+            on_success: None,
+            source: None,
             continuation: crate::state::FinishContinuation::AwaitingCommit,
         });
         let mut events = Vec::new();
@@ -1652,6 +1719,16 @@ mod tests {
             "cannot-play-assets" => Some(vec![constant(crate::dsl::restrict(
                 crate::dsl::Restriction::CannotPlay(crate::card_data::CardType::Asset),
             ))]),
+            "frozen-surcharge" => Some(vec![constant(crate::dsl::restrict(
+                crate::dsl::Restriction::ExtraActionCost {
+                    actions: crate::dsl::ActionClassSet {
+                        move_: true,
+                        fight: true,
+                        evade: true,
+                    },
+                    first_each_round: true,
+                },
+            ))]),
             _ => None,
         }
     }
@@ -1774,6 +1851,53 @@ mod tests {
         let reg = fake_registry();
         assert!(play_is_prohibited(&state, &reg, id, CardType::Asset));
         assert!(!play_is_prohibited(&state, &reg, id, CardType::Event));
+    }
+
+    #[test]
+    fn surcharge_charges_first_matching_action_then_not_again_until_reset() {
+        use super::pending_action_surcharge;
+        use crate::dsl::ActionClass;
+        let (mut state, id) = state_with_cards_in_play(&["frozen-surcharge"]);
+        let reg = fake_registry();
+
+        // First move this round: +1, and the source (instance 0) to mark.
+        let (extra, to_mark) = pending_action_surcharge(&state, &reg, id, ActionClass::Move);
+        assert_eq!(extra, 1);
+        assert_eq!(to_mark, vec![CardInstanceId(0)]);
+
+        // Mark it spent (what the action handler does on commit).
+        state
+            .investigators
+            .get_mut(&id)
+            .unwrap()
+            .action_surcharge_spent_this_round
+            .insert(CardInstanceId(0));
+
+        // Second matching action this round: no surcharge.
+        let (extra, to_mark) = pending_action_surcharge(&state, &reg, id, ActionClass::Fight);
+        assert_eq!(extra, 0);
+        assert!(to_mark.is_empty());
+
+        // New round reset → charges again.
+        state
+            .investigators
+            .get_mut(&id)
+            .unwrap()
+            .action_surcharge_spent_this_round
+            .clear();
+        let (extra, _) = pending_action_surcharge(&state, &reg, id, ActionClass::Evade);
+        assert_eq!(extra, 1);
+    }
+
+    #[test]
+    fn surcharge_two_sources_each_charge_the_first_action() {
+        use super::pending_action_surcharge;
+        use crate::dsl::ActionClass;
+        let (state, id) = state_with_cards_in_play(&["frozen-surcharge", "frozen-surcharge"]);
+        let reg = fake_registry();
+        let (extra, to_mark) = pending_action_surcharge(&state, &reg, id, ActionClass::Move);
+        assert_eq!(extra, 2, "two Frozen in Fear each surcharge the first action");
+        assert_eq!(to_mark, vec![CardInstanceId(0), CardInstanceId(1)]);
     }
 
     #[test]

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -198,6 +198,84 @@ pub(crate) fn apply_effect(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) 
             crate::state::SkillTestFollowUp::None,
             Some((**on_fail).clone()),
         ),
+        Effect::DiscardSelf => discard_self(cx, &eval_ctx),
+    }
+}
+
+/// Resolve [`Effect::DiscardSelf`]: remove `eval_ctx.source` from
+/// whichever threat area or location attachment holds it, push its code
+/// to `encounter_discard`, and emit
+/// [`Event::CardDiscarded`](crate::Event::CardDiscarded) with the
+/// matching `from` zone. Rejects loudly if there is no source or the
+/// instance is not found.
+///
+/// TODO: scoped to the two encounter zones (threat area / location
+/// attachment → encounter discard). Extend to player-controlled zones
+/// (cards in play → owner discard) when a player card first needs to
+/// discard itself by source instance.
+fn discard_self(cx: &mut Cx, eval_ctx: &EvalContext) -> EngineOutcome {
+    use crate::event::Event;
+    use crate::state::Zone;
+    let Some(source) = eval_ctx.source else {
+        return EngineOutcome::Rejected {
+            reason: "DiscardSelf: no source instance in context".into(),
+        };
+    };
+    // Locate first (immutable scan), then mutate — avoids a cross-field
+    // borrow of `cx.state` while iterating one of its maps.
+    let threat_owner = cx.state.investigators.iter().find_map(|(id, inv)| {
+        inv.threat_area
+            .iter()
+            .position(|c| c.instance_id == source)
+            .map(|pos| (*id, pos))
+    });
+    if let Some((inv_id, pos)) = threat_owner {
+        let card = cx
+            .state
+            .investigators
+            .get_mut(&inv_id)
+            .expect("found above")
+            .threat_area
+            .remove(pos);
+        cx.state.encounter_discard.push(card.code.clone());
+        cx.events.push(Event::CardDiscarded {
+            investigator: inv_id,
+            code: card.code,
+            from: Zone::ThreatArea,
+        });
+        return EngineOutcome::Done;
+    }
+
+    let att_owner = cx.state.locations.iter().find_map(|(id, loc)| {
+        loc.attachments
+            .iter()
+            .position(|c| c.instance_id == source)
+            .map(|pos| (*id, pos))
+    });
+    if let Some((loc_id, pos)) = att_owner {
+        let card = cx
+            .state
+            .locations
+            .get_mut(&loc_id)
+            .expect("found above")
+            .attachments
+            .remove(pos);
+        cx.state.encounter_discard.push(card.code.clone());
+        // `CardDiscarded` carries an `investigator`; for a location
+        // attachment, use the controller as the bookkeeping owner.
+        cx.events.push(Event::CardDiscarded {
+            investigator: eval_ctx.controller,
+            code: card.code,
+            from: Zone::LocationAttachment,
+        });
+        return EngineOutcome::Done;
+    }
+
+    EngineOutcome::Rejected {
+        reason: format!(
+            "DiscardSelf: source instance {source:?} not found in any threat area or location attachment"
+        )
+        .into(),
     }
 }
 
@@ -1566,6 +1644,90 @@ mod tests {
             .collect();
         let state = GameStateBuilder::new().with_investigator(inv).build();
         (state, id)
+    }
+
+    #[test]
+    fn discard_self_removes_threat_area_instance_to_encounter_discard() {
+        use crate::event::Event;
+        use crate::state::Zone;
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .build();
+        let inst = CardInstanceId(5);
+        state
+            .investigators
+            .get_mut(&InvestigatorId(1))
+            .unwrap()
+            .threat_area
+            .push(CardInPlay::enter_play(CardCode::new("01165"), inst));
+        let mut events = Vec::new();
+        let outcome = {
+            let mut cx = Cx {
+                state: &mut state,
+                events: &mut events,
+            };
+            let mut c = EvalContext::for_controller(InvestigatorId(1));
+            c.source = Some(inst);
+            apply_effect(&mut cx, &super::Effect::DiscardSelf, c)
+        };
+        assert_eq!(outcome, EngineOutcome::Done);
+        assert!(state.investigators[&InvestigatorId(1)]
+            .threat_area
+            .is_empty());
+        assert_eq!(state.encounter_discard, vec![CardCode::new("01165")]);
+        assert!(events.iter().any(|e| matches!(
+            e,
+            Event::CardDiscarded { from: Zone::ThreatArea, code, .. } if code.as_str() == "01165"
+        )));
+    }
+
+    #[test]
+    fn discard_self_removes_location_attachment_to_encounter_discard() {
+        use crate::event::Event;
+        use crate::state::Zone;
+        use crate::test_support::test_location;
+        let mut loc = test_location(3, "Study");
+        loc.attachments
+            .push(CardInPlay::enter_play(CardCode::new("01168"), CardInstanceId(9)));
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_location(loc)
+            .build();
+        let mut events = Vec::new();
+        let outcome = {
+            let mut cx = Cx {
+                state: &mut state,
+                events: &mut events,
+            };
+            let mut c = EvalContext::for_controller(InvestigatorId(1));
+            c.source = Some(CardInstanceId(9));
+            apply_effect(&mut cx, &super::Effect::DiscardSelf, c)
+        };
+        assert_eq!(outcome, EngineOutcome::Done);
+        assert!(state.locations[&LocationId(3)].attachments.is_empty());
+        assert_eq!(state.encounter_discard, vec![CardCode::new("01168")]);
+        assert!(events.iter().any(|e| matches!(
+            e,
+            Event::CardDiscarded { from: Zone::LocationAttachment, code, .. } if code.as_str() == "01168"
+        )));
+    }
+
+    #[test]
+    fn discard_self_rejects_without_source() {
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .build();
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+        let outcome = apply_effect(
+            &mut cx,
+            &super::Effect::DiscardSelf,
+            EvalContext::for_controller(InvestigatorId(1)),
+        );
+        assert!(matches!(outcome, EngineOutcome::Rejected { .. }));
     }
 
     #[test]

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -199,6 +199,11 @@ pub(crate) fn apply_effect(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) 
             Some((**on_fail).clone()),
         ),
         Effect::DiscardSelf => discard_self(cx, &eval_ctx),
+        Effect::Restrict(_) => EngineOutcome::Rejected {
+            reason: "Effect::Restrict is a constant marker — inspected at decision points, \
+                     never executed"
+                .into(),
+        },
     }
 }
 
@@ -775,6 +780,34 @@ pub fn effective_shroud(registry: &CardRegistry, location: &crate::state::Locati
     }
     let total = i32::from(location.shroud) + delta;
     u8::try_from(total.clamp(0, i32::from(u8::MAX))).unwrap_or(u8::MAX)
+}
+
+/// Whether `investigator` is currently forbidden from playing a card of
+/// `card_type` by an active `Restriction::CannotPlay` constant ability on
+/// any of their controlled instances (Dissonant Voices 01165: assets and
+/// events). Checked in `play_card` validation.
+#[must_use]
+pub fn play_is_prohibited(
+    state: &GameState,
+    registry: &CardRegistry,
+    investigator: InvestigatorId,
+    card_type: crate::card_data::CardType,
+) -> bool {
+    let Some(inv) = state.investigators.get(&investigator) else {
+        return false;
+    };
+    inv.controlled_card_instances().any(|c| {
+        (registry.abilities_for)(&c.code)
+            .into_iter()
+            .flatten()
+            .any(|a| {
+                a.trigger == Trigger::Constant
+                    && matches!(
+                        &a.effect,
+                        Effect::Restrict(crate::dsl::Restriction::CannotPlay(t)) if *t == card_type
+                    )
+            })
+    })
 }
 
 /// Shared core of [`constant_skill_modifier`] and
@@ -1616,6 +1649,9 @@ mod tests {
                 2,
                 ModifierScope::WhileInPlay,
             ))]),
+            "cannot-play-assets" => Some(vec![constant(crate::dsl::restrict(
+                crate::dsl::Restriction::CannotPlay(crate::card_data::CardType::Asset),
+            ))]),
             _ => None,
         }
     }
@@ -1728,6 +1764,25 @@ mod tests {
             EvalContext::for_controller(InvestigatorId(1)),
         );
         assert!(matches!(outcome, EngineOutcome::Rejected { .. }));
+    }
+
+    #[test]
+    fn play_is_prohibited_matches_only_the_forbidden_type() {
+        use super::play_is_prohibited;
+        use crate::card_data::CardType;
+        let (state, id) = state_with_cards_in_play(&["cannot-play-assets"]);
+        let reg = fake_registry();
+        assert!(play_is_prohibited(&state, &reg, id, CardType::Asset));
+        assert!(!play_is_prohibited(&state, &reg, id, CardType::Event));
+    }
+
+    #[test]
+    fn play_is_prohibited_false_with_no_restriction() {
+        use super::play_is_prohibited;
+        use crate::card_data::CardType;
+        let (state, id) = state_with_cards_in_play(&["willpower-plus-1"]);
+        let reg = fake_registry();
+        assert!(!play_is_prohibited(&state, &reg, id, CardType::Asset));
     }
 
     #[test]

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -670,6 +670,35 @@ pub fn unconditional_constant_stat_modifier(
     )
 }
 
+/// A location's **effective shroud**: its printed `shroud` plus every
+/// `Stat::Shroud` `Modify(WhileInPlay)` constant ability on its
+/// attachments (Obscuring Fog 01168's `+2`). Clamped to `[0, u8::MAX]`.
+/// Read by `investigate` in place of the raw printed shroud.
+#[must_use]
+pub fn effective_shroud(registry: &CardRegistry, location: &crate::state::Location) -> u8 {
+    let mut delta: i32 = 0;
+    for att in &location.attachments {
+        let Some(abilities) = (registry.abilities_for)(&att.code) else {
+            continue;
+        };
+        for ability in &abilities {
+            if ability.trigger != Trigger::Constant {
+                continue;
+            }
+            if let Effect::Modify {
+                stat: Stat::Shroud,
+                delta: d,
+                scope: ModifierScope::WhileInPlay,
+            } = &ability.effect
+            {
+                delta += i32::from(*d);
+            }
+        }
+    }
+    let total = i32::from(location.shroud) + delta;
+    u8::try_from(total.clamp(0, i32::from(u8::MAX))).unwrap_or(u8::MAX)
+}
+
 /// Shared core of [`constant_skill_modifier`] and
 /// [`unconditional_constant_stat_modifier`]: sum the `delta` of every
 /// `Trigger::Constant` `Effect::Modify` on `controller`'s cards in play
@@ -792,8 +821,8 @@ mod tests {
     use crate::{assert_event, assert_event_count, assert_no_event};
 
     use super::{
-        apply_effect, constant_skill_modifier, unconditional_constant_stat_modifier, EngineOutcome,
-        EvalContext,
+        apply_effect, constant_skill_modifier, effective_shroud,
+        unconditional_constant_stat_modifier, EngineOutcome, EvalContext,
     };
     use crate::engine::Cx;
 
@@ -1504,6 +1533,11 @@ mod tests {
                 1,
                 ModifierScope::WhileInPlay,
             ))]),
+            "shroud-plus-2" => Some(vec![constant(modify(
+                Stat::Shroud,
+                2,
+                ModifierScope::WhileInPlay,
+            ))]),
             _ => None,
         }
     }
@@ -1532,6 +1566,26 @@ mod tests {
             .collect();
         let state = GameStateBuilder::new().with_investigator(inv).build();
         (state, id)
+    }
+
+    #[test]
+    fn effective_shroud_adds_attachment_shroud_modifiers() {
+        use crate::test_support::test_location;
+        let mut loc = test_location(3, "Study"); // printed shroud 2
+        loc.attachments.push(CardInPlay::enter_play(
+            CardCode::new("shroud-plus-2"),
+            CardInstanceId(0),
+        ));
+        let reg = fake_registry();
+        assert_eq!(effective_shroud(&reg, &loc), 4);
+    }
+
+    #[test]
+    fn effective_shroud_is_printed_value_with_no_attachments() {
+        use crate::test_support::test_location;
+        let loc = test_location(3, "Study"); // printed shroud 2
+        let reg = fake_registry();
+        assert_eq!(effective_shroud(&reg, &loc), 2);
     }
 
     #[test]

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -23,7 +23,8 @@ pub use dispatch::encounter::{
     reshuffle_encounter_discard, resolve_encounter_card, spawn_set_aside_enemy,
 };
 pub use dispatch::reveal::reveal_location;
-pub use evaluator::{location_id_by_code, EvalContext};
+pub use dispatch::threat_area::{attach_to_location, place_in_threat_area};
+pub use evaluator::{effective_shroud, location_id_by_code, EvalContext};
 pub use outcome::{EngineOutcome, InputRequest, ResumeToken};
 pub use pathfinding::shortest_first_steps;
 

--- a/crates/game-core/src/event.rs
+++ b/crates/game-core/src/event.rs
@@ -328,6 +328,19 @@ pub enum Event {
         /// The minted in-play instance id.
         instance_id: CardInstanceId,
     },
+    /// An encounter card was attached to a location (Obscuring Fog
+    /// 01168's Revelation). The location-attachment mirror of
+    /// [`CardEnteredThreatArea`](Event::CardEnteredThreatArea); the
+    /// discard mirror reuses [`CardDiscarded`](Event::CardDiscarded) with
+    /// `from: Zone::LocationAttachment`.
+    CardAttachedToLocation {
+        /// The location the card attached to.
+        location: LocationId,
+        /// The card code that attached.
+        code: CardCode,
+        /// The minted in-play instance id.
+        instance_id: CardInstanceId,
+    },
     /// A card was discarded — moved from `from` to the investigator's
     /// discard pile. Fires for played events after their on-play
     /// effects resolve; future card effects ("discard a card from

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -43,10 +43,10 @@ pub use action::{Action, EngineRecord, InputResponse, PlayerAction};
 pub use card_data::{CardMetadata, CardType, Class, SkillIcons, Slot};
 pub use card_registry::CardRegistry;
 pub use engine::{
-    apply, attach_to_location, effective_shroud, location_id_by_code,
-    place_doom_on_current_agenda, place_in_threat_area, reshuffle_encounter_discard,
-    resolve_encounter_card, reveal_location, shortest_first_steps, spawn_set_aside_enemy,
-    take_damage, ApplyResult, Cx, EngineOutcome, EvalContext, InputRequest, ResumeToken,
+    apply, attach_to_location, effective_shroud, location_id_by_code, place_doom_on_current_agenda,
+    place_in_threat_area, reshuffle_encounter_discard, resolve_encounter_card, reveal_location,
+    shortest_first_steps, spawn_set_aside_enemy, take_damage, ApplyResult, Cx, EngineOutcome,
+    EvalContext, InputRequest, ResumeToken,
 };
 pub use event::{Event, FailureReason};
 pub use rng::RngState;

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -43,7 +43,8 @@ pub use action::{Action, EngineRecord, InputResponse, PlayerAction};
 pub use card_data::{CardMetadata, CardType, Class, SkillIcons, Slot};
 pub use card_registry::CardRegistry;
 pub use engine::{
-    apply, location_id_by_code, place_doom_on_current_agenda, reshuffle_encounter_discard,
+    apply, attach_to_location, effective_shroud, location_id_by_code,
+    place_doom_on_current_agenda, place_in_threat_area, reshuffle_encounter_discard,
     resolve_encounter_card, reveal_location, shortest_first_steps, spawn_set_aside_enemy,
     take_damage, ApplyResult, Cx, EngineOutcome, EvalContext, InputRequest, ResumeToken,
 };

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -279,6 +279,7 @@ impl GameStateBuilder {
             enemy_attack_pending: None,
             hunter_move_pending: None,
             spawn_engage_pending: None,
+            pending_end_turn: None,
             hand_size_discard_pending: self.hand_size_discard_pending,
             act_round_end_pending: None,
             pending_revelation_discard: None,

--- a/crates/game-core/src/state/card.rs
+++ b/crates/game-core/src/state/card.rs
@@ -72,6 +72,10 @@ pub enum Zone {
     /// Cards there are at the investigator's location. Used as the
     /// `from` zone when a threat-area card is discarded.
     ThreatArea,
+    /// A location's attachment zone — encounter cards attached to a
+    /// location (Obscuring Fog 01168). Used as the `from` zone when an
+    /// attachment is discarded.
+    LocationAttachment,
 }
 
 /// Unique identifier for a specific copy of a card in play.

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -416,6 +416,17 @@ pub struct InFlightSkillTest {
     /// [`follow_up`](Self::follow_up). Orthogonal to `follow_up` —
     /// success and margin-keyed-failure are separate axes.
     pub on_fail: Option<card_dsl::dsl::Effect>,
+    /// Effect to run **on success** after the chaos token resolves (the
+    /// success-side mirror of [`on_fail`](Self::on_fail)). Carried by
+    /// `Effect::SkillTest` with a success branch — Frozen in Fear 01164's
+    /// end-of-turn willpower test discards the card on success. `None` for
+    /// action tests and failure-only card tests.
+    pub on_success: Option<card_dsl::dsl::Effect>,
+    /// The firing card instance, threaded so the `on_success` / `on_fail`
+    /// eval-contexts can resolve [`Effect::DiscardSelf`] across the
+    /// suspend/resume boundary. `None` for action tests and effects with
+    /// no originating instance.
+    pub source: Option<CardInstanceId>,
     /// Where the resolution driver should resume on the next call to
     /// `drive_skill_test`. Initialized to
     /// [`FinishContinuation::AwaitingCommit`] at

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -430,7 +430,7 @@ pub struct InFlightSkillTest {
     /// action tests and failure-only card tests.
     pub on_success: Option<card_dsl::dsl::Effect>,
     /// The firing card instance, threaded so the `on_success` / `on_fail`
-    /// eval-contexts can resolve [`Effect::DiscardSelf`] across the
+    /// eval-contexts can resolve [`Effect::DiscardSelf`](card_dsl::dsl::Effect::DiscardSelf) across the
     /// suspend/resume boundary. `None` for action tests and effects with
     /// no originating instance.
     pub source: Option<CardInstanceId>,

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -960,6 +960,7 @@ impl GameState {
             revealed: false,
             printed_clues,
             connections: Vec::new(),
+            attachments: Vec::new(),
         }
     }
 

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -215,6 +215,13 @@ pub struct GameState {
     pub hunter_move_pending: Option<HunterChoice>,
     /// Suspended engagement-on-spawn choice (#128). See [`SpawnEngagePending`].
     pub spawn_engage_pending: Option<SpawnEngagePending>,
+    /// Suspended end-of-turn continuation (C4c, #235): `Some(active)` while
+    /// `end_turn` is paused on a suspending `EndOfTurn` forced effect
+    /// (Frozen in Fear 01164's willpower test). The skill-test commit-resume
+    /// path re-enters `resume_end_turn` to run the stranded rotation /
+    /// phase-end once the test resolves. Defaults to `None`.
+    #[serde(default)]
+    pub pending_end_turn: Option<InvestigatorId>,
     /// Suspended upkeep hand-size discard (#111). See [`HandSizeDiscard`].
     pub hand_size_discard_pending: Option<HandSizeDiscard>,
     /// Suspended act round-end clue-spend window (#275). `Some` only while

--- a/crates/game-core/src/state/investigator.rs
+++ b/crates/game-core/src/state/investigator.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::card::{CardCode, CardInPlay};
+use super::card::{CardCode, CardInPlay, CardInstanceId};
 use super::location::LocationId;
 use super::Skills;
 
@@ -101,6 +101,13 @@ pub struct Investigator {
     /// serialized before this field was added still deserialize.
     #[serde(default)]
     pub removed_from_game: Vec<CardCode>,
+    /// Source instances whose [`ExtraActionCost`](crate::dsl::Restriction::ExtraActionCost)
+    /// with `first_each_round` has already surcharged an action this round
+    /// (Frozen in Fear 01164). Cleared at the round boundary. Keyed by
+    /// instance so multiple surcharge sources track independently. Defaults
+    /// to empty for backward-compatible deserialization.
+    #[serde(default)]
+    pub action_surcharge_spent_this_round: std::collections::BTreeSet<CardInstanceId>,
 }
 
 impl Investigator {

--- a/crates/game-core/src/state/location.rs
+++ b/crates/game-core/src/state/location.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use card_dsl::card_data::ClueValue;
 
-use super::card::CardCode;
+use super::card::{CardCode, CardInPlay};
 
 /// Stable identifier for a location within a scenario.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
@@ -44,6 +44,11 @@ pub struct Location {
     pub revealed: bool,
     /// Locations physically connected to this one (movement targets).
     pub connections: Vec<LocationId>,
+    /// Encounter cards attached to this location (e.g. Obscuring Fog
+    /// 01168 grants `+2` shroud while attached). Empty for the common
+    /// case; discarded back to the encounter discard via
+    /// [`Effect::DiscardSelf`](crate::dsl::Effect::DiscardSelf).
+    pub attachments: Vec<CardInPlay>,
 }
 
 impl Location {
@@ -73,6 +78,7 @@ impl Location {
             printed_clues: ClueValue::Fixed(clues),
             revealed: true,
             connections: Vec::new(),
+            attachments: Vec::new(),
         }
     }
 }
@@ -93,6 +99,7 @@ mod location_code_tests {
             printed_clues: ClueValue::Fixed(0),
             revealed: true,
             connections: Vec::new(),
+            attachments: Vec::new(),
         };
         assert_eq!(loc.code, CardCode("01112".into()));
     }
@@ -120,6 +127,7 @@ mod location_code_tests {
             printed_clues: ClueValue::Fixed(3),
             revealed: false,
             connections: vec![LocationId(1)],
+            attachments: Vec::new(),
         };
         let json = serde_json::to_string(&original).expect("serialize");
         let back: Location = serde_json::from_str(&json).expect("deserialize");

--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -57,6 +57,7 @@ pub fn test_investigator(id: u32) -> Investigator {
         cards_in_play: Vec::new(),
         threat_area: Vec::new(),
         removed_from_game: Vec::new(),
+        action_surcharge_spent_this_round: std::collections::BTreeSet::new(),
     }
 }
 

--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -79,6 +79,7 @@ pub fn test_location(id: u32, name: impl Into<String>) -> Location {
         printed_clues: ClueValue::Fixed(0),
         revealed: true,
         connections: Vec::new(),
+        attachments: Vec::new(),
     }
 }
 

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -469,6 +469,8 @@ mod tests {
             tested_location: None,
             follow_up: SkillTestFollowUp::None,
             on_fail: None,
+            on_success: None,
+            source: None,
             continuation: crate::state::FinishContinuation::AwaitingCommit,
         });
         state

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -79,7 +79,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
         )])
     } else if code.as_str() == DOUBLE_FORCED {
         // Two distinct forced `EnteredLocation` abilities at the same timing
-        // point — exercises the 2+-simultaneous reject path.
+        // point — exercises ordered multi-resolution (both fire in order).
         Some(vec![
             on_event(
                 EventPattern::EnteredLocation,
@@ -616,7 +616,7 @@ fn successful_investigate_fires_after_location_investigated_forced() {
 }
 
 #[test]
-fn two_simultaneous_forced_triggers_reject_loudly() {
+fn two_simultaneous_forced_triggers_resolve_in_order() {
     install_mock_registry();
 
     let mut loc = test_location(10, "Double-Forced Room");
@@ -631,18 +631,21 @@ fn two_simultaneous_forced_triggers_reject_loudly() {
     let mut events = Vec::new();
     let outcome = fire_forced_on_enter(&mut state, &mut events, InvestigatorId(1), LocationId(10));
 
-    // 2+ simultaneous forced triggers reject loudly — no order is chosen.
-    // `fire_forced_triggers` counts hits first, before calling `apply_effect`,
-    // so the reject happens before any effect is resolved.
-    assert!(
-        matches!(outcome, EngineOutcome::Rejected { .. }),
-        "expected Rejected for 2+ simultaneous forced triggers; got {outcome:?}"
+    // Both simultaneous forced triggers resolve in a fixed deterministic
+    // order (no reject) — #213 will let the player choose the order; a
+    // fixed order is the stand-in. Each deals 1 horror, so the total is 2.
+    assert_eq!(
+        outcome,
+        EngineOutcome::Done,
+        "expected ordered resolution of both forced triggers; got {outcome:?}"
     );
-    // No horror was applied — the reject fires before any effect runs.
-    assert_eq!(state.investigators[&InvestigatorId(1)].horror, 0);
-    // No events were emitted on this path.
-    assert!(
-        events.is_empty(),
-        "no events should be emitted on the 2+ reject path"
+    assert_eq!(state.investigators[&InvestigatorId(1)].horror, 2);
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| matches!(e, Event::HorrorTaken { amount: 1, .. }))
+            .count(),
+        2,
+        "both forced effects must emit their HorrorTaken event; events = {events:?}"
     );
 }

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -20,8 +20,13 @@ zone + shared scan source + `EndOfTurn`/`AfterLocationInvestigated`
 forced points), the test-treachery engine prereq
 ([#286](https://github.com/talelburg/eldritch/issues/286):
 `Effect::SkillTest` + `ForEachPointFailed` + suspendable-revelation
-discard), and C4b (the four one-shot Revelation treacheries —
-01162/01163/01166/01167). **Next: C4c → C5 → C7.**
+discard), C4b (the four one-shot Revelation treacheries —
+01162/01163/01166/01167), and C4c (the three persistent threat-area /
+attachment treacheries — Obscuring Fog 01168, Dissonant Voices 01165,
+Frozen in Fear 01164 — with the location attachment zone, inspectable-DSL
+constant restrictions, `Effect::DiscardSelf`, deterministic
+simultaneous-forced-trigger resolution, and end-turn resume plumbing).
+**Next: C5 → C7** (C6d also gates C7b).
 
 Design specs:
 [Gathering design](../superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md),
@@ -74,7 +79,7 @@ root dependency; C7 is the playable Won/Lost gate; #212 lands after C.
 | C4a | [#233](https://github.com/talelburg/eldritch/issues/233) | threat-area zone + shared scan source (in-C consolidation seam) | ✅ PR #285 |
 | — | [#286](https://github.com/talelburg/eldritch/issues/286) | infra: `Effect::SkillTest` + `ForEachPointFailed` + failure-side follow-up + suspendable-revelation discard (prerequisite for C4b's test treacheries) | ✅ PR #287 |
 | C4b | [#234](https://github.com/talelburg/eldritch/issues/234) | one-shot Revelation treacheries (×4) | ✅ PR #288 |
-| C4c | [#235](https://github.com/talelburg/eldritch/issues/235) | persistent threat-area treacheries (×3) | — |
+| C4c | [#235](https://github.com/talelburg/eldritch/issues/235) | persistent threat-area / attachment treacheries (×3) | ✅ PR #289 |
 | C5a | [#236](https://github.com/talelburg/eldritch/issues/236) | Cover Up before-timing interrupt + `GameEnd` | — |
 | C5b | [#237](https://github.com/talelburg/eldritch/issues/237) | Guard Dog damage-from-enemy window | — |
 | C5c | [#238](https://github.com/talelburg/eldritch/issues/238) | .38 Special signature + Cover Up content | — |
@@ -141,6 +146,10 @@ Devourer Below, campaign log + `Fact` enum) is **Phase 9**, not Phase 7.
 - **A card effect initiates a skill test via `Effect::SkillTest { skill, difficulty, on_fail }` with a margin-keyed `Effect::ForEachPointFailed` failure branch; a suspending Revelation discards via `GameState.pending_revelation_discard` (C4b prereq [#286](https://github.com/talelburg/eldritch/issues/286), PR #287).** `SkillTest` calls `start_skill_test` (always suspends at the commit window); `on_fail` (on `InFlightSkillTest.on_fail`, orthogonal to the success-side `follow_up`) runs on failure with the margin in `EvalContext::failed_by`. A test-initiating Revelation suspends, so `resolve_encounter_card` records the treachery in `pending_revelation_discard`, flushed at skill-test teardown (no-op for a plain Investigate — the seam C4c extends). **`Active` status = in-play, not turn ownership, so Mythos-phase treachery tests are legal.**
 
 - **Threat-area scan source (C4a, [#233](https://github.com/talelburg/eldritch/issues/233), PR #285) + C4c ([#235](https://github.com/talelburg/eldritch/issues/235)) extension points.** `Investigator::controlled_card_instances()` (chains `cards_in_play` + `threat_area`) is the single scan source for both reaction-window and forced instance scans; cards enter/leave the threat area via `dispatch::threat_area::{place_in_threat_area, discard_from_threat_area}`. New forced points `EndOfTurn` and `AfterLocationInvestigated` (skill-test `PostOnResolution`, successful Investigate) landed. **C4c must:** thread the *source instance* into the forced `EvalContext` (`resolve_one` binds controller only); extend `AfterLocationInvestigated` to also scan the investigated *location's* attachment zone (Obscuring Fog 01168 attaches to a location, not the threat area); and extend `pending_revelation_discard` (above) for persistent treacheries that stay in the threat area instead of discarding. Suspension at these forced points is unmodeled (#212 reentrancy).
+
+- **A persistent treachery is one with any non-Revelation ability; it owns its own disposition (C4c, [#235](https://github.com/talelburg/eldritch/issues/235), PR #289).** `resolve_encounter_card` auto-discards a treachery after its Revelation **only if every ability is `Trigger::Revelation`**; a card carrying a `Constant`/`OnEvent` ability places itself (threat area via `place_in_threat_area`, or location via `attach_to_location`) and discards itself later via the typed `Effect::DiscardSelf` (which finds the firing instance through `EvalContext::source`). No suppress-discard flag. **A new persistent treachery needs no routing change — give it an ongoing ability and a self-placement Revelation.** Constant restrictions extend the inspectable DSL (`Stat::Shroud`, `Restriction::{CannotPlay, ExtraActionCost}` under `Effect::Restrict`), read by `effective_shroud` / `play_is_prohibited` / `pending_action_surcharge` the way `constant_skill_modifier` already reads `Modify` — **not** via new registry query hooks. `ExtraActionCost`'s `first_each_round` stays a field (tracked per source instance in `Investigator.action_surcharge_spent_this_round`) until a second consumer needs the gate on a non-cost mechanism.
+
+- **Simultaneous forced triggers resolve in a fixed deterministic order, and a suspending forced effect at end-of-turn resumes via `pending_end_turn` (C4c, PR #289).** `fire_forced_triggers` now resolves *all* collected hits in collection order (board cards before threat-area/attachment instances; `BTreeMap` order) instead of rejecting on 2+ — this is the partial #213 stand-in (player-chosen ordering is still #213). It lets Dissonant Voices' `RoundEnded` discard coexist with agenda 01107's `RoundEnded` doom. A hit that *suspends* abandons later hits (#212 reentrancy); safe while no point has 2+ simultaneous suspending hits. `Effect::SkillTest` gained a success-side `on_success` (mirror of `on_fail`); a suspending `EndOfTurn` forced effect (Frozen in Fear's willpower test) strands `end_turn` before rotation, so `end_turn` records `pending_end_turn` and the skill-test commit-resume path re-enters `resume_end_turn` (rotation / phase-end) — mirroring `spawn_engage_pending`/`resume_spawn_engage`.
 
 ## Open questions
 

--- a/docs/superpowers/plans/2026-06-14-c4c-persistent-treacheries.md
+++ b/docs/superpowers/plans/2026-06-14-c4c-persistent-treacheries.md
@@ -1,0 +1,1002 @@
+# C4c — Persistent threat-area / attachment treacheries — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement The Gathering's three persistent encounter treacheries (Frozen in Fear 01164, Dissonant Voices 01165, Obscuring Fog 01168), each staying in play, enforcing a constant restriction, and discarding itself at a forced timing point.
+
+**Architecture:** Extend the inspectable DSL (`Stat::Shroud`, `Restriction`, `Effect::Restrict`, `Effect::DiscardSelf`, `SkillTest.on_success`) so the engine reads constant restrictions from `abilities_for` the way `constant_skill_modifier` already does. Add a location attachment zone, derive persistence from "has a non-Revelation ability," thread the firing instance through forced triggers, and track per-round action surcharges per source instance.
+
+**Tech Stack:** Rust workspace (`card-dsl`, `game-core`, `cards`); serde; event-sourced engine with validate-first dispatch handlers.
+
+**Spec:** `docs/superpowers/specs/2026-06-14-phase-7-slice-1-c4c-persistent-treacheries-design.md`
+
+**CI gauntlet (run before push):**
+```sh
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+
+---
+
+## Task 1 — Location attachment zone
+
+**Files:**
+- Modify: `crates/game-core/src/state/location.rs` (add `attachments` field + `new` default + serde test)
+- Modify: `crates/game-core/src/state/card.rs:62` (`Zone` enum — add `LocationAttachment`)
+- Modify: `crates/game-core/src/event.rs` (add `Event::CardAttachedToLocation`)
+- Modify: `crates/game-core/src/engine/dispatch/threat_area.rs` (add `attach_to_location`)
+
+- [ ] **Step 1: Add the `attachments` field.** In `location.rs`, add to the `Location` struct (after `connections`):
+```rust
+    /// Encounter cards attached to this location (e.g. Obscuring Fog
+    /// 01168 grants `+2` shroud while attached). Empty for the common
+    /// case. Discarded back to the encounter discard via
+    /// `Effect::DiscardSelf`.
+    pub attachments: Vec<CardInPlay>,
+```
+Add the import: change `use super::card::CardCode;` to also import `CardInPlay` (`use super::card::{CardCode, CardInPlay};`). Set `attachments: Vec::new()` in `Location::new` and in the two struct literals in the existing `#[cfg(test)]` block.
+
+- [ ] **Step 2: Add the `Zone` variant.** In `card.rs`, after the `ThreatArea` variant:
+```rust
+    /// A location's attachment zone — encounter cards attached to a
+    /// location (Obscuring Fog 01168). Used as the `from` zone when an
+    /// attachment is discarded.
+    LocationAttachment,
+```
+
+- [ ] **Step 3: Add the event.** In `event.rs`, beside `CardEnteredThreatArea`, add (mirror its shape and doc style; `location: LocationId`):
+```rust
+    /// An encounter card was attached to a location (Obscuring Fog
+    /// 01168's Revelation). The mirror of
+    /// [`CardEnteredThreatArea`](Event::CardEnteredThreatArea) for the
+    /// location attachment zone.
+    CardAttachedToLocation {
+        /// The location the card attached to.
+        location: LocationId,
+        /// The printed code of the attached card.
+        code: CardCode,
+        /// The minted in-play instance id.
+        instance_id: CardInstanceId,
+    },
+```
+Ensure `LocationId` is imported in `event.rs` (it is used elsewhere; confirm).
+
+- [ ] **Step 4: Write the failing test for `attach_to_location`.** In `threat_area.rs`'s `#[cfg(test)] mod tests`, add (uses `test_location`):
+```rust
+    #[test]
+    fn attach_mints_id_pushes_to_location_and_emits_event() {
+        use crate::test_support::test_location;
+        let mut state = GameStateBuilder::new()
+            .with_location(test_location(7, "Study"))
+            .build();
+        let mut events = Vec::new();
+        let id = {
+            let mut cx = Cx { state: &mut state, events: &mut events };
+            attach_to_location(&mut cx, LocationId(7), CardCode::new("01168"))
+        };
+        assert_eq!(id, Some(CardInstanceId(0)));
+        let loc = &state.locations[&LocationId(7)];
+        assert_eq!(loc.attachments.len(), 1);
+        assert_eq!(loc.attachments[0].code.as_str(), "01168");
+        assert!(events.iter().any(|e| matches!(
+            e,
+            Event::CardAttachedToLocation { code, location, .. }
+                if code.as_str() == "01168" && *location == LocationId(7)
+        )));
+    }
+```
+Add `LocationId` to the test module imports (`use crate::state::{... , LocationId};`).
+
+- [ ] **Step 5: Run it — verify it fails to compile** (`attach_to_location` undefined).
+Run: `cargo test -p game-core attach_mints_id`
+Expected: compile error, unresolved `attach_to_location`.
+
+- [ ] **Step 6: Implement `attach_to_location`.** In `threat_area.rs`, after `place_in_threat_area` (mirror it; keep the `#[cfg_attr(not(test), allow(dead_code))]` only until Task 9 wires the first production caller — Obscuring Fog calls it):
+```rust
+/// Attach `code` to `location` as a fresh in-play instance, minting an
+/// instance id and emitting [`Event::CardAttachedToLocation`]. Returns
+/// the minted id, or `None` if the location isn't in state.
+///
+/// **No limit enforcement** — "Limit 1 per location" is printed on
+/// specific cards (Obscuring Fog 01168), not a property of all
+/// attachments, so the limit lives in the card's Revelation, not here.
+pub(super) fn attach_to_location(
+    cx: &mut Cx,
+    location: LocationId,
+    code: CardCode,
+) -> Option<CardInstanceId> {
+    if !cx.state.locations.contains_key(&location) {
+        return None;
+    }
+    let instance_id = CardInstanceId(cx.state.next_card_instance_id);
+    cx.state.next_card_instance_id = cx.state.next_card_instance_id.saturating_add(1);
+    let loc = cx
+        .state
+        .locations
+        .get_mut(&location)
+        .expect("existence checked above");
+    loc.attachments
+        .push(CardInPlay::enter_play(code.clone(), instance_id));
+    cx.events.push(Event::CardAttachedToLocation {
+        location,
+        code,
+        instance_id,
+    });
+    Some(instance_id)
+}
+```
+Add `LocationId` to the module's `use crate::state::{...}` line.
+
+- [ ] **Step 7: Run tests.** `cargo test -p game-core threat_area` → all pass (including the new test and the serde roundtrip in `location.rs`).
+
+- [ ] **Step 8: Commit.**
+```bash
+git add crates/game-core/src/state/location.rs crates/game-core/src/state/card.rs crates/game-core/src/event.rs crates/game-core/src/engine/dispatch/threat_area.rs
+git commit -m "engine: location attachment zone + attach_to_location helper"
+```
+
+---
+
+## Task 2 — Derived persistence (no suppress flag)
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/encounter.rs` (treachery arm in `resolve_encounter_card`, ~line 124-153)
+- Test: same file's test module, or `crates/cards/tests/` if registry needed. Use a unit test with a synthetic registry is hard here; prefer an integration test in `crates/cards/tests/persistent_treachery.rs` once cards exist. For Task 2, add a **focused unit test** by extracting the persistence predicate.
+
+- [ ] **Step 1: Add the persistence predicate (pure, unit-testable).** In `encounter.rs`, above `resolve_encounter_card`:
+```rust
+/// A treachery is **persistent** (stays in play after its Revelation,
+/// owning its own disposition) iff it has at least one ability whose
+/// trigger is not `Trigger::Revelation` — the ongoing `Constant`
+/// restriction / `OnEvent` forced-discard abilities the three C4c
+/// treacheries carry. One-shot treacheries have only a `Revelation`, so
+/// they auto-discard after it resolves.
+///
+/// TODO: assumes every persistent treachery carries an ongoing ability
+/// and every one-shot carries none (holds for all Core+Dunwich
+/// treacheries). Revisit with an explicit persistence marker only if a
+/// treachery must persist with no ongoing ability, or auto-discard
+/// despite carrying one.
+fn treachery_is_persistent(abilities: &[crate::dsl::Ability]) -> bool {
+    abilities
+        .iter()
+        .any(|a| a.trigger != Trigger::Revelation)
+}
+```
+
+- [ ] **Step 2: Write the failing unit test.** In `encounter.rs` test module:
+```rust
+    #[test]
+    fn persistence_is_derived_from_non_revelation_abilities() {
+        use card_dsl::dsl::{revelation, constant, modify, native, Ability};
+        use card_dsl::card_data::{ModifierScope, Stat};
+        // one-shot: only Revelation
+        let one_shot: Vec<Ability> = vec![revelation(native("x:rev"))];
+        assert!(!super::treachery_is_persistent(&one_shot));
+        // persistent: has a Constant ability
+        let persistent: Vec<Ability> = vec![
+            revelation(native("y:rev")),
+            constant(modify(Stat::Willpower, 1, ModifierScope::WhileInPlay)),
+        ];
+        assert!(super::treachery_is_persistent(&persistent));
+    }
+```
+
+- [ ] **Step 3: Run it.** `cargo test -p game-core persistence_is_derived` → PASS (predicate already added). (If the test module lacks the imports, add them.)
+
+- [ ] **Step 4: Wire it into the treachery arm.** In `resolve_encounter_card`, replace the unconditional discard at the end of the `CardType::Treachery` arm. Current tail:
+```rust
+            cx.state.encounter_discard.push(code);
+            EngineOutcome::Done
+```
+becomes:
+```rust
+            if treachery_is_persistent(&abilities) {
+                // Persistent: the card placed itself (threat area /
+                // attachment) during its Revelation and owns its own
+                // disposition (including the Obscuring Fog limit-1
+                // discard). Do not auto-discard.
+                EngineOutcome::Done
+            } else {
+                cx.state.encounter_discard.push(code);
+                EngineOutcome::Done
+            }
+```
+Note `abilities` is already bound earlier in the arm (`let abilities = (registry.abilities_for)(&code).unwrap_or_default();`). The suspend path (`pending_revelation_discard`) is unchanged — none of these three test on Revelation, so persistence and suspension never co-occur here.
+
+- [ ] **Step 5: Run the existing encounter tests** to confirm one-shot behavior is preserved.
+Run: `cargo test -p game-core encounter`
+Expected: PASS (one-shots still discard; nothing persistent in game-core unit tests yet).
+
+- [ ] **Step 6: Commit.**
+```bash
+git add crates/game-core/src/engine/dispatch/encounter.rs
+git commit -m "engine: derive treachery persistence from non-Revelation abilities"
+```
+
+---
+
+## Task 3 — `Stat::Shroud` + `effective_shroud`
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs:541` (`Stat` enum — add `Shroud`)
+- Modify: `crates/game-core/src/engine/evaluator.rs` (add `effective_shroud`)
+- Modify: `crates/game-core/src/engine/dispatch/actions.rs:98` (read effective shroud)
+
+- [ ] **Step 1: Add `Stat::Shroud`.** In `dsl.rs`, in `enum Stat`, add `Shroud,` after `MaxSanity`. Update the doc comment to mention "plus location shroud (Obscuring Fog)".
+
+- [ ] **Step 2: Write the failing test for `effective_shroud`.** In `evaluator.rs` test module:
+```rust
+    #[test]
+    fn effective_shroud_adds_attachment_shroud_modifiers() {
+        // A location with printed shroud 2 and one attachment carrying
+        // a Constant Modify(Shroud, +2) reads as effective shroud 4.
+        // Uses a fake registry mapping the attachment code to that
+        // ability. (Mirror the registry-install pattern used by other
+        // evaluator tests in this module.)
+        // ... build state with location shroud 2 + an attachment whose
+        //     code resolves to constant(modify(Stat::Shroud, 2, WhileInPlay))
+        // assert_eq!(effective_shroud(&state, reg, &location), 4);
+    }
+```
+Implement the test concretely following the nearest existing registry-based test in `evaluator.rs` (search for `install` / `CardRegistry` usage in that module; reuse its fake-registry helper). The attachment goes in `location.attachments`.
+
+- [ ] **Step 3: Run it — fails** (`effective_shroud` undefined).
+Run: `cargo test -p game-core effective_shroud`
+
+- [ ] **Step 4: Implement `effective_shroud`.** In `evaluator.rs`, near `unconditional_constant_stat_modifier`:
+```rust
+/// A location's **effective shroud**: its printed `shroud` plus every
+/// `Stat::Shroud` `Modify(WhileInPlay)` on its attachments (Obscuring
+/// Fog 01168's `+2`). Clamped to `0` on the low end and `u8::MAX` on the
+/// high end. Read by `investigate` in place of the raw printed shroud.
+#[must_use]
+pub fn effective_shroud(
+    state: &GameState,
+    registry: &CardRegistry,
+    location: &crate::state::Location,
+) -> u8 {
+    let mut delta: i32 = 0;
+    for att in &location.attachments {
+        let Some(abilities) = (registry.abilities_for)(&att.code) else {
+            continue;
+        };
+        for ability in &abilities {
+            if ability.trigger != Trigger::Constant {
+                continue;
+            }
+            if let Effect::Modify { stat: Stat::Shroud, delta: d, scope: ModifierScope::WhileInPlay } =
+                &ability.effect
+            {
+                delta += i32::from(*d);
+            }
+        }
+    }
+    let total = i32::from(location.shroud) + delta;
+    u8::try_from(total.clamp(0, i32::from(u8::MAX))).unwrap_or(u8::MAX)
+}
+```
+Confirm `Stat`, `ModifierScope`, `Effect`, `Trigger` are imported in `evaluator.rs` (they are used by the existing constant-modifier code).
+
+- [ ] **Step 5: Read effective shroud in `investigate`.** In `actions.rs`, replace line ~98:
+```rust
+    let difficulty = i8::try_from(location.shroud).unwrap_or(i8::MAX);
+```
+with (the registry may be absent in bare unit tests — fall back to printed shroud):
+```rust
+    let shroud = match crate::card_registry::current() {
+        Some(reg) => crate::engine::evaluator::effective_shroud(cx.state, reg, location),
+        None => location.shroud,
+    };
+    let difficulty = i8::try_from(shroud).unwrap_or(i8::MAX);
+```
+Note: `location` is an immutable borrow here; `effective_shroud` only reads. If the borrow checker complains (because `cx.state` is borrowed via `location`), capture the needed fields first (`let printed = location.shroud; let loc_id = location.id;`) then call `effective_shroud` with a fresh `cx.state.locations[&loc_id]` lookup, or compute shroud before the mutate section. Resolve during implementation.
+
+- [ ] **Step 6: Run tests.** `cargo test -p game-core effective_shroud` and `cargo test -p game-core investigate` → PASS.
+
+- [ ] **Step 7: Commit.**
+```bash
+git add crates/card-dsl/src/dsl.rs crates/game-core/src/engine/evaluator.rs crates/game-core/src/engine/dispatch/actions.rs
+git commit -m "engine: Stat::Shroud + effective_shroud read by investigate"
+```
+
+---
+
+## Task 4 — `Effect::DiscardSelf`
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs` (`Effect` enum — add `DiscardSelf`; add `discard_self()` builder)
+- Modify: `crates/game-core/src/engine/evaluator.rs` (`apply_effect` arm + `discard_self` fn)
+
+- [ ] **Step 1: Add the variant + builder.** In `dsl.rs`, in `enum Effect`, add:
+```rust
+    /// Discard the firing card instance (the `source` in
+    /// [`EvalContext`](../../game_core/engine/evaluator/struct.EvalContext.html)).
+    /// Used by persistent treacheries' `Forced` self-discard abilities.
+    /// Locates the instance in a threat area or location attachment and
+    /// discards it to the encounter discard.
+    DiscardSelf,
+```
+And a builder near `native`:
+```rust
+/// Build an [`Effect::DiscardSelf`].
+#[must_use]
+pub fn discard_self() -> Effect {
+    Effect::DiscardSelf
+}
+```
+
+- [ ] **Step 2: Write the failing test.** In `evaluator.rs` test module:
+```rust
+    #[test]
+    fn discard_self_removes_threat_area_instance_to_encounter_discard() {
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .build();
+        // Put an instance into the threat area directly.
+        let inst = CardInstanceId(5);
+        state.investigators.get_mut(&InvestigatorId(1)).unwrap()
+            .threat_area.push(CardInPlay::enter_play(CardCode::new("01165"), inst));
+        let mut events = Vec::new();
+        let outcome = {
+            let mut cx = Cx { state: &mut state, events: &mut events };
+            let mut ctx = EvalContext::for_controller(InvestigatorId(1));
+            ctx.source = Some(inst);
+            apply_effect(&mut cx, &Effect::DiscardSelf, ctx)
+        };
+        assert_eq!(outcome, EngineOutcome::Done);
+        assert!(state.investigators[&InvestigatorId(1)].threat_area.is_empty());
+        assert_eq!(state.encounter_discard, vec![CardCode::new("01165")]);
+        assert!(events.iter().any(|e| matches!(
+            e, Event::CardDiscarded { from: Zone::ThreatArea, code, .. } if code.as_str() == "01165"
+        )));
+    }
+
+    #[test]
+    fn discard_self_removes_location_attachment_to_encounter_discard() {
+        let mut state = GameStateBuilder::new()
+            .with_location(test_location(3, "Study"))
+            .build();
+        let inst = CardInstanceId(9);
+        state.locations.get_mut(&LocationId(3)).unwrap()
+            .attachments.push(CardInPlay::enter_play(CardCode::new("01168"), inst));
+        let mut events = Vec::new();
+        let outcome = {
+            let mut cx = Cx { state: &mut state, events: &mut events };
+            let mut ctx = EvalContext::for_controller(InvestigatorId(1));
+            ctx.source = Some(inst);
+            apply_effect(&mut cx, &Effect::DiscardSelf, ctx)
+        };
+        assert_eq!(outcome, EngineOutcome::Done);
+        assert!(state.locations[&LocationId(3)].attachments.is_empty());
+        assert_eq!(state.encounter_discard, vec![CardCode::new("01168")]);
+        assert!(events.iter().any(|e| matches!(
+            e, Event::CardDiscarded { from: Zone::LocationAttachment, code, .. } if code.as_str() == "01168"
+        )));
+    }
+
+    #[test]
+    fn discard_self_rejects_without_source() {
+        let mut state = GameStateBuilder::new().with_investigator(test_investigator(1)).build();
+        let mut events = Vec::new();
+        let mut cx = Cx { state: &mut state, events: &mut events };
+        let outcome = apply_effect(&mut cx, &Effect::DiscardSelf, EvalContext::for_controller(InvestigatorId(1)));
+        assert!(matches!(outcome, EngineOutcome::Rejected { .. }));
+    }
+```
+Add the needed imports to the test module (`CardInPlay`, `CardCode`, `CardInstanceId`, `LocationId`, `Zone`, `test_location`, `test_investigator`).
+
+- [ ] **Step 3: Run — fails** (no `DiscardSelf` arm).
+Run: `cargo test -p game-core discard_self`
+
+- [ ] **Step 4: Implement the arm + helper.** In `apply_effect`, add:
+```rust
+        Effect::DiscardSelf => discard_self(cx, &eval_ctx),
+```
+And the helper:
+```rust
+/// Resolve [`Effect::DiscardSelf`]: remove `eval_ctx.source` from
+/// whichever threat area or location attachment holds it, push its code
+/// to `encounter_discard`, and emit `CardDiscarded` with the matching
+/// `from` zone. Rejects loudly if there is no source or the instance is
+/// not found.
+///
+/// TODO: scoped to the two encounter zones (threat area / location
+/// attachment → encounter discard). Extend to player-controlled zones
+/// (cards_in_play → owner discard) when a player card first needs to
+/// discard itself by source instance.
+fn discard_self(cx: &mut Cx, eval_ctx: &EvalContext) -> EngineOutcome {
+    let Some(source) = eval_ctx.source else {
+        return EngineOutcome::Rejected {
+            reason: "DiscardSelf: no source instance in context".into(),
+        };
+    };
+    // Threat areas.
+    for (inv_id, inv) in cx.state.investigators.iter_mut() {
+        if let Some(pos) = inv.threat_area.iter().position(|c| c.instance_id == source) {
+            let card = inv.threat_area.remove(pos);
+            cx.state.encounter_discard.push(card.code.clone());
+            cx.events.push(Event::CardDiscarded {
+                investigator: *inv_id,
+                code: card.code,
+                from: Zone::ThreatArea,
+            });
+            return EngineOutcome::Done;
+        }
+    }
+    // Location attachments.
+    for loc in cx.state.locations.values_mut() {
+        if let Some(pos) = loc.attachments.iter().position(|c| c.instance_id == source) {
+            let card = loc.attachments.remove(pos);
+            cx.state.encounter_discard.push(card.code.clone());
+            // CardDiscarded carries `investigator`; for a location
+            // attachment use the controller as the bookkeeping owner.
+            cx.events.push(Event::CardDiscarded {
+                investigator: eval_ctx.controller,
+                code: card.code,
+                from: Zone::LocationAttachment,
+            });
+            return EngineOutcome::Done;
+        }
+    }
+    EngineOutcome::Rejected {
+        reason: format!("DiscardSelf: source instance {source:?} not found in any threat area or location attachment").into(),
+    }
+}
+```
+Note: `Event::CardDiscarded`'s exact fields (`investigator`, `code`, `from`) — confirm against `event.rs:336`. If the borrow of `cx.state.investigators.iter_mut()` conflicts with `cx.events.push`, collect the removal then push after the loop (capture `inv_id`/`code` in locals). Resolve during implementation.
+
+- [ ] **Step 5: Run tests.** `cargo test -p game-core discard_self` → PASS.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add crates/card-dsl/src/dsl.rs crates/game-core/src/engine/evaluator.rs
+git commit -m "engine: Effect::DiscardSelf — source-instance-driven self-discard"
+```
+
+---
+
+## Task 5 — Forced-trigger source threading + scan extensions
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/forced_triggers.rs` (`ForcedHit.source`, `resolve_one`, `RoundEnded`/`AfterLocationInvestigated` arms, `push_matching` signature)
+
+- [ ] **Step 1: Add `source` to `ForcedHit`.** Change the struct to:
+```rust
+struct ForcedHit {
+    code: CardCode,
+    ability_index: usize,
+    controller: InvestigatorId,
+    source: Option<CardInstanceId>,
+}
+```
+Add `use crate::state::CardInstanceId;` to the imports.
+
+- [ ] **Step 2: Thread `source` into `push_matching`.** Add a `source: Option<CardInstanceId>` parameter and set it in the pushed `ForcedHit`. Update every `push_matching(...)` call: board scans (act/agenda in `PhaseEnded`/`ActAdvanced`/`AgendaAdvanced`/`EnemyDefeated`/`RoundEnded`-board, and `EnteredLocation`) pass `None`; instance scans pass `Some(card.instance_id)`.
+
+- [ ] **Step 3: `resolve_one` uses the source.** Replace the final line:
+```rust
+    apply_effect(cx, &effect, EvalContext::for_controller(hit.controller))
+```
+with:
+```rust
+    let ctx = match hit.source {
+        Some(src) => EvalContext::for_controller_with_source(hit.controller, src),
+        None => EvalContext::for_controller(hit.controller),
+    };
+    apply_effect(cx, &effect, ctx)
+```
+
+- [ ] **Step 4: `EndOfTurn` / `AfterLocationInvestigated` bind source.** In both arms, the `for card in inv.controlled_card_instances()` loop already iterates instances — change `push_matching(reg, &card.code, *investigator, &mut hits, |p| ...)` to pass `Some(card.instance_id)` as the new source arg.
+
+- [ ] **Step 5: Extend `AfterLocationInvestigated` to scan location attachments.** After the controlled-instances loop in that arm, add:
+```rust
+            if let Some(loc) = state.locations.get(_location) {
+                for att in &loc.attachments {
+                    push_matching(reg, &att.code, *investigator, Some(att.instance_id), &mut hits, |p| {
+                        matches!(p, EventPattern::AfterLocationInvestigated)
+                    });
+                }
+            }
+```
+Rename the `location: _location` binding to `location` so it's usable (drop the underscore; update the doc note that it's now read).
+
+- [ ] **Step 6: Extend `RoundEnded` to scan threat areas.** After the act/agenda board scans in the `RoundEnded` arm, add (binding controller = the instance's owning investigator, source = the instance):
+```rust
+            for (inv_id, inv) in &state.investigators {
+                for card in inv.controlled_card_instances() {
+                    push_matching(reg, &card.code, *inv_id, Some(card.instance_id), &mut hits, |p| {
+                        matches!(p, EventPattern::RoundEnded)
+                    });
+                }
+            }
+```
+
+- [ ] **Step 7: Write a unit test** that an `EndOfTurn` forced ability on a threat-area card resolves with the source threaded. In `forced_triggers.rs` test module (or extend an existing C4a test): install a fake registry mapping a synthetic code to `on_event(EndOfTurn, After, discard_self())`, put that instance in an investigator's threat area, fire `ForcedTriggerPoint::EndOfTurn`, assert the instance is discarded (proving source reached `DiscardSelf`). Follow the registry-install pattern already in this module's tests.
+
+- [ ] **Step 8: Run.** `cargo test -p game-core forced` → PASS.
+
+- [ ] **Step 9: Commit.**
+```bash
+git add crates/game-core/src/engine/dispatch/forced_triggers.rs
+git commit -m "engine: thread firing instance through forced triggers + scan threat areas/attachments"
+```
+
+---
+
+## Task 6 — Obscuring Fog (01168)
+
+**Files:**
+- Create: `crates/cards/src/impls/treachery_01168.rs`
+- Modify: `crates/cards/src/impls/mod.rs` (register module + wire into `abilities_for` / `native_effect_for` / metadata as siblings do)
+- Test: `crates/cards/tests/persistent_treachery.rs` (new integration test, installs `cards::REGISTRY`)
+
+- [ ] **Step 1: Confirm the card text** in `data/arkhamdb-snapshot/pack/core/core_encounter.json` (01168): Revelation attach to your location; Limit 1 per location; +2 shroud; Forced after attached location successfully investigated → discard. (Already verified in spec.)
+
+- [ ] **Step 2: Write the card impl.** Model on `treachery_01167.rs` for the native pattern. The placement native does limit-1:
+```rust
+//! Obscuring Fog (The Gathering treachery, 01168).
+//!
+//! ```text
+//! Revelation - Attach to your location. Limit 1 per location.
+//! Attached location gets +2 shroud.
+//! Forced - After attached location is successfully investigated:
+//!   Discard Obscuring Fog.
+//! ```
+use card_dsl::card_data::{ModifierScope, Stat};
+use card_dsl::dsl::{
+    constant, discard_self, modify, native, on_event, revelation, Ability, EventPattern, EventTiming,
+};
+use game_core::card_registry::NativeEffectFn;
+use game_core::state::{CardCode, Zone};
+use game_core::{attach_to_location_pub, Cx, EngineOutcome, EvalContext, Event};
+
+pub const CODE: &str = "01168";
+const LIMIT1_ATTACH: &str = "01168:limit1-attach";
+
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![
+        revelation(native(LIMIT1_ATTACH)),
+        constant(modify(Stat::Shroud, 2, ModifierScope::WhileInPlay)),
+        on_event(EventPattern::AfterLocationInvestigated, EventTiming::After, discard_self()),
+    ]
+}
+
+pub(crate) fn native_effect_for(tag: &str) -> Option<NativeEffectFn> {
+    (tag == LIMIT1_ATTACH).then_some(limit1_attach as NativeEffectFn)
+}
+
+fn limit1_attach(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
+    let Some(loc_id) = cx
+        .state
+        .investigators
+        .get(&ctx.controller)
+        .and_then(|inv| inv.current_location)
+    else {
+        return EngineOutcome::Rejected {
+            reason: "01168 limit1-attach: controller has no location".into(),
+        };
+    };
+    // Limit 1 per location (printed): if an Obscuring Fog is already
+    // attached here, this copy is discarded to the encounter discard
+    // instead of attaching (a treachery that cannot enter play is
+    // discarded).
+    let already = cx.state.locations.get(&loc_id).is_some_and(|loc| {
+        loc.attachments.iter().any(|c| c.code.as_str() == CODE)
+    });
+    if already {
+        cx.state.encounter_discard.push(CardCode::new(CODE));
+        cx.events.push(Event::CardDiscarded {
+            investigator: ctx.controller,
+            code: CardCode::new(CODE),
+            from: Zone::LocationAttachment,
+        });
+        return EngineOutcome::Done;
+    }
+    game_core::attach_to_location_pub(cx, loc_id, CardCode::new(CODE));
+    EngineOutcome::Done
+}
+```
+**Note:** `attach_to_location` is `pub(super)` in `threat_area.rs`. Expose a thin `pub` re-export from `game-core` (e.g. `pub fn attach_to_location_pub(...)` in `lib.rs` delegating, or make the helper `pub` and re-export) so the `cards` crate can call it — mirror how `place_in_threat_area` is exposed for Dissonant Voices/Frozen in Fear (do this once in Task 6 and reuse). Match the existing public-surface convention (`spawn_set_aside_enemy`, `take_damage`, `place_doom_on_current_agenda` are precedents).
+
+- [ ] **Step 3: Register the module.** In `crates/cards/src/impls/mod.rs`, add `pub mod treachery_01168;` and add its arms to whatever dispatch the crate uses for `abilities_for` / `native_effect_for` (grep for `treachery_01167` to find every site and mirror them).
+
+- [ ] **Step 4: Write the integration test.** `crates/cards/tests/persistent_treachery.rs`:
+```rust
+//! C4c persistent-treachery integration tests (needs real card metadata
+//! + abilities, so it installs cards::REGISTRY in its own process).
+use game_core::card_registry;
+// ... build a game with one investigator at a location (shroud 2),
+//     reveal 01168 (or call resolve_encounter_card), assert:
+//   - 01168 is attached to the investigator's location
+//   - effective_shroud at that location is 4
+//   - revealing a 2nd 01168 discards it (limit 1) — only one attachment
+//   - firing AfterLocationInvestigated discards the attachment
+fn install() { let _ = card_registry::install(cards::REGISTRY); }
+```
+Flesh out following `crates/cards/tests/play_card.rs` for the setup/registry/idiom. Assert attach, effective shroud 4, limit-1, and forced discard.
+
+- [ ] **Step 5: Run — fails, then passes after impl/registration.**
+Run: `cargo test -p cards --test persistent_treachery`
+Also run the card's own unit test: `cargo test -p cards treachery_01168`.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add crates/cards/src/impls/treachery_01168.rs crates/cards/src/impls/mod.rs crates/cards/tests/persistent_treachery.rs crates/game-core/src/lib.rs crates/game-core/src/engine/dispatch/threat_area.rs
+git commit -m "card: Obscuring Fog (01168) — location attachment + shroud + forced discard"
+```
+
+---
+
+## Task 7 — `Restriction::CannotPlay` + `play_is_prohibited`, then Dissonant Voices (01165)
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs` (`Restriction` enum, `Effect::Restrict`, `restrict()` builder)
+- Modify: `crates/game-core/src/engine/evaluator.rs` (`play_is_prohibited`; `Effect::Restrict` arm in `apply_effect` is a **no-op constant marker** — see step)
+- Modify: `crates/game-core/src/engine/dispatch/cards.rs` or wherever `play_card` validates (grep `fn play_card`)
+- Create: `crates/cards/src/impls/treachery_01165.rs`; register in `mod.rs`; extend `persistent_treachery.rs`
+
+- [ ] **Step 1: Add the DSL.** In `dsl.rs`:
+```rust
+/// A constant prohibition or cost increase a card imposes while in play.
+/// Read by the engine at the relevant decision point (play / action
+/// cost). Carried by a [`Trigger::Constant`] ability via
+/// [`Effect::Restrict`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Restriction {
+    /// The controller cannot play cards of this type (Dissonant Voices
+    /// 01165: assets and events — one `CannotPlay` per type).
+    CannotPlay(crate::card_data::CardType),
+    /// Performing one of `actions` costs `1` additional action. When
+    /// `first_each_round` is set, only the first such action each round
+    /// is surcharged (Frozen in Fear 01164).
+    ///
+    /// TODO: the `first_each_round` gate also appears on non-cost
+    /// mechanisms (suppressing attacks of opportunity on the first
+    /// action each round; a forced trigger on the first move each turn).
+    /// Promote it to a shared "first-applicable each round/turn" scope
+    /// spanning constant modifiers and forced triggers once a second
+    /// mechanism needs the same gate — not while action cost is its only
+    /// consumer.
+    ExtraActionCost {
+        /// Which actions are surcharged.
+        actions: ActionClassSet,
+        /// Gate to the first matching action each round.
+        first_each_round: bool,
+    },
+}
+
+/// The action kinds an [`Restriction::ExtraActionCost`] can surcharge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ActionClassSet {
+    /// Surcharge the move action.
+    pub move_: bool,
+    /// Surcharge the fight action.
+    pub fight: bool,
+    /// Surcharge the evade action.
+    pub evade: bool,
+}
+
+/// One action kind, for querying [`ActionClassSet`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActionClass {
+    /// The move action.
+    Move,
+    /// The fight action.
+    Fight,
+    /// The evade action.
+    Evade,
+}
+
+impl ActionClassSet {
+    /// Whether this set includes `class`.
+    #[must_use]
+    pub fn contains(self, class: ActionClass) -> bool {
+        match class {
+            ActionClass::Move => self.move_,
+            ActionClass::Fight => self.fight,
+            ActionClass::Evade => self.evade,
+        }
+    }
+}
+```
+Add to `enum Effect`:
+```rust
+    /// A constant restriction (under [`Trigger::Constant`]). Inert as an
+    /// executed effect — the engine *inspects* it at decision points
+    /// (see `play_is_prohibited` / `pending_action_surcharge`), it is
+    /// never "run".
+    Restrict(Restriction),
+```
+And the builder:
+```rust
+/// Build an [`Effect::Restrict`].
+#[must_use]
+pub fn restrict(restriction: Restriction) -> Effect {
+    Effect::Restrict(restriction)
+}
+```
+
+- [ ] **Step 2: `apply_effect` arm for `Restrict` is a no-op.** Constant restrictions are inspected, not executed; if one is ever reached as an executed effect, that's a misuse:
+```rust
+        Effect::Restrict(_) => EngineOutcome::Rejected {
+            reason: "Effect::Restrict is a constant marker, inspected not executed".into(),
+        },
+```
+
+- [ ] **Step 3: Write the failing test for `play_is_prohibited`.** In `evaluator.rs` test module: build an investigator with a threat-area instance whose code resolves (fake registry) to `constant(restrict(CannotPlay(CardType::Asset)))`; assert `play_is_prohibited(state, reg, inv, CardType::Asset)` is true and `CardType::Event` is false.
+
+- [ ] **Step 4: Implement `play_is_prohibited`.** In `evaluator.rs`:
+```rust
+/// Whether `investigator` is currently forbidden from playing a card of
+/// `card_type` by an active `Restriction::CannotPlay` constant ability on
+/// any of their controlled instances (Dissonant Voices 01165).
+#[must_use]
+pub fn play_is_prohibited(
+    state: &GameState,
+    registry: &CardRegistry,
+    investigator: InvestigatorId,
+    card_type: crate::card_data::CardType,
+) -> bool {
+    let Some(inv) = state.investigators.get(&investigator) else {
+        return false;
+    };
+    inv.controlled_card_instances().any(|c| {
+        (registry.abilities_for)(&c.code)
+            .into_iter()
+            .flatten()
+            .any(|a| {
+                a.trigger == Trigger::Constant
+                    && matches!(&a.effect, Effect::Restrict(Restriction::CannotPlay(t)) if *t == card_type)
+            })
+    })
+}
+```
+
+- [ ] **Step 5: Wire into `play_card`.** Grep `fn play_card`. After the card-type is known to be Asset or Event and before the on-play mutation, add a rejection:
+```rust
+    if let Some(reg) = crate::card_registry::current() {
+        if crate::engine::evaluator::play_is_prohibited(cx.state, reg, investigator, card_type) {
+            return EngineOutcome::Rejected {
+                reason: format!("PlayCard: {investigator:?} cannot play {card_type:?} (a constant restriction forbids it)").into(),
+            };
+        }
+    }
+```
+Place it among the existing validate-first checks (before any mutation). Confirm the local variable holding the card's type name.
+
+- [ ] **Step 6: Write Dissonant Voices.** `treachery_01165.rs` (CODE `"01165"`), abilities:
+```rust
+pub fn abilities() -> Vec<Ability> {
+    vec![
+        revelation(native(TO_THREAT_AREA)),
+        constant(restrict(Restriction::CannotPlay(CardType::Asset))),
+        constant(restrict(Restriction::CannotPlay(CardType::Event))),
+        on_event(EventPattern::RoundEnded, EventTiming::After, discard_self()),
+    ]
+}
+```
+Placement native `TO_THREAT_AREA` = `"01165:to-threat-area"` calling the public `place_in_threat_area` re-export with `ctx.controller` + `CardCode::new(CODE)`. (Expose `place_in_threat_area` publicly the same way as `attach_to_location` in Task 6 if not already.)
+
+- [ ] **Step 7: Register + extend the integration test.** Add `pub mod treachery_01165;` + dispatch arms in `mod.rs`. In `persistent_treachery.rs`, add a case: reveal 01165 → in threat area; `play_card` of an asset/event rejects; firing `RoundEnded` discards it.
+
+- [ ] **Step 8: Run.** `cargo test -p cards --test persistent_treachery` + `cargo test -p game-core play_is_prohibited` → PASS.
+
+- [ ] **Step 9: Commit.**
+```bash
+git add -A
+git commit -m "card: Dissonant Voices (01165) + Restriction::CannotPlay play gate"
+```
+
+---
+
+## Task 8 — `on_success` skill test + per-round action surcharge
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs` (`Effect::SkillTest` gains `on_success`; `skill_test` builder + a `skill_test_full` or extend signature)
+- Modify: `crates/game-core/src/state/game_state.rs` (`InFlightSkillTest` gains `on_success` + `source`)
+- Modify: `crates/game-core/src/engine/dispatch/skill_test.rs` (`start_skill_test` signature; `finish_skill_test` success branch)
+- Modify: `crates/game-core/src/engine/evaluator.rs` (`Effect::SkillTest` arm passes `on_success` + `eval_ctx.source`)
+- Modify: `crates/game-core/src/state/investigator.rs` (`action_surcharge_spent_this_round` field)
+- Modify: `crates/game-core/src/engine/dispatch/phases.rs` (reset the set at round increment)
+- Modify: `crates/game-core/src/engine/dispatch/actions.rs` + `combat.rs` (move/fight/evade cost) and a `pending_action_surcharge` helper in `evaluator.rs`
+
+- [ ] **Step 1: `Effect::SkillTest.on_success`.** In `dsl.rs`, change the variant to add `on_success: Option<Box<Effect>>` (beside `on_fail`). Update the `skill_test(skill, difficulty, on_fail)` builder to set `on_success: None`, and add:
+```rust
+/// Build an [`Effect::SkillTest`] with both success- and failure-side
+/// follow-ups (Frozen in Fear 01164 discards itself on success).
+#[must_use]
+pub fn skill_test_with_success(
+    skill: crate::card_data::SkillKind,
+    difficulty: u8,
+    on_success: Effect,
+    on_fail: Effect,
+) -> Effect {
+    Effect::SkillTest {
+        skill,
+        difficulty,
+        on_success: Some(Box::new(on_success)),
+        on_fail: Box::new(on_fail),
+    }
+}
+```
+Check `Effect::SkillTest`'s current `on_fail` type — the existing builder boxes it (`native(...)` is `Effect`). Match it. For "no on_fail" (Frozen in Fear has none), provide a no-op: use `Effect::Seq(vec![])` as the empty failure branch (confirm `apply_seq` treats empty as Done), or make `on_fail` itself `Option`. **Decision:** keep `on_fail` as-is; pass `Effect::Seq(vec![])` for Frozen in Fear's empty failure side. Verify `Seq(vec![])` → `Done`.
+
+- [ ] **Step 2: Update the `Effect::SkillTest` destructuring** everywhere it's matched (evaluator arm ~line 188; card test in `treachery_01167.rs` and `treachery_0116x` C4b tests that destructure `Effect::SkillTest { skill, difficulty, on_fail }`). Add `on_success` to each pattern. Run `grep -rn "Effect::SkillTest" crates/` to find them all.
+
+- [ ] **Step 3: `InFlightSkillTest` carries `on_success` + `source`.** Add fields:
+```rust
+    /// Effect to run **on success** after the chaos token resolves (the
+    /// success-side mirror of [`on_fail`](Self::on_fail)). Frozen in Fear
+    /// 01164 discards itself on a successful end-of-turn willpower test.
+    pub on_success: Option<card_dsl::dsl::Effect>,
+    /// The firing card instance, threaded so `on_success`/`on_fail`
+    /// eval-contexts can resolve `Effect::DiscardSelf` across the
+    /// suspend/resume boundary.
+    pub source: Option<crate::state::CardInstanceId>,
+```
+
+- [ ] **Step 4: `start_skill_test` signature.** Add `on_success: Option<Effect>` and `source: Option<CardInstanceId>` params after `on_fail`; store them in the `InFlightSkillTest` literal. Update **all callers** (`investigate`, `fight`, `evade`, the `Effect::SkillTest` evaluator arm, any test). Action callers pass `None, None`.
+
+- [ ] **Step 5: Run `on_success` in `finish_skill_test`.** In the success branch (line ~182), after `apply_skill_test_follow_up`, capture `on_success` + `source` from the snapshot (like `on_fail`) and run:
+```rust
+    if succeeded {
+        apply_skill_test_follow_up(cx, investigator, follow_up);
+        if let Some(effect) = &on_success {
+            let ctx = match source {
+                Some(src) => EvalContext::for_controller_with_source(investigator, src),
+                None => EvalContext::for_controller(investigator),
+            };
+            let outcome = apply_effect(cx, effect, ctx);
+            debug_assert!(matches!(outcome, EngineOutcome::Done),
+                "skill-test on_success must resolve to Done in scope: {outcome:?}");
+        }
+    } else if let Some(effect) = &on_fail {
+        let mut ctx = match source {
+            Some(src) => EvalContext::for_controller_with_source(investigator, src),
+            None => EvalContext::for_controller(investigator),
+        };
+        ctx.failed_by = Some(failed_by);
+        // ... existing apply_effect + debug_assert
+    }
+```
+Bind `on_success`/`source` locals from `in_flight` next to the existing `on_fail` snapshot (line ~157).
+
+- [ ] **Step 6: Evaluator passes `on_success` + source.** In the `Effect::SkillTest` arm, destructure `on_success` and pass `on_success.as_deref().cloned()` (or `.map(|b| (**b).clone())`) and `eval_ctx.source` into `start_skill_test`.
+
+- [ ] **Step 7: Per-round surcharge field.** In `investigator.rs`, add:
+```rust
+    /// Source instances whose [`Restriction::ExtraActionCost`] with
+    /// `first_each_round` has already surcharged an action this round.
+    /// Reset at the round boundary. Keyed by instance so multiple
+    /// surcharge sources track independently.
+    pub action_surcharge_spent_this_round: std::collections::BTreeSet<CardInstanceId>,
+```
+Default it in the investigator constructor / `test_investigator` fixture (grep for the struct literal(s) and `Investigator::new`).
+
+- [ ] **Step 8: Reset at round increment.** Grep `phases.rs` for the round-counter increment (the `round_increments_on_mythos_entry_via_driver` test points at it). At that site, for every investigator: `inv.action_surcharge_spent_this_round.clear();`.
+
+- [ ] **Step 9: `pending_action_surcharge` helper.** In `evaluator.rs`:
+```rust
+/// Extra action cost for `investigator` performing `action_class`, plus
+/// the `first_each_round` source instances to mark spent on commit.
+/// Sums `Restriction::ExtraActionCost` deltas (1 each) from active
+/// constant abilities whose `actions` include `action_class`; a
+/// `first_each_round` source already in
+/// `action_surcharge_spent_this_round` contributes 0.
+#[must_use]
+pub fn pending_action_surcharge(
+    state: &GameState,
+    registry: &CardRegistry,
+    investigator: InvestigatorId,
+    action_class: crate::dsl::ActionClass,
+) -> (u8, Vec<CardInstanceId>) {
+    let Some(inv) = state.investigators.get(&investigator) else {
+        return (0, Vec::new());
+    };
+    let mut extra: u8 = 0;
+    let mut to_mark = Vec::new();
+    for card in inv.controlled_card_instances() {
+        let Some(abilities) = (registry.abilities_for)(&card.code) else { continue; };
+        for a in &abilities {
+            if a.trigger != Trigger::Constant { continue; }
+            let Effect::Restrict(Restriction::ExtraActionCost { actions, first_each_round }) = &a.effect
+                else { continue; };
+            if !actions.contains(action_class) { continue; }
+            if *first_each_round {
+                if inv.action_surcharge_spent_this_round.contains(&card.instance_id) { continue; }
+                to_mark.push(card.instance_id);
+            }
+            extra = extra.saturating_add(1);
+        }
+    }
+    (extra, to_mark)
+}
+```
+
+- [ ] **Step 10: Apply surcharge in move/fight/evade.** In each handler (`actions.rs` `move_action`; `combat.rs` fight + evade — grep `fn fight`/`fn evade`), replace the `actions_remaining < 1` check + `spend_one_action` with:
+```rust
+    let (extra, to_mark) = match crate::card_registry::current() {
+        Some(reg) => crate::engine::evaluator::pending_action_surcharge(cx.state, reg, investigator, crate::dsl::ActionClass::Move /* or Fight/Evade */),
+        None => (0, Vec::new()),
+    };
+    let cost = 1u8.saturating_add(extra);
+    // ... in the validate block:
+    if inv.actions_remaining < cost {
+        return EngineOutcome::Rejected { reason: format!("<action> requires {cost} action point(s)").into() };
+    }
+    // ... in the mutate block, replace spend_one_action with:
+    spend_actions(cx, investigator, cost);
+    if let Some(inv) = cx.state.investigators.get_mut(&investigator) {
+        inv.action_surcharge_spent_this_round.extend(to_mark);
+    }
+```
+Add `spend_actions(cx, inv, n)` near `spend_one_action` in `actions.rs` (generalize it; have `spend_one_action` call `spend_actions(cx, inv, 1)` to stay DRY). Confirm whether `fight`/`evade` currently call `spend_one_action`.
+
+- [ ] **Step 11: Tests.** In `evaluator.rs`: `pending_action_surcharge` charges first move then 0 the second (same `inv` with the instance marked), resets when the set is cleared, and two sources each charge. Add an `on_success` skill-test unit/integration test (success runs the effect). Run `cargo test -p game-core surcharge` and `cargo test -p game-core skill_test`.
+
+- [ ] **Step 12: Commit.**
+```bash
+git add -A
+git commit -m "engine: SkillTest on_success + per-instance per-round action surcharge"
+```
+
+---
+
+## Task 9 — Frozen in Fear (01164)
+
+**Files:**
+- Create: `crates/cards/src/impls/treachery_01164.rs`; register in `mod.rs`; extend `persistent_treachery.rs`
+
+- [ ] **Step 1: Confirm text** (01164, `core_encounter.json`) — verified in spec.
+
+- [ ] **Step 2: Write the impl.** CODE `"01164"`, native `TO_THREAT_AREA = "01164:to-threat-area"` (calls public `place_in_threat_area`). Abilities:
+```rust
+pub fn abilities() -> Vec<Ability> {
+    let actions = ActionClassSet { move_: true, fight: true, evade: true };
+    vec![
+        revelation(native(TO_THREAT_AREA)),
+        constant(restrict(Restriction::ExtraActionCost { actions, first_each_round: true })),
+        on_event(
+            EventPattern::EndOfTurn,
+            EventTiming::After,
+            skill_test_with_success(SkillKind::Willpower, 3, discard_self(), Effect::Seq(vec![])),
+        ),
+    ]
+}
+```
+
+- [ ] **Step 3: Register** in `mod.rs` (module + dispatch arms; no `native_effect_for` beyond `TO_THREAT_AREA`).
+
+- [ ] **Step 4: Extend the integration test.** In `persistent_treachery.rs`: reveal 01164 → threat area; first move that round costs 2 actions, second move costs 1; surcharge resets next round; fire `EndOfTurn` and resolve the willpower(3) test — on success the card is discarded, on failure it remains. (Drive the chaos bag / commit window via the harness used by other skill-test integration tests; seed a deterministic token for the success and failure cases.)
+
+- [ ] **Step 5: Run.** `cargo test -p cards --test persistent_treachery` + `cargo test -p cards treachery_01164` → PASS.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add -A
+git commit -m "card: Frozen in Fear (01164) — action surcharge + end-of-turn willpower discard"
+```
+
+---
+
+## Task 10 — Full gauntlet + phase doc
+
+- [ ] **Step 1: Run the full CI gauntlet** (all six commands at the top). Fix every warning/lint/doc-link failure.
+
+- [ ] **Step 2: Update the phase doc** `docs/phases/phase-7-the-gathering.md`: flip the C4c row to `✅ PR #NN`, update the Status paragraph ("Next: C5 → C7"), and add a **Decisions made** entry only if load-bearing for future PRs — candidates: derived persistence rule; `Effect::DiscardSelf` source-instance model; the `first_each_round` generalization TODO. Apply the "would a future PR-author choose differently without this entry?" test; keep to 1–2 entries. **Do this as the final commit, after CI is green on the opened PR** (per `feedback_phase_doc_updates`).
+
+- [ ] **Step 3: Commit + open PR** (`gh pr create`, template, `Closes #235.`), watch CI, then update the phase doc as the last commit.
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** Seam 1→T1, Seam 2→T2, Seam 3 (shroud)→T3 / (CannotPlay)→T7 / (ExtraActionCost)→T8, Seam 4→T4, Seam 5→T8, Seam 6→T5, Seam 7→T8; cards→T6/T7/T9. All seams mapped.
+- **Cross-task type consistency:** `attach_to_location` (T1) exposed publicly in T6; `discard_self()`/`Effect::DiscardSelf` (T4) used by T5/T6/T7/T9; `ForcedHit.source` (T5) feeds `DiscardSelf` (T4); `pending_action_surcharge`/`ActionClass`/`ActionClassSet` (T8) used by T9; `skill_test_with_success` (T8) used by T9.
+- **Known implementation-time confirmations (flagged inline):** exact `Event::CardDiscarded` fields; borrow-checker shuffles in `discard_self`/`effective_shroud`; the round-increment site in `phases.rs`; whether `fight`/`evade` use `spend_one_action`; the `cards` crate's dispatch wiring sites (grep `treachery_01167`); `Effect::Seq(vec![])` ⇒ `Done`.

--- a/docs/superpowers/specs/2026-06-14-phase-7-slice-1-c4c-persistent-treacheries-design.md
+++ b/docs/superpowers/specs/2026-06-14-phase-7-slice-1-c4c-persistent-treacheries-design.md
@@ -1,0 +1,247 @@
+# Phase 7 Slice 1 — C4c: persistent threat-area / attachment treacheries
+
+**Issue:** [#235](https://github.com/talelburg/eldritch/issues/235) (Group C, sub-slice C4c).
+**Depends on:** C4a (threat-area zone + forced points #233/PR #285), C3c (`RoundEnded` #232/PR #278), #286 (`Effect::SkillTest` + suspendable-revelation discard, PR #287).
+**Date:** 2026-06-14.
+
+## Goal
+
+Implement the three persistent encounter treacheries from The Gathering's
+encounter sets — each *stays in play* (threat area or location
+attachment), enforces a **constant restriction**, and **discards itself**
+at a forced timing point. Card texts (verified against
+`data/arkhamdb-snapshot/pack/core/core_encounter.json`):
+
+- **Frozen in Fear (01164)** — `Revelation` - Put into play in your threat
+  area. *The first time you perform one of the following actions (move,
+  fight, or evade) each round, it costs 1 additional action.* `Forced` -
+  At the end of your turn: Test [willpower] (3). If you succeed, discard
+  Frozen in Fear.
+- **Dissonant Voices (01165)** — `Revelation` - Put into play in your
+  threat area. *You cannot play assets or events.* `Forced` - At the end
+  of the round: Discard Dissonant Voices.
+- **Obscuring Fog (01168)** — `Revelation` - Attach to your location.
+  *Limit 1 per location. Attached location gets +2 shroud.* `Forced` -
+  After attached location is successfully investigated: Discard Obscuring
+  Fog.
+
+## Design overview
+
+The work splits into **shared engine seams** and **three thin card
+impls**. The constant restrictions are modeled by *extending the
+inspectable DSL* (chosen over card-local registry query hooks) so the
+engine reads them from `abilities_for` exactly as it already reads
+`Trigger::Constant` `Effect::Modify` in `constant_skill_modifier`.
+
+### Seam 1 — location attachment zone
+
+`Location` gains `attachments: Vec<CardInPlay>` (defaulted empty in
+`Location::new` and existing struct literals). New `Zone::LocationAttachment`
+variant and `Event::CardAttachedToLocation { location, code, instance_id }`
+mirroring `Event::CardEnteredThreatArea`.
+
+Two helpers beside the existing threat-area pair in
+`dispatch/threat_area.rs` (or a sibling `attachments.rs`):
+
+- `attach_to_location(cx, location_id, code) -> Option<CardInstanceId>` —
+  mints an instance, pushes onto the location's `attachments`, emits
+  `CardAttachedToLocation`. **Generic — no limit enforcement** (the
+  "Limit 1 per location" clause is printed on Obscuring Fog specifically;
+  other attachments need not carry it, so the limit lives in the card, not
+  the helper).
+- `discard_from_location_attachment` is *not* a separate helper — discard
+  is unified in Seam 4 (`Effect::DiscardSelf`).
+
+### Seam 2 — derived persistence (replaces any "suppress-discard" flag)
+
+`resolve_encounter_card`'s treachery arm today always pushes the card to
+`encounter_discard` after the `Revelation` resolves. Persistent
+treacheries must not be auto-discarded — instead of a side-channel state
+flag, the engine **derives** persistence from the card's abilities:
+
+> A treachery is **persistent** iff it has at least one ability whose
+> trigger is not `Trigger::Revelation`.
+
+One-shot treacheries (01162/01163/01166/01167) have *only* a `Revelation`,
+so they auto-discard as today. All three C4c cards carry `Revelation` +
+`Constant`/`OnEvent` ongoing abilities, so the arm skips the auto-discard
+and the **card fully owns its disposition** in every path — it places
+itself (threat area / attachment) on the normal path, and discards itself
+to `encounter_discard` on the limit-1 path (Obscuring Fog).
+
+`TODO`: this derivation assumes every persistent treachery carries an
+ongoing ability and every one-shot carries none — true for all
+Core+Dunwich treacheries. Revisit with an explicit persistence marker
+only if a treachery ever needs to persist with no ongoing ability, or
+auto-discard despite carrying one.
+
+### Seam 3 — constant restrictions in the inspectable DSL
+
+`card-dsl` additions:
+
+- `Stat::Shroud` — a location stat an `Effect::Modify` can adjust
+  (Obscuring Fog's `+2`).
+- `enum Restriction { CannotPlay(CardType), ExtraActionCost { actions, first_each_round: bool } }`
+  where `actions` enumerates the gated action kinds (move / fight / evade
+  for Frozen in Fear). Represent `actions` as a small explicit set type
+  (e.g. a struct of `move`/`fight`/`evade` bools, or a `Vec<ActionClass>`)
+  — concrete shape chosen during implementation; it must be `Copy`/`Clone`
+  + serde + `PartialEq`.
+- `Effect::Restrict(Restriction)` + a `restrict(restriction)` builder,
+  used only under `Trigger::Constant`.
+
+`game-core` query helpers, each mirroring `sum_constant_modify`'s
+"scan controlled instances, look up abilities, sum/test matching
+`Trigger::Constant` effects" shape:
+
+- `effective_shroud(state, reg, location) -> u8` — printed `location.shroud`
+  plus every `Stat::Shroud` `Modify(WhileInPlay)` on that location's
+  `attachments`. Read by `investigate` in place of the raw
+  `location.shroud` at `actions.rs:98`.
+- `play_is_prohibited(state, reg, investigator, card_type) -> bool` — true
+  if any active `Restriction::CannotPlay(card_type)` on the investigator's
+  controlled instances matches. Checked in `play_card` validation
+  (reject before mutation).
+- `pending_action_surcharge(state, reg, investigator, action_class) -> (u8, Vec<CardInstanceId>)`
+  — sums the extra action cost from `Restriction::ExtraActionCost`
+  restrictions whose `actions` include `action_class`; for
+  `first_each_round` restrictions, *excludes* source instances already in
+  the per-round spent-set (Seam 5). Returns the extra cost **and** the
+  list of `first_each_round` source instances to mark spent on commit
+  (so cost-peek stays read-only for validate-first).
+
+`TODO` at `ExtraActionCost`: the `first_each_round` gate also appears on
+non-cost mechanisms (a constant ability that suppresses attacks of
+opportunity on the first action each round; a forced trigger that fires
+on the first move each turn). Promote `first_each_round` to a shared
+"first-applicable each round/turn" scope spanning constant modifiers and
+forced triggers once a second mechanism needs the same gate — not while
+action-cost is its only consumer.
+
+### Seam 4 — unified self-discard (`Effect::DiscardSelf`)
+
+One typed effect replaces per-card discard logic. `apply_effect` for
+`Effect::DiscardSelf` reads `eval_ctx.source` (the firing instance,
+threaded by Seam 6), locates it across all investigators' `threat_area`
+and all locations' `attachments`, removes it, pushes its code to
+`encounter_discard`, and emits `Event::CardDiscarded { from: <the zone it
+was found in> }`. Rejects loudly if `source` is `None` or the instance is
+not found (a forced self-discard must have a source).
+
+`TODO`: scoped to the two encounter zones (threat area, location
+attachment → `encounter_discard`). Extend to player-controlled zones
+(`cards_in_play` → the owner's `discard`) when a player card first needs
+to discard itself by source instance.
+
+### Seam 5 — per-round surcharge tracking (per source instance)
+
+`Investigator` gains `action_surcharge_spent_this_round: BTreeSet<CardInstanceId>`
+(`BTree` for deterministic serde). Reset to empty for every investigator
+at the round boundary (the round-increment site reached on Mythos entry —
+located during implementation; co-located with the existing round
+counter). Keying by **source instance** (not a single bool) means two
+copies of Frozen in Fear each charge their own first action (+2 total,
+rules-correct) and a future independent surcharge tracks separately.
+
+Move/fight/evade handlers change from "spend 1 action" to:
+1. `let (extra, to_mark) = pending_action_surcharge(state, reg, inv, class);`
+2. `let cost = 1 + extra;`
+3. validate `actions_remaining >= cost` (reject otherwise — validate-first,
+   nothing marked);
+4. on commit: spend `cost` actions and insert `to_mark` into the
+   spent-set.
+
+This needs a `spend_actions(cx, inv, n)` generalizing the existing
+`spend_one_action`.
+
+### Seam 6 — forced-trigger source threading + scan extensions
+
+`ForcedHit` gains `source: Option<CardInstanceId>`. `resolve_one` uses
+`EvalContext::for_controller_with_source` when `source` is `Some`, else
+`for_controller`. In `collect_forced_hits`:
+
+- **`EndOfTurn`** (already scans the investigator's controlled instances)
+  and **`AfterLocationInvestigated`** — bind `source = the scanned
+  instance`. Additionally extend `AfterLocationInvestigated` to scan the
+  **investigated location's `attachments`** (Obscuring Fog attaches to the
+  location, not the threat area), binding `source = the attachment
+  instance`, `controller = the investigating investigator`.
+- **`RoundEnded`** (today scans only the current act + agenda, board
+  cards, `source = None`) — additionally scan **each investigator's
+  controlled instances** for `RoundEnded` forced abilities, binding
+  `source = instance`, `controller = that investigator` (Dissonant Voices
+  lives in the threat area).
+
+Board-card hits (act/agenda) keep `source = None`.
+
+### Seam 7 — success-side skill test (`on_success`)
+
+`Effect::SkillTest` today carries only `on_fail` (the failure-side
+follow-up from #286). Frozen in Fear discards on **success**, so add a
+symmetric `on_success: Option<Box<Effect>>`. Thread it through
+`start_skill_test` → `InFlightSkillTest` (which must also remember the
+**source instance**, so the `on_success`/`on_fail` eval-contexts carry it
+across the suspend/resume) → run the `on_success` effect at skill-test
+teardown on success, mirroring where `on_fail` runs on failure. This
+closes a real asymmetry; Frozen in Fear is the concrete driver.
+
+## The three card impls
+
+Each is a module `crates/cards/src/impls/treachery_<code>.rs` with `CODE`,
+`abilities()`, a card-local placement native (placement keeps the card's
+own `CODE`, which the evaluator doesn't carry), and tests. Discard and
+restriction enforcement are engine-side (Seams 3/4), so the impls stay
+thin. The forced abilities are `Trigger::OnEvent { pattern, timing: After }`
+constructed via the existing forced-ability builder (the one C3c/C4a used
+for agenda/location forced effects — exact builder name confirmed during
+implementation).
+
+- **Obscuring Fog 01168** — `revelation(native(LIMIT1_ATTACH))` (if the
+  controller's location already holds an 01168 attachment → push code to
+  `encounter_discard` + emit `CardDiscarded`; else `attach_to_location`);
+  `constant(modify(Stat::Shroud, 2, WhileInPlay))`;
+  `forced_after(AfterLocationInvestigated, DiscardSelf)`.
+- **Dissonant Voices 01165** — `revelation(native(TO_THREAT_AREA))`
+  (`place_in_threat_area(cx, ctx.controller, CardCode::new(CODE))`);
+  `constant(restrict(CannotPlay(Asset)))` + `constant(restrict(CannotPlay(Event)))`;
+  `forced_after(RoundEnded, DiscardSelf)`.
+- **Frozen in Fear 01164** — `revelation(native(TO_THREAT_AREA))`;
+  `constant(restrict(ExtraActionCost { {Move,Fight,Evade}, first_each_round: true }))`;
+  `forced_after(EndOfTurn, SkillTest(Willpower, 3, on_success = DiscardSelf, on_fail = none))`.
+
+## Test plan (TDD, simpler cards first to land the seams)
+
+1. **Attachment zone + helpers** — `attach_to_location` mints/pushes/emits;
+   `Location::new` defaults attachments empty; serde roundtrip.
+2. **Derived persistence** — `resolve_encounter_card` auto-discards an
+   all-Revelation treachery (regression) but *not* one with an ongoing
+   ability (unit, synthetic abilities).
+3. **`Stat::Shroud` + `effective_shroud`** — printed + attachment modifiers.
+4. **`Effect::DiscardSelf`** — finds + discards a threat-area instance and
+   a location-attachment instance, right `from` zone; rejects with no
+   source / unknown instance.
+5. **Obscuring Fog** (card test, integration with registry) — attach,
+   +2 effective shroud at its location, limit-1 discards the second copy,
+   `AfterLocationInvestigated` discards it; investigate uses raised shroud.
+6. **`Restriction::CannotPlay` + `play_is_prohibited`** — `play_card`
+   rejects an asset/event while the restriction is active; unrelated
+   types unaffected.
+7. **Dissonant Voices** (card test) — to threat area, blocks
+   asset/event play, `RoundEnded` discards it.
+8. **`on_success` skill test + per-round surcharge** — success runs the
+   `on_success` effect; `pending_action_surcharge` charges the first
+   gated action and not the second (same round), resets next round; two
+   sources each charge.
+9. **Frozen in Fear** (card test) — to threat area, first move/fight/evade
+   that round costs 2 actions and subsequent ones cost 1, surcharge resets
+   next round, `EndOfTurn` willpower(3): success discards / failure keeps.
+10. **Full strict gauntlet** (fmt, clippy host + wasm, test, doc, wasm-build).
+
+## Out of scope / explicit non-goals
+
+- Player-card self-discard zones (Seam 4 `TODO`).
+- The general "first-applicable each round/turn" scope (Seam 5 `TODO`).
+- Orne Library's location-gated (un-gated) `ExtraActionCost` — Dunwich
+  scenario content, Phase 10.
+- Multi-investigator interactions beyond what the per-instance keying
+  already gives for free.


### PR DESCRIPTION
## Summary

Implements The Gathering's three **persistent** encounter treacheries (Group C, sub-slice C4c) — each stays in play, enforces a constant restriction, and discards itself at a forced timing point:

- **Obscuring Fog (01168)** — attaches to your location (Limit 1 per location); attached location gets +2 shroud; Forced: discard after it's successfully investigated.
- **Dissonant Voices (01165)** — enters your threat area; you cannot play assets or events; Forced: discard at end of round.
- **Frozen in Fear (01164)** — enters your threat area; first move/fight/evade each round costs +1 action; Forced: end-of-turn willpower(3) test, discard on success.

Spec: `docs/superpowers/specs/2026-06-14-phase-7-slice-1-c4c-persistent-treacheries-design.md` · Plan: `docs/superpowers/plans/2026-06-14-c4c-persistent-treacheries.md`

## Engine machinery

- **Location attachment zone** (`Location.attachments`, `Zone::LocationAttachment`, `Event::CardAttachedToLocation`, `attach_to_location`).
- **Derived persistence** — a treachery with any non-Revelation ability owns its own disposition and isn't auto-discarded after Revelation (no side-channel flag).
- **Inspectable-DSL restrictions** — `Stat::Shroud` + `effective_shroud`; `Restriction::{CannotPlay, ExtraActionCost}` + `Effect::Restrict`, read by `play_is_prohibited` / `pending_action_surcharge` (mirroring the existing constant-modifier scan).
- **Unified `Effect::DiscardSelf`** — source-instance-driven; finds the firing card across threat areas / attachments.
- **Per-instance per-round surcharge** tracking, reset at the round boundary.
- **Forced-trigger source threading** + **deterministic multi-resolve** of simultaneous forced triggers (replaces the prior reject-on-2+), so Dissonant Voices' round-end discard coexists with agenda 01107's round-end doom.
- **`SkillTest.on_success`** (success-side mirror of `on_fail`).
- **`pending_end_turn` / `resume_end_turn`** — so a suspending end-of-turn skill test (Frozen in Fear) doesn't strand turn progression; the commit-resume path re-enters end-turn rotation/phase-end.

## Design decisions

- Constant restrictions extend the **inspectable DSL** (engine reads `abilities_for`) rather than adding card-local registry query hooks — one coherent constant-ability model.
- Three design gaps surfaced and resolved mid-implementation (with sign-off): the RoundEnded collision → deterministic multi-resolve; the suspending end-of-turn test stranding `end_turn` → resume plumbing (mirrors `spawn_engage_pending`). `first_each_round` stays a field on `ExtraActionCost` (not a shared scope) until a second non-cost consumer justifies generalizing — `TODO` records the trigger.

## Testing

Per-card unit tests + `crates/cards/tests/persistent_treachery.rs` (8 integration tests through the real corpus: attach/shroud/limit-1/forced-discard, play prohibition, round-end coexistence with agenda 01107, surcharge first-vs-subsequent, end-of-turn success/failure with turn resume). Full local gauntlet green (fmt, host clippy, strict test, doc, wasm-build, wasm-clippy); headless wasm-test runs in CI.

Pre-push code review completed; one comment-accuracy finding fixed.

Closes #235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)