### PR TITLE
engine: TriggerKind on Trigger::OnEvent (Axis-B T1)

### DIFF
--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -176,7 +176,33 @@ pub enum Trigger {
         /// Whether the trigger fires before or after the matching
         /// event finalizes.
         timing: EventTiming,
+        /// Whether this is a mandatory **forced** ability or an optional
+        /// player **reaction**. Determines which phase of the two-phase
+        /// `emit_event` dispatch it participates in — Rules Reference p.2:
+        /// "all forced abilities … must resolve before any `[reaction]`
+        /// abilities … may be initiated." Replaces the earlier
+        /// route-by-`EventPattern` heuristic (which forced twin patterns
+        /// for one game moment, e.g. `AfterLocationInvestigated` forced
+        /// vs `SuccessfullyInvestigated` reaction).
+        kind: TriggerKind,
     },
+}
+
+/// Whether an [`Trigger::OnEvent`] ability resolves mandatorily (forced)
+/// or is an optional player reaction.
+///
+/// Forced abilities all resolve before any reaction abilities at the same
+/// timing point (Rules Reference p.2), and the engine's `emit_event`
+/// dispatch keys its two phases off this distinction rather than guessing
+/// from the [`EventPattern`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum TriggerKind {
+    /// Mandatory; resolves automatically (the player only orders
+    /// simultaneous ones). Phase 1 of `emit_event`.
+    Forced,
+    /// Optional; the controller may use it in the reaction window.
+    /// Phase 2 of `emit_event`.
+    Reaction,
 }
 
 /// Which engine event(s) an [`Trigger::OnEvent`] ability listens for.
@@ -946,13 +972,36 @@ pub fn on_skill_test_resolution(outcome: TestOutcome, effect: Effect) -> Ability
 /// and timing. Costs are empty — reactive triggers fire from the
 /// engine's reaction-window plumbing, not via player activation.
 #[must_use]
-pub fn on_event(pattern: EventPattern, timing: EventTiming, effect: Effect) -> Ability {
+pub fn on_event(
+    pattern: EventPattern,
+    timing: EventTiming,
+    kind: TriggerKind,
+    effect: Effect,
+) -> Ability {
     Ability {
-        trigger: Trigger::OnEvent { pattern, timing },
+        trigger: Trigger::OnEvent {
+            pattern,
+            timing,
+            kind,
+        },
         costs: Vec::new(),
         effect,
         usage_limit: None,
     }
+}
+
+/// Construct a mandatory **forced** [`Trigger::OnEvent`] ability
+/// (`TriggerKind::Forced`). Convenience wrapper over [`on_event`].
+#[must_use]
+pub fn forced_on_event(pattern: EventPattern, timing: EventTiming, effect: Effect) -> Ability {
+    on_event(pattern, timing, TriggerKind::Forced, effect)
+}
+
+/// Construct an optional player **reaction** [`Trigger::OnEvent`] ability
+/// (`TriggerKind::Reaction`). Convenience wrapper over [`on_event`].
+#[must_use]
+pub fn reaction_on_event(pattern: EventPattern, timing: EventTiming, effect: Effect) -> Ability {
+    on_event(pattern, timing, TriggerKind::Reaction, effect)
 }
 
 /// Construct a [`Trigger::Revelation`]-driven [`Ability`] wrapping
@@ -1448,6 +1497,7 @@ mod tests {
                 code: None,
             },
             EventTiming::After,
+            TriggerKind::Reaction,
             discover_clue(LocationTarget::YourLocation, 1),
         );
         assert_eq!(
@@ -1458,6 +1508,7 @@ mod tests {
                     code: None,
                 },
                 timing: EventTiming::After,
+                kind: TriggerKind::Reaction,
             },
         );
         assert!(matches!(
@@ -1484,6 +1535,7 @@ mod tests {
                 code: None,
             },
             timing: EventTiming::After,
+            kind: TriggerKind::Reaction,
         };
         let after_controller = Trigger::OnEvent {
             pattern: EventPattern::EnemyDefeated {
@@ -1491,6 +1543,7 @@ mod tests {
                 code: None,
             },
             timing: EventTiming::After,
+            kind: TriggerKind::Reaction,
         };
         let before_controller = Trigger::OnEvent {
             pattern: EventPattern::EnemyDefeated {
@@ -1498,6 +1551,7 @@ mod tests {
                 code: None,
             },
             timing: EventTiming::Before,
+            kind: TriggerKind::Reaction,
         };
         assert_ne!(after_any, Trigger::Constant);
         assert_ne!(after_any, Trigger::OnPlay);
@@ -1522,12 +1576,43 @@ mod tests {
                     code: None,
                 },
                 timing,
+                TriggerKind::Reaction,
                 discover_clue(LocationTarget::YourLocation, 1),
             );
             let json = serde_json::to_string(&original).expect("serialize");
             let recovered: Ability = serde_json::from_str(&json).expect("deserialize");
             assert_eq!(original, recovered);
         }
+    }
+
+    /// `Trigger::OnEvent` carries an explicit `TriggerKind` (forced vs
+    /// reaction), and it round-trips through serde. The kind retires the
+    /// old route-by-pattern dispatch (umbrella §2, Axis-B T1).
+    #[test]
+    fn on_event_carries_trigger_kind() {
+        let t = Trigger::OnEvent {
+            pattern: EventPattern::EnemyDefeated {
+                by_controller: true,
+                code: None,
+            },
+            timing: EventTiming::After,
+            kind: TriggerKind::Reaction,
+        };
+        let json = serde_json::to_string(&t).expect("serialize");
+        let back: Trigger = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(t, back);
+        // Forced and Reaction are distinct.
+        assert_ne!(
+            t,
+            Trigger::OnEvent {
+                pattern: EventPattern::EnemyDefeated {
+                    by_controller: true,
+                    code: None,
+                },
+                timing: EventTiming::After,
+                kind: TriggerKind::Forced,
+            },
+        );
     }
 
     /// The `revelation` builder produces the new Trigger variant with

