### PR TITLE
card: C6b — Dr. Milan Christopher 01033 (Seeker ally)

### DIFF
--- a/crates/cards/src/impls/dr_milan_christopher.rs
+++ b/crates/cards/src/impls/dr_milan_christopher.rs
@@ -1,0 +1,86 @@
+//! Dr. Milan Christopher (Seeker ally asset, 01033).
+//!
+//! ```text
+//! Ally. Miskatonic.
+//! You get +1 [intellect].
+//! [reaction] After you successfully investigate: Gain 1 resource.
+//! ```
+//!
+//! Two abilities: a `Constant` +1 intellect while in play, and an
+//! `OnEvent` reaction at the after-successful-investigate window (C6a
+//! #241) that gains the controller 1 resource. "after **you**
+//! investigate" is enforced by the window being controller-scoped, so the
+//! pattern is bare and the effect's `You` resolves to the controller.
+//!
+//! # Ally-soak gap
+//!
+//! Card metadata gives Dr. Milan `health: 1, sanity: 2` — ally
+//! damage/horror soak, not a max-stat boost on the controller. The DSL
+//! doesn't model soak yet (#44, shared with Holy Rosary / Beat Cop), so
+//! this impl ships only the +1 intellect and the reaction; the card is
+//! mechanically weaker than printed until the soak primitive lands.
+
+use card_dsl::dsl::{
+    constant, gain_resources, modify, on_event, Ability, EventPattern, EventTiming,
+    InvestigatorTarget, ModifierScope, Stat,
+};
+
+/// `ArkhamDB` code for the original-Core printing.
+pub const CODE: &str = "01033";
+
+/// +1 intellect while in play, and "after you successfully investigate,
+/// gain 1 resource."
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![
+        constant(modify(Stat::Intellect, 1, ModifierScope::WhileInPlay)),
+        on_event(
+            EventPattern::SuccessfullyInvestigated,
+            EventTiming::After,
+            gain_resources(InvestigatorTarget::You, 1),
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use card_dsl::dsl::{
+        Effect, EventPattern, EventTiming, InvestigatorTarget, ModifierScope, Stat, Trigger,
+    };
+
+    #[test]
+    fn abilities_are_constant_intellect_and_after_investigate_reaction() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 2);
+
+        assert_eq!(abilities[0].trigger, Trigger::Constant);
+        assert!(matches!(
+            abilities[0].effect,
+            Effect::Modify {
+                stat: Stat::Intellect,
+                delta: 1,
+                scope: ModifierScope::WhileInPlay,
+            }
+        ));
+
+        assert_eq!(
+            abilities[1].trigger,
+            Trigger::OnEvent {
+                pattern: EventPattern::SuccessfullyInvestigated,
+                timing: EventTiming::After,
+            },
+        );
+        assert_eq!(
+            abilities[1].effect,
+            Effect::GainResources {
+                target: InvestigatorTarget::You,
+                amount: 1,
+            },
+        );
+    }
+
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(super::CODE), Some(super::abilities()));
+    }
+}

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -69,6 +69,7 @@ pub mod attic;
 pub mod automatic_45;
 pub mod cellar;
 pub mod deduction;
+pub mod dr_milan_christopher;
 pub mod emergency_cache;
 pub mod guard_dog;
 pub mod guts;
@@ -109,6 +110,7 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
         automatic_45::CODE => Some(automatic_45::abilities()),
         cellar::CODE => Some(cellar::abilities()),
         deduction::CODE => Some(deduction::abilities()),
+        dr_milan_christopher::CODE => Some(dr_milan_christopher::abilities()),
         emergency_cache::CODE => Some(emergency_cache::abilities()),
         guard_dog::CODE => Some(guard_dog::abilities()),
         guts::CODE => Some(guts::abilities()),

