### PR TITLE
card: C5d (split) — .45 Automatic, Physical Training, Machete (Guardian L0 assets)

### DIFF
--- a/crates/cards/src/impls/automatic_45.rs
+++ b/crates/cards/src/impls/automatic_45.rs
@@ -1,0 +1,67 @@
+//! .45 Automatic (Guardian firearm asset, 01016).
+//!
+//! ```text
+//! Uses (4 ammo).
+//! [action] Spend 1 ammo: Fight. You get +1 [combat] for this attack.
+//! This attack deals +1 damage.
+//! ```
+//!
+//! The same shape as Roland's .38 Special (01006), only simpler: a flat
+//! `+1` combat modifier instead of the clue-conditional `+1/+3`. Ammo (4)
+//! comes from the corpus (`CardKind::Asset.uses`, pipeline-parsed); the
+//! ability spends 1 per use via `Cost::SpendUses` and fights through the
+//! inspectable `Effect::Fight`, dealing `1 + 1` damage on success.
+
+use card_dsl::card_data::UseKind;
+use card_dsl::dsl::{activated, fight, Ability, Cost, IntExpr};
+
+/// `ArkhamDB` code for the .45 Automatic (original-Core printing).
+pub const CODE: &str = "01016";
+
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![activated(
+        1,
+        vec![Cost::SpendUses {
+            kind: UseKind::Ammo,
+            count: 1,
+        }],
+        fight(IntExpr::Lit(1), 1),
+    )]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use card_dsl::dsl::{Effect, Trigger};
+
+    #[test]
+    fn one_activated_fight_ability_spending_ammo() {
+        let abilities = abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(abilities[0].trigger, Trigger::Activated { action_cost: 1 });
+        assert_eq!(
+            abilities[0].costs,
+            vec![Cost::SpendUses {
+                kind: UseKind::Ammo,
+                count: 1
+            }]
+        );
+        let Effect::Fight {
+            combat_modifier,
+            extra_damage,
+        } = &abilities[0].effect
+        else {
+            panic!("expected Effect::Fight");
+        };
+        assert_eq!(*combat_modifier, IntExpr::Lit(1));
+        assert_eq!(*extra_damage, 1);
+    }
+
+    /// Catches a `pub mod` rename or a fat-fingered match arm in
+    /// `impls::abilities_for` — the registry must dispatch CODE here.
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(CODE), Some(abilities()));
+    }
+}

