### PR TITLE
card: C6c — neutral cards (Emergency Cache + 4 draw-skills + Unexpected Courage)

### DIFF
--- a/crates/cards/src/impls/emergency_cache.rs
+++ b/crates/cards/src/impls/emergency_cache.rs
@@ -1,0 +1,42 @@
+//! Emergency Cache (Neutral event, 01088).
+//!
+//! ```text
+//! Gain 3 resources.
+//! ```
+//!
+//! A plain `OnPlay` resource gain — the simplest player event.
+
+use card_dsl::dsl::{gain_resources, on_play, Ability, InvestigatorTarget};
+
+/// `ArkhamDB` code for the original-Core printing.
+pub const CODE: &str = "01088";
+
+/// On play, gain 3 resources.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![on_play(gain_resources(InvestigatorTarget::You, 3))]
+}
+
+#[cfg(test)]
+mod tests {
+    use card_dsl::dsl::{Effect, InvestigatorTarget, Trigger};
+
+    #[test]
+    fn abilities_are_one_on_play_gain_three_resources() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(abilities[0].trigger, Trigger::OnPlay);
+        assert_eq!(
+            abilities[0].effect,
+            Effect::GainResources {
+                target: InvestigatorTarget::You,
+                amount: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(super::CODE), Some(super::abilities()));
+    }
+}

--- a/crates/cards/src/impls/guts.rs
+++ b/crates/cards/src/impls/guts.rs
@@ -1,0 +1,60 @@
+//! Guts (Neutral skill, 01089).
+//!
+//! ```text
+//! Max 1 committed per skill test.
+//! 2 willpower icons.
+//! If this test is successful, draw 1 card.
+//! ```
+//!
+//! The 2 willpower icons and the "Max 1 committed per skill test" cap are
+//! printed metadata (`SkillIcons` + `CardKind::Skill.commit_limit`,
+//! enforced at the commit window, #311), not `abilities()`. `abilities()`
+//! describes only the triggered effect: an `OnSkillTestResolution` gated on
+//! `Success` that draws 1 card. No kind narrowing — it draws on **any**
+//! successful test the card is committed to (unlike Deduction's
+//! Investigate-only bonus).
+
+use card_dsl::dsl::{
+    draw_cards, on_skill_test_resolution, Ability, InvestigatorTarget, TestOutcome,
+};
+
+/// `ArkhamDB` code for the original-Core printing.
+pub const CODE: &str = "01089";
+
+/// On any successful test this is committed to, draw 1 card.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![on_skill_test_resolution(
+        TestOutcome::Success,
+        draw_cards(InvestigatorTarget::You, 1),
+    )]
+}
+
+#[cfg(test)]
+mod tests {
+    use card_dsl::dsl::{Effect, InvestigatorTarget, TestOutcome, Trigger};
+
+    #[test]
+    fn abilities_are_one_on_success_draw_one() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(
+            abilities[0].trigger,
+            Trigger::OnSkillTestResolution {
+                outcome: TestOutcome::Success,
+            },
+        );
+        assert_eq!(
+            abilities[0].effect,
+            Effect::DrawCards {
+                target: InvestigatorTarget::You,
+                count: 1,
+            },
+        );
+    }
+
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(super::CODE), Some(super::abilities()));
+    }
+}

