### PR TITLE
infra: consolidate instance-id minting + put-into-play construction (#296)

### DIFF
--- a/crates/cards/tests/agenda_reverses.rs
+++ b/crates/cards/tests/agenda_reverses.rs
@@ -82,7 +82,7 @@ fn agenda_01106_reverse_digs_until_a_ghoul_and_the_lead_draws_it() {
     );
     assert!(state
         .enemies
-        .contains_key(&EnemyId(state.next_enemy_id - 1)));
+        .contains_key(&EnemyId(state.enemy_ids.peek() - 1)));
     // The Ghoul left both deck and discard (it was drawn into play).
     assert!(!state.encounter_deck.contains(&CardCode::new("01160")));
     assert!(!state.encounter_discard.contains(&CardCode::new("01160")));

--- a/crates/cards/tests/play_card.rs
+++ b/crates/cards/tests/play_card.rs
@@ -127,7 +127,7 @@ fn asset_enters_play_with_instance_id_from_state_counter() {
     use game_core::state::CardInstanceId;
 
     let (state, id, _loc) = play_state(vec![HOLY_ROSARY]);
-    assert_eq!(state.next_card_instance_id, 0, "counter starts at 0");
+    assert_eq!(state.card_instance_ids.peek(), 0, "counter starts at 0");
 
     let result = apply(
         state,
@@ -146,7 +146,8 @@ fn asset_enters_play_with_instance_id_from_state_counter() {
         "first asset gets id 0",
     );
     assert_eq!(
-        result.state.next_card_instance_id, 1,
+        result.state.card_instance_ids.peek(),
+        1,
         "counter advances after assigning",
     );
 }
@@ -183,7 +184,8 @@ fn two_copies_of_magnifying_glass_get_distinct_instance_ids() {
     assert_eq!(in_play[0].instance_id, CardInstanceId(0));
     assert_eq!(in_play[1].instance_id, CardInstanceId(1));
     assert_eq!(
-        after_second.state.next_card_instance_id, 2,
+        after_second.state.card_instance_ids.peek(),
+        2,
         "counter advances once per play",
     );
 }

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -5,7 +5,7 @@ use crate::card_data::CardType;
 use crate::card_registry;
 use crate::dsl::Trigger;
 use crate::event::Event;
-use crate::state::{CardCode, CardInPlay, CardInstanceId, InvestigatorId, Phase, Status, Zone};
+use crate::state::{CardCode, InvestigatorId, Phase, Status, Zone};
 
 use super::super::evaluator::{apply_effect, EvalContext};
 use super::super::outcome::EngineOutcome;
@@ -513,27 +513,23 @@ pub(super) fn play_card(
     }
     match destination {
         super::PlayDestination::InPlay => {
-            let instance_id = CardInstanceId(cx.state.next_card_instance_id);
-            cx.state.next_card_instance_id = cx.state.next_card_instance_id.saturating_add(1);
-            // Seed the named-uses pool ("ammo") from the asset's printed
-            // `uses` before moving the code into the instance.
-            let initial_uses = crate::card_registry::current()
-                .and_then(|reg| (reg.metadata_for)(&code))
-                .and_then(|m| match &m.kind {
-                    crate::card_data::CardKind::Asset { uses, .. } => *uses,
-                    _ => None,
-                });
-            let inv_mut = cx
+            // Remove the card from hand, then mint + seed its in-play
+            // instance via the shared constructor (mints the id, seeds the
+            // asset uses-pool) and push it into the play area.
+            let played = cx
                 .state
                 .investigators
                 .get_mut(&investigator)
-                .expect("checked");
-            let card = inv_mut.hand.remove(idx);
-            let mut in_play = CardInPlay::enter_play(card, instance_id);
-            if let Some(u) = initial_uses {
-                in_play.uses.insert(u.kind, u.count);
-            }
-            inv_mut.cards_in_play.push(in_play);
+                .expect("checked")
+                .hand
+                .remove(idx);
+            let in_play = super::threat_area::new_in_play_instance(cx, played);
+            cx.state
+                .investigators
+                .get_mut(&investigator)
+                .expect("checked")
+                .cards_in_play
+                .push(in_play);
         }
         super::PlayDestination::Discard => {
             let inv_mut = cx

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -5,8 +5,7 @@ use crate::card_registry;
 use crate::dsl::Trigger;
 use crate::event::Event;
 use crate::state::{
-    CardCode, Enemy, EnemyId, InvestigatorId, LocationId, Phase, PhaseStep, SpawnEngagePending,
-    WindowKind,
+    CardCode, Enemy, InvestigatorId, LocationId, Phase, PhaseStep, SpawnEngagePending, WindowKind,
 };
 
 use super::super::evaluator::{apply_effect, EvalContext};
@@ -406,8 +405,7 @@ pub(super) fn spawn_enemy_at(
     //    the `One` and (post-resume) `Tie` cases set `engaged_with` via
     //    `engage_enemy_with` so the `EnemyEngaged` event always pairs with
     //    the mutation.
-    let enemy_id = EnemyId(cx.state.next_enemy_id);
-    cx.state.next_enemy_id = cx.state.next_enemy_id.saturating_add(1);
+    let enemy_id = cx.state.mint_enemy_id();
 
     let enemy = Enemy {
         id: enemy_id,

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -405,7 +405,7 @@ pub(super) fn spawn_enemy_at(
     //    the `One` and (post-resume) `Tie` cases set `engaged_with` via
     //    `engage_enemy_with` so the `EnemyEngaged` event always pairs with
     //    the mutation.
-    let enemy_id = cx.state.mint_enemy_id();
+    let enemy_id = cx.state.enemy_ids.mint();
 
     let enemy = Enemy {
         id: enemy_id,

--- a/crates/game-core/src/engine/dispatch/threat_area.rs
+++ b/crates/game-core/src/engine/dispatch/threat_area.rs
@@ -21,7 +21,7 @@ use super::Cx;
 ///
 /// [#296]: https://github.com/talelburg/eldritch/issues/296
 pub(super) fn new_in_play_instance(cx: &mut Cx, code: CardCode) -> CardInPlay {
-    let instance_id = cx.state.mint_card_instance_id();
+    let instance_id = cx.state.card_instance_ids.mint();
     let uses = crate::card_registry::current()
         .and_then(|reg| (reg.metadata_for)(&code))
         .and_then(|m| match &m.kind {

--- a/crates/game-core/src/engine/dispatch/threat_area.rs
+++ b/crates/game-core/src/engine/dispatch/threat_area.rs
@@ -4,10 +4,36 @@
 //! persist here (and the Revelation routing that places them) is C4c
 //! (#235).
 
+use crate::card_data::CardKind;
 use crate::event::Event;
 use crate::state::{CardCode, CardInPlay, CardInstanceId, InvestigatorId, LocationId, Zone};
 
 use super::Cx;
+
+/// Mint a fresh in-play instance of `code`: allocate its id, build the
+/// `CardInPlay`, and seed the named-uses pool ("ammo") from the asset's
+/// printed `uses` if any. Does **not** place it in a zone — the caller
+/// pushes it into `cards_in_play` / `threat_area` / a location's
+/// attachments and emits the zone-specific event.
+///
+/// The single construction point shared by `place_in_threat_area`,
+/// `attach_to_location`, and `play_card`'s in-play branch ([#296]).
+///
+/// [#296]: https://github.com/talelburg/eldritch/issues/296
+pub(super) fn new_in_play_instance(cx: &mut Cx, code: CardCode) -> CardInPlay {
+    let instance_id = cx.state.mint_card_instance_id();
+    let uses = crate::card_registry::current()
+        .and_then(|reg| (reg.metadata_for)(&code))
+        .and_then(|m| match &m.kind {
+            CardKind::Asset { uses, .. } => *uses,
+            _ => None,
+        });
+    let mut card = CardInPlay::enter_play(code, instance_id);
+    if let Some(u) = uses {
+        card.uses.insert(u.kind, u.count);
+    }
+    card
+}
 
 /// Place `code` into `investigator`'s threat area as a fresh in-play
 /// instance, minting an instance id from the per-state counter, and
@@ -24,15 +50,14 @@ pub fn place_in_threat_area(
     if !cx.state.investigators.contains_key(&investigator) {
         return None;
     }
-    let instance_id = CardInstanceId(cx.state.next_card_instance_id);
-    cx.state.next_card_instance_id = cx.state.next_card_instance_id.saturating_add(1);
+    let card = new_in_play_instance(cx, code.clone());
+    let instance_id = card.instance_id;
     let inv = cx
         .state
         .investigators
         .get_mut(&investigator)
         .expect("existence checked above");
-    inv.threat_area
-        .push(CardInPlay::enter_play(code.clone(), instance_id));
+    inv.threat_area.push(card);
     cx.events.push(Event::CardEnteredThreatArea {
         investigator,
         code,
@@ -57,15 +82,14 @@ pub fn attach_to_location(
     if !cx.state.locations.contains_key(&location) {
         return None;
     }
-    let instance_id = CardInstanceId(cx.state.next_card_instance_id);
-    cx.state.next_card_instance_id = cx.state.next_card_instance_id.saturating_add(1);
+    let card = new_in_play_instance(cx, code.clone());
+    let instance_id = card.instance_id;
     let loc = cx
         .state
         .locations
         .get_mut(&location)
         .expect("existence checked above");
-    loc.attachments
-        .push(CardInPlay::enter_play(code.clone(), instance_id));
+    loc.attachments.push(card);
     cx.events.push(Event::CardAttachedToLocation {
         location,
         code,

--- a/crates/game-core/src/event.rs
+++ b/crates/game-core/src/event.rs
@@ -211,7 +211,7 @@ pub enum Event {
     /// the on-spawn engagement uniformly with mid-game engagements.
     EnemySpawned {
         /// The newly-spawned enemy's stable id (freshly minted from
-        /// [`GameState::next_enemy_id`](crate::state::GameState::next_enemy_id)).
+        /// [`GameState::enemy_ids`](crate::state::GameState::enemy_ids)).
         enemy: EnemyId,
         /// Printed code of the spawned enemy.
         code: CardCode,

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -31,7 +31,7 @@ use std::collections::{BTreeMap, VecDeque};
 use crate::rng::RngState;
 use crate::scenario::ScenarioId;
 use crate::state::{
-    ChaosBag, Enemy, EnemyId, FastActorScope, GameState, HandSizeDiscard, Investigator,
+    ChaosBag, Counter, Enemy, EnemyId, FastActorScope, GameState, HandSizeDiscard, Investigator,
     InvestigatorId, Location, LocationId, OpenWindow, Phase, TokenModifiers, WindowKind,
 };
 
@@ -268,9 +268,9 @@ impl GameStateBuilder {
             turn_order: self.turn_order,
             rng: self.rng,
             mulligan_pending: self.mulligan_pending,
-            next_card_instance_id: 0,
-            next_enemy_id: 0,
-            next_location_id: 0,
+            card_instance_ids: Counter::new(),
+            enemy_ids: Counter::new(),
+            location_ids: Counter::new(),
             pending_skill_modifiers: Vec::new(),
             in_flight_skill_test: None,
             open_windows: self.open_windows,

--- a/crates/game-core/src/state/card.rs
+++ b/crates/game-core/src/state/card.rs
@@ -78,17 +78,16 @@ pub enum Zone {
     LocationAttachment,
 }
 
-/// Unique identifier for a specific copy of a card in play.
-///
-/// Assigned by the engine when a card enters play (via the per-state
-/// [`next_card_instance_id`](crate::state::GameState::next_card_instance_id)
-/// counter). Lets card effects target a specific copy when an
-/// investigator has multiple of the same card in play (e.g. two
-/// copies of Magnifying Glass — exhausting one shouldn't exhaust the
-/// other).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct CardInstanceId(pub u32);
+crate::state::define_id! {
+    /// Unique identifier for a specific copy of a card in play.
+    ///
+    /// Minted by the engine when a card enters play (via the per-state
+    /// `card_instance_ids` [`Counter`](crate::state::Counter)). Lets card
+    /// effects target a specific copy when an investigator has multiple of
+    /// the same card in play (e.g. two copies of Magnifying Glass —
+    /// exhausting one shouldn't exhaust the other).
+    pub struct CardInstanceId;
+}
 
 // `UseKind` is defined in `card-dsl` (the lowest layer) so the printed
 // metadata (`card_data::Uses`) and this runtime pool share one type;

--- a/crates/game-core/src/state/counter.rs
+++ b/crates/game-core/src/state/counter.rs
@@ -1,0 +1,147 @@
+//! Monotonic id allocation.
+//!
+//! [`Counter<T>`] is a `u32` id allocator phantom-typed by the id it
+//! mints, so the "which counter mints which id" invariant is structural:
+//! a `Counter<EnemyId>` mints only `EnemyId`s, and minting from the wrong
+//! counter won't type-check. The `define_id!` macro (crate-internal)
+//! defines a `u32`-wrapping id newtype together with the [`FromRawId`]
+//! impl `Counter` needs, so a new id type is one macro call.
+
+use std::marker::PhantomData;
+
+use serde::{Deserialize, Serialize};
+
+/// Construct an id newtype from a raw counter value — the per-type bridge
+/// [`Counter::mint`] uses. Implemented for each id type by the
+/// `define_id!` macro; rarely called directly (the ids are already
+/// `pub`-constructible tuple structs).
+pub trait FromRawId {
+    fn from_raw(raw: u32) -> Self;
+}
+
+/// A monotonic id allocator that mints exactly one id type.
+///
+/// The phantom `T` ties the counter to its newtype: [`mint`](Self::mint)
+/// yields a `T`, and you cannot mint an `EnemyId` from a
+/// `Counter<CardInstanceId>`. Serializes transparently as its underlying
+/// `u32`, so persisted state is just a number.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Counter<T> {
+    next: u32,
+    #[serde(skip)]
+    _id: PhantomData<fn() -> T>,
+}
+
+impl<T> Counter<T> {
+    /// A fresh counter starting at 0.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            next: 0,
+            _id: PhantomData,
+        }
+    }
+
+    /// A counter positioned at `next` — for test setup and replay restore.
+    #[must_use]
+    pub fn at(next: u32) -> Self {
+        Self {
+            next,
+            _id: PhantomData,
+        }
+    }
+
+    /// The next value that would be minted, without advancing.
+    #[must_use]
+    pub fn peek(&self) -> u32 {
+        self.next
+    }
+}
+
+impl<T: FromRawId> Counter<T> {
+    /// Mint the next id and advance the counter (saturating).
+    pub fn mint(&mut self) -> T {
+        let id = T::from_raw(self.next);
+        self.next = self.next.saturating_add(1);
+        id
+    }
+}
+
+impl<T> Default for Counter<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// Hand-written (not derived) so equality doesn't require `T: PartialEq` —
+// the phantom carries no value, so two counters are equal iff their next
+// values match.
+impl<T> PartialEq for Counter<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.next == other.next
+    }
+}
+
+impl<T> Eq for Counter<T> {}
+
+/// Define a scenario-scoped id newtype: a `u32`-wrapping tuple struct with
+/// the standard id derives, plus its `FromRawId` impl so a [`Counter`] can
+/// mint it. The single definition point for the engine's allocated ids
+/// (`CardInstanceId`, `EnemyId`, `LocationId`, …).
+///
+/// ```ignore
+/// define_id! {
+///     /// Stable identifier for an enemy within a scenario.
+///     pub struct EnemyId;
+/// }
+/// ```
+macro_rules! define_id {
+    ($(#[$meta:meta])* $vis:vis struct $Name:ident;) => {
+        $(#[$meta])*
+        #[derive(
+            Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord,
+            ::serde::Serialize, ::serde::Deserialize,
+        )]
+        $vis struct $Name(pub u32);
+
+        impl $crate::state::FromRawId for $Name {
+            fn from_raw(raw: u32) -> Self {
+                Self(raw)
+            }
+        }
+    };
+}
+pub(crate) use define_id;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A local id type to exercise the allocator without depending on the
+    // engine's real id newtypes.
+    define_id! {
+        /// Test-only id.
+        struct TestId;
+    }
+
+    #[test]
+    fn mint_is_monotonic_and_peek_does_not_advance() {
+        let mut c: Counter<TestId> = Counter::new();
+        assert_eq!(c.peek(), 0);
+        assert_eq!(c.mint(), TestId(0));
+        assert_eq!(c.mint(), TestId(1));
+        assert_eq!(c.peek(), 2, "peek reflects the next id without minting");
+    }
+
+    #[test]
+    fn at_positions_the_counter_and_serializes_transparently() {
+        let c: Counter<TestId> = Counter::at(7);
+        assert_eq!(c.peek(), 7);
+        // Transparent: a bare number, not an object.
+        let json = serde_json::to_string(&c).unwrap();
+        assert_eq!(json, "7");
+        let back: Counter<TestId> = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.peek(), 7);
+    }
+}

--- a/crates/game-core/src/state/counter.rs
+++ b/crates/game-core/src/state/counter.rs
@@ -4,20 +4,12 @@
 //! mints, so the "which counter mints which id" invariant is structural:
 //! a `Counter<EnemyId>` mints only `EnemyId`s, and minting from the wrong
 //! counter won't type-check. The `define_id!` macro (crate-internal)
-//! defines a `u32`-wrapping id newtype together with the [`FromRawId`]
-//! impl `Counter` needs, so a new id type is one macro call.
+//! defines a `u32`-wrapping id newtype together with the `From<u32>` impl
+//! `Counter` mints through, so a new id type is one macro call.
 
 use std::marker::PhantomData;
 
 use serde::{Deserialize, Serialize};
-
-/// Construct an id newtype from a raw counter value — the per-type bridge
-/// [`Counter::mint`] uses. Implemented for each id type by the
-/// `define_id!` macro; rarely called directly (the ids are already
-/// `pub`-constructible tuple structs).
-pub trait FromRawId {
-    fn from_raw(raw: u32) -> Self;
-}
 
 /// A monotonic id allocator that mints exactly one id type.
 ///
@@ -59,10 +51,10 @@ impl<T> Counter<T> {
     }
 }
 
-impl<T: FromRawId> Counter<T> {
+impl<T: From<u32>> Counter<T> {
     /// Mint the next id and advance the counter (saturating).
     pub fn mint(&mut self) -> T {
-        let id = T::from_raw(self.next);
+        let id = T::from(self.next);
         self.next = self.next.saturating_add(1);
         id
     }
@@ -86,8 +78,8 @@ impl<T> PartialEq for Counter<T> {
 impl<T> Eq for Counter<T> {}
 
 /// Define a scenario-scoped id newtype: a `u32`-wrapping tuple struct with
-/// the standard id derives, plus its `FromRawId` impl so a [`Counter`] can
-/// mint it. The single definition point for the engine's allocated ids
+/// the standard id derives, plus the `From<u32>` impl a [`Counter`] mints
+/// through. The single definition point for the engine's allocated ids
 /// (`CardInstanceId`, `EnemyId`, `LocationId`, …).
 ///
 /// ```ignore
@@ -105,8 +97,8 @@ macro_rules! define_id {
         )]
         $vis struct $Name(pub u32);
 
-        impl $crate::state::FromRawId for $Name {
-            fn from_raw(raw: u32) -> Self {
+        impl ::core::convert::From<u32> for $Name {
+            fn from(raw: u32) -> Self {
                 Self(raw)
             }
         }

--- a/crates/game-core/src/state/enemy.rs
+++ b/crates/game-core/src/state/enemy.rs
@@ -6,9 +6,10 @@ use serde::{Deserialize, Serialize};
 use super::{card::CardCode, investigator::InvestigatorId, location::LocationId};
 use crate::card_data::Prey;
 
-/// Stable identifier for an enemy within a scenario.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct EnemyId(pub u32);
+crate::state::define_id! {
+    /// Stable identifier for an enemy within a scenario.
+    pub struct EnemyId;
+}
 
 /// An enemy in play during a scenario.
 ///

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use super::{
     card::{CardCode, CardInstanceId},
     chaos_bag::{ChaosBag, TokenModifiers},
+    counter::Counter,
     enemy::{Enemy, EnemyId},
     investigator::{Investigator, InvestigatorId},
     location::{Location, LocationId},
@@ -101,27 +102,16 @@ pub struct GameState {
     ///   setup ends and the Investigation phase begins. While `Some`,
     ///   the engine rejects every non-Mulligan player action.
     pub mulligan_pending: Option<InvestigatorId>,
-    /// Monotonic counter for assigning [`CardInstanceId`]s when cards
-    /// enter play. Starts at 0 and increments after each assignment;
-    /// guarantees uniqueness within a scenario and deterministic ids
-    /// across replays.
-    pub next_card_instance_id: u32,
-    /// Monotonic counter for assigning [`EnemyId`]s when enemies
-    /// enter play via the encounter deck (see
-    /// `crate::engine::dispatch::spawn_enemy`). Starts at 0 and
-    /// increments after each assignment; guarantees uniqueness within
-    /// a scenario and deterministic ids across replays.
-    ///
-    /// Distinct from [`next_card_instance_id`](Self::next_card_instance_id)
-    /// because [`EnemyId`] and [`CardInstanceId`] are distinct types —
-    /// enemies aren't tracked in the `CardInPlay` registry.
-    pub next_enemy_id: u32,
-    /// Monotonic counter for assigning [`LocationId`]s when scenarios
-    /// build their board via `add_location` / `add_set_aside_location`
-    /// (added in a later task). Starts at 0 and increments after each
-    /// assignment; guarantees uniqueness within a scenario and
-    /// deterministic ids across replays.
-    pub next_location_id: u32,
+    /// Allocator for [`CardInstanceId`]s, minted when cards enter play.
+    /// Deterministic across replays; serializes as a bare `u32`.
+    pub card_instance_ids: Counter<CardInstanceId>,
+    /// Allocator for [`EnemyId`]s, minted when enemies enter play via the
+    /// encounter deck (see `crate::engine::dispatch::spawn_enemy`).
+    /// Independent of [`card_instance_ids`](Self::card_instance_ids) — the
+    /// phantom-typed [`Counter`] mints only `EnemyId`s.
+    pub enemy_ids: Counter<EnemyId>,
+    /// Allocator for [`LocationId`]s, minted as scenarios build their board.
+    pub location_ids: Counter<LocationId>,
     /// In-flight skill modifiers contributed by activated / triggered
     /// abilities with [`ModifierScope::ThisSkillTest`] scope.
     /// Accumulates between activation and skill-test resolution; the
@@ -976,30 +966,7 @@ pub struct PendingSkillModifier {
     pub source: Option<CardInstanceId>,
 }
 
-/// Read a monotonic `u32` id counter, advance it (saturating), and wrap
-/// the pre-increment value in its newtype. The single read-then-increment
-/// point shared by every `GameState::mint_*_id`; the newtype constructor
-/// (`CardInstanceId` / `EnemyId` / `LocationId`) is the per-type bridge.
-fn mint_id<T>(counter: &mut u32, wrap: impl FnOnce(u32) -> T) -> T {
-    let id = wrap(*counter);
-    *counter = counter.saturating_add(1);
-    id
-}
-
 impl GameState {
-    /// Mint the next [`CardInstanceId`] and advance the counter. The one
-    /// place card-instance ids are allocated — call this instead of
-    /// hand-rolling the read-then-increment.
-    pub fn mint_card_instance_id(&mut self) -> CardInstanceId {
-        mint_id(&mut self.next_card_instance_id, CardInstanceId)
-    }
-
-    /// Mint the next [`EnemyId`] and advance the counter. The one place
-    /// enemy ids are allocated.
-    pub fn mint_enemy_id(&mut self) -> EnemyId {
-        mint_id(&mut self.next_enemy_id, EnemyId)
-    }
-
     /// The topmost open window that has unresolved reaction triggers,
     /// if any. Used by the dispatcher's "is reaction work pending?"
     /// guards. Pure Fast-gating windows (empty `pending_triggers`)
@@ -1046,12 +1013,6 @@ impl GameState {
             .rposition(|w| !w.pending_triggers.is_empty())
     }
 
-    /// Mint a fresh, deterministic [`LocationId`] (sequential from
-    /// `next_location_id`).
-    fn mint_location_id(&mut self) -> LocationId {
-        mint_id(&mut self.next_location_id, LocationId)
-    }
-
     /// Build a [`Location`] from its card `metadata`, minting a fresh id.
     /// Panics if `metadata` is not a `Location` card (a build-time
     /// invariant — scenarios hand their own location cards).
@@ -1067,7 +1028,7 @@ impl GameState {
                 metadata.code
             ),
         };
-        let id = self.mint_location_id();
+        let id = self.location_ids.mint();
         Location {
             id,
             code: CardCode::new(metadata.code.clone()),
@@ -1218,22 +1179,23 @@ mod fast_actor_scope_tests {
 }
 
 #[cfg(test)]
-mod next_location_id_tests {
+mod location_id_counter_tests {
     use crate::test_support::GameStateBuilder;
 
     #[test]
-    fn game_state_starts_next_location_id_at_zero() {
+    fn game_state_starts_location_ids_at_zero() {
         let state = GameStateBuilder::new().build();
-        assert_eq!(state.next_location_id, 0);
+        assert_eq!(state.location_ids.peek(), 0);
     }
 
     #[test]
-    fn next_location_id_round_trips_through_serde() {
+    fn location_ids_round_trip_through_serde() {
+        use crate::state::Counter;
         let mut state = GameStateBuilder::new().build();
-        state.next_location_id = 7;
+        state.location_ids = Counter::at(7);
         let json = serde_json::to_string(&state).expect("serialize");
         let back: crate::state::GameState = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(back.next_location_id, 7);
+        assert_eq!(back.location_ids.peek(), 7);
     }
 }
 
@@ -1249,38 +1211,38 @@ mod clue_interrupt_pending_tests {
 }
 
 #[cfg(test)]
-mod next_enemy_id_tests {
+mod id_counter_tests {
     use super::*;
     use crate::test_support::GameStateBuilder;
 
     #[test]
-    fn game_state_has_next_enemy_id_counter_starting_at_zero() {
+    fn game_state_starts_enemy_ids_at_zero() {
         let state = GameStateBuilder::new().build();
-        assert_eq!(state.next_enemy_id, 0);
+        assert_eq!(state.enemy_ids.peek(), 0);
     }
 
     #[test]
-    fn next_enemy_id_round_trips_through_serde() {
+    fn enemy_ids_round_trip_through_serde() {
         let mut state = GameStateBuilder::new().build();
-        state.next_enemy_id = 42;
+        state.enemy_ids = Counter::at(42);
         let json = serde_json::to_string(&state).expect("serialize");
         let back: GameState = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(back.next_enemy_id, 42);
+        assert_eq!(back.enemy_ids.peek(), 42);
     }
 
     #[test]
-    fn mint_helpers_allocate_monotonically_from_independent_counters() {
+    fn each_id_counter_mints_independently() {
         let mut state = GameStateBuilder::new().build();
-        assert_eq!(state.mint_card_instance_id(), CardInstanceId(0));
-        assert_eq!(state.mint_card_instance_id(), CardInstanceId(1));
+        assert_eq!(state.card_instance_ids.mint(), CardInstanceId(0));
+        assert_eq!(state.card_instance_ids.mint(), CardInstanceId(1));
         // Each id type draws from its own counter — minting one doesn't
-        // disturb the others (all three delegate to the same `mint_id`).
-        assert_eq!(state.mint_enemy_id(), EnemyId(0));
-        assert_eq!(state.mint_location_id(), LocationId(0));
-        assert_eq!(state.mint_enemy_id(), EnemyId(1));
-        assert_eq!(state.next_card_instance_id, 2);
-        assert_eq!(state.next_enemy_id, 2);
-        assert_eq!(state.next_location_id, 1);
+        // disturb the others.
+        assert_eq!(state.enemy_ids.mint(), EnemyId(0));
+        assert_eq!(state.location_ids.mint(), LocationId(0));
+        assert_eq!(state.enemy_ids.mint(), EnemyId(1));
+        assert_eq!(state.card_instance_ids.peek(), 2);
+        assert_eq!(state.enemy_ids.peek(), 2);
+        assert_eq!(state.location_ids.peek(), 1);
     }
 }
 
@@ -1474,7 +1436,7 @@ mod add_location_tests {
             crate::card_data::ClueValue::PerInvestigator(2)
         );
         assert!(study.connections.is_empty());
-        assert_eq!(state.next_location_id, 2, "counter advanced twice");
+        assert_eq!(state.location_ids.peek(), 2, "counter advanced twice");
     }
 
     #[test]

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -976,22 +976,28 @@ pub struct PendingSkillModifier {
     pub source: Option<CardInstanceId>,
 }
 
+/// Read a monotonic `u32` id counter, advance it (saturating), and wrap
+/// the pre-increment value in its newtype. The single read-then-increment
+/// point shared by every `GameState::mint_*_id`; the newtype constructor
+/// (`CardInstanceId` / `EnemyId` / `LocationId`) is the per-type bridge.
+fn mint_id<T>(counter: &mut u32, wrap: impl FnOnce(u32) -> T) -> T {
+    let id = wrap(*counter);
+    *counter = counter.saturating_add(1);
+    id
+}
+
 impl GameState {
     /// Mint the next [`CardInstanceId`] and advance the counter. The one
     /// place card-instance ids are allocated — call this instead of
     /// hand-rolling the read-then-increment.
     pub fn mint_card_instance_id(&mut self) -> CardInstanceId {
-        let id = CardInstanceId(self.next_card_instance_id);
-        self.next_card_instance_id = self.next_card_instance_id.saturating_add(1);
-        id
+        mint_id(&mut self.next_card_instance_id, CardInstanceId)
     }
 
     /// Mint the next [`EnemyId`] and advance the counter. The one place
     /// enemy ids are allocated.
     pub fn mint_enemy_id(&mut self) -> EnemyId {
-        let id = EnemyId(self.next_enemy_id);
-        self.next_enemy_id = self.next_enemy_id.saturating_add(1);
-        id
+        mint_id(&mut self.next_enemy_id, EnemyId)
     }
 
     /// The topmost open window that has unresolved reaction triggers,
@@ -1043,9 +1049,7 @@ impl GameState {
     /// Mint a fresh, deterministic [`LocationId`] (sequential from
     /// `next_location_id`).
     fn mint_location_id(&mut self) -> LocationId {
-        let id = LocationId(self.next_location_id);
-        self.next_location_id = self.next_location_id.saturating_add(1);
-        id
+        mint_id(&mut self.next_location_id, LocationId)
     }
 
     /// Build a [`Location`] from its card `metadata`, minting a fresh id.
@@ -1265,16 +1269,18 @@ mod next_enemy_id_tests {
     }
 
     #[test]
-    fn mint_helpers_allocate_monotonically_and_advance_their_counters() {
+    fn mint_helpers_allocate_monotonically_from_independent_counters() {
         let mut state = GameStateBuilder::new().build();
         assert_eq!(state.mint_card_instance_id(), CardInstanceId(0));
         assert_eq!(state.mint_card_instance_id(), CardInstanceId(1));
-        assert_eq!(state.next_card_instance_id, 2);
-        // The enemy counter is independent of the card-instance counter.
+        // Each id type draws from its own counter — minting one doesn't
+        // disturb the others (all three delegate to the same `mint_id`).
         assert_eq!(state.mint_enemy_id(), EnemyId(0));
+        assert_eq!(state.mint_location_id(), LocationId(0));
         assert_eq!(state.mint_enemy_id(), EnemyId(1));
+        assert_eq!(state.next_card_instance_id, 2);
         assert_eq!(state.next_enemy_id, 2);
-        assert_eq!(state.next_card_instance_id, 2, "card counter untouched");
+        assert_eq!(state.next_location_id, 1);
     }
 }
 

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -977,6 +977,23 @@ pub struct PendingSkillModifier {
 }
 
 impl GameState {
+    /// Mint the next [`CardInstanceId`] and advance the counter. The one
+    /// place card-instance ids are allocated — call this instead of
+    /// hand-rolling the read-then-increment.
+    pub fn mint_card_instance_id(&mut self) -> CardInstanceId {
+        let id = CardInstanceId(self.next_card_instance_id);
+        self.next_card_instance_id = self.next_card_instance_id.saturating_add(1);
+        id
+    }
+
+    /// Mint the next [`EnemyId`] and advance the counter. The one place
+    /// enemy ids are allocated.
+    pub fn mint_enemy_id(&mut self) -> EnemyId {
+        let id = EnemyId(self.next_enemy_id);
+        self.next_enemy_id = self.next_enemy_id.saturating_add(1);
+        id
+    }
+
     /// The topmost open window that has unresolved reaction triggers,
     /// if any. Used by the dispatcher's "is reaction work pending?"
     /// guards. Pure Fast-gating windows (empty `pending_triggers`)
@@ -1245,6 +1262,19 @@ mod next_enemy_id_tests {
         let json = serde_json::to_string(&state).expect("serialize");
         let back: GameState = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back.next_enemy_id, 42);
+    }
+
+    #[test]
+    fn mint_helpers_allocate_monotonically_and_advance_their_counters() {
+        let mut state = GameStateBuilder::new().build();
+        assert_eq!(state.mint_card_instance_id(), CardInstanceId(0));
+        assert_eq!(state.mint_card_instance_id(), CardInstanceId(1));
+        assert_eq!(state.next_card_instance_id, 2);
+        // The enemy counter is independent of the card-instance counter.
+        assert_eq!(state.mint_enemy_id(), EnemyId(0));
+        assert_eq!(state.mint_enemy_id(), EnemyId(1));
+        assert_eq!(state.next_enemy_id, 2);
+        assert_eq!(state.next_card_instance_id, 2, "card counter untouched");
     }
 }
 

--- a/crates/game-core/src/state/investigator.rs
+++ b/crates/game-core/src/state/investigator.rs
@@ -75,7 +75,7 @@ pub struct Investigator {
     /// per-instance state (exhaust, named-uses, accumulated horror /
     /// damage on the asset itself). Instance ids are assigned by the
     /// engine from
-    /// [`GameState::next_card_instance_id`](crate::state::GameState::next_card_instance_id)
+    /// [`GameState::card_instance_ids`](crate::state::GameState::card_instance_ids)
     /// at enter-play time so duplicate codes are still individually
     /// addressable.
     pub cards_in_play: Vec<CardInPlay>,

--- a/crates/game-core/src/state/location.rs
+++ b/crates/game-core/src/state/location.rs
@@ -6,9 +6,10 @@ use card_dsl::card_data::ClueValue;
 
 use super::card::{CardCode, CardInPlay};
 
-/// Stable identifier for a location within a scenario.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct LocationId(pub u32);
+crate::state::define_id! {
+    /// Stable identifier for a location within a scenario.
+    pub struct LocationId;
+}
 
 /// A location in the current scenario.
 ///

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -19,7 +19,7 @@ pub use builder::GameStateBuilder;
 pub use card::{AbilityUsageRecord, CardCode, CardInPlay, CardInstanceId, UseKind, Zone};
 pub use card_dsl::card_data::{SkillKind, Skills};
 pub use chaos_bag::{resolve_token, ChaosBag, ChaosToken, TokenModifiers, TokenResolution};
-pub use counter::{Counter, FromRawId};
+pub use counter::Counter;
 // `define_id!` is used by the id submodules; kept crate-internal.
 pub(crate) use counter::define_id;
 pub use enemy::{Enemy, EnemyId};

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -8,6 +8,7 @@
 pub mod builder;
 pub mod card;
 pub mod chaos_bag;
+pub mod counter;
 pub mod enemy;
 pub mod game_state;
 pub mod investigator;
@@ -18,6 +19,9 @@ pub use builder::GameStateBuilder;
 pub use card::{AbilityUsageRecord, CardCode, CardInPlay, CardInstanceId, UseKind, Zone};
 pub use card_dsl::card_data::{SkillKind, Skills};
 pub use chaos_bag::{resolve_token, ChaosBag, ChaosToken, TokenModifiers, TokenResolution};
+pub use counter::{Counter, FromRawId};
+// `define_id!` is used by the id submodules; kept crate-internal.
+pub(crate) use counter::define_id;
 pub use enemy::{Enemy, EnemyId};
 pub use game_state::{
     Act, ActRoundEndPending, Agenda, ClueInterruptPending, EnemyAttackSource, FastActorScope,


### PR DESCRIPTION
## Summary

Started as a small refactor extracted from #295's review (consolidate the duplicated id-minting + in-play construction) and grew into a cleaner id-allocation model. Pure refactor — no behavior change.

### Put-into-play construction
- **`new_in_play_instance(cx, code)`** (`threat_area.rs`) is the single mint+seed constructor — allocates the id, builds the `CardInPlay`, seeds the asset uses-pool — adopted by `place_in_threat_area`, `attach_to_location`, and `play_card`'s in-play branch. Each caller still owns its zone placement + event (no `put_in_play(zone)` mega-function, which would just relocate the per-zone branching).
- **`CardInPlay::enter_play` stays a pure constructor** (explicit id, no `cx`/registry); no test fixtures touched.

### `Counter<T>` — phantom-typed id allocation
- **`Counter<T>`** replaces the four hand-rolled `Id(next_X); next_X += 1` sites *and* the three `GameState::mint_*_id` methods. It's a `u32` allocator phantom-typed by the id it mints, so the **"which counter mints which id" invariant is structural**: you cannot mint an `EnemyId` from a `Counter<CardInstanceId>` — it won't type-check (the bug the earlier free-fn `mint_id(&mut self.next_enemy_id, CardInstanceId)` would have compiled).
- **`define_id!`** defines a `u32`-wrapping id newtype + its `From<u32>` impl (which `Counter::mint` mints through), so `CardInstanceId` / `EnemyId` / `LocationId` collapse from a repeated 10-derive block to a 4-line macro call, and a new id type is one call with zero hand-written impls.
- `GameState`'s `next_*_id: u32` fields become `Counter<...>`. `#[serde(transparent)]` keeps the persisted value a bare `u32` (only the field *key* renames; no GameState snapshots exist today). Call sites: `state.enemy_ids.mint()` / `.peek()` / `Counter::at(n)`.

## Testing

Full strict gauntlet green locally — all seven CI jobs. The existing suite (70 test binaries) is the regression net for a behavior-preserving refactor; added focused unit tests for `Counter` (monotonic mint, transparent serde) and the per-counter independence.

Closes #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
