### PR TITLE
engine: skill-test resume via a SkillTest continuation frame (Axis-B T4)

### DIFF
--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -324,20 +324,15 @@ pub(super) struct ActivateCheckResult {
     pub source_exhausted: bool,
 }
 
-/// Resume the top frame of the continuation stack (umbrella §1 / Axis-B).
-///
-/// The single resume entry point that `resolve_input` routes to before the
-/// legacy `pending_*` ladder. [`Continuation`](crate::state::Continuation)
-/// is uninhabited until Task 3, so the stack is statically always empty
-/// and this is unreachable today; Tasks 3–5 add the per-frame resume arms.
-fn resume_continuation(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
-    // Task 3: the only frame is `Resolution` (an open window). If it has
-    // pending reaction triggers, drive the reaction window; otherwise it is
-    // a pure-Fast window (empty `pending_triggers`) that `Skip` closes.
+/// Resume the open window at the top of the stack: drive its reaction
+/// triggers if any are pending, else close the pure-Fast window on `Skip`.
+fn resume_window(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
+    // If the window has pending reaction triggers, drive the reaction
+    // window; otherwise it is a pure-Fast window (empty `pending_triggers`)
+    // that `Skip` closes.
     if cx.state.top_reaction_window().is_some() {
         return reaction_windows::resume_reaction_window(cx, response);
     }
-    // Pure-Fast window (Option B): no pending triggers; only `Skip` is valid.
     if matches!(response, InputResponse::Skip) {
         let idx = cx.state.continuations.len() - 1;
         return reaction_windows::close_reaction_window_at(cx, idx);
@@ -348,6 +343,34 @@ fn resume_continuation(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
              submit InputResponse::Skip to close it, got {response:?}",
         )
         .into(),
+    }
+}
+
+/// Resume a skill test parked at its commit window: the active investigator
+/// submits their commit list via [`InputResponse::CommitCards`].
+fn resume_skill_test_commit(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
+    match response {
+        InputResponse::CommitCards { indices } => {
+            let outcome = skill_test::finish_skill_test(cx, indices);
+            // If the resolved test was a suspending `EndOfTurn` forced
+            // effect (Frozen in Fear 01164), `end_turn` was stranded before
+            // rotation; resume it now that the test is fully done (C4c,
+            // #235). Only on `Done` — an `AwaitingInput` mid-teardown leaves
+            // `pending_end_turn` set for the next resume.
+            if matches!(outcome, EngineOutcome::Done) {
+                if let Some(active_id) = cx.state.pending_end_turn.take() {
+                    return phases::resume_end_turn(cx, active_id);
+                }
+            }
+            outcome
+        }
+        other => EngineOutcome::Rejected {
+            reason: format!(
+                "ResolveInput: skill-test commit window expects InputResponse::CommitCards, \
+                 got {other:?}",
+            )
+            .into(),
+        },
     }
 }
 
@@ -377,12 +400,18 @@ fn resume_continuation(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
 /// index. This covers the `MythosAfterDraws` window after all Fast
 /// plays have been made and the player is done.
 pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
-    // Single resume router (umbrella §1 / Axis-B): the continuation stack
-    // takes priority over the legacy `pending_*` ladder below. Empty until
-    // Task 3 begins pushing frames (`Continuation` is uninhabited today),
-    // so this currently always falls through.
-    if !cx.state.continuations.is_empty() {
-        return resume_continuation(cx, response);
+    // Continuation router (umbrella §1 / Axis-B), split by frame priority:
+    //
+    // - An open **window** (`Resolution`) nests above everything — a reaction
+    //   window mid-skill-test, a Fast window — so it resumes FIRST.
+    // - The **skill-test commit** frame (`SkillTest`) is the *outermost* test
+    //   suspension, so it resumes LAST (below), after the legacy mid-test modes
+    //   (e.g. `clue_interrupt`, which is an *inner* suspension of the test).
+    if matches!(
+        cx.state.continuations.last(),
+        Some(crate::state::Continuation::Resolution(_))
+    ) {
+        return resume_window(cx, response);
     }
 
     // Hunter movement, spawn engagement, and hand-size discard are three
@@ -437,32 +466,17 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
     // frames, handled by the continuation router at the top of this function
     // (umbrella §1 / Axis-B T3) — so no window check is needed here.
 
-    if cx.state.in_flight_skill_test.is_none() {
-        return EngineOutcome::Rejected {
-            reason: "ResolveInput: no AwaitingInput prompt is currently outstanding".into(),
-        };
+    // The skill-test commit window (`Continuation::SkillTest` frame) resumes
+    // here — *after* the legacy mid-test modes above (clue_interrupt et al.),
+    // which are inner suspensions of an in-flight test (Axis-B T4).
+    if matches!(
+        cx.state.continuations.last(),
+        Some(crate::state::Continuation::SkillTest)
+    ) {
+        return resume_skill_test_commit(cx, response);
     }
-    match response {
-        InputResponse::CommitCards { indices } => {
-            let outcome = skill_test::finish_skill_test(cx, indices);
-            // If the resolved test was a suspending `EndOfTurn` forced
-            // effect (Frozen in Fear 01164), `end_turn` was stranded before
-            // rotation; resume it now that the test is fully done (C4c,
-            // #235). Only on `Done` — an `AwaitingInput` mid-teardown leaves
-            // `pending_end_turn` set for the next resume.
-            if matches!(outcome, EngineOutcome::Done) {
-                if let Some(active_id) = cx.state.pending_end_turn.take() {
-                    return phases::resume_end_turn(cx, active_id);
-                }
-            }
-            outcome
-        }
-        other => EngineOutcome::Rejected {
-            reason: format!(
-                "ResolveInput: skill-test commit window expects InputResponse::CommitCards, \
-                 got {other:?}",
-            )
-            .into(),
-        },
+
+    EngineOutcome::Rejected {
+        reason: "ResolveInput: no AwaitingInput prompt is currently outstanding".into(),
     }
 }

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -96,6 +96,12 @@ pub(in crate::engine) fn start_skill_test(
         test_modifier,
         bonus_attack_damage: 0,
     });
+    // Resume-handle on the one stack (Axis-B T4): the test parks at its
+    // commit window. Resolution (reaction/fast) frames push *above* this
+    // when a window opens mid-test; popped when the test fully resolves.
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::SkillTest);
     cx.events.push(Event::SkillTestStarted {
         investigator,
         skill,
@@ -348,6 +354,25 @@ pub(super) fn drive_skill_test(cx: &mut Cx) -> EngineOutcome {
                     cx.state.encounter_discard.push(code);
                 }
                 cx.state.in_flight_skill_test = None;
+                // Remove this test's SkillTest resume-handle (Axis-B T4).
+                // Usually it is the top frame, but a player-window gate can
+                // legitimately sit above it (#69/#70/#71), so remove the
+                // (unique — no nesting today) SkillTest frame by position
+                // rather than popping the top.
+                let frame = cx
+                    .state
+                    .continuations
+                    .iter()
+                    .rposition(|c| matches!(c, crate::state::Continuation::SkillTest));
+                match frame {
+                    Some(pos) => {
+                        cx.state.continuations.remove(pos);
+                    }
+                    None => debug_assert!(
+                        false,
+                        "skill-test teardown: no SkillTest frame on the continuation stack",
+                    ),
+                }
                 return EngineOutcome::Done;
             }
         }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -3929,6 +3929,47 @@ mod tests {
     }
 
     #[test]
+    fn skill_test_pushes_and_pops_a_continuation_frame() {
+        // Axis-B T4: the commit window is a `Continuation::SkillTest` frame
+        // on the one stack, pushed when the test parks and popped when it
+        // fully resolves.
+        let id = InvestigatorId(1);
+        let state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_chaos_bag(bag_only_zero())
+            .build();
+        let paused = apply(
+            state,
+            Action::Player(PlayerAction::PerformSkillTest {
+                investigator: id,
+                skill: SkillKind::Intellect,
+                difficulty: 3,
+            }),
+        );
+        assert!(matches!(
+            paused.outcome,
+            EngineOutcome::AwaitingInput { .. }
+        ));
+        assert_eq!(
+            paused.state.continuations,
+            vec![crate::state::Continuation::SkillTest],
+            "parking at the commit window pushes exactly one SkillTest frame",
+        );
+
+        let resumed = apply(
+            paused.state,
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::CommitCards { indices: vec![] },
+            }),
+        );
+        assert_eq!(resumed.outcome, EngineOutcome::Done);
+        assert!(
+            resumed.state.continuations.is_empty(),
+            "resolving the test pops the SkillTest frame",
+        );
+    }
+
+    #[test]
     fn commit_window_discards_committed_cards_into_discard_pile() {
         // Two cards in hand; commit both. After resolution, both are
         // in the discard pile, neither in hand, and CardDiscarded

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -407,6 +407,12 @@ pub enum Continuation {
     /// `open_windows` entry. (Task 5 parameterizes this into the shared
     /// forced+reaction resolution loop.)
     Resolution(OpenWindow),
+    /// A skill test is mid-resolution. A resume-handle only — the test's
+    /// data lives in the singleton [`GameState::in_flight_skill_test`]
+    /// field (read by many call sites; no nesting today), so this frame
+    /// carries no payload. Pushed when the test starts (parking at its
+    /// commit window) and popped when it fully resolves (Axis-B T4).
+    SkillTest,
 }
 
 impl Continuation {
@@ -415,6 +421,7 @@ impl Continuation {
     pub fn as_window(&self) -> Option<&OpenWindow> {
         match self {
             Continuation::Resolution(w) => Some(w),
+            Continuation::SkillTest => None,
         }
     }
 
@@ -422,6 +429,7 @@ impl Continuation {
     pub fn as_window_mut(&mut self) -> Option<&mut OpenWindow> {
         match self {
             Continuation::Resolution(w) => Some(w),
+            Continuation::SkillTest => None,
         }
     }
 }


### PR DESCRIPTION
Fourth task of the Axis-B trigger-dispatch foundation (plan; kickoff #327).

## What
Routes the skill-test commit window through the one stack as a `Continuation::SkillTest` frame — a **resume-handle** (the test data stays in the singleton `in_flight_skill_test`, read by many call sites; no nesting today). Pushed when the test parks at its commit window; removed when it fully resolves.

## Router split (the interesting bit)
With the `SkillTest` frame on the stack, a single "non-empty stack → resume top" router would intercept *inner* mid-test suspensions (Cover Up's `clue_interrupt`, which suspends during the Investigate follow-up). So the router splits **by frame priority**, preserving the original `resolve_input` precedence:
- An open **window** (`Resolution`) nests above everything → resumes **first** (top of `resolve_input`).
- Legacy mid-test modes (`clue_interrupt` et al.) → next (they're *inner* suspensions of the test).
- The **`SkillTest` commit frame** → **last** (outermost test suspension).

Teardown removes the `SkillTest` frame **by position, not pop**, because a player-window gate can legitimately sit above it (the `#69/#70/#71` `[R, B]` case).

## Behavior-preserving
Full suite green (76 suites) — including the Cover Up clue-interrupt tests (which initially regressed and drove the router split) and the `[R, B]` close-the-right-window test (which drove the by-position teardown). Plus a new frame-lifecycle test. Strict gauntlet green (test, clippy host+wasm, fmt, doc, wasm-build).

Closes #331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)