### PR TITLE
engine: OnCommit firing + bonus-attack-damage (Vicious Blow 01025 prereq)

### DIFF
--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -612,6 +612,15 @@ pub enum Effect {
         /// Bonus damage beyond the base 1 (.38 Special: +1).
         extra_damage: u8,
     },
+    /// Add `N` to the in-flight skill test's bonus attack damage —
+    /// Vicious Blow 01025's "that attack deals +1 damage." Accumulated at
+    /// commit time (under [`Trigger::OnCommit`]) onto the in-flight
+    /// record; **only a Fight skill test's follow-up reads it**, so the
+    /// "during an attack" qualifier is intrinsic (committing to a
+    /// non-attack test accumulates harmlessly and changes nothing), as is
+    /// "if successful" (the Fight follow-up deals damage only on success).
+    /// A no-op when there is no in-flight test.
+    BoostAttackDamage(u8),
     /// A constant restriction the source card imposes while in play
     /// (under [`Trigger::Constant`]). **Inspected, not executed** — the
     /// engine reads it at the relevant decision point (`play_is_prohibited`
@@ -978,6 +987,13 @@ pub fn deal_horror(target: InvestigatorTarget, amount: u8) -> Effect {
     Effect::DealHorror { target, amount }
 }
 
+/// Build an [`Effect::BoostAttackDamage`] adding `amount` to the
+/// in-flight Fight test's bonus damage (Vicious Blow 01025).
+#[must_use]
+pub fn boost_attack_damage(amount: u8) -> Effect {
+    Effect::BoostAttackDamage(amount)
+}
+
 /// Build an [`Effect::Modify`].
 #[must_use]
 pub fn modify(stat: Stat, delta: i8, scope: ModifierScope) -> Effect {
@@ -1334,6 +1350,17 @@ mod tests {
     #[test]
     fn native_effect_round_trips_through_serde_json() {
         let effect = native("01108:board-build");
+        let json = serde_json::to_string(&effect).expect("serialize");
+        let recovered: Effect = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(effect, recovered);
+    }
+
+    /// `Effect::BoostAttackDamage` (Vicious Blow 01025's "+1 damage")
+    /// round-trips through serde, and the builder constructs the variant.
+    #[test]
+    fn boost_attack_damage_round_trips_through_serde_json() {
+        let effect = boost_attack_damage(1);
+        assert_eq!(effect, Effect::BoostAttackDamage(1));
         let json = serde_json::to_string(&effect).expect("serialize");
         let recovered: Effect = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(effect, recovered);

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -94,6 +94,7 @@ pub(in crate::engine) fn start_skill_test(
         source,
         continuation: FinishContinuation::AwaitingCommit,
         test_modifier,
+        bonus_attack_damage: 0,
     });
     cx.events.push(Event::SkillTestStarted {
         investigator,
@@ -187,6 +188,11 @@ pub(super) fn finish_skill_test(cx: &mut Cx, indices: &[u32]) -> EngineOutcome {
         .expect("in_flight_skill_test was Some immediately above")
         .committed_by_active
         .clone_from(&indices_u8);
+
+    // Fire committed cards' OnCommit effects (Vicious Blow's attack buff)
+    // before the test resolves — the commit step precedes resolution, and
+    // a Fight follow-up's damage reads the accumulator they populate.
+    fire_on_commit(cx, investigator, &indices_u8);
 
     let (succeeded, failed_by) =
         resolve_chaos_token_and_emit(cx, investigator, skill, difficulty, skill_value);
@@ -605,11 +611,20 @@ fn apply_skill_test_follow_up(
             // Mid-test enemy disappearance isn't possible in Phase 3
             // (no commit-window effects mutate enemies), so
             // damage_enemy's enemy-missing panic stays loud. A weapon's
-            // bonus damage (.38 Special's +1) rides on `extra_damage`.
+            // bonus damage (.38 Special's +1) rides on `extra_damage`; a
+            // committed skill's bonus (Vicious Blow's +1) accumulates on
+            // the in-flight record at commit time (#307). The in-flight
+            // test is still present here — it's torn down only at the end
+            // of resolution — so the accumulator is readable.
+            let bonus = cx
+                .state
+                .in_flight_skill_test
+                .as_ref()
+                .map_or(0, |t| t.bonus_attack_damage);
             super::combat::damage_enemy(
                 cx,
                 enemy,
-                1u8.saturating_add(extra_damage),
+                1u8.saturating_add(extra_damage).saturating_add(bonus),
                 Some(investigator),
             );
             EngineOutcome::Done
@@ -798,6 +813,62 @@ fn fire_on_skill_test_resolution(
     }
 }
 
+/// Iterate the active investigator's committed cards and fire each
+/// [`Trigger::OnCommit`] ability's effect.
+///
+/// Called inside `finish_skill_test` after the commit indices are
+/// validated and **before** the chaos token resolves — committing a card
+/// happens before the test is resolved (Rules Reference: the commit step
+/// precedes skill-test resolution). The in-scope consumer
+/// ([`Effect::BoostAttackDamage`](crate::dsl::Effect::BoostAttackDamage),
+/// Vicious Blow 01025) accumulates onto the in-flight record so the Fight
+/// follow-up reads it; it never suspends.
+///
+/// **Rejections panic.** As with [`fire_on_skill_test_resolution`], an
+/// `OnCommit` effect that returns non-`Done` is a card-impl bug — there is
+/// no resume path mid-commit, so surface it loudly. A suspending commit
+/// effect is #212 reentrancy work. No-op without an installed registry
+/// (engine-only tests that don't touch card data never commit real cards).
+fn fire_on_commit(cx: &mut Cx, investigator: InvestigatorId, indices_u8: &[u8]) {
+    let Some(reg) = card_registry::current() else {
+        return;
+    };
+    // Snapshot the committed hand codes before re-borrowing state mutably
+    // during apply_effect calls. The cards are still in hand at commit.
+    let codes: Vec<CardCode> = {
+        let inv = cx
+            .state
+            .investigators
+            .get(&investigator)
+            .unwrap_or_else(|| {
+                unreachable!(
+                    "fire_on_commit: investigator {investigator:?} vanished while test was in \
+                     flight; this is a state-corruption invariant violation"
+                )
+            });
+        indices_u8
+            .iter()
+            .map(|&i| inv.hand[usize::from(i)].clone())
+            .collect()
+    };
+
+    for code in &codes {
+        let Some(abilities) = (reg.abilities_for)(code) else {
+            continue;
+        };
+        for ability in abilities {
+            if !matches!(ability.trigger, Trigger::OnCommit) {
+                continue;
+            }
+            let eval_ctx = EvalContext::for_controller(investigator);
+            let result = apply_effect(cx, &ability.effect, eval_ctx);
+            if let EngineOutcome::Rejected { reason } = result {
+                unreachable!("OnCommit: effect for card {code:?} rejected unexpectedly: {reason}");
+            }
+        }
+    }
+}
+
 /// Public dispatch wrapper for [`PlayerAction::PerformSkillTest`].
 ///
 /// Opens the commit window with no action-specific follow-up. The
@@ -871,6 +942,63 @@ mod tests {
     use crate::event::Event;
     use crate::scenario::{SymbolOutcome, TokenEffect};
     use crate::test_support::{test_investigator, GameStateBuilder};
+
+    /// The `Fight` follow-up deals `1 + extra_damage + bonus_attack_damage`,
+    /// reading the commit-time accumulator off the in-flight record
+    /// (Vicious Blow 01025). With `extra_damage: 1` (a weapon bonus) and
+    /// `bonus_attack_damage: 2`, the attack deals `1 + 1 + 2 = 4`.
+    #[test]
+    fn fight_follow_up_adds_bonus_attack_damage() {
+        use crate::state::EnemyId;
+        use crate::test_support::test_enemy;
+
+        let inv = InvestigatorId(1);
+        let mut enemy = test_enemy(7, "Goon");
+        enemy.max_health = 10; // avoid clamping so the dealt damage is observable
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_enemy(enemy)
+            .build();
+        state.in_flight_skill_test = Some(InFlightSkillTest {
+            investigator: inv,
+            skill: SkillKind::Combat,
+            kind: SkillTestKind::Fight,
+            difficulty: 2,
+            committed_by_active: Vec::new(),
+            tested_location: None,
+            follow_up: SkillTestFollowUp::Fight {
+                enemy: EnemyId(7),
+                extra_damage: 1,
+            },
+            on_fail: None,
+            on_success: None,
+            source: None,
+            continuation: FinishContinuation::AwaitingCommit,
+            test_modifier: 0,
+            bonus_attack_damage: 2,
+        });
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+
+        let out = apply_skill_test_follow_up(
+            &mut cx,
+            inv,
+            SkillTestFollowUp::Fight {
+                enemy: EnemyId(7),
+                extra_damage: 1,
+            },
+        );
+
+        assert_eq!(out, EngineOutcome::Done);
+        assert_eq!(
+            state.enemies[&EnemyId(7)].damage,
+            4,
+            "1 base + 1 extra_damage + 2 bonus_attack_damage"
+        );
+    }
 
     #[test]
     fn apply_symbol_outcome_runs_immediate_always_and_on_fail_only_on_failure() {

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -243,7 +243,19 @@ pub(crate) fn apply_effect(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) 
             combat_modifier,
             extra_damage,
         } => apply_fight(cx, &eval_ctx, combat_modifier, *extra_damage),
+        Effect::BoostAttackDamage(amount) => boost_attack_damage_effect(cx, *amount),
     }
+}
+
+/// Add `amount` to the in-flight skill test's `bonus_attack_damage`
+/// accumulator (Vicious Blow 01025). A no-op when there is no in-flight
+/// test. The Fight follow-up is the only reader, so this is inert for
+/// non-attack tests.
+fn boost_attack_damage_effect(cx: &mut Cx, amount: u8) -> EngineOutcome {
+    if let Some(test) = cx.state.in_flight_skill_test.as_mut() {
+        test.bonus_attack_damage = test.bonus_attack_damage.saturating_add(amount);
+    }
+    EngineOutcome::Done
 }
 
 /// Resolve [`Effect::Fight`]: snapshot the combat modifier, auto-target
@@ -1205,9 +1217,9 @@ pub fn location_id_by_code(state: &GameState, code: &str) -> Option<crate::state
 mod tests {
     use crate::card_registry::CardRegistry;
     use crate::dsl::{
-        constant, deal_damage, deal_horror, discover_clue, for_each_point_failed, gain_resources,
-        modify, on_play, seq, Ability, Effect, InvestigatorTarget, LocationTarget, ModifierScope,
-        SkillTestKind, Stat,
+        boost_attack_damage, constant, deal_damage, deal_horror, discover_clue,
+        for_each_point_failed, gain_resources, modify, on_play, seq, Ability, Effect,
+        InvestigatorTarget, LocationTarget, ModifierScope, SkillTestKind, Stat,
     };
     use crate::event::Event;
     use crate::state::{
@@ -1524,6 +1536,7 @@ mod tests {
             source: None,
             continuation: crate::state::FinishContinuation::AwaitingCommit,
             test_modifier: 0,
+            bonus_attack_damage: 0,
         });
         let mut events = Vec::new();
 
@@ -1540,6 +1553,64 @@ mod tests {
         assert_eq!(state.locations[&tested].clues, 1);
         assert_eq!(state.locations[&elsewhere].clues, 0);
         assert_eq!(state.investigators[&InvestigatorId(1)].clues, 1);
+    }
+
+    /// `Effect::BoostAttackDamage` accumulates onto the in-flight test's
+    /// `bonus_attack_damage`; repeated applications stack. A no-op with no
+    /// in-flight test.
+    #[test]
+    fn boost_attack_damage_accumulates_on_in_flight_test() {
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .build();
+        let mut events = Vec::new();
+
+        // No in-flight test: a clean no-op (no panic, nothing to mutate).
+        let outcome = apply_effect(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            &boost_attack_damage(1),
+            ctx(1),
+        );
+        assert_eq!(outcome, EngineOutcome::Done);
+
+        state.in_flight_skill_test = Some(crate::state::InFlightSkillTest {
+            investigator: InvestigatorId(1),
+            skill: SkillKind::Combat,
+            kind: SkillTestKind::Fight,
+            difficulty: 3,
+            committed_by_active: Vec::new(),
+            tested_location: None,
+            follow_up: crate::state::SkillTestFollowUp::None,
+            on_fail: None,
+            on_success: None,
+            source: None,
+            continuation: crate::state::FinishContinuation::AwaitingCommit,
+            test_modifier: 0,
+            bonus_attack_damage: 0,
+        });
+
+        for _ in 0..2 {
+            apply_effect(
+                &mut Cx {
+                    state: &mut state,
+                    events: &mut events,
+                },
+                &boost_attack_damage(1),
+                ctx(1),
+            );
+        }
+        assert_eq!(
+            state
+                .in_flight_skill_test
+                .as_ref()
+                .unwrap()
+                .bonus_attack_damage,
+            2,
+            "two BoostAttackDamage(1) applications should stack to 2"
+        );
     }
 
     #[test]
@@ -1598,6 +1669,7 @@ mod tests {
             source: None,
             continuation: crate::state::FinishContinuation::AwaitingCommit,
             test_modifier: 0,
+            bonus_attack_damage: 0,
         });
         state
     }
@@ -1763,6 +1835,7 @@ mod tests {
             source: None,
             continuation: crate::state::FinishContinuation::AwaitingCommit,
             test_modifier: 0,
+            bonus_attack_damage: 0,
         });
         let mut events = Vec::new();
 

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -471,6 +471,13 @@ pub struct InFlightSkillTest {
     /// modifiers — this is the one-shot "+N for this attack" a weapon
     /// grants.
     pub test_modifier: i8,
+    /// Bonus damage added to this attack, accumulated at commit time by
+    /// [`Effect::BoostAttackDamage`](crate::dsl::Effect::BoostAttackDamage)
+    /// (Vicious Blow 01025). Read **only** by the `Fight` follow-up, which
+    /// deals `1 + extra_damage + bonus_attack_damage` on success — so it
+    /// is inert for non-Fight tests. `0` for every test that no
+    /// commit-time attack buff touches (regression-safe).
+    pub bonus_attack_damage: u8,
 }
 
 /// Where the skill-test resolution driver should resume on the next

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -473,6 +473,7 @@ mod tests {
             source: None,
             continuation: crate::state::FinishContinuation::AwaitingCommit,
             test_modifier: 0,
+            bonus_attack_damage: 0,
         });
         state
     }