--- a/crates/cards/src/impls/machete.rs
+++ b/crates/cards/src/impls/machete.rs
@@ -1,0 +1,71 @@
+//! Machete (Guardian melee weapon asset, 01020).
+//!
+//! ```text
+//! [action]: Fight. You get +1 [combat] for this attack. If the attacked
+//! enemy is the only enemy engaged with you, this attack deals +1 damage.
+//! ```
+//!
+//! A bare `[action]` Fight (no exhaust, no uses) with a flat `+1` combat
+//! modifier, dealing `1 + 1` damage on success.
+//!
+//! # The conditional `+1` damage is modeled as unconditional — on purpose
+//!
+//! Machete's bonus damage is printed as conditional on the attacked enemy
+//! being "the only enemy engaged with you." We encode it as an
+//! **unconditional** `extra_damage: 1`. This is exact under today's engine,
+//! not an approximation: [`Effect::Fight`](card_dsl::dsl::Effect::Fight)
+//! auto-targets the single engaged enemy, and `effect_initiates_fight`
+//! rejects a fight with ≠1 engaged enemy **before** any cost is paid — so
+//! at the moment Machete resolves, the attacked enemy is *necessarily* the
+//! only enemy engaged with the controller, and the condition always holds.
+//!
+//! TODO(#300): when multi-target Fight lands (the #212/#213 cluster, where
+//! the player chooses which engaged enemy to attack), this stops being
+//! equivalent — Machete must then grant `+1` only when the attacked enemy
+//! is the sole engaged one. At that point `Effect::Fight.extra_damage`
+//! needs to become conditional (an `IntExpr` gated on a "sole engaged
+//! enemy" `Condition`) and this impl updated.
+
+use card_dsl::dsl::{activated, fight, Ability, IntExpr};
+
+/// `ArkhamDB` code for Machete (original-Core printing).
+pub const CODE: &str = "01020";
+
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![activated(1, vec![], fight(IntExpr::Lit(1), 1))]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use card_dsl::dsl::{Effect, Trigger};
+
+    #[test]
+    fn one_costless_activated_fight_ability() {
+        let abilities = abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(abilities[0].trigger, Trigger::Activated { action_cost: 1 });
+        assert!(
+            abilities[0].costs.is_empty(),
+            "Machete's Fight has no exhaust/uses cost — just the action",
+        );
+        let Effect::Fight {
+            combat_modifier,
+            extra_damage,
+        } = &abilities[0].effect
+        else {
+            panic!("expected Effect::Fight");
+        };
+        assert_eq!(*combat_modifier, IntExpr::Lit(1));
+        // Unconditional +1 — see the module doc-comment / TODO(#300).
+        assert_eq!(*extra_damage, 1);
+    }
+
+    /// Catches a `pub mod` rename or a fat-fingered match arm in
+    /// `impls::abilities_for` — the registry must dispatch CODE here.
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(CODE), Some(abilities()));
+    }
+}

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -30,6 +30,14 @@
 //! - Hyperawareness (01034) — two `Trigger::Activated { action_cost: 0 }`
 //!   abilities with `Cost::Resources(1)` and `ThisSkillTest`-scoped
 //!   `Modify`.
+//! - .45 Automatic (01016) — `Trigger::Activated { action_cost: 1 }`,
+//!   `Cost::SpendUses(Ammo)` + `Effect::Fight` (flat +1 combat, +1 damage).
+//! - Physical Training (01017) — two `Trigger::Activated { action_cost: 0 }`
+//!   abilities (`Cost::Resources(1)`, `ThisSkillTest` `Modify`), willpower
+//!   / combat (the Hyperawareness shape).
+//! - Machete (01020) — bare `Trigger::Activated { action_cost: 1 }` +
+//!   `Effect::Fight` (flat +1 combat, +1 damage; conditional-damage caveat
+//!   in the impl, TODO(#300)).
 //! - Attic (01113) — `Trigger::OnEvent` (`EnteredLocation`, `After`) +
 //!   `DealHorror(You, 1)`.
 //! - Cellar (01114) — `Trigger::OnEvent` (`EnteredLocation`, `After`) +
@@ -58,12 +66,15 @@ pub mod agenda_01105;
 pub mod agenda_01106;
 pub mod agenda_01107;
 pub mod attic;
+pub mod automatic_45;
 pub mod cellar;
 pub mod deduction;
 pub mod guard_dog;
 pub mod holy_rosary;
 pub mod hyperawareness;
+pub mod machete;
 pub mod magnifying_glass;
+pub mod physical_training;
 pub mod roland_38_special;
 pub mod roland_banks;
 pub mod treachery_01007;
@@ -88,12 +99,15 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
         agenda_01106::CODE => Some(agenda_01106::abilities()),
         agenda_01107::CODE => Some(agenda_01107::abilities()),
         attic::CODE => Some(attic::abilities()),
+        automatic_45::CODE => Some(automatic_45::abilities()),
         cellar::CODE => Some(cellar::abilities()),
         deduction::CODE => Some(deduction::abilities()),
         guard_dog::CODE => Some(guard_dog::abilities()),
         holy_rosary::CODE => Some(holy_rosary::abilities()),
         hyperawareness::CODE => Some(hyperawareness::abilities()),
+        machete::CODE => Some(machete::abilities()),
         magnifying_glass::CODE => Some(magnifying_glass::abilities()),