--- a/crates/cards/tests/dr_milan.rs
+++ b/crates/cards/tests/dr_milan.rs
@@ -1,0 +1,98 @@
+//! C6b integration: Dr. Milan Christopher 01033 end-to-end against the
+//! real `cards::REGISTRY` — the +1 intellect constant ability and the
+//! after-successful-investigate reaction (engine window from #241).
+//!
+//! Own process → installs `cards::REGISTRY`.
+
+use std::sync::Once;
+
+use game_core::engine::EngineOutcome;
+use game_core::state::{
+    CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, InvestigatorId, LocationId, Phase,
+    TokenModifiers,
+};
+use game_core::test_support::{test_investigator, test_location, GameStateBuilder};
+use game_core::{Action, GameState, InputResponse, PlayerAction};
+
+const DR_MILAN: &str = "01033";
+const INV: InvestigatorId = InvestigatorId(1);
+const LOC: LocationId = LocationId(10);
+
+fn install() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// Board: the investigator at a 1-clue location of shroud 2 with **base
+/// intellect 1**, Dr. Milan in play, a `Numeric(0)` bag. Without Dr.
+/// Milan's +1 intellect the Investigate (1 vs 2) would fail; with it
+/// (2 vs 2) it succeeds — so the constant ability is load-bearing here.
+fn board() -> GameState {
+    install();
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(LOC);
+    inv.skills.intellect = 1;
+    inv.cards_in_play.push(CardInPlay::enter_play(
+        CardCode::new(DR_MILAN),
+        CardInstanceId(1),
+    ));
+    let mut loc = test_location(10, "Study"); // shroud 2 by default
+    loc.clues = 1;
+    GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_active_investigator(INV)
+        .with_turn_order([INV])
+        .with_investigator(inv)
+        .with_location(loc)
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default())
+        .build()
+}
+
+fn commit_nothing() -> Action {
+    Action::Player(PlayerAction::ResolveInput {
+        response: InputResponse::CommitCards { indices: vec![] },
+    })
+}
+
+#[test]
+fn dr_milan_plus_one_intellect_succeeds_then_reaction_gains_resource() {
+    let state = board();
+    let resources_before = state.investigators[&INV].resources;
+
+    // Investigate → commit window.
+    let paused_commit = game_core::engine::apply(
+        state,
+        Action::Player(PlayerAction::Investigate { investigator: INV }),
+    );
+    assert!(matches!(
+        paused_commit.outcome,
+        EngineOutcome::AwaitingInput { .. }
+    ));
+
+    // Commit nothing → intellect 1 + Dr. Milan's +1 = 2 ≥ shroud 2 →
+    // success → clue discovered → after-investigate window suspends.
+    let paused_reaction = game_core::engine::apply(paused_commit.state, commit_nothing());
+    assert!(
+        matches!(paused_reaction.outcome, EngineOutcome::AwaitingInput { .. }),
+        "the +1 intellect should make the test succeed and open Dr. Milan's window, got {:?}",
+        paused_reaction.outcome,
+    );
+
+    // Fire the reaction → gain 1 resource → resume → Done.
+    let resumed = game_core::engine::apply(
+        paused_reaction.state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickIndex(0),
+        }),
+    );
+    assert_eq!(resumed.outcome, EngineOutcome::Done);
+    assert_eq!(resumed.state.locations[&LOC].clues, 0, "clue discovered");
+    assert_eq!(
+        resumed.state.investigators[&INV].resources,
+        resources_before + 1,
+        "Dr. Milan's reaction gained a resource",
+    );
+}

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -19,7 +19,10 @@ them.** Deferred so far: C5d's Beat Cop + First Aid
 [#302](https://github.com/talelburg/eldritch/issues/302)); C5e's Evidence!
 / Dodge / Dynamite Blast
 ([#304](https://github.com/talelburg/eldritch/issues/304)–[#306](https://github.com/talelburg/eldritch/issues/306)).
-**Next: C6** (C6d gates C7b) **→ C7.**
+**C6 is complete** (C6a window, C6b Dr. Milan, C6c neutral cards, C6d
+encounter deck). **Next: C7** — C7a (registry swap + web `SCENARIO_ID`
+repoint) → C7b (the end-to-end Won/Lost integration test that closes
+Slice 1).
 
 Design specs:
 [Gathering design](../superpowers/specs/2026-06-10-phase-7-slice-1-gathering-design.md),
@@ -81,7 +84,7 @@ root dependency; C7 is the playable Won/Lost gate; #212 lands after C.
 | — | [#307](https://github.com/talelburg/eldritch/issues/307) | infra: `Trigger::OnCommit` firing + `Effect::BoostAttackDamage` / `InFlightSkillTest.bonus_attack_damage` (prerequisite for C5e's Vicious Blow) | ✅ PR #308 |
 | C5e | [#240](https://github.com/talelburg/eldritch/issues/240) | Guardian L0 events + skill (×4) — **only Vicious Blow 01025 was implementable; shipped (PR #309).** Engine prereq landed (PR #308); Evidence! ([#304](https://github.com/talelburg/eldritch/issues/304), reaction-event-play), Dodge ([#305](https://github.com/talelburg/eldritch/issues/305), attack-cancellation), Dynamite Blast ([#306](https://github.com/talelburg/eldritch/issues/306), location-choice = #212/#213) carved to follow-ups | ✅ PR #309 |
 | C6a | [#241](https://github.com/talelburg/eldritch/issues/241) | Dr. Milan after-investigate window | ✅ PR #318 |
-| C6b | [#242](https://github.com/talelburg/eldritch/issues/242) | Seeker deck cards | — |
+| C6b | [#242](https://github.com/talelburg/eldritch/issues/242) | Seeker deck cards — **only Dr. Milan 01033 implementable** (its window: C6a); Old Book of Lore ([#319](https://github.com/talelburg/eldritch/issues/319)), Research Librarian ([#320](https://github.com/talelburg/eldritch/issues/320)), Medical Texts ([#321](https://github.com/talelburg/eldritch/issues/321)), Mind over Matter ([#322](https://github.com/talelburg/eldritch/issues/322)), Barricade ([#323](https://github.com/talelburg/eldritch/issues/323)) carved to follow-ups | ✅ PR #324 |
 | — | [#310](https://github.com/talelburg/eldritch/issues/310) | infra: `Effect::DrawCards` primitive (prerequisite for C6c's draw-skills) | ✅ PR #314 |
 | — | [#311](https://github.com/talelburg/eldritch/issues/311) | infra: enforce "Max N committed per skill test" commit cap (prerequisite for C6c's skills) | ✅ PR #315 |
 | C6c | [#243](https://github.com/talelburg/eldritch/issues/243) | Neutral deck cards — **Emergency Cache 01088 + 5 skills** shipped on prereqs #310/#311; Knife 01086 ([#312](https://github.com/talelburg/eldritch/issues/312), discard-self-asset cost) + Flashlight 01087 ([#313](https://github.com/talelburg/eldritch/issues/313), `Effect::Investigate` + shroud) carved to follow-ups | ✅ PR #316 |


### PR DESCRIPTION
## Summary

Implements **Dr. Milan Christopher 01033** — "You get +1 [intellect]. / [reaction] After you successfully investigate: Gain 1 resource." — on the after-investigate window from #241 (PR #318). The only implementable C6b Seeker card; the other five are carved to follow-ups, so this closes #242.

## What changed

- `dr_milan_christopher.rs` — two abilities:
  - `constant(modify(Intellect, +1, WhileInPlay))` — the +1 intellect.
  - `on_event(SuccessfullyInvestigated, After, gain_resources(You, 1))` — the reaction in the after-successful-investigate window. The window is controller-scoped, so "after **you** investigate" needs no qualifier and `You` resolves to the controller.
- Registered in `impls/mod.rs`.
- **Ally soak** (health 1 / sanity 2) is not modeled (DSL gap #44, shared with Holy Rosary / Beat Cop) — only the +1 intellect and reaction ship; noted in the module doc.

## Test notes

- **Impl unit** — two-ability shape (constant intellect + OnEvent reaction) + registry dispatch.
- **Integration** (`crates/cards/tests/dr_milan.rs`, real `cards::REGISTRY`) — base intellect **1** + Dr. Milan's **+1** = 2 clears shroud 2 (so the constant ability is load-bearing: without it the test would fail), then the after-investigate reaction is fired to gain a resource.

Full strict gauntlet green locally (all 7 jobs).

## Deferred (the other five C6b Seeker cards)

Carved to follow-ups, blocked on machinery: Old Book of Lore (#319, choose-investigator + search-top-3), Research Librarian (#320, deck-search tutor), Medical Texts (#321, `Effect::Heal` + choice), Mind over Matter (#322, stat-substitution modifier), Barricade (#323, location attachment + enemy-movement block).

## Linked issues

Closes #242.
