### PR TITLE
engine: unify open_windows into the continuation stack (Axis-B T3)

### DIFF
--- a/crates/cards/tests/guard_dog_soak.rs
+++ b/crates/cards/tests/guard_dog_soak.rs
@@ -351,7 +351,7 @@ fn only_guard_dogs_reaction_is_offered_not_another_controlled_soaker() {
     // Exactly one pending soak window, keyed to Guard Dog's instance — not
     // the Vest's (a controlled soaker with no `EnemyAttackDamagedSelf`).
     let soak_windows: Vec<_> = state
-        .open_windows
+        .open_windows()
         .iter()
         .filter_map(|w| match w.kind {
             game_core::state::WindowKind::AfterEnemyAttackDamagedAsset { asset, .. } => Some(asset),
@@ -492,7 +492,7 @@ fn two_attackers_suspend_on_first_soak_then_resume_second_attacker() {
         "no parked attack after both attackers fully resolve"
     );
     assert!(
-        state.open_windows.is_empty(),
+        state.open_windows().is_empty(),
         "no soak windows left open once both attacks resolve"
     );
 }
@@ -567,9 +567,9 @@ fn move_attack_of_opportunity_soaks_onto_guard_dog_without_stranding_a_window() 
     // The bug guard: no stranded soak window, and the outcome is NOT a
     // dangling AwaitingInput on a soak window — AoO does not open one.
     assert!(
-        state.open_windows.is_empty(),
+        state.open_windows().is_empty(),
         "no reaction window stranded by the AoO: {:?}",
-        state.open_windows
+        state.open_windows()
     );
     assert!(
         !matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -681,7 +681,7 @@ fn drive_attack_loop(
 
         // If the attack opened a soak reaction window, suspend: park the
         // rest and surface the queued window (see fn doc step 4).
-        if !cx.state.open_windows.is_empty() {
+        if !cx.state.open_windows().is_empty() {
             // Single-soak-window-per-attack invariant: `pending_enemy_attack`
             // holds one parked loop, so resume (which `take()`s it) assumes
             // exactly one soak window per suspension. One attack queues one
@@ -692,11 +692,11 @@ fn drive_attack_loop(
             // drain. TODO(#294): drain all same-attack soak windows before
             // resuming (coordinates with simultaneous-trigger ordering #213).
             debug_assert_eq!(
-                cx.state.open_windows.len(),
+                cx.state.open_windows().len(),
                 1,
                 "drive_attack_loop suspended on {} open windows; multi-soak-\
                  window-per-attack resume is unhandled (TODO(#294))",
-                cx.state.open_windows.len(),
+                cx.state.open_windows().len(),
             );
             cx.state.pending_enemy_attack = Some(PendingEnemyAttack {
                 investigator,
@@ -892,7 +892,7 @@ mod combat_tests {
         assert_event!(events, Event::DamageTaken { investigator, amount: 2 } if *investigator == id);
         assert_event!(events, Event::HorrorTaken { investigator, amount: 1 } if *investigator == id);
         assert!(
-            state.open_windows.is_empty(),
+            state.open_windows().is_empty(),
             "no soak window without soakers"
         );
     }

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -330,11 +330,24 @@ pub(super) struct ActivateCheckResult {
 /// legacy `pending_*` ladder. [`Continuation`](crate::state::Continuation)
 /// is uninhabited until Task 3, so the stack is statically always empty
 /// and this is unreachable today; Tasks 3–5 add the per-frame resume arms.
-fn resume_continuation(cx: &mut Cx, _response: &InputResponse) -> EngineOutcome {
-    match cx.state.continuations.last() {
-        // No frame variants yet — uninhabited match (Tasks 3–5).
-        Some(frame) => match *frame {},
-        None => unreachable!("resume_continuation: router only calls this with a non-empty stack"),
+fn resume_continuation(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
+    // Task 3: the only frame is `Resolution` (an open window). If it has
+    // pending reaction triggers, drive the reaction window; otherwise it is
+    // a pure-Fast window (empty `pending_triggers`) that `Skip` closes.
+    if cx.state.top_reaction_window().is_some() {
+        return reaction_windows::resume_reaction_window(cx, response);
+    }
+    // Pure-Fast window (Option B): no pending triggers; only `Skip` is valid.
+    if matches!(response, InputResponse::Skip) {
+        let idx = cx.state.continuations.len() - 1;
+        return reaction_windows::close_reaction_window_at(cx, idx);
+    }
+    EngineOutcome::Rejected {
+        reason: format!(
+            "ResolveInput: a Fast-play window is open (no pending triggers); \
+             submit InputResponse::Skip to close it, got {response:?}",
+        )
+        .into(),
     }
 }
 
@@ -420,27 +433,9 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
         return clue_interrupt::resume_clue_interrupt(cx, response);
     }
 
-    if cx.state.top_reaction_window().is_some() {
-        return reaction_windows::resume_reaction_window(cx, response);
-    }
-
-    // Pure-Fast window path (Option B): no reaction-driven window is
-    // pending, but a window (e.g. MythosAfterDraws) may still be on the
-    // stack with empty pending_triggers. Skip is the only valid response
-    // here — PickIndex / CommitCards reject below.
-    if !cx.state.open_windows.is_empty() {
-        if matches!(response, InputResponse::Skip) {
-            let idx = cx.state.open_windows.len() - 1;
-            return reaction_windows::close_reaction_window_at(cx, idx);
-        }
-        return EngineOutcome::Rejected {
-            reason: format!(
-                "ResolveInput: a Fast-play window is open (no pending triggers); \
-                 submit InputResponse::Skip to close it, got {response:?}",
-            )
-            .into(),
-        };
-    }
+    // Open windows (reaction + pure-Fast) are `Continuation::Resolution`
+    // frames, handled by the continuation router at the top of this function
+    // (umbrella §1 / Axis-B T3) — so no window check is needed here.
 
     if cx.state.in_flight_skill_test.is_none() {
         return EngineOutcome::Rejected {

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -1787,7 +1787,7 @@ mod upkeep_phase_tests {
         );
         assert_eq!(state.phase, Phase::Mythos, "cascade lands in Mythos");
         assert!(
-            state.open_windows.is_empty(),
+            state.open_windows().is_empty(),
             "UpkeepBegins must not persist on the stack"
         );
     }
@@ -3021,11 +3021,13 @@ mod enemy_phase_tests {
         state.turn_order = vec![inv_id];
         state.active_investigator = None;
         state.enemy_attack_pending = Some(inv_id);
-        state.open_windows.push(OpenWindow {
-            kind: WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked),
-            pending_triggers: Vec::new(),
-            fast_actors: FastActorScope::Any,
-        });
+        state
+            .continuations
+            .push(crate::state::Continuation::Resolution(OpenWindow {
+                kind: WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked),
+                pending_triggers: Vec::new(),
+                fast_actors: FastActorScope::Any,
+            }));
 
         let result = apply(
             state,

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -17,8 +17,8 @@ use crate::card_registry;
 use crate::dsl::{EventPattern, EventTiming, Trigger};
 use crate::event::Event;
 use crate::state::{
-    CardCode, CardInstanceId, FastActorScope, FinishContinuation, GameState, InvestigatorId,
-    OpenWindow, PendingTrigger, Phase, PhaseStep, Status, WindowKind,
+    CardCode, CardInstanceId, Continuation, FastActorScope, FinishContinuation, GameState,
+    InvestigatorId, OpenWindow, PendingTrigger, Phase, PhaseStep, Status, WindowKind,
 };
 
 use super::super::evaluator::{apply_effect, EvalContext};
@@ -55,11 +55,13 @@ pub(super) fn queue_reaction_window(cx: &mut Cx, kind: WindowKind) {
     // Reaction windows admit any investigator's Fast actions
     // (Rules Reference: Fast may be played at any player window).
     // Multi-window nesting is now structural — push twice is valid.
-    cx.state.open_windows.push(OpenWindow {
-        kind,
-        pending_triggers,
-        fast_actors: FastActorScope::Any,
-    });
+    cx.state
+        .continuations
+        .push(Continuation::Resolution(OpenWindow {
+            kind,
+            pending_triggers,
+            fast_actors: FastActorScope::Any,
+        }));
 }
 
 /// Scan every investigator's `cards_in_play` for
@@ -313,6 +315,9 @@ pub(super) fn resume_reaction_window(cx: &mut Cx, response: &InputResponse) -> E
 /// Fire the pending trigger at index `i` in the open reaction window.
 /// Rejects out-of-bounds; the window stays open so the client can
 /// retry with a corrected index.
+// Mostly invariant-violation `unreachable!` arms + the Resolution-frame
+// unwrapping (Axis-B T3); over the line limit but cohesive.
+#[allow(clippy::too_many_lines)]
 fn fire_pending_trigger(cx: &mut Cx, i: u32) -> EngineOutcome {
     // Capture the index of the reaction window we're driving up-front
     // so the close path removes the same entry (not the absolute top of
@@ -324,7 +329,9 @@ fn fire_pending_trigger(cx: &mut Cx, i: u32) -> EngineOutcome {
         .expect("fire_pending_trigger: caller checked is_some");
     // Snapshot to avoid borrowing state across the apply_effect call.
     let (trigger, pending_idx) = {
-        let window = &cx.state.open_windows[window_idx];
+        let window = cx.state.continuations[window_idx]
+            .as_window()
+            .expect("fire_pending_trigger: top_reaction_window_index points at a Resolution frame");
         let idx = match usize::try_from(i) {
             Ok(idx) if idx < window.pending_triggers.len() => idx,
             _ => {
@@ -406,8 +413,11 @@ fn fire_pending_trigger(cx: &mut Cx, i: u32) -> EngineOutcome {
     // `eval_ctx.attacking_enemy`. Mirrors `failed_by` /
     // `clue_discovery_count`. `None` for all other window kinds. (C5b
     // #237.)
-    if let WindowKind::AfterEnemyAttackDamagedAsset { enemy, .. } =
-        cx.state.open_windows[window_idx].kind
+    if let WindowKind::AfterEnemyAttackDamagedAsset { enemy, .. } = cx.state.continuations
+        [window_idx]
+        .as_window()
+        .expect("fire_pending_trigger: window_idx is a Resolution frame")
+        .kind
     {
         eval_ctx.attacking_enemy = Some(enemy);
     }
@@ -426,7 +436,9 @@ fn fire_pending_trigger(cx: &mut Cx, i: u32) -> EngineOutcome {
     // Drop the fired entry now that resolution succeeded. The window
     // we drove sits at `window_idx` — apply_effect does not push or
     // pop `open_windows` entries, so the index remains valid.
-    let window = &mut cx.state.open_windows[window_idx];
+    let window = cx.state.continuations[window_idx]
+        .as_window_mut()
+        .expect("fire_pending_trigger: window_idx is a Resolution frame");
     window.pending_triggers.remove(pending_idx);
 
     // If more triggers remain pending, re-emit AwaitingInput so the
@@ -514,9 +526,10 @@ pub(super) fn close_reaction_window_at(cx: &mut Cx, idx: usize) -> EngineOutcome
     {
         let window = cx
             .state
-            .open_windows
+            .continuations
             .get(idx)
-            .expect("close_reaction_window_at: caller-supplied index must be in bounds");
+            .and_then(Continuation::as_window)
+            .expect("close_reaction_window_at: caller-supplied index must be a Resolution frame");
         if let Some(forced) = window.pending_triggers.iter().find(|t| t.forced) {
             return EngineOutcome::Rejected {
                 reason: format!(
@@ -531,8 +544,13 @@ pub(super) fn close_reaction_window_at(cx: &mut Cx, idx: usize) -> EngineOutcome
             };
         }
     }
-    let window = cx.state.open_windows.remove(idx);
-    let kind = window.kind;
+    let kind = cx
+        .state
+        .continuations
+        .remove(idx)
+        .as_window()
+        .map(|w| w.kind)
+        .expect("close_reaction_window_at: removed frame must be a Resolution window");
     cx.events.push(Event::WindowClosed { kind });
 
     // Run any kind-specific continuation (e.g. MythosAfterDraws →
@@ -816,16 +834,17 @@ pub(super) fn open_fast_window(cx: &mut Cx, kind: WindowKind) -> EngineOutcome {
     // Push first so any_fast_play_eligible's check_play_card call sees
     // this window in state.open_windows when evaluating permissive_window.
     let pending_triggers = scan_pending_triggers(cx.state, kind);
-    cx.state.open_windows.push(OpenWindow {
-        kind,
-        pending_triggers,
-        fast_actors: FastActorScope::Any,
-    });
+    cx.state
+        .continuations
+        .push(Continuation::Resolution(OpenWindow {
+            kind,
+            pending_triggers,
+            fast_actors: FastActorScope::Any,
+        }));
 
     let has_pending = !cx
         .state
-        .open_windows
-        .last()
+        .top_window()
         .expect("just pushed; cannot be empty")
         .pending_triggers
         .is_empty();
@@ -834,8 +853,8 @@ pub(super) fn open_fast_window(cx: &mut Cx, kind: WindowKind) -> EngineOutcome {
     if !has_pending && !has_fast_eligible {
         // Auto-skip: nothing to do. Pop the window we just pushed,
         // emit WindowClosed, and run the continuation inline, so the
-        // net effect on state.open_windows is the same as before the fix.
-        let _ = cx.state.open_windows.pop();
+        // net effect on the continuation stack is the same as before.
+        let _ = cx.state.continuations.pop();
         cx.events.push(Event::WindowClosed { kind });
         return run_window_continuation(cx, kind);
     }
@@ -902,8 +921,7 @@ pub(super) fn check_play_card(
         state.phase == Phase::Investigation && state.active_investigator == Some(investigator);
     let owner_is_active = state.active_investigator == Some(investigator);
     let permissive_window = state
-        .open_windows
-        .last()
+        .top_window()
         .is_some_and(|w| w.fast_actors.permits(investigator));
     // Non-asset/non-event card types are filtered out by
     // `resolve_play_target` above, so `card_type` here is always one of
@@ -1017,8 +1035,7 @@ pub(super) fn check_activate_ability(
     let active_during_investigation =
         state.phase == Phase::Investigation && state.active_investigator == Some(investigator);
     let in_permissive_window = state
-        .open_windows
-        .last()
+        .top_window()
         .is_some_and(|w| w.fast_actors.permits(investigator));
     if action_cost > 0 {
         // Action-cost ability: requires Investigation phase + active investigator.
@@ -1363,7 +1380,7 @@ mod open_fast_window_tests {
         );
 
         assert!(
-            state.open_windows.is_empty(),
+            state.open_windows().is_empty(),
             "auto-skip must not leave the window on the stack"
         );
         assert!(

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -31,8 +31,9 @@ use std::collections::{BTreeMap, VecDeque};
 use crate::rng::RngState;
 use crate::scenario::ScenarioId;
 use crate::state::{
-    ChaosBag, Counter, Enemy, EnemyId, FastActorScope, GameState, HandSizeDiscard, Investigator,
-    InvestigatorId, Location, LocationId, OpenWindow, Phase, TokenModifiers, WindowKind,
+    ChaosBag, Continuation, Counter, Enemy, EnemyId, FastActorScope, GameState, HandSizeDiscard,
+    Investigator, InvestigatorId, Location, LocationId, OpenWindow, Phase, TokenModifiers,
+    WindowKind,
 };
 
 /// Fluent builder for a [`GameState`].
@@ -273,8 +274,13 @@ impl GameStateBuilder {
             location_ids: Counter::new(),
             pending_skill_modifiers: Vec::new(),
             in_flight_skill_test: None,
-            open_windows: self.open_windows,
-            continuations: Vec::new(),
+            // Builder-staged windows become `Resolution` frames on the one
+            // continuation stack (Axis-B T3).
+            continuations: self
+                .open_windows
+                .into_iter()
+                .map(Continuation::Resolution)
+                .collect(),
             scenario_id: self.scenario_id,
             mythos_draw_pending: None,
             enemy_attack_pending: None,
@@ -331,9 +337,9 @@ mod with_open_window_tests {
                 FastActorScope::Any,
             )
             .build();
-        assert_eq!(state.open_windows.len(), 1);
-        assert_eq!(state.open_windows[0].fast_actors, FastActorScope::Any);
-        assert!(state.open_windows[0].pending_triggers.is_empty());
+        assert_eq!(state.open_windows().len(), 1);
+        assert_eq!(state.open_windows()[0].fast_actors, FastActorScope::Any);
+        assert!(state.open_windows()[0].pending_triggers.is_empty());
     }
 
     #[test]
@@ -349,9 +355,9 @@ mod with_open_window_tests {
                 FastActorScope::ActiveInvestigator(InvestigatorId(1)),
             )
             .build();
-        assert_eq!(state.open_windows.len(), 2);
+        assert_eq!(state.open_windows().len(), 2);
         assert!(matches!(
-            state.open_windows[1].kind,
+            state.open_windows()[1].kind,
             WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins)
         ));
     }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -154,11 +154,13 @@ pub struct GameState {
     /// Multi-window queueing (one effect that queues two windows in
     /// the same apply) is now structural — push twice, drive resumes
     /// in reverse open order.
-    pub open_windows: Vec<OpenWindow>,
     /// The single suspend/resume stack (umbrella §1 / Axis-B): the top
     /// frame is resumed by `resolve_input`, taking priority over the
-    /// legacy `pending_*` modes. Empty until Task 3 begins pushing
-    /// frames; `#[serde(default)]` so pre-field states still load.
+    /// legacy `pending_*` modes. Open reaction/fast windows live here as
+    /// [`Continuation::Resolution`] frames (the former `open_windows` Vec,
+    /// absorbed into the one stack). `#[serde(default)]` so pre-field
+    /// states still load. Inspect windows via [`Self::open_windows`] /
+    /// [`Self::top_reaction_window`] / [`Self::top_window`].
     #[serde(default)]
     pub continuations: Vec<Continuation>,
     /// Identifier of the scenario this state belongs to, if any.
@@ -392,14 +394,37 @@ pub struct PendingEnemyAttack {
 /// (umbrella §1 / Axis-B): a typed resume point, not a closure, so it
 /// serializes for replay/persistence like every other state field.
 ///
-/// Uninhabited for now — Task 2 lands the field + the single resume
-/// router with the stack always empty; Task 3 adds the first real variant
-/// (`Resolution`, the shared forced/reaction loop), Task 4 adds
-/// `SkillTest`, and Axis A adds `Choice`. Because the enum has no
-/// variants yet, the stack is statically always empty and the router's
-/// resume branch is unreachable.
+/// Task 3 adds the first variant (`Resolution`, an open reaction/fast
+/// window — see [`OpenWindow`]); Task 4 adds `SkillTest`, and Axis A adds
+/// `Choice`. The reaction window is just "paused, the player may act here,
+/// resume on act/pass," so it is a continuation frame: this absorbs the
+/// former `open_windows` Vec into the one stack (umbrella §1 — no separate
+/// window structure to keep in sync).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum Continuation {}
+pub enum Continuation {
+    /// An open reaction / fast / framework window. The player may fire a
+    /// pending trigger or play a Fast card, or pass. Payload is the former
+    /// `open_windows` entry. (Task 5 parameterizes this into the shared
+    /// forced+reaction resolution loop.)
+    Resolution(OpenWindow),
+}
+
+impl Continuation {
+    /// The window payload if this frame is a [`Continuation::Resolution`].
+    #[must_use]
+    pub fn as_window(&self) -> Option<&OpenWindow> {
+        match self {
+            Continuation::Resolution(w) => Some(w),
+        }
+    }
+
+    /// Mutable counterpart to [`Self::as_window`].
+    pub fn as_window_mut(&mut self) -> Option<&mut OpenWindow> {
+        match self {
+            Continuation::Resolution(w) => Some(w),
+        }
+    }
+}
 
 /// A skill test paused mid-resolution at the commit window.
 ///
@@ -1010,8 +1035,7 @@ impl GameState {
     /// are skipped — they don't block dispatch.
     #[must_use]
     pub fn top_reaction_window(&self) -> Option<&OpenWindow> {
-        self.open_windows
-            .iter()
+        self.windows()
             .rev()
             .find(|w| !w.pending_triggers.is_empty())
     }
@@ -1020,10 +1044,37 @@ impl GameState {
     /// applies: windows with empty `pending_triggers` are skipped —
     /// phase-gate-only windows are not exposed as reaction-work.
     pub fn top_reaction_window_mut(&mut self) -> Option<&mut OpenWindow> {
-        self.open_windows
+        self.continuations
             .iter_mut()
             .rev()
+            .filter_map(Continuation::as_window_mut)
             .find(|w| !w.pending_triggers.is_empty())
+    }
+
+    /// Iterator over the open windows on the continuation stack, in stack
+    /// order (bottom to top). The windows are `Continuation::Resolution`
+    /// frames; non-window frames (Task 4+) are skipped.
+    fn windows(&self) -> impl DoubleEndedIterator<Item = &OpenWindow> {
+        self.continuations
+            .iter()
+            .filter_map(Continuation::as_window)
+    }
+
+    /// The open windows as a `Vec` of references, in stack order. Read
+    /// accessor for callers (and tests) that inspect the window stack the
+    /// way they used to read the former `open_windows` field.
+    #[must_use]
+    pub fn open_windows(&self) -> Vec<&OpenWindow> {
+        self.windows().collect()
+    }
+
+    /// The topmost open window regardless of pending triggers (the former
+    /// `open_windows.last()`), e.g. for the Fast-play `permissive_window`
+    /// timing gate. Distinct from [`Self::top_reaction_window`], which
+    /// skips empty-`pending_triggers` (pure-Fast) windows.
+    #[must_use]
+    pub fn top_window(&self) -> Option<&OpenWindow> {
+        self.windows().next_back()
     }
 
     /// Index into [`Self::open_windows`] of the topmost window with
@@ -1045,9 +1096,10 @@ impl GameState {
     /// window, by construction, has no forced triggers to guard against.
     #[must_use]
     pub fn top_reaction_window_index(&self) -> Option<usize> {
-        self.open_windows
-            .iter()
-            .rposition(|w| !w.pending_triggers.is_empty())
+        self.continuations.iter().rposition(|c| {
+            c.as_window()
+                .is_some_and(|w| !w.pending_triggers.is_empty())
+        })
     }
 
     /// Build a [`Location`] from its card `metadata`, minting a fresh id.
@@ -1265,6 +1317,29 @@ mod continuation_stack_tests {
             .remove("continuations");
         let back: GameState = serde_json::from_value(v).expect("deserialize without the field");
         assert!(back.continuations.is_empty());
+    }
+
+    #[test]
+    fn open_window_lives_on_the_continuation_stack_as_a_resolution_frame() {
+        // Axis-B T3: a window is a `Continuation::Resolution` frame on the
+        // one stack — there is no separate `open_windows` Vec.
+        let state = GameStateBuilder::new()
+            .with_open_window(
+                WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws),
+                FastActorScope::Any,
+            )
+            .build();
+        assert_eq!(state.continuations.len(), 1);
+        assert!(matches!(
+            state.continuations[0],
+            Continuation::Resolution(_)
+        ));
+        // The read accessor surfaces it as the former `open_windows` view.
+        assert_eq!(state.open_windows().len(), 1);
+        assert_eq!(
+            state.open_windows()[0].kind,
+            WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws),
+        );
     }
 }
 

--- a/crates/game-core/tests/reaction_windows.rs
+++ b/crates/game-core/tests/reaction_windows.rs
@@ -966,17 +966,22 @@ fn close_reaction_window_at_removes_reaction_window_not_empty_phase_gate_on_top(
     );
     // Confirm the stack before the injection: one reaction window with
     // one pending trigger.
-    assert_eq!(paused.state.open_windows.len(), 1);
-    assert!(!paused.state.open_windows[0].pending_triggers.is_empty());
+    assert_eq!(paused.state.open_windows().len(), 1);
+    assert!(!paused.state.open_windows()[0].pending_triggers.is_empty());
 
     // Inject an empty player-window gate on top to create the
     // [R (pending), B (empty)] shape.
-    paused.state.open_windows.push(OpenWindow::new_empty(
-        WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins),
-        FastActorScope::Any,
-    ));
+    paused
+        .state
+        .continuations
+        .push(game_core::state::Continuation::Resolution(
+            OpenWindow::new_empty(
+                WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins),
+                FastActorScope::Any,
+            ),
+        ));
     assert_eq!(
-        paused.state.open_windows.len(),
+        paused.state.open_windows().len(),
         2,
         "stack is [R, B] after injection"
     );
@@ -992,14 +997,14 @@ fn close_reaction_window_at_removes_reaction_window_not_empty_phase_gate_on_top(
 
     // The player-window gate (B) must still be on the stack.
     assert_eq!(
-        resumed.state.open_windows.len(),
+        resumed.state.open_windows().len(),
         1,
         "after closing R the stack must contain exactly one window (B), \
          got {:?}",
-        resumed.state.open_windows,
+        resumed.state.open_windows(),
     );
     assert_eq!(
-        resumed.state.open_windows[0].kind,
+        resumed.state.open_windows()[0].kind,
         WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins),
         "the surviving window must be the player-window gate, not the reaction window",
     );

--- a/crates/scenarios/tests/mythos_phase.rs
+++ b/crates/scenarios/tests/mythos_phase.rs
@@ -645,17 +645,17 @@ fn mythos_after_draws_window_stays_open_when_fast_event_in_hand() {
 
     // The window must remain on the stack — it was NOT auto-skipped.
     assert!(
-        !result.state.open_windows.is_empty(),
+        !result.state.open_windows().is_empty(),
         "MythosAfterDraws window must stay on stack when Fast event is in hand; \
          pre-fix this would have been empty (window auto-skipped)"
     );
     assert!(
         matches!(
-            result.state.open_windows.last(),
+            result.state.open_windows().last(),
             Some(w) if w.kind == WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws)
         ),
         "top open window must be MythosAfterDraws; got {:?}",
-        result.state.open_windows.last()
+        result.state.open_windows().last()
     );
 
     // Phase must still be Mythos — the window continuation (mythos_phase_end)
@@ -714,7 +714,7 @@ fn mythos_after_draws_window_closed_by_skip_and_transitions_to_investigation() {
     let draw_result = apply(state, Action::Player(PlayerAction::DrawEncounterCard));
     assert_eq!(draw_result.outcome, EngineOutcome::Done);
     assert!(
-        !draw_result.state.open_windows.is_empty(),
+        !draw_result.state.open_windows().is_empty(),
         "window must be open before Skip test"
     );
 
@@ -739,7 +739,7 @@ fn mythos_after_draws_window_closed_by_skip_and_transitions_to_investigation() {
     // that defect is still fixed — only the old "open_windows empty" shape
     // changes now that investigation_phase opens its own window.)
     assert_eq!(
-        skip_result.state.open_windows.len(),
+        skip_result.state.open_windows().len(),
         1,
         "InvestigationBegins window must be open (Fast card is eligible); \
          MythosAfterDraws must be gone"
@@ -747,11 +747,11 @@ fn mythos_after_draws_window_closed_by_skip_and_transitions_to_investigation() {
     assert!(
         skip_result
             .state
-            .open_windows
+            .open_windows()
             .last()
             .is_some_and(|w| w.kind == WindowKind::PlayerWindow(PhaseStep::InvestigationBegins)),
         "top window must be InvestigationBegins; got {:?}",
-        skip_result.state.open_windows.last()
+        skip_result.state.open_windows().last()
     );
 
     // mythos_phase_end ran: phase transitioned to Investigation.


### PR DESCRIPTION
Third task of the Axis-B trigger-dispatch foundation (plan; kickoff #327). **The big one** — but a *pure, behavior-preserving refactor*.

## What
Absorbs `GameState.open_windows: Vec<OpenWindow>` into the one continuation stack as `Continuation::Resolution(OpenWindow)` frames. There is no longer a separate window structure to keep in sync (umbrella §1 — avoids the marker/dual-bookkeeping trap).

- The single resume router (top of `resolve_input`, from T2) now drives open windows via `resume_continuation` → reaction-window resume or pure-Fast `Skip`. The dedicated reaction-window + pure-Fast branches in `resolve_input` are removed (superseded).
- `GameState` window accessors rewired onto the stack: `top_reaction_window` / `_mut` / `_index`; plus **new** `top_window` (topmost regardless of pending, for the Fast `permissive_window` gate) and an `open_windows()` read view (so call sites + tests inspect the stack the way they read the old field).
- `Continuation::as_window` / `as_window_mut` extract the frame payload; the builder stages windows and wraps them into frames at `build()`.

## Behavior-preserving
No semantic change — `kind`/parameterization of the shared loop comes in T5. The safety net is the regression suite: **all existing reaction-window, fast-window, mulligan, and skill-test tests stay green** (76 suites), plus one new test asserting a window is a `Resolution` frame on the stack. Full strict gauntlet green (test, clippy host+wasm, fmt, doc, wasm-build).

## Review notes
- Largest single change in Axis B; the diff is mostly mechanical `open_windows` → stack rewiring.
- Router ordering: windows now resume ahead of the legacy `clue_interrupt`/etc. checks, but they never coexist (different timings), so behavior is unchanged — confirmed by the green suite.

Closes #330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)