### PR TITLE
engine: weapon support — ammo/uses + inspectable Effect::Fight (C5c prereq)

### DIFF
--- a/crates/card-data-pipeline/src/main.rs
+++ b/crates/card-data-pipeline/src/main.rs
@@ -628,6 +628,9 @@ fn parse_uses(text: &str) -> Option<(u8, &'static str)> {
     let count: u8 = num.trim().parse().ok()?;
     let variant = match kind.trim().to_ascii_lowercase().as_str() {
         "ammo" => "Ammo",
+        "charges" => "Charges",
+        "secrets" => "Secrets",
+        "supplies" => "Supplies",
         other => {
             eprintln!("warning: unmodeled Uses kind {other:?}; emitting uses: None");
             return None;
@@ -777,9 +780,13 @@ mod tests {
             parse_uses("Uses (4 ammo).\n[action] Spend 1 ammo: Fight."),
             Some((4u8, "Ammo"))
         );
+        // All modeled UseKind variants map (not just ammo).
+        assert_eq!(parse_uses("Uses (5 charges)."), Some((5u8, "Charges")));
+        assert_eq!(parse_uses("Uses (3 secrets)."), Some((3u8, "Secrets")));
+        assert_eq!(parse_uses("Uses (3 supplies)."), Some((3u8, "Supplies")));
         assert_eq!(parse_uses("Some other card text."), None);
-        // Unmodeled kind → None (with a build warning).
-        assert_eq!(parse_uses("Uses (3 supplies)."), None);
+        // Genuinely unmodeled kind → None (with a build warning).
+        assert_eq!(parse_uses("Uses (4 time)."), None);
     }
 
     #[test]

--- a/crates/card-data-pipeline/src/main.rs
+++ b/crates/card-data-pipeline/src/main.rs
@@ -239,6 +239,9 @@ struct NormalizedCard {
     quantity: u8,
     pack_code: String,
     is_fast: bool,
+    /// Limited-use tokens parsed from a `Uses (N <kind>)` clause, as
+    /// `(count, UsesKind-variant-name)`. `None` when absent or unmodeled.
+    uses: Option<(u8, &'static str)>,
     // Encounter-card stats. `clues` is a location's starting clues AND an
     // act's advance threshold (same JSON field); consumer interprets by kind.
     shroud: Option<u8>,
@@ -288,6 +291,7 @@ fn normalize(raw: RawCard) -> Result<NormalizedCard, String> {
         .is_some_and(|t| has_keyword(t, "Retaliate"));
     let prey = raw.text.as_deref().map_or(PreyParse::None, parse_prey);
     let spawn_name = raw.text.as_deref().and_then(parse_spawn_name);
+    let uses = raw.text.as_deref().and_then(parse_uses);
 
     Ok(NormalizedCard {
         code: raw.code,
@@ -310,6 +314,7 @@ fn normalize(raw: RawCard) -> Result<NormalizedCard, String> {
         quantity: raw.quantity.unwrap_or(1),
         pack_code: raw.pack_code,
         is_fast,
+        uses,
         shroud: raw.shroud,
         clues: raw.clues,
         clues_fixed: raw.clues_fixed.unwrap_or(false),
@@ -414,7 +419,7 @@ fn render(all: &BTreeMap<String, NormalizedCard>) -> String {
     out.push_str(
         "use card_dsl::card_data::{\n    \
          CardKind, CardMetadata, Class, ClueValue, HealthValue, Prey, PreyDirection, PreyMeasure,\n    \
-         SkillIcons, SkillKind, Skills, Slot, Spawn, SpawnLocation,\n};\n\n\
+         SkillIcons, SkillKind, Skills, Slot, Spawn, SpawnLocation, Uses, UsesKind,\n};\n\n\
          /// Every card from the pinned snapshot, sorted by code.\n\
          #[must_use]\n\
          pub fn all_cards() -> Vec<CardMetadata> {\n    vec![\n",
@@ -480,7 +485,7 @@ fn render_kind(c: &NormalizedCard) -> String {
         ),
         "Asset" => format!(
             "CardKind::Asset {{ class: Class::{}, cost: {}, xp: {}, slots: {}, \
-             health: {}, sanity: {}, skill_icons: {}, is_fast: {}, deck_limit: {} }}",
+             health: {}, sanity: {}, skill_icons: {}, is_fast: {}, deck_limit: {}, uses: {} }}",
             c.class,
             opt_i8(c.cost),
             opt_u8(c.xp),
@@ -490,6 +495,7 @@ fn render_kind(c: &NormalizedCard) -> String {
             icons,
             c.is_fast,
             c.deck_limit,
+            uses_lit(c.uses),
         ),
         "Event" => format!(
             "CardKind::Event {{ class: Class::{}, cost: {}, xp: {}, \
@@ -578,6 +584,16 @@ fn opt_u8(v: Option<u8>) -> String {
     }
 }
 
+/// Emit the `Option<Uses>` literal for an asset's parsed `uses`.
+fn uses_lit(uses: Option<(u8, &'static str)>) -> String {
+    match uses {
+        Some((count, variant)) => {
+            format!("Some(Uses {{ kind: UsesKind::{variant}, count: {count} }})")
+        }
+        None => "None".into(),
+    }
+}
+
 /// Emit the `ClueValue` literal for a location's clues.
 fn clue_value_lit(clues: u8, fixed: bool) -> String {
     if fixed {
@@ -596,6 +612,28 @@ fn strip_html_bold(s: &str) -> String {
 /// (e.g. `"Hunter."`). Bold tags are stripped first.
 fn has_keyword(text: &str, keyword: &str) -> bool {
     strip_html_bold(text).contains(&format!("{keyword}."))
+}
+
+/// Parse a printed `Uses (N <kind>)` clause into `(count, variant)`, where
+/// `variant` is the `UsesKind` Rust variant name for code emission. Returns
+/// `None` when absent; warns + returns `None` for an unmodeled kind rather
+/// than silently approximating.
+fn parse_uses(text: &str) -> Option<(u8, &'static str)> {
+    let plain = strip_html_bold(text);
+    let start = plain.find("Uses (")? + "Uses (".len();
+    let inner = &plain[start..];
+    let end = inner.find(')')?;
+    let body = inner[..end].trim(); // e.g. "4 ammo"
+    let (num, kind) = body.split_once(' ')?;
+    let count: u8 = num.trim().parse().ok()?;
+    let variant = match kind.trim().to_ascii_lowercase().as_str() {
+        "ammo" => "Ammo",
+        other => {
+            eprintln!("warning: unmodeled Uses kind {other:?}; emitting uses: None");
+            return None;
+        }
+    };
+    Some((count, variant))
 }
 
 /// Parsed Prey line. `None` = no printed prey (emit `Prey::Default`);
@@ -712,8 +750,8 @@ const GENERATED_HEADER: &str = "\
 mod tests {
     use super::{
         clue_value_lit, emit_card, has_keyword, health_value_opt_lit, map_card_type, map_class,
-        normalize, parse_prey, parse_slots, parse_spawn_name, parse_traits, prey_lit, process_raw,
-        strip_html_bold, NormalizedCard, PreyParse, RawCard,
+        normalize, parse_prey, parse_slots, parse_spawn_name, parse_traits, parse_uses, prey_lit,
+        process_raw, strip_html_bold, NormalizedCard, PreyParse, RawCard,
     };
     use std::collections::BTreeMap;
     use std::path::Path;
@@ -731,6 +769,17 @@ mod tests {
         assert!(has_keyword("Hunter. Retaliate.", "Hunter"));
         assert!(has_keyword("Hunter. Retaliate.", "Retaliate"));
         assert!(!has_keyword("<b>Spawn</b> - Attic.", "Hunter"));
+    }
+
+    #[test]
+    fn parse_uses_reads_ammo_count() {
+        assert_eq!(
+            parse_uses("Uses (4 ammo).\n[action] Spend 1 ammo: Fight."),
+            Some((4u8, "Ammo"))
+        );
+        assert_eq!(parse_uses("Some other card text."), None);
+        // Unmodeled kind → None (with a build warning).
+        assert_eq!(parse_uses("Uses (3 supplies)."), None);
     }
 
     #[test]
@@ -866,6 +915,7 @@ mod tests {
             quantity: 1,
             pack_code: "core".into(),
             is_fast: false,
+            uses: None,
             shroud: None,
             clues: None,
             clues_fixed: false,

--- a/crates/card-data-pipeline/src/main.rs
+++ b/crates/card-data-pipeline/src/main.rs
@@ -419,7 +419,7 @@ fn render(all: &BTreeMap<String, NormalizedCard>) -> String {
     out.push_str(
         "use card_dsl::card_data::{\n    \
          CardKind, CardMetadata, Class, ClueValue, HealthValue, Prey, PreyDirection, PreyMeasure,\n    \
-         SkillIcons, SkillKind, Skills, Slot, Spawn, SpawnLocation, Uses, UsesKind,\n};\n\n\
+         SkillIcons, SkillKind, Skills, Slot, Spawn, SpawnLocation, UseKind, Uses,\n};\n\n\
          /// Every card from the pinned snapshot, sorted by code.\n\
          #[must_use]\n\
          pub fn all_cards() -> Vec<CardMetadata> {\n    vec![\n",
@@ -588,7 +588,7 @@ fn opt_u8(v: Option<u8>) -> String {
 fn uses_lit(uses: Option<(u8, &'static str)>) -> String {
     match uses {
         Some((count, variant)) => {
-            format!("Some(Uses {{ kind: UsesKind::{variant}, count: {count} }})")
+            format!("Some(Uses {{ kind: UseKind::{variant}, count: {count} }})")
         }
         None => "None".into(),
     }

--- a/crates/card-dsl/src/card_data.rs
+++ b/crates/card-dsl/src/card_data.rs
@@ -267,6 +267,28 @@ pub enum HealthValue {
     PerInvestigator(u8),
 }
 
+/// Limited-use tokens an asset enters play with ("Uses (4 ammo)").
+/// Spending them is a [`Cost::SpendUses`](crate::dsl::Cost::SpendUses);
+/// depletion blocks the ability that pays in them. Pipeline-parsed from
+/// card text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Uses {
+    /// What the tokens are called on the card.
+    pub kind: UsesKind,
+    /// How many the asset enters play with.
+    pub count: u8,
+}
+
+/// The named token type an asset's `Uses (N <kind>)` grants. Only the
+/// kinds Slice-1 cards print are modeled; others land as their cards do
+/// (the pipeline warns and emits `None` for an unmodeled kind rather than
+/// silently approximating).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum UsesKind {
+    /// "Uses (N ammo)" — firearms.
+    Ammo,
+}
+
 /// Per-card-type data. The discriminant mirrors [`CardType`] — read it
 /// via [`CardMetadata::card_type`]. Player variants carry a [`Class`];
 /// encounter variants do not (encounter cards have no player class).
@@ -308,6 +330,9 @@ pub enum CardKind {
         is_fast: bool,
         /// Maximum copies per deck.
         deck_limit: u8,
+        /// Limited-use tokens granted on enter-play ("Uses (N ammo)"),
+        /// or `None`. Pipeline-parsed from card text.
+        uses: Option<Uses>,
     },
     /// Event — played from hand, then discarded.
     Event {
@@ -524,12 +549,24 @@ mod is_fast_tests {
                 skill_icons: SkillIcons::default(),
                 is_fast: true,
                 deck_limit: 2,
+                uses: None,
             },
         };
         let json = serde_json::to_string(&original).expect("serialize");
         let back: CardMetadata = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, original);
         assert!(matches!(back.kind, CardKind::Asset { is_fast: true, .. }));
+    }
+
+    #[test]
+    fn asset_uses_round_trips() {
+        let uses = Some(Uses {
+            kind: UsesKind::Ammo,
+            count: 4,
+        });
+        let json = serde_json::to_string(&uses).expect("serialize");
+        let back: Option<Uses> = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, uses);
     }
 
     #[test]

--- a/crates/card-dsl/src/card_data.rs
+++ b/crates/card-dsl/src/card_data.rs
@@ -270,23 +270,42 @@ pub enum HealthValue {
 /// Limited-use tokens an asset enters play with ("Uses (4 ammo)").
 /// Spending them is a [`Cost::SpendUses`](crate::dsl::Cost::SpendUses);
 /// depletion blocks the ability that pays in them. Pipeline-parsed from
-/// card text.
+/// card text. The engine's runtime uses-pool is seeded from this on
+/// enter-play.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Uses {
     /// What the tokens are called on the card.
-    pub kind: UsesKind,
+    pub kind: UseKind,
     /// How many the asset enters play with.
     pub count: u8,
 }
 
-/// The named token type an asset's `Uses (N <kind>)` grants. Only the
-/// kinds Slice-1 cards print are modeled; others land as their cards do
-/// (the pipeline warns and emits `None` for an unmodeled kind rather than
-/// silently approximating).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum UsesKind {
-    /// "Uses (N ammo)" — firearms.
+/// A named-uses kind for asset cards that track a finite resource.
+///
+/// Translation of the rulebook's typed-uses taxonomy. Cards declare
+/// what flavor of uses they have ("Uses (3 charges)", "Uses (1 ammo)")
+/// and effects spend them with a [`Cost::SpendUses`](crate::dsl::Cost::SpendUses).
+///
+/// Lives here in `card-dsl` (the lowest layer) so both the printed
+/// metadata ([`Uses`]) and the engine's runtime pool key off one type;
+/// `game_core::state` re-exports it at the historical path.
+///
+/// Phase-3 minimal set; cards using exotic uses (Time on some Dunwich
+/// cards, Resource on a few Mystic effects) add their variant when
+/// they land.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum UseKind {
+    /// Charges — most spell assets (Rite of Seeking, Shrivelling).
+    Charges,
+    /// Ammo — firearms (.38 Special, .45 Automatic).
     Ammo,
+    /// Secrets — Seeker investigation aids (Encyclopedia, Old Book of
+    /// Lore in some cycles).
+    Secrets,
+    /// Supplies — Survivor tools (First Aid in some cycles, expedition
+    /// caches).
+    Supplies,
 }
 
 /// Per-card-type data. The discriminant mirrors [`CardType`] — read it
@@ -561,7 +580,7 @@ mod is_fast_tests {
     #[test]
     fn asset_uses_round_trips() {
         let uses = Some(Uses {
-            kind: UsesKind::Ammo,
+            kind: UseKind::Ammo,
             count: 4,
         });
         let json = serde_json::to_string(&uses).expect("serialize");

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -372,6 +372,15 @@ pub enum Cost {
     /// reject with a TODO. Test-side seam is
     /// `ChoiceResolver` (in `game_core::test_support`).
     DiscardCardFromHand,
+    /// Spend `count` tokens of the named [`UseKind`] from the source
+    /// asset's runtime uses-pool (".38 Special": "Spend 1 ammo").
+    /// Insufficient remaining of that kind rejects the activation.
+    SpendUses {
+        /// Which uses-kind to spend (Ammo, Charges, …).
+        kind: crate::card_data::UseKind,
+        /// How many to spend.
+        count: u8,
+    },
 }
 
 // ---- usage limits ----------------------------------------------

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -788,6 +788,41 @@ pub enum Condition {
     /// there's an in-flight test whose kind matches; rejects when
     /// no test is in flight.
     SkillTestKind(SkillTestKind),
+    /// Holds when the controller's current location has ≥1 clue.
+    /// ".38 Special": "if there are 1 or more clues on your location".
+    LocationHasClues,
+}
+
+/// An integer computed at effect-evaluation time. Lets a numeric field
+/// carry a condition-gated value without duplicating the surrounding
+/// effect — ".38 Special" reads its combat modifier as
+/// `IntExpr::cond(LocationHasClues, 3, 1)` rather than an
+/// [`Effect::If`] wrapping two near-identical `fight(…)` nodes.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum IntExpr {
+    /// A literal value.
+    Lit(i8),
+    /// `then` if `when` holds at eval time, else `otherwise`.
+    Cond {
+        /// Predicate evaluated against current state.
+        when: Condition,
+        /// Value when the predicate holds.
+        then: i8,
+        /// Value when it does not.
+        otherwise: i8,
+    },
+}
+
+impl IntExpr {
+    /// Construct an [`IntExpr::Cond`].
+    #[must_use]
+    pub fn cond(when: Condition, then: i8, otherwise: i8) -> Self {
+        Self::Cond {
+            when,
+            then,
+            otherwise,
+        }
+    }
 }
 
 /// Result of a skill test, as a discrete value usable in conditions.

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -596,6 +596,19 @@ pub enum Effect {
         /// Printed `ArkhamDB` code of the card to place.
         code: String,
     },
+    /// Initiate a Fight against the single enemy engaged with the
+    /// controller, applying `combat_modifier` (resolved at eval, e.g.
+    /// .38 Special's +1/+3) for this attack and dealing `1 + extra_damage`
+    /// on success. Auto-targets when exactly one enemy is engaged; the
+    /// activation check rejects ≠1 engaged *before* any cost is paid, so
+    /// the evaluator can assume a single target. Inspectable (not
+    /// `Native`) precisely so that pre-charge target check can see it.
+    Fight {
+        /// Combat modifier for this attack, resolved against state at eval.
+        combat_modifier: IntExpr,
+        /// Bonus damage beyond the base 1 (.38 Special: +1).
+        extra_damage: u8,
+    },
     /// A constant restriction the source card imposes while in play
     /// (under [`Trigger::Constant`]). **Inspected, not executed** — the
     /// engine reads it at the relevant decision point (`play_is_prohibited`
@@ -1044,6 +1057,16 @@ pub fn discard_self() -> Effect {
 #[must_use]
 pub fn put_into_threat_area(code: impl Into<String>) -> Effect {
     Effect::PutIntoThreatArea { code: code.into() }
+}
+
+/// Build an [`Effect::Fight`] with the given combat modifier and bonus
+/// damage (.38 Special: `fight(IntExpr::cond(LocationHasClues, 3, 1), 1)`).
+#[must_use]
+pub fn fight(combat_modifier: IntExpr, extra_damage: u8) -> Effect {
+    Effect::Fight {
+        combat_modifier,
+        extra_damage,
+    }
 }
 
 /// Build an [`Effect::Restrict`] carrying a constant [`Restriction`].

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -372,9 +372,9 @@ pub enum Cost {
     /// reject with a TODO. Test-side seam is
     /// `ChoiceResolver` (in `game_core::test_support`).
     DiscardCardFromHand,
-    /// Spend `count` tokens of the named [`UseKind`] from the source
-    /// asset's runtime uses-pool (".38 Special": "Spend 1 ammo").
-    /// Insufficient remaining of that kind rejects the activation.
+    /// Spend `count` tokens of the named [`UseKind`](crate::card_data::UseKind)
+    /// from the source asset's runtime uses-pool (".38 Special": "Spend 1
+    /// ammo"). Insufficient remaining of that kind rejects the activation.
     SpendUses {
         /// Which uses-kind to spend (Ammo, Charges, …).
         kind: crate::card_data::UseKind,

--- a/crates/cards/src/generated/cards.rs
+++ b/crates/cards/src/generated/cards.rs
@@ -8,7 +8,7 @@
 
 use card_dsl::card_data::{
     CardKind, CardMetadata, Class, ClueValue, HealthValue, Prey, PreyDirection, PreyMeasure,
-    SkillIcons, SkillKind, Skills, Slot, Spawn, SpawnLocation,
+    SkillIcons, SkillKind, Skills, Slot, Spawn, SpawnLocation, Uses, UsesKind,
 };
 
 /// Every card from the pinned snapshot, sorted by code.
@@ -69,7 +69,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Firearm".to_owned()],
             text: Some("Roland Banks deck only.\nUses (4 ammo).\n[action] Spend 1 ammo: <b>Fight.</b> You get +1 [combat] for this attack (if there are 1 or more clues on your location, you get +3 [combat], instead). This attack deals +1 damage.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(3), xp: None, slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 1, wild: 1 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(3), xp: None, slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 1, wild: 1 }, is_fast: false, deck_limit: 1, uses: Some(Uses { kind: UsesKind::Ammo, count: 4 }) },
         },
         CardMetadata {
             code: "01007".to_owned(),
@@ -85,7 +85,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned()],
             text: Some("Daisy Walker deck only.\nYou have 2 additional hand slots, which can only be used to hold [[Tome]] assets.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: None, slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 1, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: None, slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 1, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 1, uses: None },
         },
         CardMetadata {
             code: "01009".to_owned(),
@@ -93,7 +93,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Tome".to_owned()],
             text: Some("<b>Revelation</b> - Put The Necronomicon into play in your threat area, with 3 horror on it. It cannot leave play while it has 1 or more horror on it.\nTreat each [elder_sign] you reveal on a chaos token as a [auto_fail].\n[action]: Move 1 horror from The Necronomicon to Daisy Walker. Then, if The Necronomicon has no horror on it, discard it.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: None, xp: None, slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: None, xp: None, slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 1, uses: None },
         },
         CardMetadata {
             code: "01010".to_owned(),
@@ -117,7 +117,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Relic".to_owned()],
             text: Some("Agnes Baker deck only.\n[reaction] After you play a [[Spell]] card: Draw 1 card.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(3), xp: None, slots: vec![Slot::Accessory], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 1, agility: 0, wild: 1 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(3), xp: None, slots: vec![Slot::Accessory], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 1, agility: 0, wild: 1 }, is_fast: false, deck_limit: 1, uses: None },
         },
         CardMetadata {
             code: "01013".to_owned(),
@@ -133,7 +133,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Relic".to_owned()],
             text: Some("Wendy Adams deck only.\nYou may play the topmost event in your discard pile as if it were in your hand.\n<b>Forced</b> - After you play an event or discard an event from play: Place it on the bottom of your deck instead of in your discard pile.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: None, slots: vec![Slot::Accessory], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 2 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: None, slots: vec![Slot::Accessory], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 2 }, is_fast: false, deck_limit: 1, uses: None },
         },
         CardMetadata {
             code: "01015".to_owned(),
@@ -149,7 +149,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Firearm".to_owned()],
             text: Some("Uses (4 ammo).\n[action] Spend 1 ammo: <b>Fight.</b> You get +1 [combat] for this attack. This attack deals +1 damage.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(4), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(4), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UsesKind::Ammo, count: 4 }) },
         },
         CardMetadata {
             code: "01017".to_owned(),
@@ -157,7 +157,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned()],
             text: Some("[fast] Spend 1 resource: You get +1 [willpower] for this skill test.\n[fast] Spend 1 resource: You get +1 [combat] for this skill test.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(2), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(2), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01018".to_owned(),
@@ -165,7 +165,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Police".to_owned()],
             text: Some("You get +1 [combat].\n[fast] Discard Beat Cop: Deal 1 damage to an enemy at your location.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(4), xp: Some(0), slots: vec![Slot::Ally], health: Some(2), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(4), xp: Some(0), slots: vec![Slot::Ally], health: Some(2), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01019".to_owned(),
@@ -173,7 +173,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned(), "Science".to_owned()],
             text: Some("Uses (3 supplies). If First Aid has no supplies, discard it.\n[action] Spend 1 supply: Heal 1 damage or horror from an investigator at your location.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(2), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(2), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01020".to_owned(),
@@ -181,7 +181,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Melee".to_owned()],
             text: Some("[action]: <b>Fight.</b> You get +1 [combat] for this attack. If the attacked enemy is the only enemy engaged with you, this attack deals +1 damage.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(3), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(3), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01021".to_owned(),
@@ -189,7 +189,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Creature".to_owned()],
             text: Some("[reaction] When an enemy attack deals damage to Guard Dog: Deal 1 damage to the attacking enemy.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(3), xp: Some(0), slots: vec![Slot::Ally], health: Some(3), sanity: Some(1), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(3), xp: Some(0), slots: vec![Slot::Ally], health: Some(3), sanity: Some(1), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01022".to_owned(),
@@ -237,7 +237,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned()],
             text: Some("You get +1 [willpower].\n[fast] While an investigator at your location is taking his or her turn, discard Police Badge: That investigator may take 2 additional actions this turn.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(3), xp: Some(2), slots: vec![Slot::Accessory], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(3), xp: Some(2), slots: vec![Slot::Accessory], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01028".to_owned(),
@@ -245,7 +245,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Police".to_owned()],
             text: Some("You get +1 [combat].\n[fast] Exhaust Beat Cop and deal 1 damage to it: Deal 1 damage to an enemy at your location.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(4), xp: Some(2), slots: vec![Slot::Ally], health: Some(3), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(4), xp: Some(2), slots: vec![Slot::Ally], health: Some(3), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01029".to_owned(),
@@ -253,7 +253,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Firearm".to_owned()],
             text: Some("Uses (2 ammo).\n[action] Spend 1 ammo: <b>Fight.</b> You get +3 [combat] for this attack. Instead of its standard damage, this attack deals 1 damage for each point you succeed by (to a minimum of 1, to a maximum of 5). If you fail and would damage another investigator, this attack deals 1 damage for each point you fail by (to a minimum of 1, to a maximum of 5).".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(5), xp: Some(4), slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 2, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(5), xp: Some(4), slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 2, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UsesKind::Ammo, count: 2 }) },
         },
         CardMetadata {
             code: "01030".to_owned(),
@@ -261,7 +261,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Tool".to_owned()],
             text: Some("Fast.\nYou get +1 [intellect] while investigating.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(1), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: true, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(1), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: true, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01031".to_owned(),
@@ -269,7 +269,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Tome".to_owned()],
             text: Some("[action] Exhaust Old Book of Lore: Choose an investigator at your location. That investigator searches the top 3 cards of his or her deck for a card, draws it, and shuffles the remaining cards into his or her deck.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(3), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(3), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01032".to_owned(),
@@ -277,7 +277,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Miskatonic".to_owned()],
             text: Some("[reaction] After Research Librarian enters play: Search your deck for a [[Tome]] asset and add it to your hand. Shuffle your deck.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(2), xp: Some(0), slots: vec![Slot::Ally], health: Some(1), sanity: Some(1), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(2), xp: Some(0), slots: vec![Slot::Ally], health: Some(1), sanity: Some(1), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01033".to_owned(),
@@ -285,7 +285,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Miskatonic".to_owned()],
             text: Some("You get +1 [intellect].\n[reaction] After you successfully investigate: Gain 1 resource.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(4), xp: Some(0), slots: vec![Slot::Ally], health: Some(1), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(4), xp: Some(0), slots: vec![Slot::Ally], health: Some(1), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01034".to_owned(),
@@ -293,7 +293,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned()],
             text: Some("[fast] Spend 1 resource: You get +1 [intellect] for this skill test.\n[fast] Spend 1 resource: You get +1 [agility] for this skill test.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(2), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(2), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01035".to_owned(),
@@ -301,7 +301,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Tome".to_owned()],
             text: Some("[action] Choose an investigator at your location and test [intellect] (2). If you succeed, heal 1 damage from that investigator. If you fail, deal 1 damage to that investigator.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(2), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(2), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01036".to_owned(),
@@ -341,7 +341,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Tool".to_owned()],
             text: Some("Fast.\nYou get +1 [intellect] while investigating.\n[fast] If there are no clues on your location: Return Magnifying Glass to your hand.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(0), xp: Some(1), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: true, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(0), xp: Some(1), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: true, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01041".to_owned(),
@@ -349,7 +349,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Relic".to_owned()],
             text: Some("[reaction] When a non-[[Elite]] enemy spawns at your location, discard Disc of Itzamna: Discard that enemy.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(3), xp: Some(2), slots: vec![Slot::Accessory], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 1, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(3), xp: Some(2), slots: vec![Slot::Accessory], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 1, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01042".to_owned(),
@@ -357,7 +357,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Tome".to_owned()],
             text: Some("[action] Exhaust Encyclopedia: Choose an investigator at your location. That investigator gets +2 to a skill of your choice until the end of the phase.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(2), xp: Some(2), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(2), xp: Some(2), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01043".to_owned(),
@@ -373,7 +373,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Melee".to_owned(), "Illicit".to_owned()],
             text: Some("Fast.\n[action]: <b>Fight.</b> If you succeed by 2 or more, this attack deals +1 damage.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(1), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: true, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(1), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: true, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01045".to_owned(),
@@ -381,7 +381,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned(), "Illicit".to_owned()],
             text: Some("[action] Exhaust Burglary: <b>Investigate.</b> If you succeed, instead of discovering clues, gain 3 resources.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01046".to_owned(),
@@ -389,7 +389,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned(), "Illicit".to_owned()],
             text: Some("[reaction] After you evade an enemy, exhaust Pickpocketing: Draw 1 card.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(2), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(2), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01047".to_owned(),
@@ -397,7 +397,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Firearm".to_owned(), "Illicit".to_owned()],
             text: Some("Uses (3 ammo).\n[action] Spend 1 ammo: <b>Fight.</b> You get +2 [combat] for this attack. If you succeed by 2 or more, this attack deals +1 damage.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(3), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(3), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UsesKind::Ammo, count: 3 }) },
         },
         CardMetadata {
             code: "01048".to_owned(),
@@ -405,7 +405,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Criminal".to_owned()],
             text: Some("You may take an additional action during your turn.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(6), xp: Some(0), slots: vec![Slot::Ally], health: Some(2), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(6), xp: Some(0), slots: vec![Slot::Ally], health: Some(2), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01049".to_owned(),
@@ -413,7 +413,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned()],
             text: Some("[fast] Spend 1 resource: You get +1 [combat] for this skill test.\n[fast] Spend 1 resource: You get +1 [agility] for this skill test.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(2), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(2), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01050".to_owned(),
@@ -453,7 +453,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Criminal".to_owned()],
             text: Some("You may take an additional action during your turn.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(5), xp: Some(1), slots: vec![Slot::Ally], health: Some(2), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(5), xp: Some(1), slots: vec![Slot::Ally], health: Some(2), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01055".to_owned(),
@@ -461,7 +461,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Criminal".to_owned()],
             text: Some("You get +1 [agility].\n[action] Exhaust Cat Burglar: Disengage from each enemy engaged with you and move to a connecting location. This action does not provoke attacks of opportunity.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(4), xp: Some(1), slots: vec![Slot::Ally], health: Some(2), sanity: Some(2), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(4), xp: Some(1), slots: vec![Slot::Ally], health: Some(2), sanity: Some(2), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01056".to_owned(),
@@ -485,7 +485,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned()],
             text: Some("Uses (4 secrets). If Forbidden Knowledge has no secrets, discard it.\n[fast] Exhaust Forbidden Knowledge and take 1 horror: Move 1 secret from Forbidden Knowledge to your resource pool, as a resource.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(0), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(0), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01059".to_owned(),
@@ -493,7 +493,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Charm".to_owned()],
             text: Some("You get +1 [willpower].".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(2), xp: Some(0), slots: vec![Slot::Accessory], health: None, sanity: Some(2), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(2), xp: Some(0), slots: vec![Slot::Accessory], health: None, sanity: Some(2), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01060".to_owned(),
@@ -501,7 +501,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Spell".to_owned()],
             text: Some("Uses (4 charges).\n[action] Spend 1 charge: <b>Fight.</b> This attack uses [willpower] instead of [combat] and deals +1 damage. If a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol is revealed during this attack, take 1 horror.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(3), xp: Some(0), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(3), xp: Some(0), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01061".to_owned(),
@@ -509,7 +509,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Spell".to_owned()],
             text: Some("Uses (3 charges).\n[action] Exhaust Scrying and spend 1 charge: Look at the top 3 cards of any investigator's deck or the encounter deck. Return them to the top of that deck in any order.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(1), xp: Some(0), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(1), xp: Some(0), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01062".to_owned(),
@@ -517,7 +517,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned()],
             text: Some("[fast] Spend 1 resource: You get +1 [willpower] for this skill test.\n[fast] Spend 1 resource: You get +1 [intellect] for this skill test.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(2), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(2), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01063".to_owned(),
@@ -525,7 +525,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Sorcerer".to_owned()],
             text: Some("<b>Forced</b> - After Arcane Initiate enters play: Place 1 doom on it.\n[fast] Exhaust Arcane Initiate: Search the top 3 cards of your deck for a [[Spell]] card and draw it. Shuffle your deck.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(1), xp: Some(0), slots: vec![Slot::Ally], health: Some(1), sanity: Some(2), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(1), xp: Some(0), slots: vec![Slot::Ally], health: Some(1), sanity: Some(2), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01064".to_owned(),
@@ -581,7 +581,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Tome".to_owned()],
             text: Some("You have 1 additional arcane slot.\n[action] Exhaust Book of Shadows: Add 1 charge to a [[Spell]] asset you control.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(4), xp: Some(3), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(4), xp: Some(3), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01071".to_owned(),
@@ -589,7 +589,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Relic".to_owned()],
             text: Some("Uses (4 charges). If Grotesque Statue has no charges, discard it.\n[reaction] When you would reveal a chaos token, spend 1 charge: Reveal 2 chaos tokens instead of 1. Choose 1 of those tokens to resolve, and ignore the other.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(2), xp: Some(4), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(2), xp: Some(4), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01072".to_owned(),
@@ -597,7 +597,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Armor".to_owned()],
             text: None,
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Survivor, cost: Some(0), xp: Some(0), slots: vec![Slot::Body], health: Some(2), sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Survivor, cost: Some(0), xp: Some(0), slots: vec![Slot::Body], health: Some(2), sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01073".to_owned(),
@@ -605,7 +605,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned()],
             text: Some("[reaction] After you successfully investigate by 2 or more, exhaust Scavenging: Choose an [[Item]] card in your discard pile and add it to your hand.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Survivor, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Survivor, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01074".to_owned(),
@@ -613,7 +613,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Melee".to_owned()],
             text: Some("[action]: <b>Fight.</b> You get +2 [combat] for this attack. This attack deals +1 damage. If a [skull] or [auto_fail] symbol is revealed during this attack, discard Baseball Bat after the attack resolves.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Survivor, cost: Some(2), xp: Some(0), slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Survivor, cost: Some(2), xp: Some(0), slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01075".to_owned(),
@@ -621,7 +621,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Charm".to_owned()],
             text: Some("[reaction] After you fail a skill test, exhaust Rabbit's Foot: Draw 1 card.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Survivor, cost: Some(1), xp: Some(0), slots: vec![Slot::Accessory], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Survivor, cost: Some(1), xp: Some(0), slots: vec![Slot::Accessory], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01076".to_owned(),
@@ -629,7 +629,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Creature".to_owned()],
             text: Some("[fast] Discard Stray Cat: Automatically evade a non-[[Elite]] enemy at your location.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Survivor, cost: Some(1), xp: Some(0), slots: vec![Slot::Ally], health: Some(1), sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Survivor, cost: Some(1), xp: Some(0), slots: vec![Slot::Ally], health: Some(1), sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01077".to_owned(),
@@ -637,7 +637,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned()],
             text: Some("[fast] Spend 1 resource: You get +1 [willpower] for this skill test.\n[fast] Spend 1 resource: You get +1 [agility] for this skill test.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Survivor, cost: Some(2), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Survivor, cost: Some(2), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01078".to_owned(),
@@ -677,7 +677,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned()],
             text: Some("[reaction] When an enemy attacks you, exhaust Aquinnah and deal 1 horror to her: Deal that enemy's damage to another enemy at your location, instead. (You still take horror dealt by the attack.)".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Survivor, cost: Some(5), xp: Some(1), slots: vec![Slot::Ally], health: Some(1), sanity: Some(4), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Survivor, cost: Some(5), xp: Some(1), slots: vec![Slot::Ally], health: Some(1), sanity: Some(4), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01083".to_owned(),
@@ -709,7 +709,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Melee".to_owned()],
             text: Some("[action]: <b>Fight.</b> You get +1 [combat] for this attack.\n[action] Discard Knife: <b>Fight.</b> You get +2 [combat] for this attack. This attack deals +1 damage.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(1), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(1), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01087".to_owned(),
@@ -717,7 +717,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Tool".to_owned()],
             text: Some("Uses (3 supplies).\n[action] Spend 1 supply: <b>Investigate.</b> Your location gets -2 shroud for this investigation.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01088".to_owned(),
@@ -773,7 +773,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Armor".to_owned()],
             text: None,
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: Some(3), slots: vec![Slot::Body], health: Some(4), sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 1 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: Some(3), slots: vec![Slot::Body], health: Some(4), sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 1 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01095".to_owned(),
@@ -781,7 +781,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Relic".to_owned()],
             text: None,
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: Some(3), slots: vec![Slot::Accessory], health: None, sanity: Some(4), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: Some(3), slots: vec![Slot::Accessory], health: None, sanity: Some(4), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "01096".to_owned(),
@@ -949,7 +949,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned()],
             text: Some("While you control Lita Chantler, she gains:\n\"Each investigator at your location gets +1 [combat].\n[reaction] When an investigator at your location successfully attacks a [[Monster]] enemy: That investigator deals +1 damage.\"".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: vec![Slot::Ally], health: Some(3), sanity: Some(3), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: vec![Slot::Ally], health: Some(3), sanity: Some(3), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 1, uses: None },
         },
         CardMetadata {
             code: "01118".to_owned(),
@@ -1509,7 +1509,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Charm".to_owned()],
             text: Some("Zoey Samaras deck only.\n[reaction] After an enemy becomes engaged with you, exhaust Zoey's Cross and spend 1 resource: Deal 1 damage to that enemy.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(1), xp: None, slots: vec![Slot::Accessory], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 2, agility: 0, wild: 1 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(1), xp: None, slots: vec![Slot::Accessory], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 2, agility: 0, wild: 1 }, is_fast: false, deck_limit: 1, uses: None },
         },
         CardMetadata {
             code: "02007".to_owned(),
@@ -1541,7 +1541,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Firearm".to_owned()],
             text: Some("Jenny Barnes deck only. Uses (X ammo).\n[action] Spend 1 ammo: <b>Fight.</b> You get +2 [combat] for this attack. This attack deals +1 damage.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(-2), xp: None, slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 2, wild: 1 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(-2), xp: None, slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 2, wild: 1 }, is_fast: false, deck_limit: 1, uses: None },
         },
         CardMetadata {
             code: "02011".to_owned(),
@@ -1557,7 +1557,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Instrument".to_owned(), "Relic".to_owned()],
             text: Some("Jim Culver deck only.\n[reaction] When a [skull] token is revealed during a skill test, exhaust Jim's Trumpet: Heal 1 horror from an investigator at your location or a connecting location.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: None, slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 2, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: None, slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 2, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 1, uses: None },
         },
         CardMetadata {
             code: "02013".to_owned(),
@@ -1573,7 +1573,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Creature".to_owned()],
             text: Some("\"Ashcan\" Pete deck only.\n[action] Exhaust Duke: <b>Fight.</b> You attack with a base [combat] skill of 4. This attack deals +1 damage.\n[action] Exhaust Duke: <b>Investigate.</b> You investigate with a base [intellect] skill of 4. You may move to a connecting location immediately before investigating with this effect.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: None, slots: Vec::new(), health: Some(2), sanity: Some(3), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: None, slots: Vec::new(), health: Some(2), sanity: Some(3), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 1, uses: None },
         },
         CardMetadata {
             code: "02015".to_owned(),
@@ -1589,7 +1589,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Melee".to_owned()],
             text: Some("[action]: <b>Fight.</b> You get +1 [combat] for this attack. If you perform this attack against an enemy engaged with another investigator and you fail, you deal no damage.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(1), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(1), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02017".to_owned(),
@@ -1621,7 +1621,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Miskatonic".to_owned(), "Science".to_owned()],
             text: Some("Your maximum hand size is increased by 2.\n[reaction] After Laboratory Assistant enters play: Draw 2 cards.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(2), xp: Some(0), slots: vec![Slot::Ally], health: Some(1), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(2), xp: Some(0), slots: vec![Slot::Ally], health: Some(1), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02021".to_owned(),
@@ -1629,7 +1629,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Science".to_owned()],
             text: Some("[action] Test [intellect] (4). If you succeed, discard Strange Solution and draw 2 cards. Record in your Campaign Log that \"you have identified the solution.\"".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02022".to_owned(),
@@ -1653,7 +1653,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Illicit".to_owned()],
             text: Some("Uses (4 supplies).\n[action] Spend 1 supply: Choose an investigator at your location to heal 1 horror. Then, that investigator tests [willpower] (2). If the test succeeds, he or she heals 1 additional horror. If the test fails, he or she discards 1 card at random from his or her hand.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02025".to_owned(),
@@ -1677,7 +1677,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Criminal".to_owned()],
             text: Some("You get +1 [combat].\n<b>Forced</b> - At the end of the upkeep phase: You must either pay 1 resource or discard Hired Muscle.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(1), xp: Some(1), slots: vec![Slot::Ally], health: Some(3), sanity: Some(1), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(1), xp: Some(1), slots: vec![Slot::Ally], health: Some(3), sanity: Some(1), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02028".to_owned(),
@@ -1685,7 +1685,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Spell".to_owned()],
             text: Some("Uses (3 charges).\n[action] Spend 1 charge: <b>Investigate.</b> Investigate using [willpower] instead of [intellect]. If you succeed, discover 1 additional clue at this location. If a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol is revealed during this test, after this test resolves lose all remaining actions and immediately end your turn.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(4), xp: Some(0), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(4), xp: Some(0), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02029".to_owned(),
@@ -1693,7 +1693,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned()],
             text: Some("[reaction] After a [skull], [cultist], [tablet], or [elder_thing] symbol is revealed during a test you are performing: You get +1 skill value for this test.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(1), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(1), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02030".to_owned(),
@@ -1701,7 +1701,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Spell".to_owned()],
             text: Some("Uses (3 charges).\n[action] Spend 1 charge: Heal 1 horror from an investigator at your location.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(2), xp: Some(0), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(2), xp: Some(0), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02031".to_owned(),
@@ -1717,7 +1717,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Melee".to_owned()],
             text: Some("[action]: <b>Fight.</b> If you have no resources in your resource pool, this attack deals +1 damage.\n[fast] During an attack using Fire Axe, spend 1 resource: You get +2 [combat] for this skill test. (Limit three times per attack.)".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Survivor, cost: Some(1), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Survivor, cost: Some(1), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02033".to_owned(),
@@ -1725,7 +1725,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Miskatonic".to_owned()],
             text: Some("You get +1 [agility].\n[reaction] After your turn ends: Heal 1 horror from Peter Sylvestre.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Survivor, cost: Some(3), xp: Some(0), slots: vec![Slot::Ally], health: Some(1), sanity: Some(2), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Survivor, cost: Some(3), xp: Some(0), slots: vec![Slot::Ally], health: Some(1), sanity: Some(2), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02034".to_owned(),
@@ -1741,7 +1741,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Miskatonic".to_owned()],
             text: Some("You get +1 [agility] and +1 [willpower].\n[reaction] After your turn ends: Heal 1 horror from Peter Sylvestre.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Survivor, cost: Some(3), xp: Some(2), slots: vec![Slot::Ally], health: Some(1), sanity: Some(3), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Survivor, cost: Some(3), xp: Some(2), slots: vec![Slot::Ally], health: Some(1), sanity: Some(3), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02036".to_owned(),
@@ -1749,7 +1749,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Melee".to_owned()],
             text: Some("[action]: <b>Fight.</b> You get +1 [combat] for this attack. If you succeed, you may spend 1 additional action to deal +1 damage for this attack.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02037".to_owned(),
@@ -1781,7 +1781,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Miskatonic".to_owned()],
             text: Some("[reaction] After you draw a non-weakness card, discard that card and exhaust Dr. Henry Armitage: Gain 3 resources.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: None, slots: vec![Slot::Ally], health: Some(2), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 2 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: None, slots: vec![Slot::Ally], health: Some(2), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 2 }, is_fast: false, deck_limit: 1, uses: None },
         },
         CardMetadata {
             code: "02042".to_owned(),
@@ -1925,7 +1925,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Science".to_owned()],
             text: Some("[action]: <b>Fight.</b> This attack uses [intellect] instead of [combat]. If used to attack The Experiment, this attack deals +6 damage. If you succeed, remove Alchemical Concoction from the game.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 0 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 0, uses: None },
         },
         CardMetadata {
             code: "02060".to_owned(),
@@ -1933,7 +1933,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Miskatonic".to_owned()],
             text: Some("<b>Revelation</b> - Put \"Jazz\" Mulligan into play at your location.\nWhile \"Jazz\" Mulligan is not controlled by a player, he gains: \"[action]: <b>Parley.</b> Test [intellect] (3). If successful, take control of \"Jazz\" Mulligan.\"\nWhile you control \"Jazz\" Mulligan, you ignore the text on each unrevealed [[Miskatonic]] location.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: Vec::new(), health: Some(2), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 0 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: Vec::new(), health: Some(2), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 0, uses: None },
         },
         CardMetadata {
             code: "02061".to_owned(),
@@ -1941,7 +1941,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Miskatonic".to_owned()],
             text: Some("You get +1 [intellect].\n[reaction] After you discover the last remaining clue in your location, exhaust Professor Warren Rice: Draw 1 card.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(3), xp: None, slots: vec![Slot::Ally], health: Some(2), sanity: Some(3), skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(3), xp: None, slots: vec![Slot::Ally], health: Some(2), sanity: Some(3), skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 1, uses: None },
         },
         CardMetadata {
             code: "02063".to_owned(),
@@ -2077,7 +2077,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Humanoid".to_owned(), "Criminal".to_owned()],
             text: Some("<b>Forced</b> - At the start of the enemy phase, if no investigator controls Peter Clover: Deal 1 damage to him.\n[fast] Exhaust Peter Clover: Automatically evade a [[Criminal]] enemy in your location.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: Vec::new(), health: Some(3), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 0 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: Vec::new(), health: Some(3), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 0, uses: None },
         },
         CardMetadata {
             code: "02080".to_owned(),
@@ -2085,7 +2085,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Miskatonic".to_owned()],
             text: Some("You get +1 [combat].\n[reaction] After you defeat an enemy, exhaust Dr. Francis Morgan: Draw 1 card.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(3), xp: None, slots: vec![Slot::Ally], health: Some(4), sanity: Some(1), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 1 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(3), xp: None, slots: vec![Slot::Ally], health: Some(4), sanity: Some(1), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 1 }, is_fast: false, deck_limit: 1, uses: None },
         },
         CardMetadata {
             code: "02081".to_owned(),
@@ -2293,7 +2293,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned()],
             text: Some("You get +1 [willpower].\nBrother Xavier may be assigned damage and/or horror dealt to other investigators at your location.\n[reaction] When Brother Xavier is defeated: Deal 2 damage to an enemy at your location.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(5), xp: Some(1), slots: vec![Slot::Ally], health: Some(3), sanity: Some(3), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(5), xp: Some(1), slots: vec![Slot::Ally], health: Some(3), sanity: Some(3), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02107".to_owned(),
@@ -2309,7 +2309,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned()],
             text: Some("[fast] During your turn, if you are not engaged with any enemies, exhaust Pathfinder: Move to a connecting location.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(3), xp: Some(1), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(3), xp: Some(1), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02109".to_owned(),
@@ -2325,7 +2325,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned()],
             text: Some("Permanent.\nIn between each game of a campaign, you may swap up to two level 0 cards out of your deck in exchange for an equal number of level 0 cards. (You must still follow all deckbuilding rules for your investigator).".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: None, xp: Some(1), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Rogue, cost: None, xp: Some(1), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02111".to_owned(),
@@ -2341,7 +2341,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Spell".to_owned(), "Song".to_owned()],
             text: Some("Uses (5 charges).\n[action] Spend 1 charge: <b>Fight.</b> This attack uses [willpower] instead of [combat]. You get +1 [willpower] for this attack. If a [skull] symbol is revealed during this attack, this attack deals +2 damage.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(2), xp: Some(2), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(2), xp: Some(2), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02113".to_owned(),
@@ -2357,7 +2357,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Tool".to_owned(), "Melee".to_owned()],
             text: Some("[action]: <b>Fight.</b> You get +1 [combat] for this attack.\n[action] Exile Fire Extinguisher: <b>Evade.</b> You get +3 [agility] for this test. If you are successful, evade each other enemy engaged with you, as well.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Asset { class: Class::Survivor, cost: Some(2), xp: Some(1), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Survivor, cost: Some(2), xp: Some(1), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02115".to_owned(),
@@ -2373,7 +2373,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned()],
             text: Some("Uses (3 supplies).\n[fast] Spend 1 supply, exhaust Smoking Pipe, and take 1 damage: Heal 1 horror.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02117".to_owned(),
@@ -2381,7 +2381,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned()],
             text: Some("Uses (3 supplies).\n[fast] Spend 1 supply, exhaust Painkillers, and take 1 horror: Heal 1 damage.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02119".to_owned(),
@@ -2541,7 +2541,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Miskatonic".to_owned()],
             text: Some("You get +2 [intellect] while investigating [[Miskatonic]] locations.\n<b>Forced</b> - When Harold Walsted leaves play: Remove him from the game and add 1 [tablet] token to the chaos bag for the remainder of the campaign.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: Vec::new(), health: Some(1), sanity: Some(1), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 0 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: Vec::new(), health: Some(1), sanity: Some(1), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 0, uses: None },
         },
         CardMetadata {
             code: "02139".to_owned(),
@@ -2549,7 +2549,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Miskatonic".to_owned()],
             text: Some("While you control Adam Lynch, treat the \"[action] [action]\" ability on the Security Office as if it were an \"[action]\" ability.\n<b>Forced</b> - When Adam Lynch leaves play: Remove him from the game and add 1 [tablet] token to the chaos bag for the remainder of the campaign.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: Vec::new(), health: Some(1), sanity: Some(1), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 0 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: Vec::new(), health: Some(1), sanity: Some(1), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 0, uses: None },
         },
         CardMetadata {
             code: "02140".to_owned(),
@@ -2557,7 +2557,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Tome".to_owned()],
             text: Some("You get +1 [intellect].\n[action]: Gain 2 resources.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: None, slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: None, slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 1, uses: None },
         },
         CardMetadata {
             code: "02141".to_owned(),
@@ -2613,7 +2613,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned()],
             text: Some("You have 1 additional hand slot, which can only be used to hold a [[Weapon]] asset.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(2), xp: Some(0), slots: vec![Slot::Body], health: Some(1), sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(2), xp: Some(0), slots: vec![Slot::Body], health: Some(1), sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02148".to_owned(),
@@ -2629,7 +2629,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Miskatonic".to_owned()],
             text: Some("[reaction] After Art Student enters play: Discover 1 clue at your location.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(2), xp: Some(0), slots: vec![Slot::Ally], health: Some(1), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(2), xp: Some(0), slots: vec![Slot::Ally], health: Some(1), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02150".to_owned(),
@@ -2653,7 +2653,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Melee".to_owned(), "Illicit".to_owned()],
             text: Some("Fast.\n[action] <b>Fight.</b> You get +2 [combat] for this attack. If you succeed by 2 or more, this attack deals +1 damage.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(1), xp: Some(2), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 1, wild: 0 }, is_fast: true, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(1), xp: Some(2), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 1, wild: 0 }, is_fast: true, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02153".to_owned(),
@@ -2669,7 +2669,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Spell".to_owned()],
             text: Some("Uses (4 charges).\n[action] Spend one charge: <b>Fight.</b> This attack uses [willpower] instead of [combat]. You get +2 [willpower] and deal +1 damage for this attack. If a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol is revealed during this attack, take 1 horror. ".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(3), xp: Some(3), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(3), xp: Some(3), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02155".to_owned(),
@@ -2677,7 +2677,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned()],
             text: Some("You get +2 [intellect] while investigating if you have no clues.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Asset { class: Class::Survivor, cost: Some(1), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Survivor, cost: Some(1), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02156".to_owned(),
@@ -2693,7 +2693,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned()],
             text: Some("Permanent.\nYou have 1 additional accessory slot.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: None, xp: Some(3), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: None, xp: Some(3), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02158".to_owned(),
@@ -2701,7 +2701,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned()],
             text: Some("Permanent.\nYou have 1 additional ally slot.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: None, xp: Some(3), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: None, xp: Some(3), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02160".to_owned(),
@@ -2861,7 +2861,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Bystander".to_owned()],
             text: Some("Surge.\n<b>Revelation</b> - Put Helpless Passenger into play at the location to your left (or at your location if you cannot).\n[action] <b>Parley.</b> Take control of Helpless Passenger.\n<b>Forced</b> - If Helpless Passenger leaves play: Each investigator takes 1 horror.".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: Vec::new(), health: Some(1), sanity: Some(1), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 0 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: Vec::new(), health: Some(1), sanity: Some(1), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 0, uses: None },
         },
         CardMetadata {
             code: "02180".to_owned(),
@@ -2909,7 +2909,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned()],
             text: Some("Permanent.\n[fast] Spend 2 resources: You get +1 [intellect] until the end of the phase.\n[fast] Spend 2 resources: You get +1 [combat] until the end of the phase.".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: None, xp: Some(3), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Guardian, cost: None, xp: Some(3), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02186".to_owned(),
@@ -2925,7 +2925,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned()],
             text: Some("Permanent.\nWhile you have 5 or more cards in your hand, Higher Education gains:\n\"[fast] Spend 1 resource: You get +2 [willpower] for this skill test.\n[fast] Spend 1 resource: You get +2 [intellect] for this skill test.\"".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: None, xp: Some(3), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Seeker, cost: None, xp: Some(3), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02188".to_owned(),
@@ -2933,7 +2933,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned()],
             text: Some("Limit 1 per investigator.\n[reaction] When your turn begins, if there are no other investigators at your location: Gain 1 resource.".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02189".to_owned(),
@@ -2941,7 +2941,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned()],
             text: Some("Permanent.\n[fast] Spend 2 resources: You get +3 [intellect] for this skill test.\n[fast] Spend 2 resources: You get +3 [agility] for this skill test.".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: None, xp: Some(3), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Rogue, cost: None, xp: Some(3), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02190".to_owned(),
@@ -2957,7 +2957,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Spell".to_owned(), "Pact".to_owned()],
             text: Some("Permanent.\n[fast] Add 1 doom to Blood Pact: You get +3 [willpower] for this skill test. (Limit once per test.)\n[fast] Add 1 doom to Blood Pact: You get +3 [combat] for this skill test. (Limit once per test.)".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: None, xp: Some(3), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Mystic, cost: None, xp: Some(3), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02192".to_owned(),
@@ -2973,7 +2973,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned()],
             text: Some("Permanent.\n[fast] Spend 1 resource: You get +1 [combat] for this skill test.\n[fast] Spend 1 resource: You get +1 [agility] for this skill test.".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Asset { class: Class::Survivor, cost: None, xp: Some(3), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Survivor, cost: None, xp: Some(3), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02194".to_owned(),
@@ -3141,7 +3141,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Key".to_owned()],
             text: Some("<b>Revelation</b> - Take control of Key to the Chamber.\n[fast] If The Hidden Chamber is connected to your location: Attach Key to the Chamber to The Hidden Chamber.".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 0 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 0, uses: None },
         },
         CardMetadata {
             code: "02216".to_owned(),
@@ -3157,7 +3157,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Dunwich".to_owned()],
             text: Some("You get +1 [willpower].\n[reaction] After you succeed at a [willpower] test on a treachery card, exhaust Zebulon Whateley: Draw 1 card.".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(3), xp: None, slots: vec![Slot::Ally], health: Some(1), sanity: Some(4), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(3), xp: None, slots: vec![Slot::Ally], health: Some(1), sanity: Some(4), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 1, uses: None },
         },
         CardMetadata {
             code: "02218".to_owned(),
@@ -3165,7 +3165,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Dunwich".to_owned()],
             text: Some("You get +1 [agility].\n[reaction] After you evade an enemy, exhaust Earl Sawyer: Draw 1 card.".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(3), xp: None, slots: vec![Slot::Ally], health: Some(3), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 1 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(3), xp: None, slots: vec![Slot::Ally], health: Some(3), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 1 }, is_fast: false, deck_limit: 1, uses: None },
         },
         CardMetadata {
             code: "02219".to_owned(),
@@ -3173,7 +3173,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned()],
             text: Some("Powder of Ibn Ghazi enters play with X clues on it, where X is the number of characters who \"survived the Dunwich Legacy\" in your Campaign Log.\n[fast]: Move 1 clue from Powder of Ibn Ghazi to an exhausted Brood of Yog-Sothoth at your location.".to_owned()),
             pack_code: "bota".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 1, uses: None },
         },
         CardMetadata {
             code: "02220".to_owned(),
@@ -3229,7 +3229,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Firearm".to_owned()],
             text: Some("Uses (3 ammo).\n[action] Spend 1 ammo: <b>Fight.</b> You get +3 [combat] and deal +2 damage for this attack. Cannot be used to attack enemies engaged with you.".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(4), xp: Some(4), slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(4), xp: Some(4), slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UsesKind::Ammo, count: 3 }) },
         },
         CardMetadata {
             code: "02227".to_owned(),
@@ -3261,7 +3261,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Relic".to_owned()],
             text: Some("Exceptional.\n[reaction] When you reveal a non-[auto_fail] chaos token, spend 2 resources: Ignore that chaos token and reveal another one to resolve. If that token has a [auto_fail] symbol, remove Lucky Dice from the game (cannot be ignored/canceled).".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(2), xp: Some(2), slots: vec![Slot::Accessory], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(2), xp: Some(2), slots: vec![Slot::Accessory], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 1, uses: None },
         },
         CardMetadata {
             code: "02231".to_owned(),
@@ -3277,7 +3277,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Sorcerer".to_owned()],
             text: Some("You get +1 [intellect].\n[fast] Exhaust Alyssa Graham: Look at the top card of either the encounter deck or any player deck. You may then add 1 doom to Alyssa Graham to place the looked-at card on the bottom of its deck.".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(4), xp: Some(0), slots: vec![Slot::Ally], health: Some(1), sanity: Some(3), skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(4), xp: Some(0), slots: vec![Slot::Ally], health: Some(1), sanity: Some(3), skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02233".to_owned(),
@@ -3285,7 +3285,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Spell".to_owned()],
             text: Some("Uses (3 charges).\n[action] Spend 1 charge: <b>Investigate.</b> Investigate using [willpower] instead of [intellect]. You get +2 [willpower] for this test. If successful, you discover 2 additional clues at this location. If a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol is revealed during this test, after this test resolves lose all remaining actions and immediately end your turn.".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(5), xp: Some(4), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 2, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(5), xp: Some(4), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 2, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02234".to_owned(),
@@ -3293,7 +3293,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Condition".to_owned()],
             text: Some("Limit 1 per investigator.\nDuring the upkeep phase, you may choose to not gain resources.\nWhile you have no resources in your resource pool, you get +1 [willpower], +1 [intellect], +1 [combat], and +1 [agility].".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Asset { class: Class::Survivor, cost: Some(3), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Survivor, cost: Some(3), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02235".to_owned(),
@@ -3445,7 +3445,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Spell".to_owned()],
             text: Some("[action] <b>Fight.</b> This attack uses [willpower] instead of [combat]. You get +2 [willpower] for this attack for each clue on the attacked enemy. Use this ability only on an [[Abomination]] enemy.".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 0 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(0), xp: None, slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 0, uses: None },
         },
         CardMetadata {
             code: "02255".to_owned(),
@@ -3509,7 +3509,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Science".to_owned()],
             text: Some("Researched. Uses (4 supplies).\n[action] Spend 1 supply: Heal 2 damage from an investigator at your location.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(1), xp: Some(4), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 2, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(1), xp: Some(4), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 2, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02263".to_owned(),
@@ -3517,7 +3517,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Science".to_owned()],
             text: Some("Researched. Uses (3 supplies).\n[action] Spend 1 supply: <b>Fight.</b> Attack with a base [combat] skill of 6. This attack deals +2 damage.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(1), xp: Some(4), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 2, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(1), xp: Some(4), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 2, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02264".to_owned(),
@@ -3525,7 +3525,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Science".to_owned()],
             text: Some("Researched. Uses (4 supplies).\n[action] Spend 1 supply: <b>Evade.</b> Evade with a base [agility] skill of 6.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(1), xp: Some(4), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 2, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(1), xp: Some(4), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 2, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02265".to_owned(),
@@ -3533,7 +3533,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Criminal".to_owned()],
             text: Some("[fast] Spend 1 resource: Choose an [[Item]] asset from your hand and play it (paying its cost).".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(4), xp: Some(0), slots: vec![Slot::Ally], health: Some(3), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(4), xp: Some(0), slots: vec![Slot::Ally], health: Some(3), sanity: Some(2), skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02266".to_owned(),
@@ -3565,7 +3565,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Relic".to_owned()],
             text: Some("[reaction] After a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol is revealed during a skill test at your location, exhaust Jewel of Aureolus: Draw 1 card or gain 2 resources.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(3), xp: Some(3), slots: vec![Slot::Accessory], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(3), xp: Some(3), slots: vec![Slot::Accessory], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02270".to_owned(),
@@ -3589,7 +3589,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Clothing".to_owned()],
             text: Some("Reduce the difficulty of skill tests you perform during 'parley' actions by 2.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(1), xp: Some(0), slots: vec![Slot::Body], health: Some(1), sanity: Some(1), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(1), xp: Some(0), slots: vec![Slot::Body], health: Some(1), sanity: Some(1), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02273".to_owned(),
@@ -3813,7 +3813,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Firearm".to_owned()],
             text: Some("Uses (3 ammo).\n[action] Spend 1 ammo: <b>Fight.</b> You get +5 [combat] for this attack. This attack deals +2 damage.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(6), xp: Some(5), slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(6), xp: Some(5), slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UsesKind::Ammo, count: 3 }) },
         },
         CardMetadata {
             code: "02302".to_owned(),
@@ -3821,7 +3821,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Miskatonic".to_owned()],
             text: Some("[reaction] When you draw an encounter card from the encounter deck, exhaust Dr. William T. Maleson and place 1 of your clues on your location: Cancel the drawing of that card and shuffle it back into the encounter deck. Then, draw a new card from the top of the encounter deck.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(1), xp: Some(0), slots: vec![Slot::Ally], health: Some(2), sanity: Some(2), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(1), xp: Some(0), slots: vec![Slot::Ally], health: Some(2), sanity: Some(2), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02303".to_owned(),
@@ -3837,7 +3837,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Firearm".to_owned(), "Illicit".to_owned()],
             text: Some("Uses (4 ammo).\n[action] Spend 1 ammo: <b>Fight.</b> You may spend any number of additional actions when you perform this attack. You get +2 [combat] for this attack for each action being spent (including this ability's [action] cost). This attack deals +2 damage.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(5), xp: Some(4), slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 2, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(5), xp: Some(4), slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 2, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UsesKind::Ammo, count: 4 }) },
         },
         CardMetadata {
             code: "02305".to_owned(),
@@ -3845,7 +3845,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Relic".to_owned()],
             text: Some("Exceptional.\n[reaction] When a phase begins, remove The Gold Pocket Watch from the game: Skip this phase.\n[reaction] After a phase ends, remove The Gold Pocket Watch from the game: Repeat that phase.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(2), xp: Some(4), slots: vec![Slot::Accessory], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 1 },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(2), xp: Some(4), slots: vec![Slot::Accessory], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 1, uses: None },
         },
         CardMetadata {
             code: "02306".to_owned(),
@@ -3853,7 +3853,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Spell".to_owned()],
             text: Some("Uses (4 charges).\n[action] Spend 1 charge: <b>Fight.</b> This attack uses [willpower] instead of [combat]. You get +3 [willpower] and deal +2 damage for this attack. If a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol is revealed during this attack, take 2 horror.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(3), xp: Some(5), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 2, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(3), xp: Some(5), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 2, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02307".to_owned(),
@@ -3869,7 +3869,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned()],
             text: Some("[reaction] When an enemy attacks you, exhaust Aquinnah and deal 1 horror to her: Deal that enemy's damage to any enemy at your location, instead. (You still take horror dealt by the attack.)".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Asset { class: Class::Survivor, cost: Some(4), xp: Some(3), slots: vec![Slot::Ally], health: Some(1), sanity: Some(4), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Survivor, cost: Some(4), xp: Some(3), slots: vec![Slot::Ally], health: Some(1), sanity: Some(4), skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02309".to_owned(),
@@ -3877,7 +3877,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned()],
             text: Some("[reaction] After a skill test is failed, if a skill card you own is committed to that test, exhaust Try and Try Again: Return that skill card to your hand.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Asset { class: Class::Survivor, cost: Some(2), xp: Some(3), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 2, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Survivor, cost: Some(2), xp: Some(3), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 2, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02310".to_owned(),
@@ -3885,7 +3885,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Ally".to_owned(), "Conspirator".to_owned()],
             text: Some("Fast.\n[reaction] After The Red-Gloved Man enters play: Choose two of your skills. While The Red-Gloved Man is in play, raise the base value of each of those skills to 6.\n<b>Forced</b> - At the end of the mythos phase: Discard The Red-Gloved Man.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: Some(5), slots: vec![Slot::Ally], health: Some(4), sanity: Some(4), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: true, deck_limit: 2 },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: Some(5), slots: vec![Slot::Ally], health: Some(4), sanity: Some(4), skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: true, deck_limit: 2, uses: None },
         },
         CardMetadata {
             code: "02312".to_owned(),

--- a/crates/cards/src/generated/cards.rs
+++ b/crates/cards/src/generated/cards.rs
@@ -8,7 +8,7 @@
 
 use card_dsl::card_data::{
     CardKind, CardMetadata, Class, ClueValue, HealthValue, Prey, PreyDirection, PreyMeasure,
-    SkillIcons, SkillKind, Skills, Slot, Spawn, SpawnLocation, Uses, UsesKind,
+    SkillIcons, SkillKind, Skills, Slot, Spawn, SpawnLocation, UseKind, Uses,
 };
 
 /// Every card from the pinned snapshot, sorted by code.
@@ -69,7 +69,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Firearm".to_owned()],
             text: Some("Roland Banks deck only.\nUses (4 ammo).\n[action] Spend 1 ammo: <b>Fight.</b> You get +1 [combat] for this attack (if there are 1 or more clues on your location, you get +3 [combat], instead). This attack deals +1 damage.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(3), xp: None, slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 1, wild: 1 }, is_fast: false, deck_limit: 1, uses: Some(Uses { kind: UsesKind::Ammo, count: 4 }) },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(3), xp: None, slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 1, wild: 1 }, is_fast: false, deck_limit: 1, uses: Some(Uses { kind: UseKind::Ammo, count: 4 }) },
         },
         CardMetadata {
             code: "01007".to_owned(),
@@ -149,7 +149,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Firearm".to_owned()],
             text: Some("Uses (4 ammo).\n[action] Spend 1 ammo: <b>Fight.</b> You get +1 [combat] for this attack. This attack deals +1 damage.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(4), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UsesKind::Ammo, count: 4 }) },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(4), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Ammo, count: 4 }) },
         },
         CardMetadata {
             code: "01017".to_owned(),
@@ -253,7 +253,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Firearm".to_owned()],
             text: Some("Uses (2 ammo).\n[action] Spend 1 ammo: <b>Fight.</b> You get +3 [combat] for this attack. Instead of its standard damage, this attack deals 1 damage for each point you succeed by (to a minimum of 1, to a maximum of 5). If you fail and would damage another investigator, this attack deals 1 damage for each point you fail by (to a minimum of 1, to a maximum of 5).".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(5), xp: Some(4), slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 2, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UsesKind::Ammo, count: 2 }) },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(5), xp: Some(4), slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 2, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Ammo, count: 2 }) },
         },
         CardMetadata {
             code: "01030".to_owned(),
@@ -397,7 +397,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Firearm".to_owned(), "Illicit".to_owned()],
             text: Some("Uses (3 ammo).\n[action] Spend 1 ammo: <b>Fight.</b> You get +2 [combat] for this attack. If you succeed by 2 or more, this attack deals +1 damage.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(3), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UsesKind::Ammo, count: 3 }) },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(3), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Ammo, count: 3 }) },
         },
         CardMetadata {
             code: "01048".to_owned(),
@@ -3229,7 +3229,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Firearm".to_owned()],
             text: Some("Uses (3 ammo).\n[action] Spend 1 ammo: <b>Fight.</b> You get +3 [combat] and deal +2 damage for this attack. Cannot be used to attack enemies engaged with you.".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(4), xp: Some(4), slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UsesKind::Ammo, count: 3 }) },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(4), xp: Some(4), slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 1, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Ammo, count: 3 }) },
         },
         CardMetadata {
             code: "02227".to_owned(),
@@ -3813,7 +3813,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Firearm".to_owned()],
             text: Some("Uses (3 ammo).\n[action] Spend 1 ammo: <b>Fight.</b> You get +5 [combat] for this attack. This attack deals +2 damage.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(6), xp: Some(5), slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UsesKind::Ammo, count: 3 }) },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(6), xp: Some(5), slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Ammo, count: 3 }) },
         },
         CardMetadata {
             code: "02302".to_owned(),
@@ -3837,7 +3837,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Firearm".to_owned(), "Illicit".to_owned()],
             text: Some("Uses (4 ammo).\n[action] Spend 1 ammo: <b>Fight.</b> You may spend any number of additional actions when you perform this attack. You get +2 [combat] for this attack for each action being spent (including this ability's [action] cost). This attack deals +2 damage.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(5), xp: Some(4), slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 2, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UsesKind::Ammo, count: 4 }) },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(5), xp: Some(4), slots: vec![Slot::Hand, Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 2, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Ammo, count: 4 }) },
         },
         CardMetadata {
             code: "02305".to_owned(),

--- a/crates/cards/src/generated/cards.rs
+++ b/crates/cards/src/generated/cards.rs
@@ -173,7 +173,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned(), "Science".to_owned()],
             text: Some("Uses (3 supplies). If First Aid has no supplies, discard it.\n[action] Spend 1 supply: Heal 1 damage or horror from an investigator at your location.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Guardian, cost: Some(2), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
+            kind: CardKind::Asset { class: Class::Guardian, cost: Some(2), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Supplies, count: 3 }) },
         },
         CardMetadata {
             code: "01020".to_owned(),
@@ -485,7 +485,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Talent".to_owned()],
             text: Some("Uses (4 secrets). If Forbidden Knowledge has no secrets, discard it.\n[fast] Exhaust Forbidden Knowledge and take 1 horror: Move 1 secret from Forbidden Knowledge to your resource pool, as a resource.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(0), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(0), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Secrets, count: 4 }) },
         },
         CardMetadata {
             code: "01059".to_owned(),
@@ -501,7 +501,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Spell".to_owned()],
             text: Some("Uses (4 charges).\n[action] Spend 1 charge: <b>Fight.</b> This attack uses [willpower] instead of [combat] and deals +1 damage. If a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol is revealed during this attack, take 1 horror.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(3), xp: Some(0), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(3), xp: Some(0), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Charges, count: 4 }) },
         },
         CardMetadata {
             code: "01061".to_owned(),
@@ -509,7 +509,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Spell".to_owned()],
             text: Some("Uses (3 charges).\n[action] Exhaust Scrying and spend 1 charge: Look at the top 3 cards of any investigator's deck or the encounter deck. Return them to the top of that deck in any order.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(1), xp: Some(0), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(1), xp: Some(0), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Charges, count: 3 }) },
         },
         CardMetadata {
             code: "01062".to_owned(),
@@ -589,7 +589,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Relic".to_owned()],
             text: Some("Uses (4 charges). If Grotesque Statue has no charges, discard it.\n[reaction] When you would reveal a chaos token, spend 1 charge: Reveal 2 chaos tokens instead of 1. Choose 1 of those tokens to resolve, and ignore the other.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(2), xp: Some(4), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 2, uses: None },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(2), xp: Some(4), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 0, wild: 1 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Charges, count: 4 }) },
         },
         CardMetadata {
             code: "01072".to_owned(),
@@ -717,7 +717,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Tool".to_owned()],
             text: Some("Uses (3 supplies).\n[action] Spend 1 supply: <b>Investigate.</b> Your location gets -2 shroud for this investigation.".to_owned()),
             pack_code: "core".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(2), xp: Some(0), slots: vec![Slot::Hand], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Supplies, count: 3 }) },
         },
         CardMetadata {
             code: "01088".to_owned(),
@@ -1653,7 +1653,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Illicit".to_owned()],
             text: Some("Uses (4 supplies).\n[action] Spend 1 supply: Choose an investigator at your location to heal 1 horror. Then, that investigator tests [willpower] (2). If the test succeeds, he or she heals 1 additional horror. If the test fails, he or she discards 1 card at random from his or her hand.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Rogue, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
+            kind: CardKind::Asset { class: Class::Rogue, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Supplies, count: 4 }) },
         },
         CardMetadata {
             code: "02025".to_owned(),
@@ -1685,7 +1685,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Spell".to_owned()],
             text: Some("Uses (3 charges).\n[action] Spend 1 charge: <b>Investigate.</b> Investigate using [willpower] instead of [intellect]. If you succeed, discover 1 additional clue at this location. If a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol is revealed during this test, after this test resolves lose all remaining actions and immediately end your turn.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(4), xp: Some(0), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(4), xp: Some(0), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 1, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Charges, count: 3 }) },
         },
         CardMetadata {
             code: "02029".to_owned(),
@@ -1701,7 +1701,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Spell".to_owned()],
             text: Some("Uses (3 charges).\n[action] Spend 1 charge: Heal 1 horror from an investigator at your location.".to_owned()),
             pack_code: "dwl".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(2), xp: Some(0), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(2), xp: Some(0), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Charges, count: 3 }) },
         },
         CardMetadata {
             code: "02031".to_owned(),
@@ -2341,7 +2341,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Spell".to_owned(), "Song".to_owned()],
             text: Some("Uses (5 charges).\n[action] Spend 1 charge: <b>Fight.</b> This attack uses [willpower] instead of [combat]. You get +1 [willpower] for this attack. If a [skull] symbol is revealed during this attack, this attack deals +2 damage.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(2), xp: Some(2), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(2), xp: Some(2), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Charges, count: 5 }) },
         },
         CardMetadata {
             code: "02113".to_owned(),
@@ -2373,7 +2373,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned()],
             text: Some("Uses (3 supplies).\n[fast] Spend 1 supply, exhaust Smoking Pipe, and take 1 damage: Heal 1 horror.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Supplies, count: 3 }) },
         },
         CardMetadata {
             code: "02117".to_owned(),
@@ -2381,7 +2381,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned()],
             text: Some("Uses (3 supplies).\n[fast] Spend 1 supply, exhaust Painkillers, and take 1 horror: Heal 1 damage.".to_owned()),
             pack_code: "tmm".to_owned(),
-            kind: CardKind::Asset { class: Class::Neutral, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
+            kind: CardKind::Asset { class: Class::Neutral, cost: Some(1), xp: Some(0), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Supplies, count: 3 }) },
         },
         CardMetadata {
             code: "02119".to_owned(),
@@ -2669,7 +2669,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Spell".to_owned()],
             text: Some("Uses (4 charges).\n[action] Spend one charge: <b>Fight.</b> This attack uses [willpower] instead of [combat]. You get +2 [willpower] and deal +1 damage for this attack. If a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol is revealed during this attack, take 1 horror. ".to_owned()),
             pack_code: "tece".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(3), xp: Some(3), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(3), xp: Some(3), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 1, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Charges, count: 4 }) },
         },
         CardMetadata {
             code: "02155".to_owned(),
@@ -3285,7 +3285,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Spell".to_owned()],
             text: Some("Uses (3 charges).\n[action] Spend 1 charge: <b>Investigate.</b> Investigate using [willpower] instead of [intellect]. You get +2 [willpower] for this test. If successful, you discover 2 additional clues at this location. If a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol is revealed during this test, after this test resolves lose all remaining actions and immediately end your turn.".to_owned()),
             pack_code: "uau".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(5), xp: Some(4), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 2, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(5), xp: Some(4), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 2, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Charges, count: 3 }) },
         },
         CardMetadata {
             code: "02234".to_owned(),
@@ -3509,7 +3509,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Science".to_owned()],
             text: Some("Researched. Uses (4 supplies).\n[action] Spend 1 supply: Heal 2 damage from an investigator at your location.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(1), xp: Some(4), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 2, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(1), xp: Some(4), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 2, intellect: 0, combat: 0, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Supplies, count: 4 }) },
         },
         CardMetadata {
             code: "02263".to_owned(),
@@ -3517,7 +3517,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Science".to_owned()],
             text: Some("Researched. Uses (3 supplies).\n[action] Spend 1 supply: <b>Fight.</b> Attack with a base [combat] skill of 6. This attack deals +2 damage.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(1), xp: Some(4), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 2, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(1), xp: Some(4), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 2, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Supplies, count: 3 }) },
         },
         CardMetadata {
             code: "02264".to_owned(),
@@ -3525,7 +3525,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Item".to_owned(), "Science".to_owned()],
             text: Some("Researched. Uses (4 supplies).\n[action] Spend 1 supply: <b>Evade.</b> Evade with a base [agility] skill of 6.".to_owned()),
             pack_code: "wda".to_owned(),
-            kind: CardKind::Asset { class: Class::Seeker, cost: Some(1), xp: Some(4), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 2, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
+            kind: CardKind::Asset { class: Class::Seeker, cost: Some(1), xp: Some(4), slots: Vec::new(), health: None, sanity: None, skill_icons: SkillIcons { willpower: 0, intellect: 0, combat: 0, agility: 2, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Supplies, count: 4 }) },
         },
         CardMetadata {
             code: "02265".to_owned(),
@@ -3853,7 +3853,7 @@ pub fn all_cards() -> Vec<CardMetadata> {
             traits: vec!["Spell".to_owned()],
             text: Some("Uses (4 charges).\n[action] Spend 1 charge: <b>Fight.</b> This attack uses [willpower] instead of [combat]. You get +3 [willpower] and deal +2 damage for this attack. If a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol is revealed during this attack, take 2 horror.".to_owned()),
             pack_code: "litas".to_owned(),
-            kind: CardKind::Asset { class: Class::Mystic, cost: Some(3), xp: Some(5), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 2, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: None },
+            kind: CardKind::Asset { class: Class::Mystic, cost: Some(3), xp: Some(5), slots: vec![Slot::Arcane], health: None, sanity: None, skill_icons: SkillIcons { willpower: 1, intellect: 0, combat: 2, agility: 0, wild: 0 }, is_fast: false, deck_limit: 2, uses: Some(Uses { kind: UseKind::Charges, count: 4 }) },
         },
         CardMetadata {
             code: "02307".to_owned(),

--- a/crates/cards/tests/reject_rollback.rs
+++ b/crates/cards/tests/reject_rollback.rs
@@ -56,6 +56,7 @@ fn probe_metadata(code: &CardCode) -> Option<&'static CardMetadata> {
             skill_icons: SkillIcons::default(),
             is_fast: false,
             deck_limit: 2,
+            uses: None,
         },
     }))
 }

--- a/crates/game-core/src/card_registry.rs
+++ b/crates/game-core/src/card_registry.rs
@@ -120,6 +120,7 @@ mod tests {
                 skill_icons: SkillIcons::default(),
                 is_fast: false,
                 deck_limit: 2,
+                uses: None,
             },
         }
     }

--- a/crates/game-core/src/engine/dispatch/abilities.rs
+++ b/crates/game-core/src/engine/dispatch/abilities.rs
@@ -1,9 +1,11 @@
 //! Activated-ability dispatch handlers.
 
+use std::collections::BTreeMap;
+
 use crate::card_registry;
 use crate::dsl::{Cost, Trigger};
 use crate::event::Event;
-use crate::state::{CardCode, CardInstanceId, Investigator, InvestigatorId};
+use crate::state::{CardCode, CardInstanceId, Investigator, InvestigatorId, UseKind};
 
 use super::super::evaluator::{apply_effect, EvalContext};
 use super::super::outcome::EngineOutcome;
@@ -148,6 +150,22 @@ fn pay_activation_costs(
                     code: source_code.clone(),
                 });
             }
+            Cost::SpendUses { kind, count } => {
+                let card = &mut cx
+                    .state
+                    .investigators
+                    .get_mut(&investigator)
+                    .expect("validated above")
+                    .cards_in_play[in_play_pos];
+                let remaining = card.uses.entry(*kind).or_insert(0);
+                *remaining = remaining.saturating_sub(*count);
+                cx.events.push(Event::UsesSpent {
+                    investigator,
+                    instance_id,
+                    kind: *kind,
+                    amount: *count,
+                });
+            }
             Cost::DiscardCardFromHand => {
                 unreachable!("DiscardCardFromHand rejected earlier in check_cost_payable")
             }
@@ -209,6 +227,7 @@ pub(super) fn check_cost_payable(
     cost: &Cost,
     inv: &Investigator,
     source_exhausted: bool,
+    source_uses: &BTreeMap<UseKind, u8>,
 ) -> Result<(), String> {
     match cost {
         Cost::Resources(n) => {
@@ -230,10 +249,43 @@ pub(super) fn check_cost_payable(
             }
             Ok(())
         }
+        Cost::SpendUses { kind, count } => {
+            let remaining = source_uses.get(kind).copied().unwrap_or(0);
+            if remaining < *count {
+                return Err(format!(
+                    "ActivateAbility: needs {count} {kind:?} use(s); source has {remaining}",
+                ));
+            }
+            Ok(())
+        }
         Cost::DiscardCardFromHand => Err(
             "TODO: Cost::DiscardCardFromHand requires AwaitingInput + ResolveInput \
              dispatch; no card uses this cost yet so the engine consumer hasn't landed."
                 .to_string(),
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::fixtures::test_investigator;
+
+    #[test]
+    fn spend_uses_payable_only_with_enough_of_the_named_kind() {
+        let inv = test_investigator(1);
+        let ammo4: BTreeMap<UseKind, u8> = [(UseKind::Ammo, 4)].into_iter().collect();
+        let empty: BTreeMap<UseKind, u8> = BTreeMap::new();
+        let cost = Cost::SpendUses {
+            kind: UseKind::Ammo,
+            count: 1,
+        };
+        // Enough of the right kind → payable.
+        assert!(check_cost_payable(&cost, &inv, false, &ammo4).is_ok());
+        // No ammo at all → reject.
+        assert!(check_cost_payable(&cost, &inv, false, &empty).is_err());
+        // Wrong kind present, no ammo → reject.
+        let charges: BTreeMap<UseKind, u8> = [(UseKind::Charges, 4)].into_iter().collect();
+        assert!(check_cost_payable(&cost, &inv, false, &charges).is_err());
     }
 }

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -139,6 +139,7 @@ pub(super) fn investigate(cx: &mut Cx, investigator: InvestigatorId) -> EngineOu
         None,
         None,
         None,
+        0, // no weapon/effect modifier on a base Investigate
     )
 }
 
@@ -481,10 +482,14 @@ pub(super) fn fight(cx: &mut Cx, investigator: InvestigatorId, enemy_id: EnemyId
         SkillKind::Combat,
         SkillTestKind::Fight,
         fight_difficulty,
-        SkillTestFollowUp::Fight { enemy: enemy_id },
+        SkillTestFollowUp::Fight {
+            enemy: enemy_id,
+            extra_damage: 0,
+        },
         None,
         None,
         None,
+        0, // base Fight: no weapon modifier
     )
 }
 
@@ -523,5 +528,6 @@ pub(super) fn evade(cx: &mut Cx, investigator: InvestigatorId, enemy_id: EnemyId
         None,
         None,
         None,
+        0, // no weapon/effect modifier on a base Evade
     )
 }

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -515,15 +515,25 @@ pub(super) fn play_card(
         super::PlayDestination::InPlay => {
             let instance_id = CardInstanceId(cx.state.next_card_instance_id);
             cx.state.next_card_instance_id = cx.state.next_card_instance_id.saturating_add(1);
+            // Seed the named-uses pool ("ammo") from the asset's printed
+            // `uses` before moving the code into the instance.
+            let initial_uses = crate::card_registry::current()
+                .and_then(|reg| (reg.metadata_for)(&code))
+                .and_then(|m| match &m.kind {
+                    crate::card_data::CardKind::Asset { uses, .. } => *uses,
+                    _ => None,
+                });
             let inv_mut = cx
                 .state
                 .investigators
                 .get_mut(&investigator)
                 .expect("checked");
             let card = inv_mut.hand.remove(idx);
-            inv_mut
-                .cards_in_play
-                .push(CardInPlay::enter_play(card, instance_id));
+            let mut in_play = CardInPlay::enter_play(card, instance_id);
+            if let Some(u) = initial_uses {
+                in_play.uses.insert(u.kind, u.count);
+            }
+            inv_mut.cards_in_play.push(in_play);
         }
         super::PlayDestination::Discard => {
             let inv_mut = cx

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -5,11 +5,32 @@ use std::collections::BTreeMap;
 use crate::engine::EngineOutcome;
 use crate::event::Event;
 use crate::state::{
-    CardInstanceId, DefeatCause, EnemyAttackSource, EnemyId, InvestigatorId, PendingEnemyAttack,
-    Status, WindowKind,
+    CardInstanceId, DefeatCause, EnemyAttackSource, EnemyId, GameState, InvestigatorId,
+    PendingEnemyAttack, Status, WindowKind,
 };
 
 use super::Cx;
+
+/// The single enemy currently engaged with `investigator`, or `None` if
+/// zero or 2+ are engaged. `Effect::Fight` auto-targets via this; the
+/// 2+ case is a deferred interactive choice (lands with the #212/#213
+/// interactive-choice cluster), so the activation check rejects it.
+pub(crate) fn single_engaged_enemy(
+    state: &GameState,
+    investigator: InvestigatorId,
+) -> Option<EnemyId> {
+    let mut engaged = state
+        .enemies
+        .iter()
+        .filter(|(_, e)| e.engaged_with == Some(investigator))
+        .map(|(id, _)| *id);
+    let first = engaged.next()?;
+    if engaged.next().is_some() {
+        None
+    } else {
+        Some(first)
+    }
+}
 
 /// Public entry point for card effects to deal damage to an enemy.
 ///
@@ -746,10 +767,41 @@ pub(super) fn resume_enemy_attack(cx: &mut Cx) -> EngineOutcome {
 #[cfg(test)]
 mod combat_tests {
     use super::super::Cx;
+    use super::single_engaged_enemy;
     use crate::event::Event;
     use crate::state::{EnemyId, InvestigatorId};
     use crate::test_support::{test_enemy, test_investigator, GameStateBuilder};
     use crate::{assert_event, assert_no_event};
+
+    #[test]
+    fn single_engaged_enemy_some_for_one_none_for_zero_or_two() {
+        let inv_id = InvestigatorId(1);
+        let mut e1 = test_enemy(100, "A");
+        e1.engaged_with = Some(inv_id);
+
+        // Exactly one engaged → Some.
+        let s1 = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_enemy(e1.clone())
+            .build();
+        assert_eq!(single_engaged_enemy(&s1, inv_id), Some(EnemyId(100)));
+
+        // Two engaged → None (deferred multi-target selection).
+        let mut e2 = test_enemy(101, "B");
+        e2.engaged_with = Some(inv_id);
+        let s2 = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_enemy(e1)
+            .with_enemy(e2)
+            .build();
+        assert_eq!(single_engaged_enemy(&s2, inv_id), None);
+
+        // Zero engaged → None.
+        let s0 = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .build();
+        assert_eq!(single_engaged_enemy(&s0, inv_id), None);
+    }
 
     #[test]
     fn defeating_victory_enemy_places_it_in_the_victory_display() {

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -965,6 +965,7 @@ pub(super) fn check_activate_ability(
     };
     let source_code = inv.cards_in_play[in_play_pos].code.clone();
     let source_exhausted = inv.cards_in_play[in_play_pos].exhausted;
+    let source_uses = inv.cards_in_play[in_play_pos].uses.clone();
 
     // Invariant: `resolve_activated_ability` currently returns only `Ok(...)`
     // (success) or `Err(EngineOutcome::Rejected { ... })` (validation failure).
@@ -1029,7 +1030,9 @@ pub(super) fn check_activate_ability(
     // before any mutation so an all-or-nothing reject leaves state
     // untouched.
     for cost in &costs {
-        if let Err(reason) = super::abilities::check_cost_payable(cost, inv, source_exhausted) {
+        if let Err(reason) =
+            super::abilities::check_cost_payable(cost, inv, source_exhausted, &source_uses)
+        {
             return Err(reason.into());
         }
     }

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -929,6 +929,15 @@ pub(super) fn check_play_card(
     })
 }
 
+/// True if `effect` initiates a Fight at its top level.
+///
+/// `TODO(#212/#213)`: recurse `Seq`/`If` once a card fights in only one
+/// branch — no Slice-1 card does (.38 Special's `IntExpr` branches both
+/// fight, so the Fight node is unconditionally top-level).
+fn effect_initiates_fight(effect: &crate::dsl::Effect) -> bool {
+    matches!(effect, crate::dsl::Effect::Fight { .. })
+}
+
 /// Pure-validation peer to [`activate_ability`]. Mirrors
 /// [`check_play_card`]: validation block lifted verbatim, no behavior
 /// change at the call site.
@@ -1035,6 +1044,23 @@ pub(super) fn check_activate_ability(
         {
             return Err(reason.into());
         }
+    }
+
+    // A Fight-initiating ability needs exactly one engaged enemy, validated
+    // here so the activation rejects at the check layer (and `Effect::Fight`
+    // can treat a missing target as an invariant violation). The apply-loop
+    // snapshot already guards state integrity on reject; this keeps
+    // `check_activate_ability` an honest playability oracle (it is reused by
+    // `any_fast_play_eligible`). 0 engaged → no target; 2+ → deferred
+    // multi-target selection (#212/#213 interactive-choice cluster).
+    if effect_initiates_fight(&effect)
+        && super::combat::single_engaged_enemy(state, investigator).is_none()
+    {
+        return Err(
+            "ActivateAbility: a Fight ability needs exactly one engaged enemy \
+             (0 = no target; 2+ multi-target selection deferred with #212/#213)"
+                .into(),
+        );
     }
 
     Ok(super::ActivateCheckResult {

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -606,7 +606,12 @@ fn apply_skill_test_follow_up(
             // (no commit-window effects mutate enemies), so
             // damage_enemy's enemy-missing panic stays loud. A weapon's
             // bonus damage (.38 Special's +1) rides on `extra_damage`.
-            super::combat::damage_enemy(cx, enemy, 1 + extra_damage, Some(investigator));
+            super::combat::damage_enemy(
+                cx,
+                enemy,
+                1u8.saturating_add(extra_damage),
+                Some(investigator),
+            );
             EngineOutcome::Done
         }
         SkillTestFollowUp::Evade { enemy } => {

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -35,6 +35,7 @@ pub(in crate::engine) fn start_skill_test(
     on_success: Option<card_dsl::dsl::Effect>,
     on_fail: Option<card_dsl::dsl::Effect>,
     source: Option<crate::state::CardInstanceId>,
+    test_modifier: i8,
 ) -> EngineOutcome {
     // Validate-first: investigator must exist and be Active; chaos
     // bag must be non-empty so we can draw; difficulty must be non-
@@ -92,6 +93,7 @@ pub(in crate::engine) fn start_skill_test(
         on_success,
         source,
         continuation: FinishContinuation::AwaitingCommit,
+        test_modifier,
     });
     cx.events.push(Event::SkillTestStarted {
         investigator,
@@ -416,9 +418,16 @@ fn sum_skill_value(
         constant_skill_modifier(state, reg, investigator, skill, kind)
     });
     let pending_mod = pending_skill_modifier(state, investigator, skill);
+    // One-shot modifier the initiating effect snapshotted (a weapon's
+    // "+N for this attack"); 0 for player-action tests.
+    let test_mod = state
+        .in_flight_skill_test
+        .as_ref()
+        .map_or(0, |t| t.test_modifier);
     base.saturating_add(constant_mod)
         .saturating_add(pending_mod)
         .saturating_add(icon_mod)
+        .saturating_add(test_mod)
 }
 
 /// Sum the skill-icon contribution from the cards at `indices` in
@@ -589,11 +598,15 @@ fn apply_skill_test_follow_up(
             }
             outcome
         }
-        SkillTestFollowUp::Fight { enemy } => {
+        SkillTestFollowUp::Fight {
+            enemy,
+            extra_damage,
+        } => {
             // Mid-test enemy disappearance isn't possible in Phase 3
             // (no commit-window effects mutate enemies), so
-            // damage_enemy's enemy-missing panic stays loud.
-            super::combat::damage_enemy(cx, enemy, 1, Some(investigator));
+            // damage_enemy's enemy-missing panic stays loud. A weapon's
+            // bonus damage (.38 Special's +1) rides on `extra_damage`.
+            super::combat::damage_enemy(cx, enemy, 1 + extra_damage, Some(investigator));
             EngineOutcome::Done
         }
         SkillTestFollowUp::Evade { enemy } => {
@@ -642,7 +655,7 @@ fn fire_retaliate_if_any(cx: &mut Cx, investigator: InvestigatorId, succeeded: b
         return;
     }
     let follow_up = cx.state.in_flight_skill_test.as_ref().map(|t| t.follow_up);
-    let Some(SkillTestFollowUp::Fight { enemy }) = follow_up else {
+    let Some(SkillTestFollowUp::Fight { enemy, .. }) = follow_up else {
         return;
     };
     let retaliates = cx
@@ -800,6 +813,7 @@ pub(super) fn perform_skill_test(
         None,
         None,
         None,
+        0, // bare PerformSkillTest: no effect modifier
     )
 }
 
@@ -941,6 +955,7 @@ mod tests {
                 1,
             ))),
             None,
+            0,
         );
         assert!(matches!(out, EngineOutcome::AwaitingInput { .. }));
         // What resolve_encounter_card does on a suspended revelation:
@@ -1018,6 +1033,7 @@ mod tests {
             Some(deal_horror(InvestigatorTarget::You, 1)),
             None,
             None,
+            0,
         );
         assert!(matches!(out, EngineOutcome::AwaitingInput { .. }));
         let out = finish_skill_test(&mut cx, &[]);

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -52,8 +52,8 @@
 
 use crate::card_registry::CardRegistry;
 use crate::dsl::{
-    Condition, Effect, InvestigatorTarget, LocationTarget, ModifierScope, SkillTestKind, Stat,
-    Trigger,
+    Condition, Effect, IntExpr, InvestigatorTarget, LocationTarget, ModifierScope, SkillTestKind,
+    Stat, Trigger,
 };
 use crate::event::Event;
 use crate::state::{GameState, InvestigatorId, SkillKind};
@@ -230,7 +230,57 @@ pub(crate) fn apply_effect(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) 
                      never executed"
                 .into(),
         },
+        Effect::Fight {
+            combat_modifier,
+            extra_damage,
+        } => apply_fight(cx, &eval_ctx, combat_modifier, *extra_damage),
     }
+}
+
+/// Resolve [`Effect::Fight`]: snapshot the combat modifier, auto-target
+/// the single engaged enemy, and start a Combat skill test (reusing the
+/// suspend/resume commit-window path) whose Fight follow-up deals
+/// `1 + extra_damage`. The activation check has already guaranteed
+/// exactly one engaged enemy, so a missing target here is a state-shape
+/// violation rejected loudly rather than silently no-oped.
+fn apply_fight(
+    cx: &mut Cx,
+    eval_ctx: &EvalContext,
+    combat_modifier: &IntExpr,
+    extra_damage: u8,
+) -> EngineOutcome {
+    let modifier = match eval_int_expr(cx.state, eval_ctx.controller, combat_modifier) {
+        Ok(m) => m,
+        Err(reason) => {
+            return EngineOutcome::Rejected {
+                reason: reason.into(),
+            }
+        }
+    };
+    let Some(enemy_id) =
+        crate::engine::dispatch::combat::single_engaged_enemy(cx.state, eval_ctx.controller)
+    else {
+        return EngineOutcome::Rejected {
+            reason: "Effect::Fight: expected exactly one engaged enemy (target check skipped?)"
+                .into(),
+        };
+    };
+    let fight_difficulty = cx.state.enemies.get(&enemy_id).map_or(0, |e| e.fight);
+    crate::engine::dispatch::skill_test::start_skill_test(
+        cx,
+        eval_ctx.controller,
+        SkillKind::Combat,
+        SkillTestKind::Fight,
+        fight_difficulty,
+        crate::state::SkillTestFollowUp::Fight {
+            enemy: enemy_id,
+            extra_damage,
+        },
+        None,
+        None,
+        eval_ctx.source,
+        modifier,
+    )
 }
 
 /// Resolve [`Effect::DiscardSelf`]: remove `eval_ctx.source` from
@@ -386,6 +436,30 @@ fn eval_condition(
                  or wait for an OnEvent-based reaction model to surface past-test outcome."
             ))
         }
+    }
+}
+
+/// Resolve an [`IntExpr`] against the current state for `controller`.
+///
+/// [`IntExpr::Cond`] evaluates its [`Condition`] (reusing
+/// [`eval_condition`]); an unexpressible condition propagates as `Err`,
+/// which the caller turns into [`EngineOutcome::Rejected`].
+fn eval_int_expr(
+    state: &GameState,
+    controller: InvestigatorId,
+    expr: &IntExpr,
+) -> Result<i8, String> {
+    match expr {
+        IntExpr::Lit(n) => Ok(*n),
+        IntExpr::Cond {
+            when,
+            then,
+            otherwise,
+        } => Ok(if eval_condition(state, controller, when)? {
+            *then
+        } else {
+            *otherwise
+        }),
     }
 }
 

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -328,7 +328,7 @@ fn apply_if(
     then: &Effect,
     else_: Option<&Effect>,
 ) -> EngineOutcome {
-    let holds = match eval_condition(cx.state, condition) {
+    let holds = match eval_condition(cx.state, eval_ctx.controller, condition) {
         Ok(b) => b,
         Err(reason) => {
             return EngineOutcome::Rejected {
@@ -350,13 +350,26 @@ fn apply_if(
 /// Returns `Err` for conditions that aren't expressible yet (the
 /// state shape they'd query against doesn't exist) — the caller
 /// turns those into [`EngineOutcome::Rejected`].
-fn eval_condition(state: &GameState, condition: &Condition) -> Result<bool, String> {
+fn eval_condition(
+    state: &GameState,
+    controller: InvestigatorId,
+    condition: &Condition,
+) -> Result<bool, String> {
     match condition {
         Condition::SkillTestKind(kind) => {
             let t = state.in_flight_skill_test.as_ref().ok_or_else(|| {
                 "Condition::SkillTestKind but no skill test is in flight".to_owned()
             })?;
             Ok(t.kind == *kind)
+        }
+        Condition::LocationHasClues => {
+            let has = state
+                .investigators
+                .get(&controller)
+                .and_then(|inv| inv.current_location)
+                .and_then(|loc| state.locations.get(&loc))
+                .is_some_and(|l| l.clues > 0);
+            Ok(has)
         }
         Condition::SkillTest { outcome } => {
             // Inside an [`Trigger::OnSkillTestResolution`] effect, the
@@ -1113,13 +1126,39 @@ mod tests {
     use crate::{assert_event, assert_event_count, assert_no_event};
 
     use super::{
-        apply_effect, constant_skill_modifier, effective_shroud,
+        apply_effect, constant_skill_modifier, effective_shroud, eval_condition,
         unconditional_constant_stat_modifier, EngineOutcome, EvalContext,
     };
+    use crate::dsl::Condition;
     use crate::engine::Cx;
 
     fn ctx(id: u32) -> EvalContext {
         EvalContext::for_controller(InvestigatorId(id))
+    }
+
+    #[test]
+    fn location_has_clues_condition_tracks_clue_count() {
+        let inv_id = InvestigatorId(1);
+        let loc_id = LocationId(1);
+        let with_clues = |clue_count: u8| {
+            let mut inv = test_investigator(1);
+            inv.current_location = Some(loc_id);
+            let mut loc = test_location(1, "Study");
+            loc.clues = clue_count;
+            GameStateBuilder::new()
+                .with_investigator(inv)
+                .with_location(loc)
+                .build()
+        };
+        // Condition tracks clue presence at the controller's location.
+        assert_eq!(
+            eval_condition(&with_clues(1), inv_id, &Condition::LocationHasClues),
+            Ok(true)
+        );
+        assert_eq!(
+            eval_condition(&with_clues(0), inv_id, &Condition::LocationHasClues),
+            Ok(false)
+        );
     }
 
     #[test]

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -265,7 +265,14 @@ fn apply_fight(
                 .into(),
         };
     };
-    let fight_difficulty = cx.state.enemies.get(&enemy_id).map_or(0, |e| e.fight);
+    // `enemy_id` came from `single_engaged_enemy` over this same map, so
+    // it is present — a silent 0-difficulty default would mask corruption.
+    let fight_difficulty = cx
+        .state
+        .enemies
+        .get(&enemy_id)
+        .expect("single_engaged_enemy returned an id absent from state.enemies")
+        .fight;
     crate::engine::dispatch::skill_test::start_skill_test(
         cx,
         eval_ctx.controller,

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -214,6 +214,7 @@ pub(crate) fn apply_effect(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) 
             on_success.as_ref().map(|b| (**b).clone()),
             on_fail.as_ref().map(|b| (**b).clone()),
             eval_ctx.source,
+            0, // a Revelation skill test takes its difficulty as printed
         ),
         Effect::DiscardSelf => discard_self(cx, &eval_ctx),
         Effect::PutIntoThreatArea { code } => {
@@ -1432,6 +1433,7 @@ mod tests {
             on_success: None,
             source: None,
             continuation: crate::state::FinishContinuation::AwaitingCommit,
+            test_modifier: 0,
         });
         let mut events = Vec::new();
 
@@ -1505,6 +1507,7 @@ mod tests {
             on_success: None,
             source: None,
             continuation: crate::state::FinishContinuation::AwaitingCommit,
+            test_modifier: 0,
         });
         state
     }
@@ -1669,6 +1672,7 @@ mod tests {
             on_success: None,
             source: None,
             continuation: crate::state::FinishContinuation::AwaitingCommit,
+            test_modifier: 0,
         });
         let mut events = Vec::new();
 

--- a/crates/game-core/src/event.rs
+++ b/crates/game-core/src/event.rs
@@ -18,7 +18,7 @@ use card_dsl::card_data::CardType;
 use crate::scenario::Resolution;
 use crate::state::{
     CardCode, CardInstanceId, ChaosToken, DefeatCause, EnemyId, InvestigatorId, LocationId, Phase,
-    SkillKind, TokenResolution, WindowKind, Zone,
+    SkillKind, TokenResolution, UseKind, WindowKind, Zone,
 };
 
 /// One state-change record emitted by the engine.
@@ -136,6 +136,18 @@ pub enum Event {
         /// Who paid resources.
         investigator: InvestigatorId,
         /// Amount paid.
+        amount: u8,
+    },
+    /// Tokens were spent from a source asset's runtime uses-pool to pay a
+    /// `Cost::SpendUses` (".38 Special": "Spend 1 ammo").
+    UsesSpent {
+        /// Investigator who activated the ability.
+        investigator: InvestigatorId,
+        /// The source asset instance whose uses were spent.
+        instance_id: CardInstanceId,
+        /// Which uses-kind was spent.
+        kind: UseKind,
+        /// How many were spent.
         amount: u8,
     },
     /// A skill test was declared and resolution has begun.

--- a/crates/game-core/src/state/card.rs
+++ b/crates/game-core/src/state/card.rs
@@ -90,29 +90,10 @@ pub enum Zone {
 #[serde(transparent)]
 pub struct CardInstanceId(pub u32);
 
-/// A named-uses kind for asset cards that track a finite resource.
-///
-/// Translation of the rulebook's typed-uses taxonomy. Cards declare
-/// what flavor of uses they have ("Uses (3 charges)", "Uses (1 ammo)")
-/// and effects spend them with primitives that take a [`UseKind`].
-///
-/// Phase-3 minimal set; cards using exotic uses (Time on some Dunwich
-/// cards, Resource on a few Mystic effects) add their variant when
-/// they land.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-#[non_exhaustive]
-pub enum UseKind {
-    /// Charges — most spell assets (Rite of Seeking, Shrivelling).
-    Charges,
-    /// Ammo — firearms (.38 Special, .45 Automatic).
-    Ammo,
-    /// Secrets — Seeker investigation aids (Encyclopedia, Old Book of
-    /// Lore in some cycles).
-    Secrets,
-    /// Supplies — Survivor tools (First Aid in some cycles, expedition
-    /// caches).
-    Supplies,
-}
+// `UseKind` is defined in `card-dsl` (the lowest layer) so the printed
+// metadata (`card_data::Uses`) and this runtime pool share one type;
+// re-exported here at its historical `game_core::state` path.
+pub use card_dsl::card_data::UseKind;
 
 /// State for a single copy of a card in play under an investigator's
 /// control.

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -474,6 +474,13 @@ pub struct InFlightSkillTest {
     /// invariant "outcome is known iff the test is past the commit
     /// window" is structural.
     pub continuation: FinishContinuation,
+    /// A flat modifier applied to the test total, snapshotted by the
+    /// effect that initiated the test (`Effect::Fight`'s combat
+    /// modifier). `0` for player-action tests, which take their
+    /// modifiers from cards in play. Distinct from constant/pending
+    /// modifiers — this is the one-shot "+N for this attack" a weapon
+    /// grants.
+    pub test_modifier: i8,
 }
 
 /// Where the skill-test resolution driver should resume on the next
@@ -588,6 +595,8 @@ pub enum SkillTestFollowUp {
     Fight {
         /// The enemy the Fight action targeted.
         enemy: EnemyId,
+        /// Bonus damage beyond the base 1 (weapons). `0` for a basic Fight.
+        extra_damage: u8,
     },
     /// On success, disengage the named enemy from the investigator and
     /// exhaust it. Used by [`Evade`](crate::action::PlayerAction::Evade).

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -472,6 +472,7 @@ mod tests {
             on_success: None,
             source: None,
             continuation: crate::state::FinishContinuation::AwaitingCommit,
+            test_modifier: 0,
         });
         state
     }

--- a/crates/game-core/tests/weapon_fight.rs
+++ b/crates/game-core/tests/weapon_fight.rs
@@ -185,3 +185,46 @@ fn weapon_fight_spends_ammo_and_deals_bonus_damage() {
         2
     );
 }
+
+#[test]
+fn weapon_fight_rejects_when_no_enemy_engaged() {
+    // 0 engaged → illegal (no target); reject before charging anything.
+    let (state, id, weapon) = board_with_weapon(0);
+    let actions_before = state.investigators[&id].actions_remaining;
+    let result = apply_no_commits(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id: weapon,
+            ability_index: 0,
+        }),
+    );
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    // Nothing charged: ammo still 4, actions unchanged.
+    assert_eq!(ammo_remaining(&result.state, id, weapon), 4);
+    assert_eq!(
+        result.state.investigators[&id].actions_remaining,
+        actions_before
+    );
+}
+
+#[test]
+fn weapon_fight_rejects_when_two_enemies_engaged() {
+    // 2+ engaged → deferred multi-target selection; reject, nothing charged.
+    let (state, id, weapon) = board_with_weapon(2);
+    let actions_before = state.investigators[&id].actions_remaining;
+    let result = apply_no_commits(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id: weapon,
+            ability_index: 0,
+        }),
+    );
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert_eq!(ammo_remaining(&result.state, id, weapon), 4);
+    assert_eq!(
+        result.state.investigators[&id].actions_remaining,
+        actions_before
+    );
+}

--- a/crates/game-core/tests/weapon_fight.rs
+++ b/crates/game-core/tests/weapon_fight.rs
@@ -1,0 +1,187 @@
+//! End-to-end weapon flow with a mock `CardRegistry`: a firearm-shaped
+//! asset that carries `Uses (4 ammo)` and an `[action] Spend 1 ammo:
+//! Fight` activated ability whose effect is `Effect::Fight`.
+//!
+//! Lives at `crates/game-core/tests/` (its own integration-test binary,
+//! hence its own process + `OnceLock<CardRegistry>`) so the mock
+//! registry doesn't collide with the in-crate tests. No real card has a
+//! weapon ability yet — Roland's .38 Special (C5c) is the first; until
+//! then a mock card exercises the full path.
+
+use std::sync::OnceLock;
+
+use game_core::card_data::{CardKind, CardMetadata, Class, SkillIcons, Slot, UseKind, Uses};
+use game_core::dsl::{activated, fight, Ability, Cost, IntExpr};
+use game_core::engine::EngineOutcome;
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, InvestigatorId, Phase,
+    TokenModifiers,
+};
+use game_core::test_support::{apply_no_commits, test_enemy, test_investigator, GameStateBuilder};
+use game_core::{assert_event, Action, PlayerAction};
+
+/// Mock firearm: `Uses (4 ammo)`, `[action] Spend 1 ammo: Fight. +1
+/// [combat], +1 damage.`
+const WEAPON: &str = "WEAP1";
+
+fn weapon_metadata() -> CardMetadata {
+    CardMetadata {
+        code: WEAPON.to_owned(),
+        name: "Mock Firearm".to_owned(),
+        traits: vec!["Item".to_owned(), "Weapon".to_owned(), "Firearm".to_owned()],
+        text: Some("Uses (4 ammo).\n[action] Spend 1 ammo: Fight.".to_owned()),
+        pack_code: "_mock".to_owned(),
+        kind: CardKind::Asset {
+            class: Class::Neutral,
+            cost: Some(0),
+            xp: None,
+            slots: vec![Slot::Hand],
+            health: None,
+            sanity: None,
+            skill_icons: SkillIcons::default(),
+            is_fast: false,
+            deck_limit: 1,
+            uses: Some(Uses {
+                kind: UseKind::Ammo,
+                count: 4,
+            }),
+        },
+    }
+}
+
+fn weapon_metadata_static() -> &'static CardMetadata {
+    static M: OnceLock<CardMetadata> = OnceLock::new();
+    M.get_or_init(weapon_metadata)
+}
+
+fn mock_metadata_for(code: &CardCode) -> Option<&'static CardMetadata> {
+    (code.as_str() == WEAPON).then(weapon_metadata_static)
+}
+
+fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
+    match code.as_str() {
+        // [action] Spend 1 ammo: Fight. +1 [combat], +1 damage.
+        WEAPON => Some(vec![activated(
+            1,
+            vec![Cost::SpendUses {
+                kind: UseKind::Ammo,
+                count: 1,
+            }],
+            fight(IntExpr::Lit(1), 1),
+        )]),
+        _ => None,
+    }
+}
+
+fn install_mock_registry() {
+    static INSTALL: OnceLock<()> = OnceLock::new();
+    INSTALL.get_or_init(|| {
+        let _ = game_core::card_registry::install(game_core::card_registry::CardRegistry {
+            metadata_for: mock_metadata_for,
+            abilities_for: mock_abilities_for,
+            native_effect_for: |_| None,
+        });
+    });
+}
+
+/// Board: the weapon in play (instance 0) with a freshly-seeded 4-ammo
+/// pool, the controller active with combat 3 in the Investigation phase,
+/// engaged with `enemy_count` enemies (fight 3, health 3). A `Numeric(0)`
+/// chaos bag makes the combat total deterministic.
+fn board_with_weapon(enemy_count: u32) -> (game_core::GameState, InvestigatorId, CardInstanceId) {
+    install_mock_registry();
+    let id = InvestigatorId(1);
+    let weapon_inst = CardInstanceId(0);
+
+    let mut inv = test_investigator(1);
+    inv.skills.combat = 3;
+    let mut weapon = CardInPlay::enter_play(CardCode::new(WEAPON), weapon_inst);
+    weapon.uses.insert(UseKind::Ammo, 4); // seeded as play_card would
+    inv.cards_in_play.push(weapon);
+
+    let mut builder = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_active_investigator(id)
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default());
+    for n in 0..enemy_count {
+        let mut enemy = test_enemy(100 + n, "Ghoul");
+        enemy.fight = 3;
+        enemy.max_health = 3;
+        enemy.engaged_with = Some(id);
+        builder = builder.with_enemy(enemy);
+    }
+    let state = builder.with_investigator(inv).build();
+    (state, id, weapon_inst)
+}
+
+fn ammo_remaining(state: &game_core::GameState, inv: InvestigatorId, weapon: CardInstanceId) -> u8 {
+    state.investigators[&inv]
+        .cards_in_play
+        .iter()
+        .find(|c| c.instance_id == weapon)
+        .and_then(|c| c.uses.get(&UseKind::Ammo).copied())
+        .expect("weapon must carry an ammo pool")
+}
+
+#[test]
+fn play_card_seeds_the_ammo_pool_from_metadata() {
+    install_mock_registry();
+    let id = InvestigatorId(1);
+    let mut inv = test_investigator(1);
+    inv.hand.push(CardCode::new(WEAPON));
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_active_investigator(id)
+        .with_investigator(inv)
+        .build();
+
+    let result = apply_no_commits(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        }),
+    );
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    let weapon = result.state.investigators[&id]
+        .cards_in_play
+        .first()
+        .expect("weapon entered play");
+    assert_eq!(weapon.uses.get(&UseKind::Ammo).copied(), Some(4));
+}
+
+#[test]
+fn weapon_fight_spends_ammo_and_deals_bonus_damage() {
+    let (state, id, weapon) = board_with_weapon(1);
+    assert_eq!(ammo_remaining(&state, id, weapon), 4);
+
+    // Activate → pays 1 ammo up front, then the Combat test resolves
+    // (combat 3 + modifier 1 vs fight 3 → success) dealing 1 + 1 = 2.
+    let result = apply_no_commits(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id: weapon,
+            ability_index: 0,
+        }),
+    );
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::UsesSpent {
+            kind: UseKind::Ammo,
+            amount: 1,
+            ..
+        }
+    );
+    assert_event!(result.events, Event::SkillTestStarted { difficulty: 3, .. });
+    assert_event!(result.events, Event::EnemyDamaged { amount: 2, .. });
+    assert_eq!(ammo_remaining(&result.state, id, weapon), 3);
+    assert_eq!(
+        result.state.enemies[&game_core::state::EnemyId(100)].damage,
+        2
+    );
+}

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -35,8 +35,11 @@ enemy-attack damage/horror soak mechanic — soak-first `assign_attack` →
 simultaneous `place_assignment` → asset defeat-on-overflow → the
 `AfterEnemyAttackDamagedAsset` reaction window — plus Guard Dog 01021's
 retaliate and the resumable enemy-phase attack loop;
-[PR #292](https://github.com/talelburg/eldritch/pull/292)).
-**Next: C5c → C7** (C6d also gates C7b).
+[PR #292](https://github.com/talelburg/eldritch/pull/292)), and the C5c
+weapon-support prereq ([#295](https://github.com/talelburg/eldritch/issues/295):
+ammo/uses + inspectable `Effect::Fight` — `Cost::SpendUses` + `IntExpr`
+modifier + bonus damage; [PR #297](https://github.com/talelburg/eldritch/pull/297)).
+**Next: C5c content → C7** (C6d also gates C7b).
 
 Design specs:
 [Gathering design](../superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md),
@@ -92,6 +95,7 @@ root dependency; C7 is the playable Won/Lost gate; #212 lands after C.
 | C4c | [#235](https://github.com/talelburg/eldritch/issues/235) | persistent threat-area / attachment treacheries (×3) | ✅ PR #289 |
 | C5a | [#236](https://github.com/talelburg/eldritch/issues/236) | Cover Up before-timing interrupt + `GameEnd` | ✅ PR #291 |
 | C5b | [#237](https://github.com/talelburg/eldritch/issues/237) | Guard Dog reaction + enemy-attack soak mechanic | ✅ PR #292 |
+| — | [#295](https://github.com/talelburg/eldritch/issues/295) | infra: weapon support — ammo/uses (`Cost::SpendUses`) + inspectable `Effect::Fight` (`IntExpr` modifier + bonus damage) (prerequisite for C5c's .38 Special) | ✅ PR #297 |
 | C5c | [#238](https://github.com/talelburg/eldritch/issues/238) | .38 Special signature + Cover Up content | — |
 | C5d | [#239](https://github.com/talelburg/eldritch/issues/239) | Guardian L0 assets (×6) | — |
 | C5e | [#240](https://github.com/talelburg/eldritch/issues/240) | Guardian L0 events + skill (×4) | — |
@@ -168,6 +172,8 @@ Devourer Below, campaign log + `Fact` enum) is **Phase 9**, not Phase 7.
 - **Enemy-attack damage/horror soak is `assign → place → defeat → window`; assignment is soak-first deterministic, with interactive distribution deferred to a reframed #44 (C5b, [#237](https://github.com/talelburg/eldritch/issues/237), PR #292).** `enemy_attack` builds soakers (controlled assets with `CardKind::Asset` remaining `health`/`sanity` capacity), `assign_attack` fills them by `CardInstanceId` order before the investigator (symmetric for damage/horror), `place_assignment` places simultaneously (RR p.7) then defeats overflowed assets (`accumulated_* >= printed stat` → discard), and returns surviving damaged assets. The window-queuing lives in the **caller** (`drive_attack_loop`), not `enemy_attack`, so the enemy phase opens reaction windows while attacks of opportunity don't (see next entry). **#44's remaining scope is now just the interactive `{target → points}` distribution** (replacing the soak-first `assign_attack` body, `TODO(#44)`); soak-first is the only deterministic default that makes a soak reaction observable. A new soak reaction adds an `EnemyAttackDamagedSelf` ability (bare; self-bound to the soaked instance via `scan_pending_triggers`) — **no routing change**; the attacking enemy reaches the effect via `EvalContext.attacking_enemy`. Guard Dog's retaliate is `Effect::Native` (first card to damage a specific enemy from a reaction; public entry `deal_damage_to_enemy`).
 
 - **The enemy-phase attack loop suspends/resumes around a soak reaction window via `pending_enemy_attack`; attacks of opportunity soak but do NOT yet open the window (C5b, PR #292).** `drive_attack_loop` parks the remaining attackers and returns `AwaitingInput` when an attack opens a soak window; `resume_enemy_attack` (from the `AfterEnemyAttackDamagedAsset` window-close continuation) re-enters at the next attacker, advancing the enemy-phase cursor exactly once via the extracted `after_enemy_phase_attacks`. **AoO is the deferred gap:** full AoO reactions need a new mechanism to suspend/resume the *triggering action* (Move's relocation, Investigate's already-suspending skill test), so `fire_attacks_of_opportunity` deliberately drops the soak-window survivors (window-safe; Guard Dog soaks AoO damage but doesn't retaliate). The fast-follow ([#293](https://github.com/talelburg/eldritch/issues/293)) routes `fire_attacks_of_opportunity` through `drive_attack_loop` (`EnemyAttackSource::AttackOfOpportunity` is the reserved-but-unconstructed variant) + action suspension. Multi-soak-window-per-attack resume ([#294](https://github.com/talelburg/eldritch/issues/294)) is `debug_assert`-guarded (unreachable in Slice 1: only Guard Dog reacts, two copies need two illegal Ally slots; coordinates with #213).
+
+- **A weapon needs no engine work — it's `Cost::SpendUses` + `Effect::Fight` data, with ammo from the corpus (C5c prereq [#295](https://github.com/talelburg/eldritch/issues/295), PR #297).** `Uses (N <kind>)` is pipeline-parsed into `CardKind::Asset.uses`; the kind enum (`UseKind`) lives in `card-dsl` so the printed metadata and the engine's `CardInPlay.uses` runtime pool share one type. A firearm's ability is `activated(cost, vec![Cost::SpendUses { kind, count }], fight(IntExpr::cond(LocationHasClues, hi, lo), extra_damage))` — the inspectable `Effect::Fight` auto-targets the single engaged enemy, snapshots its modifier onto `InFlightSkillTest.test_modifier`, and reuses the skill-test suspend/resume path; the Fight follow-up deals `1 + extra_damage`. **`Effect::Fight` is typed, not `Native`,** so `check_activate_ability` can reject a fire with ≠1 engaged enemy before charging (multi-target selection deferred to the #212/#213 cluster; `effect_initiates_fight` is top-level-only, `TODO(#212/#213)` for a `Seq`/`If`-nested Fight). Conditional numeric values use `IntExpr { Lit, Cond }` over the general `Condition` (e.g. `LocationHasClues`) rather than duplicating the effect in an `Effect::If`. **A future weapon (breadth slices) lands via corpus + this data — no new engine primitives.** Instance-id-mint / put-into-play helper consolidation surfaced here is deferred to [#296](https://github.com/talelburg/eldritch/issues/296).
 
 ## Open questions
 

--- a/docs/superpowers/plans/2026-06-15-weapon-support-ammo-effect-fight.md
+++ b/docs/superpowers/plans/2026-06-15-weapon-support-ammo-effect-fight.md
@@ -1,0 +1,837 @@
+# Weapon Support (ammo/uses + `Effect::Fight`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the engine machinery a weapon-with-ammo asset needs — `Uses (N <kind>)` tracking, a `Cost::SpendUses` payment, and an inspectable `Effect::Fight` that initiates a Combat skill test with a (possibly clue-conditional) combat modifier and bonus damage — leaving the `.38 Special` / `Cover Up` card impls (C5c #238) as pure content.
+
+**Architecture:** Ammo is pipeline-parsed from card text into `CardKind::Asset.uses`, mirrored onto each `CardInstance` as `uses_remaining`, and spent through the existing activated-ability cost flow. The new `Effect::Fight` resolves a value-level `IntExpr` modifier against state, auto-targets the single engaged enemy, and reuses the existing skill-test suspend/resume path; the in-flight test carries a flat `test_modifier` and the Fight follow-up deals `1 + extra_damage`. Validate-first: `check_activate_ability` rejects a Fight ability fired with ≠1 engaged enemy before charging anything.
+
+**Tech Stack:** Rust workspace — `card-dsl` (types), `card-data-pipeline` (ingestion), `game-core` (engine). This is issue **#295**; the consumer is **#238**.
+
+**CI gauntlet (run before every commit that touches code):**
+```sh
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+```
+Run `cargo run -p card-data-pipeline` only in the task that changes the pipeline.
+
+---
+
+## File Structure
+
+**`card-dsl` (types):**
+- `crates/card-dsl/src/card_data.rs` — add `Uses` struct + `UsesKind` enum; add `uses: Option<Uses>` to `CardKind::Asset` (line 292).
+- `crates/card-dsl/src/dsl.rs` — add `Cost::SpendUses` (enum at 360); `IntExpr` enum + builders; `Condition::LocationHasClues` (enum at 767); `Effect::Fight` (enum at 475) + `fight(...)` builder.
+
+**`card-data-pipeline` (ingestion):**
+- `crates/card-data-pipeline/src/main.rs` — `parse_uses()`; thread into the Asset `EmitCard` (line ~301) + the Asset emit format string (line 481).
+- `crates/cards/src/generated/cards.rs` — regenerated (never hand-edited).
+
+**`game-core` (engine):**
+- `crates/game-core/src/state/card.rs` — `uses_remaining: Option<u8>` on `CardInPlay` (struct 136, `enter_play` 215).
+- `crates/game-core/src/event.rs` — `Event::UsesSpent`.
+- `crates/game-core/src/engine/dispatch/abilities.rs` — `Cost::SpendUses` validate (`check_cost_payable`) + pay (`pay_activation_costs`).
+- `crates/game-core/src/engine/dispatch/reaction_windows.rs` — thread `source_uses_remaining` into `check_activate_ability` (938); add the Fight target precondition.
+- `crates/game-core/src/engine/dispatch/cards.rs` — init `uses_remaining` from metadata on asset enter-play (~526).
+- `crates/game-core/src/state/game_state.rs` — `test_modifier: i8` on `InFlightSkillTest` (408); `extra_damage: u8` on `SkillTestFollowUp::Fight` (588).
+- `crates/game-core/src/engine/dispatch/skill_test.rs` — `start_skill_test` param (28); `sum_skill_value` reads `test_modifier` (400); Fight follow-up deals `1 + extra_damage` (592).
+- `crates/game-core/src/engine/evaluator.rs` — `Effect::Fight` arm (`apply_effect` 151); `Condition::LocationHasClues` arm (`eval_condition` 353); `IntExpr` resolver.
+- `crates/game-core/src/engine/dispatch/actions.rs` — base `PlayerAction::Fight` passes `extra_damage: 0` to the follow-up (457).
+
+---
+
+## Task 1: `Uses` / `UsesKind` metadata types + `CardKind::Asset.uses`
+
+**Files:**
+- Modify: `crates/card-dsl/src/card_data.rs:292`
+- Test: same file (`#[cfg(test)]`)
+
+- [ ] **Step 1: Add the types and field.** Above the `CardKind` enum (near other metadata types), add:
+
+```rust
+/// Limited-use tokens an asset enters play with ("Uses (4 ammo)").
+/// Spending them is a `Cost::SpendUses`; depletion blocks the ability.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Uses {
+    /// What the tokens are called on the card.
+    pub kind: UsesKind,
+    /// How many the asset enters play with.
+    pub count: u8,
+}
+
+/// The named token type an asset's `Uses (N <kind>)` grants. Only the
+/// kinds Slice-1 cards print are modeled; others land as their cards do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum UsesKind {
+    /// "Uses (N ammo)" — firearms.
+    Ammo,
+}
+```
+
+Then add the field to `CardKind::Asset` (after `deck_limit` at line 310, keeping the trailing comma):
+
+```rust
+        /// Maximum copies per deck.
+        deck_limit: u8,
+        /// Limited-use tokens granted on enter-play ("Uses (N ammo)"),
+        /// or `None`. Pipeline-parsed from card text.
+        uses: Option<Uses>,
+```
+
+- [ ] **Step 2: Fix every `CardKind::Asset { … }` literal in this crate.** The non-`..` constructor in the card_data tests (line ~517) needs `uses: None`. Search:
+
+Run: `grep -rn 'CardKind::Asset {' crates/card-dsl/src | grep -v '\.\.'`
+For each hit, add `uses: None,` before the closing brace.
+
+- [ ] **Step 3: Add a round-trip test.** In the `#[cfg(test)]` module:
+
+```rust
+#[test]
+fn asset_uses_round_trips() {
+    let uses = Some(Uses { kind: UsesKind::Ammo, count: 4 });
+    let json = serde_json::to_string(&uses).unwrap();
+    let back: Option<Uses> = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, uses);
+}
+```
+
+- [ ] **Step 4: Compile + test the crate.**
+
+Run: `cargo test -p card-dsl`
+Expected: PASS (other crates won't compile yet — that's Task 2+).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add crates/card-dsl/src/card_data.rs
+git commit -m "card-dsl: add Uses/UsesKind + CardKind::Asset.uses field"
+```
+
+---
+
+## Task 2: Pipeline parses `Uses (N <kind>)`
+
+**Files:**
+- Modify: `crates/card-data-pipeline/src/main.rs` (parse fn + Asset `EmitCard` build ~301 + emit string ~481)
+- Test: same file (`#[cfg(test)]` at ~714)
+
+- [ ] **Step 1: Write the failing parser test.** In the test module:
+
+```rust
+#[test]
+fn parse_uses_reads_ammo_count() {
+    assert_eq!(
+        parse_uses("Uses (4 ammo).\n[action] Spend 1 ammo: Fight."),
+        Some((4u8, "Ammo"))
+    );
+    assert_eq!(parse_uses("Some other card text."), None);
+}
+```
+
+- [ ] **Step 2: Run it — fails (no `parse_uses`).**
+
+Run: `cargo test -p card-data-pipeline parse_uses_reads_ammo_count`
+Expected: FAIL — cannot find function `parse_uses`.
+
+- [ ] **Step 3: Implement `parse_uses`.** Add near `parse_spawn_name` (~648). Returns the count and the Rust enum-variant string for emission; unknown kinds emit a build warning and yield `None` (no silent approximation):
+
+```rust
+/// Parse a printed `Uses (N <kind>)` clause into `(count, variant)` where
+/// `variant` is the `UsesKind` Rust variant name for code emission. Returns
+/// `None` when absent; warns + returns `None` for an unmodeled kind.
+fn parse_uses(text: &str) -> Option<(u8, &'static str)> {
+    let plain = strip_html_bold(text);
+    let start = plain.find("Uses (")? + "Uses (".len();
+    let inner = &plain[start..];
+    let end = inner.find(')')?;
+    let body = inner[..end].trim(); // e.g. "4 ammo"
+    let (num, kind) = body.split_once(' ')?;
+    let count: u8 = num.trim().parse().ok()?;
+    let variant = match kind.trim().to_ascii_lowercase().as_str() {
+        "ammo" => "Ammo",
+        other => {
+            eprintln!("warning: unmodeled Uses kind {other:?}; emitting uses: None");
+            return None;
+        }
+    };
+    Some((count, variant))
+}
+```
+
+- [ ] **Step 4: Run it — passes.**
+
+Run: `cargo test -p card-data-pipeline parse_uses_reads_ammo_count`
+Expected: PASS.
+
+- [ ] **Step 5: Thread `uses` into the Asset emit.** The `EmitCard` intermediate struct carries an extra field for assets. Add `uses: Option<(u8, &'static str)>` to the struct (~230) defaulting `None`, set it for assets where the Asset branch builds (`uses: parse_uses(raw.text.as_deref().unwrap_or(""))`, ~301), and extend the `"Asset"` emit format string (line 481) to append `, uses: {}` rendering either `None` or `Some(Uses {{ kind: UsesKind::{}, count: {} }})`. Add a small helper:
+
+```rust
+fn uses_lit(uses: Option<(u8, &'static str)>) -> String {
+    match uses {
+        None => "None".to_owned(),
+        Some((count, variant)) => {
+            format!("Some(Uses {{ kind: UsesKind::{variant}, count: {count} }})")
+        }
+    }
+}
+```
+
+Ensure the generated file's `use` line imports `Uses, UsesKind` (the emit prelude — find where `SkillIcons`/`Slot` are imported in the generated header string and add `Uses, UsesKind`).
+
+- [ ] **Step 6: Regenerate the corpus.**
+
+Run: `cargo run -p card-data-pipeline`
+Then: `grep -n '"01006"' -A6 crates/cards/src/generated/cards.rs`
+Expected: the 01006 Asset now ends with `…, deck_limit: 1, uses: Some(Uses { kind: UsesKind::Ammo, count: 4 }) }`. Spot-check a non-uses asset (01008) shows `uses: None`.
+
+- [ ] **Step 7: Build the cards crate.**
+
+Run: `cargo build -p cards`
+Expected: compiles (the new field is populated for every asset).
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add crates/card-data-pipeline/src/main.rs crates/cards/src/generated/cards.rs
+git commit -m "card-data-pipeline: parse Uses (N kind) into CardKind::Asset.uses"
+```
+
+---
+
+## Task 3: `CardInPlay.uses_remaining` + init on asset enter-play
+
+**Files:**
+- Modify: `crates/game-core/src/state/card.rs:136,215`
+- Modify: `crates/game-core/src/engine/dispatch/cards.rs:~526`
+- Test: `crates/game-core/src/state/card.rs` (`#[cfg(test)]`)
+
+- [ ] **Step 1: Add the field.** In `struct CardInPlay` (after `clues` at 162):
+
+```rust
+    /// Remaining limited-use tokens ("ammo") for an asset that entered
+    /// play with `CardKind::Asset.uses`. `None` for cards without uses
+    /// and for non-asset in-play instances (threat-area/attachments).
+    pub uses_remaining: Option<u8>,
+```
+
+In `enter_play` (215), initialize `uses_remaining: None` (the asset enter-play path sets the real value — see Step 3, keeping `enter_play` generic for threat-area/attachment callers).
+
+- [ ] **Step 2: Write the failing init test.** In `cards.rs`-adjacent engine tests is heavier; instead test the state default here and the init in Task-3 Step 4. Add to `card.rs` tests:
+
+```rust
+#[test]
+fn enter_play_defaults_uses_remaining_to_none() {
+    let c = CardInPlay::enter_play(CardCode::new("01006"), CardInstanceId(1));
+    assert_eq!(c.uses_remaining, None);
+}
+```
+
+- [ ] **Step 3: Init from metadata on asset enter-play.** In `cards.rs` `play_card`, immediately after the asset is pushed to `cards_in_play` (~526), set its uses from the registry metadata:
+
+```rust
+// Seed limited-use tokens (ammo) from the asset's printed `uses`.
+let initial_uses = card_registry::current()
+    .and_then(|reg| (reg.metadata_for)(&code))
+    .and_then(|m| match &m.kind {
+        crate::card_data::CardKind::Asset { uses, .. } => uses.as_ref().map(|u| u.count),
+        _ => None,
+    });
+if let Some(inv) = cx.state.investigators.get_mut(&investigator) {
+    if let Some(card) = inv.cards_in_play.last_mut() {
+        card.uses_remaining = initial_uses;
+    }
+}
+```
+
+(Use the variable name the surrounding code already binds for the played card's code / investigator id; adjust if they differ.)
+
+- [ ] **Step 4: Run state test + build.**
+
+Run: `cargo test -p game-core enter_play_defaults_uses_remaining_to_none`
+Expected: PASS.
+Run: `cargo build -p game-core`
+Expected: compiles.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add crates/game-core/src/state/card.rs crates/game-core/src/engine/dispatch/cards.rs
+git commit -m "game-core: CardInPlay.uses_remaining + init from metadata on asset enter-play"
+```
+
+---
+
+## Task 4: `Cost::SpendUses` + `Event::UsesSpent` (validate + pay)
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs:360` (Cost variant)
+- Modify: `crates/game-core/src/event.rs` (new event)
+- Modify: `crates/game-core/src/engine/dispatch/abilities.rs` (`check_cost_payable`, `pay_activation_costs`)
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs:938` (thread `source_uses_remaining`)
+- Test: `crates/game-core/src/engine/dispatch/abilities.rs` (`#[cfg(test)]`)
+
+- [ ] **Step 1: Add the `Cost` variant.** In `enum Cost` (360):
+
+```rust
+    /// Spend `n` limited-use tokens from the source asset's
+    /// `uses_remaining`. Insufficient remaining rejects the activation.
+    SpendUses(u8),
+```
+
+- [ ] **Step 2: Add the event.** In `event.rs`, beside `ResourcesPaid` (135):
+
+```rust
+    /// `n` limited-use tokens were spent from a source asset's
+    /// `uses_remaining` to pay a `Cost::SpendUses`.
+    UsesSpent {
+        /// Investigator who activated the ability.
+        investigator: InvestigatorId,
+        /// The source asset instance whose uses were spent.
+        instance_id: CardInstanceId,
+        /// How many were spent.
+        amount: u8,
+    },
+```
+
+- [ ] **Step 3: Thread `source_uses_remaining` to the validator.** `check_cost_payable` currently takes `(cost, inv, source_exhausted)`. Add a `source_uses_remaining: Option<u8>` parameter. In `check_activate_ability` (reaction_windows.rs:938), read the source card's `uses_remaining` (it already locates the source instance for `source_exhausted`) and pass it through. Add the `SpendUses` arm to `check_cost_payable`:
+
+```rust
+        Cost::SpendUses(n) => match source_uses_remaining {
+            Some(rem) if rem >= *n => Ok(()),
+            Some(rem) => Err(format!(
+                "ActivateAbility: needs {n} uses; source has {rem} remaining"
+            )),
+            None => Err(
+                "ActivateAbility: SpendUses on a source with no uses tokens".to_string(),
+            ),
+        },
+```
+
+- [ ] **Step 4: Pay it.** In `pay_activation_costs`, add the `SpendUses` arm (it has `investigator`, `instance_id`, `in_play_pos`):
+
+```rust
+            Cost::SpendUses(n) => {
+                let card = &mut cx
+                    .state
+                    .investigators
+                    .get_mut(&investigator)
+                    .expect("validated above")
+                    .cards_in_play[in_play_pos];
+                card.uses_remaining =
+                    Some(card.uses_remaining.unwrap_or(0).saturating_sub(*n));
+                cx.events.push(Event::UsesSpent {
+                    investigator,
+                    instance_id,
+                    amount: *n,
+                });
+            }
+```
+
+- [ ] **Step 5: Write tests.** In `abilities.rs` tests, add unit coverage for the validator (pure, no registry needed):
+
+```rust
+#[test]
+fn spend_uses_payable_only_with_enough_remaining() {
+    let inv = Investigator::test_investigator(InvestigatorId(1));
+    assert!(check_cost_payable(&Cost::SpendUses(1), &inv, false, Some(4)).is_ok());
+    assert!(check_cost_payable(&Cost::SpendUses(1), &inv, false, Some(0)).is_err());
+    assert!(check_cost_payable(&Cost::SpendUses(1), &inv, false, None).is_err());
+}
+```
+
+(Match the `test_investigator` constructor the file already uses; if `check_cost_payable` isn't in scope, `use super::check_cost_payable`.)
+
+- [ ] **Step 6: Run + full gauntlet.**
+
+Run: `cargo test -p game-core spend_uses_payable_only_with_enough_remaining`
+Expected: PASS.
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features` then `cargo clippy --all-targets --all-features -- -D warnings` then `cargo fmt --check`
+Expected: all green (existing `check_cost_payable` callers updated for the new param; any non-`..` `Event` matches handle `UsesSpent`).
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add crates/card-dsl/src/dsl.rs crates/game-core/src/event.rs \
+        crates/game-core/src/engine/dispatch/abilities.rs \
+        crates/game-core/src/engine/dispatch/reaction_windows.rs
+git commit -m "game-core: Cost::SpendUses validate+pay + Event::UsesSpent"
+```
+
+---
+
+## Task 5: `IntExpr` + `Condition::LocationHasClues`
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs` (`IntExpr` near Condition ~759; `Condition::LocationHasClues` at 767)
+- Modify: `crates/game-core/src/engine/evaluator.rs` (`eval_condition` 353; `IntExpr` resolver)
+- Test: both files
+
+- [ ] **Step 1: Add `Condition::LocationHasClues`.** In `enum Condition` (767):
+
+```rust
+    /// Holds when the controller's current location has ≥1 clue.
+    /// "if there are 1 or more clues on your location" (.38 Special).
+    LocationHasClues,
+```
+
+- [ ] **Step 2: Add `IntExpr` + builders.** Below the `Condition` enum:
+
+```rust
+/// An integer computed at effect-evaluation time. Lets a numeric field
+/// carry a condition-gated value without duplicating the surrounding
+/// effect (".38 Special": +1, or +3 instead if clues on your location).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum IntExpr {
+    /// A literal value.
+    Lit(i8),
+    /// `then` if `when` holds at eval time, else `otherwise`.
+    Cond {
+        /// Predicate evaluated against current state.
+        when: Condition,
+        /// Value when the predicate holds.
+        then: i8,
+        /// Value when it does not.
+        otherwise: i8,
+    },
+}
+
+/// Build an [`IntExpr::Cond`].
+#[must_use]
+pub fn int_cond(when: Condition, then: i8, otherwise: i8) -> IntExpr {
+    IntExpr::Cond { when, then, otherwise }
+}
+```
+
+- [ ] **Step 3: Write the failing eval test.** In `evaluator.rs` tests. `eval_condition` gains a `controller` parameter in Step 5, so call it with three args. Build the state with the crate's verified `GameStateBuilder` + location fixtures (mirror how the Investigate/Deduction tests in `engine/mod.rs` stand up a location with clues and an investigator located there — set `location.clues = 1`, `investigator.current_location = Some(loc_id)`):
+
+```rust
+#[test]
+fn location_has_clues_condition_tracks_clue_count() {
+    let inv_id = InvestigatorId(1);
+    let loc_id = LocationId(1);
+    // Helper inline: build a state with the investigator at `loc_id`,
+    // which has `clue_count` clues. (Use the same Location/investigator
+    // fixtures the Investigate tests use.)
+    let with_clues = |clue_count: u8| {
+        let mut inv = test_investigator(1);
+        inv.current_location = Some(loc_id);
+        let mut loc = test_location(loc_id, "Study");
+        loc.clues = clue_count;
+        GameStateBuilder::new()
+            .with_investigator(inv)
+            .with_location(loc)
+            .build()
+    };
+    assert_eq!(
+        eval_condition(&with_clues(1), inv_id, &Condition::LocationHasClues),
+        Ok(true)
+    );
+    assert_eq!(
+        eval_condition(&with_clues(0), inv_id, &Condition::LocationHasClues),
+        Ok(false)
+    );
+}
+```
+
+(If the exact location fixture differs — e.g. `test_location` takes different args or `with_location` is named differently — match the signatures the Investigate tests already call; the assertion shape is the load-bearing part.)
+
+- [ ] **Step 4: Run — fails (unhandled variant).**
+
+Run: `cargo test -p game-core location_has_clues_condition_tracks_clue_count`
+Expected: FAIL (non-exhaustive match or assertion).
+
+- [ ] **Step 5: Implement the eval arm.** `eval_condition` (353) currently takes `&GameState`. `LocationHasClues` needs the controller; thread the controller in via the call site (it runs under `apply_effect`, which has `eval_ctx.controller`). Change `eval_condition` to also accept `controller: InvestigatorId` (update its one caller in the `Effect::If` arm), and add:
+
+```rust
+        Condition::LocationHasClues => {
+            let has = state
+                .investigators
+                .get(&controller)
+                .and_then(|inv| inv.current_location)
+                .and_then(|loc| state.locations.get(&loc))
+                .is_some_and(|l| l.clues > 0);
+            Ok(has)
+        }
+```
+
+- [ ] **Step 6: Add the `IntExpr` resolver.** Near `eval_condition`:
+
+```rust
+/// Resolve an [`IntExpr`] against current state for `controller`.
+pub(crate) fn eval_int_expr(
+    state: &GameState,
+    controller: InvestigatorId,
+    expr: &IntExpr,
+) -> Result<i8, String> {
+    match expr {
+        IntExpr::Lit(n) => Ok(*n),
+        IntExpr::Cond { when, then, otherwise } => {
+            Ok(if eval_condition(state, controller, when)? { *then } else { *otherwise })
+        }
+    }
+}
+```
+
+- [ ] **Step 7: Run + gauntlet.**
+
+Run: `cargo test -p game-core location_has_clues_condition_tracks_clue_count`
+Expected: PASS.
+Run the full gauntlet (test/clippy/fmt). Expected: green.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add crates/card-dsl/src/dsl.rs crates/game-core/src/engine/evaluator.rs
+git commit -m "dsl+engine: IntExpr value-expr + Condition::LocationHasClues"
+```
+
+---
+
+## Task 6: `InFlightSkillTest.test_modifier` + parameterized Fight follow-up
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs:408,588`
+- Modify: `crates/game-core/src/engine/dispatch/skill_test.rs:28,177,400,592`
+- Modify: `crates/game-core/src/engine/dispatch/actions.rs:457` (base Fight passes `extra_damage: 0`)
+- Test: `crates/game-core/src/engine/dispatch/skill_test.rs` / engine tests
+
+- [ ] **Step 1: Add `test_modifier`.** In `struct InFlightSkillTest` (after `continuation`, 476):
+
+```rust
+    /// A flat modifier applied to the test total, snapshotted by the
+    /// initiating effect (`Effect::Fight`'s combat modifier). `0` for
+    /// player-action tests, which take their modifiers from cards in
+    /// play. Distinct from constant/pending modifiers — this is the
+    /// one-shot "+N for this attack" a weapon grants.
+    pub test_modifier: i8,
+```
+
+- [ ] **Step 2: Add `extra_damage` to the Fight follow-up.** In `SkillTestFollowUp::Fight` (588):
+
+```rust
+    Fight {
+        /// The enemy the Fight action targeted.
+        enemy: EnemyId,
+        /// Bonus damage beyond the base 1 (weapons). `0` for a basic Fight.
+        extra_damage: u8,
+    },
+```
+
+- [ ] **Step 3: Add `test_modifier` to `start_skill_test`.** Add a `test_modifier: i8` parameter (skill_test.rs:28) after `source`, set it in the `InFlightSkillTest { … }` literal (83), and update **every** caller (`actions.rs` fight/evade/investigate, the bare `PerformSkillTest`, `Effect::SkillTest` in the evaluator) to pass `0` except the new `Effect::Fight` path (Task 7).
+
+- [ ] **Step 4: Apply it in the total.** In `sum_skill_value` (400) — it already takes `state` — add the in-flight modifier:
+
+```rust
+    let test_mod = state
+        .in_flight_skill_test
+        .as_ref()
+        .map_or(0, |t| t.test_modifier);
+    base.saturating_add(constant_mod)
+        .saturating_add(pending_mod)
+        .saturating_add(icon_mod)
+        .saturating_add(test_mod)
+```
+
+- [ ] **Step 5: Deal `1 + extra_damage` in the follow-up.** In the `SkillTestFollowUp::Fight` arm (592) and the retaliate guard (645), destructure `{ enemy, extra_damage }`; change the damage call:
+
+```rust
+        SkillTestFollowUp::Fight { enemy, extra_damage } => {
+            super::combat::damage_enemy(cx, enemy, 1 + extra_damage, Some(investigator));
+            EngineOutcome::Done
+        }
+```
+
+In the retaliate guard (`let Some(SkillTestFollowUp::Fight { enemy }) = …`), change the pattern to `Fight { enemy, .. }`.
+
+- [ ] **Step 6: Base Fight passes `0`.** In `actions.rs` `fight` (484), change the follow-up to `SkillTestFollowUp::Fight { enemy: enemy_id, extra_damage: 0 }` and the `start_skill_test` call to pass the new `test_modifier: 0` argument.
+
+- [ ] **Step 7: Regression test — base Fight unchanged.** The existing Fight tests in `engine/mod.rs` (~1858) already assert combat 3 vs fight 3 → 1 damage. Run them:
+
+Run: `cargo test -p game-core fight`
+Expected: PASS (unchanged behavior: modifier 0, deals 1).
+
+- [ ] **Step 8: Full gauntlet.** Run test/clippy/fmt. Expected: green (all `start_skill_test` callers + all `SkillTestFollowUp::Fight` matches updated).
+
+- [ ] **Step 9: Commit.**
+
+```bash
+git add crates/game-core/src/state/game_state.rs \
+        crates/game-core/src/engine/dispatch/skill_test.rs \
+        crates/game-core/src/engine/dispatch/actions.rs
+git commit -m "game-core: InFlightSkillTest.test_modifier + Fight follow-up extra_damage"
+```
+
+---
+
+## Task 7: `Effect::Fight` (builder + evaluator: auto-target, snapshot modifier, start test)
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs:475` (variant + `fight` builder)
+- Modify: `crates/game-core/src/engine/evaluator.rs:151` (`apply_effect` arm)
+- Test: `crates/cards/tests/` (integration — real registry) + an engine unit test
+
+- [ ] **Step 1: Add the `Effect` variant + builder.** In `enum Effect` (475), beside `PutIntoThreatArea`:
+
+```rust
+    /// Initiate a Fight against the single enemy engaged with the
+    /// controller, applying a (possibly conditional) combat modifier
+    /// for this attack and dealing `1 + extra_damage` on success.
+    /// Auto-targets when exactly one enemy is engaged; the activation
+    /// check rejects ≠1 engaged before any cost is paid.
+    Fight {
+        /// Combat modifier for this attack, resolved at eval.
+        combat_modifier: IntExpr,
+        /// Bonus damage beyond the base 1.
+        extra_damage: u8,
+    },
+```
+
+Builder (near `put_into_threat_area`, ~1001):
+
+```rust
+/// Build an [`Effect::Fight`].
+#[must_use]
+pub fn fight(combat_modifier: IntExpr, extra_damage: u8) -> Effect {
+    Effect::Fight { combat_modifier, extra_damage }
+}
+```
+
+- [ ] **Step 2: Write the failing unit test for `single_engaged_enemy`** (pure helper, added in Step 4). In `crates/game-core/src/engine/dispatch/combat.rs` tests, using the verified `GameStateBuilder` / `test_enemy` fixtures (same as `engine/mod.rs`'s `fight_evade_scenario`):
+
+```rust
+#[test]
+fn single_engaged_enemy_some_for_one_none_for_zero_or_two() {
+    let inv_id = InvestigatorId(1);
+    let mut e1 = test_enemy(100, "A");
+    e1.engaged_with = Some(inv_id);
+    // one engaged → Some
+    let s1 = GameStateBuilder::new()
+        .with_investigator(test_investigator(1))
+        .with_enemy(e1.clone())
+        .build();
+    assert_eq!(single_engaged_enemy(&s1, inv_id), Some(EnemyId(100)));
+    // two engaged → None (deferred multi-target)
+    let mut e2 = test_enemy(101, "B");
+    e2.engaged_with = Some(inv_id);
+    let s2 = GameStateBuilder::new()
+        .with_investigator(test_investigator(1))
+        .with_enemy(e1)
+        .with_enemy(e2)
+        .build();
+    assert_eq!(single_engaged_enemy(&s2, inv_id), None);
+    // zero engaged → None
+    let s0 = GameStateBuilder::new()
+        .with_investigator(test_investigator(1))
+        .build();
+    assert_eq!(single_engaged_enemy(&s0, inv_id), None);
+}
+```
+
+The end-to-end `Effect::Fight` behavior (suspend → commit → `1 + extra_damage` damage) is exercised through a real activated weapon in the integration test in Step 6, the registry-backed home CLAUDE.md prescribes — not a direct `apply_effect` call, which would need hand-built `Cx` scaffolding.
+
+- [ ] **Step 3: Run — fails (no `single_engaged_enemy`).**
+
+Run: `cargo test -p game-core single_engaged_enemy_some_for_one`
+Expected: FAIL — cannot find function.
+
+- [ ] **Step 4: Implement the evaluator arm.** In `apply_effect` (152), add:
+
+```rust
+        Effect::Fight { combat_modifier, extra_damage } => {
+            let modifier = match eval_int_expr(cx.state, eval_ctx.controller, combat_modifier) {
+                Ok(m) => m,
+                Err(reason) => return EngineOutcome::Rejected { reason: reason.into() },
+            };
+            let Some(enemy_id) = single_engaged_enemy(cx.state, eval_ctx.controller) else {
+                return EngineOutcome::Rejected {
+                    reason: "Effect::Fight: expected exactly one engaged enemy".into(),
+                };
+            };
+            let fight_difficulty = cx.state.enemies.get(&enemy_id).map_or(0, |e| e.fight);
+            crate::engine::dispatch::skill_test::start_skill_test(
+                cx,
+                eval_ctx.controller,
+                SkillKind::Combat,
+                SkillTestKind::Fight,
+                fight_difficulty,
+                SkillTestFollowUp::Fight { enemy: enemy_id, extra_damage: *extra_damage },
+                None,
+                None,
+                eval_ctx.source,
+                modifier, // test_modifier
+            )
+        }
+```
+
+Add a shared helper (used again by the activation check in Task 8) near the top of `evaluator.rs` or in `combat.rs` — put it in `combat.rs` and `pub(crate)` it so both sites call one implementation:
+
+```rust
+/// The single enemy engaged with `investigator`, or `None` if zero or
+/// 2+ are engaged (the 2+ case is a deferred interactive choice).
+pub(crate) fn single_engaged_enemy(
+    state: &GameState,
+    investigator: InvestigatorId,
+) -> Option<EnemyId> {
+    let mut engaged = state
+        .enemies
+        .iter()
+        .filter(|(_, e)| e.engaged_with == Some(investigator))
+        .map(|(id, _)| *id);
+    let first = engaged.next()?;
+    if engaged.next().is_some() { None } else { Some(first) }
+}
+```
+
+- [ ] **Step 5: Run — passes.**
+
+Run: `cargo test -p game-core single_engaged_enemy_some_for_one`
+Expected: PASS.
+
+- [ ] **Step 6: End-to-end integration test (registry-backed).** Create `crates/cards/tests/weapon_fight.rs`. Define a synthetic weapon registry following the `crates/scenarios/src/test_fixtures/synth_cards.rs` template: a `_synth_weapon` asset whose `metadata_for` returns `CardKind::Asset { …, uses: Some(Uses { kind: UsesKind::Ammo, count: 4 }) }` and whose `abilities_for` returns `vec![activated(1, vec![Cost::SpendUses(1)], fight(IntExpr::Lit(1), 1))]`. Install it via `game_core::card_registry::install`, put the weapon in play (with one engaged enemy of `fight = 3`, `max_health = 3`, the active investigator at `combat = 3` in the Investigation phase), then:
+
+```rust
+// Activate the weapon → suspends at the commit window.
+let r1 = apply(state, Action::Player(PlayerAction::ActivateAbility {
+    investigator: inv_id, instance_id: weapon_inst, ability_index: 0,
+}));
+assert!(matches!(r1.outcome, EngineOutcome::AwaitingInput { .. }));
+// Ammo was spent up front (4 → 3).
+assert_eq!(r1.state.investigators[&inv_id].cards_in_play
+    .iter().find(|c| c.instance_id == weapon_inst).unwrap().uses_remaining, Some(3));
+// Commit no cards → auto-success token (combat 3 + modifier 1 vs fight 3).
+let r2 = apply(r1.state, Action::Player(PlayerAction::ResolveInput {
+    response: InputResponse::CommitCards { indices: vec![] },
+}));
+// Base 1 + extra_damage 1 = 2 damage.
+assert_event!(r2.events, Event::EnemyDamaged { amount: 2, .. });
+```
+
+(Use the `apply` / chaos-bag / commit helpers the existing `crates/cards/tests/play_card.rs` integration test uses; a deterministic 0-modifier bag makes combat 3 + mod 1 ≥ fight 3 succeed.)
+
+- [ ] **Step 7: Run integration test + gauntlet, then commit.**
+
+Run: `cargo test -p cards --test weapon_fight`
+Expected: PASS. Then the full gauntlet (test/clippy/fmt). Expected: green.
+
+```bash
+git add crates/card-dsl/src/dsl.rs crates/game-core/src/engine/evaluator.rs \
+        crates/game-core/src/engine/dispatch/combat.rs crates/cards/tests/weapon_fight.rs
+git commit -m "dsl+engine: Effect::Fight — auto-target single enemy, snapshot modifier, bonus damage"
+```
+
+---
+
+## Task 8: Validate-first target check in `check_activate_ability`
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs:938`
+- Test: `crates/cards/tests/weapon_fight.rs` (extend Task 7's integration test — registry-backed, the home CLAUDE.md prescribes for activation checks needing real abilities)
+
+- [ ] **Step 1: Write the failing test.** Extend `crates/cards/tests/weapon_fight.rs` (same `_synth_weapon` registry as Task 7). Activating the weapon while the investigator is engaged with **two** enemies must reject **without** charging action or ammo:
+
+```rust
+#[test]
+fn weapon_fight_rejects_when_two_enemies_engaged() {
+    // _synth_weapon in play; active investigator engaged with TWO enemies.
+    let before_actions = state.investigators[&inv_id].actions_remaining;
+    let r = apply(state, Action::Player(PlayerAction::ActivateAbility {
+        investigator: inv_id, instance_id: weapon_inst, ability_index: 0,
+    }));
+    assert!(matches!(r.outcome, EngineOutcome::Rejected { .. }));
+    // Nothing charged: ammo still 4, actions unchanged.
+    assert_eq!(r.state.investigators[&inv_id].cards_in_play
+        .iter().find(|c| c.instance_id == weapon_inst).unwrap().uses_remaining, Some(4));
+    assert_eq!(r.state.investigators[&inv_id].actions_remaining, before_actions);
+}
+```
+
+Add a companion `weapon_fight_rejects_when_no_enemy_engaged` (0 engaged → reject, nothing charged).
+
+- [ ] **Step 2: Run — fails (no target precondition yet; activation proceeds and charges).**
+
+Run: `cargo test -p cards --test weapon_fight weapon_fight_rejects`
+Expected: FAIL (currently the activation suspends/charges instead of rejecting).
+
+- [ ] **Step 3: Add the precondition.** In `check_activate_ability` (938), after the effect is resolved and before returning `Ok(ActivateCheckResult { … })`, add:
+
+```rust
+    // Validate-first: a Fight-initiating ability needs exactly one engaged
+    // enemy, checked before any action/ammo is charged. 0 → illegal (no
+    // target); 2+ → deferred interactive target selection (#212/#213).
+    if effect_initiates_fight(&effect)
+        && super::combat::single_engaged_enemy(state, investigator).is_none()
+    {
+        return Err(
+            "ActivateAbility: a Fight ability needs exactly one engaged enemy \
+             (0 = no target; 2+ multi-target selection deferred with #212/#213)"
+                .to_string(),
+        );
+    }
+```
+
+Add the introspection helper in the same module (top-level node suffices for Slice 1; a Fight nested only inside a `Seq`/`If` branch is a documented TODO):
+
+```rust
+/// True if `effect` initiates a Fight at its top level. TODO(#212/#213):
+/// recurse `Seq`/`If` once a card fights in only one branch — no Slice-1
+/// card does (.38 Special's IntExpr branches both fight).
+fn effect_initiates_fight(effect: &crate::dsl::Effect) -> bool {
+    matches!(effect, crate::dsl::Effect::Fight { .. })
+}
+```
+
+- [ ] **Step 4: Run — passes.**
+
+Run: `cargo test -p cards --test weapon_fight`
+Expected: PASS — the reject tests now pass, and Task 7's happy-path test (exactly one engaged enemy → suspends + spends ammo) still passes, covering the `Ok` branch.
+
+- [ ] **Step 5: Gauntlet + commit.**
+
+```bash
+git add crates/game-core/src/engine/dispatch/reaction_windows.rs \
+        crates/cards/tests/weapon_fight.rs
+git commit -m "game-core: validate-first Fight target check before charging activation"
+```
+
+---
+
+## Task 9: Doc-comment sweep + final gauntlet
+
+**Files:**
+- Modify: doc-comments on the new public items (warnings-as-errors `cargo doc`).
+
+- [ ] **Step 1: Run the doc job.**
+
+Run: `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
+Expected: PASS — fix any broken intra-doc links on the new `Uses`, `IntExpr`, `Effect::Fight`, `Cost::SpendUses`, `Event::UsesSpent`, `Condition::LocationHasClues` items.
+
+- [ ] **Step 2: Run the wasm jobs** (the engine compiles to wasm; new code must too).
+
+Run: `cargo build -p web --target wasm32-unknown-unknown`
+Run: `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 3: Full gauntlet one more time.**
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features` · `cargo clippy --all-targets --all-features -- -D warnings` · `cargo fmt --check`
+Expected: all green.
+
+- [ ] **Step 4: Commit anything outstanding** (doc fixes).
+
+```bash
+git add -A && git commit -m "engine: doc-comment fixes for weapon-support surface"
+```
+
+---
+
+## Self-review notes (coverage vs. #295)
+
+- Ammo/uses: Tasks 1–4 (types → pipeline → instance field → cost). ✅
+- `Effect::Fight` + `IntExpr` + `Condition::LocationHasClues`: Tasks 5–7. ✅
+- This-test modifier + bonus-damage follow-up: Task 6. ✅
+- Validate-first target check (0/2+ engaged): Task 8. ✅
+- Base `PlayerAction::Fight` unchanged: Task 6 Step 6–7 (regression). ✅
+- Out of scope (multi-target select, nested-branch Fight, `PutIntoThreatArea { clues }`): deferred / lands in C5c PR 2 — not in this plan. ✅
+
+The `.38 Special` and `Cover Up` card impls (C5c #238) ride on this and get their own plan once #295 merges.

--- a/docs/superpowers/specs/2026-06-15-phase-7-c5c-roland-signature-weakness-design.md
+++ b/docs/superpowers/specs/2026-06-15-phase-7-c5c-roland-signature-weakness-design.md
@@ -1,0 +1,155 @@
+# C5c — Roland's signature (.38 Special) + weakness (Cover Up)
+
+Phase 7, Slice 1, Group C. Issues: **#295** (engine prereq), **#238** (C5c card content).
+
+## Goal
+
+Ship Roland Banks' signature/weakness pair for The Gathering:
+
+- **Roland's .38 Special 01006** — `Roland Banks deck only. Uses (4 ammo). [action] Spend 1 ammo: Fight. You get +1 [combat] for this attack (if there are 1 or more clues on your location, you get +3 [combat], instead). This attack deals +1 damage.`
+- **Cover Up 01007** — `Revelation - Put Cover Up into play in your threat area, with 3 clues on it. [reaction] When you would discover 1 or more clues at your location: Discard that many clues from Cover Up instead. Forced - When the game ends, if there are any clues on Cover Up: You suffer 1 mental trauma.`
+
+(Card text verified against `data/arkhamdb-snapshot/pack/core/core.json` on 2026-06-15.)
+
+The work splits along the engine/content seam, following the #276 / #286 prerequisite pattern.
+
+## Decomposition
+
+- **PR 1 — engine prereq (#295, `engine`/`infra`):** weapon support — ammo/uses + an inspectable `Effect::Fight`. No card content.
+- **PR 2 — C5c card content (#238, `card`):** the two card impls + tests, plus the tiny `PutIntoThreatArea { clues }` extension Cover Up needs. Rides on PR 1.
+
+## PR 1 — engine prereq (#295)
+
+The full design lives in #295. Summary of the surface it adds:
+
+1. **Ammo / Uses — pipeline-parsed.** `Uses (N <kind>)` parsed from asset text →
+   `CardKind::Asset { uses: Option<Uses { kind: UsesKind, count: u8 }>, … }`.
+   `CardInstance.uses_remaining: Option<u8>` initialized from metadata on
+   asset enter-play. New `Cost::SpendUses(u8)` validated/paid in the
+   activation flow, emitting `Event::UsesSpent`. Generalizes to every
+   future uses-card.
+
+2. **Inspectable `Effect::Fight { combat_modifier: IntExpr, extra_damage: u8 }`.**
+   Resolves the modifier against current state, auto-targets the single
+   engaged enemy, starts a Combat skill test reusing the existing
+   suspend/resume commit-window path.
+
+3. **`IntExpr` — `Lit(i8)` + `Cond { when: Condition, then: i8, otherwise: i8 }`.**
+   A value-level conditional resolved at eval, so the modifier reads as
+   `IntExpr::cond(LocationHasClues, 3, 1)` rather than an `Effect::If`
+   duplicating the whole `fight(...)` node. Condition-agnostic — the
+   minimum generalization this card forces.
+
+4. **`Condition::LocationHasClues`** — already pre-named in the
+   `Condition` doc comments; ≥1 clue on the controller's location.
+
+5. **This-test modifier** — `InFlightSkillTest.test_modifier: i8`, applied
+   at total computation; `0` for player-action tests.
+
+6. **Parameterized Fight follow-up** — `SkillTestFollowUp::Fight { enemy,
+   extra_damage: u8 }` deals `1 + extra_damage`; stays `Copy`.
+
+7. **Validate-first target check** — `check_activate_ability` rejects, before
+   charging action or ammo, when an `Effect::Fight` ability is fired without
+   exactly one engaged enemy (`0` → illegal; `2+` → TODO, deferred with the
+   #212/#213 interactive-choice cluster).
+
+Base `PlayerAction::Fight` is unchanged (modifier 0, deals 1) — covered by a
+regression test.
+
+## PR 2 — C5c card content (#238)
+
+### Roland's .38 Special 01006 (`crates/cards/src/impls/roland_38_special.rs`)
+
+(Player-card impls are named by card name — `holy_rosary`, `magnifying_glass`,
+`guard_dog` — not code; only treacheries use the `treachery_NNNNN` form.)
+
+A single activated ability; ammo (4) comes from the corpus via PR 1's
+pipeline parse, so it is **not** hand-typed here:
+
+```rust
+activated(
+    1,                                  // [action]
+    vec![Cost::SpendUses(1)],           // Spend 1 ammo
+    fight(
+        IntExpr::cond(Condition::LocationHasClues, 3, 1),  // +1, or +3 instead if clues
+        1,                                                 // +1 damage
+    ),
+)
+```
+
+Card tests:
+- **+3 path** — a clue on the investigator's location: the in-flight test's
+  `test_modifier` is 3; a Combat total that beats fight by the right margin;
+  the Fight follow-up deals 2 damage.
+- **+1 path** — no clues: modifier 1.
+- **ammo** — `uses_remaining` decrements per activation; activation rejects
+  when ammo is 0 (`Cost::SpendUses` unpayable).
+
+### Cover Up 01007 (`crates/cards/src/impls/treachery_01007.rs`)
+
+A port of the synthetic Cover Up that C5a (#236) already built and proved
+(`crates/scenarios/src/test_fixtures/synth_cards.rs`): its
+`WouldDiscoverClues` before-timing interrupt, the `clue_interrupt_pending`
+suspension, `clue_discovery_count` threading, the `GameEnd` forced point, and
+`Event::TraumaSuffered` all exist. C5c moves the two native effects into the
+real card module and adds the placement Revelation:
+
+```rust
+vec![
+    revelation(put_into_threat_area_with_clues(CODE, 3)),
+    on_event(WouldDiscoverClues, Before, native("01007:discard_clues")),
+    on_event(GameEnd, After, native("01007:trauma")),
+]
+```
+
+- **`PutIntoThreatArea { code, clues }` extension** (engine, but tiny and
+  Cover-Up-specific, so it lands here not in #295): the effect mints the
+  threat-area instance with `clues` already on it. Existing callers
+  (Dissonant Voices 01165) pass `0` — the `put_into_threat_area(code)`
+  builder keeps that arity; a new `put_into_threat_area_with_clues(code, n)`
+  builder serves Cover Up.
+- **Native effects** — `01007:discard_clues` (discard the threaded count from
+  the source instance instead of discovering) and `01007:trauma` (suffer 1
+  mental trauma at game end iff the source still holds clues), registered via
+  `treachery_01007::native_effect_for` in `impls/mod.rs`. Direct ports of the
+  synth bodies, keyed to the real instance via `EvalContext::source`.
+
+Cover Up is a **persistent treachery** (it has non-Revelation abilities), so
+`resolve_encounter_card` does not auto-discard it after revelation — the C4c
+disposition rule already handles this; no routing change.
+
+Card tests:
+- Revelation puts Cover Up in the threat area with 3 clues.
+- Reaction: a clue discovery at the investigator's location discards that many
+  clues from Cover Up instead of discovering them.
+- Game-end forced: trauma fires iff clues remain (3 clues → trauma; 0 → no
+  trauma).
+
+## Testing
+
+- **Engine (#295):** unit tests for ammo (pay/reject), `Effect::Fight`
+  (modifier into total, bonus damage, auto-target, 2+-engaged rejection),
+  `IntExpr`/`Condition::LocationHasClues` eval, and a `Uses (N kind)` pipeline
+  parse test. Base-Fight regression.
+- **C5c (#238):** the per-card tests above, plus an integration test in
+  `crates/cards/tests/` driving `.38 Special` end-to-end through the real
+  registry (ammo → activate → commit → damage). Cover Up's interrupt is
+  already integration-shaped from C5a.
+
+## Out of scope / deferred
+
+- **Multi-enemy weapon target selection** — auto-targets the single engaged
+  enemy; 2+ engaged rejects with a TODO, landing with the #212/#213
+  interactive-choice cluster.
+- **A Fight reachable only inside a `Seq`/`If` branch** — `.38 Special` fights
+  unconditionally in both `IntExpr` branches; the nested-Fight validate case
+  is a documented TODO.
+- **Trauma persistence** (campaign log / max-stat reduction) — Phase 9. C5c
+  only emits `Event::TraumaSuffered` (as C5a established).
+
+## Open questions
+
+None blocking. The `UsesKind` enum starts with just `Ammo` (the only kind a
+Slice-1 card prints); other kinds (Supplies, Charges, Secrets) are added by
+the pipeline as cards that print them land.


### PR DESCRIPTION
## Summary

Engine prerequisite for C5c (#238) — the machinery a firearm-with-ammo asset needs to fight, with **no card content** (Roland's .38 Special + Cover Up land in the follow-up PR). Sibling pattern to #276 / #286.

Spec: `docs/superpowers/specs/2026-06-15-phase-7-c5c-roland-signature-weakness-design.md`
Plan: `docs/superpowers/plans/2026-06-15-weapon-support-ammo-effect-fight.md`

## What's in it

- **Ammo / uses** — pipeline parses `Uses (N <kind>)` from asset text into `CardKind::Asset.uses`. `UseKind` (Charges/Ammo/Secrets/Supplies) moved down into `card-dsl` so the printed metadata and the engine's existing `CardInPlay.uses` runtime pool share one type; `game_core::state` re-exports it. The pool is seeded on asset enter-play. New `Cost::SpendUses { kind, count }` (validate + pay) + `Event::UsesSpent`.
- **`Effect::Fight { combat_modifier: IntExpr, extra_damage }`** — inspectable effect that auto-targets the single engaged enemy, snapshots the combat modifier onto the in-flight test, and starts a Combat skill test reusing the existing suspend/resume path; the Fight follow-up deals `1 + extra_damage`.
- **`IntExpr { Lit, Cond }` + `Condition::LocationHasClues`** — a value-level conditional so `.38 Special`'s "+1 (+3 if clues)" reads as `fight(IntExpr::cond(LocationHasClues, 3, 1), 1)` instead of duplicating the effect.
- **`InFlightSkillTest.test_modifier`** applied in `sum_skill_value`; base Fight/Evade/Investigate/Revelation pass `0` (unchanged behavior).
- **Validate-first target check** — a Fight ability fired with ≠1 engaged enemy rejects at `check_activate_ability` (0 = no target; 2+ = deferred multi-target).

## Design decisions worth flagging

- **`UseKind` unified into `card-dsl`, not duplicated.** The engine already had a dormant `CardInPlay.uses: BTreeMap<UseKind,u8>` pool and a `UseKind` enum; rather than add a parallel `uses_remaining` field (as the plan first assumed), the kind enum moved to the lowest layer so metadata and runtime share it.
- **`Effect::Fight` is a typed/inspectable DSL variant, not `Effect::Native`** — required so the validate-first target check can introspect it (mirrors the C4c precedent of extending the inspectable DSL over registry hooks). The clue-conditional lives in `IntExpr`, parameterized over the general `Condition`, so the effect carries no card-specific shape.
- **Multi-enemy weapon target selection is deferred** (auto-target single; reject 2+) to land with the #212/#213 interactive-choice cluster.
- The validate-first check is also a correctness *belt* — the apply loop already snapshots state and restores on `Rejected` — but it keeps `check_activate_ability` an honest playability oracle (it's reused by `any_fast_play_eligible`).

## Follow-ups filed

- **#296** (`infra`) — consolidate instance-id minting + put-into-play construction helpers (the ammo-seeding block in `play_card` surfaced the duplication; orthogonal to this feature).

## Testing

Full strict gauntlet green locally — all seven CI jobs (test, clippy, fmt, doc, wasm-build, wasm-clippy). New `crates/game-core/tests/weapon_fight.rs` drives a mock firearm end-to-end (play seeds 4 ammo → activate spends 1 + deals 2 damage; 0/2-enemy rejects charge nothing), plus unit tests for `parse_uses`, `single_engaged_enemy`, `LocationHasClues`/`IntExpr`, and `Cost::SpendUses`.

Closes #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
