### PR TITLE
design: trigger-dispatch rework — umbrella + Axis-B foundation specs & plan (#327)

### DIFF
--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -117,12 +117,26 @@ when picked up.
 - **Deferred optional Gathering content** (off the win/lose path, so cut
   from Slice 1): Lita Chantler's parley/take-control and the Parlor
   (`01115`) **Resign** action.
-- **Engine north-star (cross-slice, may be its own slice).** `emit_event`
+- **Engine north-star — trigger-dispatch rework (cross-slice; kickoff
+  [#327](https://github.com/talelburg/eldritch/issues/327)).** `emit_event`
   dispatch unification (`#212`) + iterative simultaneous-trigger ordering
-  (`#213`, RR p.17 — player picks order even in solo) + the trigger
-  index (`#117`); plus the optional click-to-resolve UX for *lone* forced
-  effects. Slice 1's `fire_forced_triggers` is a forward-compatible
-  subset; this work replaces its single-trigger-only limitation.
+  (`#213`) + the trigger index (`#117`), unblocking the deferred-card
+  choice/reaction cluster. Designed in
+  [umbrella](../superpowers/specs/2026-06-16-trigger-dispatch-rework-umbrella-design.md)
+  + [Axis-B foundation](../superpowers/specs/2026-06-16-trigger-dispatch-rework-axis-b-foundation-design.md)
+  specs ([Axis-B plan](../superpowers/plans/2026-06-16-trigger-dispatch-axis-b-foundation.md)).
+  Five axes: **B** trigger-dispatch spine (one continuation stack +
+  two-phase forced-then-reaction `emit_event` + #117 index; tasks
+  [#328](https://github.com/talelburg/eldritch/issues/328)–[#333](https://github.com/talelburg/eldritch/issues/333),
+  closes #212/#213/#117/#294), **A** interactive choice
+  ([#334](https://github.com/talelburg/eldritch/issues/334)), **C**
+  reaction-event-play ([#335](https://github.com/talelburg/eldritch/issues/335)),
+  **D** cancellation/replacement ([#336](https://github.com/talelburg/eldritch/issues/336)),
+  **E** orthogonal card prereqs (#301/#302/#306/#312/#313/#319/#320/#322/#323).
+  Slice 1's `fire_forced_triggers` is a forward-compatible subset Axis B
+  replaces. **Note:** #213's "one mixed pool" framing was corrected to
+  RR-accurate two-phase (forced-all-before-reaction, RR p.2; issue text
+  amended).
 
 Campaign sequencing beyond The Gathering (The Midnight Masks, The
 Devourer Below, campaign log + `Fact` enum) is **Phase 9**, not Phase 7.

--- a/docs/superpowers/plans/2026-06-16-trigger-dispatch-axis-b-foundation.md
+++ b/docs/superpowers/plans/2026-06-16-trigger-dispatch-axis-b-foundation.md
@@ -1,0 +1,366 @@
+# Trigger-Dispatch Axis-B Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the engine's two hand-wired trigger-dispatch paths (`fire_forced_triggers` + `queue_reaction_window`) and its scattered suspension modes with one continuation stack and one `emit_event` chokepoint doing rules-correct two-phase (forced-then-reaction) dispatch.
+
+**Architecture:** A `GameState.continuations: Vec<Continuation>` stack is the single suspend/resume authority (one router atop `resolve_input`). `open_windows` is absorbed into it as `Resolution` frames; `emit_event(cx, TimingEvent)` runs one shared iterative-resolution loop twice (forced: no-skip/lead; reaction: skippable/player-order). The #117 event-keyed index is the final task, swapped in behind the scan interface. No new cards.
+
+**Tech Stack:** Rust (workspace crates `card-dsl`, `game-core`); `serde` for replay-safe state; the `TestGame`/`GameStateBuilder` test builders and `assert_event!`/`assert_no_event!` macros in `game-core::test_support`.
+
+**Specs:** `docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-axis-b-foundation-design.md` (read first) and the umbrella `…-umbrella-design.md`.
+
+**Per-task discipline:** every task ends green under the full CI gauntlet:
+```sh
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+```
+One branch+PR per task (`engine/<slug>`); commit body ends with `Closes #NN.`
+
+---
+
+## File map
+
+| File | Responsibility | Tasks |
+|---|---|---|
+| `crates/card-dsl/src/dsl.rs` | `Trigger::OnEvent` gains `kind: TriggerKind` | 1 |
+| `crates/cards/src/impls/*.rs` | existing `OnEvent` cards set `kind` | 1 |
+| `crates/game-core/src/state/game_state.rs` | `continuations: Vec<Continuation>`; `Continuation`, `TimingEvent`, `Decider`, `Candidate` types; `OpenWindow` absorbed | 2,3,4,5 |
+| `crates/game-core/src/state/builder.rs` | builder default for `continuations` | 2 |
+| `crates/game-core/src/engine/dispatch/mod.rs` | single resume router in `resolve_input` | 2,3,4,5 |
+| `crates/game-core/src/engine/dispatch/reaction_windows.rs` | windows → `Resolution` frames; the shared loop | 3,5 |
+| `crates/game-core/src/engine/dispatch/skill_test.rs` | skill-test resume via `SkillTest` frame | 4 |
+| `crates/game-core/src/engine/dispatch/emit.rs` (new) | `emit_event` + `TimingEvent` dispatch | 5 |
+| `crates/game-core/src/engine/dispatch/forced_triggers.rs` | folded into `emit.rs`; deleted | 5 |
+| `crates/game-core/src/engine/trigger_index.rs` (new) | #117 event-keyed index behind the scan interface | 6 |
+
+---
+
+## Task 1: `TriggerKind` on `Trigger::OnEvent`
+
+Make forced-vs-reaction an explicit DSL property instead of routed-by-pattern. Behavior-preserving: dispatch still chooses paths exactly as today, but now reads the field.
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs` (`Trigger::OnEvent`, builder helpers)
+- Modify: every `crates/cards/src/impls/*.rs` with an `OnEvent` ability
+- Test: `crates/card-dsl/src/dsl.rs` `#[cfg(test)]`
+
+- [ ] **Step 1: Write the failing test** (in `dsl.rs` tests)
+
+```rust
+#[test]
+fn on_event_carries_trigger_kind() {
+    let t = Trigger::OnEvent {
+        pattern: EventPattern::EnemyDefeated { by_controller: true, code: None },
+        timing: EventTiming::After,
+        kind: TriggerKind::Reaction,
+    };
+    // serde round-trips the new field
+    let json = serde_json::to_string(&t).unwrap();
+    let back: Trigger = serde_json::from_str(&json).unwrap();
+    assert_eq!(t, back);
+}
+```
+
+- [ ] **Step 2: Run, verify it fails to compile** (`TriggerKind` undefined)
+
+Run: `cargo test -p card-dsl on_event_carries_trigger_kind`
+Expected: FAIL — `cannot find type TriggerKind`.
+
+- [ ] **Step 3: Add `TriggerKind` and the field**
+
+```rust
+/// Whether an `OnEvent` ability resolves mandatorily (forced) or is an
+/// optional player reaction. Determines which phase of `emit_event`
+/// dispatch the ability participates in (RR p.2: all forced resolve
+/// before any reaction at the same timing point).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TriggerKind {
+    Forced,
+    Reaction,
+}
+```
+Add `kind: TriggerKind` to `Trigger::OnEvent`. Update the `on_event(...)` builder helper(s) to take a `kind` (or add `forced_on_event` / `reaction_on_event` convenience builders — match the existing builder style in this file).
+
+- [ ] **Step 4: Classify every existing `OnEvent` card.** For each `crates/cards/src/impls/*.rs` ability with `Trigger::OnEvent`, set `kind`: scenario-structure forced effects (act/agenda/location/persistent-treachery) → `TriggerKind::Forced`; player "[reaction]" abilities (Roland 01001, Dr. Milan 01033, Guard Dog 01021) → `TriggerKind::Reaction`. Grep: `rg "OnEvent" crates/cards/src`.
+
+- [ ] **Step 5: Run the gauntlet**
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: PASS (all card + engine tests still green; dispatch unchanged — it may still infer the path, the field is just present).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/card-dsl/src/dsl.rs crates/cards/src/impls
+git commit -m "engine: TriggerKind { Forced, Reaction } on Trigger::OnEvent
+
+Explicit forced-vs-reaction DSL property, replacing route-by-pattern.
+Behavior-preserving; dispatch reads the field in a later task. Closes #NN."
+```
+
+---
+
+## Task 2: continuation stack scaffolding + single resume router
+
+Add the empty stack and route through it first; falls through to the legacy `pending_*` ladder when empty. No frames pushed yet — pure plumbing.
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (field + `Continuation` enum skeleton)
+- Modify: `crates/game-core/src/state/builder.rs` (default `Vec::new()`)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (`resolve_input` head)
+- Test: `game_state.rs` `#[cfg(test)]`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn continuations_default_empty_and_absent_field_loads() {
+    let s = GameStateBuilder::default().build();
+    assert!(s.continuations.is_empty());
+    // older serialized states (no field) still deserialize
+    let mut v = serde_json::to_value(&s).unwrap();
+    v.as_object_mut().unwrap().remove("continuations");
+    let back: GameState = serde_json::from_value(v).unwrap();
+    assert!(back.continuations.is_empty());
+}
+```
+
+- [ ] **Step 2: Run, verify it fails** (`no field continuations`)
+
+Run: `cargo test -p game-core continuations_default_empty_and_absent_field_loads`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the field + skeleton enum**
+
+In `game_state.rs`:
+```rust
+/// The single suspend/resume stack (umbrella §1). Empty when nothing is
+/// paused; the top frame is resumed by `resolve_input`. Legacy `pending_*`
+/// modes remain on their own fields until the later cleanup pass.
+#[serde(default)]
+pub continuations: Vec<Continuation>,
+```
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Continuation {
+    // Variants land in tasks 3–5. Empty enum is illegal in Rust, so
+    // task 3 introduces the first variant (`Resolution`); until then this
+    // type is declared but the field stays empty.
+}
+```
+Because an empty enum can't be constructed, **introduce `Continuation` with its first real variant in Task 3** and in Task 2 keep `continuations: Vec<Continuation>` with `Continuation` defined as a placeholder unit-like enum carrying one `#[doc(hidden)]` `Reserved` variant, OR sequence Task 3 immediately. Simplest: add the field typed `Vec<Continuation>` and define `Continuation` with the `Resolution` variant now (its body filled in Task 3). Pick the latter to avoid a throwaway variant.
+
+- [ ] **Step 4: Add the router head in `resolve_input`** (`dispatch/mod.rs`)
+
+At the very top of `resolve_input`, before the existing `hunter_move_pending` checks:
+```rust
+// Single resume router (umbrella §1): the continuation stack takes
+// priority over the legacy pending_* ladder. Empty → fall through.
+if let Some(top) = cx.state.continuations.last() {
+    return resume_continuation(cx, response);
+}
+```
+Add a `resume_continuation(cx, response)` stub that `match`es the top frame; with no variants resumable yet it is unreachable, so:
+```rust
+fn resume_continuation(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
+    // Frames + their resume arms land in tasks 3–5.
+    unreachable!("resume_continuation: no frames pushed until task 3")
+}
+```
+
+- [ ] **Step 5: Run the gauntlet** — Expected PASS (stack always empty, router never taken).
+
+- [ ] **Step 6: Commit** (`Closes #NN.`)
+
+---
+
+## Task 3: window unification (pure refactor) + the shared resolution loop
+
+Absorb `open_windows: Vec<OpenWindow>` into `continuations` as `Continuation::Resolution` frames (reaction run: `can_skip=true`). This is the largest task and is **behavior-preserving** — the entire existing reaction/fast-window + skill-test test suite must stay green.
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (`Continuation::Resolution`, `Decider`, `Candidate`; remove/forward `open_windows` helpers)
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (the whole open/scan/resume/close pipeline)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (`resume_continuation` Resolution arm; the `apply_player_action` reject-guard)
+- Test: existing suite is the spec; add one new frame test.
+
+- [ ] **Step 1: Define the frame + parameters** (`game_state.rs`)
+
+```rust
+pub enum Continuation {
+    /// One iterative trigger-resolution loop — serves both the forced run
+    /// and a reaction window (Axis-B spec "One loop, two phases").
+    Resolution {
+        kind: WindowKind,
+        candidates: Vec<Candidate>,
+        can_skip: bool,
+        decider: Decider,
+        fast_actors: FastActorScope,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Decider { Lead, PlayerOrder { cursor: InvestigatorId } }
+
+/// A resolvable option in a resolution loop: a pending in-play trigger
+/// (today's `PendingTrigger`) or, from Axis C, a Fast play from hand.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Candidate { Trigger(PendingTrigger) }
+```
+(`Candidate` is an enum now so Axis C can add `FastPlay { .. }` without reshaping.)
+
+- [ ] **Step 2: Replace `open_windows` reads with topmost-`Resolution`-frame reads.** Transform each function in `reaction_windows.rs` to operate on the stack:
+  - `queue_reaction_window` → push a `Continuation::Resolution { kind, candidates, can_skip: true, decider: PlayerOrder{ active }, fast_actors }`.
+  - `open_fast_window` → same, for the framework `PlayerWindow` kinds.
+  - `top_reaction_window` / `top_reaction_window_index` → find the topmost `Resolution` frame (skip ones with empty candidates, preserving today's semantics).
+  - `resume_reaction_window` / `fire_pending_trigger` / `close_reaction_window_at` / `run_window_continuation` → operate on the frame at the computed stack index; `close` pops the frame.
+  Keep the helper names and signatures where possible to minimize call-site churn; the bodies now read/write `cx.state.continuations` instead of `cx.state.open_windows`.
+
+- [ ] **Step 3: Repoint the gates.** In `dispatch/mod.rs` `apply_player_action`, the reaction-window reject-guard reads the topmost `Resolution` frame instead of `top_reaction_window()` over `open_windows`. In `reaction_windows.rs` `check_play_card`, `permissive_window` reads the topmost `Resolution` frame's `fast_actors`. In `resume_continuation` (task 2 stub), add the `Resolution` arm delegating to `resume_reaction_window`.
+
+- [ ] **Step 4: Remove `open_windows`.** Delete the field from `game_state.rs` + `builder.rs`; `GameState::top_reaction_window*` now front the stack. Fix all compile errors (the borrow-checker + the deleted-field references are the worklist).
+
+- [ ] **Step 5: Add one frame-level test**
+
+```rust
+#[test]
+fn reaction_window_lives_on_the_continuation_stack() {
+    // (build a state that opens an AfterEnemyDefeated window via a defeat;
+    //  assert the open window is a Continuation::Resolution frame, not a
+    //  separate open_windows entry — open_windows no longer exists.)
+    // Use the existing Roland reaction integration setup as the template:
+    //   crates/cards/tests/ (the AfterEnemyDefeated reaction test).
+}
+```
+(Flesh out from the existing Roland/Guard-Dog reaction test; the assertion is "the suspension is a `Resolution` frame on `continuations`.")
+
+- [ ] **Step 6: Run the full gauntlet — the regression net is the point.**
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: PASS — every existing reaction-window, fast-window, mulligan, skill-test, and integration test (`crates/cards/tests/*`) green, unchanged behavior. Also run `wasm-pack test --headless --firefox crates/web` per CLAUDE.md if web touches state shape.
+
+- [ ] **Step 7: Commit** (`Closes #NN.`) — note "pure refactor, behavior-preserving" in the body.
+
+---
+
+## Task 4: skill-test resume via a `SkillTest` frame
+
+The skill-test driver currently re-enters via `close_reaction_window_at` checking `in_flight_skill_test`. Route its resumption through the stack so it composes with the forced loop in task 5. `in_flight_skill_test` stays as the data store (singleton).
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (`Continuation::SkillTest`)
+- Modify: `crates/game-core/src/engine/dispatch/skill_test.rs`, `reaction_windows.rs` (`close_reaction_window_at` re-entry), `dispatch/mod.rs` (`resume_continuation` arm, the `in_flight` commit route)
+- Test: existing skill-test suite + one frame test.
+
+- [ ] **Step 1: Add the variant**
+
+```rust
+// in Continuation:
+/// The skill-test driver is mid-resolution; data is the singleton
+/// `in_flight_skill_test` field (read by many call sites; no nesting today).
+SkillTest,
+```
+
+- [ ] **Step 2: Push/pop the frame around the skill-test lifecycle.** `start_skill_test` pushes `Continuation::SkillTest` when it parks at the commit window; `finish_skill_test`/`drive_skill_test` pop it when the test fully resolves (`in_flight_skill_test` cleared). `close_reaction_window_at`'s "re-enter `drive_skill_test` if `in_flight` is set" becomes "the stack top is now `SkillTest` → resume it."
+
+- [ ] **Step 3: Route in `resume_continuation`.** Add the `SkillTest` arm: `CommitCards { indices }` → `finish_skill_test` (preserving the `pending_end_turn` resume tail currently in `resolve_input`).
+
+- [ ] **Step 4: Run the gauntlet** — Expected PASS (skill-test, reaction-mid-skill-test, Frozen-in-Fear, Roland-defeat-during-fight all green, unchanged).
+
+- [ ] **Step 5: Commit** (`Closes #NN.`)
+
+---
+
+## Task 5: `TimingEvent` + `emit_event` + the forced run + two-phase
+
+The semantic change. Define `TimingEvent`, build `emit_event` driving phase 1 (forced run of the shared loop) → phase 2 (reaction window), and migrate the 9 dispatch call sites. Fold `forced_triggers.rs` in and delete it.
+
+**Files:**
+- Create: `crates/game-core/src/engine/dispatch/emit.rs` (`TimingEvent`, `emit_event`, the forced run)
+- Modify: `game_state.rs` (forced run reuses `Continuation::Resolution` with `can_skip:false, decider:Lead`)
+- Modify: call sites — `combat.rs:95,108,661`, `skill_test.rs:645,765`, `act_agenda.rs:77,245`, `phases.rs:229,555,647,661`, `actions.rs:299`, `mod.rs:230`
+- Delete: `forced_triggers.rs` (logic moves into `emit.rs`)
+- Test: a new `emit.rs` test module + the existing simultaneous-forced/reentrancy integration tests.
+
+- [ ] **Step 1: Write the failing two-phase test** (the `EnemyDefeated` anchor)
+
+```rust
+// emit.rs tests (or crates/cards/tests/ for registry access):
+// An enemy defeat fires the forced act advance AND opens the reaction
+// window from one emit_event call.
+#[test]
+fn emit_enemy_defeated_runs_forced_then_reaction() {
+    // setup: act with EnemyDefeated forced advance + an investigator with
+    // a Reaction OnEvent (Roland). Defeat the enemy via emit_event.
+    // assert: act advanced (phase-1 forced) AND a Resolution reaction
+    // frame is open (phase-2) for Roland.
+}
+```
+
+- [ ] **Step 2: Run, verify it fails** (`emit_event` undefined).
+
+- [ ] **Step 3: Define `TimingEvent`** in `emit.rs` by merging `ForcedTriggerPoint` (all variants) + the event-driven `WindowKind` variants (`AfterEnemyDefeated`, `AfterSuccessfulInvestigate`, `AfterEnemyAttackDamagedAsset`). Each variant carries its binding (copy the fields from the two source enums). Map each to its `EventPattern` discriminant (`fn pattern(&self) -> EventPattern`) and its logged `Event` where one exists (`fn log_event(&self) -> Option<Event>`).
+
+- [ ] **Step 4: Implement `emit_event`** — push `log_event()` if `Some`; collect forced `Candidate`s (kind `Forced`, matching pattern/timing) via the scan; run the shared loop with `can_skip:false, decider:Lead` (Task 3's loop, parameterized); then run phase 2 (the reaction window) via the Task-3 `queue_reaction_window` path. A forced candidate whose effect suspends parks its `Resolution` frame and resumes — reentrancy. Move `collect_forced_hits`/`resolve_one` logic from `forced_triggers.rs` into the loop's candidate-resolution.
+
+- [ ] **Step 5: Migrate the call sites.** Replace each `fire_forced_triggers(cx, &ForcedTriggerPoint::X{..})` and event-driven `queue_reaction_window(cx, WindowKind::Y{..})` with `emit_event(cx, TimingEvent::Z{..})`. For sites that today call BOTH (combat.rs:95+108 — defeat), one `emit_event` replaces both. The framework `open_fast_window(PlayerWindow(..))` sites are untouched. Delete `forced_triggers.rs` and its `mod`/`use` in `dispatch/mod.rs` + `engine/mod.rs:38`; update `test_support` (`fire_forced_at`) to drive `emit_event`.
+
+- [ ] **Step 6: Add the simultaneous-forced + reentrancy tests**
+  - Two simultaneous `RoundEnded` forced (agenda 01107 doom + Dissonant Voices 01165 discard) → the lead-investigator ordering loop resolves both (2+ → `PickSingle` round-trip).
+  - Frozen in Fear 01164 `EndOfTurn` forced effect suspends on its test → the forced candidate parks, the skill-test frame resolves, dispatch completes (reentrancy; no abandoned sibling).
+  - Remove the `drive_attack_loop` `debug_assert` and add the two-Guard-Dog multi-soak test (#294): one attack damaging two `EnemyAttackDamagedSelf` reactors drains both windows, cursor advances once.
+
+- [ ] **Step 7: Run the full gauntlet + wasm.** Expected PASS.
+
+- [ ] **Step 8: Commit** (`Closes #212. Closes #213. Closes #294.` — and reference the issue text already amended).
+
+---
+
+## Task 6: #117 event-keyed trigger index (final)
+
+Swap the full-scan for the index behind the scan interface introduced in task 5. Isolated so a desync bug is unambiguous.
+
+**Files:**
+- Create: `crates/game-core/src/engine/trigger_index.rs`
+- Modify: enter/leave-play sites (`cards.rs` play_card, `threat_area.rs` place/discard, elimination drains, registry install), `emit.rs` (scan calls the index)
+- Test: `trigger_index.rs` tests + the defensive leave-play-mid-window test.
+
+- [ ] **Step 1: Write the failing index test**
+
+```rust
+#[test]
+fn index_buckets_on_event_triggers_by_pattern_kind() {
+    // enter two cards with EnemyDefeated reactions + one with RoundEnded;
+    // assert the index returns exactly the EnemyDefeated bucket for an
+    // EnemyDefeated lookup, and that leaving play removes the entry.
+}
+```
+
+- [ ] **Step 2: Run, verify it fails.**
+
+- [ ] **Step 3: Build `TriggerIndex`** — `BTreeMap<TriggerKindDiscriminant, Vec<(InvestigatorId, CardInstanceId, u8)>>` maintained at enter/leave-play, seeded at registry install (walk all in-play cards). `TriggerKindDiscriminant` is the `EventPattern` discriminant (smallest API per #117).
+
+- [ ] **Step 4: Route the scan through the index.** The single scan function from task 5 looks up the bucket + applies the existing `trigger_matches` filter, instead of the full board walk. Add a **debug-only cross-check**: in `debug_assert`, the index result equals a full scan (catches desync at the source; removable later).
+
+- [ ] **Step 5: Add the defensive test** — a card leaving play mid-window is absent from the next scan (the #117 acceptance test).
+
+- [ ] **Step 6: Run the gauntlet + a microbenchmark** showing the scan is now O(matching) not O(board) (criterion or a simple timed loop, per #117 acceptance).
+
+- [ ] **Step 7: Commit** (`Closes #117.`)
+
+---
+
+## Self-review
+
+**Spec coverage:** §1 one-stack → tasks 2–4; §2 emit_event two-phase + TimingEvent → task 5; #213 forced-ordering loop → task 5 (shared loop from task 3); TriggerKind DSL field → task 1; #117 index → task 6; window unification → task 3; skill-test frame → task 4. All §5 closes/corrects (#212/#213/#117/#294) covered. Test strategy (Dissonant Voices+agenda, Frozen in Fear, two Guard Dogs, defeat anchor) → task 5/6 steps. ✓
+
+**Placeholder scan:** the refactor tasks (3,4) intentionally use "transform these named functions; existing suite is the green-gate" rather than reproducing hundreds of moved lines — appropriate for behavior-preserving refactors, with the exact functions named and the verification command given. New-type/new-logic steps (1,2,5,6) carry real code. No "TBD/handle edge cases" placeholders.
+
+**Type consistency:** `Continuation::Resolution { kind, candidates, can_skip, decider, fast_actors }`, `Decider::{Lead, PlayerOrder}`, `Candidate::Trigger`, `TimingEvent`, `TriggerKind::{Forced, Reaction}` used consistently across tasks 1–6. `emit_event(cx, TimingEvent)` signature stable. ✓
+
+## Out of scope (this plan)
+
+Axes A/C/D; migrating the orthogonal `pending_*` modes; newly-arising forced hits mid-loop; skill-test nesting; multiplayer reaction-phase player-order (all per the spec's Out-of-scope).

--- a/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-axis-b-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-axis-b-foundation-design.md
@@ -87,9 +87,19 @@ machinery (offered set, `PickSingle`/`OptionId`, usage limits) with
 
 ### `emit_event` two-phase dispatch
 
-`emit_event(cx, event)` is the chokepoint for events that have a matching
-`EventPattern`. It pushes the event, then per (Before/After) timing runs the
-shared resolution loop twice — phase 1 (forced), then phase 2 (reaction):
+`emit_event(cx, te: TimingEvent)` is the dispatch chokepoint. **`TimingEvent` is
+the unified dispatch key** — the merge of today's `ForcedTriggerPoint` + the
+event-driven `WindowKind` variants (both already carry the binding context:
+controller / source / attacking enemy / location / code). It maps to an
+`EventPattern` discriminant and pushes the corresponding logged `Event` where one
+exists (e.g. `TimingEvent::EnemyDefeated` → `Event::EnemyDefeated`). This is
+necessary because the three enums are *not* 1:1: several `EventPattern`s are
+pure timing points with no logged `Event` (`RoundEnded`, `EndOfTurn`, `GameEnd`,
+`AfterLocationInvestigated`, `SuccessfullyInvestigated`, `WouldDiscoverClues`,
+`EnemyAttackDamagedSelf`), and the logged `Event` frequently lacks the binding
+dispatch needs — which is exactly why `ForcedTriggerPoint`/`WindowKind` exist
+today. `emit_event` then, per (Before/After) timing, runs the shared resolution
+loop twice — phase 1 (forced), then phase 2 (reaction):
 
 1. **Phase 1 — forced.** Collect `kind: Forced` `OnEvent` hits. 0 → skip. 1 →
    resolve. 2+ → push a `Resolution` frame (`can_skip=false`, `decider=lead`) and
@@ -145,15 +155,16 @@ at enter/leave-play, not smeared across per-timing-point scan arms.
 4. **Skill-test frame (pure refactor):** the driver resumes via a
    `Continuation::SkillTest` frame; `in_flight_skill_test` stays as data.
    Behavior identical.
-5. **`emit_event` + the forced run + two-phase driving:** introduce `emit_event`;
+5. **`TimingEvent` + `emit_event` + the forced run + two-phase driving:** define
+   `TimingEvent` by merging `ForcedTriggerPoint` + the event-driven `WindowKind`
+   variants (each carrying its binding); map each to its `EventPattern`
+   discriminant + its logged `Event` (where one exists). Introduce `emit_event`;
    add the forced run of the shared loop (`can_skip=false`, `decider=lead`) and
-   have `emit_event` drive phase 1 → phase 2; replace the explicit
-   `fire_forced_triggers` / event-driven `queue_reaction_window` call sites with
-   `emit_event`. **Binding-context audit:** every migrated `Event`
-   variant must carry what its old `ForcedTriggerPoint` / `WindowKind` carried;
-   enrich the few that don't. Collapse `ForcedTriggerPoint` + the event-driven
-   `WindowKind` variants into the event-keyed dispatch (framework `PlayerWindow`
-   steps survive). Closes #212/#213; dissolves #294 + the 2+-reject.
+   have `emit_event` drive phase 1 → phase 2. Replace the explicit
+   `fire_forced_triggers` / event-driven `queue_reaction_window` call sites (combat
+   ×2, skill_test ×2, act_agenda ×2, phases ×4, actions ×1, mod ×1) with
+   `emit_event`. The framework `PlayerWindow(PhaseStep)` `open_fast_window` sites
+   survive (no `EventPattern`). Closes #212/#213; dissolves #294 + the 2+-reject.
 6. **#117 index (final):** swap the full-scan for the index behind the scan
    interface; enter/leave-play maintenance + install seed + the defensive
    "index survives a card leaving play mid-window" test. Closes #117.

--- a/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-axis-b-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-axis-b-foundation-design.md
@@ -97,20 +97,10 @@ shared resolution loop twice — phase 1 (forced), then phase 2 (reaction):
    whose effect suspends (Frozen in Fear's test; later a choice) parks on the
    stack and resumes the loop — **this dissolves #294 and the abandon-on-suspend
    caveat.**
-2. **Phase 2 — reaction.** Run the same loop (`can_skip=true`, `decider=player-order`)
-   over `kind: Reaction` abilities + Fast plays; skip = pass.
-
-**`Event` vs `EventPattern` (why two enums).** `Event` (game-core) is the ground
-*fact* — concrete ids (`EnemyDefeated { enemy, by, code }`), for the log/replay/
-client + as the binding source threaded into `EvalContext`. `EventPattern`
-(card-dsl) is the listener's *filter* — a predicate relative to the listener
-(`{ by_controller: bool, code: Option<String> }`; `by_controller` and the
-`Option` wildcard are meaningless on a concrete fact). The match is
-`same_discriminant && predicate(pattern, event, listener)`. They can't merge:
-the relative/wildcard qualifiers can't live on a fact, and — decisively —
-`card-dsl` is below `game-core`, so `EventPattern` cannot reference engine ids
-(`EnemyId`/`InvestigatorId`/`LocationId`). The only shared part is the
-discriminant case-list, which is exactly the `TriggerKind` key #117 indexes by.
+2. **Phase 2 — reaction.** One loop run **per investigator in player order**
+   (lead first, then clockwise — RR "In Player Order"); each run's candidates are
+   *that* investigator's eligible `kind: Reaction` abilities + Fast plays,
+   `can_skip=true`, that investigator decides. In solo (Slice 1) this is one run.
 
 The `EnemyDefeated` anchor: the defeat site calls `emit_event(cx,
 Event::EnemyDefeated { by, code, .. })` once; phase 1 runs the forced act-3
@@ -209,6 +199,12 @@ Existing content exercises every new path — no new cards needed:
   list, with a `TODO` for merge-in if such a card lands.
 - Skill-test nesting (one in flight today; `in_flight_skill_test` stays a
   singleton — `TODO` to move into the frame if nesting ever arrives).
+- **Exact multiplayer reaction-phase ordering.** Phase 2 runs per investigator in
+  player order; whether priority *returns to the lead after any action* (the
+  common LCG priority-reset) vs. strict one-pass-per-investigator is a Phase-8
+  question to verify against Appendix II. Solo (Slice 1) collapses both to one
+  run, and the `decider` parameter localizes the choice — so no restructure is
+  needed to settle it later.
 
 ## Risks
 

--- a/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-axis-b-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-axis-b-foundation-design.md
@@ -40,16 +40,16 @@ fields per the umbrella's incremental boundary).
 
 ```rust
 enum Continuation {
-    /// A reaction / fast / framework window is open; the player may act.
-    /// Absorbs `open_windows`-the-Vec: payload is the former `OpenWindow`
-    /// (kind, pending_triggers, fast_actors).
-    Window(OpenWindow),
-    /// The #213 forced-ordering loop for one (event, timing). Resolve one
-    /// forced hit (lead-investigator-chosen when 2+), remove it, repeat.
-    ForcedOrdering {
+    /// One iterative trigger-resolution loop — used for BOTH the forced phase
+    /// and the reaction window (see "One loop, two phases" below). Absorbs
+    /// `open_windows`-the-Vec; the former `OpenWindow` (kind, pending, fast_actors)
+    /// plus the loop parameters live in the frame.
+    Resolution {
+        candidates: Vec<Candidate>,   // forced abilities | reaction abilities + fast plays
+        can_skip: bool,               // forced: false; reaction: true
+        decider: Decider,             // lead (forced) | player-order (reaction)
         binding: EventBinding,        // controller / source / attacking enemy / location, from the event
         timing: EventTiming,
-        remaining: Vec<ForcedHit>,
     },
     /// The skill-test driver is mid-resolution; data is in the singleton
     /// `in_flight_skill_test` field (read by many call sites; no nesting today).
@@ -58,25 +58,59 @@ enum Continuation {
 }
 ```
 
-Window data moves *into* the `Window` frame — **no marker-pointing-at-a-separate-Vec**
+Window data moves *into* the frame — **no marker-pointing-at-a-separate-Vec**
 (that dual-bookkeeping is the trap). `in_flight_skill_test` stays a singleton
 field referenced by the `SkillTest` frame (widely read; only one in flight). The
 orthogonal phase `pending_*` modes (mulligan, hand-size discard, hunter-move,
 act-round-end, enemy-attack-loop, end-turn) are untouched.
 
+#### One loop, two phases
+
+The forced phase and the reaction window are **the same iterative loop** —
+collect candidates → present (with skip iff `can_skip`) → decider picks one →
+resolve (or skip → end) → re-collect → repeat until empty. Today
+`fire_forced_triggers` and `resume_reaction_window` are two separate
+implementations of that one loop; this collapses them. The two phases are two
+*parameterized runs*:
+
+| | forced phase | reaction phase |
+|---|---|---|
+| `can_skip` | false (mandatory) | true (pass) |
+| `candidates` | `Forced` `OnEvent` abilities | `Reaction` abilities **+ Fast plays from hand** (Axis C) |
+| `decider` | lead investigator (RR p.17) | player order (RR p.2; = the one player in solo) |
+
+The rules *vocabulary* stays distinct (a forced resolution and a reaction window
+are different concepts; prompts/logs say which), but via the parameters — not two
+code paths. The simpler forced path thereby adopts the reaction window's existing
+machinery (offered set, `PickSingle`/`OptionId`, usage limits) with
+`can_skip=false`, instead of maintaining its own.
+
 ### `emit_event` two-phase dispatch
 
 `emit_event(cx, event)` is the chokepoint for events that have a matching
-`EventPattern`. It pushes the event, then per (Before/After) timing:
+`EventPattern`. It pushes the event, then per (Before/After) timing runs the
+shared resolution loop twice — phase 1 (forced), then phase 2 (reaction):
 
-1. **Phase 1 — forced.** Collect forced hits (the `kind: Forced` `OnEvent`
-   abilities). 0 → skip. 1 → resolve. 2+ → push a `ForcedOrdering` frame and
-   present the lead-investigator choice (iterative: resolve one, remove, re-present
-   the rest — RR p.2/p.17). Mandatory, no skip. A hit whose effect suspends
-   (Frozen in Fear's test; later a choice) parks on the stack and resumes the
-   loop — **this is what dissolves #294 and the abandon-on-suspend caveat.**
-2. **Phase 2 — reaction.** Open the reaction window (push a `Window` frame);
-   optional reactions + Fast plays resolve in player order, skip = pass.
+1. **Phase 1 — forced.** Collect `kind: Forced` `OnEvent` hits. 0 → skip. 1 →
+   resolve. 2+ → push a `Resolution` frame (`can_skip=false`, `decider=lead`) and
+   run the loop (resolve one, remove, re-present the rest — RR p.2/p.17). A hit
+   whose effect suspends (Frozen in Fear's test; later a choice) parks on the
+   stack and resumes the loop — **this dissolves #294 and the abandon-on-suspend
+   caveat.**
+2. **Phase 2 — reaction.** Run the same loop (`can_skip=true`, `decider=player-order`)
+   over `kind: Reaction` abilities + Fast plays; skip = pass.
+
+**`Event` vs `EventPattern` (why two enums).** `Event` (game-core) is the ground
+*fact* — concrete ids (`EnemyDefeated { enemy, by, code }`), for the log/replay/
+client + as the binding source threaded into `EvalContext`. `EventPattern`
+(card-dsl) is the listener's *filter* — a predicate relative to the listener
+(`{ by_controller: bool, code: Option<String> }`; `by_controller` and the
+`Option` wildcard are meaningless on a concrete fact). The match is
+`same_discriminant && predicate(pattern, event, listener)`. They can't merge:
+the relative/wildcard qualifiers can't live on a fact, and — decisively —
+`card-dsl` is below `game-core`, so `EventPattern` cannot reference engine ids
+(`EnemyId`/`InvestigatorId`/`LocationId`). The only shared part is the
+discriminant case-list, which is exactly the `TriggerKind` key #117 indexes by.
 
 The `EnemyDefeated` anchor: the defeat site calls `emit_event(cx,
 Event::EnemyDefeated { by, code, .. })` once; phase 1 runs the forced act-3
@@ -111,19 +145,21 @@ at enter/leave-play, not smeared across per-timing-point scan arms.
    `GameState` (serde, absent-field-loads test) + the single resume router at the
    top of `resolve_input` (empty stack → falls through to legacy). No frames
    pushed yet.
-3. **Window unification (pure refactor):** `open_windows` → `Continuation::Window`
-   frames. Rewire `top_reaction_window(_index)`, `close_reaction_window_at`,
-   `resume_reaction_window`, `open_fast_window`, the `apply_player_action`
-   reject-guard, and `check_play_card`'s `permissive_window` to operate on the
-   topmost `Window` frame. Behavior identical; all existing window/skill-test/
-   reaction tests stay green.
+3. **Window unification (pure refactor):** `open_windows` → `Continuation::Resolution`
+   frames (the reaction run: `can_skip=true`). Rewire `top_reaction_window(_index)`,
+   `close_reaction_window_at`, `resume_reaction_window`, `open_fast_window`, the
+   `apply_player_action` reject-guard, and `check_play_card`'s `permissive_window`
+   to operate on the topmost `Resolution` frame. Behavior identical; all existing
+   window/skill-test/reaction tests stay green. (This also lands the shared loop
+   that task 5's forced run reuses.)
 4. **Skill-test frame (pure refactor):** the driver resumes via a
    `Continuation::SkillTest` frame; `in_flight_skill_test` stays as data.
    Behavior identical.
-5. **`emit_event` + two-phase + #213 forced-ordering loop:** introduce
-   `emit_event`; build the `ForcedOrdering` frame + iterative loop; replace the
-   explicit `fire_forced_triggers` / event-driven `queue_reaction_window` call
-   sites with `emit_event`. **Binding-context audit:** every migrated `Event`
+5. **`emit_event` + the forced run + two-phase driving:** introduce `emit_event`;
+   add the forced run of the shared loop (`can_skip=false`, `decider=lead`) and
+   have `emit_event` drive phase 1 → phase 2; replace the explicit
+   `fire_forced_triggers` / event-driven `queue_reaction_window` call sites with
+   `emit_event`. **Binding-context audit:** every migrated `Event`
    variant must carry what its old `ForcedTriggerPoint` / `WindowKind` carried;
    enrich the few that don't. Collapse `ForcedTriggerPoint` + the event-driven
    `WindowKind` variants into the event-keyed dispatch (framework `PlayerWindow`

--- a/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-axis-b-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-axis-b-foundation-design.md
@@ -199,12 +199,13 @@ Existing content exercises every new path — no new cards needed:
   list, with a `TODO` for merge-in if such a card lands.
 - Skill-test nesting (one in flight today; `in_flight_skill_test` stays a
   singleton — `TODO` to move into the frame if nesting ever arrives).
-- **Exact multiplayer reaction-phase ordering.** Phase 2 runs per investigator in
-  player order; whether priority *returns to the lead after any action* (the
-  common LCG priority-reset) vs. strict one-pass-per-investigator is a Phase-8
-  question to verify against Appendix II. Solo (Slice 1) collapses both to one
-  run, and the `decider` parameter localizes the choice — so no restructure is
-  needed to settle it later.
+- **Multiplayer reaction-phase ordering.** Verified against the RR (Appendix II +
+  full-text search): Arkham has **no priority-reset** mechanic — the only window
+  ordering rule is "In Player Order" (lead first, then clockwise), so phase 2 is
+  one pass per investigator, each resolving their eligible reactions/Fasts. That
+  model is rules-complete; the only deferral is that *multiplayer* player-order is
+  unexercised until Phase 8 (Slice 1 is solo → one run). The `decider` parameter
+  already localizes it.
 
 ## Risks
 

--- a/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-axis-b-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-axis-b-foundation-design.md
@@ -1,0 +1,187 @@
+# Axis B — trigger-dispatch foundation (#212 / #213 / #117)
+
+**Status:** design. First buildable sub-project of the trigger-dispatch rework
+(umbrella: `2026-06-16-trigger-dispatch-rework-umbrella-design.md`). Read the
+umbrella first — this spec assumes its §1–§5 decisions.
+
+**One-line goal:** replace the engine's two hand-wired trigger-dispatch paths and
+its proliferation of suspension modes with **one continuation stack** and **one
+`emit_event` chokepoint** doing rules-correct two-phase (forced-then-reaction)
+dispatch. No new cards; correctness-complete; the foundation Axes A/C/D build on.
+
+## What's wrong today (recap, from reading the engine)
+
+- **Two parallel dispatch paths.** Forced abilities fire immediately via
+  `fire_forced_triggers(cx, ForcedTriggerPoint)` (collect-then-resolve, fixed
+  deterministic order, **abandons later hits on suspend** — its own doc-comment
+  flags this as the reentrancy gap). Optional reactions open a window via
+  `queue_reaction_window` / `open_fast_window` (`open_windows` stack, player
+  pick/skip). The same game moment can need both (an enemy defeat → forced act-3
+  advance **and** Roland's reaction), wired as two separate calls.
+- **forced-vs-reaction routed by `EventPattern`** (C6a workaround for "no
+  `Trigger::Forced`"), forcing twin patterns for one moment
+  (`AfterLocationInvestigated` forced vs `SuccessfullyInvestigated` reaction).
+- **Event emission is `cx.events.push` with no dispatch hook** (the #212 smell).
+- **Suspension is hand-rolled per feature.** The skill-test driver is itself a
+  continuation state machine (`FinishContinuation`: AwaitingCommit → PostFollowUp
+  → PostRetaliate → PostOnResolution; `close_reaction_window_at` re-enters
+  `drive_skill_test`). Each suspension mode is a `pending_*` field + a guard in
+  `apply_player_action` + a route in `resolve_input`.
+
+## Target architecture
+
+### The one stack
+
+`GameState` gains `continuations: Vec<Continuation>` (serde, replay-safe). It is
+the single suspend/resume authority. The single resume router lives at the top of
+`resolve_input`: if the stack is non-empty, resume its top frame; else fall
+through to the legacy `pending_*` ladder (unchanged — those modes stay on their
+fields per the umbrella's incremental boundary).
+
+```rust
+enum Continuation {
+    /// A reaction / fast / framework window is open; the player may act.
+    /// Absorbs `open_windows`-the-Vec: payload is the former `OpenWindow`
+    /// (kind, pending_triggers, fast_actors).
+    Window(OpenWindow),
+    /// The #213 forced-ordering loop for one (event, timing). Resolve one
+    /// forced hit (lead-investigator-chosen when 2+), remove it, repeat.
+    ForcedOrdering {
+        binding: EventBinding,        // controller / source / attacking enemy / location, from the event
+        timing: EventTiming,
+        remaining: Vec<ForcedHit>,
+    },
+    /// The skill-test driver is mid-resolution; data is in the singleton
+    /// `in_flight_skill_test` field (read by many call sites; no nesting today).
+    SkillTest,
+    // Axis A adds Choice { .. }; Axis D adds whatever cancellation needs.
+}
+```
+
+Window data moves *into* the `Window` frame — **no marker-pointing-at-a-separate-Vec**
+(that dual-bookkeeping is the trap). `in_flight_skill_test` stays a singleton
+field referenced by the `SkillTest` frame (widely read; only one in flight). The
+orthogonal phase `pending_*` modes (mulligan, hand-size discard, hunter-move,
+act-round-end, enemy-attack-loop, end-turn) are untouched.
+
+### `emit_event` two-phase dispatch
+
+`emit_event(cx, event)` is the chokepoint for events that have a matching
+`EventPattern`. It pushes the event, then per (Before/After) timing:
+
+1. **Phase 1 — forced.** Collect forced hits (the `kind: Forced` `OnEvent`
+   abilities). 0 → skip. 1 → resolve. 2+ → push a `ForcedOrdering` frame and
+   present the lead-investigator choice (iterative: resolve one, remove, re-present
+   the rest — RR p.2/p.17). Mandatory, no skip. A hit whose effect suspends
+   (Frozen in Fear's test; later a choice) parks on the stack and resumes the
+   loop — **this is what dissolves #294 and the abandon-on-suspend caveat.**
+2. **Phase 2 — reaction.** Open the reaction window (push a `Window` frame);
+   optional reactions + Fast plays resolve in player order, skip = pass.
+
+The `EnemyDefeated` anchor: the defeat site calls `emit_event(cx,
+Event::EnemyDefeated { by, code, .. })` once; phase 1 runs the forced act-3
+advance, phase 2 opens the Roland window. Framework `PlayerWindow(PhaseStep)`
+windows have no `EventPattern` and stay explicit `open_fast_window` calls.
+
+### The DSL change
+
+`Trigger::OnEvent { pattern, timing }` → `{ pattern, timing, kind: TriggerKind }`
+where `TriggerKind = Forced | Reaction`. Retires route-by-pattern; lets one
+moment carry both a forced and a reaction listener. Existing `OnEvent` cards are
+classified at migration (the current forced points → `Forced`; the current
+reaction-window cards → `Reaction`).
+
+### The scan interface + #117 (final task)
+
+`emit_event` collects hits through **one scan function**, implemented first with
+the existing full board walk (`collect_forced_hits` / `scan_pending_triggers`
+logic, unified). The **#117 event-keyed index** (`TriggerKind → Vec<entry>`,
+maintained at `CardInPlay` enter/leave-play, seeded at registry install) is
+swapped in behind that interface as the **last task** — isolating its new
+invariant (every zone transition updates the index or it desyncs) from the
+dispatch restructure. Net maintainability win: trigger-discovery registered once
+at enter/leave-play, not smeared across per-timing-point scan arms.
+
+## Proposed task breakdown (refined in the plan)
+
+1. **DSL: `TriggerKind` on `Trigger::OnEvent`** + classify all existing `OnEvent`
+   cards; serde round-trip. (No behavior change yet — both dispatch paths read
+   the field instead of inferring from which path they're in.)
+2. **Continuation stack scaffolding:** `continuations: Vec<Continuation>` on
+   `GameState` (serde, absent-field-loads test) + the single resume router at the
+   top of `resolve_input` (empty stack → falls through to legacy). No frames
+   pushed yet.
+3. **Window unification (pure refactor):** `open_windows` → `Continuation::Window`
+   frames. Rewire `top_reaction_window(_index)`, `close_reaction_window_at`,
+   `resume_reaction_window`, `open_fast_window`, the `apply_player_action`
+   reject-guard, and `check_play_card`'s `permissive_window` to operate on the
+   topmost `Window` frame. Behavior identical; all existing window/skill-test/
+   reaction tests stay green.
+4. **Skill-test frame (pure refactor):** the driver resumes via a
+   `Continuation::SkillTest` frame; `in_flight_skill_test` stays as data.
+   Behavior identical.
+5. **`emit_event` + two-phase + #213 forced-ordering loop:** introduce
+   `emit_event`; build the `ForcedOrdering` frame + iterative loop; replace the
+   explicit `fire_forced_triggers` / event-driven `queue_reaction_window` call
+   sites with `emit_event`. **Binding-context audit:** every migrated `Event`
+   variant must carry what its old `ForcedTriggerPoint` / `WindowKind` carried;
+   enrich the few that don't. Collapse `ForcedTriggerPoint` + the event-driven
+   `WindowKind` variants into the event-keyed dispatch (framework `PlayerWindow`
+   steps survive). Closes #212/#213; dissolves #294 + the 2+-reject.
+6. **#117 index (final):** swap the full-scan for the index behind the scan
+   interface; enter/leave-play maintenance + install seed + the defensive
+   "index survives a card leaving play mid-window" test. Closes #117.
+
+Tasks 1–4 are behavior-preserving and independently mergeable; 5 is the
+semantic change; 6 is the optimization. Each its own work issue + PR.
+
+## Test strategy
+
+Existing content exercises every new path — no new cards needed:
+
+- **Two-phase + simultaneous forced ordering:** agenda 01107's `RoundEnded` doom
+  + Dissonant Voices 01165's `RoundEnded` discard (2 simultaneous forced → the
+  lead-investigator ordering loop).
+- **Reentrancy / suspend-mid-forced:** Frozen in Fear 01164's `EndOfTurn` forced
+  effect that suspends on a willpower test — the forced hit suspends, the
+  skill-test frame resolves, control returns to (here, finishes) the dispatch.
+- **#294 dissolved:** a single attack damaging two `EnemyAttackDamagedSelf`
+  reactors (two Guard Dogs) drains both soak windows then resumes — the
+  `debug_assert` guard in `drive_attack_loop` is removed/relaxed.
+- **Unification anchor:** an enemy defeat fires the forced advance *and* opens
+  the reaction window from one `emit_event`.
+- **Window unification regression net:** the full existing reaction-window,
+  fast-window, mulligan, and skill-test suite stays green across tasks 3–4.
+
+## Closes / corrects
+
+- Closes #212 (emit_event chokepoint), #213 (two-phase iterative ordering; issue
+  text already amended to match), #117 (index), #294 (multi-soak resume).
+- Removes `fire_forced_triggers`' fixed-order + abandon-on-suspend + 2+-reject;
+  the `ForcedTriggerPoint` enum and the event-driven `WindowKind` variants
+  collapse into the event-keyed dispatch.
+
+## Out of scope
+
+- Axis A (`ChooseOne` / target-selection choice frames), Axis C
+  (reaction-event-play), Axis D (cancellation / Before-firing) — later
+  sub-projects. The `Continuation` enum is designed to accept their variants.
+- Migrating the orthogonal `pending_*` phase modes onto the stack (later cleanup).
+- **Newly-arising forced hits mid-loop** (a forced effect that creates a new
+  simultaneous forced trigger at the same point — "delayed effects"): no
+  Slice-1+ card does this; the `ForcedOrdering` loop drains a fixed `remaining`
+  list, with a `TODO` for merge-in if such a card lands.
+- Skill-test nesting (one in flight today; `in_flight_skill_test` stays a
+  singleton — `TODO` to move into the frame if nesting ever arrives).
+
+## Risks
+
+- **Window unification (task 3) is the largest single change** — it touches every
+  `open_windows` reader. Mitigated by being a pure refactor with a large existing
+  regression net; land it on its own PR.
+- **Binding-context audit (task 5)** is where a migrated event could silently drop
+  context a dispatch needs. Mitigated by per-event tests asserting the fired
+  effect sees the right `controller` / `source` / `attacking_enemy`.
+- **Index desync (task 6)** — mitigated by landing it last, behind a stable scan
+  interface, with the defensive leave-play-mid-window test (and optionally a
+  debug-only cross-check against the full scan).

--- a/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-umbrella-design.md
+++ b/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-umbrella-design.md
@@ -1,0 +1,334 @@
+# Trigger-dispatch rework (#212 / #213 / #117) — umbrella architecture
+
+**Status:** design approved (umbrella). Foundation (Axis B) deep-dive is the
+next spec; Axes A/C/D and the orthogonal card prereqs (Axis E) follow.
+
+**Scope of this doc:** the *shared abstractions* across the four trigger/choice
+subsystems, so they stay coherent as each ships in its own spec. It is not the
+Axis-B implementation plan (that is a separate spec + plan).
+
+## Why this exists
+
+Phase-7 Slice 1 shipped every Gathering card implementable on today's engine and
+carved the rest to follow-ups. A cluster of those follow-ups is blocked on the
+same missing machinery — the work issues #212 (`emit_event` dispatch
+unification), #213 (iterative simultaneous-trigger ordering), and #117 (trigger
+index) describe. The phase doc files this under "Engine north-star
+(cross-slice, may be its own slice)."
+
+The deferred cards, with verbatim text (verified against
+`data/arkhamdb-snapshot/pack/core/core.json`):
+
+| Code | Card | Text |
+|---|---|---|
+| 01022 | Evidence! | Fast. Play after you defeat an enemy. / Discover 1 clue at your location. |
+| 01023 | Dodge | Fast. Play when an enemy attacks an investigator at your location. / Cancel that attack. |
+| 01024 | Dynamite Blast | Choose either your location or a connecting location. Deal 3 damage to each enemy and to each investigator at the chosen location. |
+| 01018 | Beat Cop | You get +1 [combat]. / [fast] Discard Beat Cop: Deal 1 damage to an enemy at your location. |
+| 01019 | First Aid | Uses (3 supplies). If First Aid has no supplies, discard it. / [action] Spend 1 supply: Heal 1 damage or horror from an investigator at your location. |
+| 01035 | Medical Texts | [action] Choose an investigator at your location and test [intellect] (2). If you succeed, heal 1 damage from that investigator. If you fail, deal 1 damage to that investigator. |
+| 01031 | Old Book of Lore | [action] Exhaust Old Book of Lore: Choose an investigator at your location. That investigator searches the top 3 cards of his or her deck for a card, draws it, and shuffles the remaining cards into his or her deck. |
+| 01032 | Research Librarian | [reaction] After Research Librarian enters play: Search your deck for a [[Tome]] asset and add it to your hand. Shuffle your deck. |
+| 01036 | Mind over Matter | Fast. Play only during your turn. / Until the end of the round, you may use your [intellect] in place of your [combat] and [agility]. |
+| 01038 | Barricade | Attach to your location. / Non-[[Elite]] enemies cannot move into attached location. / **Forced** - When an investigator leaves attached location: Discard Barricade. |
+| 01086 | Knife | [action]: Fight. You get +1 [combat] for this attack. / [action] Discard Knife: Fight. You get +2 [combat] for this attack. This attack deals +1 damage. |
+| 01087 | Flashlight | Uses (3 supplies). / [action] Spend 1 supply: Investigate. Your location gets -2 shroud for this investigation. |
+
+## The five axes the cards need
+
+- **Axis A — interactive choice.** `Effect::ChooseOne`,
+  `LocationTarget::ChosenByController`, `InvestigatorTarget::ChosenByController`
+  are `AwaitingInput` stubs in `evaluator.rs`. Dynamite Blast, Beat Cop (2+
+  targets), First Aid, Old Book of Lore, Medical Texts.
+- **Axis B — trigger-dispatch spine.** #212 + #117 + #213. No new cards but
+  correctness-critical; the foundation everything else builds on.
+- **Axis C — reaction-event-play.** A Fast event played from hand inside a
+  reaction window, gated by a play-timing predicate. Evidence!, Dodge, Mind over
+  Matter (play half).
+- **Axis D — attack cancellation.** A new cancel/replacement subsystem. Dodge.
+- **Axis E — orthogonal per-card primitives.** Not trigger work; separate
+  prereqs in the #295/#276 mold. `Effect::Heal`, deck-search, `Effect::Investigate`,
+  discard-self cost, stat-substitution, location attachment, AoE damage.
+
+## Current architecture (what the rework changes)
+
+Established by reading the engine, not the issues:
+
+- **`apply(state, action) -> ApplyResult`** is the only mutator. `Cx { state,
+  events }` is threaded through handlers; `EvalContext` carries the card-text
+  "you"/"source". Outcome is `Done | AwaitingInput { request, resume_token } |
+  Rejected`.
+- **Two parallel trigger-dispatch paths.** Forced abilities fire immediately via
+  `fire_forced_triggers(cx, ForcedTriggerPoint)` (collect-then-resolve, fixed
+  deterministic order, **abandons later hits on suspend** — its own doc-comment
+  flags this as the #212 reentrancy gap). Optional reactions open a window via
+  `queue_reaction_window(cx, WindowKind)` (player-driven pick/skip). Today
+  forced-vs-reaction is routed **by `EventPattern`** (the C6a workaround for "the
+  engine has no `Trigger::Forced`"), which is why `AfterLocationInvestigated`
+  (forced) and `SuccessfullyInvestigated` (reaction) had to be invented as twin
+  patterns for the same game moment.
+- **Event emission is `cx.events.push(...)` at ~many sites**, with no dispatch
+  hook — the manual-wiring smell #212 names.
+- **~9 hand-wired suspension modes.** Each is a `pending_*` field on `GameState`
+  (`in_flight_skill_test`, `clue_interrupt_pending`, `hunter_move_pending`,
+  `spawn_engage_pending`, `hand_size_discard_pending`, `act_round_end_pending`,
+  `open_windows`, `pending_end_turn`, `pending_enemy_attack`) wired three times:
+  the field, a reject-guard in `apply_player_action`, and a route in
+  `resolve_input`. The evaluator's `Seq` loop documents it **cannot resume
+  mid-`Seq`** once `ChooseOne` starts returning `AwaitingInput`.
+
+The single missing primitive under all of it: **suspend and resume from the
+*middle* of a computation, with nesting.** Both the forced path's
+abandon-on-suspend and the evaluator's can't-resume-mid-`Seq` are the same gap.
+
+## Rules grounding (verified against `data/rules-reference/ahc01_rules_reference_web.pdf`)
+
+- **Forced before reaction** (p.2, "Forced Abilities"): *"For any given timing
+  point, all forced abilities initiated in reference to that timing point must
+  resolve before any [reaction] abilities referencing the same timing point in
+  the same manner may be initiated."*
+- **Simultaneous forced ordering** (p.17, "Priority of Simultaneous
+  Resolution"): *"If two or more forced abilities (including delayed effects)
+  would resolve at the same time, the lead investigator determines the order in
+  which the abilities resolve."* And: *"If an effect affects multiple players
+  simultaneously, but the players must individually make choices to resolve the
+  effect, these choices are made in player order."*
+- **When vs after** (p.2): a forced/reaction ability with a "when…" timing point
+  initiates *before* the triggering condition's impact resolves; an "after…"
+  ability *immediately after* the impact has resolved. → maps to
+  `EventTiming::{Before, After}`.
+- **Fast** (p.11): a fast event *"may be played from a player's hand any time
+  its play instructions specify. If the instructions specify when/after a timing
+  point, the card may be played **as if the described timing point were a
+  triggering condition** … If the instructions specify a duration or period …
+  during any player window within that period."* Free 󲅺 abilities: *"may be used
+  during any player window."* Reaction 󲆍 abilities: *"may be used any time its
+  triggering condition is met."*
+
+**Correction to issue #213:** the issue proposes "uniform across forced and
+optional triggers, with skip available only when every remaining trigger is
+optional" — one mixed pool. RR p.2 forbids interleaving an optional reaction
+ahead of an unresolved forced at the same point. The correct model is **two-phase
+per (timing point, Before/After): forced-first, then reaction.** This satisfies
+the issue's acceptance criteria (forced can't be skipped; skip offered only when
+all remaining are optional — trivially true once forced have all resolved) while
+being rules-accurate, and it matches the engine's *existing* split, so it is
+*less* of a rewrite than the issue's "one chokepoint" prose implies. Update #213
+to reflect two-phase.
+
+## §1 — Continuation model (decision: unified stack, incremental migration)
+
+A single `Vec<Continuation>` on `GameState` is the one suspend/resume mechanism.
+The migration is **incremental**, not big-bang:
+
+- **On the stack now:** trigger-dispatch frames (the #213 ordering loop),
+  `ChooseOne` / target-selection choice frames, and the skill-test +
+  reaction-window *resumptions* that interleave with them.
+- **Stay on their `pending_*` fields (cleanup later, tracked follow-up):**
+  mulligan, hand-size discard, hunter-move, act-round-end, enemy-attack-loop,
+  end-turn. These never nest under trigger dispatch (different phases), so they
+  don't need to be on the stack yet.
+
+**Key reframing that makes this clean:** a `Continuation` is a **resume-handle**
+— a typed frame (tag + minimal payload naming which resume fn to call), *not* a
+relocation of every feature's working state. A frame can say "resume the
+skill-test driver" while `in_flight_skill_test` stays where it is as that
+feature's storage. So we migrate *control flow* (one router in `resolve_input`,
+the suspend/resume discipline) now; deleting `pending_*` fields is optional later
+cleanup, not a prerequisite.
+
+Rejected alternatives:
+
+- **Full unified stack (big-bang).** Migrate all ~9 modes now. Cleaner end state
+  (one router, no legacy paths) but rewrites intricate, well-tested
+  mulligan/upkeep/hunter/enemy-phase resume code unrelated to triggers, for zero
+  functional gain, and locks the `Continuation` shape before the new machinery
+  proves it. Against the surgical principle.
+- **Per-feature `pending_*` (status quo extended).** Fails the requirement by
+  construction: `Option<PendingChoice>` + `Option<PendingTriggerDispatch>` can't
+  represent a choice arising while a trigger dispatch is already suspended
+  (depth > 1). Deepens the exact smell #212 was filed to kill.
+
+The decision criterion was **"can it represent depth > 1?"** — proven necessary
+by the #213 ordering loop (resolving one trigger can emit events that open a
+window/choice which must fully resolve before re-presenting siblings) and by
+Dynamite Blast (choice → AoE → defeat → after-defeat window → that reaction's
+effect is itself a choice; depth 4).
+
+## §2 — `emit_event` chokepoint + two-phase dispatch
+
+1. **`emit_event(cx, event)` is the chokepoint for events that have a matching
+   `EventPattern`.** Pure notifications (`CardsDrawn`, `ResourcesGained`,
+   `ActionsRemainingChanged`, …) keep `cx.events.push`. Rationale: `emit_event`
+   *can suspend* (fire a forced trigger / open a window / hit a choice), so every
+   `emit_event` site is a pause point — and not every emission site is a safe
+   place to pause (cf. the `unreachable!("window closed while a skill test is in
+   flight")` guards in `run_window_continuation`). Keeping the pause surface
+   equal to the *listenable* surface (= events with an `EventPattern`) is the
+   honest scope. A card can only listen to an `EventPattern` that exists, so
+   adding a reaction to a today-notification event requires adding the pattern
+   *and* converting that one emit site, coupled — they can't drift apart. This
+   satisfies #212's "never forget the window" goal for every currently-listenable
+   event without making the whole emission surface suspendable.
+
+2. **Per window-bearing event, dispatch is two-phase, per (Before/After)
+   timing** (RR p.2):
+   - **Phase 1 — forced:** collect forced hits; if 2+, the lead investigator
+     orders them *iteratively* (resolve one → re-collect → repeat, honoring
+     delayed effects + state changes). Mandatory, no skip. **This is #213's real
+     ordering loop**, replacing `fire_forced_triggers`' fixed order *and* its
+     abandon-on-suspend.
+   - **Phase 2 — reaction:** open the reaction window; optional reactions + Fast
+     plays (Axis C) resolve in player order, repeatedly, skip = pass. Today's
+     `queue_reaction_window`, generalized.
+
+3. **Backing store = the #117 event-keyed index** (`TriggerKind → Vec<entry>`,
+   maintained at `CardInPlay` enter/leave-play, seeded at registry install),
+   replacing the full board walk in both phases. #117's defensive test
+   (index survives a card leaving play mid-window) carries over.
+
+4. **forced-vs-optional becomes an explicit per-ability property** on the DSL
+   trigger: `Trigger::OnEvent { pattern, timing, kind: TriggerKind::{Forced,
+   Reaction} }` (field on the existing variant, not a separate `Trigger::Forced`
+   — they share pattern/timing and differ only in mandatory/ordering-phase).
+   Retires the C6a route-by-pattern wart; lets one game moment carry both a
+   forced and a reaction listener without inventing twin patterns.
+
+5. **Both phases suspend/resume on the continuation stack** (§1). A forced hit
+   that suspends (Frozen in Fear's test; a `ChooseOne`) parks a frame and resumes
+   its siblings — **#294 (two-Guard-Dog multi-soak) and the `fire_forced_triggers`
+   reentrancy caveat both dissolve out of this.**
+
+6. **Before-timing dispatch** (fire around the event, before its impact) is part
+   of the `emit_event` *signature* (it carries timing), but the Before-*firing*
+   wiring lands with its first consumer (Axis D) — no speculative code. After-
+   timing is today's path.
+
+## §3 — the choice / input contract (shared)
+
+1. **`Continuation` frames are typed, not closures** — matching the engine's
+   established pattern (`InFlightSkillTest.FinishContinuation`,
+   `ClueInterruptPending`). `Continuation` is an enum; each sub-project adds the
+   variant(s) it needs; the stack gives them one ordering + one router.
+
+2. **`InputRequest` gains structure.** Today `{ prompt: String }` can't render
+   "pick one of these 3 locations." It gains a typed options payload — a
+   `Vec<ChoiceOption>` carrying an opaque id + a render label (+ enough
+   discriminant for the host to show location/investigator/branch). The frame
+   stores the **offered set**, so resume validates "is this id in the set I
+   offered" — tighter than today's `PickLocation(any id)` + re-derive.
+
+3. **`InputResponse` taxonomy converges to two selection families** plus a
+   pass/binary signal:
+   - **`PickSingle`** — one `OptionId` from the offered set. Consolidates today's
+     `PickLocation` / `PickInvestigator` / `PickIndex` and the new `ChooseOne`
+     branch pick (all are "echo back one id"; the distinction bought only log
+     readability, recovered by the structured request + the resolved binding in
+     the event log). This makes the reaction window and the choice evaluator
+     speak one protocol.
+   - **`PickMultiple`** — a `Vec<OptionId>` *subset* of the offered set.
+     Constraints (`min`/`max`/`exact`) live in the request/frame, not the
+     variant. Adopted for *new* multi-selects now; the legacy
+     `CommitCards { indices }` / `DiscardCards { indices }` fold into it
+     **when their suspension modes migrate to the stack** (the §1 cleanup pass),
+     not as a now-rewrite of working legacy paths.
+   - **`Skip` / `Confirm`** stay distinct — "decline / I'm done" and "yes" are
+     different intents from "selected zero items"; overloading is a footgun.
+
+4. **One uniform resolve convention for all selections** (`ChooseOne`,
+   `*::ChosenByController`): enumerate legal options → **0 ⇒ reject** (or no-op
+   under "may") → **1 ⇒ auto-bind** (the Fight / Beat-Cop "single engaged enemy"
+   precedent in `check_activate_ability`) → **2+ ⇒ suspend** with a choice frame.
+   Solo play auto-resolves the common case; only genuinely-ambiguous choices
+   round-trip.
+
+## §4 — how each axis attaches (each its own spec)
+
+- **Axis A (choice)** — evaluator. Strategy: resolve an effect tree in **two
+  passes — a pure *planning* pass that grounds all choices/targets (can suspend
+  to gather them; re-entrant because it mutates nothing), then an *execution*
+  pass over the ground plan (mutates once).** This dissolves the "can't resume
+  mid-`Seq`" problem without reifying the whole tree walk, and holds for every
+  deferred card (choices are all resolvable before the dependent mutation;
+  Medical Texts' post-test heal is already ground once the investigator is
+  picked, so existing skill-test suspension handles the middle). Out of scope
+  (no deferred card needs it): a choice whose legal options depend on a mutation
+  *earlier in the same tree*.
+
+- **Axis C (reaction-event-play)** — the reaction phase of `emit_event` admits a
+  **Fast event play from hand** as an offered option alongside "fire a pending
+  trigger," and a **play-timing predicate** gates it. Crucially the predicate is
+  **the same `EventPattern` match from §2** (RR p.11: a fast event with a
+  when/after instruction plays "as if the described timing point were a
+  triggering condition"). So a Fast event in hand is offered in a window iff its
+  play-instruction pattern matches that window's event → becomes another
+  `PickSingle` option. **Correction to carry in:** the current
+  `fast_actors: FastActorScope::Any` + its comment ("Fast may be played at any
+  player window") conflates reaction windows with player windows; Axis C tightens
+  it to the pattern-matched predicate rather than inheriting the blanket.
+
+- **Axis D (cancellation)** — §2's **Before-timing dispatch** plus a
+  **cancel/replacement signal**: a fired Before-reaction returns a "cancel"
+  result the emitting site honors (skips the impact). The umbrella's only
+  obligation is that `emit_event`'s Before-phase can carry a cancel result back
+  to the call site; where the cancel window opens and how the parked attack is
+  discarded is the Axis-D spec.
+
+## §5 — decomposition, sequencing, card readiness
+
+Five sub-projects, each its own spec → plan → issues → PRs. Axis B is built
+first; it blocks the rest. Axes A and C are independent of each other (both need
+only B); D needs B (Dodge also needs C). Axis E is mostly independent of all.
+
+**Sub-project 1 — Axis B foundation** (next spec; no new cards,
+correctness-complete): continuation stack + single resume router; `emit_event`
+two-phase dispatch; #117 index; #213 ordering loop; the `kind: Forced|Reaction`
+DSL field; migrate skill-test + reaction-window resumptions onto the stack.
+Closes #212/#213/#117; **dissolves #294** and the `fire_forced_triggers`
+2+-reject. Testable today against Guard Dog, agenda+Dissonant-Voices
+`RoundEnded`, Frozen in Fear.
+
+**Sub-project 2 — Axis A** (choice): per §4.
+**Sub-project 3 — Axis C** (reaction-event-play): per §4.
+**Sub-project 4 — Axis D** (cancellation): per §4.
+**Axis E** — orthogonal card prereqs filed separately (#301/#302/#306/#312/
+#313/#319/#320/#322/#323), #295/#276 mold, parallelizable.
+
+**Card readiness matrix** (✓ = required):
+
+| Card | B | A | C | D | Axis-E prereq |
+|---|---|---|---|---|---|
+| Evidence! 01022 | ✓ | | ✓ | | — (DiscoverClue exists) → earliest shippable |
+| Dynamite Blast 01024 | ✓ | ✓ | | | AoE-at-location |
+| Beat Cop 01018 | ✓ | ✓¹ | | | discard-self cost |
+| First Aid 01019 | ✓ | ✓ | | | Heal + uses-discard |
+| Medical Texts 01035 | ✓ | ✓ | | | Heal |
+| Old Book of Lore 01031 | ✓ | ✓ | | | deck-search top-N |
+| Dodge 01023 | ✓ | | ✓ | ✓ | — |
+| Barricade 01038 | ✓² | | | | attachment + movement-block |
+| Research Librarian 01032 | ✓³ | ✓¹ | | | deck-search by-trait |
+| Mind over Matter 01036 | | | ⁴ | | stat-sub + until-end-of-round |
+| Knife 01086 | | | | | discard-self cost — pure Axis E |
+| Flashlight 01087 | | | | | Investigate-effect + shroud — pure Axis E |
+
+¹ auto-resolves single target on B alone; A only for the 2+ case. ² B for the
+forced-on-leave trigger (new pattern + emit site). ³ B for the after-enters-play
+reaction window. ⁴ "during your turn" may already pass the existing play gate —
+verify; main blocker is Axis E.
+
+**Takeaway:** the trigger rework (B+A+C+D) directly unblocks Evidence!, Dynamite
+Blast, Beat Cop, First Aid, Medical Texts, Old Book of Lore, Dodge, and
+Barricade's trigger half. **Knife, Flashlight, and Mind over Matter are really
+Axis-E work** that can proceed independently of this effort.
+
+## Open questions (for the per-axis specs, not blocking the umbrella)
+
+- Exact `Continuation` enum variants and the `OptionId` representation — settle
+  in the Axis-B spec against real consumers, then legacy migration is mechanical.
+- Whether a condition-less Fast asset / free 󲅺 ability is legal inside a
+  reaction (vs. framework player) window — not needed by the Axis-C cards
+  (Evidence!/Dodge are condition-matched; Mind over Matter is "during your
+  turn"); make precise when a card forces it.
+- Research Librarian's "find a [[Tome]]" when 2+ Tomes are in deck — does the
+  deck-search primitive own the selection, or does it route through Axis A? Decide
+  in the deck-search prereq spec.

--- a/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-umbrella-design.md
+++ b/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-umbrella-design.md
@@ -366,3 +366,11 @@ Axis-E work** that can proceed independently of this effort.
 - Research Librarian's "find a [[Tome]]" when 2+ Tomes are in deck — does the
   deck-search primitive own the selection, or does it route through Axis A? Decide
   in the deck-search prereq spec.
+- **What `Event` is *for* (future, not blocking).** The server ships full state to
+  the client, so the replay/reconstruction rationale for the event log is weaker
+  than originally planned — `Event` is mostly a *log*. That should eventually
+  drive what has the right to be an `Event` vs. a dispatch-only `TimingEvent` vs.
+  pure internal state. Revisit when the Event taxonomy is reworked; Axis B keeps
+  the two separate (consolidating `ForcedTriggerPoint`+`WindowKind` into
+  `TimingEvent`, 4 enums → 3) precisely so this can be decided later without
+  re-coupling dispatch to the log.

--- a/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-umbrella-design.md
+++ b/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-umbrella-design.md
@@ -121,21 +121,29 @@ to reflect two-phase.
 A single `Vec<Continuation>` on `GameState` is the one suspend/resume mechanism.
 The migration is **incremental**, not big-bang:
 
-- **On the stack now:** trigger-dispatch frames (the #213 ordering loop),
-  `ChooseOne` / target-selection choice frames, and the skill-test +
-  reaction-window *resumptions* that interleave with them.
+- **On the stack now:** the #213 forced-ordering loop, `ChooseOne` /
+  target-selection choice frames (Axis A), and **the reaction/fast windows** —
+  `open_windows`-the-Vec is *absorbed into the one stack* as `Continuation::Window`
+  frames (a window is just "paused, the player may act here, resume on
+  act/pass"). This covers both reaction windows and the framework
+  `PlayerWindow(PhaseStep)` windows. The skill-test driver also resumes through
+  the stack (a `Continuation::SkillTest` frame).
 - **Stay on their `pending_*` fields (cleanup later, tracked follow-up):**
   mulligan, hand-size discard, hunter-move, act-round-end, enemy-attack-loop,
   end-turn. These never nest under trigger dispatch (different phases), so they
   don't need to be on the stack yet.
 
-**Key reframing that makes this clean:** a `Continuation` is a **resume-handle**
-— a typed frame (tag + minimal payload naming which resume fn to call), *not* a
-relocation of every feature's working state. A frame can say "resume the
-skill-test driver" while `in_flight_skill_test` stays where it is as that
-feature's storage. So we migrate *control flow* (one router in `resolve_input`,
-the suspend/resume discipline) now; deleting `pending_*` fields is optional later
-cleanup, not a prerequisite.
+**One stack, no dual-bookkeeping.** The trap to avoid is a `Continuation` *marker*
+that points at a still-separate `open_windows` Vec — two structures kept in sync
+is the worst option. So windows' data moves *into* their frames. The one
+exception is `in_flight_skill_test`, which stays a **singleton field** referenced
+by the `SkillTest` frame — not a competing stack (only ever one test in flight;
+no nesting today) but payload that lives beside the stack because it's read by
+many call sites (`drive_skill_test`, the `unreachable!` guards). If skill tests
+ever nest, that data moves into the frame too. Net: one stack
+(`Window` + `ForcedOrdering` + `Choice` frames, plus a `SkillTest` frame-ref),
+zero sync bookkeeping. The truly-orthogonal phase `pending_*` modes above are
+singletons in disjoint phases, migrated only in the later cleanup pass.
 
 Rejected alternatives:
 
@@ -182,10 +190,20 @@ effect is itself a choice; depth 4).
      plays (Axis C) resolve in player order, repeatedly, skip = pass. Today's
      `queue_reaction_window`, generalized.
 
-3. **Backing store = the #117 event-keyed index** (`TriggerKind → Vec<entry>`,
-   maintained at `CardInPlay` enter/leave-play, seeded at registry install),
-   replacing the full board walk in both phases. #117's defensive test
-   (index survives a card leaving play mid-window) carries over.
+3. **Backing store: scan behind an index-shaped interface; the #117 index is the
+   final Axis-B task.** `emit_event` calls one scan function; it is implemented
+   with the existing full board walk first (correctness, obviously so), then the
+   **#117 event-keyed index** (`TriggerKind → Vec<entry>`, maintained at
+   `CardInPlay` enter/leave-play, seeded at registry install) is swapped in
+   behind that interface as the **last task of Axis B**. The index is not just
+   perf — it is the more *maintainable* end-state: trigger-discovery knowledge is
+   registered once at enter/leave-play instead of smeared across per-timing-point
+   scan arms (each of which re-walks zones; C4a bolted on threat_area, C4c bolted
+   on location attachments), so a new zone or timing point needs no scan-code
+   edit. Landing it as its own final task isolates the index's new invariant
+   (every zone transition must update it, or it desyncs) from the dispatch
+   restructure. #117's defensive test (index survives a card leaving play
+   mid-window) carries over.
 
 4. **forced-vs-optional becomes an explicit per-ability property** on the DSL
    trigger: `Trigger::OnEvent { pattern, timing, kind: TriggerKind::{Forced,

--- a/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-umbrella-design.md
+++ b/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-umbrella-design.md
@@ -141,8 +141,9 @@ by the `SkillTest` frame — not a competing stack (only ever one test in flight
 no nesting today) but payload that lives beside the stack because it's read by
 many call sites (`drive_skill_test`, the `unreachable!` guards). If skill tests
 ever nest, that data moves into the frame too. Net: one stack
-(`Window` + `ForcedOrdering` + `Choice` frames, plus a `SkillTest` frame-ref),
-zero sync bookkeeping. The truly-orthogonal phase `pending_*` modes above are
+(a shared `Resolution` frame serving both the forced and reaction runs — see the
+Axis-B spec's "One loop, two phases" — plus `Choice` frames and a `SkillTest`
+frame-ref), zero sync bookkeeping. The truly-orthogonal phase `pending_*` modes above are
 singletons in disjoint phases, migrated only in the later cleanup pass.
 
 Rejected alternatives:

--- a/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-umbrella-design.md
+++ b/docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-umbrella-design.md
@@ -200,9 +200,16 @@ effect is itself a choice; depth 4).
    reentrancy caveat both dissolve out of this.**
 
 6. **Before-timing dispatch** (fire around the event, before its impact) is part
-   of the `emit_event` *signature* (it carries timing), but the Before-*firing*
-   wiring lands with its first consumer (Axis D) — no speculative code. After-
-   timing is today's path.
+   of the `emit_event` *signature* (it carries timing). Before-timing is **not
+   speculative — it already exists**: Cover Up 01007's `[reaction] When you would
+   discover 1 or more clues … discard that many from Cover Up instead`
+   (`EventPattern::WouldDiscoverClues`, `EventTiming::Before`) is a Before-timing
+   *replacement* reaction, currently implemented as a card-local seam at the
+   `discover_clue` chokepoint (`clue_interrupt_pending`; C5a explicitly scoped it
+   as "not a general before-timing subsystem … a future before-timing interrupt
+   reuses this seam"). The general Before-*firing* wiring through `emit_event`
+   lands with Axis D, which **absorbs the `clue_interrupt` seam** as its second
+   consumer (see §4 D). After-timing is today's path.
 
 ## §3 — the choice / input contract (shared)
 
@@ -267,12 +274,20 @@ effect is itself a choice; depth 4).
   player window") conflates reaction windows with player windows; Axis C tightens
   it to the pattern-matched predicate rather than inheriting the blanket.
 
-- **Axis D (cancellation)** — §2's **Before-timing dispatch** plus a
-  **cancel/replacement signal**: a fired Before-reaction returns a "cancel"
-  result the emitting site honors (skips the impact). The umbrella's only
-  obligation is that `emit_event`'s Before-phase can carry a cancel result back
-  to the call site; where the cancel window opens and how the parked attack is
-  discarded is the Axis-D spec.
+- **Axis D (cancellation / replacement)** — §2's **Before-timing dispatch** plus
+  a **cancel/replacement signal**: a fired Before-reaction returns a result the
+  emitting site honors (skips or replaces the impact). **Cancel is the degenerate
+  case of replacement** ("replace with nothing"), so Cover Up 01007 ("discover
+  clues → discard from Cover Up *instead*") and Dodge 01023 ("an enemy attacks →
+  *cancel* that attack") are the same family. Axis D generalizes both and **folds
+  in Cover Up's card-local `clue_interrupt` seam** (an existing consumer that
+  validates the general design — not a greenfield subsystem). The umbrella's only
+  obligation is that `emit_event`'s Before-phase can carry a cancel/replacement
+  result back to the call site; where the window opens, how the parked attack is
+  discarded, and the seam migration are the Axis-D spec. **Worked dependency:** the
+  `WouldDiscoverClues` interrupt + `discover_clue` reentrancy that C5a built
+  bounded to "terminal-position discovery" is the concrete thing Axis D
+  generalizes; revisit that bound here.
 
 ## §5 — decomposition, sequencing, card readiness
 


### PR DESCRIPTION
## What

Kickoff for the trigger-dispatch rework (the #212/#213/#117 north-star). Lands the design + plan; no engine code yet.

- **Umbrella architecture spec** — `docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-umbrella-design.md`
- **Axis-B foundation spec** — `docs/superpowers/specs/2026-06-16-trigger-dispatch-rework-axis-b-foundation-design.md`
- **Axis-B implementation plan** — `docs/superpowers/plans/2026-06-16-trigger-dispatch-axis-b-foundation.md`
- **Phase-7 doc** — north-star bullet repointed at the kickoff + axis/task breakdown.

## Design decisions (load-bearing)

- **One continuation stack** (`Vec<Continuation>`), incremental migration: trigger-dispatch + window + skill-test resumptions move on now; orthogonal `pending_*` phase modes stay (later cleanup). `open_windows` is *absorbed* (no marker dual-bookkeeping); `in_flight_skill_test` stays a singleton frame-ref.
- **`emit_event` two-phase dispatch**, RR-accurate **forced-then-reaction** (RR p.2) — corrects #213's "one mixed pool" framing (issue amended). Forced and reaction are one parameterized resolution loop (`can_skip`/candidate-source/decider).
- **`TimingEvent`** consolidates the two existing dispatch-key enums (`ForcedTriggerPoint` + event-driven `WindowKind`), kept separate from the observability/replay `Event` log (4 enums → 3).
- **`TriggerKind { Forced, Reaction }`** on `Trigger::OnEvent` retires route-by-pattern.
- **#117 index** is Axis-B's final task, swapped behind the scan interface.
- Verified vs the Rules Reference: forced-before-reaction (p.2), simultaneous-forced ordering by the lead (p.17), and **no priority-reset** in AHC (reaction phase = one pass in player order).

## Breakdown

Kickoff #327; Axis-B tasks #328–#333 (closes #212/#213/#117/#294); trackers #334 (A), #335 (C), #336 (D); Axis E = existing card-prereq issues.

Closes #327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)