--- a/crates/game-core/tests/commit_attack_buff.rs
+++ b/crates/game-core/tests/commit_attack_buff.rs
@@ -1,0 +1,155 @@
+//! End-to-end commit-time attack buff with a mock `CardRegistry`: a
+//! skill card carrying `[Trigger::OnCommit] BoostAttackDamage(1)`
+//! (Vicious-Blow-shaped). Verifies that committing it to a Fight skill
+//! test adds +1 to the attack's damage on success, and that the
+//! `OnCommit` firing path fires committed cards' effects at the commit
+//! step (no such firing existed before #307).
+//!
+//! Lives at `crates/game-core/tests/` (its own integration-test binary,
+//! hence its own process + `OnceLock<CardRegistry>`). No real card has an
+//! `OnCommit` ability yet — Vicious Blow 01025 (the consumer, #240) is the
+//! first; until then this mock skill exercises the full commit path.
+
+use std::sync::OnceLock;
+
+use game_core::card_data::{CardKind, CardMetadata, Class, SkillIcons};
+use game_core::dsl::{boost_attack_damage, on_commit, Ability};
+use game_core::engine::EngineOutcome;
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, ChaosBag, ChaosToken, EnemyId, InvestigatorId, Phase, TokenModifiers,
+};
+use game_core::test_support::{test_enemy, test_investigator, GameStateBuilder};
+use game_core::{assert_event, Action, InputResponse, PlayerAction};
+
+/// Mock skill: combat icon + `[OnCommit] that attack deals +1 damage`.
+const SKILL: &str = "VBLOW-MOCK";
+
+fn skill_metadata() -> CardMetadata {
+    CardMetadata {
+        code: SKILL.to_owned(),
+        name: "Mock Vicious Blow".to_owned(),
+        traits: vec!["Practiced".to_owned()],
+        text: Some(
+            "If this skill test is successful during an attack, that attack deals +1 damage."
+                .to_owned(),
+        ),
+        pack_code: "_mock".to_owned(),
+        kind: CardKind::Skill {
+            class: Class::Guardian,
+            xp: Some(0),
+            skill_icons: SkillIcons {
+                combat: 1,
+                ..SkillIcons::default()
+            },
+            deck_limit: 2,
+        },
+    }
+}
+
+fn skill_metadata_static() -> &'static CardMetadata {
+    static M: OnceLock<CardMetadata> = OnceLock::new();
+    M.get_or_init(skill_metadata)
+}
+
+fn mock_metadata_for(code: &CardCode) -> Option<&'static CardMetadata> {
+    (code.as_str() == SKILL).then(skill_metadata_static)
+}
+
+fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
+    match code.as_str() {
+        SKILL => Some(vec![on_commit(boost_attack_damage(1))]),
+        _ => None,
+    }
+}
+
+fn install_mock_registry() {
+    static INSTALL: OnceLock<()> = OnceLock::new();
+    INSTALL.get_or_init(|| {
+        let _ = game_core::card_registry::install(game_core::card_registry::CardRegistry {
+            metadata_for: mock_metadata_for,
+            abilities_for: mock_abilities_for,
+            native_effect_for: |_| None,
+        });
+    });
+}
+
+/// Board: the controller (combat 3) engaged with one enemy (fight 2,
+/// health 10 so the dealt damage is observable, not clamped), the mock
+/// skill in hand, a `Numeric(0)` chaos bag for a deterministic success.
+fn board() -> (game_core::GameState, InvestigatorId, EnemyId) {
+    install_mock_registry();
+    let id = InvestigatorId(1);
+    let enemy_id = EnemyId(100);
+
+    let mut inv = test_investigator(1);
+    inv.skills.combat = 3;
+    inv.hand = vec![CardCode::new(SKILL)];
+
+    let mut enemy = test_enemy(100, "Ghoul");
+    enemy.fight = 2;
+    enemy.max_health = 10;
+    enemy.engaged_with = Some(id);
+
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_active_investigator(id)
+        .with_turn_order([id])
+        .with_investigator(inv)
+        .with_enemy(enemy)
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default())
+        .build();
+    (state, id, enemy_id)
+}
+
+fn fight_action(inv: InvestigatorId, enemy: EnemyId) -> Action {
+    Action::Player(PlayerAction::Fight {
+        investigator: inv,
+        enemy,
+    })
+}
+
+/// Committing the `OnCommit` skill to a successful Fight test deals
+/// `1 base + 1 bonus = 2` damage.
+#[test]
+fn committing_vicious_blow_adds_one_attack_damage() {
+    let (state, id, enemy_id) = board();
+
+    let paused = game_core::engine::apply(state, fight_action(id, enemy_id));
+    assert!(matches!(
+        paused.outcome,
+        EngineOutcome::AwaitingInput { .. }
+    ));
+
+    let result = game_core::engine::apply(
+        paused.state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::CommitCards { indices: vec![0] },
+        }),
+    );
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(result.events, Event::EnemyDamaged { amount: 2, .. });
+    assert_eq!(result.state.enemies[&enemy_id].damage, 2);
+}
+
+/// Without committing the skill, the same Fight deals the base `1`
+/// damage — the `OnCommit` buff only applies when committed (regression
+/// guard that the accumulator defaults to 0).
+#[test]
+fn fight_without_commit_deals_base_damage() {
+    let (state, id, enemy_id) = board();
+
+    let paused = game_core::engine::apply(state, fight_action(id, enemy_id));
+    let result = game_core::engine::apply(
+        paused.state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::CommitCards { indices: vec![] },
+        }),
+    );
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(result.events, Event::EnemyDamaged { amount: 1, .. });
+    assert_eq!(result.state.enemies[&enemy_id].damage, 1);
+}

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -6,12 +6,19 @@
 Engine spine (A1/A2) and scenario plumbing (B1/B2) shipped; **Group C**
 (the Gathering content, decomposed into C1–C7, kickoff
 [#246](https://github.com/talelburg/eldritch/issues/246)) is done through
-**C5c**, with **C5d partially shipped** (the three engine-free Guardian
-assets; PR #303) — see the Group C breakdown table below for per-sub-slice
-state. **Next: finish C5d (Beat Cop + First Aid, blocked on
-[#301](https://github.com/talelburg/eldritch/issues/301) /
-[#302](https://github.com/talelburg/eldritch/issues/302)) → C7** (C6d
-also gates C7b).
+**C5c**, with **C5d** and **C5e** each partially shipped: C5d landed the
+three engine-free Guardian assets (PR #303), and C5e landed only its
+engine prereq (`OnCommit` firing + bonus-attack-damage, PR #308) — its
+four cards are all choice-/cancellation-/reaction-blocked. See the Group C
+breakdown table below for per-sub-slice state. **Strategy: ship every card
+implementable on today's engine, file follow-ups for the rest, then build
+the deferred machinery (the #212/#213 choice cluster and friends) and
+return for them.** Deferred so far: C5d's Beat Cop + First Aid
+([#301](https://github.com/talelburg/eldritch/issues/301) /
+[#302](https://github.com/talelburg/eldritch/issues/302)); C5e's Evidence!
+/ Dodge / Dynamite Blast + Vicious Blow card
+([#304](https://github.com/talelburg/eldritch/issues/304)–[#306](https://github.com/talelburg/eldritch/issues/306),
+card under #240). **Next: C6** (C6d gates C7b) **→ C7.**
 
 Design specs:
 [Gathering design](../superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md),
@@ -70,7 +77,8 @@ root dependency; C7 is the playable Won/Lost gate; #212 lands after C.
 | — | [#295](https://github.com/talelburg/eldritch/issues/295) | infra: weapon support — ammo/uses (`Cost::SpendUses`) + inspectable `Effect::Fight` (`IntExpr` modifier + bonus damage) (prerequisite for C5c's .38 Special) | ✅ PR #297 |
 | C5c | [#238](https://github.com/talelburg/eldritch/issues/238) | .38 Special signature + Cover Up content | ✅ PR #298 |
 | C5d | [#239](https://github.com/talelburg/eldritch/issues/239) | Guardian L0 assets — **3 engine-free shipped** (.45 Automatic, Physical Training, Machete); Beat Cop + First Aid deferred to [#301](https://github.com/talelburg/eldritch/issues/301) / [#302](https://github.com/talelburg/eldritch/issues/302); Guard Dog already in C5b | 🛠️ PR #303 (partial; #239 open) |
-| C5e | [#240](https://github.com/talelburg/eldritch/issues/240) | Guardian L0 events + skill (×4) | — |
+| — | [#307](https://github.com/talelburg/eldritch/issues/307) | infra: `Trigger::OnCommit` firing + `Effect::BoostAttackDamage` / `InFlightSkillTest.bonus_attack_damage` (prerequisite for C5e's Vicious Blow) | ✅ PR #308 |
+| C5e | [#240](https://github.com/talelburg/eldritch/issues/240) | Guardian L0 events + skill (×4) — **all four blocked on engine machinery, none shipped.** Engine prereq landed (PR #308); Evidence! ([#304](https://github.com/talelburg/eldritch/issues/304), reaction-event-play), Dodge ([#305](https://github.com/talelburg/eldritch/issues/305), attack-cancellation), Dynamite Blast ([#306](https://github.com/talelburg/eldritch/issues/306), location-choice = #212/#213) carved to follow-ups; Vicious Blow card now unblocked, still tracked under #240 | 🛠️ prereq done (#240 open) |
 | C6a | [#241](https://github.com/talelburg/eldritch/issues/241) | Dr. Milan after-investigate window | — |
 | C6b | [#242](https://github.com/talelburg/eldritch/issues/242) | Seeker deck cards | — |
 | C6c | [#243](https://github.com/talelburg/eldritch/issues/243) | Neutral deck cards | — |
@@ -148,6 +156,8 @@ Devourer Below, campaign log + `Fact` enum) is **Phase 9**, not Phase 7.
 - **A weapon needs no engine work — it's `Cost::SpendUses` + `Effect::Fight` data, with ammo from the corpus (C5c prereq [#295](https://github.com/talelburg/eldritch/issues/295), PR #297).** `Uses (N <kind>)` is pipeline-parsed into `CardKind::Asset.uses`; the kind enum (`UseKind`) lives in `card-dsl` so the printed metadata and the engine's `CardInPlay.uses` runtime pool share one type. A firearm's ability is `activated(cost, vec![Cost::SpendUses { kind, count }], fight(IntExpr::cond(LocationHasClues, hi, lo), extra_damage))` — the inspectable `Effect::Fight` auto-targets the single engaged enemy, snapshots its modifier onto `InFlightSkillTest.test_modifier`, and reuses the skill-test suspend/resume path; the Fight follow-up deals `1 + extra_damage`. **`Effect::Fight` is typed, not `Native`,** so `check_activate_ability` can reject a fire with ≠1 engaged enemy before charging (multi-target selection deferred to the #212/#213 cluster; `effect_initiates_fight` is top-level-only, `TODO(#212/#213)` for a `Seq`/`If`-nested Fight). Conditional numeric values use `IntExpr { Lit, Cond }` over the general `Condition` (e.g. `LocationHasClues`) rather than duplicating the effect in an `Effect::If`. **A future weapon (breadth slices) lands via corpus + this data — no new engine primitives.** Instance-id-mint / put-into-play helper consolidation surfaced here is deferred to [#296](https://github.com/talelburg/eldritch/issues/296).
 
 - **C5d ships only the engine-free Guardian assets; Beat Cop + First Aid are split to engine follow-ups (C5d, PR #303).** .45 Automatic (01016), Physical Training (01017), and Machete (01020) are pure corpus + existing-primitive data (`Effect::Fight` / `Cost::SpendUses` / `ThisSkillTest` `Modify`). The other two need new primitives, so they're carved out the way #276/#286/#295 carved earlier C prereqs: Beat Cop's fast ability wants choose-target "deal damage to an enemy at your location" + a discard-self cost ([#301](https://github.com/talelburg/eldritch/issues/301)); First Aid wants `Effect::Heal` + uses-depletion auto-discard ([#302](https://github.com/talelburg/eldritch/issues/302)). #239 stays open tracking that content; Guard Dog (01021) already shipped in C5b. **Machete's "+1 damage if the attacked enemy is the only enemy engaged with you" is encoded as unconditional `extra_damage: 1`** — exact while Fight is single-target (`Effect::Fight` auto-targets the lone engaged enemy and rejects ≠1 before cost), with [#300](https://github.com/talelburg/eldritch/issues/300) revisiting when multi-target Fight lands.
+
+- **C5e ships no cards — all four are blocked, so only its engine prereq landed (C5e prereq [#307](https://github.com/talelburg/eldritch/issues/307), PR #308).** `Trigger::OnCommit` was never fired (compiled + serde-round-tripped, but no engine path ran a committed card's effect); `fire_on_commit` now runs committed cards' `OnCommit` effects at the commit step, **before** chaos resolution (committing precedes resolution), mirroring `fire_on_skill_test_resolution`. Vicious Blow's "+1 damage" is `Effect::BoostAttackDamage(u8)`, accumulated onto `InFlightSkillTest.bonus_attack_damage`; the Fight follow-up deals `1 + extra_damage + bonus_attack_damage`. **The "during an attack" / "if successful" qualifiers are intrinsic — not a new `Condition`:** only the Fight follow-up reads the accumulator, and it deals damage only on success, so committing the buff to a non-attack test is a harmless no-op. The Vicious Blow *card* (now unblocked) stays under #240; the other three carved to follow-ups blocked on bigger machinery — Evidence! ([#304](https://github.com/talelburg/eldritch/issues/304)) on reaction-event-play (the play-card gate defers card play-timing restrictions), Dodge ([#305](https://github.com/talelburg/eldritch/issues/305)) on a new attack-cancellation subsystem, Dynamite Blast ([#306](https://github.com/talelburg/eldritch/issues/306)) on the #212/#213 location-choice.
 
 ## Open questions
 


### PR DESCRIPTION
## Summary

Adds the engine machinery **Vicious Blow 01025** needs — `Trigger::OnCommit` firing and a committed-skill attack-damage hook — as a prerequisite PR. The Vicious Blow card itself stays pure content under #240. Sibling to #276 / #286 / #295; **not** blocked on the #212/#213 interactive-choice cluster.

Two gaps existed: `Trigger::OnCommit` was never fired (it compiled and round-tripped through serde but no engine path ran a committed card's effect — `grep -rn OnCommit crates/game-core/src` was empty), and a committed skill had no way to add attack damage (the Fight follow-up's `1 + extra_damage` only carried a *weapon's* printed bonus).

## What changed

- **`Effect::BoostAttackDamage(u8)`** + `boost_attack_damage` builder (card-dsl): accumulates onto the in-flight test's new `InFlightSkillTest.bonus_attack_damage` field. The **"during an attack"** and **"if successful"** qualifiers are *intrinsic* — only a Fight follow-up reads the accumulator, and it deals damage only on success — so committing to a non-attack test is a harmless no-op and no new `Condition` is needed.
- **`fire_on_commit`** (skill_test.rs): fires committed cards' `OnCommit` effects at the commit step, **before** chaos resolution (committing precedes resolution per the Rules Reference). Mirrors the existing `fire_on_skill_test_resolution`. No-op without an installed registry; rejections panic (no mid-commit resume path — a suspending commit effect is #212 reentrancy work).
- **Fight follow-up** now deals `1 + extra_damage + bonus_attack_damage`, reading the accumulator off the still-present in-flight record.

## Test notes

Built TDD, red-then-green at each layer:
- **Evaluator unit** (`boost_attack_damage_accumulates_on_in_flight_test`): the effect stacks onto the accumulator; clean no-op with no in-flight test.
- **Follow-up unit** (`fight_follow_up_adds_bonus_attack_damage`): `extra_damage: 1` + `bonus_attack_damage: 2` → attack deals `1 + 1 + 2 = 4`.
- **Integration** (`tests/commit_attack_buff.rs`, mock registry with an `on_commit(boost_attack_damage(1))` skill): committing to a successful Fight deals **2** (1 base + 1 bonus); not committing deals the base **1** (regression guard that the accumulator defaults to 0).

Full strict gauntlet green locally (all 7 CI jobs): `test` (warnings-as-errors), `clippy`, `fmt`, `doc`, `wasm-build`, `wasm-test`, `wasm-clippy`. The `bonus_attack_damage` field defaults to 0, so base `PlayerAction::Fight` and every existing test are unchanged.

## Linked issues

Closes #307.
