### PR TITLE
engine: C5a — Cover Up before-timing interrupt window + GameEnd forced point (#236)

### DIFF
--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -297,7 +297,7 @@ pub enum EventPattern {
     /// (paired with [`EventTiming::Before`]), never by the general
     /// reaction-window pipeline — `trigger_matches` returns `false` for
     /// it, like the forced-only patterns above. First consumer: Cover Up
-    /// 01007's "[reaction] When you would discover 1 or more clues at your
+    /// 01007's "`[reaction]` When you would discover 1 or more clues at your
     /// location: Discard that many clues from Cover Up instead." (C5a #236.)
     WouldDiscoverClues,
     /// The game ended (a scenario resolution latched). Fired forced via

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -292,6 +292,21 @@ pub enum EventPattern {
     /// C4c (#235) extends it to the investigated location's attachment
     /// zone for Obscuring Fog (01168), the first consumer.
     AfterLocationInvestigated,
+    /// An investigator is about to discover one or more clues. Matched
+    /// **only** by the clue-discovery interrupt seam in `discover_clue`
+    /// (paired with [`EventTiming::Before`]), never by the general
+    /// reaction-window pipeline — `trigger_matches` returns `false` for
+    /// it, like the forced-only patterns above. First consumer: Cover Up
+    /// 01007's "[reaction] When you would discover 1 or more clues at your
+    /// location: Discard that many clues from Cover Up instead." (C5a #236.)
+    WouldDiscoverClues,
+    /// The game ended (a scenario resolution latched). Fired forced via
+    /// `ForcedTriggerPoint::GameEnd` from `fire_scenario_resolution`,
+    /// scanning every investigator's controlled card instances; binds
+    /// controller = each instance's controller. First consumer: Cover Up
+    /// 01007's "Forced - When the game ends, if there are any clues on
+    /// Cover Up: You suffer 1 mental trauma." (C5a #236.)
+    GameEnd,
 }
 
 /// The four game phases, mirrored in `card-dsl` so [`EventPattern`] can
@@ -1434,6 +1449,15 @@ mod tests {
         let json = serde_json::to_string(&p).unwrap();
         let back: EventPattern = serde_json::from_str(&json).unwrap();
         assert_eq!(p, back);
+    }
+
+    #[test]
+    fn would_discover_clues_and_game_end_round_trip() {
+        for p in [EventPattern::WouldDiscoverClues, EventPattern::GameEnd] {
+            let json = serde_json::to_string(&p).expect("serialize");
+            let back: EventPattern = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(p, back);
+        }
     }
 
     #[test]

--- a/crates/game-core/src/engine/dispatch/clue_interrupt.rs
+++ b/crates/game-core/src/engine/dispatch/clue_interrupt.rs
@@ -1,0 +1,88 @@
+//! Resume path for the before-timing clue-discovery interrupt (C5a #236).
+//!
+//! `discover_clue` suspends with `clue_interrupt_pending` set when an
+//! eligible `WouldDiscoverClues` reaction is controlled. On resume:
+//! `Confirm` runs the interrupt card's effect (the card-local Native
+//! "discard that many from self", with the replaced count threaded via
+//! `EvalContext.clue_discovery_count`) and discovers nothing; `Skip`
+//! performs the deferred discovery. Either way, if a skill test is
+//! mid-flight, re-enter `drive_skill_test` (its continuation was
+//! pre-advanced to `PostFollowUp` before the follow-up suspended).
+
+use super::Cx;
+use crate::action::InputResponse;
+use crate::card_registry;
+use crate::engine::evaluator::{apply_effect, perform_discovery, EvalContext};
+use crate::engine::outcome::EngineOutcome;
+
+pub(crate) fn resume_clue_interrupt(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
+    let pending = match cx.state.clue_interrupt_pending.take() {
+        Some(p) => p,
+        None => {
+            return EngineOutcome::Rejected {
+                reason: "resume_clue_interrupt: no clue interrupt pending".into(),
+            }
+        }
+    };
+    match response {
+        InputResponse::Confirm => {
+            // Run the WouldDiscoverClues ability's effect (Native discard
+            // from self), threading the replaced count + source instance.
+            let Some(reg) = card_registry::current() else {
+                return EngineOutcome::Rejected {
+                    reason: "resume_clue_interrupt: registry vanished".into(),
+                };
+            };
+            let Some(inv) = cx.state.investigators.get(&pending.controller) else {
+                return EngineOutcome::Rejected {
+                    reason: "resume_clue_interrupt: controller vanished".into(),
+                };
+            };
+            let Some(card) = inv
+                .controlled_card_instances()
+                .find(|c| c.instance_id == pending.source)
+            else {
+                return EngineOutcome::Rejected {
+                    reason: "resume_clue_interrupt: source instance vanished".into(),
+                };
+            };
+            let code = card.code.clone();
+            let Some(abilities) = (reg.abilities_for)(&code) else {
+                return EngineOutcome::Rejected {
+                    reason: "resume_clue_interrupt: source has no abilities".into(),
+                };
+            };
+            let effect = abilities[pending.ability_index].effect.clone();
+            let mut ctx =
+                EvalContext::for_controller_with_source(pending.controller, pending.source);
+            ctx.clue_discovery_count = Some(pending.count);
+            let outcome = apply_effect(cx, &effect, ctx);
+            if !matches!(outcome, EngineOutcome::Done) {
+                return outcome;
+            }
+        }
+        InputResponse::Skip => {
+            // Decline the reaction: the discovery resolves normally.
+            perform_discovery(cx, pending.location, pending.count, pending.controller);
+        }
+        other => {
+            // Restore the pending so a retry with a valid response works.
+            // (The apply loop also restores state on Rejected, but be
+            // explicit since we already `take()`-d.)
+            cx.state.clue_interrupt_pending = Some(pending);
+            return EngineOutcome::Rejected {
+                reason: format!("resume_clue_interrupt: expected Confirm or Skip, got {other:?}")
+                    .into(),
+            };
+        }
+    }
+    // If a skill test was mid-flight (the dominant path: Investigate's
+    // follow-up discovery), resume its driver. Its continuation was
+    // pre-advanced to PostFollowUp by `finish_skill_test` before the
+    // follow-up suspended, so this picks up at the right step.
+    if cx.state.in_flight_skill_test.is_some() {
+        super::skill_test::drive_skill_test(cx)
+    } else {
+        EngineOutcome::Done
+    }
+}

--- a/crates/game-core/src/engine/dispatch/clue_interrupt.rs
+++ b/crates/game-core/src/engine/dispatch/clue_interrupt.rs
@@ -16,13 +16,10 @@ use crate::engine::evaluator::{apply_effect, perform_discovery, EvalContext};
 use crate::engine::outcome::EngineOutcome;
 
 pub(crate) fn resume_clue_interrupt(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
-    let pending = match cx.state.clue_interrupt_pending.take() {
-        Some(p) => p,
-        None => {
-            return EngineOutcome::Rejected {
-                reason: "resume_clue_interrupt: no clue interrupt pending".into(),
-            }
-        }
+    let Some(pending) = cx.state.clue_interrupt_pending.take() else {
+        return EngineOutcome::Rejected {
+            reason: "resume_clue_interrupt: no clue interrupt pending".into(),
+        };
     };
     match response {
         InputResponse::Confirm => {

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -87,6 +87,12 @@ pub(crate) enum ForcedTriggerPoint {
         /// location's attachment zone.
         location: LocationId,
     },
+    /// The game ended (a scenario resolution latched). Scans every
+    /// investigator's controlled card instances (threat area + in play)
+    /// for `EventPattern::GameEnd` forced abilities; binds controller =
+    /// each instance's controller. First consumer: Cover Up 01007's
+    /// game-end mental-trauma forced (C5a #236).
+    GameEnd,
 }
 
 struct ForcedHit {
@@ -292,6 +298,24 @@ fn collect_forced_hits(
                         Some(att.instance_id),
                         &mut hits,
                         |p| matches!(p, EventPattern::AfterLocationInvestigated),
+                    );
+                }
+            }
+        }
+        ForcedTriggerPoint::GameEnd => {
+            // Scan every investigator's controlled instances; bind
+            // controller = each card's controller, source = the instance.
+            // `state.investigators` is a BTreeMap, so iteration order is
+            // deterministic — consistent with the fixed-order contract.
+            for (inv_id, inv) in &state.investigators {
+                for card in inv.controlled_card_instances() {
+                    push_matching(
+                        reg,
+                        &card.code,
+                        *inv_id,
+                        Some(card.instance_id),
+                        &mut hits,
+                        |p| matches!(p, EventPattern::GameEnd),
                     );
                 }
             }

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -18,6 +18,7 @@ use super::Cx;
 mod abilities;
 pub(crate) mod act_agenda;
 mod actions;
+mod clue_interrupt;
 // pub(super): evaluator reaches grant_resources via the full path
 // crate::engine::dispatch::cards::grant_resources (a sibling of dispatch).
 pub(super) mod cards;
@@ -84,6 +85,20 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
                      to fire a pending trigger, or InputResponse::Skip to close \
                      the window (rejected if forced triggers remain) before any \
                      other action"
+                .into(),
+        };
+    }
+
+    // A pending clue-discovery interrupt (C5a #236) blocks every action but
+    // `ResolveInput`. It coexists with an in-flight skill test (it suspends
+    // mid-follow-up), so it must precede the skill-test guard.
+    if cx.state.clue_interrupt_pending.is_some()
+        && !matches!(action, PlayerAction::ResolveInput { .. })
+    {
+        return EngineOutcome::Rejected {
+            reason: "a clue-discovery interrupt is pending; submit a PlayerAction::ResolveInput \
+                     with InputResponse::Confirm (replace) or Skip (discover normally) before \
+                     any other action"
                 .into(),
         };
     }
@@ -372,6 +387,13 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
     // reaction-window check like hand-size discard.
     if cx.state.act_round_end_pending.is_some() {
         return phases::resume_act_round_end_advance(cx, response);
+    }
+
+    // Before-timing clue-discovery interrupt (C5a #236): arises mid-skill-
+    // test (during the Investigate follow-up), so route it before the
+    // reaction-window and skill-test resume paths.
+    if cx.state.clue_interrupt_pending.is_some() {
+        return clue_interrupt::resume_clue_interrupt(cx, response);
     }
 
     if cx.state.top_reaction_window().is_some() {

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -183,6 +183,9 @@ fn trigger_matches(
         // windows.
         // EndOfTurn and AfterLocationInvestigated are likewise forced-only
         // (`ForcedTriggerPoint::EndOfTurn` / `AfterLocationInvestigated`).
+        // WouldDiscoverClues is matched only by the `discover_clue`
+        // interrupt seam, and GameEnd only by `ForcedTriggerPoint::GameEnd`
+        // — both seam/forced-only, never player windows (C5a #236).
         (
             WindowKind::PlayerWindow(_) | WindowKind::AfterEnemyDefeated { .. },
             EventPattern::EnemyDefeated { .. }
@@ -194,7 +197,9 @@ fn trigger_matches(
             | EventPattern::AgendaAdvanced
             | EventPattern::RoundEnded
             | EventPattern::EndOfTurn
-            | EventPattern::AfterLocationInvestigated,
+            | EventPattern::AfterLocationInvestigated
+            | EventPattern::WouldDiscoverClues
+            | EventPattern::GameEnd,
         ) => false,
     }
 }
@@ -1045,6 +1050,36 @@ mod check_play_card_tests {
             err.contains("not in state"),
             "error should say not in state, got: {err}"
         );
+    }
+}
+
+#[cfg(test)]
+mod trigger_matches_tests {
+    use super::*;
+    use crate::state::PhaseStep;
+
+    #[test]
+    fn would_discover_clues_never_matches_a_player_window() {
+        // The before-timing clue-discovery interrupt (Cover Up 01007) is
+        // matched only by the `discover_clue` seam, never a player reaction
+        // window — even with After timing. (C5a #236.)
+        assert!(!trigger_matches(
+            WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws),
+            &EventPattern::WouldDiscoverClues,
+            EventTiming::After,
+            InvestigatorId(1),
+        ));
+    }
+
+    #[test]
+    fn game_end_never_matches_a_player_window() {
+        // GameEnd is forced-only (`ForcedTriggerPoint::GameEnd`).
+        assert!(!trigger_matches(
+            WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws),
+            &EventPattern::GameEnd,
+            EventTiming::After,
+            InvestigatorId(1),
+        ));
     }
 }
 

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -197,8 +197,32 @@ pub(super) fn finish_skill_test(cx: &mut Cx, indices: &[u32]) -> EngineOutcome {
         None => EvalContext::for_controller(investigator),
     };
 
+    // Pre-advance the continuation to PostFollowUp BEFORE running the
+    // follow-up, so a follow-up that suspends on a clue-discovery interrupt
+    // (Cover Up 01007) resumes at PostFollowUp rather than re-running the
+    // follow-up. `on_success` never co-occurs with a suspending follow-up
+    // in scope (Investigate sets on_success=None; SkillTest-effect tests
+    // set follow_up=None), so running on_success after the follow-up is
+    // safe. (C5a #236.)
+    cx.state
+        .in_flight_skill_test
+        .as_mut()
+        .expect("in_flight_skill_test was Some immediately above")
+        .continuation = FinishContinuation::PostFollowUp { succeeded };
+
     if succeeded {
-        apply_skill_test_follow_up(cx, investigator, follow_up);
+        let outcome = apply_skill_test_follow_up(cx, investigator, follow_up);
+        if matches!(outcome, EngineOutcome::AwaitingInput { .. }) {
+            // The follow-up suspended (clue-discovery interrupt). The
+            // continuation is already PostFollowUp; resume re-enters the
+            // driver there. Don't run on_success now — it doesn't co-occur
+            // with a suspending follow-up in scope.
+            return outcome;
+        }
+        debug_assert!(
+            matches!(outcome, EngineOutcome::Done),
+            "skill-test follow-up must resolve to Done or AwaitingInput: {outcome:?}"
+        );
         if let Some(effect) = &on_success {
             // Success-side card effect (Frozen in Fear 01164 discards
             // itself on a successful end-of-turn willpower test). In-scope
@@ -224,16 +248,6 @@ pub(super) fn finish_skill_test(cx: &mut Cx, indices: &[u32]) -> EngineOutcome {
             "revelation on_fail must resolve to Done in C4b scope: {outcome:?}"
         );
     }
-
-    // Step 2 is complete. Advance the continuation (carrying the
-    // outcome forward) and let the driver handle the remaining
-    // steps (including the possibly-queued reaction window from
-    // inside the follow-up).
-    cx.state
-        .in_flight_skill_test
-        .as_mut()
-        .expect("in_flight_skill_test was Some immediately above")
-        .continuation = FinishContinuation::PostFollowUp { succeeded };
 
     drive_skill_test(cx)
 }
@@ -554,31 +568,33 @@ fn apply_skill_test_follow_up(
     cx: &mut Cx,
     investigator: InvestigatorId,
     follow_up: SkillTestFollowUp,
-) {
+) -> EngineOutcome {
     match follow_up {
-        SkillTestFollowUp::None => {}
+        SkillTestFollowUp::None => EngineOutcome::Done,
         SkillTestFollowUp::Investigate => {
             let effect = discover_clue(LocationTarget::YourLocation, 1);
+            // discover_clue may suspend on a before-timing interrupt
+            // (Cover Up 01007). Propagate AwaitingInput; the Investigate
+            // follow-up has no source card, so `for_controller` is correct.
+            // The only rejection path ("controller between locations")
+            // can't occur post-Investigate (the action validated a
+            // location), so a Rejected here is still an invariant violation.
             let eval_ctx = EvalContext::for_controller(investigator);
-            // Same caveat as the pre-refactor `investigate`: the only
-            // remaining rejection path inside `discover_clue` is
-            // "controller is between locations", which the Investigate
-            // action validates before starting the test. Empty-
-            // location is a silent no-op by design. Any rejection
-            // here is a state-corruption invariant violation.
             let outcome = apply_effect(cx, &effect, eval_ctx);
-            if let EngineOutcome::Rejected { reason } = outcome {
+            if let EngineOutcome::Rejected { reason } = &outcome {
                 unreachable!(
                     "Investigate follow-up: discover_clue rejected unexpectedly after \
                      validation: {reason}"
                 );
             }
+            outcome
         }
         SkillTestFollowUp::Fight { enemy } => {
             // Mid-test enemy disappearance isn't possible in Phase 3
             // (no commit-window effects mutate enemies), so
             // damage_enemy's enemy-missing panic stays loud.
             super::combat::damage_enemy(cx, enemy, 1, Some(investigator));
+            EngineOutcome::Done
         }
         SkillTestFollowUp::Evade { enemy } => {
             let e = cx.state.enemies.get_mut(&enemy).unwrap_or_else(|| {
@@ -594,6 +610,7 @@ fn apply_skill_test_follow_up(
                 investigator,
             });
             cx.events.push(Event::EnemyExhausted { enemy });
+            EngineOutcome::Done
         }
     }
 }

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -89,6 +89,11 @@ pub struct EvalContext {
     /// skill-test driver runs an [`Effect::SkillTest`]'s `on_fail`. Read
     /// by [`Effect::ForEachPointFailed`]. `None` outside that window.
     pub failed_by: Option<u8>,
+    /// The clue count a before-timing discovery interrupt is replacing,
+    /// set only while resolving an `EventPattern::WouldDiscoverClues`
+    /// ability's effect (so the card-local "discard that many" Native
+    /// reads it). `None` outside that window. Mirrors `failed_by`.
+    pub clue_discovery_count: Option<u8>,
 }
 
 impl EvalContext {
@@ -101,6 +106,7 @@ impl EvalContext {
             controller,
             source: None,
             failed_by: None,
+            clue_discovery_count: None,
         }
     }
 
@@ -117,6 +123,7 @@ impl EvalContext {
             controller,
             source: Some(source),
             failed_by: None,
+            clue_discovery_count: None,
         }
     }
 }
