### PR TITLE
card: C5c — Roland's .38 Special + Cover Up (#238)

### DIFF
--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -595,6 +595,9 @@ pub enum Effect {
     PutIntoThreatArea {
         /// Printed `ArkhamDB` code of the card to place.
         code: String,
+        /// Clues to seed on the placed instance ("with 3 clues on it",
+        /// Cover Up 01007). `0` for cards that enter clue-less.
+        clues: u8,
     },
     /// Initiate a Fight against the single enemy engaged with the
     /// controller, applying `combat_modifier` (resolved at eval, e.g.
@@ -1053,10 +1056,24 @@ pub fn discard_self() -> Effect {
     Effect::DiscardSelf
 }
 
-/// Build an [`Effect::PutIntoThreatArea`] for the card with printed `code`.
+/// Build an [`Effect::PutIntoThreatArea`] that enters clue-less.
 #[must_use]
 pub fn put_into_threat_area(code: impl Into<String>) -> Effect {
-    Effect::PutIntoThreatArea { code: code.into() }
+    Effect::PutIntoThreatArea {
+        code: code.into(),
+        clues: 0,
+    }
+}
+
+/// Build an [`Effect::PutIntoThreatArea`] seeding `clues` on the placed
+/// instance (Cover Up 01007: "Put Cover Up into play in your threat area,
+/// with 3 clues on it").
+#[must_use]
+pub fn put_into_threat_area_with_clues(code: impl Into<String>, clues: u8) -> Effect {
+    Effect::PutIntoThreatArea {
+        code: code.into(),
+        clues,
+    }
 }
 
 /// Build an [`Effect::Fight`] with the given combat modifier and bonus

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -66,6 +66,7 @@ pub mod hyperawareness;
 pub mod magnifying_glass;
 pub mod roland_38_special;
 pub mod roland_banks;
+pub mod treachery_01007;
 pub mod treachery_01162;
 pub mod treachery_01163;
 pub mod treachery_01164;
@@ -95,6 +96,7 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
         magnifying_glass::CODE => Some(magnifying_glass::abilities()),
         roland_38_special::CODE => Some(roland_38_special::abilities()),
         roland_banks::CODE => Some(roland_banks::abilities()),
+        treachery_01007::CODE => Some(treachery_01007::abilities()),
         treachery_01162::CODE => Some(treachery_01162::abilities()),
         treachery_01163::CODE => Some(treachery_01163::abilities()),
         treachery_01164::CODE => Some(treachery_01164::abilities()),
@@ -117,6 +119,7 @@ pub fn native_effect_for(tag: &str) -> Option<game_core::card_registry::NativeEf
         .or_else(|| agenda_01106::native_effect_for(tag))
         .or_else(|| agenda_01107::native_effect_for(tag))
         .or_else(|| guard_dog::native_effect_for(tag))
+        .or_else(|| treachery_01007::native_effect_for(tag))
         .or_else(|| treachery_01166::native_effect_for(tag))
         .or_else(|| treachery_01167::native_effect_for(tag))
         .or_else(|| treachery_01168::native_effect_for(tag))

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -64,6 +64,7 @@ pub mod guard_dog;
 pub mod holy_rosary;
 pub mod hyperawareness;
 pub mod magnifying_glass;
+pub mod roland_38_special;
 pub mod roland_banks;
 pub mod treachery_01162;
 pub mod treachery_01163;
@@ -92,6 +93,7 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
         holy_rosary::CODE => Some(holy_rosary::abilities()),
         hyperawareness::CODE => Some(hyperawareness::abilities()),
         magnifying_glass::CODE => Some(magnifying_glass::abilities()),
+        roland_38_special::CODE => Some(roland_38_special::abilities()),
         roland_banks::CODE => Some(roland_banks::abilities()),
         treachery_01162::CODE => Some(treachery_01162::abilities()),
         treachery_01163::CODE => Some(treachery_01163::abilities()),

--- a/crates/cards/src/impls/roland_38_special.rs
+++ b/crates/cards/src/impls/roland_38_special.rs
@@ -1,0 +1,65 @@
+//! Roland's .38 Special (Roland Banks signature asset, 01006).
+//!
+//! ```text
+//! Roland Banks deck only.
+//! Uses (4 ammo).
+//! [action] Spend 1 ammo: Fight. You get +1 [combat] for this attack
+//! (if there are 1 or more clues on your location, you get +3 [combat],
+//! instead). This attack deals +1 damage.
+//! ```
+//!
+//! Ammo (4) comes from the corpus (`CardKind::Asset.uses`, pipeline-
+//! parsed); the ability spends 1 per use via `Cost::SpendUses` and fights
+//! through `Effect::Fight`, whose combat modifier is `+3` when the
+//! investigator's location holds a clue and `+1` otherwise (`IntExpr::cond`
+//! over `Condition::LocationHasClues`), dealing `1 + 1` damage on success.
+
+use card_dsl::card_data::UseKind;
+use card_dsl::dsl::{activated, fight, Ability, Condition, Cost, IntExpr};
+
+/// `ArkhamDB` code for Roland's .38 Special.
+pub const CODE: &str = "01006";
+
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![activated(
+        1,
+        vec![Cost::SpendUses {
+            kind: UseKind::Ammo,
+            count: 1,
+        }],
+        fight(IntExpr::cond(Condition::LocationHasClues, 3, 1), 1),
+    )]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use card_dsl::dsl::{Effect, Trigger};
+
+    #[test]
+    fn one_activated_fight_ability_spending_ammo() {
+        let abilities = abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(abilities[0].trigger, Trigger::Activated { action_cost: 1 });
+        assert_eq!(
+            abilities[0].costs,
+            vec![Cost::SpendUses {
+                kind: UseKind::Ammo,
+                count: 1
+            }]
+        );
+        let Effect::Fight {
+            combat_modifier,
+            extra_damage,
+        } = &abilities[0].effect
+        else {
+            panic!("expected Effect::Fight");
+        };
+        assert_eq!(*extra_damage, 1);
+        assert_eq!(
+            *combat_modifier,
+            IntExpr::cond(Condition::LocationHasClues, 3, 1)
+        );
+    }
+}