+        physical_training::CODE => Some(physical_training::abilities()),
         roland_38_special::CODE => Some(roland_38_special::abilities()),
         roland_banks::CODE => Some(roland_banks::abilities()),
         treachery_01007::CODE => Some(treachery_01007::abilities()),

--- a/crates/cards/src/impls/physical_training.rs
+++ b/crates/cards/src/impls/physical_training.rs
@@ -1,0 +1,100 @@
+//! Physical Training (Guardian talent asset, 01017).
+//!
+//! ```text
+//! Talent.
+//! [fast] Spend 1 resource: You get +1 [willpower] for this skill test.
+//! [fast] Spend 1 resource: You get +1 [combat] for this skill test.
+//! ```
+//!
+//! Structurally identical to Hyperawareness (01034) — two `[fast]`
+//! activated abilities, each paying 1 resource for a `+1` push to a stat
+//! with [`ModifierScope::ThisSkillTest`] scope — only the stats differ
+//! (willpower / combat here, intellect / agility there).
+//!
+//! # Two abilities, two indices
+//!
+//! The willpower ability is at `ability_index: 0`; the combat ability is
+//! at `ability_index: 1`. The order is significant — the
+//! [`PlayerAction::ActivateAbility`] action carries the index, so tests
+//! and clients must pick the matching slot.
+//!
+//! [`PlayerAction::ActivateAbility`]: game_core::PlayerAction::ActivateAbility
+
+use card_dsl::dsl::{activated, modify, Ability, Cost, ModifierScope, Stat};
+
+/// `ArkhamDB` code for Physical Training (original-Core printing).
+pub const CODE: &str = "01017";
+
+/// Physical Training's two activated `[fast]` abilities.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![
+        // Index 0: +1 willpower for this skill test.
+        activated(
+            0,
+            vec![Cost::Resources(1)],
+            modify(Stat::Willpower, 1, ModifierScope::ThisSkillTest),
+        ),
+        // Index 1: +1 combat for this skill test.
+        activated(
+            0,
+            vec![Cost::Resources(1)],
+            modify(Stat::Combat, 1, ModifierScope::ThisSkillTest),
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use card_dsl::dsl::{Effect, Trigger};
+
+    #[test]
+    fn abilities_are_two_fast_resource_costed_modifies() {
+        let abilities = abilities();
+        assert_eq!(abilities.len(), 2);
+        for (idx, ability) in abilities.iter().enumerate() {
+            assert_eq!(
+                ability.trigger,
+                Trigger::Activated { action_cost: 0 },
+                "ability {idx} must be [fast] (action_cost = 0)",
+            );
+            assert_eq!(
+                ability.costs,
+                vec![Cost::Resources(1)],
+                "ability {idx} must cost exactly 1 resource",
+            );
+        }
+    }
+
+    #[test]
+    fn willpower_ability_pushes_willpower_for_this_skill_test() {
+        assert!(matches!(
+            abilities()[0].effect,
+            Effect::Modify {
+                stat: Stat::Willpower,
+                delta: 1,
+                scope: ModifierScope::ThisSkillTest,
+            }
+        ));
+    }
+
+    #[test]
+    fn combat_ability_pushes_combat_for_this_skill_test() {
+        assert!(matches!(
+            abilities()[1].effect,
+            Effect::Modify {
+                stat: Stat::Combat,
+                delta: 1,
+                scope: ModifierScope::ThisSkillTest,
+            }
+        ));
+    }
+
+    /// Catches a `pub mod` rename or a fat-fingered match arm in
+    /// `impls::abilities_for` — the registry must dispatch CODE here.
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(CODE), Some(abilities()));
+    }
+}