--- a/crates/cards/src/impls/manual_dexterity.rs
+++ b/crates/cards/src/impls/manual_dexterity.rs
@@ -1,0 +1,57 @@
+//! Manual Dexterity (Neutral skill, 01092).
+//!
+//! ```text
+//! Max 1 committed per skill test.
+//! 2 agility icons.
+//! If this test is successful, draw 1 card.
+//! ```
+//!
+//! Same shape as Guts 01089 (agility icons). Icons + the "Max 1 committed"
+//! cap are printed metadata (#311); `abilities()` is the
+//! `OnSkillTestResolution { Success }` draw, firing on any successful
+//! committed-to test.
+
+use card_dsl::dsl::{
+    draw_cards, on_skill_test_resolution, Ability, InvestigatorTarget, TestOutcome,
+};
+
+/// `ArkhamDB` code for the original-Core printing.
+pub const CODE: &str = "01092";
+
+/// On any successful test this is committed to, draw 1 card.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![on_skill_test_resolution(
+        TestOutcome::Success,
+        draw_cards(InvestigatorTarget::You, 1),
+    )]
+}
+
+#[cfg(test)]
+mod tests {
+    use card_dsl::dsl::{Effect, InvestigatorTarget, TestOutcome, Trigger};
+
+    #[test]
+    fn abilities_are_one_on_success_draw_one() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(
+            abilities[0].trigger,
+            Trigger::OnSkillTestResolution {
+                outcome: TestOutcome::Success,
+            },
+        );
+        assert_eq!(
+            abilities[0].effect,
+            Effect::DrawCards {
+                target: InvestigatorTarget::You,
+                count: 1,
+            },
+        );
+    }
+
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(super::CODE), Some(super::abilities()));
+    }
+}

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -69,11 +69,16 @@ pub mod attic;
 pub mod automatic_45;
 pub mod cellar;
 pub mod deduction;
+pub mod emergency_cache;
 pub mod guard_dog;
+pub mod guts;
 pub mod holy_rosary;
 pub mod hyperawareness;
 pub mod machete;
 pub mod magnifying_glass;
+pub mod manual_dexterity;
+pub mod overpower;
+pub mod perception;
 pub mod physical_training;
 pub mod roland_38_special;
 pub mod roland_banks;
@@ -85,6 +90,7 @@ pub mod treachery_01165;
 pub mod treachery_01166;
 pub mod treachery_01167;
 pub mod treachery_01168;
+pub mod unexpected_courage;
 pub mod vicious_blow;
 pub mod working_a_hunch;
 
@@ -103,11 +109,16 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
         automatic_45::CODE => Some(automatic_45::abilities()),
         cellar::CODE => Some(cellar::abilities()),
         deduction::CODE => Some(deduction::abilities()),
+        emergency_cache::CODE => Some(emergency_cache::abilities()),
         guard_dog::CODE => Some(guard_dog::abilities()),
+        guts::CODE => Some(guts::abilities()),
         holy_rosary::CODE => Some(holy_rosary::abilities()),
         hyperawareness::CODE => Some(hyperawareness::abilities()),
         machete::CODE => Some(machete::abilities()),
         magnifying_glass::CODE => Some(magnifying_glass::abilities()),
+        manual_dexterity::CODE => Some(manual_dexterity::abilities()),
+        overpower::CODE => Some(overpower::abilities()),
+        perception::CODE => Some(perception::abilities()),
         physical_training::CODE => Some(physical_training::abilities()),
         roland_38_special::CODE => Some(roland_38_special::abilities()),
         roland_banks::CODE => Some(roland_banks::abilities()),
@@ -119,6 +130,7 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
         treachery_01166::CODE => Some(treachery_01166::abilities()),
         treachery_01167::CODE => Some(treachery_01167::abilities()),
         treachery_01168::CODE => Some(treachery_01168::abilities()),
+        unexpected_courage::CODE => Some(unexpected_courage::abilities()),
         vicious_blow::CODE => Some(vicious_blow::abilities()),
         working_a_hunch::CODE => Some(working_a_hunch::abilities()),
         _ => None,