@@ -1008,6 +1015,12 @@ mod tests {
 
     fn ctx(id: u32) -> EvalContext {
         EvalContext::for_controller(InvestigatorId(id))
+    }
+
+    #[test]
+    fn eval_context_defaults_clue_discovery_count_to_none() {
+        let ctx = EvalContext::for_controller(InvestigatorId(1));
+        assert_eq!(ctx.clue_discovery_count, None);
     }
 
     #[test]

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -537,24 +537,28 @@ fn discover_clue(
             // Read-only scan first (collect the hit), then set the pending
             // state — keeps the immutable borrow of the investigator
             // disjoint from the later mutable write.
-            let hit = cx.state.investigators.get(&eval_ctx.controller).and_then(|inv| {
-                inv.controlled_card_instances().find_map(|card| {
-                    if card.clues == 0 {
-                        return None;
-                    }
-                    let abilities = (reg.abilities_for)(&card.code)?;
-                    let idx = abilities.iter().position(|a| {
-                        matches!(
-                            &a.trigger,
-                            crate::dsl::Trigger::OnEvent {
-                                pattern: crate::dsl::EventPattern::WouldDiscoverClues,
-                                timing: crate::dsl::EventTiming::Before,
-                            }
-                        )
-                    })?;
-                    Some((card.instance_id, idx))
-                })
-            });
+            let hit = cx
+                .state
+                .investigators
+                .get(&eval_ctx.controller)
+                .and_then(|inv| {
+                    inv.controlled_card_instances().find_map(|card| {
+                        if card.clues == 0 {
+                            return None;
+                        }
+                        let abilities = (reg.abilities_for)(&card.code)?;
+                        let idx = abilities.iter().position(|a| {
+                            matches!(
+                                &a.trigger,
+                                crate::dsl::Trigger::OnEvent {
+                                    pattern: crate::dsl::EventPattern::WouldDiscoverClues,
+                                    timing: crate::dsl::EventTiming::Before,
+                                }
+                            )
+                        })?;
+                        Some((card.instance_id, idx))
+                    })
+                });
             if let Some((source, ability_index)) = hit {
                 cx.state.clue_interrupt_pending = Some(crate::state::ClueInterruptPending {
                     controller: eval_ctx.controller,
@@ -592,7 +596,11 @@ pub(crate) fn perform_discovery(
     count: u8,
     controller: crate::state::InvestigatorId,
 ) {
-    let location = cx.state.locations.get(&location_id).expect("location exists");
+    let location = cx
+        .state
+        .locations
+        .get(&location_id)
+        .expect("location exists");
     // Cap the discovery at the location's actual clue count — a card
     // can't pull more clues than exist.
     let actually_taken = count.min(location.clues);

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -521,11 +521,22 @@ fn discover_clue(
 
     // Before-timing clue-discovery interrupt (Cover Up 01007, C5a #236).
     // Offer the controller a chance to replace this discovery iff they
-    // control a card with a `WouldDiscoverClues` reaction, that card holds
-    // >= 1 clue (RR p.2 — the reaction needs game-state potential), and the
-    // discovery is at the controller's own location ("at your location").
-    // No registry (unit context) or no eligible card → fall through to the
-    // normal discovery below.
+    // control a card with a `WouldDiscoverClues` reaction at the
+    // controller's own location ("at your location"). No registry (unit
+    // context) or no eligible card → fall through to the normal discovery.
+    //
+    // The `card.clues > 0` gate below is NOT generic to the trigger point:
+    // it is a single-consumer stand-in for the eligibility rule "a
+    // triggered ability can only be initiated if its effect has the
+    // potential to change the game state" (RR p.2), which the engine does
+    // not yet model generically (no reaction window checks potential). For
+    // Cover Up specifically, an emptied card sits in the threat area until
+    // game end, so without this gate the engine would prompt a never-useful
+    // interrupt on every discovery for the rest of the game.
+    // TODO(#212): when a second `WouldDiscoverClues` card lands (one whose
+    // potential isn't "holds clues to discard"), lift this into a
+    // card-provided per-ability "has potential" predicate rather than a
+    // hardcoded clue check here.
     if let Some(reg) = crate::card_registry::current() {
         let at_your_location = cx
             .state
@@ -543,6 +554,7 @@ fn discover_clue(
                 .get(&eval_ctx.controller)
                 .and_then(|inv| {
                     inv.controlled_card_instances().find_map(|card| {
+                        // Single-consumer eligibility stand-in (see above).
                         if card.clues == 0 {
                             return None;
                         }

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -560,6 +560,14 @@ fn discover_clue(
                     })
                 });
             if let Some((source, ability_index)) = hit {
+                // TODO(#212): `count` is the *requested* count, not the
+                // capped/actually-discoverable one. Per the card, "discard
+                // that many" means the number you would actually discover
+                // (`min(count, location.clues)`). They coincide in Slice 1
+                // (Investigate is count=1 and the empty-location early-return
+                // above guarantees >= 1 clue present), so this is latent
+                // until a multi-count or sub-availability discovery is
+                // reachable.
                 cx.state.clue_interrupt_pending = Some(crate::state::ClueInterruptPending {
                     controller: eval_ctx.controller,
                     location: location_id,

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -508,10 +508,6 @@ fn discover_clue(
         // discovered"). Don't reject; just do nothing.
         return EngineOutcome::Done;
     }
-    // Cap the discovery at the location's actual clue count — a card
-    // can't pull more clues than exist.
-    let actually_taken = count.min(location.clues);
-    let new_location_count = location.clues - actually_taken;
 
     if !cx.state.investigators.contains_key(&eval_ctx.controller) {
         return EngineOutcome::Rejected {
@@ -523,8 +519,84 @@ fn discover_clue(
         };
     }
 
-    // Commit the mutations. From here both writes succeed
-    // unconditionally.
+    // Before-timing clue-discovery interrupt (Cover Up 01007, C5a #236).
+    // Offer the controller a chance to replace this discovery iff they
+    // control a card with a `WouldDiscoverClues` reaction, that card holds
+    // >= 1 clue (RR p.2 — the reaction needs game-state potential), and the
+    // discovery is at the controller's own location ("at your location").
+    // No registry (unit context) or no eligible card → fall through to the
+    // normal discovery below.
+    if let Some(reg) = crate::card_registry::current() {
+        let at_your_location = cx
+            .state
+            .investigators
+            .get(&eval_ctx.controller)
+            .and_then(|i| i.current_location)
+            == Some(location_id);
+        if at_your_location {
+            // Read-only scan first (collect the hit), then set the pending
+            // state — keeps the immutable borrow of the investigator
+            // disjoint from the later mutable write.
+            let hit = cx.state.investigators.get(&eval_ctx.controller).and_then(|inv| {
+                inv.controlled_card_instances().find_map(|card| {
+                    if card.clues == 0 {
+                        return None;
+                    }
+                    let abilities = (reg.abilities_for)(&card.code)?;
+                    let idx = abilities.iter().position(|a| {
+                        matches!(
+                            &a.trigger,
+                            crate::dsl::Trigger::OnEvent {
+                                pattern: crate::dsl::EventPattern::WouldDiscoverClues,
+                                timing: crate::dsl::EventTiming::Before,
+                            }
+                        )
+                    })?;
+                    Some((card.instance_id, idx))
+                })
+            });
+            if let Some((source, ability_index)) = hit {
+                cx.state.clue_interrupt_pending = Some(crate::state::ClueInterruptPending {
+                    controller: eval_ctx.controller,
+                    location: location_id,
+                    count,
+                    source,
+                    ability_index,
+                });
+                return EngineOutcome::AwaitingInput {
+                    request: crate::engine::outcome::InputRequest {
+                        prompt: "You would discover clue(s). Use the interrupt to discard that \
+                                 many from the source card instead? Confirm = replace, \
+                                 Skip = discover normally."
+                            .to_owned(),
+                    },
+                    resume_token: crate::engine::outcome::ResumeToken(0),
+                };
+            }
+        }
+    }
+
+    perform_discovery(cx, location_id, count, eval_ctx.controller);
+    EngineOutcome::Done
+}
+
+/// Move `count` clues (capped at availability) from `location_id` to
+/// `controller`, emitting `CluePlaced` + `LocationCluesChanged`. The
+/// committed mutation half of [`discover_clue`], factored out so the
+/// clue-discovery interrupt's `Skip` resume can perform the deferred
+/// discovery (C5a #236). Caller guarantees both ids exist and the
+/// location has clues.
+pub(crate) fn perform_discovery(
+    cx: &mut Cx,
+    location_id: crate::state::LocationId,
+    count: u8,
+    controller: crate::state::InvestigatorId,
+) {
+    let location = cx.state.locations.get(&location_id).expect("location exists");
+    // Cap the discovery at the location's actual clue count — a card
+    // can't pull more clues than exist.
+    let actually_taken = count.min(location.clues);
+    let new_location_count = location.clues - actually_taken;
     cx.state
         .locations
         .get_mut(&location_id)
@@ -533,19 +605,17 @@ fn discover_clue(
     let investigator = cx
         .state
         .investigators
-        .get_mut(&eval_ctx.controller)
+        .get_mut(&controller)
         .expect("checked above");
     investigator.clues = investigator.clues.saturating_add(actually_taken);
-
     cx.events.push(Event::CluePlaced {
-        investigator: eval_ctx.controller,
+        investigator: controller,
         count: actually_taken,
     });
     cx.events.push(Event::LocationCluesChanged {
         location: location_id,
         new_count: new_location_count,
     });
-    EngineOutcome::Done
 }
 
 fn deal_damage_effect(
@@ -1132,6 +1202,39 @@ mod tests {
             events,
             Event::LocationCluesChanged { location, new_count: 2 } if *location == loc_id
         );
+    }
+
+    #[test]
+    fn discover_clue_without_registry_discovers_normally() {
+        // No registry installed (game-core unit context) → the interrupt
+        // scan finds nothing → discovery proceeds exactly as before.
+        // Regression guard for the seam's "fall through" path (C5a #236).
+        let inv_id = InvestigatorId(1);
+        let loc_id = LocationId(10);
+        let mut investigator = test_investigator(1);
+        investigator.current_location = Some(loc_id);
+        let mut location = test_location(10, "Study");
+        location.clues = 3;
+
+        let mut state = GameStateBuilder::new()
+            .with_investigator(investigator)
+            .with_location(location)
+            .build();
+        let mut events = Vec::new();
+
+        let outcome = apply_effect(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            &discover_clue(LocationTarget::YourLocation, 1),
+            ctx(1),
+        );
+
+        assert_eq!(outcome, EngineOutcome::Done);
+        assert!(state.clue_interrupt_pending.is_none());
+        assert_eq!(state.locations[&loc_id].clues, 2);
+        assert_eq!(state.investigators[&inv_id].clues, 1);
     }
 
     #[test]

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -222,6 +222,12 @@ fn fire_scenario_resolution(cx: &mut Cx, registry: Option<&ScenarioRegistry>) {
         }
     }
 
+    // Fire game-end Forced abilities (Cover Up 01007's mental trauma, C5a
+    // #236). Non-interactive in scope; a suspending GameEnd hit is #212
+    // reentrancy work. Runs even when no scenario module is registered, so
+    // it precedes the module lookup below.
+    let _ = fire_forced_triggers(cx, &ForcedTriggerPoint::GameEnd);
+
     let Some(id) = cx.state.scenario_id.as_ref() else {
         return;
     };
@@ -4259,6 +4265,23 @@ mod tests {
         );
         assert_eq!(result.outcome, EngineOutcome::Done);
         assert_event!(result.events, Event::ScenarioResolved { .. });
+    }
+
+    #[test]
+    fn game_end_forced_point_is_noop_without_matching_cards() {
+        // The GameEnd forced point (C5a #236) fires at resolution but is a
+        // no-op with no controlled cards carrying a GameEnd ability: the
+        // resolution still fires, and no TraumaSuffered is emitted.
+        let state = terminal_act_state(Some("unknown"));
+        let result = super::apply_with_scenario_registry(
+            state,
+            Action::Player(PlayerAction::AdvanceAct {
+                investigator: InvestigatorId(1),
+            }),
+            None,
+        );
+        assert_event!(result.events, Event::ScenarioResolved { .. });
+        assert_no_event!(result.events, Event::TraumaSuffered { .. });
     }
 
     #[test]

--- a/crates/game-core/src/event.rs
+++ b/crates/game-core/src/event.rs
@@ -26,6 +26,17 @@ use crate::state::{
 /// Phase-1 minimal set. Later phases add events for skill-test
 /// commits, card plays, ability triggers, encounter draws, doom changes,
 /// trauma, scenario resolution, etc.
+/// Which trauma track a [`Event::TraumaSuffered`] applies to. Trauma is a
+/// cross-scenario campaign concept (Phase 9 owns persistence / max-stat
+/// reduction); this event makes it observable now without modeling state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum TraumaKind {
+    /// Physical trauma (reduces max health in campaign play).
+    Physical,
+    /// Mental trauma (reduces max sanity in campaign play).
+    Mental,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Event {
@@ -99,6 +110,17 @@ pub enum Event {
         /// Who took horror.
         investigator: InvestigatorId,
         /// Amount of horror.
+        amount: u8,
+    },
+    /// An investigator suffered trauma. Emitted by Cover Up 01007's
+    /// game-end Forced ability. Observable + replay-visible; persistence
+    /// (campaign log, max-stat reduction) is Phase 9 — no state mutation.
+    TraumaSuffered {
+        /// Who suffered the trauma.
+        investigator: InvestigatorId,
+        /// Physical or mental.
+        kind: TraumaKind,
+        /// How many trauma.
         amount: u8,
     },
     /// An investigator gained resources.
@@ -602,5 +624,22 @@ mod card_revealed_event_tests {
         let json = serde_json::to_string(&ev).expect("serialize");
         let back: Event = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, ev);
+    }
+}
+
+#[cfg(test)]
+mod trauma_event_tests {
+    use super::*;
+
+    #[test]
+    fn trauma_suffered_round_trips() {
+        let e = Event::TraumaSuffered {
+            investigator: InvestigatorId(1),
+            kind: TraumaKind::Mental,
+            amount: 1,
+        };
+        let json = serde_json::to_string(&e).expect("serialize");
+        let back: Event = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(e, back);
     }
 }

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -48,7 +48,7 @@ pub use engine::{
     shortest_first_steps, spawn_set_aside_enemy, take_damage, ApplyResult, Cx, EngineOutcome,
     EvalContext, InputRequest, ResumeToken,
 };
-pub use event::{Event, FailureReason};
+pub use event::{Event, FailureReason, TraumaKind};
 pub use rng::RngState;
 pub use scenario::{Resolution, ScenarioId, ScenarioModule, ScenarioRegistry};
 pub use state::{

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -282,6 +282,7 @@ impl GameStateBuilder {
             pending_end_turn: None,
             hand_size_discard_pending: self.hand_size_discard_pending,
             act_round_end_pending: None,
+            clue_interrupt_pending: None,
             pending_revelation_discard: None,
             encounter_deck: VecDeque::new(),
             encounter_discard: Vec::new(),

--- a/crates/game-core/src/state/card.rs
+++ b/crates/game-core/src/state/card.rs
@@ -154,6 +154,12 @@ pub struct CardInPlay {
     /// Horror accumulated on this asset (for horror-soak / ally
     /// sanity). Distinct from the controlling investigator's horror.
     pub accumulated_horror: u8,
+    /// Clues sitting on this card instance (Cover Up 01007 enters the
+    /// threat area "with 3 clues on it"). Distinct from the investigator
+    /// and location clue pools; defaults to 0. Most cards never carry
+    /// clues, so absent on the wire → 0.
+    #[serde(default)]
+    pub clues: u8,
     /// Per-ability usage counter for "Limit X per \[period\]" caps. Key
     /// is the ability index within the card's `abilities()`; value
     /// records the last round the ability fired and how many times.
@@ -214,6 +220,7 @@ impl CardInPlay {
             uses: BTreeMap::new(),
             accumulated_damage: 0,
             accumulated_horror: 0,
+            clues: 0,
             ability_usage: BTreeMap::new(),
         }
     }
@@ -266,5 +273,29 @@ impl CardInPlay {
             record.count = 0;
         }
         record.count = record.count.saturating_add(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CardCode, CardInPlay, CardInstanceId};
+
+    #[test]
+    fn enter_play_defaults_clues_to_zero() {
+        let c = CardInPlay::enter_play(CardCode("_x".into()), CardInstanceId(1));
+        assert_eq!(c.clues, 0);
+    }
+
+    #[test]
+    fn card_in_play_deserializes_when_clues_field_absent() {
+        // A state serialized before `clues` existed must still load (field
+        // defaults to 0), mirroring the `ability_usage` serde-default test.
+        let json = r#"{
+            "code": "_x", "instance_id": 1, "exhausted": false,
+            "uses": {}, "accumulated_damage": 0, "accumulated_horror": 0,
+            "ability_usage": {}
+        }"#;
+        let c: CardInPlay = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(c.clues, 0);
     }
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -228,6 +228,9 @@ pub struct GameState {
     /// awaiting the group's Confirm/Skip at the end of the round. See
     /// [`ActRoundEndPending`].
     pub act_round_end_pending: Option<ActRoundEndPending>,
+    /// Suspended clue-discovery interrupt (C5a, #236). See [`ClueInterruptPending`].
+    #[serde(default)]
+    pub clue_interrupt_pending: Option<ClueInterruptPending>,
     /// A treachery whose Revelation suspended (e.g. initiated a skill
     /// test) and must be pushed to [`encounter_discard`](Self::encounter_discard)
     /// once the suspending sub-resolution completes. Set by
@@ -820,6 +823,27 @@ pub struct SpawnEngagePending {
     pub chain_count: usize,
 }
 
+/// Suspended before-timing clue-discovery interrupt (C5a, #236). `Some`
+/// while `discover_clue` is paused offering the controller the choice to
+/// replace a discovery (Cover Up 01007's `[reaction]`). The resume path
+/// (`resume_clue_interrupt`) applies the choice, then re-enters
+/// `drive_skill_test` if a test is mid-flight.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ClueInterruptPending {
+    /// The investigator who would discover (and controls the interrupt card).
+    pub controller: InvestigatorId,
+    /// The location the discovery is from.
+    pub location: LocationId,
+    /// How many clues the discovery would move.
+    pub count: u8,
+    /// The interrupting card instance (Cover Up) — `source` for its effect.
+    pub source: CardInstanceId,
+    /// Index of the `WouldDiscoverClues` ability on the source card, so the
+    /// resume runs the right effect on `Confirm`.
+    pub ability_index: usize,
+}
+
 /// Suspended upkeep maximum-hand-size discard (#111). `Some` only while
 /// the upkeep phase is paused at step 4.5 waiting for an over-cap
 /// investigator to choose discards; cleared once the queue drains.
@@ -1135,6 +1159,17 @@ mod next_location_id_tests {
         let json = serde_json::to_string(&state).expect("serialize");
         let back: crate::state::GameState = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back.next_location_id, 7);
+    }
+}
+
+#[cfg(test)]
+mod clue_interrupt_pending_tests {
+    use crate::test_support::GameStateBuilder;
+
+    #[test]
+    fn clue_interrupt_pending_defaults_none_and_absent_field_loads() {
+        let s = GameStateBuilder::new().build();
+        assert!(s.clue_interrupt_pending.is_none());
     }
 }
 

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -828,8 +828,11 @@ pub struct SpawnEngagePending {
 /// replace a discovery (Cover Up 01007's `[reaction]`). The resume path
 /// (`resume_clue_interrupt`) applies the choice, then re-enters
 /// `drive_skill_test` if a test is mid-flight.
+// Not `#[non_exhaustive]`: plain serialized suspension state with no
+// construction invariant, and integration tests build it directly to
+// exercise the resume's count-coupling (no count>1 discovery source exists
+// through Investigate in Slice 1).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[non_exhaustive]
 pub struct ClueInterruptPending {
     /// The investigator who would discover (and controls the interrupt card).
     pub controller: InvestigatorId,

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -20,8 +20,8 @@ pub use card_dsl::card_data::{SkillKind, Skills};
 pub use chaos_bag::{resolve_token, ChaosBag, ChaosToken, TokenModifiers, TokenResolution};
 pub use enemy::{Enemy, EnemyId};
 pub use game_state::{
-    Act, ActRoundEndPending, Agenda, FastActorScope, FinishContinuation, GameState,
-    HandSizeDiscard, HunterChoice, InFlightSkillTest, OpenWindow, PendingSkillModifier,
+    Act, ActRoundEndPending, Agenda, ClueInterruptPending, FastActorScope, FinishContinuation,
+    GameState, HandSizeDiscard, HunterChoice, InFlightSkillTest, OpenWindow, PendingSkillModifier,
     PendingTrigger, PhaseStep, RoundEndAdvance, SkillTestFollowUp, SpawnEngagePending, WindowKind,
 };
 pub use investigator::{DefeatCause, Investigator, InvestigatorId, Status};

--- a/crates/scenarios/src/test_fixtures/synth_cards.rs
+++ b/crates/scenarios/src/test_fixtures/synth_cards.rs
@@ -70,7 +70,7 @@ pub const SYNTH_FAST_EVENT_CODE: &str = "_synth_fast_event";
 /// Code for the synthetic Cover-Up-shaped treachery (C5a #236). Carries a
 /// `WouldDiscoverClues` before-timing interrupt + a `GameEnd` forced
 /// trauma, both backed by Native effects on [`TEST_REGISTRY`]. Underscore
-/// prefix guarantees no collision with real ArkhamDB codes.
+/// prefix guarantees no collision with real `ArkhamDB` codes.
 pub const SYNTH_COVER_UP_CODE: &str = "_synth_cover_up";
 
 /// Native-effect tag: discard the replaced clue count from the synthetic
@@ -221,7 +221,11 @@ fn synth_cover_up_discard(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
         };
     };
     if let Some(inv) = cx.state.investigators.get_mut(&ctx.controller) {
-        for card in inv.threat_area.iter_mut().chain(inv.cards_in_play.iter_mut()) {
+        for card in inv
+            .threat_area
+            .iter_mut()
+            .chain(inv.cards_in_play.iter_mut())
+        {
             if card.instance_id == source {
                 let take = count.min(card.clues);
                 card.clues -= take;

--- a/crates/scenarios/src/test_fixtures/synth_cards.rs
+++ b/crates/scenarios/src/test_fixtures/synth_cards.rs
@@ -214,6 +214,12 @@ fn synth_cover_up_metadata_static() -> &'static CardMetadata {
 /// Native: discard the replaced clue count from the interrupting card
 /// instance (Cover Up 01007's "discard that many from Cover Up instead").
 fn synth_cover_up_discard(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
+    // The seam threads the replaced count via `clue_discovery_count`; a
+    // missing value means a wiring regression, not a legal 0-clue discard.
+    debug_assert!(
+        ctx.clue_discovery_count.is_some(),
+        "synth_cover_up_discard: clue_discovery_count not threaded"
+    );
     let count = ctx.clue_discovery_count.unwrap_or(0);
     let Some(source) = ctx.source else {
         return EngineOutcome::Rejected {

--- a/crates/scenarios/src/test_fixtures/synth_cards.rs
+++ b/crates/scenarios/src/test_fixtures/synth_cards.rs
@@ -18,8 +18,13 @@ use std::sync::OnceLock;
 use game_core::card_data::{
     CardKind, CardMetadata, Class, HealthValue, Prey, SkillIcons, Spawn, SpawnLocation,
 };
-use game_core::card_registry::CardRegistry;
-use game_core::dsl::{gain_resources, on_play, revelation, Ability, InvestigatorTarget};
+use game_core::card_registry::{CardRegistry, NativeEffectFn};
+use game_core::dsl::{
+    gain_resources, native, on_event, on_play, revelation, Ability, EventPattern, EventTiming,
+    InvestigatorTarget,
+};
+use game_core::engine::{Cx, EngineOutcome, EvalContext};
+use game_core::event::{Event, TraumaKind};
 use game_core::state::CardCode;
 
 /// Code for the synthetic location used by the synth-enemy's spawn
@@ -61,6 +66,20 @@ pub const SYNTH_SURGE_TREACHERY_CODE: &str = "_synth_surge_treachery";
 /// `card_type: Event` so `check_play_card`'s timing gate allows it
 /// inside a permissive window.
 pub const SYNTH_FAST_EVENT_CODE: &str = "_synth_fast_event";
+
+/// Code for the synthetic Cover-Up-shaped treachery (C5a #236). Carries a
+/// `WouldDiscoverClues` before-timing interrupt + a `GameEnd` forced
+/// trauma, both backed by Native effects on [`TEST_REGISTRY`]. Underscore
+/// prefix guarantees no collision with real ArkhamDB codes.
+pub const SYNTH_COVER_UP_CODE: &str = "_synth_cover_up";
+
+/// Native-effect tag: discard the replaced clue count from the synthetic
+/// Cover Up (C5a #236).
+pub const SYNTH_COVER_UP_DISCARD_TAG: &str = "_synth_cover_up:discard_clues";
+
+/// Native-effect tag: suffer 1 mental trauma at game end if the synthetic
+/// Cover Up still holds clues (C5a #236).
+pub const SYNTH_COVER_UP_TRAUMA_TAG: &str = "_synth_cover_up:trauma";
 
 /// Static metadata for the synthetic treachery. Only `code`/`name`/the
 /// `Treachery` kind carry meaning for the tests.
@@ -167,6 +186,78 @@ fn synth_fast_event_metadata_static() -> &'static CardMetadata {
     M.get_or_init(synth_fast_event_metadata)
 }
 
+fn synth_cover_up_metadata() -> CardMetadata {
+    CardMetadata {
+        code: SYNTH_COVER_UP_CODE.to_owned(),
+        name: "Synthetic Cover Up".to_owned(),
+        text: Some(
+            "Reaction: when you would discover clues at your location, \
+             discard that many from this card instead. Forced: at game end, \
+             if any clues remain, suffer 1 mental trauma. (Synthetic.)"
+                .to_owned(),
+        ),
+        traits: Vec::new(),
+        pack_code: "_synth".to_owned(),
+        kind: CardKind::Treachery {
+            surge: false,
+            peril: false,
+            quantity: 1,
+        },
+    }
+}
+
+fn synth_cover_up_metadata_static() -> &'static CardMetadata {
+    static M: OnceLock<CardMetadata> = OnceLock::new();
+    M.get_or_init(synth_cover_up_metadata)
+}
+
+/// Native: discard the replaced clue count from the interrupting card
+/// instance (Cover Up 01007's "discard that many from Cover Up instead").
+fn synth_cover_up_discard(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
+    let count = ctx.clue_discovery_count.unwrap_or(0);
+    let Some(source) = ctx.source else {
+        return EngineOutcome::Rejected {
+            reason: "synth_cover_up_discard: no source instance".into(),
+        };
+    };
+    if let Some(inv) = cx.state.investigators.get_mut(&ctx.controller) {
+        for card in inv.threat_area.iter_mut().chain(inv.cards_in_play.iter_mut()) {
+            if card.instance_id == source {
+                let take = count.min(card.clues);
+                card.clues -= take;
+                break;
+            }
+        }
+    }
+    EngineOutcome::Done
+}
+
+/// Native: at game end, if the source card holds any clues, suffer 1
+/// mental trauma (Cover Up 01007's Forced).
+fn synth_cover_up_trauma(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
+    let Some(source) = ctx.source else {
+        return EngineOutcome::Rejected {
+            reason: "synth_cover_up_trauma: no source instance".into(),
+        };
+    };
+    let has_clues = cx
+        .state
+        .investigators
+        .get(&ctx.controller)
+        .is_some_and(|inv| {
+            inv.controlled_card_instances()
+                .any(|c| c.instance_id == source && c.clues > 0)
+        });
+    if has_clues {
+        cx.events.push(Event::TraumaSuffered {
+            investigator: ctx.controller,
+            kind: TraumaKind::Mental,
+            amount: 1,
+        });
+    }
+    EngineOutcome::Done
+}
+
 /// `metadata_for` function pointer used by [`TEST_REGISTRY`].
 fn metadata_for(code: &CardCode) -> Option<&'static CardMetadata> {
     match code.as_str() {
@@ -174,6 +265,7 @@ fn metadata_for(code: &CardCode) -> Option<&'static CardMetadata> {
         SYNTH_ENEMY_CODE => Some(synth_enemy_metadata_static()),
         SYNTH_SURGE_TREACHERY_CODE => Some(synth_surge_treachery_metadata_static()),
         SYNTH_FAST_EVENT_CODE => Some(synth_fast_event_metadata_static()),
+        SYNTH_COVER_UP_CODE => Some(synth_cover_up_metadata_static()),
         _ => None,
     }
 }
@@ -185,9 +277,30 @@ fn abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
             Some(vec![revelation(gain_resources(InvestigatorTarget::You, 1))])
         }
         SYNTH_FAST_EVENT_CODE => Some(vec![on_play(gain_resources(InvestigatorTarget::You, 1))]),
+        SYNTH_COVER_UP_CODE => Some(vec![
+            on_event(
+                EventPattern::WouldDiscoverClues,
+                EventTiming::Before,
+                native(SYNTH_COVER_UP_DISCARD_TAG),
+            ),
+            on_event(
+                EventPattern::GameEnd,
+                EventTiming::After,
+                native(SYNTH_COVER_UP_TRAUMA_TAG),
+            ),
+        ]),
         // SYNTH_ENEMY_CODE intentionally returns None — the synthetic
         // enemy has no Revelation effect; the spawn handler is the
         // only thing exercised by the integration test.
+        _ => None,
+    }
+}
+
+/// `native_effect_for` function pointer used by [`TEST_REGISTRY`].
+fn native_effect_for(tag: &str) -> Option<NativeEffectFn> {
+    match tag {
+        SYNTH_COVER_UP_DISCARD_TAG => Some(synth_cover_up_discard),
+        SYNTH_COVER_UP_TRAUMA_TAG => Some(synth_cover_up_trauma),
         _ => None,
     }
 }
@@ -203,7 +316,7 @@ fn abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
 pub const TEST_REGISTRY: CardRegistry = CardRegistry {
     metadata_for,
     abilities_for,
-    native_effect_for: |_| None,
+    native_effect_for,
 };
 
 #[cfg(test)]
@@ -237,6 +350,34 @@ mod tests {
         let code = CardCode(SYNTH_TREACHERY_CODE.into());
         assert!((TEST_REGISTRY.metadata_for)(&code).is_some());
         assert!((TEST_REGISTRY.abilities_for)(&code).is_some());
+    }
+
+    #[test]
+    fn cover_up_fixture_has_interrupt_and_gameend_abilities() {
+        let code = CardCode(SYNTH_COVER_UP_CODE.into());
+        let abilities = abilities_for(&code).expect("cover up abilities");
+        assert_eq!(abilities.len(), 2);
+        assert!(matches!(
+            abilities[0].trigger,
+            game_core::dsl::Trigger::OnEvent {
+                pattern: game_core::dsl::EventPattern::WouldDiscoverClues,
+                timing: game_core::dsl::EventTiming::Before,
+            }
+        ));
+        assert!(matches!(
+            abilities[1].trigger,
+            game_core::dsl::Trigger::OnEvent {
+                pattern: game_core::dsl::EventPattern::GameEnd,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn native_effect_for_resolves_cover_up_tags() {
+        assert!(native_effect_for(SYNTH_COVER_UP_DISCARD_TAG).is_some());
+        assert!(native_effect_for(SYNTH_COVER_UP_TRAUMA_TAG).is_some());
+        assert!(native_effect_for("nope").is_none());
     }
 
     #[test]

--- a/crates/scenarios/tests/cover_up_interrupt.rs
+++ b/crates/scenarios/tests/cover_up_interrupt.rs
@@ -8,8 +8,8 @@ use game_core::engine::{apply, EngineOutcome};
 use game_core::event::{Event, TraumaKind};
 use game_core::scenario::{Resolution, ScenarioId};
 use game_core::state::{
-    Act, CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, GameState, InvestigatorId,
-    LocationId, Phase,
+    Act, CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, ClueInterruptPending,
+    GameState, InvestigatorId, LocationId, Phase,
 };
 use game_core::test_support::{test_investigator, test_location, GameStateBuilder};
 use game_core::{Action, InputResponse, PlayerAction};
@@ -148,6 +148,83 @@ fn no_interrupt_when_cover_up_has_no_clues() {
         "discovery resolved normally"
     );
     assert_eq!(state.investigators[&INV].clues, 1);
+}
+
+/// State paused at a clue-discovery interrupt for a `count`-clue discovery
+/// with a Cover Up holding `cover_up_clues`. Built directly (no `count > 1`
+/// discovery source exists through Investigate in Slice 1) to exercise the
+/// `ClueInterruptPending.count` → `clue_discovery_count` → discard-from-self
+/// coupling and the `min(count, clues)` cap on `Confirm`.
+fn paused_interrupt_state(count: u8, loc_clues: u8, cover_up_clues: u8) -> GameState {
+    let mut investigator = test_investigator(1);
+    investigator.threat_area.push(cover_up(cover_up_clues));
+    let mut location = test_location(10, "Study");
+    location.clues = loc_clues;
+    let mut state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator_at(investigator, LOC)
+        .with_location(location)
+        .with_active_investigator(INV)
+        .with_turn_order([INV])
+        .build();
+    state.clue_interrupt_pending = Some(ClueInterruptPending {
+        controller: INV,
+        location: LOC,
+        count,
+        source: CardInstanceId(1),
+        ability_index: 0,
+    });
+    state
+}
+
+#[test]
+fn confirm_discards_the_full_replaced_count() {
+    install();
+    // count=2, Cover Up holds 3 → discover nothing, discard exactly 2.
+    let r = apply(
+        paused_interrupt_state(2, 5, 3),
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    );
+    assert!(
+        matches!(r.outcome, EngineOutcome::Done),
+        "got {:?}",
+        r.outcome
+    );
+    assert_eq!(r.state.locations[&LOC].clues, 5, "location untouched");
+    assert_eq!(r.state.investigators[&INV].clues, 0, "discovered nothing");
+    let cu = r.state.investigators[&INV]
+        .threat_area
+        .iter()
+        .find(|c| c.code.as_str() == SYNTH_COVER_UP_CODE)
+        .unwrap();
+    assert_eq!(cu.clues, 1, "2 of 3 clues discarded from Cover Up");
+}
+
+#[test]
+fn confirm_caps_discard_at_cover_up_clue_count() {
+    install();
+    // count=3 but Cover Up only holds 1 → discard is capped at 1 (no
+    // underflow), and the discovery is still fully replaced.
+    let r = apply(
+        paused_interrupt_state(3, 5, 1),
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    );
+    assert!(
+        matches!(r.outcome, EngineOutcome::Done),
+        "got {:?}",
+        r.outcome
+    );
+    assert_eq!(r.state.investigators[&INV].clues, 0, "discovered nothing");
+    let cu = r.state.investigators[&INV]
+        .threat_area
+        .iter()
+        .find(|c| c.code.as_str() == SYNTH_COVER_UP_CODE)
+        .unwrap();
+    assert_eq!(cu.clues, 0, "discard capped at the 1 clue Cover Up held");
 }
 
 /// Terminal-act state whose `AdvanceAct` latches a Won resolution, with a

--- a/crates/scenarios/tests/cover_up_interrupt.rs
+++ b/crates/scenarios/tests/cover_up_interrupt.rs
@@ -1,6 +1,6 @@
 //! C5a (#236) integration: Cover Up's before-timing clue-discovery
 //! interrupt and its game-end mental-trauma forced point, against the
-//! synthetic Cover-Up fixture. Own process → installs TEST_REGISTRY.
+//! synthetic Cover-Up fixture. Own process → installs `TEST_REGISTRY`.
 
 use std::sync::Once;
 
@@ -89,7 +89,11 @@ fn confirm_replaces_discovery_with_discard_from_cover_up() {
             response: InputResponse::Confirm,
         }),
     );
-    assert!(matches!(r.outcome, EngineOutcome::Done), "got {:?}", r.outcome);
+    assert!(
+        matches!(r.outcome, EngineOutcome::Done),
+        "got {:?}",
+        r.outcome
+    );
 
     assert_eq!(r.state.locations[&LOC].clues, 2, "location clues unchanged");
     assert_eq!(
@@ -139,7 +143,10 @@ fn no_interrupt_when_cover_up_has_no_clues() {
         "no interrupt expected, got {outcome:?}"
     );
     assert!(state.clue_interrupt_pending.is_none());
-    assert_eq!(state.locations[&LOC].clues, 1, "discovery resolved normally");
+    assert_eq!(
+        state.locations[&LOC].clues, 1,
+        "discovery resolved normally"
+    );
     assert_eq!(state.investigators[&INV].clues, 1);
 }
 

--- a/crates/scenarios/tests/cover_up_interrupt.rs
+++ b/crates/scenarios/tests/cover_up_interrupt.rs
@@ -1,0 +1,214 @@
+//! C5a (#236) integration: Cover Up's before-timing clue-discovery
+//! interrupt and its game-end mental-trauma forced point, against the
+//! synthetic Cover-Up fixture. Own process → installs TEST_REGISTRY.
+
+use std::sync::Once;
+
+use game_core::engine::{apply, EngineOutcome};
+use game_core::event::{Event, TraumaKind};
+use game_core::scenario::{Resolution, ScenarioId};
+use game_core::state::{
+    Act, CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, GameState, InvestigatorId,
+    LocationId, Phase,
+};
+use game_core::test_support::{test_investigator, test_location, GameStateBuilder};
+use game_core::{Action, InputResponse, PlayerAction};
+use scenarios::test_fixtures::synth_cards::{SYNTH_COVER_UP_CODE, TEST_REGISTRY};
+
+static INSTALL: Once = Once::new();
+fn install() {
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(TEST_REGISTRY);
+    });
+}
+
+const INV: InvestigatorId = InvestigatorId(1);
+const LOC: LocationId = LocationId(10);
+
+/// A Cover-Up fixture instance carrying `clues`, for the threat area.
+fn cover_up(clues: u8) -> CardInPlay {
+    let mut c = CardInPlay::enter_play(CardCode(SYNTH_COVER_UP_CODE.into()), CardInstanceId(1));
+    c.clues = clues;
+    c
+}
+
+/// Investigation-phase state: the active investigator at a revealed
+/// location holding `loc_clues`, with a Cover Up holding `cover_up_clues`
+/// in their threat area. Chaos bag is a single +0 token so the
+/// Intellect-3-vs-shroud-2 investigate always succeeds.
+fn investigate_state(loc_clues: u8, cover_up_clues: u8) -> GameState {
+    let mut investigator = test_investigator(1);
+    investigator.threat_area.push(cover_up(cover_up_clues));
+    let mut location = test_location(10, "Study");
+    location.clues = loc_clues;
+    GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator_at(investigator, LOC)
+        .with_location(location)
+        .with_active_investigator(INV)
+        .with_turn_order([INV])
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_rng_seed(1)
+        .build()
+}
+
+/// Run Investigate + commit-nothing, returning the state paused at the
+/// clue-discovery interrupt (or resolved, if none was offered) plus the
+/// last outcome.
+fn investigate_to_interrupt(state: GameState) -> (GameState, EngineOutcome) {
+    let r = apply(
+        state,
+        Action::Player(PlayerAction::Investigate { investigator: INV }),
+    );
+    assert!(
+        matches!(r.outcome, EngineOutcome::AwaitingInput { .. }),
+        "Investigate should open the commit window, got {:?}",
+        r.outcome
+    );
+    let r = apply(
+        r.state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::CommitCards { indices: vec![] },
+        }),
+    );
+    (r.state, r.outcome)
+}
+
+#[test]
+fn confirm_replaces_discovery_with_discard_from_cover_up() {
+    install();
+    let (state, outcome) = investigate_to_interrupt(investigate_state(2, 3));
+    assert!(
+        matches!(outcome, EngineOutcome::AwaitingInput { .. }),
+        "expected interrupt prompt, got {outcome:?}"
+    );
+
+    let r = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    );
+    assert!(matches!(r.outcome, EngineOutcome::Done), "got {:?}", r.outcome);
+
+    assert_eq!(r.state.locations[&LOC].clues, 2, "location clues unchanged");
+    assert_eq!(
+        r.state.investigators[&INV].clues, 0,
+        "investigator discovered nothing"
+    );
+    let cu = r.state.investigators[&INV]
+        .threat_area
+        .iter()
+        .find(|c| c.code.as_str() == SYNTH_COVER_UP_CODE)
+        .expect("cover up present");
+    assert_eq!(cu.clues, 2, "1 clue discarded from Cover Up");
+}
+
+#[test]
+fn skip_discovers_normally() {
+    install();
+    let (state, outcome) = investigate_to_interrupt(investigate_state(2, 3));
+    assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
+
+    let r = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Skip,
+        }),
+    );
+    assert!(matches!(r.outcome, EngineOutcome::Done));
+
+    assert_eq!(r.state.locations[&LOC].clues, 1, "location -1");
+    assert_eq!(r.state.investigators[&INV].clues, 1, "investigator +1");
+    let cu = r.state.investigators[&INV]
+        .threat_area
+        .iter()
+        .find(|c| c.code.as_str() == SYNTH_COVER_UP_CODE)
+        .unwrap();
+    assert_eq!(cu.clues, 3, "Cover Up untouched on Skip");
+}
+
+#[test]
+fn no_interrupt_when_cover_up_has_no_clues() {
+    install();
+    // Cover Up with 0 clues: the reaction has no game-state potential, so
+    // it is not offered — the commit window resolves straight to Done.
+    let (state, outcome) = investigate_to_interrupt(investigate_state(2, 0));
+    assert!(
+        matches!(outcome, EngineOutcome::Done),
+        "no interrupt expected, got {outcome:?}"
+    );
+    assert!(state.clue_interrupt_pending.is_none());
+    assert_eq!(state.locations[&LOC].clues, 1, "discovery resolved normally");
+    assert_eq!(state.investigators[&INV].clues, 1);
+}
+
+/// Terminal-act state whose `AdvanceAct` latches a Won resolution, with a
+/// Cover Up holding `cover_up_clues` in the investigator's threat area.
+fn resolving_state(cover_up_clues: u8) -> GameState {
+    let mut investigator = test_investigator(1);
+    investigator.clues = 1; // enough to meet the act's clue threshold
+    investigator.threat_area.push(cover_up(cover_up_clues));
+    let mut state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(investigator)
+        .with_active_investigator(INV)
+        .with_turn_order([INV])
+        .with_scenario_id(ScenarioId::new("unknown"))
+        .build();
+    state.act_deck = vec![Act {
+        code: CardCode("_test_act".into()),
+        clue_threshold: 1,
+        resolution: Some(Resolution::Won { id: "test".into() }),
+        round_end_advance: None,
+    }];
+    state
+}
+
+#[test]
+fn game_end_emits_trauma_when_cover_up_has_clues() {
+    install();
+    let r = apply(
+        resolving_state(3),
+        Action::Player(PlayerAction::AdvanceAct { investigator: INV }),
+    );
+    assert!(
+        r.events
+            .iter()
+            .any(|e| matches!(e, Event::ScenarioResolved { .. })),
+        "resolution should latch; events = {:?}",
+        r.events
+    );
+    assert!(
+        r.events.iter().any(|e| matches!(
+            e,
+            Event::TraumaSuffered {
+                kind: TraumaKind::Mental,
+                amount: 1,
+                ..
+            }
+        )),
+        "expected mental trauma at game end; events = {:?}",
+        r.events
+    );
+}
+
+#[test]
+fn game_end_emits_no_trauma_when_cover_up_empty() {
+    install();
+    let r = apply(
+        resolving_state(0),
+        Action::Player(PlayerAction::AdvanceAct { investigator: INV }),
+    );
+    assert!(r
+        .events
+        .iter()
+        .any(|e| matches!(e, Event::ScenarioResolved { .. })));
+    assert!(
+        !r.events
+            .iter()
+            .any(|e| matches!(e, Event::TraumaSuffered { .. })),
+        "no trauma when Cover Up is empty; events = {:?}",
+        r.events
+    );
+}

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -25,8 +25,12 @@ discard), C4b (the four one-shot Revelation treacheries —
 attachment treacheries — Obscuring Fog 01168, Dissonant Voices 01165,
 Frozen in Fear 01164 — with the location attachment zone, inspectable-DSL
 constant restrictions, `Effect::DiscardSelf`, deterministic
-simultaneous-forced-trigger resolution, and end-turn resume plumbing).
-**Next: C5 → C7** (C6d also gates C7b).
+simultaneous-forced-trigger resolution, and end-turn resume plumbing), and
+C5a ([#236](https://github.com/talelburg/eldritch/issues/236): Cover Up's
+before-timing clue-discovery replacement interrupt at the `discover_clue`
+chokepoint — `clue_interrupt_pending` suspension + pre-advanced skill-test
+resume — plus `ForcedTriggerPoint::GameEnd` and `Event::TraumaSuffered`).
+**Next: C5b → C7** (C6d also gates C7b).
 
 Design specs:
 [Gathering design](../superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md),
@@ -80,7 +84,7 @@ root dependency; C7 is the playable Won/Lost gate; #212 lands after C.
 | — | [#286](https://github.com/talelburg/eldritch/issues/286) | infra: `Effect::SkillTest` + `ForEachPointFailed` + failure-side follow-up + suspendable-revelation discard (prerequisite for C4b's test treacheries) | ✅ PR #287 |
 | C4b | [#234](https://github.com/talelburg/eldritch/issues/234) | one-shot Revelation treacheries (×4) | ✅ PR #288 |
 | C4c | [#235](https://github.com/talelburg/eldritch/issues/235) | persistent threat-area / attachment treacheries (×3) | ✅ PR #289 |
-| C5a | [#236](https://github.com/talelburg/eldritch/issues/236) | Cover Up before-timing interrupt + `GameEnd` | — |
+| C5a | [#236](https://github.com/talelburg/eldritch/issues/236) | Cover Up before-timing interrupt + `GameEnd` | ✅ PR #291 |
 | C5b | [#237](https://github.com/talelburg/eldritch/issues/237) | Guard Dog damage-from-enemy window | — |
 | C5c | [#238](https://github.com/talelburg/eldritch/issues/238) | .38 Special signature + Cover Up content | — |
 | C5d | [#239](https://github.com/talelburg/eldritch/issues/239) | Guardian L0 assets (×6) | — |
@@ -150,6 +154,10 @@ Devourer Below, campaign log + `Fact` enum) is **Phase 9**, not Phase 7.
 - **A persistent treachery is one with any non-Revelation ability; it owns its own disposition (C4c, [#235](https://github.com/talelburg/eldritch/issues/235), PR #289).** `resolve_encounter_card` auto-discards a treachery after its Revelation **only if every ability is `Trigger::Revelation`**; a card carrying a `Constant`/`OnEvent` ability places itself (threat area via `place_in_threat_area`, or location via `attach_to_location`) and discards itself later via the typed `Effect::DiscardSelf` (which finds the firing instance through `EvalContext::source`). No suppress-discard flag. **A new persistent treachery needs no routing change — give it an ongoing ability and a self-placement Revelation.** Constant restrictions extend the inspectable DSL (`Stat::Shroud`, `Restriction::{CannotPlay, ExtraActionCost}` under `Effect::Restrict`), read by `effective_shroud` / `play_is_prohibited` / `pending_action_surcharge` the way `constant_skill_modifier` already reads `Modify` — **not** via new registry query hooks. `ExtraActionCost`'s `first_each_round` stays a field (tracked per source instance in `Investigator.action_surcharge_spent_this_round`) until a second consumer needs the gate on a non-cost mechanism.
 
 - **Simultaneous forced triggers resolve in a fixed deterministic order, and a suspending forced effect at end-of-turn resumes via `pending_end_turn` (C4c, PR #289).** `fire_forced_triggers` now resolves *all* collected hits in collection order (board cards before threat-area/attachment instances; `BTreeMap` order) instead of rejecting on 2+ — this is the partial #213 stand-in (player-chosen ordering is still #213). It lets Dissonant Voices' `RoundEnded` discard coexist with agenda 01107's `RoundEnded` doom. A hit that *suspends* abandons later hits (#212 reentrancy); safe while no point has 2+ simultaneous suspending hits. `Effect::SkillTest` gained a success-side `on_success` (mirror of `on_fail`); a suspending `EndOfTurn` forced effect (Frozen in Fear's willpower test) strands `end_turn` before rotation, so `end_turn` records `pending_end_turn` and the skill-test commit-resume path re-enters `resume_end_turn` (rotation / phase-end) — mirroring `spawn_engage_pending`/`resume_spawn_engage`.
+
+- **Before-timing clue-discovery interrupt is a card-local seam at the `discover_clue` chokepoint, not a general before-timing reaction-window subsystem (C5a, [#236](https://github.com/talelburg/eldritch/issues/236), PR #291).** When the controller holds a `WouldDiscoverClues` (`EventTiming::Before`) reaction, `discover_clue` suspends with a yes/no `AwaitingInput` (`GameState.clue_interrupt_pending`); `resume_clue_interrupt` (routed before the skill-test path in `resolve_input`) runs the card-local `Effect::Native` replacement on `Confirm` (count threaded via `EvalContext.clue_discovery_count`) or the deferred discovery on `Skip`. Reentrancy: `finish_skill_test` **pre-advances** its continuation to `PostFollowUp` before the Investigate follow-up, so a suspending discovery resumes through `in_flight_skill_test` without re-running the follow-up — **bounded to terminal-position discovery** (the base Investigate follow-up, the only Slice-1 clue source; nested-in-`Seq` is #212). **A future before-timing interrupt reuses this seam.** The seam's `card.clues > 0` eligibility gate is a **single-consumer stand-in for RR p.2's "ability must have potential to change the game state"** — the engine models this nowhere; lift it into a card-provided per-ability predicate when a 2nd `WouldDiscoverClues` card lands (`TODO(#212)`). Bespoke effects (discard-from-self, suffer-trauma) stay `Effect::Native`, integration-tested via `synth_cards::TEST_REGISTRY`.
+
+- **`ForcedTriggerPoint::GameEnd` fires once from `fire_scenario_resolution` on the resolution latch; game-end trauma is `Event::TraumaSuffered`-only (C5a, PR #291).** It scans every investigator's `controlled_card_instances()` for `EventPattern::GameEnd` forced abilities, before the scenario-module `apply_resolution` hook (so it runs even with no module). Trauma persistence (campaign log, max-stat reduction) is **Phase 9** — C5a emits the event and mutates no state.
 
 ## Open questions
 

--- a/docs/superpowers/plans/2026-06-15-phase-7-c5a-cover-up-interrupt-gameend.md
+++ b/docs/superpowers/plans/2026-06-15-phase-7-c5a-cover-up-interrupt-gameend.md
@@ -1,0 +1,1339 @@
+# C5a — Cover Up interrupt window + GameEnd forced point — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the engine machinery for Cover Up 01007's optional before-timing clue-discovery replacement interrupt and its game-end mental-trauma forced point, data-driven (no `01007` literal in the engine) and verified against a synthetic fixture.
+
+**Architecture:** A minimal card-local seam at the `discover_clue` chokepoint suspends with a yes/no `AwaitingInput` when an eligible interrupt card is controlled; the skill-test driver pre-advances its continuation so resume threads through the existing `in_flight_skill_test` state machine. A new `ForcedTriggerPoint::GameEnd` fires once from `fire_scenario_resolution`. Bespoke card effects (discard-from-self, suffer-trauma) stay `Effect::Native`, exercised via an extended `synth_cards::TEST_REGISTRY` in an integration test.
+
+**Tech Stack:** Rust, `game-core` kernel + `card-dsl` + `scenarios` test fixtures. Strict CI: `cargo fmt`, `clippy -D warnings`, `RUSTFLAGS=-D warnings test`, `RUSTDOCFLAGS=-D warnings doc`, wasm build/clippy.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-phase-7-c5a-cover-up-interrupt-gameend-design.md`
+
+**Branch:** `engine/cover-up-interrupt` (already created; spec committed).
+
+---
+
+## File structure
+
+- `crates/game-core/src/state/card.rs` — add `CardInPlay.clues` field + `enter_play` default.
+- `crates/game-core/src/event.rs` — add `Event::TraumaSuffered` + `TraumaKind`.
+- `crates/card-dsl/src/dsl.rs` — add `EventPattern::WouldDiscoverClues` + `EventPattern::GameEnd`.
+- `crates/game-core/src/engine/dispatch/reaction_windows.rs` — exclude the two new patterns from `trigger_matches`.
+- `crates/game-core/src/engine/evaluator.rs` — `EvalContext.clue_discovery_count`; extract `perform_discovery`; add the interrupt scan + suspend in `discover_clue`.
+- `crates/game-core/src/state/game_state.rs` — `ClueInterruptPending` struct + `clue_interrupt_pending` field.
+- `crates/game-core/src/engine/dispatch/clue_interrupt.rs` — **new** — `resume_clue_interrupt`.
+- `crates/game-core/src/engine/dispatch/mod.rs` — route + guard the new suspension mode; register the new module.
+- `crates/game-core/src/engine/dispatch/skill_test.rs` — pre-advance continuation; propagate `AwaitingInput` from the Investigate follow-up.
+- `crates/game-core/src/engine/dispatch/forced_triggers.rs` — `ForcedTriggerPoint::GameEnd` variant + collect arm.
+- `crates/game-core/src/engine/mod.rs` — fire `GameEnd` from `fire_scenario_resolution`.
+- `crates/scenarios/src/test_fixtures/synth_cards.rs` — Cover-Up-shaped fixture card + Native effects + `native_effect_for` wiring.
+- `crates/scenarios/tests/cover_up_interrupt.rs` — **new** — integration tests.
+
+Run the full gauntlet (below) before the final push. Per-task, the single-crate test command shown is enough for the red/green loop.
+
+```sh
+# Full gauntlet (run before push)
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+
+---
+
+## Task 1: Clue storage on a card instance
+
+**Files:**
+- Modify: `crates/game-core/src/state/card.rs` (struct `CardInPlay` ~136-174; `enter_play` ~209-219)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)]` module in `crates/game-core/src/state/card.rs`:
+
+```rust
+#[test]
+fn enter_play_defaults_clues_to_zero() {
+    let c = CardInPlay::enter_play(CardCode("_x".into()), CardInstanceId(1));
+    assert_eq!(c.clues, 0);
+}
+
+#[test]
+fn card_in_play_deserializes_when_clues_field_absent() {
+    // A state serialized before `clues` existed must still load (field
+    // defaults to 0), mirroring the `ability_usage` serde-default test.
+    let json = r#"{
+        "code": "_x", "instance_id": 1, "exhausted": false,
+        "uses": {}, "accumulated_damage": 0, "accumulated_horror": 0,
+        "ability_usage": {}
+    }"#;
+    let c: CardInPlay = serde_json::from_str(json).expect("deserialize");
+    assert_eq!(c.clues, 0);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p game-core enter_play_defaults_clues_to_zero`
+Expected: FAIL — `no field 'clues' on type 'CardInPlay'`.
+
+- [ ] **Step 3: Add the field + default**
+
+In the `CardInPlay` struct, after `accumulated_horror` (before `ability_usage`):
+
+```rust
+    /// Clues sitting on this card instance (Cover Up 01007 enters the
+    /// threat area "with 3 clues on it"). Distinct from the investigator
+    /// and location clue pools; defaults to 0. Most cards never carry
+    /// clues, so absent on the wire → 0.
+    #[serde(default)]
+    pub clues: u8,
+```
+
+In `enter_play`, add `clues: 0,` to the constructed `Self { … }` (after `accumulated_horror: 0,`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p game-core -- card::tests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/game-core/src/state/card.rs
+git commit -m "engine: clue storage on CardInPlay (CardInPlay.clues)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `Event::TraumaSuffered` + `TraumaKind`
+
+**Files:**
+- Modify: `crates/game-core/src/event.rs` (enum `Event` starts ~31; add near `DamageTaken` ~91)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)]` module in `crates/game-core/src/event.rs` (or create one if absent — match the file's existing test style; if none, append):
+
+```rust
+#[test]
+fn trauma_suffered_round_trips() {
+    let e = Event::TraumaSuffered {
+        investigator: crate::state::InvestigatorId(1),
+        kind: TraumaKind::Mental,
+        amount: 1,
+    };
+    let json = serde_json::to_string(&e).expect("serialize");
+    let back: Event = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(e, back);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p game-core trauma_suffered_round_trips`
+Expected: FAIL — `no variant named TraumaSuffered` / `cannot find type TraumaKind`.
+
+- [ ] **Step 3: Add the variant + enum**
+
+In `event.rs`, add the `TraumaKind` enum just above `pub enum Event` (keep derives matching the file's other public enums):
+
+```rust
+/// Which trauma track a [`Event::TraumaSuffered`] applies to. Trauma is a
+/// cross-scenario campaign concept (Phase 9 owns persistence / sanity
+/// reduction); this event makes it observable now without modeling state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum TraumaKind {
+    /// Physical trauma (reduces max health in campaign play).
+    Physical,
+    /// Mental trauma (reduces max sanity in campaign play).
+    Mental,
+}
+```
+
+Add the `Event` variant after `DamageTaken { … }`:
+
+```rust
+    /// An investigator suffered trauma. Emitted by Cover Up 01007's
+    /// game-end Forced ability. Observable + replay-visible; persistence
+    /// (campaign log, max-stat reduction) is Phase 9 — no state mutation.
+    TraumaSuffered {
+        /// Who suffered the trauma.
+        investigator: InvestigatorId,
+        /// Physical or mental.
+        kind: TraumaKind,
+        /// How many trauma.
+        amount: u8,
+    },
+```
+
+If `TraumaKind` needs re-export, add it to the `pub use` list in `crates/game-core/src/lib.rs` alongside the other `event::` exports (grep `pub use crate::event` / `event::{` to find the line; add `TraumaKind`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p game-core trauma_suffered_round_trips`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/game-core/src/event.rs crates/game-core/src/lib.rs
+git commit -m "engine: Event::TraumaSuffered + TraumaKind
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: DSL trigger patterns `WouldDiscoverClues` + `GameEnd`
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs` (enum `EventPattern` ~190-295)
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (`trigger_matches` ~142-200)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)]` module in `crates/card-dsl/src/dsl.rs` (the module already round-trips `EventPattern` variants):
+
+```rust
+#[test]
+fn would_discover_clues_and_game_end_round_trip() {
+    for p in [EventPattern::WouldDiscoverClues, EventPattern::GameEnd] {
+        let json = serde_json::to_string(&p).expect("serialize");
+        let back: EventPattern = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(p, back);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p card-dsl would_discover_clues_and_game_end_round_trip`
+Expected: FAIL — `no variant named WouldDiscoverClues`.
+
+- [ ] **Step 3: Add the variants**
+
+In `EventPattern`, after `AfterLocationInvestigated`:
+
+```rust
+    /// An investigator is about to discover one or more clues. Matched
+    /// **only** by the clue-discovery interrupt seam in `discover_clue`
+    /// (paired with [`EventTiming::Before`]), never by the general
+    /// reaction-window pipeline — `trigger_matches` returns `false` for
+    /// it, like the forced-only patterns above. First consumer: Cover Up
+    /// 01007's "[reaction] When you would discover 1 or more clues at your
+    /// location: Discard that many clues from Cover Up instead." (C5a #236.)
+    WouldDiscoverClues,
+    /// The game ended (a scenario resolution latched). Fired forced via
+    /// `ForcedTriggerPoint::GameEnd` from `fire_scenario_resolution`,
+    /// scanning every investigator's controlled card instances; binds
+    /// controller = each instance's controller. First consumer: Cover Up
+    /// 01007's "Forced - When the game ends, if there are any clues on
+    /// Cover Up: You suffer 1 mental trauma." (C5a #236.)
+    GameEnd,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p card-dsl would_discover_clues_and_game_end_round_trip`
+Expected: PASS.
+
+- [ ] **Step 5: Exclude both from `trigger_matches`**
+
+`trigger_matches` in `reaction_windows.rs` matches `OnEvent` patterns against player reaction windows. Both new patterns are seam/forced-only and must never match a player window. Find the block that already returns `false` for the forced-only patterns (`EnteredLocation | PhaseEnded | … | EndOfTurn | AfterLocationInvestigated`) and add the two new variants to it. Run `cargo build -p game-core` first to let the non-exhaustive-match warning point you at the exact arm. The edit adds `| EventPattern::WouldDiscoverClues | EventPattern::GameEnd` to that false-returning group.
+
+- [ ] **Step 6: Add a regression test for `trigger_matches`**
+
+Add to the `reaction_windows.rs` test module a test asserting an `OnEvent { WouldDiscoverClues, Before }` ability does not match a player window (mirror the nearest existing `trigger_matches` test — grep `fn trigger_matches` in that module's tests for the shape; assert the function returns `false`).
+
+- [ ] **Step 7: Run tests**
+
+Run: `cargo test -p game-core -- reaction_windows`
+Expected: PASS. Also `cargo build -p game-core` clean (no non-exhaustive warning).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/card-dsl/src/dsl.rs crates/game-core/src/engine/dispatch/reaction_windows.rs
+git commit -m "engine: EventPattern::WouldDiscoverClues + GameEnd (seam/forced-only)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `EvalContext.clue_discovery_count`
+
+**Files:**
+- Modify: `crates/game-core/src/engine/evaluator.rs` (`EvalContext` ~75-122)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the evaluator's `#[cfg(test)]` module:
+
+```rust
+#[test]
+fn eval_context_defaults_clue_discovery_count_to_none() {
+    let ctx = EvalContext::for_controller(crate::state::InvestigatorId(1));
+    assert_eq!(ctx.clue_discovery_count, None);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p game-core eval_context_defaults_clue_discovery_count_to_none`
+Expected: FAIL — `no field clue_discovery_count`.
+
+- [ ] **Step 3: Add the field + thread through constructors**
+
+In `EvalContext`, after `failed_by`:
+
+```rust
+    /// The clue count a before-timing discovery interrupt is replacing,
+    /// set only while resolving an `EventPattern::WouldDiscoverClues`
+    /// ability's effect (so the card-local "discard that many" Native
+    /// reads it). `None` outside that window. Mirrors `failed_by`.
+    pub clue_discovery_count: Option<u8>,
+```
+
+Add `clue_discovery_count: None,` to the `Self { … }` in both `for_controller` and `for_controller_with_source`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p game-core eval_context_defaults_clue_discovery_count_to_none`
+Expected: PASS. (If other call sites construct `EvalContext` with a struct literal, the compiler will flag them; there are none outside the two constructors — verify with `cargo build -p game-core`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/game-core/src/engine/evaluator.rs
+git commit -m "engine: EvalContext.clue_discovery_count for the discovery interrupt
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `ClueInterruptPending` state
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (pending fields ~210-235; add a struct near `HandSizeDiscard`/`SpawnEngagePending` definitions)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `game_state.rs` test module:
+
+```rust
+#[test]
+fn clue_interrupt_pending_defaults_none_and_absent_field_loads() {
+    let s = GameStateBuilder::new().build();
+    assert!(s.clue_interrupt_pending.is_none());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p game-core clue_interrupt_pending_defaults_none_and_absent_field_loads`
+Expected: FAIL — `no field clue_interrupt_pending`.
+
+- [ ] **Step 3: Add the struct + field**
+
+Near the other suspension structs (e.g. just before or after `SpawnEngagePending`), add:
+
+```rust
+/// Suspended before-timing clue-discovery interrupt (C5a, #236). `Some`
+/// while `discover_clue` is paused offering the controller the choice to
+/// replace a discovery (Cover Up 01007's `[reaction]`). The resume path
+/// (`resume_clue_interrupt`) applies the choice, then re-enters
+/// `drive_skill_test` if a test is mid-flight.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClueInterruptPending {
+    /// The investigator who would discover (and controls the interrupt card).
+    pub controller: InvestigatorId,
+    /// The location the discovery is from.
+    pub location: LocationId,
+    /// How many clues the discovery would move.
+    pub count: u8,
+    /// The interrupting card instance (Cover Up) — `source` for its effect.
+    pub source: CardInstanceId,
+    /// Index of the `WouldDiscoverClues` ability on the source card, so the
+    /// resume runs the right effect on `Confirm`.
+    pub ability_index: usize,
+}
+```
+
+Add the field to `GameState`, alongside the other `pending_*` fields:
+
+```rust
+    /// Suspended clue-discovery interrupt (C5a, #236). See [`ClueInterruptPending`].
+    #[serde(default)]
+    pub clue_interrupt_pending: Option<ClueInterruptPending>,
+```
+
+Add `clue_interrupt_pending: None,` to wherever `GameState` is constructed with explicit field defaults (grep for `hand_size_discard_pending: None` to find the construction site(s) — typically the builder and/or a `Default`-like fn; mirror it). Re-export `ClueInterruptPending` from `lib.rs` if the other pending structs are re-exported (grep `SpawnEngagePending` in `lib.rs`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p game-core clue_interrupt_pending_defaults_none_and_absent_field_loads`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/game-core/src/state/game_state.rs crates/game-core/src/lib.rs
+git commit -m "engine: ClueInterruptPending suspension state
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Interrupt seam in `discover_clue`
+
+Extract the discovery mutation into a reusable helper, then add the eligibility scan + suspend ahead of it. Without an installed registry (game-core unit tests), the scan finds nothing and discovery proceeds unchanged — so existing behavior is preserved and unit-tested here; the firing path is integration-tested in Task 11.
+
+**Files:**
+- Modify: `crates/game-core/src/engine/evaluator.rs` (`discover_clue` ~466-542)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the evaluator test module:
+
+```rust
+#[test]
+fn discover_clue_without_registry_discovers_normally() {
+    // No registry installed (game-core unit context) → no interrupt scan
+    // hit → discovery proceeds exactly as before. Regression guard for the
+    // seam's "fall through when no eligible interrupt" path.
+    use crate::dsl::{discover_clue, LocationTarget};
+    // Build: investigator at a location with 1 clue. (Mirror the existing
+    // `discover_clue_moves_one_clue_from_location_to_controller` setup in
+    // this module for the exact builder calls.)
+    // ... construct `cx`, `eval_ctx`, location with 1 clue ...
+    let outcome = apply_effect(
+        &mut cx,
+        &discover_clue(LocationTarget::YourLocation, 1),
+        eval_ctx,
+    );
+    assert!(matches!(outcome, EngineOutcome::Done));
+    // location -1, investigator +1 (assert via the same accessors the
+    // sibling test uses).
+}
+```
+
+Copy the exact builder/`cx`/`eval_ctx` construction from the existing `discover_clue_moves_one_clue_from_location_to_controller` test in this module (read it first) so this compiles; the only assertion that matters is that the outcome is `Done` and the clue moved.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p game-core discover_clue_without_registry_discovers_normally`
+Expected: FAIL initially only if the helper refactor breaks compilation; otherwise it should pass once the seam is added and is a regression guard. Run it now to confirm it compiles + passes against current code (it documents current behavior). If it passes pre-change, that's expected — it guards the refactor.
+
+- [ ] **Step 3: Extract `perform_discovery`**
+
+In `discover_clue`, the mutation block (currently ~519-541: write location count, add to investigator, push `CluePlaced` + `LocationCluesChanged`, return `Done`) becomes a `pub(crate)` helper. Add:
+
+```rust
+/// Move `count` clues (capped at availability) from `location_id` to
+/// `controller`, emitting `CluePlaced` + `LocationCluesChanged`. The
+/// committed mutation half of `discover_clue`, factored out so the
+/// clue-discovery interrupt's `Skip` resume can perform the deferred
+/// discovery (C5a #236). Caller guarantees both ids exist and the
+/// location has clues.
+pub(crate) fn perform_discovery(
+    cx: &mut Cx,
+    location_id: crate::state::LocationId,
+    count: u8,
+    controller: crate::state::InvestigatorId,
+) {
+    let location = cx.state.locations.get(&location_id).expect("location exists");
+    let actually_taken = count.min(location.clues);
+    let new_location_count = location.clues - actually_taken;
+    cx.state
+        .locations
+        .get_mut(&location_id)
+        .expect("checked above")
+        .clues = new_location_count;
+    let investigator = cx
+        .state
+        .investigators
+        .get_mut(&controller)
+        .expect("checked above");
+    investigator.clues = investigator.clues.saturating_add(actually_taken);
+    cx.events.push(Event::CluePlaced {
+        investigator: controller,
+        count: actually_taken,
+    });
+    cx.events.push(Event::LocationCluesChanged {
+        location: location_id,
+        new_count: new_location_count,
+    });
+}
+```
+
+Replace the original mutation block in `discover_clue` (after its existing validations) with `perform_discovery(cx, location_id, count, eval_ctx.controller); EngineOutcome::Done`.
+
+- [ ] **Step 4: Add the interrupt scan + suspend**
+
+In `discover_clue`, **after** the existing `location.clues == 0` no-op check and the controller-exists check, **before** the `perform_discovery` call, insert the eligibility scan:
+
+```rust
+    // Before-timing clue-discovery interrupt (Cover Up 01007, C5a #236).
+    // Offer the controller a chance to replace this discovery iff they
+    // control a card with a `WouldDiscoverClues` reaction, that card holds
+    // >= 1 clue (RR p.2 — the reaction needs game-state potential), and the
+    // discovery is at the controller's own location ("at your location").
+    // No registry (unit context) or no eligible card → fall through to the
+    // normal discovery below.
+    if let Some(reg) = crate::card_registry::current() {
+        let at_your_location = cx
+            .state
+            .investigators
+            .get(&eval_ctx.controller)
+            .and_then(|i| i.current_location)
+            == Some(location_id);
+        if at_your_location {
+            if let Some(inv) = cx.state.investigators.get(&eval_ctx.controller) {
+                for card in inv.controlled_card_instances() {
+                    if card.clues == 0 {
+                        continue;
+                    }
+                    if let Some(abilities) = (reg.abilities_for)(&card.code) {
+                        if let Some(idx) = abilities.iter().position(|a| {
+                            matches!(
+                                &a.trigger,
+                                crate::dsl::Trigger::OnEvent {
+                                    pattern: crate::dsl::EventPattern::WouldDiscoverClues,
+                                    timing: crate::dsl::EventTiming::Before,
+                                }
+                            )
+                        }) {
+                            cx.state.clue_interrupt_pending =
+                                Some(crate::state::ClueInterruptPending {
+                                    controller: eval_ctx.controller,
+                                    location: location_id,
+                                    count,
+                                    source: card.instance_id,
+                                    ability_index: idx,
+                                });
+                            return EngineOutcome::AwaitingInput {
+                                request: crate::engine::outcome::InputRequest {
+                                    prompt: "You would discover clue(s). Use the interrupt to \
+                                             discard that many from the source card instead? \
+                                             Confirm = replace, Skip = discover normally."
+                                        .to_owned(),
+                                },
+                                resume_token: crate::engine::outcome::ResumeToken(0),
+                            };
+                        }
+                    }
+                }
+            }
+        }
+    }
+```
+
+(If the borrow checker objects to the nested immutable borrow of `inv` while later mutating `cx.state.clue_interrupt_pending`, collect the `(instance_id, idx)` into a local `Option` first, then set `clue_interrupt_pending` after the loop — the loop only reads.)
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p game-core -- evaluator`
+Expected: PASS (all existing `discover_clue_*` tests + the new regression test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/game-core/src/engine/evaluator.rs
+git commit -m "engine: clue-discovery interrupt seam in discover_clue
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: `resume_clue_interrupt` + routing + guard
+
+**Files:**
+- Create: `crates/game-core/src/engine/dispatch/clue_interrupt.rs`
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (module decl; `resolve_input` ~335-379; guard block ~70-160)
+
+- [ ] **Step 1: Write the new module**
+
+Create `crates/game-core/src/engine/dispatch/clue_interrupt.rs`:
+
+```rust
+//! Resume path for the before-timing clue-discovery interrupt (C5a #236).
+//!
+//! `discover_clue` suspends with `clue_interrupt_pending` set when an
+//! eligible `WouldDiscoverClues` reaction is controlled. On resume:
+//! `Confirm` runs the interrupt card's effect (the card-local Native
+//! "discard that many from self", with the replaced count threaded via
+//! `EvalContext.clue_discovery_count`) and discovers nothing; `Skip`
+//! performs the deferred discovery. Either way, if a skill test is
+//! mid-flight, re-enter `drive_skill_test` (its continuation was
+//! pre-advanced to `PostFollowUp` before the follow-up suspended).
+
+use crate::action::InputResponse;
+use crate::card_registry;
+use crate::engine::evaluator::{apply_effect, perform_discovery, EvalContext};
+use crate::engine::outcome::EngineOutcome;
+use super::Cx;
+
+pub(crate) fn resume_clue_interrupt(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
+    let pending = match cx.state.clue_interrupt_pending.take() {
+        Some(p) => p,
+        None => {
+            return EngineOutcome::Rejected {
+                reason: "resume_clue_interrupt: no clue interrupt pending".into(),
+            }
+        }
+    };
+    match response {
+        InputResponse::Confirm => {
+            // Run the WouldDiscoverClues ability's effect (Native discard
+            // from self), threading the replaced count + source instance.
+            let Some(reg) = card_registry::current() else {
+                return EngineOutcome::Rejected {
+                    reason: "resume_clue_interrupt: registry vanished".into(),
+                };
+            };
+            // Resolve the card code from the source instance.
+            let Some(inv) = cx.state.investigators.get(&pending.controller) else {
+                return EngineOutcome::Rejected {
+                    reason: "resume_clue_interrupt: controller vanished".into(),
+                };
+            };
+            let Some(card) = inv
+                .controlled_card_instances()
+                .find(|c| c.instance_id == pending.source)
+            else {
+                return EngineOutcome::Rejected {
+                    reason: "resume_clue_interrupt: source instance vanished".into(),
+                };
+            };
+            let code = card.code.clone();
+            let Some(abilities) = (reg.abilities_for)(&code) else {
+                return EngineOutcome::Rejected {
+                    reason: "resume_clue_interrupt: source has no abilities".into(),
+                };
+            };
+            let effect = abilities[pending.ability_index].effect.clone();
+            let mut ctx = EvalContext::for_controller_with_source(pending.controller, pending.source);
+            ctx.clue_discovery_count = Some(pending.count);
+            let outcome = apply_effect(cx, &effect, ctx);
+            if !matches!(outcome, EngineOutcome::Done) {
+                return outcome;
+            }
+        }
+        InputResponse::Skip => {
+            // Decline the reaction: the discovery resolves normally.
+            perform_discovery(cx, pending.location, pending.count, pending.controller);
+        }
+        other => {
+            // Restore the pending so a retry with a valid response works.
+            // (The apply loop also restores state on Rejected, but be
+            // explicit since we already `take()`-d.)
+            cx.state.clue_interrupt_pending = Some(pending);
+            return EngineOutcome::Rejected {
+                reason: format!(
+                    "resume_clue_interrupt: expected Confirm or Skip, got {other:?}"
+                )
+                .into(),
+            };
+        }
+    }
+    // If a skill test was mid-flight (the dominant path: Investigate's
+    // follow-up discovery), resume its driver. Its continuation was
+    // pre-advanced to PostFollowUp by `finish_skill_test` before the
+    // follow-up suspended, so this picks up at the right step.
+    if cx.state.in_flight_skill_test.is_some() {
+        super::skill_test::drive_skill_test(cx)
+    } else {
+        EngineOutcome::Done
+    }
+}
+```
+
+If `drive_skill_test` is `pub(super)` (it is, within the `skill_test` module), it is reachable as `super::skill_test::drive_skill_test`. If the visibility is narrower, widen it to `pub(crate)` in `skill_test.rs`.
+
+- [ ] **Step 2: Register the module + route + guard**
+
+In `crates/game-core/src/engine/dispatch/mod.rs`:
+
+1. Add the module declaration near the other `mod` lines: `mod clue_interrupt;`
+2. In `resolve_input`, add the route **before** the reaction-window / skill-test resume checks (after the `act_round_end_pending` route, before `top_reaction_window`):
+
+```rust
+    // Before-timing clue-discovery interrupt (C5a #236): arises mid-skill-
+    // test (during the Investigate follow-up), so route it before the
+    // reaction-window and skill-test resume paths.
+    if cx.state.clue_interrupt_pending.is_some() {
+        return clue_interrupt::resume_clue_interrupt(cx, response);
+    }
+```
+
+3. In the `apply_player_action` guard block, add a guard **after** the reaction-window guard and **before** the `in_flight_skill_test` guard (mirror their shape):
+
+```rust
+    // A pending clue-discovery interrupt (C5a #236) blocks every action but
+    // `ResolveInput`. It coexists with an in-flight skill test (it suspends
+    // mid-follow-up), so it must precede the skill-test guard.
+    if cx.state.clue_interrupt_pending.is_some()
+        && !matches!(action, PlayerAction::ResolveInput { .. })
+    {
+        return EngineOutcome::Rejected {
+            reason: "a clue-discovery interrupt is pending; submit a PlayerAction::ResolveInput \
+                     with InputResponse::Confirm (replace) or Skip (discover normally) before \
+                     any other action"
+                .into(),
+        };
+    }
+```
+
+Also add `clue_interrupt_pending.is_some()` to the `debug_assert!` mutual-exclusivity list at the top of `resolve_input` **only if** it is genuinely exclusive — it is NOT (it coexists with `in_flight_skill_test`), so do **not** add it there. Leave that assertion as-is.
+
+- [ ] **Step 3: Run build + tests**
+
+Run: `cargo test -p game-core -- dispatch`
+Expected: PASS (compiles; existing dispatch tests unaffected). Full firing path is covered in Task 11.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/clue_interrupt.rs crates/game-core/src/engine/dispatch/mod.rs crates/game-core/src/engine/dispatch/skill_test.rs
+git commit -m "engine: resume_clue_interrupt + routing/guard for the interrupt
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Pre-advance the skill-test continuation across the interrupt
+
+Make the Investigate follow-up's discovery suspendable: pre-advance the continuation to `PostFollowUp` before running the follow-up, and propagate `AwaitingInput` instead of asserting `Done`.
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/skill_test.rs` (`finish_skill_test` ~200-238; `apply_skill_test_follow_up` Investigate arm ~560-575)
+
+- [ ] **Step 1: Propagate `AwaitingInput` from the Investigate follow-up**
+
+`apply_skill_test_follow_up` is a free function returning `()` today; its `Investigate` arm builds `EvalContext::for_controller(investigator)` and `unreachable!`s on rejection. Change the function to return `EngineOutcome` and propagate the Investigate arm's outcome so a before-timing interrupt suspend reaches the driver. Replace the whole function so the arms are consistent:
+
+```rust
+fn apply_skill_test_follow_up(
+    cx: &mut Cx,
+    investigator: InvestigatorId,
+    follow_up: SkillTestFollowUp,
+) -> EngineOutcome {
+    match follow_up {
+        SkillTestFollowUp::None => EngineOutcome::Done,
+        SkillTestFollowUp::Investigate => {
+            let effect = discover_clue(LocationTarget::YourLocation, 1);
+            // discover_clue may suspend on a before-timing interrupt
+            // (Cover Up 01007). Propagate AwaitingInput; the Investigate
+            // follow-up has no source card, so for_controller is correct.
+            // The only rejection path ("controller between locations")
+            // can't occur post-Investigate (the action validated a
+            // location), so a Rejected here is still an invariant violation.
+            let eval_ctx = EvalContext::for_controller(investigator);
+            let outcome = apply_effect(cx, &effect, eval_ctx);
+            if let EngineOutcome::Rejected { reason } = &outcome {
+                unreachable!(
+                    "Investigate follow-up: discover_clue rejected unexpectedly after \
+                     validation: {reason}"
+                );
+            }
+            outcome
+        }
+        SkillTestFollowUp::Fight { enemy } => {
+            super::combat::damage_enemy(cx, enemy, 1, Some(investigator));
+            EngineOutcome::Done
+        }
+        SkillTestFollowUp::Evade { enemy } => {
+            let e = cx.state.enemies.get_mut(&enemy).unwrap_or_else(|| {
+                unreachable!(
+                    "Evade follow-up: enemy {enemy:?} vanished while test was in flight; \
+                     this is a state-corruption invariant violation"
+                )
+            });
+            e.engaged_with = None;
+            e.exhausted = true;
+            cx.events.push(Event::EnemyDisengaged { enemy, investigator });
+            cx.events.push(Event::EnemyExhausted { enemy });
+            EngineOutcome::Done
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Pre-advance the continuation in `finish_skill_test`**
+
+In `finish_skill_test`, the `if succeeded { apply_skill_test_follow_up(...); ... }` block runs before the continuation is set to `PostFollowUp`. Restructure so the continuation is advanced **before** the follow-up, and a suspend returns early:
+
+```rust
+    // Pre-advance the continuation BEFORE running the follow-up, so that a
+    // follow-up that suspends on a clue-discovery interrupt (Cover Up
+    // 01007) resumes at PostFollowUp rather than re-running the follow-up.
+    // on_success never co-occurs with a suspending follow-up in scope
+    // (Investigate sets on_success=None; SkillTest-effect tests set
+    // follow_up=None), so running on_success after the follow-up is safe.
+    cx.state
+        .in_flight_skill_test
+        .as_mut()
+        .expect("in_flight_skill_test was Some immediately above")
+        .continuation = FinishContinuation::PostFollowUp { succeeded };
+
+    if succeeded {
+        let outcome = apply_skill_test_follow_up(cx, investigator, follow_up);
+        if matches!(outcome, EngineOutcome::AwaitingInput { .. }) {
+            return outcome;
+        }
+        debug_assert!(
+            matches!(outcome, EngineOutcome::Done),
+            "skill-test follow-up must resolve to Done or AwaitingInput: {outcome:?}"
+        );
+        if let Some(effect) = &on_success {
+            let outcome = apply_effect(cx, effect, card_ctx(investigator));
+            debug_assert!(
+                matches!(outcome, EngineOutcome::Done),
+                "skill-test on_success must resolve to Done in scope: {outcome:?}"
+            );
+        }
+    } else if let Some(effect) = &on_fail {
+        let mut ctx = card_ctx(investigator);
+        ctx.failed_by = Some(failed_by);
+        let outcome = apply_effect(cx, effect, ctx);
+        debug_assert!(
+            matches!(outcome, EngineOutcome::Done),
+            "revelation on_fail must resolve to Done in C4b scope: {outcome:?}"
+        );
+    }
+
+    drive_skill_test(cx)
+```
+
+Remove the now-duplicate `continuation = PostFollowUp` assignment that previously sat just before `drive_skill_test(cx)` (the pre-advance above replaces it).
+
+- [ ] **Step 3: Run the skill-test tests (regression)**
+
+Run: `cargo test -p game-core -- skill_test`
+Expected: PASS — the reorder is behavior-preserving for all in-scope tests (no card has both a suspending follow-up and an `on_success`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/skill_test.rs
+git commit -m "engine: pre-advance skill-test continuation across the clue interrupt
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: `ForcedTriggerPoint::GameEnd` + fire at resolution
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/forced_triggers.rs` (enum ~26-90; `collect_forced_hits` ~144-301)
+- Modify: `crates/game-core/src/engine/mod.rs` (`fire_scenario_resolution` ~184-233)
+
+- [ ] **Step 1: Add the variant**
+
+In `ForcedTriggerPoint`, after `AfterLocationInvestigated { … }`:
+
+```rust
+    /// The game ended (a scenario resolution latched). Scans every
+    /// investigator's controlled card instances (threat area + in play)
+    /// for `EventPattern::GameEnd` forced abilities; binds controller =
+    /// each instance's controller. First consumer: Cover Up 01007's
+    /// game-end mental-trauma forced (C5a #236).
+    GameEnd,
+```
+
+- [ ] **Step 2: Add the collect arm**
+
+In `collect_forced_hits`, add a match arm for `ForcedTriggerPoint::GameEnd`:
+
+```rust
+        ForcedTriggerPoint::GameEnd => {
+            // Scan every investigator's controlled instances; bind
+            // controller = each card's controller, source = the instance.
+            for (inv_id, inv) in &state.investigators {
+                for card in inv.controlled_card_instances() {
+                    push_matching(
+                        reg,
+                        &card.code,
+                        *inv_id,
+                        Some(card.instance_id),
+                        &mut hits,
+                        |p| matches!(p, EventPattern::GameEnd),
+                    );
+                }
+            }
+        }
+```
+
+(`state.investigators` is a `BTreeMap`, so iteration order is deterministic — consistent with `fire_forced_triggers`' fixed-order contract.)
+
+- [ ] **Step 3: Fire from `fire_scenario_resolution`**
+
+In `engine/mod.rs`, `fire_scenario_resolution` runs after the resolution latches. After the victory-display scan block and **before** the `apply_resolution` module hook (so trauma is observed as part of the resolution), add:
+
+```rust
+    // Fire game-end Forced abilities (Cover Up 01007's mental trauma, C5a
+    // #236). Non-interactive in scope; a suspending GameEnd hit is #212
+    // reentrancy work. Runs even with no scenario module registered.
+    let _ = crate::engine::dispatch::forced_triggers::fire_forced_triggers(
+        cx,
+        &crate::engine::dispatch::forced_triggers::ForcedTriggerPoint::GameEnd,
+    );
+```
+
+Confirm the path to `fire_forced_triggers` / `ForcedTriggerPoint` is reachable from `mod.rs` (both are `pub(crate)` in the `forced_triggers` module). Adjust the `use`/path to match how `mod.rs` already references `dispatch` items.
+
+- [ ] **Step 4: Write a game-core unit test (no registry → no-op; with a hand-rolled registry → fires)**
+
+The cleanest no-registry assertion: `GameEnd` firing is a no-op when nothing matches. Add to the `engine/mod.rs` test module a test that latches a resolution with no controlled cards and asserts no `TraumaSuffered` event and that the existing `ScenarioResolved` still fires (regression that the new call doesn't break the resolution path). The firing-with-trauma path is integration-tested in Task 11.
+
+```rust
+#[test]
+fn game_end_forced_point_is_noop_without_matching_cards() {
+    // Latch a resolution (mirror an existing resolution test in this
+    // module for the setup), apply the triggering action, and assert
+    // ScenarioResolved fires and no TraumaSuffered is emitted.
+    // ... setup per the nearest existing resolution test ...
+    assert!(events.iter().any(|e| matches!(e, Event::ScenarioResolved { .. })));
+    assert!(!events.iter().any(|e| matches!(e, Event::TraumaSuffered { .. })));
+}
+```
+
+Read the nearest existing resolution test in `engine/mod.rs` (grep `ScenarioResolved`) and copy its setup.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p game-core -- forced_triggers` and `cargo test -p game-core game_end_forced_point_is_noop_without_matching_cards`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/forced_triggers.rs crates/game-core/src/engine/mod.rs
+git commit -m "engine: ForcedTriggerPoint::GameEnd fired at scenario resolution
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Cover-Up-shaped synthetic fixture + Native effects
+
+**Files:**
+- Modify: `crates/scenarios/src/test_fixtures/synth_cards.rs` (codes, metadata, `abilities_for`, `TEST_REGISTRY`, tests)
+
+- [ ] **Step 1: Add the fixture code + metadata**
+
+After the existing `pub const SYNTH_*_CODE` lines, add:
+
+```rust
+/// Code for the synthetic Cover-Up-shaped treachery (C5a #236). Carries a
+/// `WouldDiscoverClues` before-timing interrupt + a `GameEnd` forced
+/// trauma, both backed by Native effects on [`TEST_REGISTRY`]. Underscore
+/// prefix guarantees no collision with real ArkhamDB codes.
+pub const SYNTH_COVER_UP_CODE: &str = "_synth_cover_up";
+
+/// Native-effect tags for the synthetic Cover Up (C5a #236).
+pub const SYNTH_COVER_UP_DISCARD_TAG: &str = "_synth_cover_up:discard_clues";
+pub const SYNTH_COVER_UP_TRAUMA_TAG: &str = "_synth_cover_up:trauma";
+```
+
+Add a metadata fn (mirror `synth_surge_treachery_metadata`):
+
+```rust
+fn synth_cover_up_metadata() -> CardMetadata {
+    CardMetadata {
+        code: SYNTH_COVER_UP_CODE.to_owned(),
+        name: "Synthetic Cover Up".to_owned(),
+        text: Some(
+            "Reaction: when you would discover clues at your location, \
+             discard that many from this card instead. Forced: at game end, \
+             if any clues remain, suffer 1 mental trauma. (Synthetic.)"
+                .to_owned(),
+        ),
+        traits: Vec::new(),
+        pack_code: "_synth".to_owned(),
+        kind: CardKind::Treachery {
+            surge: false,
+            peril: false,
+            quantity: 1,
+        },
+    }
+}
+
+fn synth_cover_up_metadata_static() -> &'static CardMetadata {
+    static M: OnceLock<CardMetadata> = OnceLock::new();
+    M.get_or_init(synth_cover_up_metadata)
+}
+```
+
+Add `SYNTH_COVER_UP_CODE => Some(synth_cover_up_metadata_static()),` to `metadata_for`.
+
+- [ ] **Step 2: Add the abilities**
+
+Extend the imports at the top of the file:
+
+```rust
+use game_core::dsl::{
+    native, on_event, EventPattern, EventTiming, // add these
+    gain_resources, on_play, revelation, Ability, InvestigatorTarget,
+};
+```
+
+(`native(tag)` builds `Effect::Native { tag }` — see `card_dsl::dsl::native`. `on_event(pattern, timing, effect)` builds an `OnEvent` ability — see `dsl.rs:828`.)
+
+Add to `abilities_for`:
+
+```rust
+        SYNTH_COVER_UP_CODE => Some(vec![
+            on_event(
+                EventPattern::WouldDiscoverClues,
+                EventTiming::Before,
+                native(SYNTH_COVER_UP_DISCARD_TAG),
+            ),
+            on_event(
+                EventPattern::GameEnd,
+                EventTiming::After,
+                native(SYNTH_COVER_UP_TRAUMA_TAG),
+            ),
+        ]),
+```
+
+- [ ] **Step 3: Add the Native effects + wire `native_effect_for`**
+
+Add two native functions (signature `fn(&mut Cx, &EvalContext) -> EngineOutcome`). Add imports: `use game_core::card_registry::NativeEffectFn; use game_core::engine::{Cx, EngineOutcome, EvalContext}; use game_core::event::{Event, TraumaKind};`.
+
+```rust
+/// Native: discard the replaced clue count from the interrupting card
+/// instance (Cover Up 01007's "discard that many from Cover Up instead").
+fn synth_cover_up_discard(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
+    let count = ctx.clue_discovery_count.unwrap_or(0);
+    let Some(source) = ctx.source else {
+        return EngineOutcome::Rejected {
+            reason: "synth_cover_up_discard: no source instance".into(),
+        };
+    };
+    if let Some(inv) = cx.state.investigators.get_mut(&ctx.controller) {
+        for card in inv.threat_area.iter_mut().chain(inv.cards_in_play.iter_mut()) {
+            if card.instance_id == source {
+                let take = count.min(card.clues);
+                card.clues -= take;
+                break;
+            }
+        }
+    }
+    EngineOutcome::Done
+}
+
+/// Native: at game end, if the source card holds any clues, suffer 1
+/// mental trauma (Cover Up 01007's Forced).
+fn synth_cover_up_trauma(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
+    let Some(source) = ctx.source else {
+        return EngineOutcome::Rejected {
+            reason: "synth_cover_up_trauma: no source instance".into(),
+        };
+    };
+    let has_clues = cx
+        .state
+        .investigators
+        .get(&ctx.controller)
+        .map(|inv| {
+            inv.controlled_card_instances()
+                .any(|c| c.instance_id == source && c.clues > 0)
+        })
+        .unwrap_or(false);
+    if has_clues {
+        cx.events.push(Event::TraumaSuffered {
+            investigator: ctx.controller,
+            kind: TraumaKind::Mental,
+            amount: 1,
+        });
+    }
+    EngineOutcome::Done
+}
+
+/// `native_effect_for` function pointer used by [`TEST_REGISTRY`].
+fn native_effect_for(tag: &str) -> Option<NativeEffectFn> {
+    match tag {
+        SYNTH_COVER_UP_DISCARD_TAG => Some(synth_cover_up_discard),
+        SYNTH_COVER_UP_TRAUMA_TAG => Some(synth_cover_up_trauma),
+        _ => None,
+    }
+}
+```
+
+Change `TEST_REGISTRY` to use it:
+
+```rust
+pub const TEST_REGISTRY: CardRegistry = CardRegistry {
+    metadata_for,
+    abilities_for,
+    native_effect_for,
+};
+```
+
+- [ ] **Step 4: Add fixture unit tests**
+
+```rust
+#[test]
+fn cover_up_fixture_has_interrupt_and_gameend_abilities() {
+    let code = CardCode(SYNTH_COVER_UP_CODE.into());
+    let abilities = abilities_for(&code).expect("cover up abilities");
+    assert_eq!(abilities.len(), 2);
+    assert!(matches!(
+        abilities[0].trigger,
+        game_core::dsl::Trigger::OnEvent {
+            pattern: game_core::dsl::EventPattern::WouldDiscoverClues,
+            timing: game_core::dsl::EventTiming::Before,
+        }
+    ));
+}
+
+#[test]
+fn native_effect_for_resolves_cover_up_tags() {
+    assert!(native_effect_for(SYNTH_COVER_UP_DISCARD_TAG).is_some());
+    assert!(native_effect_for(SYNTH_COVER_UP_TRAUMA_TAG).is_some());
+    assert!(native_effect_for("nope").is_none());
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p scenarios -- synth_cards`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/scenarios/src/test_fixtures/synth_cards.rs
+git commit -m "test: synthetic Cover-Up fixture + Native effects on TEST_REGISTRY
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Integration tests — the firing paths
+
+**Files:**
+- Create: `crates/scenarios/tests/cover_up_interrupt.rs`
+
+Drive a real successful Investigate with the fixture in the investigator's threat area, exercising both `Confirm` and `Skip`, plus the `GameEnd` trauma. Use a deterministic chaos bag (`ChaosToken::Numeric(0)`) and Intellect ≥ shroud so the test always succeeds.
+
+- [ ] **Step 1: Write the test scaffold + helpers**
+
+Create `crates/scenarios/tests/cover_up_interrupt.rs`:
+
+```rust
+//! C5a (#236) integration: Cover Up's before-timing clue-discovery
+//! interrupt and its game-end mental-trauma forced point, against the
+//! synthetic Cover-Up fixture. Own process → installs TEST_REGISTRY.
+
+use std::sync::Once;
+
+use game_core::engine::{apply, EngineOutcome};
+use game_core::event::{Event, TraumaKind};
+use game_core::state::{
+    CardInPlay, CardInstanceId, ChaosBag, ChaosToken, GameState, InvestigatorId, LocationId,
+    Phase,
+};
+use game_core::test_support::{test_investigator, test_location, GameStateBuilder};
+use game_core::{Action, InputResponse, PlayerAction};
+use scenarios::test_fixtures::synth_cards::{SYNTH_COVER_UP_CODE, TEST_REGISTRY};
+
+static INSTALL: Once = Once::new();
+fn install() {
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(TEST_REGISTRY);
+    });
+}
+```
+
+Read `crates/game-core/src/test_support/builder.rs` and an existing engine investigate test to confirm the exact builder API (`with_investigator`, `with_active_investigator`, `with_phase`, `test_location`, chaos-bag setter). Adjust the imports/calls below to match. The state to build for the interrupt tests:
+- Investigation phase, one active investigator at a location.
+- The location has ≥1 clue and a shroud the investigator's Intellect beats.
+- `chaos_bag = ChaosBag::new([ChaosToken::Numeric(0)])`.
+- A `CardInPlay` for `SYNTH_COVER_UP_CODE` in the investigator's `threat_area` with `clues = 3`.
+
+- [ ] **Step 2: Test — `Confirm` replaces the discovery**
+
+```rust
+#[test]
+fn confirm_replaces_discovery_with_discard_from_cover_up() {
+    install();
+    let mut state = /* build per Step 1: loc with 2 clues, cover up with 3 clues in threat area */;
+    let inv = /* the active investigator id */;
+    let loc = /* the location id */;
+
+    // Investigate → commit nothing → reach the interrupt AwaitingInput.
+    let r = apply(state, Action::Player(PlayerAction::Investigate { investigator: inv }));
+    state = r.state;
+    let r = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput { response: InputResponse::CommitCards { indices: vec![] } }),
+    );
+    assert!(
+        matches!(r.outcome, EngineOutcome::AwaitingInput { .. }),
+        "expected interrupt prompt, got {:?}", r.outcome
+    );
+    state = r.state;
+
+    // Confirm: discover nothing; discard 1 from Cover Up (the base
+    // Investigate discovers 1).
+    let r = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput { response: InputResponse::Confirm }),
+    );
+    assert!(matches!(r.outcome, EngineOutcome::Done), "got {:?}", r.outcome);
+    state = r.state;
+
+    assert_eq!(state.locations[&loc].clues, 2, "location clues unchanged");
+    assert_eq!(state.investigators[&inv].clues, 0, "investigator discovered nothing");
+    let cover_up = state.investigators[&inv].threat_area.iter()
+        .find(|c| c.code.as_str() == SYNTH_COVER_UP_CODE).expect("cover up present");
+    assert_eq!(cover_up.clues, 2, "1 clue discarded from Cover Up");
+}
+```
+
+- [ ] **Step 3: Test — `Skip` discovers normally**
+
+```rust
+#[test]
+fn skip_discovers_normally() {
+    install();
+    let mut state = /* same build: loc 2 clues, cover up 3 clues */;
+    let inv = /* id */; let loc = /* id */;
+    let r = apply(state, Action::Player(PlayerAction::Investigate { investigator: inv }));
+    state = r.state;
+    let r = apply(state, Action::Player(PlayerAction::ResolveInput {
+        response: InputResponse::CommitCards { indices: vec![] } }));
+    state = r.state;
+    let r = apply(state, Action::Player(PlayerAction::ResolveInput { response: InputResponse::Skip }));
+    assert!(matches!(r.outcome, EngineOutcome::Done));
+    state = r.state;
+    assert_eq!(state.locations[&loc].clues, 1, "location -1");
+    assert_eq!(state.investigators[&inv].clues, 1, "investigator +1");
+    let cover_up = state.investigators[&inv].threat_area.iter()
+        .find(|c| c.code.as_str() == SYNTH_COVER_UP_CODE).unwrap();
+    assert_eq!(cover_up.clues, 3, "Cover Up untouched on Skip");
+}
+```
+
+- [ ] **Step 4: Test — ineligible when Cover Up has 0 clues**
+
+```rust
+#[test]
+fn no_interrupt_when_cover_up_has_no_clues() {
+    install();
+    let mut state = /* build: cover up with clues = 0 */;
+    let inv = /* id */;
+    let r = apply(state, Action::Player(PlayerAction::Investigate { investigator: inv }));
+    state = r.state;
+    // commit window resolves straight to Done — no interrupt offered.
+    let r = apply(state, Action::Player(PlayerAction::ResolveInput {
+        response: InputResponse::CommitCards { indices: vec![] } }));
+    assert!(matches!(r.outcome, EngineOutcome::Done), "no interrupt; got {:?}", r.outcome);
+}
+```
+
+- [ ] **Step 5: Test — GameEnd trauma fires iff clues remain**
+
+Drive (or hand-latch) a resolution. The simplest deterministic latch: build a state whose act deck advances to a Won resolution, or directly construct a one-act board and `AdvanceAct` to terminal. Read `crates/scenarios/tests/closing_demo.rs` for the act-advance-to-Won pattern. Then:
+
+```rust
+#[test]
+fn game_end_emits_trauma_when_cover_up_has_clues() {
+    install();
+    let mut state = /* build a board that resolves on the next action, cover up clues = 3 */;
+    // ... apply the resolution-latching action ...
+    let r = apply(state, /* resolution-latching action */);
+    assert!(r.events.iter().any(|e| matches!(
+        e, Event::TraumaSuffered { kind: TraumaKind::Mental, amount: 1, .. }
+    )), "expected mental trauma at game end; events = {:?}", r.events);
+}
+
+#[test]
+fn game_end_emits_no_trauma_when_cover_up_empty() {
+    install();
+    let mut state = /* same, but cover up clues = 0 */;
+    let r = apply(state, /* resolution-latching action */);
+    assert!(!r.events.iter().any(|e| matches!(e, Event::TraumaSuffered { .. })));
+}
+```
+
+If building a resolving board is heavy, an acceptable alternative for the trauma half is a focused game-core integration test that calls the resolution path via the lowest-friction latch available (e.g. last-investigator-defeated `Lost`, per `elimination.rs`'s `last_investigator_defeated_latches_lost_resolution`). Prefer the act-advance Won path if the builder makes it easy.
+
+- [ ] **Step 6: Run the integration tests**
+
+Run: `cargo test -p scenarios --test cover_up_interrupt`
+Expected: all PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/scenarios/tests/cover_up_interrupt.rs
+git commit -m "test: integration coverage for Cover Up interrupt + GameEnd trauma
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Full gauntlet + push + PR
+
+- [ ] **Step 1: Run the full strict gauntlet**
+
+```sh
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+
+Expected: all green. Fix any clippy/doc issues (e.g. intra-doc links for the new types) inline.
+
+- [ ] **Step 2: Push + open PR**
+
+```bash
+git push -u origin engine/cover-up-interrupt
+gh pr create --fill --base main
+```
+
+PR body: one-paragraph design summary (the seam at `discover_clue`, pre-advance reentrancy, GameEnd at `fire_scenario_resolution`, Native effects + integration test), the verified Cover Up card text, the RR p.2 optional-reaction citation, and `Closes #236.` Link the spec.
+
+- [ ] **Step 3: Watch CI**
+
+Run: `gh pr checks <PR#> --watch` (background). Fix failures with follow-up commits to the same branch.
+
+- [ ] **Step 4: Phase-doc update (final commit, only once CI is green)**
+
+Per `docs/phases/README.md`: in `docs/phases/phase-7-the-gathering.md`, flip the C5a row in the Group-C-breakdown table to `✅ PR #<N>`, update the Status paragraph's "Shipped:" list + "Next:" marker (C5a done → next C5b/C5c per the within-C5 ordering `{C5a,C5b}→{C5c,C5d}→C5e`), and add a **Decisions made** entry only if load-bearing for a future PR — candidate: "before-timing clue-discovery interrupt is a card-local seam at `discover_clue` with a `clue_interrupt_pending` suspension mode + pre-advanced skill-test continuation; bespoke effects stay `Effect::Native` integration-tested via `synth_cards::TEST_REGISTRY`; game-end trauma emits `Event::TraumaSuffered` only (persistence Phase 9)." Apply the "would a future PR-author choose differently without this entry?" test; keep it to one tight entry.
+
+- [ ] **Step 5: Merge after explicit user approval**
+
+```bash
+gh pr merge <PR#> --squash --delete-branch
+```
+
+Confirm #236 auto-closed and `git pull` on `main`.
+
+---
+
+## Self-review notes (for the executor)
+
+- **Borrow-checker hotspots:** the interrupt scan in Task 6 reads `inv.controlled_card_instances()` then writes `cx.state.clue_interrupt_pending` — collect `(instance_id, ability_index)` into a local before the write if needed. The Native discard in Task 10 iterates `threat_area`/`cards_in_play` mutably — use `iter_mut().chain(...)`.
+- **`apply_skill_test_follow_up` return type:** Task 8 may require changing it from `()` to `EngineOutcome`; update the `Fight`/`Evade`/`None` arms and the call site together (compiler-guided).
+- **Reentrancy bound (documented, in scope):** the interrupt may suspend only where `discover_clue` is the terminal effect of its eval context — true for the base Investigate follow-up, the sole clue-discovery source in Roland's Slice-1 deck (Deduction 01039 is not in it). Nested-in-`Seq` discovery suspension is #212.
+- **`GameEnd` non-suspension:** the trauma Native returns `Done`; `fire_forced_triggers`' abandon-later-hits-on-suspend caveat is not exercised. Consistent with the C4c deterministic-order stand-in.

--- a/docs/superpowers/specs/2026-06-15-phase-7-c5a-cover-up-interrupt-gameend-design.md
+++ b/docs/superpowers/specs/2026-06-15-phase-7-c5a-cover-up-interrupt-gameend-design.md
@@ -1,0 +1,198 @@
+# C5a — Cover Up before-timing interrupt window + GameEnd forced point
+
+Phase 7, Slice 1, Group C, sub-slice **C5a** ([#236](https://github.com/talelburg/eldritch/issues/236)).
+Engine machinery only; the Cover Up card content lands in C5c ([#238](https://github.com/talelburg/eldritch/issues/238)).
+
+## Goal
+
+Build the two engine mechanisms Cover Up 01007 is the first (and, in Slice 1,
+only) card to need, **without** referencing card code `01007` anywhere in the
+engine — the machinery is data-driven so the real card (C5c) plugs in via the
+registry. C5a is verified against a synthetic Cover-Up-shaped fixture.
+
+## Card text (verified against `data/arkhamdb-snapshot/pack/core/core.json:212`)
+
+> **Revelation** - Put Cover Up into play in your threat area, with 3 clues on it.
+> [reaction] When you would discover 1 or more clues at your location: Discard that many clues from Cover Up instead.
+> **Forced** - When the game ends, if there are any clues on Cover Up: You suffer 1 mental trauma.
+
+Split across the slice:
+- The **Revelation** (threat-area placement + 3 clues) is card content → **C5c**.
+- The **[reaction]** before-timing replacement interrupt → **C5a** (machinery) + C5c (the ability wiring).
+- The **Forced** game-end trauma → **C5a** (the `GameEnd` point) + C5c (the ability wiring).
+
+## Rules grounding (RR, verified)
+
+- **The reaction is optional.** "Triggered abilities on a card a player controls
+  are optionally triggered (or not) by that player at the appropriate timing
+  moment" (RR p.2). Only a bold "Forced –" command is mandatory. So the engine
+  must *offer a choice*, never auto-apply the replacement.
+- **"When … would" is a before-timing replacement.** "A reaction ability with a
+  triggering condition beginning with the word 'when…' may be used after the
+  specified triggering condition initiates, but before its impact upon the game
+  state resolves" (RR p.2). Combined with "would discover" + "instead", the
+  reaction pre-empts the discovery — it does NOT fit the forced-point dispatcher
+  or the existing After-timing reaction window.
+- **Eligibility needs game-state potential.** "A triggered ability can only be
+  initiated if its effect has the potential to change the game state" (RR p.2):
+  with 0 clues on the source card, "discard that many clues from Cover Up" does
+  nothing, so the interrupt is not offered.
+
+## Approach (decided)
+
+**Fork 1 — interrupt mechanism: minimal card-local seam, not a general
+before-timing reaction-window subsystem.** Cover Up is the only before-timing
+replacement interrupt in all of Slice 1, and general trigger-dispatch
+unification is explicitly parked in #212 (after Group C). A targeted seam at the
+`discover_clue` chokepoint is forward-compatible with #212 and matches the
+"don't generalize until 2+ consumers" convention.
+
+**Fork 2 — game-end trauma: emit a trauma event only.** Trauma is a
+cross-scenario campaign concept owned by Phase 9 (`state/investigator.rs:16`,
+`state/game_state.rs:27` both flag it as not-yet-modeled). In a single Slice-1
+scenario it has no persistent home, so C5a emits an observable
+`Event::TraumaSuffered` and leaves persistence to Phase 9. No speculative state
+field.
+
+**Bespoke effects stay `Effect::Native` (card-local), integration-tested.** The
+replacement ("discard that many from self") and the trauma ("suffer 1 mental
+trauma, if any clues") are single-consumer card logic, so they live as
+`Effect::Native` dispatched by tag — not new typed `Effect`/`Condition`
+variants. C5a is verified through an integration test that installs a registry
+exposing those natives (the existing `synth_cards::TEST_REGISTRY`,
+extended), rather than game-core unit tests (which can't install a registry).
+This keeps the DSL surface to trigger *taxonomy* only; no bespoke effect
+primitives for one-offs.
+
+## Engine machinery (what C5a builds)
+
+### 1. Clue storage on a card instance
+`CardInPlay` (`crates/game-core/src/state/card.rs`) gains `clues: u8`
+(`#[serde(default)]`) plus a small accessor. This is the substrate the interrupt
+discards from and the forced ability inspects. Distinct from `uses`
+(charges/ammo) and from the investigator/location clue pools. C5a only adds the
+field + accessor; *placing* 3 clues on entry is Cover Up's Revelation (C5c) /
+the fixture.
+
+### 2. Trigger taxonomy (data-driven matching)
+Two new `EventPattern` variants in `crates/card-dsl/src/dsl.rs`, each matched
+**only** by its dedicated dispatch site (never the general reaction-window
+pipeline — `trigger_matches` returns `false` for them, mirroring how
+`EndOfTurn`/`AfterLocationInvestigated` are forced-only):
+- `WouldDiscoverClues` — paired with `EventTiming::Before`. Cover Up's reaction
+  compiles to `OnEvent { pattern: WouldDiscoverClues, timing: Before }`.
+- `GameEnd` — Cover Up's forced compiles to `OnEvent { pattern: GameEnd, … }`
+  (timing carried for symmetry; the forced point fires it directly).
+
+### 3. The interrupt seam — `discover_clue` (`engine/evaluator.rs:466`)
+`discover_clue` is the single chokepoint every discovery routes through (base
+Investigate follow-up *and* Deduction's `OnSkillTestResolution` extra clue). The
+seam runs **before** the existing mutate step:
+1. Scan the discovering investigator's `controlled_card_instances()` (threat
+   area + in play) for an `OnEvent { WouldDiscoverClues, Before }` ability whose
+   source instance has `clues >= 1` and whose discovery location is the
+   controller's location.
+2. If eligible: latch `clue_interrupt_pending { location, count, controller,
+   source_instance }` on `GameState` and return `EngineOutcome::AwaitingInput`
+   with a yes/no prompt (`InputResponse::Confirm` = use the replacement,
+   `InputResponse::Skip` = discover normally).
+3. If not eligible: fall through to the normal discovery unchanged.
+
+`resolve_input` (`engine/dispatch/mod.rs:335`) routes `clue_interrupt_pending`
+as a new mutually-exclusive suspension mode, **before** the skill-test path
+(mirroring `pending_end_turn` / `spawn_engage_pending` / `act_round_end_pending`
+and their `dispatch/mod.rs` blocking guards):
+- `Confirm`: evaluate the interrupt ability's effect (the card-local Native
+  "discard that many from self", reading the replaced count from
+  `EvalContext.clue_discovery_count`), discovering nothing. Discard is capped at
+  `min(count, clues_on_source)`.
+- `Skip`: perform the original discovery (the deferred `discover_clue` body).
+- Then re-enter `drive_skill_test` to finish the stranded skill-test teardown.
+
+**Reentrancy.** The base-Investigate discovery moves into a resumable
+`FinishContinuation` driver step (`engine/dispatch/skill_test.rs`) so the
+suspend/resume threads through the existing `in_flight_skill_test.continuation`
+state machine rather than stranding mid-`finish_skill_test`.
+
+**Bounded caveat (documented in code).** The interrupt may suspend only where
+`discover_clue` is the *terminal* effect of its evaluation context — true for
+every Slice-1 discovery source (base Investigate + Deduction's lone extra
+clue). A `discover_clue` nested mid-`Seq`/`ForEach` that suspends would strand
+the rest of the tree; no such card exists in scope, and full resumable-evaluator
+reentrancy is #212.
+
+### 4. `EvalContext.clue_discovery_count`
+New field carrying "the count being replaced" so the Native replacement effect
+discards "that many." Set by the seam before evaluating the interrupt ability;
+mirrors how `EvalContext.failed_by` carries the skill-test margin (C4b).
+
+### 5. `ForcedTriggerPoint::GameEnd`
+Fired once from `fire_scenario_resolution` (`engine/mod.rs:184`) on the
+`None→Some` resolution latch, after the existing victory-display scan. It scans
+**all** investigators' `controlled_card_instances()` for `OnEvent { GameEnd }`
+forced abilities. Cover Up's fires the card-local Native "if any clues on self,
+emit `Event::TraumaSuffered { investigator, kind: Mental, amount: 1 }`" (the
+"if any clues" gate lives inside the Native effect — no `Condition` variant
+needed). Non-interactive (no suspension), consistent with the bounded model and
+with the existing deterministic simultaneous-forced ordering (C4c).
+
+### 6. `Event::TraumaSuffered`
+New event `{ investigator, kind: TraumaKind, amount: u8 }` with
+`TraumaKind { Physical, Mental }`. Observable + replay-visible now; persistence
+(campaign log, sanity reduction) is Phase 9. No mutation of investigator state.
+
+## Test plan (integration, `crates/scenarios/tests/`)
+
+Extend `synth_cards` with a Cover-Up-shaped fixture card declaring both
+abilities, and register its Native effects on `TEST_REGISTRY.native_effect_for`.
+Drive through `apply` with the registry installed:
+
+- **Interrupt — Confirm**: investigator with the fixture (N clues on it) at a
+  location with clues; investigate succeeds → `AwaitingInput`; `Confirm` →
+  location clue count unchanged, investigator gains 0, fixture clues drop by the
+  discovered count.
+- **Interrupt — Skip**: same setup; `Skip` → normal discovery (location −1,
+  investigator +1, fixture clues unchanged).
+- **Eligibility**: fixture with 0 clues → no `AwaitingInput`; discovery resolves
+  normally.
+- **Count coupling**: a 2-clue discovery (base + Deduction-style extra, or a
+  2-count discover) → `Confirm` discards 2 from the fixture; cap honored when
+  fixture holds fewer.
+- **GameEnd — with clues**: latch a resolution with fixture clues remaining →
+  `Event::TraumaSuffered { kind: Mental, amount: 1 }` emitted once.
+- **GameEnd — no clues**: fixture with 0 clues → no `TraumaSuffered`.
+- **Game-core unit tests** for the structural pieces that don't need the
+  registry: `CardInPlay.clues` (de)serialization default; the seam's eligibility
+  predicate and `Skip`-path fall-through; the new `FinishContinuation` step's
+  resume; `GameEnd` firing exactly once on the resolution latch.
+
+Full strict gauntlet (`fmt`, `clippy --all-targets --all-features -D warnings`,
+`RUSTFLAGS=-D warnings test`, `doc`, wasm build/clippy) green before push.
+
+## Out of scope (deferred)
+
+- Cover Up's Revelation placement + 3-clue stamping, the real `01007` impl, and
+  deck integration — **C5c** (#238).
+- Trauma persistence / campaign-log recording — **Phase 9**.
+- General before-timing reaction windows, resumable-evaluator reentrancy for
+  nested discovery, and player-chosen simultaneous-trigger ordering — **#212 /
+  #213**.
+
+## Dependencies
+
+- **C4a** (#233) — threat-area zone + `controlled_card_instances()`: Cover Up's
+  home and the scan source the seam and the `GameEnd` point both reuse.
+- Slice-1 engine spine (A1/A2): forced-trigger dispatch, `fire_forced_triggers`.
+
+## Decisions made (for the phase doc when the PR lands)
+
+- Before-timing clue-discovery interrupt is a **card-local seam at the
+  `discover_clue` chokepoint** with a `clue_interrupt_pending` suspension mode +
+  yes/no `AwaitingInput`, not a general before-timing reaction-window subsystem
+  (that's #212). Bounded to terminal-position discovery; resume re-enters
+  `drive_skill_test`.
+- **Bespoke card effects stay `Effect::Native`, integration-tested via
+  `synth_cards::TEST_REGISTRY`** rather than promoted to typed `Effect` /
+  `Condition` variants — single-consumer one-offs don't earn DSL surface; the
+  engine adds only trigger *taxonomy* (`WouldDiscoverClues`, `GameEnd`).
+- **Game-end trauma emits `Event::TraumaSuffered` only**; persistence is Phase 9.

--- a/docs/superpowers/specs/2026-06-15-phase-7-c5a-cover-up-interrupt-gameend-design.md
+++ b/docs/superpowers/specs/2026-06-15-phase-7-c5a-cover-up-interrupt-gameend-design.md
@@ -177,6 +177,12 @@ Full strict gauntlet (`fmt`, `clippy --all-targets --all-features -D warnings`,
 - General before-timing reaction windows, resumable-evaluator reentrancy for
   nested discovery, and player-chosen simultaneous-trigger ordering — **#212 /
   #213**.
+- **Generic ability eligibility (RR p.2 "potential to change the game state").**
+  The engine doesn't model this anywhere. The seam's `card.clues > 0` gate is a
+  single-consumer stand-in for it (without it, an emptied Cover Up — which stays
+  in the threat area until game end — would prompt a never-useful interrupt on
+  every discovery). When a second `WouldDiscoverClues` card lands, lift it into a
+  card-provided per-ability "has potential" predicate — **#212**.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

Slice-1 sub-slice **C5a** ([#236](https://github.com/talelburg/eldritch/issues/236)): the engine machinery for Cover Up `01007`'s two abilities — an **optional before-timing clue-discovery replacement interrupt** and a **mandatory game-end mental-trauma forced point**. Data-driven (no `01007` literal in the engine); verified against a synthetic Cover-Up fixture. The real card lands in C5c.

Card text (verified against `data/arkhamdb-snapshot/pack/core/core.json`):
> **Revelation** - Put Cover Up into play in your threat area, with 3 clues on it.
> [reaction] When you would discover 1 or more clues at your location: Discard that many clues from Cover Up instead.
> **Forced** - When the game ends, if there are any clues on Cover Up: You suffer 1 mental trauma.

The `[reaction]` is **optional** — RR p.2: *"Triggered abilities on a card a player controls are optionally triggered (or not) by that player."* Only the bold **Forced** is mandatory. The *"when … would"* wording makes it a before-timing **replacement** interrupt (RR p.2: a `when…` reaction "may be used after the specified triggering condition initiates, but before its impact upon the game state resolves").

## What changed

- **Clue-on-card storage** — `CardInPlay.clues` (substrate for "3 clues on it").
- **Trigger taxonomy** — `EventPattern::{WouldDiscoverClues, GameEnd}`, both seam/forced-only (excluded from the player reaction-window pipeline like the other forced-only patterns).
- **The interrupt seam** — at the single `discover_clue` chokepoint: when the controller holds an eligible `WouldDiscoverClues` reaction at their location, suspend with a yes/no `AwaitingInput` (`clue_interrupt_pending`). `Confirm` runs the card-local `Effect::Native` discard (count threaded via `EvalContext.clue_discovery_count`) and discovers nothing; `Skip` performs the deferred discovery.
- **Reentrancy** — `finish_skill_test` pre-advances its continuation to `PostFollowUp` *before* the Investigate follow-up, so a suspending discovery resumes cleanly through the existing `in_flight_skill_test` state machine. Bounded to terminal-position discovery (the base Investigate follow-up — the only clue source in Roland's Slice-1 deck); nested-in-`Seq` suspension is #212.
- **`ForcedTriggerPoint::GameEnd`** — fired once from `fire_scenario_resolution` on the resolution latch, scanning all controlled instances; Cover Up's Native emits `Event::TraumaSuffered` (persistence deferred to Phase 9).
- **Fixture + tests** — synthetic Cover-Up card + Native effects on `synth_cards::TEST_REGISTRY`; integration tests in `crates/scenarios/tests/cover_up_interrupt.rs`.

## Design notes

- **Card-local seam, not a general before-timing reaction-window subsystem** — that's #212. Forward-compatible subset.
- **Bespoke effects stay `Effect::Native`** (discard-from-self, suffer-trauma), integration-tested via the fixture registry, rather than new typed `Effect`/`Condition` variants — single-consumer one-offs don't earn DSL surface. The engine adds only trigger *taxonomy*.
- **The seam's `card.clues > 0` gate is a single-consumer stand-in** for RR p.2's "ability must have potential to change the game state" eligibility rule, which the engine doesn't model generically. Without it, an emptied Cover Up (which stays in the threat area until game end) would prompt a never-useful interrupt on every discovery. Documented with a `TODO(#212)` to lift into a card-provided per-ability predicate when a second `WouldDiscoverClues` card lands.

## Test notes

Full strict gauntlet green locally (fmt, host clippy, `RUSTFLAGS=-D warnings test --all`, doc, wasm build, wasm clippy). New integration coverage: `Confirm` replaces / `Skip` discovers / ineligible-when-empty / count-coupling (full discard + `min(count,clues)` cap) / GameEnd trauma with-and-without clues. Pre-push review passed (APPROVE); Medium/Low/Nit findings addressed, two left as documented #212 scope.

## Linked issues

Closes #236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)