--- a/crates/cards/src/lib.rs
+++ b/crates/cards/src/lib.rs
@@ -140,18 +140,25 @@ mod tests {
         // Phase-3 #38: Hyperawareness (01034).
         // Phase-3 #39: Deduction (01039).
         // Phase-3 #55: Roland Banks (01001).
+        // Phase-7 C5d #239: .45 Automatic (01016), Physical Training
+        // (01017), Machete (01020).
         assert!(is_playable("01037"));
         assert!(is_playable("01059"));
         assert!(is_playable("01030"));
         assert!(is_playable("01034"));
         assert!(is_playable("01039"));
         assert!(is_playable("01001"));
+        assert!(is_playable("01016"));
+        assert!(is_playable("01017"));
+        assert!(is_playable("01020"));
     }
 
     #[test]
     fn unimplemented_cards_are_not_playable() {
-        // Phase-3 doesn't touch most of the corpus.
-        assert!(!is_playable("01017")); // Physical Training
+        // Most of the corpus is still unimplemented. Fire Axe (02032)
+        // is far-future Dunwich content (Phase 10), so it stays a
+        // stable unimplemented canary as Core assets land.
+        assert!(!is_playable("02032")); // Fire Axe (Dunwich, Phase 10)
         assert!(!is_playable("99999")); // unknown code
     }
 

--- a/crates/cards/tests/play_card.rs
+++ b/crates/cards/tests/play_card.rs
@@ -30,11 +30,12 @@ const HOLY_ROSARY: &str = "01059";
 /// at your location."
 const WORKING_A_HUNCH: &str = "01037";
 