--- a/crates/cards/src/impls/treachery_01007.rs
+++ b/crates/cards/src/impls/treachery_01007.rs
@@ -1,0 +1,152 @@
+//! Cover Up (Roland Banks signature weakness, 01007).
+//!
+//! ```text
+//! Revelation - Put Cover Up into play in your threat area, with 3 clues
+//!   on it.
+//! [reaction] When you would discover 1 or more clues at your location:
+//!   Discard that many clues from Cover Up instead.
+//! Forced - When the game ends, if there are any clues on Cover Up:
+//!   You suffer 1 mental trauma.
+//! ```
+//!
+//! Persistent treachery: the Revelation self-places into the threat area
+//! with 3 clues (`Effect::PutIntoThreatArea`), so `resolve_encounter_card`
+//! does not auto-discard it. The before-timing clue-discovery interrupt
+//! and the game-end forced trauma ride the C5a seam (`WouldDiscoverClues`
+//! / `GameEnd`), backed by the two native effects below — ports of the
+//! synthetic Cover-Up fixture C5a proved (`scenarios::test_fixtures::synth_cards`).
+
+use card_dsl::dsl::{
+    native, on_event, put_into_threat_area_with_clues, revelation, Ability, EventPattern,
+    EventTiming,
+};
+use game_core::card_registry::NativeEffectFn;
+use game_core::event::TraumaKind;
+use game_core::{Cx, EngineOutcome, EvalContext, Event};
+
+/// `ArkhamDB` code for Cover Up.
+pub const CODE: &str = "01007";
+
+/// Native tag: discard the replaced clue count from Cover Up.
+const DISCARD_TAG: &str = "01007:discard_clues";
+/// Native tag: suffer 1 mental trauma at game end if clues remain.
+const TRAUMA_TAG: &str = "01007:trauma";
+
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![
+        revelation(put_into_threat_area_with_clues(CODE, 3)),
+        on_event(
+            EventPattern::WouldDiscoverClues,
+            EventTiming::Before,
+            native(DISCARD_TAG),
+        ),
+        on_event(
+            EventPattern::GameEnd,
+            EventTiming::After,
+            native(TRAUMA_TAG),
+        ),
+    ]
+}
+
+#[must_use]
+pub fn native_effect_for(tag: &str) -> Option<NativeEffectFn> {
+    match tag {
+        DISCARD_TAG => Some(discard_clues),
+        TRAUMA_TAG => Some(trauma),
+        _ => None,
+    }
+}
+
+/// "Discard that many clues from Cover Up instead" — discard the replaced
+/// count (threaded via `clue_discovery_count`) from the firing instance.
+fn discard_clues(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
+    debug_assert!(
+        ctx.clue_discovery_count.is_some(),
+        "cover_up discard: clue_discovery_count not threaded"
+    );
+    let count = ctx.clue_discovery_count.unwrap_or(0);
+    let Some(source) = ctx.source else {
+        return EngineOutcome::Rejected {
+            reason: "cover_up discard: no source instance".into(),
+        };
+    };
+    if let Some(inv) = cx.state.investigators.get_mut(&ctx.controller) {
+        for card in inv
+            .threat_area
+            .iter_mut()
+            .chain(inv.cards_in_play.iter_mut())
+        {
+            if card.instance_id == source {
+                let take = count.min(card.clues);
+                card.clues -= take;
+                break;
+            }
+        }
+    }
+    EngineOutcome::Done
+}
+
+/// "When the game ends, if there are any clues on Cover Up: You suffer 1
+/// mental trauma."
+fn trauma(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
+    let Some(source) = ctx.source else {
+        return EngineOutcome::Rejected {
+            reason: "cover_up trauma: no source instance".into(),
+        };
+    };
+    let has_clues = cx
+        .state
+        .investigators
+        .get(&ctx.controller)
+        .is_some_and(|inv| {
+            inv.controlled_card_instances()
+                .any(|c| c.instance_id == source && c.clues > 0)
+        });
+    if has_clues {
+        cx.events.push(Event::TraumaSuffered {
+            investigator: ctx.controller,
+            kind: TraumaKind::Mental,
+            amount: 1,
+        });
+    }
+    EngineOutcome::Done
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use card_dsl::dsl::{Effect, Trigger};
+
+    #[test]
+    fn revelation_places_with_three_clues_plus_interrupt_and_gameend() {
+        let abilities = abilities();
+        assert_eq!(abilities.len(), 3);
+        assert_eq!(abilities[0].trigger, Trigger::Revelation);
+        assert!(matches!(
+            &abilities[0].effect,
+            Effect::PutIntoThreatArea { code, clues: 3 } if code == CODE
+        ));
+        assert!(matches!(
+            abilities[1].trigger,
+            Trigger::OnEvent {
+                pattern: EventPattern::WouldDiscoverClues,
+                timing: EventTiming::Before,
+            }
+        ));
+        assert!(matches!(
+            abilities[2].trigger,
+            Trigger::OnEvent {
+                pattern: EventPattern::GameEnd,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn native_tags_resolve() {
+        assert!(native_effect_for(DISCARD_TAG).is_some());
+        assert!(native_effect_for(TRAUMA_TAG).is_some());
+        assert!(native_effect_for("nope").is_none());
+    }
+}

--- a/crates/cards/src/impls/treachery_01164.rs
+++ b/crates/cards/src/impls/treachery_01164.rs
@@ -55,7 +55,9 @@ mod tests {
         assert_eq!(abilities.len(), 3);
 
         assert_eq!(abilities[0].trigger, Trigger::Revelation);
-        assert!(matches!(&abilities[0].effect, Effect::PutIntoThreatArea { code } if code == CODE));
+        assert!(
+            matches!(&abilities[0].effect, Effect::PutIntoThreatArea { code, clues: 0 } if code == CODE)
+        );
 
         assert_eq!(abilities[1].trigger, Trigger::Constant);
         let Effect::Restrict(Restriction::ExtraActionCost {

--- a/crates/cards/src/impls/treachery_01165.rs
+++ b/crates/cards/src/impls/treachery_01165.rs
@@ -45,7 +45,9 @@ mod tests {
         assert_eq!(abilities.len(), 4);
 
         assert_eq!(abilities[0].trigger, Trigger::Revelation);
-        assert!(matches!(&abilities[0].effect, Effect::PutIntoThreatArea { code } if code == CODE));
+        assert!(
+            matches!(&abilities[0].effect, Effect::PutIntoThreatArea { code, clues: 0 } if code == CODE)
+        );
 
         assert_eq!(abilities[1].trigger, Trigger::Constant);
         assert!(matches!(

--- a/crates/cards/tests/cover_up.rs
+++ b/crates/cards/tests/cover_up.rs
@@ -1,0 +1,227 @@
+//! C5c (#238) integration: Cover Up 01007 end-to-end against the real
+//! `cards::REGISTRY` — the 3-clue threat-area Revelation, the before-timing
+//! clue-discovery interrupt, and the game-end mental-trauma forced point.
+//!
+//! Own process → installs `cards::REGISTRY`. The interrupt / game-end
+//! shapes mirror the C5a synthetic test (`scenarios::tests::cover_up_interrupt`),
+//! now driven through the real card.
+
+use std::sync::Once;
+
+use game_core::action::EngineRecord;
+use game_core::event::{Event, TraumaKind};
+use game_core::scenario::{Resolution, ScenarioId};
+use game_core::state::{
+    Act, CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, GameState, InvestigatorId,
+    LocationId, Phase,
+};
+use game_core::test_support::{
+    drive, test_investigator, test_location, GameStateBuilder, ScriptedResolver,
+};
+use game_core::{apply, Action, EngineOutcome, InputResponse, PlayerAction};
+
+const COVER_UP: &str = "01007";
+const INV: InvestigatorId = InvestigatorId(1);
+const LOC: LocationId = LocationId(10);
+
+static INSTALL: Once = Once::new();
+fn install() {
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// A Cover-Up instance carrying `clues`, pre-placed in the threat area.
+fn cover_up(clues: u8) -> CardInPlay {
+    let mut c = CardInPlay::enter_play(CardCode::new(COVER_UP), CardInstanceId(1));
+    c.clues = clues;
+    c
+}
+
+// ---- Revelation: places into the threat area with 3 clues -------------
+
+#[test]
+fn revelation_puts_cover_up_in_threat_area_with_three_clues() {
+    install();
+    let mut state = GameStateBuilder::new()
+        .with_investigator_at(test_investigator(1), LOC)
+        .with_location(test_location(10, "Study"))
+        .with_turn_order([INV])
+        .build();
+    state.encounter_deck.push_back(CardCode::new(COVER_UP));
+
+    let mut resolver = ScriptedResolver::new();
+    resolver.commit_cards(&[]);
+    let r = drive(
+        state,
+        Action::Engine(EngineRecord::EncounterCardRevealed { investigator: INV }),
+        resolver,
+    );
+    assert_eq!(r.outcome, EngineOutcome::Done);
+
+    let placed: Vec<_> = r.state.investigators[&INV]
+        .threat_area
+        .iter()
+        .filter(|c| c.code.as_str() == COVER_UP)
+        .collect();
+    assert_eq!(placed.len(), 1, "exactly one Cover Up in the threat area");
+    assert_eq!(placed[0].clues, 3, "enters with 3 clues");
+    assert!(
+        !r.state
+            .encounter_discard
+            .iter()
+            .any(|c| c.as_str() == COVER_UP),
+        "persistent treachery is not auto-discarded after its Revelation"
+    );
+}
+
+// ---- Reaction: discard from Cover Up instead of discovering -----------
+
+/// Investigation-phase state: active investigator at a 2-clue location,
+/// Cover Up holding `cover_up_clues` in the threat area. +0 chaos token so
+/// the Intellect-3-vs-shroud-2 Investigate always succeeds.
+fn investigate_state(cover_up_clues: u8) -> GameState {
+    let mut investigator = test_investigator(1);
+    investigator.threat_area.push(cover_up(cover_up_clues));
+    let mut location = test_location(10, "Study");
+    location.clues = 2;
+    GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator_at(investigator, LOC)
+        .with_location(location)
+        .with_active_investigator(INV)
+        .with_turn_order([INV])
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_rng_seed(1)
+        .build()
+}
+
+/// Investigate + commit-nothing, returning the state paused at the
+/// clue-discovery interrupt (or resolved if none was offered).
+fn investigate_to_interrupt(state: GameState) -> (GameState, EngineOutcome) {
+    let r = apply(
+        state,
+        Action::Player(PlayerAction::Investigate { investigator: INV }),
+    );
+    assert!(matches!(r.outcome, EngineOutcome::AwaitingInput { .. }));
+    let r = apply(
+        r.state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::CommitCards { indices: vec![] },
+        }),
+    );
+    (r.state, r.outcome)
+}
+
+#[test]
+fn confirm_discards_from_cover_up_instead_of_discovering() {
+    install();
+    let (state, outcome) = investigate_to_interrupt(investigate_state(3));
+    assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
+    let r = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    );
+    assert!(matches!(r.outcome, EngineOutcome::Done));
+    assert_eq!(r.state.locations[&LOC].clues, 2, "location clues unchanged");
+    assert_eq!(r.state.investigators[&INV].clues, 0, "discovered nothing");
+    let cu = r.state.investigators[&INV]
+        .threat_area
+        .iter()
+        .find(|c| c.code.as_str() == COVER_UP)
+        .unwrap();
+    assert_eq!(cu.clues, 2, "1 clue discarded from Cover Up");
+}
+
+#[test]
+fn skip_discovers_normally() {
+    install();
+    let (state, outcome) = investigate_to_interrupt(investigate_state(3));
+    assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
+    let r = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Skip,
+        }),
+    );
+    assert!(matches!(r.outcome, EngineOutcome::Done));
+    assert_eq!(r.state.locations[&LOC].clues, 1, "location -1");
+    assert_eq!(r.state.investigators[&INV].clues, 1, "investigator +1");
+    let cu = r.state.investigators[&INV]
+        .threat_area
+        .iter()
+        .find(|c| c.code.as_str() == COVER_UP)
+        .unwrap();
+    assert_eq!(cu.clues, 3, "Cover Up untouched on Skip");
+}
+
+// ---- Forced: game-end mental trauma if clues remain -------------------
+
+/// Terminal-act state whose `AdvanceAct` latches a Won resolution, with a
+/// Cover Up holding `cover_up_clues` in the threat area.
+fn resolving_state(cover_up_clues: u8) -> GameState {
+    let mut investigator = test_investigator(1);
+    investigator.clues = 1; // meets the act's clue threshold
+    investigator.threat_area.push(cover_up(cover_up_clues));
+    let mut state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(investigator)
+        .with_active_investigator(INV)
+        .with_turn_order([INV])
+        .with_scenario_id(ScenarioId::new("unknown"))
+        .build();
+    state.act_deck = vec![Act {
+        code: CardCode("_test_act".into()),
+        clue_threshold: 1,
+        resolution: Some(Resolution::Won { id: "test".into() }),
+        round_end_advance: None,
+    }];
+    state
+}
+
+#[test]
+fn game_end_emits_mental_trauma_when_cover_up_has_clues() {
+    install();
+    let r = apply(
+        resolving_state(3),
+        Action::Player(PlayerAction::AdvanceAct { investigator: INV }),
+    );
+    assert!(r
+        .events
+        .iter()
+        .any(|e| matches!(e, Event::ScenarioResolved { .. })));
+    assert!(
+        r.events.iter().any(|e| matches!(
+            e,
+            Event::TraumaSuffered {
+                kind: TraumaKind::Mental,
+                amount: 1,
+                ..
+            }
+        )),
+        "expected mental trauma at game end; events = {:?}",
+        r.events
+    );
+}
+
+#[test]
+fn game_end_emits_no_trauma_when_cover_up_empty() {
+    install();
+    let r = apply(
+        resolving_state(0),
+        Action::Player(PlayerAction::AdvanceAct { investigator: INV }),
+    );
+    assert!(r
+        .events
+        .iter()
+        .any(|e| matches!(e, Event::ScenarioResolved { .. })));
+    assert!(
+        !r.events
+            .iter()
+            .any(|e| matches!(e, Event::TraumaSuffered { .. })),
+        "no trauma when Cover Up is empty; events = {:?}",
+        r.events
+    );
+}

--- a/crates/cards/tests/weapon_38_special.rs
+++ b/crates/cards/tests/weapon_38_special.rs
@@ -1,0 +1,103 @@
+//! C5c (#238) integration: Roland's .38 Special 01006 end-to-end against
+//! the real `cards::REGISTRY`. Verifies the clue-conditional combat
+//! modifier (+3 with a clue on the location, +1 without) and ammo spend.
+//!
+//! Own process → installs `cards::REGISTRY`.
+
+use std::sync::Once;
+
+use game_core::engine::EngineOutcome;
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, EnemyId, InvestigatorId, Phase,
+    TokenModifiers, UseKind,
+};
+use game_core::test_support::{apply_no_commits, test_enemy, test_investigator, GameStateBuilder};
+use game_core::{assert_event, assert_no_event, Action, PlayerAction};
+
+const SPECIAL: &str = "01006";
+const INV: InvestigatorId = InvestigatorId(1);
+const LOC: game_core::state::LocationId = game_core::state::LocationId(10);
+const ENEMY: EnemyId = EnemyId(100);
+const WEAPON_INST: CardInstanceId = CardInstanceId(0);
+
+static INSTALL: Once = Once::new();
+fn install() {
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// Board: .38 Special in play with 4 ammo, the active investigator (combat
+/// 3) at a location holding `loc_clues`, engaged with a fight-**5** enemy
+/// (health 3). Fight 5 distinguishes the modifier branches: +3 → total 8
+/// hits, +1 → total 4 misses. A `Numeric(0)` chaos bag is deterministic.
+fn board(loc_clues: u8) -> game_core::GameState {
+    install();
+    let mut inv = test_investigator(1);
+    inv.skills.combat = 3;
+    let mut weapon = CardInPlay::enter_play(CardCode::new(SPECIAL), WEAPON_INST);
+    weapon.uses.insert(UseKind::Ammo, 4);
+    inv.cards_in_play.push(weapon);
+
+    let mut enemy = test_enemy(100, "Ghoul");
+    enemy.fight = 5;
+    enemy.max_health = 3;
+    enemy.engaged_with = Some(INV);
+
+    let mut location = game_core::test_support::test_location(10, "Study");
+    location.clues = loc_clues;
+
+    GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator_at(inv, LOC)
+        .with_location(location)
+        .with_enemy(enemy)
+        .with_active_investigator(INV)
+        .with_turn_order([INV])
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default())
+        .build()
+}
+
+fn ammo(state: &game_core::GameState) -> u8 {
+    state.investigators[&INV]
+        .cards_in_play
+        .iter()
+        .find(|c| c.instance_id == WEAPON_INST)
+        .and_then(|c| c.uses.get(&UseKind::Ammo).copied())
+        .expect("weapon carries an ammo pool")
+}
+
+fn fire(state: game_core::GameState) -> game_core::engine::ApplyResult {
+    apply_no_commits(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: INV,
+            instance_id: WEAPON_INST,
+            ability_index: 0,
+        }),
+    )
+}
+
+#[test]
+fn plus_three_with_a_clue_on_location_hits_for_two() {
+    // Clue present → +3: combat 3 + 3 = 6 vs fight 5 → success, 1 + 1 = 2.
+    let r = fire(board(1));
+    assert_eq!(r.outcome, EngineOutcome::Done);
+    assert_event!(r.events, Event::EnemyDamaged { amount: 2, .. });
+    assert_eq!(r.state.enemies[&ENEMY].damage, 2);
+    assert_eq!(ammo(&r.state), 3, "1 ammo spent");
+}
+
+#[test]
+fn plus_one_without_a_clue_misses() {
+    // No clue → +1: combat 3 + 1 = 4 vs fight 5 → fail, no damage. Ammo is
+    // still spent on activation regardless of the result.
+    let r = fire(board(0));
+    assert_eq!(r.outcome, EngineOutcome::Done);
+    assert_event!(r.events, Event::SkillTestFailed { .. });
+    assert_no_event!(r.events, Event::EnemyDamaged { .. });
+    assert_eq!(r.state.enemies[&ENEMY].damage, 0);
+    assert_eq!(ammo(&r.state), 3, "ammo spent even on a miss");
+}

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -217,12 +217,24 @@ pub(crate) fn apply_effect(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) 
             0, // a Revelation skill test takes its difficulty as printed
         ),
         Effect::DiscardSelf => discard_self(cx, &eval_ctx),
-        Effect::PutIntoThreatArea { code } => {
-            crate::engine::dispatch::threat_area::place_in_threat_area(
+        Effect::PutIntoThreatArea { code, clues } => {
+            let inst = crate::engine::dispatch::threat_area::place_in_threat_area(
                 cx,
                 eval_ctx.controller,
                 crate::state::CardCode::new(code.clone()),
             );
+            if *clues > 0 {
+                if let Some(id) = inst {
+                    if let Some(card) = cx
+                        .state
+                        .investigators
+                        .get_mut(&eval_ctx.controller)
+                        .and_then(|inv| inv.threat_area.iter_mut().find(|c| c.instance_id == id))
+                    {
+                        card.clues = *clues;
+                    }
+                }
+            }
             EngineOutcome::Done
         }
         Effect::Restrict(_) => EngineOutcome::Rejected {
@@ -2126,6 +2138,32 @@ mod tests {
             EvalContext::for_controller(InvestigatorId(1)),
         );
         assert!(matches!(outcome, EngineOutcome::Rejected { .. }));
+    }
+
+    #[test]
+    fn put_into_threat_area_with_clues_seeds_the_placed_instance() {
+        use crate::dsl::put_into_threat_area_with_clues;
+        let id = InvestigatorId(1);
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .build();
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+        let outcome = apply_effect(
+            &mut cx,
+            &put_into_threat_area_with_clues("01007", 3),
+            EvalContext::for_controller(id),
+        );
+        assert!(matches!(outcome, EngineOutcome::Done));
+        let placed = state.investigators[&id]
+            .threat_area
+            .iter()
+            .find(|c| c.code.as_str() == "01007")
+            .expect("Cover Up placed in threat area");
+        assert_eq!(placed.clues, 3, "Cover Up enters with 3 clues");
     }
 
     #[test]

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -223,17 +223,14 @@ pub(crate) fn apply_effect(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) 
                 eval_ctx.controller,
                 crate::state::CardCode::new(code.clone()),
             );
-            if *clues > 0 {
-                if let Some(id) = inst {
-                    if let Some(card) = cx
-                        .state
-                        .investigators
-                        .get_mut(&eval_ctx.controller)
-                        .and_then(|inv| inv.threat_area.iter_mut().find(|c| c.instance_id == id))
-                    {
-                        card.clues = *clues;
-                    }
-                }
+            let placed = inst.and_then(|id| {
+                cx.state
+                    .investigators
+                    .get_mut(&eval_ctx.controller)
+                    .and_then(|inv| inv.threat_area.iter_mut().find(|c| c.instance_id == id))
+            });
+            if let Some(card) = placed {
+                card.clues = *clues;
             }
             EngineOutcome::Done
         }

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -4,46 +4,9 @@
 
 🛠️ **Slice 1 in progress** (kickoff [#216](https://github.com/talelburg/eldritch/issues/216)).
 Engine spine (A1/A2) and scenario plumbing (B1/B2) shipped; **Group C**
-(the Gathering content) is decomposed into sub-slices C1–C7
-([#227](https://github.com/talelburg/eldritch/issues/227)–[#245](https://github.com/talelburg/eldritch/issues/245),
-kickoff [#246](https://github.com/talelburg/eldritch/issues/246)). Shipped:
-C1a (board skeleton), C1b (Act-1 board build + Act-3 forced advance-on-defeat),
-C2 (01104 symbol-token effects + location victory points),
-C3a (Prey – Lowest remaining health + Retaliate keyword),
-C3b (the six encounter enemies + pipeline keyword/spawn/health parsing),
-C3c (agenda 01107 forced abilities), C3d (act-2 round-end window),
-the act-2 reverse ([#280](https://github.com/talelburg/eldritch/issues/280):
-spawn the set-aside Ghoul Priest + reveal the Parlor), the agenda
-reverses ([#281](https://github.com/talelburg/eldritch/issues/281):
-01105/01106 + the `AgendaAdvanced` forced point), C4a (threat-area
-zone + shared scan source + `EndOfTurn`/`AfterLocationInvestigated`
-forced points), the test-treachery engine prereq
-([#286](https://github.com/talelburg/eldritch/issues/286):
-`Effect::SkillTest` + `ForEachPointFailed` + suspendable-revelation
-discard), C4b (the four one-shot Revelation treacheries —
-01162/01163/01166/01167), and C4c (the three persistent threat-area /
-attachment treacheries — Obscuring Fog 01168, Dissonant Voices 01165,
-Frozen in Fear 01164 — with the location attachment zone, inspectable-DSL
-constant restrictions, `Effect::DiscardSelf`, deterministic
-simultaneous-forced-trigger resolution, and end-turn resume plumbing), and
-C5a ([#236](https://github.com/talelburg/eldritch/issues/236): Cover Up's
-before-timing clue-discovery replacement interrupt at the `discover_clue`
-chokepoint — `clue_interrupt_pending` suspension + pre-advanced skill-test
-resume — plus `ForcedTriggerPoint::GameEnd` and `Event::TraumaSuffered`),
-and C5b ([#237](https://github.com/talelburg/eldritch/issues/237): the
-enemy-attack damage/horror soak mechanic — soak-first `assign_attack` →
-simultaneous `place_assignment` → asset defeat-on-overflow → the
-`AfterEnemyAttackDamagedAsset` reaction window — plus Guard Dog 01021's
-retaliate and the resumable enemy-phase attack loop;
-[PR #292](https://github.com/talelburg/eldritch/pull/292)), and the C5c
-weapon-support prereq ([#295](https://github.com/talelburg/eldritch/issues/295):
-ammo/uses + inspectable `Effect::Fight` — `Cost::SpendUses` + `IntExpr`
-modifier + bonus damage; [PR #297](https://github.com/talelburg/eldritch/pull/297)),
-and C5c ([#238](https://github.com/talelburg/eldritch/issues/238): Roland's
-.38 Special 01006 — clue-conditional weapon-fight — and Cover Up 01007 —
-3-clue threat-area Revelation + interrupt + game-end mental trauma — plus
-the `PutIntoThreatArea { clues }` extension;
-[PR #298](https://github.com/talelburg/eldritch/pull/298)).
+(the Gathering content, decomposed into C1–C7, kickoff
+[#246](https://github.com/talelburg/eldritch/issues/246)) is done through
+**C5c** — see the Group C breakdown table below for per-sub-slice state.
 **Next: C5d → C7** (C6d also gates C7b).
 
 Design specs:

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -38,8 +38,13 @@ retaliate and the resumable enemy-phase attack loop;
 [PR #292](https://github.com/talelburg/eldritch/pull/292)), and the C5c
 weapon-support prereq ([#295](https://github.com/talelburg/eldritch/issues/295):
 ammo/uses + inspectable `Effect::Fight` — `Cost::SpendUses` + `IntExpr`
-modifier + bonus damage; [PR #297](https://github.com/talelburg/eldritch/pull/297)).
-**Next: C5c content → C7** (C6d also gates C7b).
+modifier + bonus damage; [PR #297](https://github.com/talelburg/eldritch/pull/297)),
+and C5c ([#238](https://github.com/talelburg/eldritch/issues/238): Roland's
+.38 Special 01006 — clue-conditional weapon-fight — and Cover Up 01007 —
+3-clue threat-area Revelation + interrupt + game-end mental trauma — plus
+the `PutIntoThreatArea { clues }` extension;
+[PR #298](https://github.com/talelburg/eldritch/pull/298)).
+**Next: C5d → C7** (C6d also gates C7b).
 
 Design specs:
 [Gathering design](../superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md),
@@ -96,7 +101,7 @@ root dependency; C7 is the playable Won/Lost gate; #212 lands after C.
 | C5a | [#236](https://github.com/talelburg/eldritch/issues/236) | Cover Up before-timing interrupt + `GameEnd` | ✅ PR #291 |
 | C5b | [#237](https://github.com/talelburg/eldritch/issues/237) | Guard Dog reaction + enemy-attack soak mechanic | ✅ PR #292 |
 | — | [#295](https://github.com/talelburg/eldritch/issues/295) | infra: weapon support — ammo/uses (`Cost::SpendUses`) + inspectable `Effect::Fight` (`IntExpr` modifier + bonus damage) (prerequisite for C5c's .38 Special) | ✅ PR #297 |
-| C5c | [#238](https://github.com/talelburg/eldritch/issues/238) | .38 Special signature + Cover Up content | — |
+| C5c | [#238](https://github.com/talelburg/eldritch/issues/238) | .38 Special signature + Cover Up content | ✅ PR #298 |
 | C5d | [#239](https://github.com/talelburg/eldritch/issues/239) | Guardian L0 assets (×6) | — |
 | C5e | [#240](https://github.com/talelburg/eldritch/issues/240) | Guardian L0 events + skill (×4) | — |
 | C6a | [#241](https://github.com/talelburg/eldritch/issues/241) | Dr. Milan after-investigate window | — |

--- a/docs/superpowers/plans/2026-06-15-c5c-roland-signature-weakness.md
+++ b/docs/superpowers/plans/2026-06-15-c5c-roland-signature-weakness.md
@@ -1,0 +1,432 @@
+# C5c — Roland's .38 Special + Cover Up Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Roland Banks' signature/weakness pair for The Gathering — `.38 Special` (01006) and `Cover Up` (01007) — as card content riding on the weapon-support engine (#295, merged) and the C5a interrupt/game-end machinery.
+
+**Architecture:** Two card impls in `crates/cards/src/impls/`, registered in `impls/mod.rs`. `.38 Special` is a one-ability asset using `Effect::Fight` + `Cost::SpendUses`. `Cover Up` is a persistent treachery porting the C5a synthetic fixture's two native effects + adding a 3-clue threat-area Revelation, which needs a small engine extension: `Effect::PutIntoThreatArea` gains a `clues` field.
+
+**Tech Stack:** Rust — `card-dsl` (the `PutIntoThreatArea` field), `game-core` (evaluator arm), `cards` (the two impls + tests). Issue **#238**.
+
+**Branch:** `card/c5c-roland-signature`. **CI gauntlet** (run before each commit touching code):
+```sh
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+```
+
+---
+
+## File Structure
+
+- `crates/card-dsl/src/dsl.rs` — `Effect::PutIntoThreatArea { code, clues }`; `put_into_threat_area_with_clues(code, clues)` builder; existing `put_into_threat_area(code)` keeps `clues: 0`.
+- `crates/game-core/src/engine/evaluator.rs` — the `PutIntoThreatArea` arm seeds `clues` on the minted instance.
+- `crates/cards/src/impls/treachery_01007.rs` — **new**: Cover Up (Revelation + interrupt + game-end natives).
+- `crates/cards/src/impls/roland_38_special.rs` — **new**: .38 Special (one activated Fight ability).
+- `crates/cards/src/impls/mod.rs` — register both modules (`pub mod`, `abilities_for` arms, `native_effect_for` chain for Cover Up).
+- `crates/cards/tests/weapon_38_special.rs` — **new**: integration test (real registry) for the +3/+1 clue paths.
+- `crates/cards/tests/cover_up.rs` — **new**: integration test (real registry) for Revelation placement + interrupt + game-end trauma.
+
+Reference impls to mirror: `crates/cards/src/impls/treachery_01165.rs` (persistent treachery shape), `crates/scenarios/src/test_fixtures/synth_cards.rs` (the Cover Up native bodies to port), `crates/scenarios/tests/cover_up_interrupt.rs` (the C5a test shapes).
+
+---
+
+## Task 1: Extend `Effect::PutIntoThreatArea` with a `clues` field
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs` (variant ~595, builder ~1045)
+- Modify: `crates/game-core/src/engine/evaluator.rs` (arm ~220)
+- Test: `crates/card-dsl/src/dsl.rs` + a game-core evaluator test
+
+- [ ] **Step 1: Add the field.** In `Effect::PutIntoThreatArea`:
+
+```rust
+    PutIntoThreatArea {
+        /// Printed `ArkhamDB` code of the card to place.
+        code: String,
+        /// Clues to seed on the placed instance ("with 3 clues on it",
+        /// Cover Up 01007). `0` for cards that enter clue-less.
+        clues: u8,
+    },
+```
+
+- [ ] **Step 2: Update the builder + add the clue-bearing one.** Replace the existing `put_into_threat_area`:
+
+```rust
+/// Build an [`Effect::PutIntoThreatArea`] that enters clue-less.
+#[must_use]
+pub fn put_into_threat_area(code: impl Into<String>) -> Effect {
+    Effect::PutIntoThreatArea { code: code.into(), clues: 0 }
+}
+
+/// Build an [`Effect::PutIntoThreatArea`] seeding `clues` on the instance
+/// (Cover Up 01007: "Put Cover Up into play in your threat area, with 3
+/// clues on it").
+#[must_use]
+pub fn put_into_threat_area_with_clues(code: impl Into<String>, clues: u8) -> Effect {
+    Effect::PutIntoThreatArea { code: code.into(), clues }
+}
+```
+
+- [ ] **Step 3: Fix the existing callers' pattern matches.** The Dissonant Voices test (`treachery_01165.rs`) matches `Effect::PutIntoThreatArea { code }` — update to `{ code, .. }`. Search:
+
+Run: `grep -rn 'PutIntoThreatArea {' crates --include='*.rs' | grep -v '\.\.'`
+Fix each non-`..` match/literal (the builder bodies above, and any test pattern) to include `clues`.
+
+- [ ] **Step 4: Seed clues in the evaluator arm.** `place_in_threat_area` returns `Option<CardInstanceId>`; set the clue count on the minted instance:
+
+```rust
+        Effect::PutIntoThreatArea { code, clues } => {
+            let inst = crate::engine::dispatch::threat_area::place_in_threat_area(
+                cx,
+                eval_ctx.controller,
+                crate::state::CardCode::new(code.clone()),
+            );
+            if *clues > 0 {
+                if let Some(id) = inst {
+                    if let Some(card) = cx
+                        .state
+                        .investigators
+                        .get_mut(&eval_ctx.controller)
+                        .and_then(|inv| inv.threat_area.iter_mut().find(|c| c.instance_id == id))
+                    {
+                        card.clues = *clues;
+                    }
+                }
+            }
+            EngineOutcome::Done
+        }
+```
+
+- [ ] **Step 5: Test the clue seeding.** In `evaluator.rs` tests, add a test that applying `put_into_threat_area_with_clues("01007", 3)` for a controller leaves a threat-area instance with `clues == 3`. Use the `GameStateBuilder` + `apply_effect` pattern the other evaluator tests use (build a `Cx`, call `apply_effect`, inspect `state.investigators[&id].threat_area`).
+
+- [ ] **Step 6: Gauntlet + commit.**
+
+Run the full gauntlet. Expected: green (all `PutIntoThreatArea` callers updated).
+
+```bash
+git add crates/card-dsl/src/dsl.rs crates/game-core/src/engine/evaluator.rs
+git commit -m "dsl+engine: PutIntoThreatArea seeds clues on the placed instance"
+```
+
+---
+
+## Task 2: `.38 Special` (01006) impl
+
+**Files:**
+- Create: `crates/cards/src/impls/roland_38_special.rs`
+- Modify: `crates/cards/src/impls/mod.rs` (`pub mod` + `abilities_for` arm)
+- Test: in-module unit test + `crates/cards/tests/weapon_38_special.rs`
+
+Card text (verified `data/arkhamdb-snapshot/pack/core/core.json`, 2026-06-15):
+`Uses (4 ammo). [action] Spend 1 ammo: Fight. You get +1 [combat] for this attack (if there are 1 or more clues on your location, you get +3 [combat], instead). This attack deals +1 damage.`
+
+- [ ] **Step 1: Write the module with an ability-shape unit test first.** Create `roland_38_special.rs`:
+
+```rust
+//! Roland's .38 Special (Roland Banks signature asset, 01006).
+//!
+//! ```text
+//! Roland Banks deck only.
+//! Uses (4 ammo).
+//! [action] Spend 1 ammo: Fight. You get +1 [combat] for this attack
+//! (if there are 1 or more clues on your location, you get +3 [combat],
+//! instead). This attack deals +1 damage.
+//! ```
+//!
+//! Ammo (4) comes from the corpus (`CardKind::Asset.uses`, pipeline-
+//! parsed); the ability spends 1 per use via `Cost::SpendUses` and fights
+//! through `Effect::Fight`, whose combat modifier is `+3` when the
+//! investigator's location holds a clue, `+1` otherwise (`IntExpr::cond`),
+//! dealing `1 + 1` damage on success.
+
+use card_dsl::card_data::UseKind;
+use card_dsl::dsl::{activated, fight, Ability, Condition, Cost, IntExpr};
+
+/// `ArkhamDB` code for Roland's .38 Special.
+pub const CODE: &str = "01006";
+
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![activated(
+        1,
+        vec![Cost::SpendUses {
+            kind: UseKind::Ammo,
+            count: 1,
+        }],
+        fight(IntExpr::cond(Condition::LocationHasClues, 3, 1), 1),
+    )]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use card_dsl::dsl::{Effect, Trigger};
+
+    #[test]
+    fn one_activated_fight_ability_spending_ammo() {
+        let abilities = abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(abilities[0].trigger, Trigger::Activated { action_cost: 1 });
+        assert_eq!(
+            abilities[0].costs,
+            vec![Cost::SpendUses {
+                kind: UseKind::Ammo,
+                count: 1
+            }]
+        );
+        let Effect::Fight {
+            combat_modifier,
+            extra_damage,
+        } = &abilities[0].effect
+        else {
+            panic!("expected Effect::Fight");
+        };
+        assert_eq!(*extra_damage, 1);
+        assert_eq!(
+            *combat_modifier,
+            IntExpr::cond(Condition::LocationHasClues, 3, 1)
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the unit test.**
+
+Run: `cargo test -p cards --lib one_activated_fight_ability_spending_ammo` (or the impls path)
+Expected: PASS once registered (Step 3) — module must be reachable.
+
+- [ ] **Step 3: Register in `impls/mod.rs`.** Add `pub mod roland_38_special;` (alphabetical-ish, near `roland_banks`) and an `abilities_for` arm:
+
+```rust
+        roland_38_special::CODE => Some(roland_38_special::abilities()),
+```
+
+Match the exact dispatch style already in `abilities_for` (it dispatches `code` against each module's `CODE`).
+
+- [ ] **Step 4: Integration test — the clue-conditional end to end.** Create `crates/cards/tests/weapon_38_special.rs`, modelled on `crates/game-core/tests/weapon_fight.rs` but installing the **real** registry (`cards::REGISTRY`) and using code `"01006"`. Put a `.38 Special` in play with `uses = {Ammo: 4}` (seeded — either play it from hand or set directly), the investigator at a location, engaged with one enemy (fight 3, health 3), combat 3, a `Numeric(0)` chaos bag. Two cases:
+
+```rust
+// Clue on the location → +3 combat: total 3 + 3 = 6 vs fight 3, deals 2.
+// (No clue → +1: total 4 vs 3, still hits here; assert the modifier via
+//  the in-flight test or pick an enemy fight value that distinguishes —
+//  e.g. fight 5: +3 path (8) succeeds, +1 path (4) fails.)
+```
+
+Use **fight 5** so the two modifier branches are observable: with a clue (+3 → total 8 ≥ 5) the enemy takes 2 damage; without (+1 → total 4 < 5) the Fight fails and deals 0. Assert `EnemyDamaged { amount: 2, .. }` in the clue case and `SkillTestFailed` / no `EnemyDamaged` in the no-clue case. Assert ammo decremented 4 → 3 in both (ammo is spent on activation regardless of hit).
+
+- [ ] **Step 5: Run integration test + gauntlet, commit.**
+
+Run: `cargo test -p cards --test weapon_38_special`
+Expected: PASS. Then full gauntlet.
+
+```bash
+git add crates/cards/src/impls/roland_38_special.rs crates/cards/src/impls/mod.rs \
+        crates/cards/tests/weapon_38_special.rs
+git commit -m "card: Roland's .38 Special 01006 — clue-conditional weapon-fight"
+```
+
+---
+
+## Task 3: `Cover Up` (01007) impl
+
+**Files:**
+- Create: `crates/cards/src/impls/treachery_01007.rs`
+- Modify: `crates/cards/src/impls/mod.rs` (`pub mod` + `abilities_for` arm + `native_effect_for` chain)
+- Test: in-module unit test + `crates/cards/tests/cover_up.rs`
+
+Card text (verified, 2026-06-15):
+`Revelation - Put Cover Up into play in your threat area, with 3 clues on it. [reaction] When you would discover 1 or more clues at your location: Discard that many clues from Cover Up instead. Forced - When the game ends, if there are any clues on Cover Up: You suffer 1 mental trauma.`
+
+- [ ] **Step 1: Write the module.** Port the two native bodies from `synth_cards.rs` (`synth_cover_up_discard`, `synth_cover_up_trauma`) verbatim except the tag constants. Create `treachery_01007.rs`:
+
+```rust
+//! Cover Up (Roland Banks signature weakness, 01007).
+//!
+//! ```text
+//! Revelation - Put Cover Up into play in your threat area, with 3 clues
+//!   on it.
+//! [reaction] When you would discover 1 or more clues at your location:
+//!   Discard that many clues from Cover Up instead.
+//! Forced - When the game ends, if there are any clues on Cover Up:
+//!   You suffer 1 mental trauma.
+//! ```
+//!
+//! Persistent treachery: the Revelation self-places into the threat area
+//! with 3 clues (`Effect::PutIntoThreatArea`), so `resolve_encounter_card`
+//! does not auto-discard it. The before-timing clue interrupt and the
+//! game-end forced trauma ride the C5a seam (`WouldDiscoverClues` /
+//! `GameEnd`), backed by the two native effects below.
+
+use card_dsl::dsl::{
+    native, on_event, put_into_threat_area_with_clues, revelation, Ability, EventPattern,
+    EventTiming,
+};
+use game_core::card_registry::NativeEffectFn;
+use game_core::engine::{Cx, EngineOutcome, EvalContext};
+use game_core::event::{Event, TraumaKind};
+
+/// `ArkhamDB` code for Cover Up.
+pub const CODE: &str = "01007";
+
+/// Native tag: discard the replaced clue count from Cover Up.
+const DISCARD_TAG: &str = "01007:discard_clues";
+/// Native tag: suffer 1 mental trauma at game end if clues remain.
+const TRAUMA_TAG: &str = "01007:trauma";
+
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![
+        revelation(put_into_threat_area_with_clues(CODE, 3)),
+        on_event(
+            EventPattern::WouldDiscoverClues,
+            EventTiming::Before,
+            native(DISCARD_TAG),
+        ),
+        on_event(EventPattern::GameEnd, EventTiming::After, native(TRAUMA_TAG)),
+    ]
+}
+
+#[must_use]
+pub fn native_effect_for(tag: &str) -> Option<NativeEffectFn> {
+    match tag {
+        DISCARD_TAG => Some(discard_clues),
+        TRAUMA_TAG => Some(trauma),
+        _ => None,
+    }
+}
+
+/// "Discard that many clues from Cover Up instead" — discard the replaced
+/// count (threaded via `clue_discovery_count`) from the firing instance.
+fn discard_clues(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
+    debug_assert!(
+        ctx.clue_discovery_count.is_some(),
+        "cover_up discard: clue_discovery_count not threaded"
+    );
+    let count = ctx.clue_discovery_count.unwrap_or(0);
+    let Some(source) = ctx.source else {
+        return EngineOutcome::Rejected {
+            reason: "cover_up discard: no source instance".into(),
+        };
+    };
+    if let Some(inv) = cx.state.investigators.get_mut(&ctx.controller) {
+        for card in inv.threat_area.iter_mut().chain(inv.cards_in_play.iter_mut()) {
+            if card.instance_id == source {
+                let take = count.min(card.clues);
+                card.clues -= take;
+                break;
+            }
+        }
+    }
+    EngineOutcome::Done
+}
+
+/// "When the game ends, if there are any clues on Cover Up: You suffer 1
+/// mental trauma."
+fn trauma(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
+    let Some(source) = ctx.source else {
+        return EngineOutcome::Rejected {
+            reason: "cover_up trauma: no source instance".into(),
+        };
+    };
+    let has_clues = cx
+        .state
+        .investigators
+        .get(&ctx.controller)
+        .is_some_and(|inv| {
+            inv.controlled_card_instances()
+                .any(|c| c.instance_id == source && c.clues > 0)
+        });
+    if has_clues {
+        cx.events.push(Event::TraumaSuffered {
+            investigator: ctx.controller,
+            kind: TraumaKind::Mental,
+            amount: 1,
+        });
+    }
+    EngineOutcome::Done
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use card_dsl::dsl::{Effect, Trigger};
+
+    #[test]
+    fn revelation_places_with_three_clues_plus_interrupt_and_gameend() {
+        let abilities = abilities();
+        assert_eq!(abilities.len(), 3);
+        assert_eq!(abilities[0].trigger, Trigger::Revelation);
+        assert!(matches!(
+            &abilities[0].effect,
+            Effect::PutIntoThreatArea { code, clues: 3 } if code == CODE
+        ));
+        assert!(matches!(
+            abilities[1].trigger,
+            Trigger::OnEvent {
+                pattern: EventPattern::WouldDiscoverClues,
+                timing: EventTiming::Before,
+            }
+        ));
+        assert!(matches!(
+            abilities[2].trigger,
+            Trigger::OnEvent {
+                pattern: EventPattern::GameEnd,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn native_tags_resolve() {
+        assert!(native_effect_for(DISCARD_TAG).is_some());
+        assert!(native_effect_for(TRAUMA_TAG).is_some());
+        assert!(native_effect_for("nope").is_none());
+    }
+}
+```
+
+(Confirm `native`, `on_event`, `revelation`, `EventPattern`, `EventTiming` import paths against `treachery_01165.rs` / `synth_cards.rs`; `controlled_card_instances` and `EvalContext` fields against `synth_cards.rs`.)
+
+- [ ] **Step 2: Register in `impls/mod.rs`.** Add `pub mod treachery_01007;`, an `abilities_for` arm (`treachery_01007::CODE => Some(treachery_01007::abilities())`), and chain its `native_effect_for` into the module's `native_effect_for` (`.or_else(|| treachery_01007::native_effect_for(tag))`).
+
+- [ ] **Step 3: Run the unit tests.**
+
+Run: `cargo test -p cards --lib treachery_01007`
+Expected: PASS.
+
+- [ ] **Step 4: Integration test.** Create `crates/cards/tests/cover_up.rs`, modelled on `crates/scenarios/tests/cover_up_interrupt.rs` but installing `cards::REGISTRY` and using code `"01007"`. Cover:
+  - **Revelation placement**: resolve the encounter card (`resolve_encounter_card` path, the way the C4c persistent-treachery integration test drives it) → assert a `01007` instance is in the threat area with `clues == 3` and it was **not** auto-discarded.
+  - **Interrupt**: with Cover Up holding clues, an Investigate that would discover at the location offers the interrupt; `Confirm` discards from Cover Up instead (location/investigator clues unchanged); `Skip` discovers normally. (Mirror `confirm_replaces_discovery_with_discard_from_cover_up` / `skip_discovers_normally`.)
+  - **Game-end trauma**: at scenario resolution, `TraumaSuffered { Mental, 1 }` fires iff Cover Up holds clues. (Mirror `game_end_emits_trauma_when_cover_up_has_clues` / `..._empty`.)
+
+  Reuse the `resolve_encounter_card` / `AdvanceAct`-to-resolution helpers from the C4c (`persistent_treachery.rs`) and C5a (`cover_up_interrupt.rs`) integration tests; the only change is the registry + the real code.
+
+- [ ] **Step 5: Run integration test + gauntlet, commit.**
+
+Run: `cargo test -p cards --test cover_up`
+Expected: PASS. Then full gauntlet.
+
+```bash
+git add crates/cards/src/impls/treachery_01007.rs crates/cards/src/impls/mod.rs \
+        crates/cards/tests/cover_up.rs
+git commit -m "card: Cover Up 01007 — 3-clue threat-area Revelation + interrupt + game-end trauma"
+```
+
+---
+
+## Task 4: Doc/wasm sweep + phase doc
+
+- [ ] **Step 1: Full CI gauntlet** — test, clippy, fmt, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`, `cargo build -p web --target wasm32-unknown-unknown`, `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`. Fix any doc-link nits on the new public items.
+
+- [ ] **Step 2: (after PR is open + CI green) phase doc** — flip C5c (#238) to `✅ PR #NN` in the Group C breakdown, update the Status "Next" line (C5c → C5d/C6…), and add a Decisions entry only if load-bearing (likely none — the prereq decision already covers weapons; Cover Up is a straight port). Commit as the final commit.
+
+---
+
+## Self-review notes (coverage vs. spec)
+
+- `.38 Special`: Task 2 — clue-conditional +3/+1 + ammo, via `Effect::Fight` + `Cost::SpendUses`. ✅
+- `Cover Up`: Task 3 — 3-clue Revelation (Task 1's `PutIntoThreatArea { clues }`) + interrupt + game-end trauma, ported from the synth fixture. ✅
+- `PutIntoThreatArea { clues }` engine extension: Task 1 (spec puts it in C5c, not the prereq). ✅
+- Card tests + integration tests: Tasks 2–3. ✅
+- Out of scope (per spec): multi-enemy targeting, trauma persistence — unchanged from PR 1.


### PR DESCRIPTION
## Summary

C5c — Roland Banks' signature/weakness pair for The Gathering, the **card content** riding on the merged weapon-support engine (#295) and the C5a interrupt/game-end machinery.

Spec: `docs/superpowers/specs/2026-06-15-phase-7-c5c-roland-signature-weakness-design.md`
Plan: `docs/superpowers/plans/2026-06-15-c5c-roland-signature-weakness.md`

## What's in it

- **Roland's .38 Special 01006** (`roland_38_special.rs`) — `[action] Spend 1 ammo: Fight. +1 [combat] (+3 if 1+ clues on your location, instead). +1 damage. Uses (4 ammo).` One activated ability: `activated(1, [Cost::SpendUses { Ammo, 1 }], fight(IntExpr::cond(LocationHasClues, 3, 1), 1))`. Ammo (4) comes from the corpus.
- **Cover Up 01007** (`treachery_01007.rs`) — `Revelation - Put into threat area with 3 clues. [reaction] When you would discover clues at your location: discard that many from Cover Up instead. Forced - At game end, if clues remain: 1 mental trauma.` A persistent treachery, ported from the synthetic Cover-Up fixture C5a proved; two card-local native effects.
- **`Effect::PutIntoThreatArea { code, clues }`** — gained a `clues` field so the Revelation seeds 3 clues on the placed instance (spec puts this small extension in C5c, not the prereq). Existing callers (Dissonant Voices, Frozen in Fear) place clue-less via the unchanged `put_into_threat_area`.

## Testing

Full strict gauntlet green locally — all seven CI jobs. New integration tests against the **real** `cards::REGISTRY`:
- `weapon_38_special.rs` — drives both modifier branches against an enemy whose fight value (5) distinguishes them: +3 (clue) hits for 2 damage, +1 (no clue) misses; ammo spent either way.
- `cover_up.rs` — the 3-clue Revelation (real `EncounterCardRevealed` reveal, asserts not auto-discarded), the Confirm/Skip interrupt, and game-end trauma both ways (3 clues → `TraumaSuffered{Mental,1}`; 0 → none).

Plus per-card unit tests (ability shape, native-tag resolution) and a `PutIntoThreatArea { clues }` evaluator test.

## Review

Pre-push review (general-purpose subagent) returned clean — no Critical/Important. Verified card-text fidelity vs the snapshot, the Cover Up port preserves the C5a-proven native bodies exactly, and the persistent-treachery disposition is correctly relied upon. One minor (a triple-nested `if` in the evaluator arm) folded in.

Closes #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