--- a/crates/cards/src/impls/overpower.rs
+++ b/crates/cards/src/impls/overpower.rs
@@ -1,0 +1,57 @@
+//! Overpower (Neutral skill, 01091).
+//!
+//! ```text
+//! Max 1 committed per skill test.
+//! 2 combat icons.
+//! If this test is successful, draw 1 card.
+//! ```
+//!
+//! Same shape as Guts 01089 (combat icons). Icons + the "Max 1 committed"
+//! cap are printed metadata (#311); `abilities()` is the
+//! `OnSkillTestResolution { Success }` draw, firing on any successful
+//! committed-to test.
+
+use card_dsl::dsl::{
+    draw_cards, on_skill_test_resolution, Ability, InvestigatorTarget, TestOutcome,
+};
+
+/// `ArkhamDB` code for the original-Core printing.
+pub const CODE: &str = "01091";
+
+/// On any successful test this is committed to, draw 1 card.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![on_skill_test_resolution(
+        TestOutcome::Success,
+        draw_cards(InvestigatorTarget::You, 1),
+    )]
+}
+
+#[cfg(test)]
+mod tests {
+    use card_dsl::dsl::{Effect, InvestigatorTarget, TestOutcome, Trigger};
+
+    #[test]
+    fn abilities_are_one_on_success_draw_one() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(
+            abilities[0].trigger,
+            Trigger::OnSkillTestResolution {
+                outcome: TestOutcome::Success,
+            },
+        );
+        assert_eq!(
+            abilities[0].effect,
+            Effect::DrawCards {
+                target: InvestigatorTarget::You,
+                count: 1,
+            },
+        );
+    }
+
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(super::CODE), Some(super::abilities()));
+    }
+}

--- a/crates/cards/src/impls/perception.rs
+++ b/crates/cards/src/impls/perception.rs
@@ -1,0 +1,57 @@
+//! Perception (Neutral skill, 01090).
+//!
+//! ```text
+//! Max 1 committed per skill test.
+//! 2 intellect icons.
+//! If this test is successful, draw 1 card.
+//! ```
+//!
+//! Same shape as Guts 01089 (intellect icons). Icons + the "Max 1
+//! committed" cap are printed metadata (#311); `abilities()` is the
+//! `OnSkillTestResolution { Success }` draw, firing on any successful
+//! committed-to test.
+
+use card_dsl::dsl::{
+    draw_cards, on_skill_test_resolution, Ability, InvestigatorTarget, TestOutcome,
+};
+
+/// `ArkhamDB` code for the original-Core printing.
+pub const CODE: &str = "01090";
+
+/// On any successful test this is committed to, draw 1 card.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![on_skill_test_resolution(
+        TestOutcome::Success,
+        draw_cards(InvestigatorTarget::You, 1),
+    )]
+}
+
+#[cfg(test)]
+mod tests {
+    use card_dsl::dsl::{Effect, InvestigatorTarget, TestOutcome, Trigger};
+
+    #[test]
+    fn abilities_are_one_on_success_draw_one() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(
+            abilities[0].trigger,
+            Trigger::OnSkillTestResolution {
+                outcome: TestOutcome::Success,
+            },
+        );
+        assert_eq!(
+            abilities[0].effect,
+            Effect::DrawCards {
+                target: InvestigatorTarget::You,
+                count: 1,
+            },
+        );
+    }
+
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(super::CODE), Some(super::abilities()));
+    }
+}

--- a/crates/cards/src/impls/unexpected_courage.rs
+++ b/crates/cards/src/impls/unexpected_courage.rs
@@ -1,0 +1,39 @@
+//! Unexpected Courage (Neutral skill, 01093).
+//!
+//! ```text
+//! Max 1 committed per skill test.
+//! 2 wild icons.
+//! ```
+//!
+//! A pure-icon skill: its whole effect is the 2 wild icons it contributes
+//! when committed, which are printed metadata (`SkillIcons`), and the "Max
+//! 1 committed per skill test" cap (`CardKind::Skill.commit_limit`,
+//! enforced at the commit window, #311) — neither lives in `abilities()`.
+//! It has **no triggered ability**, so `abilities()` is empty. (An empty
+//! `abilities()` is still "implemented" — `is_playable` keys off the
+//! presence of the impl, so the card passes the deck-import gate.)
+
+use card_dsl::dsl::Ability;
+
+/// `ArkhamDB` code for the original-Core printing.
+pub const CODE: &str = "01093";
+
+/// No triggered ability — the card is entirely its icons + commit cap.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn has_no_triggered_abilities() {
+        assert!(super::abilities().is_empty());
+    }
+
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(super::CODE), Some(super::abilities()));
+        assert!(crate::is_playable(super::CODE));
+    }
+}