-/// Physical Training (01017) — Guardian Talent asset, in the corpus
-/// but unimplemented. Not on the Phase-3 roadmap (waits for later
-/// cycles' broader asset coverage). Used as the "unimplemented but
-/// known" rejection case.
-const UNIMPLEMENTED_ASSET: &str = "01017";
+/// Fire Axe (02032) — a Dunwich Legacy Survivor weapon asset, in the
+/// corpus but unimplemented. Chosen as the "unimplemented but known"
+/// rejection canary precisely because it's far-future content (the
+/// Dunwich cycle is Phase 10), so it stays unimplemented long after
+/// the Core Set assets land and won't churn this test.
+const UNIMPLEMENTED_ASSET: &str = "02032";
 
 /// Magnifying Glass (01030) — Seeker Hand-slot, deck-limit 2. Two
 /// copies in play simultaneously is rules-valid (one Hand slot each,

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -6,8 +6,12 @@
 Engine spine (A1/A2) and scenario plumbing (B1/B2) shipped; **Group C**
 (the Gathering content, decomposed into C1–C7, kickoff
 [#246](https://github.com/talelburg/eldritch/issues/246)) is done through
-**C5c** — see the Group C breakdown table below for per-sub-slice state.
-**Next: C5d → C7** (C6d also gates C7b).
+**C5c**, with **C5d partially shipped** (the three engine-free Guardian
+assets; PR #303) — see the Group C breakdown table below for per-sub-slice
+state. **Next: finish C5d (Beat Cop + First Aid, blocked on
+[#301](https://github.com/talelburg/eldritch/issues/301) /
+[#302](https://github.com/talelburg/eldritch/issues/302)) → C7** (C6d
+also gates C7b).
 
 Design specs:
 [Gathering design](../superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md),
@@ -65,7 +69,7 @@ root dependency; C7 is the playable Won/Lost gate; #212 lands after C.
 | C5b | [#237](https://github.com/talelburg/eldritch/issues/237) | Guard Dog reaction + enemy-attack soak mechanic | ✅ PR #292 |
 | — | [#295](https://github.com/talelburg/eldritch/issues/295) | infra: weapon support — ammo/uses (`Cost::SpendUses`) + inspectable `Effect::Fight` (`IntExpr` modifier + bonus damage) (prerequisite for C5c's .38 Special) | ✅ PR #297 |
 | C5c | [#238](https://github.com/talelburg/eldritch/issues/238) | .38 Special signature + Cover Up content | ✅ PR #298 |
-| C5d | [#239](https://github.com/talelburg/eldritch/issues/239) | Guardian L0 assets (×6) | — |
+| C5d | [#239](https://github.com/talelburg/eldritch/issues/239) | Guardian L0 assets — **3 engine-free shipped** (.45 Automatic, Physical Training, Machete); Beat Cop + First Aid deferred to [#301](https://github.com/talelburg/eldritch/issues/301) / [#302](https://github.com/talelburg/eldritch/issues/302); Guard Dog already in C5b | 🛠️ PR #303 (partial; #239 open) |
 | C5e | [#240](https://github.com/talelburg/eldritch/issues/240) | Guardian L0 events + skill (×4) | — |
 | C6a | [#241](https://github.com/talelburg/eldritch/issues/241) | Dr. Milan after-investigate window | — |
 | C6b | [#242](https://github.com/talelburg/eldritch/issues/242) | Seeker deck cards | — |
@@ -142,6 +146,8 @@ Devourer Below, campaign log + `Fact` enum) is **Phase 9**, not Phase 7.
 - **The enemy-phase attack loop suspends/resumes around a soak reaction window via `pending_enemy_attack`; attacks of opportunity soak but do NOT yet open the window (C5b, PR #292).** `drive_attack_loop` parks the remaining attackers and returns `AwaitingInput` when an attack opens a soak window; `resume_enemy_attack` (from the `AfterEnemyAttackDamagedAsset` window-close continuation) re-enters at the next attacker, advancing the enemy-phase cursor exactly once via the extracted `after_enemy_phase_attacks`. **AoO is the deferred gap:** full AoO reactions need a new mechanism to suspend/resume the *triggering action* (Move's relocation, Investigate's already-suspending skill test), so `fire_attacks_of_opportunity` deliberately drops the soak-window survivors (window-safe; Guard Dog soaks AoO damage but doesn't retaliate). The fast-follow ([#293](https://github.com/talelburg/eldritch/issues/293)) routes `fire_attacks_of_opportunity` through `drive_attack_loop` (`EnemyAttackSource::AttackOfOpportunity` is the reserved-but-unconstructed variant) + action suspension. Multi-soak-window-per-attack resume ([#294](https://github.com/talelburg/eldritch/issues/294)) is `debug_assert`-guarded (unreachable in Slice 1: only Guard Dog reacts, two copies need two illegal Ally slots; coordinates with #213).
 
 - **A weapon needs no engine work — it's `Cost::SpendUses` + `Effect::Fight` data, with ammo from the corpus (C5c prereq [#295](https://github.com/talelburg/eldritch/issues/295), PR #297).** `Uses (N <kind>)` is pipeline-parsed into `CardKind::Asset.uses`; the kind enum (`UseKind`) lives in `card-dsl` so the printed metadata and the engine's `CardInPlay.uses` runtime pool share one type. A firearm's ability is `activated(cost, vec![Cost::SpendUses { kind, count }], fight(IntExpr::cond(LocationHasClues, hi, lo), extra_damage))` — the inspectable `Effect::Fight` auto-targets the single engaged enemy, snapshots its modifier onto `InFlightSkillTest.test_modifier`, and reuses the skill-test suspend/resume path; the Fight follow-up deals `1 + extra_damage`. **`Effect::Fight` is typed, not `Native`,** so `check_activate_ability` can reject a fire with ≠1 engaged enemy before charging (multi-target selection deferred to the #212/#213 cluster; `effect_initiates_fight` is top-level-only, `TODO(#212/#213)` for a `Seq`/`If`-nested Fight). Conditional numeric values use `IntExpr { Lit, Cond }` over the general `Condition` (e.g. `LocationHasClues`) rather than duplicating the effect in an `Effect::If`. **A future weapon (breadth slices) lands via corpus + this data — no new engine primitives.** Instance-id-mint / put-into-play helper consolidation surfaced here is deferred to [#296](https://github.com/talelburg/eldritch/issues/296).
+
+- **C5d ships only the engine-free Guardian assets; Beat Cop + First Aid are split to engine follow-ups (C5d, PR #303).** .45 Automatic (01016), Physical Training (01017), and Machete (01020) are pure corpus + existing-primitive data (`Effect::Fight` / `Cost::SpendUses` / `ThisSkillTest` `Modify`). The other two need new primitives, so they're carved out the way #276/#286/#295 carved earlier C prereqs: Beat Cop's fast ability wants choose-target "deal damage to an enemy at your location" + a discard-self cost ([#301](https://github.com/talelburg/eldritch/issues/301)); First Aid wants `Effect::Heal` + uses-depletion auto-discard ([#302](https://github.com/talelburg/eldritch/issues/302)). #239 stays open tracking that content; Guard Dog (01021) already shipped in C5b. **Machete's "+1 damage if the attacked enemy is the only enemy engaged with you" is encoded as unconditional `extra_damage: 1`** — exact while Fight is single-target (`Effect::Fight` auto-targets the lone engaged enemy and rejects ≠1 before cost), with [#300](https://github.com/talelburg/eldritch/issues/300) revisiting when multi-target Fight lands.
 
 ## Open questions
 


### PR DESCRIPTION
## Summary

Ships the three Phase-7 C5d Guardian Level-0 assets whose entire printed text is expressible with existing engine primitives — pure card content, no engine changes. The remaining C5d cards (Beat Cop, First Aid) need new engine work and are split into follow-ups.

## What changed

- **`.45 Automatic` (01016)** — `activated(1, [Cost::SpendUses(Ammo, 1)], fight(Lit(1), 1))`. The .38 Special shape with a flat `+1` combat modifier instead of the clue-conditional `+1/+3`. Ammo from the corpus.
- **`Physical Training` (01017)** — two `[fast]` `Cost::Resources(1)` abilities pushing willpower (index 0) / combat (index 1) for this skill test. Verbatim Hyperawareness structure.
- **`Machete` (01020)** — bare `[action]` `fight(Lit(1), 1)`, no exhaust/uses cost.
- Wired all three into `impls/mod.rs` (`pub mod` + `abilities_for` arms + the "Implemented so far" doc list) and added them to `lib.rs`'s `implemented_cards_are_playable`.
- Repointed the "unimplemented but known" rejection canary (`UNIMPLEMENTED_ASSET` in `play_card.rs`, and the `lib.rs` not-playable assertion) from Physical Training (now playable) to **Fire Axe (02032)** — far-future Dunwich content, so it won't churn as Core assets land.

## Design notes

- **Machete's conditional damage is modeled as unconditional `extra_damage: 1` — exact, not approximate.** `Effect::Fight` auto-targets the single engaged enemy and `effect_initiates_fight` rejects a fight with ≠1 engaged enemy *before* any cost is paid, so "the attacked enemy is the only enemy engaged with you" is necessarily true at resolution. A load-bearing doc-comment + `TODO(#300)` records that this must become conditional when multi-target Fight lands (#212/#213 cluster).
- **Printing:** the in-scope original-Core Beat Cop (01018) has *no* reaction (the issue body's "after-enemy-defeated reaction" describes the revised printing); confirming the snapshot text was the basis for splitting it out rather than the issue text.

## Deferred to follow-ups (engine work)

- **#301** — choose-target "deal damage to an enemy at your location" + discard-self cost → unblocks **Beat Cop** (01018).
- **#302** — `Effect::Heal` + uses-depletion auto-discard → unblocks **First Aid** (01019).
- **#300** — make Machete's bonus damage conditional once multi-target Fight exists.

`#239` stays open tracking the Beat Cop + First Aid content. Guard Dog (01021) already shipped in C5b (#292).

## Test notes

Per-card shape-assertion tests + the `registry_dispatches_to_this_modules_abilities` guard, mirroring `roland_38_special` / `hyperawareness`. Full strict gauntlet green locally (fmt, host clippy, `RUSTFLAGS=-D warnings` test, doc, wasm-build, wasm-clippy).

## Linked issues

Part of #239.