### PR TITLE
engine: Effect::DrawCards primitive (C6c neutral-skills prereq)

### DIFF
--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -612,6 +612,16 @@ pub enum Effect {
         /// Bonus damage beyond the base 1 (.38 Special: +1).
         extra_damage: u8,
     },
+    /// Draw `count` cards for the resolved target investigator —
+    /// "draw 1 card" (Guts 01089, Perception 01090, Overpower 01091,
+    /// Manual Dexterity 01092). `count == 0` is a no-op. Deck-out (drawing
+    /// from an empty deck) follows the engine's existing `draw_cards`
+    /// behavior; the elimination consequence is out of this primitive's
+    /// scope.
+    DrawCards {
+        target: InvestigatorTarget,
+        count: u8,
+    },
     /// Add `N` to the in-flight skill test's bonus attack damage —
     /// Vicious Blow 01025's "that attack deals +1 damage." Accumulated at
     /// commit time (under [`Trigger::OnCommit`]) onto the in-flight
@@ -994,6 +1004,12 @@ pub fn boost_attack_damage(amount: u8) -> Effect {
     Effect::BoostAttackDamage(amount)
 }
 
+/// Build an [`Effect::DrawCards`] drawing `count` cards for `target`.
+#[must_use]
+pub fn draw_cards(target: InvestigatorTarget, count: u8) -> Effect {
+    Effect::DrawCards { target, count }
+}
+
 /// Build an [`Effect::Modify`].
 #[must_use]
 pub fn modify(stat: Stat, delta: i8, scope: ModifierScope) -> Effect {
@@ -1361,6 +1377,23 @@ mod tests {
     fn boost_attack_damage_round_trips_through_serde_json() {
         let effect = boost_attack_damage(1);
         assert_eq!(effect, Effect::BoostAttackDamage(1));
+        let json = serde_json::to_string(&effect).expect("serialize");
+        let recovered: Effect = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(effect, recovered);
+    }
+
+    /// `Effect::DrawCards` (Guts/Perception/… "draw 1 card") round-trips
+    /// through serde, and the builder constructs the variant.
+    #[test]
+    fn draw_cards_round_trips_through_serde_json() {
+        let effect = draw_cards(InvestigatorTarget::You, 1);
+        assert_eq!(
+            effect,
+            Effect::DrawCards {
+                target: InvestigatorTarget::You,
+                count: 1,
+            },
+        );
         let json = serde_json::to_string(&effect).expect("serialize");
         let recovered: Effect = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(effect, recovered);

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -83,7 +83,7 @@ pub(super) fn shuffle_player_deck(cx: &mut Cx, investigator: InvestigatorId) {
 /// Emits a single [`Event::CardsDrawn`] with the actually-drawn
 /// count, even if that's zero. A zero-count draw is informative for
 /// consumers tracking the attempt.
-pub(super) fn draw_cards(cx: &mut Cx, investigator: InvestigatorId, count: u8) {
+pub(in crate::engine) fn draw_cards(cx: &mut Cx, investigator: InvestigatorId, count: u8) {
     let inv = cx
         .state
         .investigators

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -244,7 +244,37 @@ pub(crate) fn apply_effect(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) 
             extra_damage,
         } => apply_fight(cx, &eval_ctx, combat_modifier, *extra_damage),
         Effect::BoostAttackDamage(amount) => boost_attack_damage_effect(cx, *amount),
+        Effect::DrawCards { target, count } => draw_cards_effect(cx, eval_ctx, *target, *count),
     }
+}
+
+/// Resolve [`Effect::DrawCards`]: draw `count` cards for the resolved
+/// target investigator via the engine's `draw_cards` helper. `count == 0`
+/// is a clean no-op (no target resolution, no event).
+fn draw_cards_effect(
+    cx: &mut Cx,
+    eval_ctx: EvalContext,
+    target: InvestigatorTarget,
+    count: u8,
+) -> EngineOutcome {
+    if count == 0 {
+        return EngineOutcome::Done;
+    }
+    let target_id = match resolve_investigator_target(cx.state, eval_ctx, target) {
+        Ok(id) => id,
+        Err(reason) => {
+            return EngineOutcome::Rejected {
+                reason: reason.into(),
+            }
+        }
+    };
+    if !cx.state.investigators.contains_key(&target_id) {
+        return EngineOutcome::Rejected {
+            reason: format!("DrawCards: investigator {target_id:?} is not in the state").into(),
+        };
+    }
+    crate::engine::dispatch::cards::draw_cards(cx, target_id, count);
+    EngineOutcome::Done
 }
 
 /// Add `amount` to the in-flight skill test's `bonus_attack_damage`
@@ -1217,7 +1247,7 @@ pub fn location_id_by_code(state: &GameState, code: &str) -> Option<crate::state
 mod tests {
     use crate::card_registry::CardRegistry;
     use crate::dsl::{
-        boost_attack_damage, constant, deal_damage, deal_horror, discover_clue,
+        boost_attack_damage, constant, deal_damage, deal_horror, discover_clue, draw_cards,
         for_each_point_failed, gain_resources, modify, on_play, seq, Ability, Effect,
         InvestigatorTarget, LocationTarget, ModifierScope, SkillTestKind, Stat,
     };
@@ -1611,6 +1641,49 @@ mod tests {
             2,
             "two BoostAttackDamage(1) applications should stack to 2"
         );
+    }
+
+    /// `Effect::DrawCards` moves `count` cards deck→hand for the resolved
+    /// target and emits `CardsDrawn`; `count == 0` is a no-op.
+    #[test]
+    fn draw_cards_effect_draws_for_target() {
+        let mut inv = test_investigator(1);
+        inv.deck = vec![
+            CardCode::new("d1"),
+            CardCode::new("d2"),
+            CardCode::new("d3"),
+        ];
+        inv.hand = Vec::new();
+        let mut state = GameStateBuilder::new().with_investigator(inv).build();
+        let mut events = Vec::new();
+
+        let outcome = apply_effect(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            &draw_cards(InvestigatorTarget::You, 2),
+            ctx(1),
+        );
+
+        assert_eq!(outcome, EngineOutcome::Done);
+        let inv_after = &state.investigators[&InvestigatorId(1)];
+        assert_eq!(inv_after.hand.len(), 2, "two cards moved into hand");
+        assert_eq!(inv_after.deck.len(), 1, "two cards left the deck");
+        assert_event!(events, Event::CardsDrawn { count: 2, .. });
+
+        // count == 0 → clean no-op (no further draw, no event).
+        let mut events0 = Vec::new();
+        apply_effect(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events0,
+            },
+            &draw_cards(InvestigatorTarget::You, 0),
+            ctx(1),
+        );
+        assert_eq!(state.investigators[&InvestigatorId(1)].hand.len(), 2);
+        assert!(events0.is_empty());
     }
 
     #[test]

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -82,7 +82,9 @@ root dependency; C7 is the playable Won/Lost gate; #212 lands after C.
 | C5e | [#240](https://github.com/talelburg/eldritch/issues/240) | Guardian L0 events + skill (×4) — **only Vicious Blow 01025 was implementable; shipped (PR #309).** Engine prereq landed (PR #308); Evidence! ([#304](https://github.com/talelburg/eldritch/issues/304), reaction-event-play), Dodge ([#305](https://github.com/talelburg/eldritch/issues/305), attack-cancellation), Dynamite Blast ([#306](https://github.com/talelburg/eldritch/issues/306), location-choice = #212/#213) carved to follow-ups | ✅ PR #309 |
 | C6a | [#241](https://github.com/talelburg/eldritch/issues/241) | Dr. Milan after-investigate window | — |
 | C6b | [#242](https://github.com/talelburg/eldritch/issues/242) | Seeker deck cards | — |
-| C6c | [#243](https://github.com/talelburg/eldritch/issues/243) | Neutral deck cards | — |
+| — | [#310](https://github.com/talelburg/eldritch/issues/310) | infra: `Effect::DrawCards` primitive (prerequisite for C6c's draw-skills) | ✅ PR #314 |
+| — | [#311](https://github.com/talelburg/eldritch/issues/311) | infra: enforce "Max N committed per skill test" commit cap (prerequisite for C6c's skills) | — |
+| C6c | [#243](https://github.com/talelburg/eldritch/issues/243) | Neutral deck cards — **Emergency Cache 01088 + 5 skills** shippable (prereqs #310/#311); Knife 01086 ([#312](https://github.com/talelburg/eldritch/issues/312), discard-self-asset cost) + Flashlight 01087 ([#313](https://github.com/talelburg/eldritch/issues/313), `Effect::Investigate` + shroud) carved to follow-ups | — |
 | C6d | [#284](https://github.com/talelburg/eldritch/issues/284) | encounter-deck assembly in `setup()` (quantity-aware, excludes set-aside) — gates C7b; makes Mythos draws + 01106's dig operate live | — |
 | C7a | [#244](https://github.com/talelburg/eldritch/issues/244) | registry swap + web `SCENARIO_ID` repoint (B3) | — |
 | C7b | [#245](https://github.com/talelburg/eldritch/issues/245) | end-to-end Won/Lost integration test (needs C6d) | — |


### PR DESCRIPTION
## Summary

Adds `Effect::DrawCards` so the C6c neutral skills (Guts/Perception/Overpower/Manual Dexterity — "If this test is successful, draw 1 card") can be expressed. Prereq PR; the four skills stay pure content under #243. Sibling to #307 / #295 / #286 / #276.

The engine already had the machinery — `cards::draw_cards` (opening hand, emits `CardsDrawn`, handles deck-out) — so this is only the DSL surface + evaluator arm.

## What changed

- `Effect::DrawCards { target: InvestigatorTarget, count: u8 }` + `draw_cards` builder (card-dsl). `target` for future cards that draw for another investigator; the in-scope four are all `You`.
- Evaluator arm: resolve the target, call `cards::draw_cards`. `count == 0` → clean no-op (no target resolution, no event), matching `DealDamage` / `GainResources`.
- `cards::draw_cards` widened `pub(super)` → `pub(in crate::engine)` so the evaluator can reach it (same visibility as `start_skill_test`).

## Test notes

TDD, red→green:
- **DSL** — `draw_cards` builder + serde round-trip.
- **Evaluator** (`draw_cards_effect_draws_for_target`) — `DrawCards { You, 2 }` moves 2 cards deck→hand and emits `CardsDrawn { count: 2 }`; `count == 0` draws nothing and emits no event.

Full strict gauntlet green locally (all 7 jobs).

## Linked issues

Closes #310.