--- a/crates/cards/tests/neutral_cards.rs
+++ b/crates/cards/tests/neutral_cards.rs
@@ -1,0 +1,110 @@
+//! C6c (#243) integration: the neutral cards' new effect shapes end-to-end
+//! against the real `cards::REGISTRY`.
+//!
+//! - Emergency Cache 01088: `on_play(gain_resources(You, 3))`.
+//! - Guts 01089: `on_skill_test_resolution(Success, draw_cards(You, 1))` —
+//!   draws on a successful committed-to test, not on a failed one.
+//!
+//! The other three draw-skills (Perception/Overpower/Manual Dexterity) are
+//! structurally identical to Guts; their impl unit tests cover them.
+//!
+//! Own process → installs `cards::REGISTRY`.
+
+use std::sync::Once;
+
+use game_core::engine::EngineOutcome;
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, ChaosBag, ChaosToken, InvestigatorId, Phase, SkillKind, TokenModifiers,
+};
+use game_core::test_support::{test_investigator, GameStateBuilder};
+use game_core::{assert_event, assert_no_event, Action, GameState, InputResponse, PlayerAction};
+
+const EMERGENCY_CACHE: &str = "01088";
+const GUTS: &str = "01089";
+const INV: InvestigatorId = InvestigatorId(1);
+
+fn install() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+#[test]
+fn emergency_cache_play_gains_three_resources() {
+    install();
+    let mut inv = test_investigator(1);
+    inv.hand = vec![CardCode::new(EMERGENCY_CACHE)];
+    let before = inv.resources;
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_active_investigator(INV)
+        .with_turn_order([INV])
+        .with_investigator(inv)
+        .build();
+
+    let r = game_core::engine::apply(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: INV,
+            hand_index: 0,
+        }),
+    );
+
+    assert_eq!(r.outcome, EngineOutcome::Done);
+    assert_event!(r.events, Event::ResourcesGained { amount: 3, .. });
+    assert_eq!(r.state.investigators[&INV].resources, before + 3);
+}
+
+/// Guts holding `GUTS` + spare deck cards, willpower `wp`, with a chaos bag
+/// of `token` (`Numeric(0)` → success vs difficulty 1; `AutoFail` → failure).
+fn guts_board(wp: i8, token: ChaosToken) -> GameState {
+    let mut inv = test_investigator(1);
+    inv.skills.willpower = wp;
+    inv.hand = vec![CardCode::new(GUTS)];
+    inv.deck = vec![CardCode::new("spare-1"), CardCode::new("spare-2")];
+    GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_active_investigator(INV)
+        .with_turn_order([INV])
+        .with_investigator(inv)
+        .with_chaos_bag(ChaosBag::new([token]))
+        .with_token_modifiers(TokenModifiers::default())
+        .build()
+}
+
+fn perform_and_commit_guts(state: GameState) -> game_core::engine::ApplyResult {
+    let paused = game_core::engine::apply(
+        state,
+        Action::Player(PlayerAction::PerformSkillTest {
+            investigator: INV,
+            skill: SkillKind::Willpower,
+            difficulty: 1,
+        }),
+    );
+    game_core::engine::apply(
+        paused.state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::CommitCards { indices: vec![0] },
+        }),
+    )
+}
+
+#[test]
+fn guts_draws_a_card_on_a_successful_test() {
+    install();
+    // willpower 3 + Numeric(0) vs difficulty 1 → success → draw 1.
+    let r = perform_and_commit_guts(guts_board(3, ChaosToken::Numeric(0)));
+    assert_eq!(r.outcome, EngineOutcome::Done);
+    assert_event!(r.events, Event::CardsDrawn { count: 1, .. });
+}
+
+#[test]
+fn guts_draws_nothing_on_a_failed_test() {
+    install();
+    // AutoFail → failure → no draw.
+    let r = perform_and_commit_guts(guts_board(3, ChaosToken::AutoFail));
+    assert_eq!(r.outcome, EngineOutcome::Done);
+    assert_no_event!(r.events, Event::CardsDrawn { .. });
+}

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -84,7 +84,7 @@ root dependency; C7 is the playable Won/Lost gate; #212 lands after C.
 | C6b | [#242](https://github.com/talelburg/eldritch/issues/242) | Seeker deck cards | — |
 | — | [#310](https://github.com/talelburg/eldritch/issues/310) | infra: `Effect::DrawCards` primitive (prerequisite for C6c's draw-skills) | ✅ PR #314 |
 | — | [#311](https://github.com/talelburg/eldritch/issues/311) | infra: enforce "Max N committed per skill test" commit cap (prerequisite for C6c's skills) | ✅ PR #315 |
-| C6c | [#243](https://github.com/talelburg/eldritch/issues/243) | Neutral deck cards — **Emergency Cache 01088 + 5 skills** shippable (prereqs #310/#311); Knife 01086 ([#312](https://github.com/talelburg/eldritch/issues/312), discard-self-asset cost) + Flashlight 01087 ([#313](https://github.com/talelburg/eldritch/issues/313), `Effect::Investigate` + shroud) carved to follow-ups | — |
+| C6c | [#243](https://github.com/talelburg/eldritch/issues/243) | Neutral deck cards — **Emergency Cache 01088 + 5 skills** shipped on prereqs #310/#311; Knife 01086 ([#312](https://github.com/talelburg/eldritch/issues/312), discard-self-asset cost) + Flashlight 01087 ([#313](https://github.com/talelburg/eldritch/issues/313), `Effect::Investigate` + shroud) carved to follow-ups | ✅ PR #316 |
 | C6d | [#284](https://github.com/talelburg/eldritch/issues/284) | encounter-deck assembly in `setup()` (quantity-aware, excludes set-aside) — gates C7b; makes Mythos draws + 01106's dig operate live | — |
 | C7a | [#244](https://github.com/talelburg/eldritch/issues/244) | registry swap + web `SCENARIO_ID` repoint (B3) | — |
 | C7b | [#245](https://github.com/talelburg/eldritch/issues/245) | end-to-end Won/Lost integration test (needs C6d) | — |


### PR DESCRIPTION
## Summary

The shippable C6c neutral content (#243), on the prereqs from #310 (`Effect::DrawCards`) and #311 (commit-cap enforcement). Six cards in one PR; Knife 01086 (#312) and Flashlight 01087 (#313) remain carved out, blocked on machinery.

## What changed

- **Emergency Cache 01088** — `on_play(gain_resources(You, 3))`.
- **Guts 01089 / Perception 01090 / Overpower 01091 / Manual Dexterity 01092** — `on_skill_test_resolution(Success, draw_cards(You, 1))`. Draws on **any** successful committed-to test (no kind narrowing, unlike Deduction). The "Max 1 committed per skill test" cap is printed metadata enforced at the commit window (#311), not `abilities()`.
- **Unexpected Courage 01093** — icons-only (2 wild); no triggered ability, so `abilities()` is empty (still "implemented" — `is_playable` keys off the impl's presence).
- All six registered in `impls/mod.rs`.

## Test notes

- **Per-card impl unit tests** — ability shape + registry dispatch (each card).
- **Integration** (`crates/cards/tests/neutral_cards.rs`, real `cards::REGISTRY`) — Emergency Cache play grants 3 resources; Guts draws 1 on a successful committed-to test and draws nothing on a failed one (the other three draw-skills are structurally identical).

Full strict gauntlet green locally (all 7 jobs).

## Linked issues

Closes #243.
