### PR TITLE
infra: C7a — swap server to cards::REGISTRY + repoint web to the-gathering

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -59,16 +59,15 @@ impl AppState {
 /// Install the process-global scenario + card registries the server
 /// needs to create and play games. Call once at startup.
 ///
-/// Phase 6 installs the **synthetic** fixtures (the toy scenario and
-/// its `_synth_*` cards) knowingly — the only playable content this
-/// phase. Idempotent: a second call is a no-op (the underlying
-/// `OnceLock`s reject re-installation).
-///
-/// TODO(phase-7): swap to the real `scenarios`/`cards` registries when
-/// The Gathering lands.
+/// Installs the real `scenarios::REGISTRY` (which includes The Gathering)
+/// and the real `cards::REGISTRY` (the corpus + hand-written abilities) —
+/// C7a's registry swap, now that real content is servable. The synthetic
+/// fixtures stay for per-process tests, which install their own registries.
+/// Idempotent: a second call is a no-op (the underlying `OnceLock`s reject
+/// re-installation).
 pub fn install_registries() {
     let _ = game_core::scenario_registry::install(scenarios::REGISTRY);
-    let _ = game_core::card_registry::install(scenarios::test_fixtures::synth_cards::TEST_REGISTRY);
+    let _ = game_core::card_registry::install(cards::REGISTRY);
 }
 
 /// Build the application router with all routes and shared state. The

--- a/crates/server/tests/registries.rs
+++ b/crates/server/tests/registries.rs
@@ -1,8 +1,8 @@
-//! The production server installs the synthetic scenario + card
-//! registries (D5), so the real `POST /games` for the toy scenario
-//! succeeds and synthetic card codes resolve. Process-isolated: this
-//! test binary installs the *real* synthetic registries, distinct from
-//! the mock registry other test binaries install via `common`.
+//! The production server installs the real `scenarios` + `cards`
+//! registries (C7a): `POST /games` for The Gathering succeeds and real
+//! card codes resolve. Process-isolated: this test binary installs the
+//! *production* registries via `server::install_registries()`, distinct
+//! from the mock registry other test binaries install via `common`.
 
 mod common;
 
@@ -11,35 +11,38 @@ use axum::http::{Request, StatusCode};
 use common::memory_pool;
 use game_core::scenario::ScenarioId;
 use game_core::state::CardCode;
-use scenarios::test_fixtures::synth_cards::SYNTH_TREACHERY_CODE;
-use scenarios::test_fixtures::synthetic::ID as SYNTHETIC_SCENARIO_ID;
+use scenarios::the_gathering::ID as GATHERING_SCENARIO_ID;
 use tower::ServiceExt;
 
+/// A real card with both corpus metadata and a hand-written `abilities()`
+/// impl — Dr. Milan Christopher 01033.
+const REAL_CARD: &str = "01033";
+
 #[test]
-fn install_registries_resolves_synthetic_scenario_and_cards() {
+fn install_registries_resolves_the_gathering_and_real_cards() {
     server::install_registries();
 
     let scenario = game_core::scenario_registry::current().expect("scenario registry installed");
-    let id = ScenarioId::new(SYNTHETIC_SCENARIO_ID);
+    let id = ScenarioId::new(GATHERING_SCENARIO_ID);
     assert!(
         (scenario.module_for)(&id).is_some(),
-        "synthetic scenario module must resolve"
+        "The Gathering scenario module must resolve"
     );
 
     let cards = game_core::card_registry::current().expect("card registry installed");
-    let code = CardCode(SYNTH_TREACHERY_CODE.into());
+    let code = CardCode(REAL_CARD.into());
     assert!(
         (cards.metadata_for)(&code).is_some(),
-        "synthetic card metadata must resolve"
+        "real card metadata must resolve from cards::REGISTRY"
     );
     assert!(
         (cards.abilities_for)(&code).is_some(),
-        "synthetic card abilities must resolve"
+        "real card abilities must resolve from cards::REGISTRY"
     );
 }
 
 #[tokio::test]
-async fn post_games_creates_synthetic_game_against_installed_registries() {
+async fn post_games_creates_the_gathering_against_installed_registries() {
     server::install_registries();
     let pool = memory_pool().await;
     let app = server::app(server::AppState::new(pool));
@@ -49,7 +52,7 @@ async fn post_games_creates_synthetic_game_against_installed_registries() {
         .uri("/games")
         .header("content-type", "application/json")
         .body(Body::from(format!(
-            r#"{{"scenario_id":"{SYNTHETIC_SCENARIO_ID}"}}"#
+            r#"{{"scenario_id":"{GATHERING_SCENARIO_ID}"}}"#
         )))
         .unwrap();
     let response = app.oneshot(request).await.unwrap();

--- a/crates/web/src/transport.rs
+++ b/crates/web/src/transport.rs
@@ -17,9 +17,9 @@ use crate::url::current_ws_url;
 
 /// localStorage key holding the active game id across reloads.
 const GAME_ID_KEY: &str = "eldritch_game_id";
-/// The only playable scenario this phase (D5: synthetic registries).
-// TODO(phase-7): swap to a real scenario id when The Gathering lands.
-const SCENARIO_ID: &str = "synthetic";
+/// The scenario the client requests on `POST /games` — The Gathering, now
+/// that the server installs the real `cards`/`scenarios` registries (C7a).
+const SCENARIO_ID: &str = "the-gathering";
 /// Fixed reconnect backoff. Plenty for a solo v0; not exponential.
 const RECONNECT_MS: u32 = 1000;
 

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -89,7 +89,7 @@ root dependency; C7 is the playable Won/Lost gate; #212 lands after C.
 | — | [#311](https://github.com/talelburg/eldritch/issues/311) | infra: enforce "Max N committed per skill test" commit cap (prerequisite for C6c's skills) | ✅ PR #315 |
 | C6c | [#243](https://github.com/talelburg/eldritch/issues/243) | Neutral deck cards — **Emergency Cache 01088 + 5 skills** shipped on prereqs #310/#311; Knife 01086 ([#312](https://github.com/talelburg/eldritch/issues/312), discard-self-asset cost) + Flashlight 01087 ([#313](https://github.com/talelburg/eldritch/issues/313), `Effect::Investigate` + shroud) carved to follow-ups | ✅ PR #316 |
 | C6d | [#284](https://github.com/talelburg/eldritch/issues/284) | encounter-deck assembly in `setup()` (quantity-aware, excludes set-aside) — gates C7b; makes Mythos draws + 01106's dig operate live | ✅ PR #317 |
-| C7a | [#244](https://github.com/talelburg/eldritch/issues/244) | registry swap + web `SCENARIO_ID` repoint (B3) | — |
+| C7a | [#244](https://github.com/talelburg/eldritch/issues/244) | registry swap + web `SCENARIO_ID` repoint (B3) | ✅ PR #325 |
 | C7b | [#245](https://github.com/talelburg/eldritch/issues/245) | end-to-end Won/Lost integration test (needs C6d) | — |
 
 ## Future slices (after Slice 1)


### PR DESCRIPTION
## Summary

Now that Group C's real content is servable, the production server installs the real registries instead of the synthetic fixtures (the folded-in **B3** work). Closes #244.

## What changed

- `server::install_registries()` installs **`cards::REGISTRY`** (corpus + hand-written abilities) in place of `synth_cards::TEST_REGISTRY`. The scenario registry already included The Gathering, so it's unchanged.
- `web`'s `SCENARIO_ID` repoints `"synthetic"` → `"the-gathering"`.
- The synthetic fixtures stay for per-process tests, which install their own registries (the `common` mock). Only `server/tests/registries.rs` — which exercises the *production* install — is updated.

## Test notes

`server/tests/registries.rs` (rewritten, TDD red→green): after `install_registries()`, The Gathering scenario module resolves, a real card (**Dr. Milan 01033**) resolves both `metadata_for` and `abilities_for` via `cards::REGISTRY`, and `POST /games {"scenario_id":"the-gathering"}` returns **201**.

Full strict gauntlet green locally (all 7 jobs) — other server tests (mock registry via `common`) and the web wasm tests unaffected.

## Linked issues

Closes #244.
