### PR TITLE
engine: continuation stack scaffolding + resume router (Axis-B T2)

### DIFF
--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -324,6 +324,20 @@ pub(super) struct ActivateCheckResult {
     pub source_exhausted: bool,
 }
 
+/// Resume the top frame of the continuation stack (umbrella §1 / Axis-B).
+///
+/// The single resume entry point that `resolve_input` routes to before the
+/// legacy `pending_*` ladder. [`Continuation`](crate::state::Continuation)
+/// is uninhabited until Task 3, so the stack is statically always empty
+/// and this is unreachable today; Tasks 3–5 add the per-frame resume arms.
+fn resume_continuation(cx: &mut Cx, _response: &InputResponse) -> EngineOutcome {
+    match cx.state.continuations.last() {
+        // No frame variants yet — uninhabited match (Tasks 3–5).
+        Some(frame) => match *frame {},
+        None => unreachable!("resume_continuation: router only calls this with a non-empty stack"),
+    }
+}
+
 /// Dispatch a [`PlayerAction::ResolveInput`].
 ///
 /// Routes to the right resume handler based on which suspension is
@@ -350,6 +364,14 @@ pub(super) struct ActivateCheckResult {
 /// index. This covers the `MythosAfterDraws` window after all Fast
 /// plays have been made and the player is done.
 pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
+    // Single resume router (umbrella §1 / Axis-B): the continuation stack
+    // takes priority over the legacy `pending_*` ladder below. Empty until
+    // Task 3 begins pushing frames (`Continuation` is uninhabited today),
+    // so this currently always falls through.
+    if !cx.state.continuations.is_empty() {
+        return resume_continuation(cx, response);
+    }
+
     // Hunter movement, spawn engagement, and hand-size discard are three
     // mutually exclusive suspension modes (different phases). Route to the
     // right resume handler before the reaction-window and skill-test checks.

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -274,6 +274,7 @@ impl GameStateBuilder {
             pending_skill_modifiers: Vec::new(),
             in_flight_skill_test: None,
             open_windows: self.open_windows,
+            continuations: Vec::new(),
             scenario_id: self.scenario_id,
             mythos_draw_pending: None,
             enemy_attack_pending: None,

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -155,6 +155,12 @@ pub struct GameState {
     /// the same apply) is now structural — push twice, drive resumes
     /// in reverse open order.
     pub open_windows: Vec<OpenWindow>,
+    /// The single suspend/resume stack (umbrella §1 / Axis-B): the top
+    /// frame is resumed by `resolve_input`, taking priority over the
+    /// legacy `pending_*` modes. Empty until Task 3 begins pushing
+    /// frames; `#[serde(default)]` so pre-field states still load.
+    #[serde(default)]
+    pub continuations: Vec<Continuation>,
     /// Identifier of the scenario this state belongs to, if any.
     ///
     /// `None` for tests and fixtures that don't care about scenario
@@ -381,6 +387,19 @@ pub struct PendingEnemyAttack {
     /// Which loop to re-enter.
     pub source: EnemyAttackSource,
 }
+
+/// A frame on the [`GameState::continuations`] suspend/resume stack
+/// (umbrella §1 / Axis-B): a typed resume point, not a closure, so it
+/// serializes for replay/persistence like every other state field.
+///
+/// Uninhabited for now — Task 2 lands the field + the single resume
+/// router with the stack always empty; Task 3 adds the first real variant
+/// (`Resolution`, the shared forced/reaction loop), Task 4 adds
+/// `SkillTest`, and Axis A adds `Choice`. Because the enum has no
+/// variants yet, the stack is statically always empty and the router's
+/// resume branch is unreachable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Continuation {}
 
 /// A skill test paused mid-resolution at the commit window.
 ///
@@ -1225,6 +1244,27 @@ mod clue_interrupt_pending_tests {
     fn clue_interrupt_pending_defaults_none_and_absent_field_loads() {
         let s = GameStateBuilder::new().build();
         assert!(s.clue_interrupt_pending.is_none());
+    }
+}
+
+#[cfg(test)]
+mod continuation_stack_tests {
+    use super::*;
+    use crate::test_support::GameStateBuilder;
+
+    #[test]
+    fn continuations_default_empty_and_absent_field_loads() {
+        let s = GameStateBuilder::new().build();
+        assert!(s.continuations.is_empty());
+
+        // A pre-field serialized state (no `continuations` key) still loads,
+        // defaulting to an empty stack (`#[serde(default)]`).
+        let mut v = serde_json::to_value(&s).expect("serialize");
+        v.as_object_mut()
+            .expect("state serializes to a JSON object")
+            .remove("continuations");
+        let back: GameState = serde_json::from_value(v).expect("deserialize without the field");
+        assert!(back.continuations.is_empty());
     }
 }
 

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -24,10 +24,10 @@ pub use counter::Counter;
 pub(crate) use counter::define_id;
 pub use enemy::{Enemy, EnemyId};
 pub use game_state::{
-    Act, ActRoundEndPending, Agenda, ClueInterruptPending, EnemyAttackSource, FastActorScope,
-    FinishContinuation, GameState, HandSizeDiscard, HunterChoice, InFlightSkillTest, OpenWindow,
-    PendingEnemyAttack, PendingSkillModifier, PendingTrigger, PhaseStep, RoundEndAdvance,
-    SkillTestFollowUp, SpawnEngagePending, WindowKind,
+    Act, ActRoundEndPending, Agenda, ClueInterruptPending, Continuation, EnemyAttackSource,
+    FastActorScope, FinishContinuation, GameState, HandSizeDiscard, HunterChoice,
+    InFlightSkillTest, OpenWindow, PendingEnemyAttack, PendingSkillModifier, PendingTrigger,
+    PhaseStep, RoundEndAdvance, SkillTestFollowUp, SpawnEngagePending, WindowKind,
 };
 pub use investigator::{DefeatCause, Investigator, InvestigatorId, Status};
 pub use location::{Location, LocationId};


### PR DESCRIPTION
Second task of the Axis-B trigger-dispatch foundation (plan; kickoff #327).

## What
- Adds `GameState.continuations: Vec<Continuation>` — the umbrella §1 single suspend/resume stack — with `#[serde(default)]` so pre-field states still load.
- Adds the **single resume router** at the top of `resolve_input`: it takes priority over the legacy `pending_*` ladder, falling through when the stack is empty.
- `Continuation` is **uninhabited** for now, so the stack is statically always empty and the router is unreachable — **zero behavior change**. Task 3 lands the first variant (`Resolution`, the shared forced/reaction loop); Task 4 adds `SkillTest`.

## Verification
Default-empty + absent-field-loads serde test; full strict gauntlet green (test, clippy host+wasm, fmt, doc, wasm-build).

Closes #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)