--- a/crates/cards/src/impls/act_01108.rs
+++ b/crates/cards/src/impls/act_01108.rs
@@ -21,7 +21,7 @@
 //! lives card-locally as a [`card_dsl::dsl::Effect::Native`] handler
 //! (the `board_build` fn) rather than as shared `Effect` variants (#276).
 
-use card_dsl::dsl::{native, on_event, Ability, EventPattern, EventTiming};
+use card_dsl::dsl::{forced_on_event, native, Ability, EventPattern, EventTiming};
 use game_core::card_registry::NativeEffectFn;
 use game_core::{location_id_by_code, reveal_location, Cx, EngineOutcome, EvalContext, Event};
 
@@ -34,7 +34,7 @@ const BOARD_BUILD: &str = "01108:board-build";
 /// 01108's Forced on-advance reverse: build the Act-1 board.
 #[must_use]
 pub fn abilities() -> Vec<Ability> {
-    vec![on_event(
+    vec![forced_on_event(
         EventPattern::ActAdvanced,
         EventTiming::After,
         native(BOARD_BUILD),
@@ -106,7 +106,8 @@ mod tests {
             abilities[0].trigger,
             Trigger::OnEvent {
                 pattern: EventPattern::ActAdvanced,
-                timing: EventTiming::After
+                timing: EventTiming::After,
+                kind: card_dsl::dsl::TriggerKind::Forced,
             }
         );
         assert!(

--- a/crates/cards/src/impls/act_01109.rs
+++ b/crates/cards/src/impls/act_01109.rs
@@ -36,7 +36,7 @@
 //! single-trigger forced-advance path until #213/#212; consistent with
 //! the rest of Slice 1's solo-first scope.
 
-use card_dsl::dsl::{native, on_event, Ability, EventPattern, EventTiming};
+use card_dsl::dsl::{forced_on_event, native, Ability, EventPattern, EventTiming};
 use game_core::card_registry::NativeEffectFn;
 use game_core::{
     location_id_by_code, reveal_location, spawn_set_aside_enemy, Cx, EngineOutcome, EvalContext,
@@ -56,7 +56,7 @@ const PARLOR: &str = "01115";
 /// 01109's Forced on-advance reverse: reveal the Parlor + spawn the Priest.
 #[must_use]
 pub fn abilities() -> Vec<Ability> {
-    vec![on_event(
+    vec![forced_on_event(
         EventPattern::ActAdvanced,
         EventTiming::After,
         native(REVERSE),
@@ -102,7 +102,8 @@ mod tests {
             abilities[0].trigger,
             Trigger::OnEvent {
                 pattern: EventPattern::ActAdvanced,
-                timing: EventTiming::After
+                timing: EventTiming::After,
+                kind: card_dsl::dsl::TriggerKind::Forced,
             }
         );
         assert!(

--- a/crates/cards/src/impls/act_01110.rs
+++ b/crates/cards/src/impls/act_01110.rs
@@ -17,7 +17,7 @@
 //! Won/R1 latch. The Ghoul Priest enemy + its spawn land in C3 (#231);
 //! this objective is unit-tested here and proven end-to-end in C7b (#245).
 
-use card_dsl::dsl::{advance_current_act, on_event, Ability, EventPattern, EventTiming};
+use card_dsl::dsl::{advance_current_act, forced_on_event, Ability, EventPattern, EventTiming};
 
 /// `ArkhamDB` code for Act 3, "What Have You Done?".
 pub const CODE: &str = "01110";
@@ -25,7 +25,7 @@ pub const CODE: &str = "01110";
 /// 01110's Forced objective: advance when the Ghoul Priest is defeated.
 #[must_use]
 pub fn abilities() -> Vec<Ability> {
-    vec![on_event(
+    vec![forced_on_event(
         EventPattern::EnemyDefeated {
             by_controller: false,
             code: Some("01116".to_owned()),
@@ -51,6 +51,7 @@ mod tests {
                     code: Some("01116".into()),
                 },
                 timing: EventTiming::After,
+                kind: card_dsl::dsl::TriggerKind::Forced,
             }
         );
         assert!(matches!(abilities[0].effect, Effect::AdvanceCurrentAct));

--- a/crates/cards/src/impls/agenda_01105.rs
+++ b/crates/cards/src/impls/agenda_01105.rs
@@ -34,7 +34,7 @@
 //! [#212]: https://github.com/talelburg/eldritch/issues/212
 
 use card_dsl::dsl::{
-    deal_horror, on_event, Ability, EventPattern, EventTiming, InvestigatorTarget,
+    deal_horror, forced_on_event, Ability, EventPattern, EventTiming, InvestigatorTarget,
 };
 
 /// `ArkhamDB` code for Agenda 1, "What's Going On?!".
@@ -44,7 +44,7 @@ pub const CODE: &str = "01105";
 /// 2-horror-to-the-lead branch; see the module docs / TODO #212).
 #[must_use]
 pub fn abilities() -> Vec<Ability> {
-    vec![on_event(
+    vec![forced_on_event(
         EventPattern::AgendaAdvanced,
         EventTiming::After,
         // `You` binds to the controller, which `AgendaAdvanced` sets to the
@@ -66,6 +66,7 @@ mod tests {
             Trigger::OnEvent {
                 pattern: EventPattern::AgendaAdvanced,
                 timing: EventTiming::After,
+                kind: card_dsl::dsl::TriggerKind::Forced,
             }
         );
         assert_eq!(

--- a/crates/cards/src/impls/agenda_01106.rs
+++ b/crates/cards/src/impls/agenda_01106.rs
@@ -31,7 +31,7 @@
 //! forced-advance path until #212/#213, consistent with Slice 1.
 
 use card_dsl::card_data::CardType;
-use card_dsl::dsl::{native, on_event, Ability, EventPattern, EventTiming};
+use card_dsl::dsl::{forced_on_event, native, Ability, EventPattern, EventTiming};
 use game_core::card_registry::NativeEffectFn;
 use game_core::{
     reshuffle_encounter_discard, resolve_encounter_card, Cx, EngineOutcome, EvalContext,
@@ -45,7 +45,7 @@ const REVERSE: &str = "01106:reverse";
 
 #[must_use]
 pub fn abilities() -> Vec<Ability> {
-    vec![on_event(
+    vec![forced_on_event(
         EventPattern::AgendaAdvanced,
         EventTiming::After,
         native(REVERSE),
@@ -96,6 +96,7 @@ mod tests {
             Trigger::OnEvent {
                 pattern: EventPattern::AgendaAdvanced,
                 timing: EventTiming::After,
+                kind: card_dsl::dsl::TriggerKind::Forced,
             }
         );
         assert!(

--- a/crates/cards/src/impls/agenda_01107.rs
+++ b/crates/cards/src/impls/agenda_01107.rs
@@ -20,7 +20,7 @@
 //! deferred until a map with ties lands). Engagement-on-arrival is not
 //! modeled for the forced move (the card text is positional only).
 
-use card_dsl::dsl::{native, on_event, Ability, EventPattern, EventTiming, Phase};
+use card_dsl::dsl::{forced_on_event, native, Ability, EventPattern, EventTiming, Phase};
 use game_core::card_registry::NativeEffectFn;
 use game_core::state::{EnemyId, LocationId};
 use game_core::{location_id_by_code, shortest_first_steps, Cx, EngineOutcome, EvalContext, Event};
@@ -39,14 +39,14 @@ const HALLWAY: &str = "01112";
 #[must_use]
 pub fn abilities() -> Vec<Ability> {
     vec![
-        on_event(
+        forced_on_event(
             EventPattern::PhaseEnded {
                 phase: Phase::Enemy,
             },
             EventTiming::After,
             native(MOVE_GHOULS),
         ),
-        on_event(
+        forced_on_event(
             EventPattern::RoundEnded,
             EventTiming::After,
             native(ROUND_END_DOOM),
@@ -179,7 +179,8 @@ mod tests {
                 pattern: EventPattern::PhaseEnded {
                     phase: Phase::Enemy
                 },
-                timing: EventTiming::After
+                timing: EventTiming::After,
+                kind: card_dsl::dsl::TriggerKind::Forced,
             }
         );
         assert!(matches!(&abilities[0].effect, Effect::Native { tag } if tag == MOVE_GHOULS));
@@ -187,7 +188,8 @@ mod tests {
             abilities[1].trigger,
             Trigger::OnEvent {
                 pattern: EventPattern::RoundEnded,
-                timing: EventTiming::After
+                timing: EventTiming::After,
+                kind: card_dsl::dsl::TriggerKind::Forced,
             }
         );
         assert!(matches!(&abilities[1].effect, Effect::Native { tag } if tag == ROUND_END_DOOM));

--- a/crates/cards/src/impls/attic.rs
+++ b/crates/cards/src/impls/attic.rs
@@ -12,7 +12,7 @@
 //! Forced horror lives here.
 
 use card_dsl::dsl::{
-    deal_horror, on_event, Ability, EventPattern, EventTiming, InvestigatorTarget,
+    deal_horror, forced_on_event, Ability, EventPattern, EventTiming, InvestigatorTarget,
 };
 
 /// `ArkhamDB` code for the Attic.
@@ -21,7 +21,7 @@ pub const CODE: &str = "01113";
 /// The Attic's Forced "after you enter: take 1 horror".
 #[must_use]
 pub fn abilities() -> Vec<Ability> {
-    vec![on_event(
+    vec![forced_on_event(
         EventPattern::EnteredLocation,
         EventTiming::After,
         deal_horror(InvestigatorTarget::You, 1),
@@ -41,6 +41,7 @@ mod tests {
             Trigger::OnEvent {
                 pattern: EventPattern::EnteredLocation,
                 timing: EventTiming::After,
+                kind: card_dsl::dsl::TriggerKind::Forced,
             }
         );
         assert!(matches!(

--- a/crates/cards/src/impls/cellar.rs
+++ b/crates/cards/src/impls/cellar.rs
@@ -10,7 +10,7 @@
 //! Clues / Victory are location state set by `setup()`.
 
 use card_dsl::dsl::{
-    deal_damage, on_event, Ability, EventPattern, EventTiming, InvestigatorTarget,
+    deal_damage, forced_on_event, Ability, EventPattern, EventTiming, InvestigatorTarget,
 };
 
 /// `ArkhamDB` code for the Cellar.
@@ -19,7 +19,7 @@ pub const CODE: &str = "01114";
 /// The Cellar's Forced "after you enter: take 1 damage".
 #[must_use]
 pub fn abilities() -> Vec<Ability> {
-    vec![on_event(
+    vec![forced_on_event(
         EventPattern::EnteredLocation,
         EventTiming::After,
         deal_damage(InvestigatorTarget::You, 1),
@@ -39,6 +39,7 @@ mod tests {
             Trigger::OnEvent {
                 pattern: EventPattern::EnteredLocation,
                 timing: EventTiming::After,
+                kind: card_dsl::dsl::TriggerKind::Forced,
             }
         );
         assert!(matches!(

--- a/crates/cards/src/impls/dr_milan_christopher.rs
+++ b/crates/cards/src/impls/dr_milan_christopher.rs
@@ -21,7 +21,7 @@
 //! mechanically weaker than printed until the soak primitive lands.
 
 use card_dsl::dsl::{
-    constant, gain_resources, modify, on_event, Ability, EventPattern, EventTiming,
+    constant, gain_resources, modify, reaction_on_event, Ability, EventPattern, EventTiming,
     InvestigatorTarget, ModifierScope, Stat,
 };
 
@@ -34,7 +34,7 @@ pub const CODE: &str = "01033";
 pub fn abilities() -> Vec<Ability> {
     vec![
         constant(modify(Stat::Intellect, 1, ModifierScope::WhileInPlay)),
-        on_event(
+        reaction_on_event(
             EventPattern::SuccessfullyInvestigated,
             EventTiming::After,
             gain_resources(InvestigatorTarget::You, 1),
@@ -68,6 +68,7 @@ mod tests {
             Trigger::OnEvent {
                 pattern: EventPattern::SuccessfullyInvestigated,
                 timing: EventTiming::After,
+                kind: card_dsl::dsl::TriggerKind::Reaction,
             },
         );
         assert_eq!(

--- a/crates/cards/src/impls/guard_dog.rs
+++ b/crates/cards/src/impls/guard_dog.rs
@@ -19,7 +19,7 @@
 //! instance), and reads the attacker from `EvalContext.attacking_enemy`,
 //! which the soak window binds. (C5b #237.)
 
-use card_dsl::dsl::{native, on_event, Ability, EventPattern, EventTiming};
+use card_dsl::dsl::{native, reaction_on_event, Ability, EventPattern, EventTiming};
 use game_core::card_registry::NativeEffectFn;
 use game_core::{deal_damage_to_enemy, Cx, EngineOutcome, EvalContext};
 
@@ -30,7 +30,7 @@ const RETALIATE: &str = "01021:retaliate";
 
 #[must_use]
 pub fn abilities() -> Vec<Ability> {
-    vec![on_event(
+    vec![reaction_on_event(
         EventPattern::EnemyAttackDamagedSelf,
         EventTiming::After,
         native(RETALIATE),
@@ -95,6 +95,7 @@ mod tests {
             Trigger::OnEvent {
                 pattern: EventPattern::EnemyAttackDamagedSelf,
                 timing: EventTiming::After,
+                kind: card_dsl::dsl::TriggerKind::Reaction,
             }
         );
         assert!(matches!(&abilities[0].effect, Effect::Native { tag } if tag == RETALIATE));

--- a/crates/cards/src/impls/roland_banks.rs
+++ b/crates/cards/src/impls/roland_banks.rs
@@ -33,8 +33,8 @@
 //! [`UsageLimit`]: card_dsl::dsl::UsageLimit
 
 use card_dsl::dsl::{
-    discover_clue, on_event, Ability, EventPattern, EventTiming, LocationTarget, UsageLimit,
-    UsagePeriod,
+    discover_clue, reaction_on_event, Ability, EventPattern, EventTiming, LocationTarget,
+    UsageLimit, UsagePeriod,
 };
 
 /// `ArkhamDB` code for the original-Core printing.
@@ -45,7 +45,7 @@ pub const CODE: &str = "01001";
 /// is tracked separately (#118).
 #[must_use]
 pub fn abilities() -> Vec<Ability> {
-    vec![on_event(
+    vec![reaction_on_event(
         EventPattern::EnemyDefeated {
             by_controller: true,
             code: None,
@@ -77,6 +77,7 @@ mod tests {
                     code: None,
                 },
                 timing: EventTiming::After,
+                kind: card_dsl::dsl::TriggerKind::Reaction,
             },
         );
         assert!(matches!(

--- a/crates/cards/src/impls/treachery_01007.rs
+++ b/crates/cards/src/impls/treachery_01007.rs
@@ -17,8 +17,8 @@
 //! synthetic Cover-Up fixture C5a proved (`scenarios::test_fixtures::synth_cards`).
 
 use card_dsl::dsl::{
-    native, on_event, put_into_threat_area_with_clues, revelation, Ability, EventPattern,
-    EventTiming,
+    forced_on_event, native, put_into_threat_area_with_clues, reaction_on_event, revelation,
+    Ability, EventPattern, EventTiming,
 };
 use game_core::card_registry::NativeEffectFn;
 use game_core::event::TraumaKind;
@@ -36,12 +36,12 @@ const TRAUMA_TAG: &str = "01007:trauma";
 pub fn abilities() -> Vec<Ability> {
     vec![
         revelation(put_into_threat_area_with_clues(CODE, 3)),
-        on_event(
+        reaction_on_event(
             EventPattern::WouldDiscoverClues,
             EventTiming::Before,
             native(DISCARD_TAG),
         ),
-        on_event(
+        forced_on_event(
             EventPattern::GameEnd,
             EventTiming::After,
             native(TRAUMA_TAG),
@@ -132,6 +132,7 @@ mod tests {
             Trigger::OnEvent {
                 pattern: EventPattern::WouldDiscoverClues,
                 timing: EventTiming::Before,
+                ..
             }
         ));
         assert!(matches!(

--- a/crates/cards/src/impls/treachery_01164.rs
+++ b/crates/cards/src/impls/treachery_01164.rs
@@ -20,8 +20,8 @@
 
 use card_dsl::card_data::SkillKind;
 use card_dsl::dsl::{
-    constant, discard_self, on_event, put_into_threat_area, restrict, revelation, skill_test,
-    Ability, ActionClass, EventPattern, EventTiming, Restriction,
+    constant, discard_self, forced_on_event, put_into_threat_area, restrict, revelation,
+    skill_test, Ability, ActionClass, EventPattern, EventTiming, Restriction,
 };
 
 /// `ArkhamDB` code for Frozen in Fear.
@@ -35,7 +35,7 @@ pub fn abilities() -> Vec<Ability> {
             actions: vec![ActionClass::Move, ActionClass::Fight, ActionClass::Evade],
             first_each_round: true,
         })),
-        on_event(
+        forced_on_event(
             EventPattern::EndOfTurn,
             EventTiming::After,
             // Test willpower(3): on success discard Frozen in Fear.
@@ -78,6 +78,7 @@ mod tests {
             Trigger::OnEvent {
                 pattern: EventPattern::EndOfTurn,
                 timing: EventTiming::After,
+                ..
             }
         ));
         let Effect::SkillTest {

--- a/crates/cards/src/impls/treachery_01165.rs
+++ b/crates/cards/src/impls/treachery_01165.rs
@@ -17,7 +17,7 @@
 
 use card_dsl::card_data::CardType;
 use card_dsl::dsl::{
-    constant, discard_self, on_event, put_into_threat_area, restrict, revelation, Ability,
+    constant, discard_self, forced_on_event, put_into_threat_area, restrict, revelation, Ability,
     EventPattern, EventTiming, Restriction,
 };
 
@@ -30,7 +30,7 @@ pub fn abilities() -> Vec<Ability> {
         revelation(put_into_threat_area(CODE)),
         constant(restrict(Restriction::CannotPlay(CardType::Asset))),
         constant(restrict(Restriction::CannotPlay(CardType::Event))),
-        on_event(EventPattern::RoundEnded, EventTiming::After, discard_self()),
+        forced_on_event(EventPattern::RoundEnded, EventTiming::After, discard_self()),
     ]
 }
 
@@ -64,6 +64,7 @@ mod tests {
             Trigger::OnEvent {
                 pattern: EventPattern::RoundEnded,
                 timing: EventTiming::After,
+                ..
             }
         ));
         assert!(matches!(&abilities[3].effect, Effect::DiscardSelf));

--- a/crates/cards/src/impls/treachery_01168.rs
+++ b/crates/cards/src/impls/treachery_01168.rs
@@ -18,7 +18,7 @@
 //! which finds this attachment by the firing instance.
 
 use card_dsl::dsl::{
-    constant, discard_self, modify, native, on_event, revelation, Ability, EventPattern,
+    constant, discard_self, forced_on_event, modify, native, revelation, Ability, EventPattern,
     EventTiming, ModifierScope, Stat,
 };
 use game_core::card_registry::NativeEffectFn;
@@ -35,7 +35,7 @@ pub fn abilities() -> Vec<Ability> {
     vec![
         revelation(native(LIMIT1_ATTACH)),
         constant(modify(Stat::Shroud, 2, ModifierScope::WhileInPlay)),
-        on_event(
+        forced_on_event(
             EventPattern::AfterLocationInvestigated,
             EventTiming::After,
             discard_self(),
@@ -113,6 +113,7 @@ mod tests {
             Trigger::OnEvent {
                 pattern: EventPattern::AfterLocationInvestigated,
                 timing: EventTiming::After,
+                ..
             }
         ));
         assert!(matches!(&abilities[2].effect, Effect::DiscardSelf));

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -347,7 +347,10 @@ fn push_matching(
         return;
     };
     for (idx, ability) in abilities.iter().enumerate() {
-        if let Trigger::OnEvent { pattern, timing } = &ability.trigger {
+        if let Trigger::OnEvent {
+            pattern, timing, ..
+        } = &ability.trigger
+        {
             // Only `After` timing is handled in this slice; no in-scope
             // Forced card uses `Before` ("when X would Y") timing.
             // Revisit when such a card lands.

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -109,7 +109,10 @@ fn scan_pending_triggers(state: &GameState, kind: WindowKind) -> Vec<PendingTrig
                 continue;
             };
             for (idx, ability) in abilities.iter().enumerate() {
-                let Trigger::OnEvent { pattern, timing } = &ability.trigger else {
+                let Trigger::OnEvent {
+                    pattern, timing, ..
+                } = &ability.trigger
+                else {
                     continue;
                 };
                 if !trigger_matches(kind, pattern, *timing, id) {

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -718,6 +718,7 @@ fn discover_clue(
                                 crate::dsl::Trigger::OnEvent {
                                     pattern: crate::dsl::EventPattern::WouldDiscoverClues,
                                     timing: crate::dsl::EventTiming::Before,
+                                    ..
                                 }
                             )
                         })?;

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -19,7 +19,7 @@ use game_core::card_data::CardMetadata;
 use game_core::card_registry::CardRegistry;
 use game_core::dsl::Phase as DslPhase;
 use game_core::dsl::{
-    deal_horror, on_event, Ability, EventPattern, EventTiming, InvestigatorTarget,
+    deal_horror, forced_on_event, Ability, EventPattern, EventTiming, InvestigatorTarget,
 };
 use game_core::engine::EngineOutcome;
 use game_core::event::Event;
@@ -64,13 +64,13 @@ fn mock_metadata_for(_: &CardCode) -> Option<&'static CardMetadata> {
 
 fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
     if code.as_str() == HORROR_ATTIC {
-        Some(vec![on_event(
+        Some(vec![forced_on_event(
             EventPattern::EnteredLocation,
             EventTiming::After,
             deal_horror(InvestigatorTarget::You, 1),
         )])
     } else if code.as_str() == DOOM_AGENDA || code.as_str() == DOOM_ACT {
-        Some(vec![on_event(
+        Some(vec![forced_on_event(
             EventPattern::PhaseEnded {
                 phase: DslPhase::Enemy,
             },
@@ -81,25 +81,25 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
         // Two distinct forced `EnteredLocation` abilities at the same timing
         // point — exercises ordered multi-resolution (both fire in order).
         Some(vec![
-            on_event(
+            forced_on_event(
                 EventPattern::EnteredLocation,
                 EventTiming::After,
                 deal_horror(InvestigatorTarget::You, 1),
             ),
-            on_event(
+            forced_on_event(
                 EventPattern::EnteredLocation,
                 EventTiming::After,
                 deal_horror(InvestigatorTarget::You, 1),
             ),
         ])
     } else if code.as_str() == END_OF_TURN_CARD {
-        Some(vec![on_event(
+        Some(vec![forced_on_event(
             EventPattern::EndOfTurn,
             EventTiming::After,
             deal_horror(InvestigatorTarget::You, 1),
         )])
     } else if code.as_str() == AFTER_INVESTIGATE_CARD {
-        Some(vec![on_event(
+        Some(vec![forced_on_event(
             EventPattern::AfterLocationInvestigated,
             EventTiming::After,
             deal_horror(InvestigatorTarget::You, 1),

--- a/crates/game-core/tests/native_effect.rs
+++ b/crates/game-core/tests/native_effect.rs
@@ -5,7 +5,7 @@
 
 use std::sync::OnceLock;
 
-use card_dsl::dsl::{native, on_event, Ability, EventPattern, EventTiming};
+use card_dsl::dsl::{forced_on_event, native, Ability, EventPattern, EventTiming};
 use game_core::card_data::CardMetadata;
 use game_core::card_registry::{self, CardRegistry, NativeEffectFn};
 use game_core::state::{Agenda, CardCode, GameState, InvestigatorId, Phase};
@@ -22,7 +22,7 @@ fn mock_metadata_for(_: &CardCode) -> Option<&'static CardMetadata> {
 fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
     if code.as_str() == AGENDA {
         // Forced at end of enemy phase -> a native effect tagged "test:set-doom".
-        Some(vec![on_event(
+        Some(vec![forced_on_event(
             EventPattern::PhaseEnded {
                 phase: card_dsl::dsl::Phase::Enemy,
             },
@@ -30,7 +30,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
             native("test:set-doom"),
         )])
     } else if code.as_str() == AGENDA_BAD {
-        Some(vec![on_event(
+        Some(vec![forced_on_event(
             EventPattern::PhaseEnded {
                 phase: card_dsl::dsl::Phase::Enemy,
             },

--- a/crates/game-core/tests/reaction_windows.rs
+++ b/crates/game-core/tests/reaction_windows.rs
@@ -17,7 +17,7 @@ use std::sync::OnceLock;
 use game_core::card_data::CardMetadata;
 use game_core::card_registry::CardRegistry;
 use game_core::dsl::{
-    discover_clue, gain_resources, on_event, Ability, EventPattern, EventTiming,
+    discover_clue, gain_resources, reaction_on_event, Ability, EventPattern, EventTiming,
     InvestigatorTarget, LocationTarget,
 };
 use game_core::engine::EngineOutcome;
@@ -57,7 +57,7 @@ fn mock_metadata_for(_: &CardCode) -> Option<&'static CardMetadata> {
 
 fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
     match code.as_str() {
-        ROLAND_REACTION => Some(vec![on_event(
+        ROLAND_REACTION => Some(vec![reaction_on_event(
             EventPattern::EnemyDefeated {
                 by_controller: true,
                 code: None,
@@ -65,7 +65,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
             EventTiming::After,
             discover_clue(LocationTarget::YourLocation, 1),
         )]),
-        BYSTANDER_REACTION => Some(vec![on_event(
+        BYSTANDER_REACTION => Some(vec![reaction_on_event(
             EventPattern::EnemyDefeated {
                 by_controller: false,
                 code: None,
@@ -74,7 +74,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
             gain_resources(InvestigatorTarget::You, 1),
         )]),
         TWO_REACTIONS => Some(vec![
-            on_event(
+            reaction_on_event(
                 EventPattern::EnemyDefeated {
                     by_controller: true,
                     code: None,
@@ -82,7 +82,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
                 EventTiming::After,
                 discover_clue(LocationTarget::YourLocation, 1),
             ),
-            on_event(
+            reaction_on_event(
                 EventPattern::EnemyDefeated {
                     by_controller: true,
                     code: None,
@@ -91,7 +91,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
                 gain_resources(InvestigatorTarget::You, 1),
             ),
         ]),
-        MILAN_REACTION => Some(vec![on_event(
+        MILAN_REACTION => Some(vec![reaction_on_event(
             EventPattern::SuccessfullyInvestigated,
             EventTiming::After,
             gain_resources(InvestigatorTarget::You, 1),

--- a/crates/game-core/tests/round_ended.rs
+++ b/crates/game-core/tests/round_ended.rs
@@ -3,7 +3,7 @@
 
 use std::sync::OnceLock;
 
-use card_dsl::dsl::{native, on_event, Ability, EventPattern, EventTiming};
+use card_dsl::dsl::{forced_on_event, native, Ability, EventPattern, EventTiming};
 use game_core::card_data::CardMetadata;
 use game_core::card_registry::{self, CardRegistry, NativeEffectFn};
 use game_core::state::{Agenda, CardCode, InvestigatorId};
@@ -18,7 +18,7 @@ fn mock_metadata_for(_: &CardCode) -> Option<&'static CardMetadata> {
 
 fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
     (code.as_str() == AGENDA).then(|| {
-        vec![on_event(
+        vec![forced_on_event(
             EventPattern::RoundEnded,
             EventTiming::After,
             native("test:set-doom"),

--- a/crates/scenarios/src/test_fixtures/synth_cards.rs
+++ b/crates/scenarios/src/test_fixtures/synth_cards.rs
@@ -20,8 +20,8 @@ use game_core::card_data::{
 };
 use game_core::card_registry::{CardRegistry, NativeEffectFn};
 use game_core::dsl::{
-    gain_resources, native, on_event, on_play, revelation, Ability, EventPattern, EventTiming,
-    InvestigatorTarget,
+    forced_on_event, gain_resources, native, on_play, reaction_on_event, revelation, Ability,
+    EventPattern, EventTiming, InvestigatorTarget,
 };
 use game_core::engine::{Cx, EngineOutcome, EvalContext};
 use game_core::event::{Event, TraumaKind};
@@ -288,12 +288,12 @@ fn abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
         }
         SYNTH_FAST_EVENT_CODE => Some(vec![on_play(gain_resources(InvestigatorTarget::You, 1))]),
         SYNTH_COVER_UP_CODE => Some(vec![
-            on_event(
+            reaction_on_event(
                 EventPattern::WouldDiscoverClues,
                 EventTiming::Before,
                 native(SYNTH_COVER_UP_DISCARD_TAG),
             ),
-            on_event(
+            forced_on_event(
                 EventPattern::GameEnd,
                 EventTiming::After,
                 native(SYNTH_COVER_UP_TRAUMA_TAG),
@@ -372,6 +372,7 @@ mod tests {
             game_core::dsl::Trigger::OnEvent {
                 pattern: game_core::dsl::EventPattern::WouldDiscoverClues,
                 timing: game_core::dsl::EventTiming::Before,
+                ..
             }
         ));
         assert!(matches!(


### PR DESCRIPTION
First task of the Axis-B trigger-dispatch foundation (plan: `docs/superpowers/plans/2026-06-16-trigger-dispatch-axis-b-foundation.md`; kickoff #327).

## What
Adds `TriggerKind { Forced, Reaction }` to `Trigger::OnEvent`, making forced-vs-reaction an **explicit DSL property** instead of the route-by-`EventPattern` heuristic (which had to invent twin patterns like `AfterLocationInvestigated` forced vs `SuccessfullyInvestigated` reaction for one game moment).

- New `forced_on_event` / `reaction_on_event` builders over the 4-arg `on_event` base.
- Every existing `OnEvent` card classified: scenario-structure (acts/agendas/locations/persistent treacheries) → `Forced`; Roland 01001 / Dr. Milan 01033 / Guard Dog 01021 → `Reaction`. **Cover Up 01007 carries both** — `WouldDiscoverClues` (reaction) + `GameEnd` (forced).

## Behavior-preserving
Dispatch is unchanged: the forced path and reaction windows still route by pattern and **ignore `kind`** (engine match sites take `..`). The two-phase `emit_event` dispatch reads `kind` in T5. Serde round-trip covered; full strict gauntlet green.

Closes #328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)