### PR TITLE
engine: emit_event chokepoint + TimingEvent (Axis-B T5a, closes #212)

### DIFF
--- a/crates/game-core/src/engine/dispatch/act_agenda.rs
+++ b/crates/game-core/src/engine/dispatch/act_agenda.rs
@@ -74,9 +74,9 @@ pub(super) fn advance_agenda(cx: &mut Cx) {
     // The Gathering's reverses (01105 lead discard/horror, 01106
     // dig-until-Ghoul) resolve here. `()` return can't propagate a
     // 2+-trigger reject; `debug_assert!` guards it (mirror of `advance_act`).
-    let forced = super::forced_triggers::fire_forced_triggers(
+    let forced = super::emit::emit_event(
         cx,
-        &super::forced_triggers::ForcedTriggerPoint::AgendaAdvanced { code: leaving_code },
+        &super::emit::TimingEvent::AgendaAdvanced { code: leaving_code },
     );
     debug_assert!(
         matches!(forced, EngineOutcome::Done),
@@ -242,9 +242,9 @@ pub(crate) fn advance_act(cx: &mut Cx) {
     // Reference p.3: flip the card, follow the reverse, then the next
     // card becomes current. `()` return can't propagate a 2+-trigger
     // reject; `debug_assert!` guards it (mirror of `upkeep_phase_end`).
-    let forced = super::forced_triggers::fire_forced_triggers(
+    let forced = super::emit::emit_event(
         cx,
-        &super::forced_triggers::ForcedTriggerPoint::ActAdvanced { code: leaving_code },
+        &super::emit::TimingEvent::ActAdvanced { code: leaving_code },
     );
     debug_assert!(
         matches!(forced, EngineOutcome::Done),

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -296,9 +296,9 @@ pub(super) fn move_action(
     // forced triggers, #213), `apply`'s structural rollback restores the
     // pre-move state — the partial mutation above is safe (same reliance on
     // the apply-loop snapshot that `play_card` documents).
-    super::forced_triggers::fire_forced_triggers(
+    super::emit::emit_event(
         cx,
-        &super::forced_triggers::ForcedTriggerPoint::EnteredLocation {
+        &super::emit::TimingEvent::EnteredLocation {
             investigator,
             location: destination,
         },

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -6,7 +6,7 @@ use crate::engine::EngineOutcome;
 use crate::event::Event;
 use crate::state::{
     CardInstanceId, DefeatCause, EnemyAttackSource, EnemyId, GameState, InvestigatorId,
-    PendingEnemyAttack, Status, WindowKind,
+    PendingEnemyAttack, Status,
 };
 
 use super::Cx;
@@ -86,28 +86,18 @@ pub(super) fn damage_enemy(cx: &mut Cx, enemy_id: EnemyId, amount: u8, by: Optio
                 victory,
             });
         }
-        // Queue the post-defeat reaction window. Emits
-        // `Event::WindowOpened` immediately (inside queue_reaction_window);
-        // the skill-test driver then suspends at the next step boundary
-        // (between `apply_skill_test_follow_up` and
-        // `fire_on_skill_test_resolution`) returning AwaitingInput so the
-        // player can fire their reaction triggers; see `drive_skill_test`.
-        super::reaction_windows::queue_reaction_window(
+        // Enemy defeated: dispatch the timing point through the unified
+        // chokepoint (Axis-B T5a). `emit_event` queues the after-defeat
+        // reaction window (Roland 01001 — `Event::WindowOpened` emitted now;
+        // the skill-test driver suspends at its next step boundary so the
+        // player can react) and then fires the forced act objectives (Act 3's
+        // advance-on-Ghoul-Priest-defeat). `()`/debug_assert guards the
+        // 2+-trigger forced case (#213).
+        let forced = super::emit::emit_event(
             cx,
-            WindowKind::AfterEnemyDefeated {
+            &super::emit::TimingEvent::EnemyDefeated {
                 enemy: enemy_id,
                 by,
-            },
-        );
-        // Forced act objectives keyed to this defeat (Act 3's "If the
-        // Ghoul Priest is Defeated, advance."). `()` return can't
-        // propagate a 2+-trigger reject; debug_assert guards it (mirror of
-        // upkeep_phase_end / advance_act). Ordering vs. the
-        // AfterEnemyDefeated reaction window is fixed-deterministic for
-        // now; #212/#213 revisit.
-        let forced = super::forced_triggers::fire_forced_triggers(
-            cx,
-            &super::forced_triggers::ForcedTriggerPoint::EnemyDefeated {
                 code: defeated_code,
             },
         );
@@ -658,9 +648,11 @@ fn drive_attack_loop(
         // not inside `enemy_attack` — so attacks of opportunity (which share
         // `enemy_attack`) don't strand an undriven window (C5b #237).
         for asset in damaged_survivors {
-            super::reaction_windows::queue_reaction_window(
+            // Reaction-only timing point (no forced phase) — emit_event just
+            // queues the soak window (Axis-B T5a).
+            let _ = super::emit::emit_event(
                 cx,
-                WindowKind::AfterEnemyAttackDamagedAsset {
+                &super::emit::TimingEvent::EnemyAttackDamagedSelf {
                     asset,
                     enemy: enemy_id,
                     controller: investigator,

--- a/crates/game-core/src/engine/dispatch/emit.rs
+++ b/crates/game-core/src/engine/dispatch/emit.rs
@@ -1,0 +1,158 @@
+//! The unified trigger-dispatch chokepoint (umbrella §2 / Axis-B T5a).
+//!
+//! [`emit_event`] is the single entry point for forced + reaction trigger
+//! dispatch at a framework/game timing point. A [`TimingEvent`] names the
+//! timing point and carries its binding context; `emit_event` runs the
+//! two phases — Rules Reference p.2 forced-then-reaction:
+//!
+//! 1. **forced** — mandatory abilities resolve (today via the existing
+//!    `fire_forced_triggers`; T5b replaces this with the iterative
+//!    lead-investigator ordering loop).
+//! 2. **reaction** — the optional player reaction window opens.
+//!
+//! `TimingEvent` is the merge of the engine's two pre-existing
+//! binding-carrying dispatch keys: [`ForcedTriggerPoint`] (forced) and the
+//! event-driven [`WindowKind`] variants (reaction). T5a is a behavior-
+//! preserving facade that delegates to those; it does **not** push the
+//! logged [`Event`](crate::event::Event) — call sites still emit their own
+//! (e.g. `EnemyDefeated`, `InvestigatorMoved`).
+
+use crate::state::{
+    CardCode, CardInstanceId, EnemyId, InvestigatorId, LocationId, Phase, WindowKind,
+};
+
+use super::super::outcome::EngineOutcome;
+use super::forced_triggers::{fire_forced_triggers, ForcedTriggerPoint};
+use super::Cx;
+
+/// A game/framework timing point at which forced and/or reaction triggers
+/// may fire, with the binding context the fired effects need.
+///
+/// The union of [`ForcedTriggerPoint`] (the forced dispatch key) and the
+/// event-driven [`WindowKind`] variants (the reaction dispatch key). Each
+/// variant maps to an optional forced point ([`Self::forced_point`]) and an
+/// optional reaction window ([`Self::reaction_window`]); `EnemyDefeated` is
+/// **dual** (both forced and reaction at the same point).
+///
+/// The successful-investigate moment is *not* a `TimingEvent` in T5a: its
+/// forced (Obscuring Fog) and reaction (Dr. Milan) fire at different
+/// skill-test driver steps today, so collapsing them into one timing event
+/// would reorder them (RR forced-first) — a behavior change deferred to T5b.
+/// Framework `PlayerWindow(PhaseStep)` windows are *not* timing events —
+/// they have no `EventPattern` and stay on explicit `open_fast_window`
+/// calls.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TimingEvent {
+    /// An investigator entered a location (forced only).
+    EnteredLocation {
+        investigator: InvestigatorId,
+        location: LocationId,
+    },
+    /// A phase ended (forced only).
+    PhaseEnded { phase: Phase },
+    /// An act advanced — its reverse resolves (forced only).
+    ActAdvanced { code: CardCode },
+    /// An agenda advanced — its reverse resolves (forced only).
+    AgendaAdvanced { code: CardCode },
+    /// An enemy was defeated. **Dual:** forced (act objectives keyed to the
+    /// defeat) + the after-defeat reaction window (Roland 01001, Evidence!).
+    EnemyDefeated {
+        enemy: EnemyId,
+        by: Option<InvestigatorId>,
+        code: CardCode,
+    },
+    /// The round ended, step 4.6 (forced only).
+    RoundEnded,
+    /// An investigator's turn ended, step 2.2.2 (forced only).
+    EndOfTurn { investigator: InvestigatorId },
+    /// The game ended — a scenario resolution latched (forced only).
+    GameEnd,
+    /// An enemy attack soaked damage onto a controlled asset (reaction
+    /// only — Guard Dog 01021's retaliate).
+    EnemyAttackDamagedSelf {
+        asset: CardInstanceId,
+        enemy: EnemyId,
+        controller: InvestigatorId,
+    },
+}
+
+impl TimingEvent {
+    /// The forced dispatch point for this timing event, if it fires forced
+    /// abilities. `None` for the reaction-only `EnemyAttackDamagedSelf`.
+    fn forced_point(&self) -> Option<ForcedTriggerPoint> {
+        match self {
+            TimingEvent::EnteredLocation {
+                investigator,
+                location,
+            } => Some(ForcedTriggerPoint::EnteredLocation {
+                investigator: *investigator,
+                location: *location,
+            }),
+            TimingEvent::PhaseEnded { phase } => {
+                Some(ForcedTriggerPoint::PhaseEnded { phase: *phase })
+            }
+            TimingEvent::ActAdvanced { code } => {
+                Some(ForcedTriggerPoint::ActAdvanced { code: code.clone() })
+            }
+            TimingEvent::AgendaAdvanced { code } => {
+                Some(ForcedTriggerPoint::AgendaAdvanced { code: code.clone() })
+            }
+            TimingEvent::EnemyDefeated { code, .. } => {
+                Some(ForcedTriggerPoint::EnemyDefeated { code: code.clone() })
+            }
+            TimingEvent::RoundEnded => Some(ForcedTriggerPoint::RoundEnded),
+            TimingEvent::EndOfTurn { investigator } => Some(ForcedTriggerPoint::EndOfTurn {
+                investigator: *investigator,
+            }),
+            TimingEvent::GameEnd => Some(ForcedTriggerPoint::GameEnd),
+            TimingEvent::EnemyAttackDamagedSelf { .. } => None,
+        }
+    }
+
+    /// The reaction window this timing event opens, if any. `Some` only for
+    /// the reaction-capable points.
+    fn reaction_window(&self) -> Option<WindowKind> {
+        match self {
+            TimingEvent::EnemyDefeated { enemy, by, .. } => Some(WindowKind::AfterEnemyDefeated {
+                enemy: *enemy,
+                by: *by,
+            }),
+            TimingEvent::EnemyAttackDamagedSelf {
+                asset,
+                enemy,
+                controller,
+            } => Some(WindowKind::AfterEnemyAttackDamagedAsset {
+                asset: *asset,
+                enemy: *enemy,
+                controller: *controller,
+            }),
+            _ => None,
+        }
+    }
+}
+
+/// Dispatch a timing event: queue its reaction window (phase 2), then fire
+/// its forced abilities (phase 1).
+///
+/// # Phase ordering
+///
+/// The reaction window is *queued* before forced abilities *resolve*, so
+/// `WindowOpened` is emitted before the forced effects' events — preserving
+/// the pre-T5a per-site order (each dual site called `queue_reaction_window`
+/// before `fire_forced_triggers`). The forced abilities still **resolve**
+/// synchronously here, before the player can act on the queued window (the
+/// window only suspends the surrounding driver at its next step boundary),
+/// so resolution is RR-correct forced-then-reaction.
+///
+/// Returns the forced phase's [`EngineOutcome`] (the queue itself never
+/// suspends or rejects). T5b replaces the forced phase's internals with the
+/// iterative ordering loop.
+pub(crate) fn emit_event(cx: &mut Cx, event: &TimingEvent) -> EngineOutcome {
+    if let Some(kind) = event.reaction_window() {
+        super::reaction_windows::queue_reaction_window(cx, kind);
+    }
+    match event.forced_point() {
+        Some(point) => fire_forced_triggers(cx, &point),
+        None => EngineOutcome::Done,
+    }
+}

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -22,6 +22,9 @@ mod clue_interrupt;
 // pub(super): evaluator reaches grant_resources via the full path
 // crate::engine::dispatch::cards::grant_resources (a sibling of dispatch).
 pub(super) mod cards;
+// pub(super): the unified trigger-dispatch chokepoint (Axis-B T5a); engine/mod.rs
+// re-exports emit_event + TimingEvent via pub(crate) for the GameEnd site.
+pub(super) mod emit;
 // pub(crate): engine/mod.rs re-exports `deal_damage_to_enemy` for the
 // `cards` crate (Guard Dog 01021's retaliate native, C5b #237).
 pub(crate) mod combat;

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -226,9 +226,9 @@ pub(super) fn end_turn(cx: &mut Cx) -> EngineOutcome {
     // resolves (C4c, #235 — mirrors `spawn_engage_pending`). A single
     // suspending hit is handled; 2+ simultaneous suspends are #212/#213
     // reentrancy work. A `Rejected` propagates as-is.
-    let end_of_turn = super::forced_triggers::fire_forced_triggers(
+    let end_of_turn = super::emit::emit_event(
         cx,
-        &super::forced_triggers::ForcedTriggerPoint::EndOfTurn {
+        &super::emit::TimingEvent::EndOfTurn {
             investigator: active_id,
         },
     );
@@ -552,9 +552,9 @@ pub(super) fn enemy_phase_end(cx: &mut Cx) -> EngineOutcome {
     // Fire forced act/agenda abilities keyed to `PhaseEnded { Enemy }`.
     // Single-trigger path: 0 → Done (no-op); 1 → resolves immediately;
     // 2+ → rejects loudly (#213 adds the ordering loop).
-    let forced = super::forced_triggers::fire_forced_triggers(
+    let forced = super::emit::emit_event(
         cx,
-        &super::forced_triggers::ForcedTriggerPoint::PhaseEnded {
+        &super::emit::TimingEvent::PhaseEnded {
             phase: Phase::Enemy,
         },
     );
@@ -644,9 +644,9 @@ fn upkeep_phase_end(cx: &mut Cx) -> EngineOutcome {
     // the forced path here; `debug_assert!` guards it for now. #212's
     // `emit_event` restructure will centralise forced-trigger dispatch and
     // remove this limitation.
-    let forced = super::forced_triggers::fire_forced_triggers(
+    let forced = super::emit::emit_event(
         cx,
-        &super::forced_triggers::ForcedTriggerPoint::PhaseEnded {
+        &super::emit::TimingEvent::PhaseEnded {
             phase: Phase::Upkeep,
         },
     );
@@ -658,10 +658,7 @@ fn upkeep_phase_end(cx: &mut Cx) -> EngineOutcome {
     // "Upkeep phase ends. Round ends." (RR p.24) — fire round-end Forced
     // effects (agenda 01107's doom) after the upkeep-phase-end ones. Both
     // resolve to Done in-slice (doom just increments a counter).
-    let round_end = super::forced_triggers::fire_forced_triggers(
-        cx,
-        &super::forced_triggers::ForcedTriggerPoint::RoundEnded,
-    );
+    let round_end = super::emit::emit_event(cx, &super::emit::TimingEvent::RoundEnded);
     debug_assert!(
         matches!(round_end, EngineOutcome::Done),
         "upkeep_phase_end RoundEnded forced did not resolve to Done: {round_end:?} \

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -36,6 +36,9 @@ pub use pathfinding::shortest_first_steps;
 // `move_action` (EnteredLocation) and `enemy_phase_end`/`upkeep_phase_end`
 // (PhaseEnded).
 pub(crate) use dispatch::forced_triggers::{fire_forced_triggers, ForcedTriggerPoint};
+// The unified trigger-dispatch chokepoint (Axis-B T5a): the GameEnd site below
+// and `fire_scenario_resolution` route through it.
+pub(crate) use dispatch::emit::{emit_event, TimingEvent};
 
 use crate::action::Action;
 use crate::event::Event;
@@ -227,7 +230,7 @@ fn fire_scenario_resolution(cx: &mut Cx, registry: Option<&ScenarioRegistry>) {
     // #236). Non-interactive in scope; a suspending GameEnd hit is #212
     // reentrancy work. Runs even when no scenario module is registered, so
     // it precedes the module lookup below.
-    let _ = fire_forced_triggers(cx, &ForcedTriggerPoint::GameEnd);
+    let _ = emit_event(cx, &TimingEvent::GameEnd);
 
     let Some(id) = cx.state.scenario_id.as_ref() else {
         return;

--- a/docs/superpowers/plans/2026-06-16-trigger-dispatch-t5-emit-event.md
+++ b/docs/superpowers/plans/2026-06-16-trigger-dispatch-t5-emit-event.md
@@ -1,0 +1,151 @@
+# Axis-B T5 — `emit_event` + `TimingEvent` + two-phase dispatch (implementation plan)
+
+> **For agentic workers:** sub-plan of the Axis-B foundation
+> (`2026-06-16-trigger-dispatch-axis-b-foundation-design.md`, task 5). Steps use
+> checkbox syntax. Decomposed into **T5a** (chokepoint, behavior-preserving,
+> closes #212) and **T5b** (iterative ordering + reentrancy, closes #213/#294).
+> The semantic change; a pre-push `/code-review` pass runs on **T5b** before its PR.
+
+**Goal:** route every forced/reaction trigger dispatch through one
+`emit_event(cx, TimingEvent)` chokepoint, then replace the forced path's
+fixed-order resolution with the rules-correct iterative lead-investigator
+ordering loop with reentrancy.
+
+**Why split:** T5a is mechanical + behavior-preserving (like T3/T4) — it unifies
+the *call sites*. T5b is the actual behavior change (player-chosen forced order,
+suspend-mid-forced reentrancy). Splitting keeps the semantic diff small and
+reviewable, and maps cleanly to the issues (#212 vs #213/#294).
+
+---
+
+## Current dispatch call sites → `TimingEvent` mapping
+
+Every site today calls `fire_forced_triggers(ForcedTriggerPoint::X)` and/or
+`queue_reaction_window(WindowKind::Y)`. After T5a each becomes one
+`emit_event(cx, TimingEvent::Z { … })`. `TimingEvent` is the **union** of
+`ForcedTriggerPoint` + the event-driven `WindowKind` variants; each maps to a
+phase-1 forced `EventPattern` and an optional phase-2 reaction `WindowKind`.
+
+| Site | Today | `TimingEvent` | phase-1 forced pattern | phase-2 reaction window |
+|---|---|---|---|---|
+| combat.rs:95+108 (enemy defeat) | `queue(AfterEnemyDefeated)` **+** `forced(EnemyDefeated)` | `EnemyDefeated { enemy, by, code }` | `EnemyDefeated` | `AfterEnemyDefeated { enemy, by }` |
+| skill_test.rs:670+790 (successful investigate) | `queue(AfterSuccessfulInvestigate)` **+** `forced(AfterLocationInvestigated)` | `SuccessfullyInvestigated { investigator, location }` | `AfterLocationInvestigated` | `AfterSuccessfulInvestigate { investigator }` |
+| combat.rs:661 (soak) | `queue(AfterEnemyAttackDamagedAsset)` | `EnemyAttackDamagedSelf { asset, enemy, controller }` | — | `AfterEnemyAttackDamagedAsset { … }` |
+| act_agenda.rs:245 | `forced(ActAdvanced { code })` | `ActAdvanced { code }` | `ActAdvanced` | — |
+| act_agenda.rs:77 | `forced(AgendaAdvanced { code })` | `AgendaAdvanced { code }` | `AgendaAdvanced` | — |
+| mod.rs:230 | `forced(GameEnd)` | `GameEnd` | `GameEnd` | — |
+| phases.rs:229 | `forced(EndOfTurn { investigator })` | `EndOfTurn { investigator }` | `EndOfTurn` | — |
+| phases.rs:555,647 | `forced(PhaseEnded { phase })` | `PhaseEnded { phase }` | `PhaseEnded` | — |
+| phases.rs:661 | `forced(RoundEnded)` | `RoundEnded` | `RoundEnded` | — |
+| actions.rs:299 | `forced(EnteredLocation { investigator, location })` | `EnteredLocation { investigator, location }` | `EnteredLocation` | — |
+
+Framework `PlayerWindow(PhaseStep)` windows (`open_fast_window`) have no
+`EventPattern` and are **not** `TimingEvent`s — they stay as explicit
+`open_fast_window` calls. The two **dual** sites (defeat, investigate) collapse
+two calls into one `emit_event`; the investigate one also collapses the C6a twin
+patterns (`AfterLocationInvestigated` forced + `SuccessfullyInvestigated`
+reaction) into one timing point.
+
+**Log events stay at their call sites.** `emit_event` is dispatch-only — it does
+*not* push the logged `Event` (callers already emit `EnemyDefeated`,
+`InvestigatorMoved`, etc.). This keeps T5a a pure dispatch-chokepoint
+unification with no change to event emission.
+
+**Ordering preservation (T5a).** Each dual site today calls `queue_reaction_window`
+*before* `fire_forced_triggers`, so `WindowOpened` is emitted before the forced
+effect's events; the forced effect still *resolves* synchronously before the
+player can act on the window (RR-correct). `emit_event` replicates this exactly:
+**phase-2 queues the reaction window first, then phase-1 resolves forced** —
+preserving event order. (T5b revisits forced *resolution* order, not the queue.)
+
+---
+
+## T5a — `TimingEvent` + `emit_event` chokepoint (closes #212, behavior-preserving)
+
+**Files:** create `crates/game-core/src/engine/dispatch/emit.rs`; modify
+`forced_triggers.rs` (port collection to `TimingEvent`), the 10 call sites,
+`dispatch/mod.rs` (module wiring), `engine/mod.rs` (re-exports for `test_support`).
+
+- [ ] **Step 1: Define `TimingEvent`** in `emit.rs` — one variant per the mapping
+  table's middle column, each carrying its binding. Add:
+  - `fn forced_pattern(&self) -> EventPattern` (phase-1 match key + `code` narrowing where present).
+  - `fn forced_controller(&self, state) -> binding` — port the per-variant controller/source/scan binding from `collect_forced_hits` (lead investigator for board cards; the entering/ending investigator; each instance's controller for GameEnd; etc.).
+  - `fn reaction_window(&self) -> Option<WindowKind>` — `Some` only for `EnemyDefeated`, `SuccessfullyInvestigated`, `EnemyAttackDamagedSelf`; `None` otherwise.
+
+- [ ] **Step 2: Port `collect_forced_hits` / `resolve_one`** from `forced_triggers.rs`
+  into `emit.rs`, keyed off `TimingEvent` instead of `ForcedTriggerPoint`. The
+  body is the same per-variant scan (board cards → threat-area/attachment
+  instances, `BTreeMap` order); the resolution is the same fixed-deterministic
+  loop (`fire_forced` today) — **no semantic change in T5a**. Delete
+  `ForcedTriggerPoint` and `forced_triggers.rs`.
+
+- [ ] **Step 3: Implement `emit_event`**:
+  ```
+  fn emit_event(cx, te: TimingEvent) -> EngineOutcome {
+      // phase 2 first to preserve WindowOpened-before-forced event order
+      if let Some(wk) = te.reaction_window() { queue_reaction_window(cx, wk); }
+      // phase 1: forced, fixed-order (the ported fire_forced logic)
+      run_forced(cx, &te)   // returns Done / AwaitingInput / Rejected as fire_forced did
+  }
+  ```
+  (T5b reorders/replaces phase-1's internals; T5a keeps `run_forced` == today's
+  `fire_forced_triggers`.)
+
+- [ ] **Step 4: Migrate the 10 call sites** per the table — each `fire_forced` /
+  `queue_reaction` (or the dual pair) becomes one `emit_event(cx, TimingEvent::Z { … })`.
+  Update `test_support`'s `fire_forced_at` to drive `emit_event`.
+
+- [ ] **Step 5: Gauntlet** — the full existing suite is the behavior-preserving
+  gate (defeat→Roland reaction + act-3 advance; investigate→Milan + Obscuring Fog;
+  soak→Guard Dog; RoundEnded; phase-end). All green, unchanged.
+
+- [ ] **Step 6: Commit** — `Closes #212.`
+
+## T5b — iterative forced-ordering loop + reentrancy (closes #213, #294)
+
+**Files:** `emit.rs` (the forced run), `game_state.rs` (the forced-loop frame),
+`dispatch/mod.rs` (resume routing), `combat.rs` (remove the #294 `debug_assert`).
+
+- [ ] **Step 1 (failing test): 2+ simultaneous forced → player picks order.**
+  Agenda 01107 `RoundEnded` doom + Dissonant Voices 01165 `RoundEnded` discard:
+  assert the engine surfaces a choice (lead investigator orders the two) rather
+  than resolving in fixed order. (Integration test with the real registry.)
+
+- [ ] **Step 2: The forced run as a parameterized resolution loop.** Per the
+  Axis-B spec "One loop, two phases": the forced phase reuses the shared
+  iterative loop with `can_skip=false`, `decider=Lead`, candidates = the
+  collected forced hits. Resolve one (lead-chosen when 2+) → re-collect → repeat.
+  Carry loop state in a `Continuation` frame so a forced hit whose effect
+  suspends (Frozen in Fear's `EndOfTurn` test) parks and resumes the remaining
+  hits — **reentrancy**. Decide here: extend the `Resolution` frame with the loop
+  params, vs. a dedicated `ForcedOrdering` frame (record the choice in the spec's
+  Decisions).
+
+- [ ] **Step 3: Reentrancy test** — Frozen in Fear `EndOfTurn` forced effect
+  suspends on its willpower test; after the test resolves, dispatch continues /
+  completes without abandoning siblings.
+
+- [ ] **Step 4: Dissolve #294** — remove the `drive_attack_loop` `debug_assert`
+  (one attack damaging two `EnemyAttackDamagedSelf` reactors) and add the
+  two-Guard-Dog multi-soak test: both windows drain, cursor advances once.
+
+- [ ] **Step 5: `/code-review` pass** (pre-push, per the inline-execution plan) —
+  present findings before opening the PR.
+
+- [ ] **Step 6: Gauntlet + commit** — `Closes #213. Closes #294.`
+
+## Out of scope (T5)
+
+Axes A/C/D; the Before-timing firing (Axis D); migrating the orthogonal
+`pending_*` modes; the #117 index (T6). Newly-arising forced hits mid-loop
+(delayed effects) stay out — no Slice-1+ card produces them.
+
+## Risks
+
+- **T5a ordering** — the WindowOpened-before-forced event order at dual sites;
+  preserved by queuing the window before resolving forced. The suite's
+  event-order assertions are the check.
+- **T5b frame shape** — the forced-loop continuation frame must compose with the
+  existing `Resolution`/`SkillTest` frames (a forced hit that opens a reaction
+  window, or starts a skill test, nests above the forced-loop frame). The
+  Frozen-in-Fear + Dissonant-Voices tests exercise this.

--- a/docs/superpowers/plans/2026-06-16-trigger-dispatch-t5-emit-event.md
+++ b/docs/superpowers/plans/2026-06-16-trigger-dispatch-t5-emit-event.md
@@ -72,24 +72,31 @@ preserving event order. (T5b revisits forced *resolution* order, not the queue.)
   - `fn forced_controller(&self, state) -> binding` — port the per-variant controller/source/scan binding from `collect_forced_hits` (lead investigator for board cards; the entering/ending investigator; each instance's controller for GameEnd; etc.).
   - `fn reaction_window(&self) -> Option<WindowKind>` — `Some` only for `EnemyDefeated`, `SuccessfullyInvestigated`, `EnemyAttackDamagedSelf`; `None` otherwise.
 
-- [ ] **Step 2: Port `collect_forced_hits` / `resolve_one`** from `forced_triggers.rs`
-  into `emit.rs`, keyed off `TimingEvent` instead of `ForcedTriggerPoint`. The
-  body is the same per-variant scan (board cards → threat-area/attachment
-  instances, `BTreeMap` order); the resolution is the same fixed-deterministic
-  loop (`fire_forced` today) — **no semantic change in T5a**. Delete
-  `ForcedTriggerPoint` and `forced_triggers.rs`.
+- [ ] **Step 2: `TimingEvent` is a thin facade (no porting in T5a).** Add two
+  mapping methods rather than moving the forced scan:
+  - `fn forced_point(&self) -> Option<ForcedTriggerPoint>` — reconstruct the
+    existing `ForcedTriggerPoint` with the same binding (1:1 field copy;
+    `SuccessfullyInvestigated → AfterLocationInvestigated { investigator, location }`;
+    `EnemyAttackDamagedSelf → None`).
+  - `fn reaction_window(&self) -> Option<WindowKind>` — `Some` only for the three
+    reaction-capable points.
+  `forced_triggers.rs` (ForcedTriggerPoint + `fire_forced_triggers` +
+  `collect_forced_hits`) **stays unchanged** — T5b (which rewrites the forced
+  loop) absorbs/deletes it. This keeps T5a's diff to the chokepoint + call sites.
 
-- [ ] **Step 3: Implement `emit_event`**:
+- [ ] **Step 3: Implement `emit_event`** — delegate to the existing helpers:
   ```
   fn emit_event(cx, te: TimingEvent) -> EngineOutcome {
       // phase 2 first to preserve WindowOpened-before-forced event order
       if let Some(wk) = te.reaction_window() { queue_reaction_window(cx, wk); }
-      // phase 1: forced, fixed-order (the ported fire_forced logic)
-      run_forced(cx, &te)   // returns Done / AwaitingInput / Rejected as fire_forced did
+      // phase 1: forced, fixed-order (today's fire_forced_triggers, unchanged)
+      match te.forced_point() {
+          Some(fp) => fire_forced_triggers(cx, &fp),
+          None => EngineOutcome::Done,
+      }
   }
   ```
-  (T5b reorders/replaces phase-1's internals; T5a keeps `run_forced` == today's
-  `fire_forced_triggers`.)
+  (T5b replaces phase-1's internals with the iterative loop.)
 
 - [ ] **Step 4: Migrate the 10 call sites** per the table — each `fire_forced` /
   `queue_reaction` (or the dual pair) becomes one `emit_event(cx, TimingEvent::Z { … })`.

--- a/docs/superpowers/plans/2026-06-16-trigger-dispatch-t5-emit-event.md
+++ b/docs/superpowers/plans/2026-06-16-trigger-dispatch-t5-emit-event.md
@@ -111,15 +111,18 @@ preserving event order. (T5b revisits forced *resolution* order, not the queue.)
   assert the engine surfaces a choice (lead investigator orders the two) rather
   than resolving in fixed order. (Integration test with the real registry.)
 
-- [ ] **Step 2: The forced run as a parameterized resolution loop.** Per the
-  Axis-B spec "One loop, two phases": the forced phase reuses the shared
-  iterative loop with `can_skip=false`, `decider=Lead`, candidates = the
-  collected forced hits. Resolve one (lead-chosen when 2+) → re-collect → repeat.
-  Carry loop state in a `Continuation` frame so a forced hit whose effect
-  suspends (Frozen in Fear's `EndOfTurn` test) parks and resumes the remaining
-  hits — **reentrancy**. Decide here: extend the `Resolution` frame with the loop
-  params, vs. a dedicated `ForcedOrdering` frame (record the choice in the spec's
-  Decisions).
+- [ ] **Step 2: The forced run as the *shared* parameterized resolution loop.**
+  Per the already-settled "One loop, two phases" decision (umbrella §1 + Axis-B
+  spec — we explicitly rejected a separate `ForcedOrdering` frame when
+  consolidating forced + reaction ordering): the forced phase is the **same
+  `Continuation::Resolution` loop** as the reaction window, run with
+  `can_skip=false`, `decider=Lead`, candidates = the collected forced hits.
+  So T5b's work is to **generalize the existing `Resolution` frame** (today it
+  wraps an `OpenWindow` — the reaction run) to carry the loop params
+  (`can_skip` / `decider` / candidate source), then drive a forced run through
+  it. Resolve one (lead-chosen when 2+) → re-collect → repeat; a forced hit whose
+  effect suspends (Frozen in Fear's `EndOfTurn` test) parks the frame and resumes
+  the remaining hits — **reentrancy**. No new frame variant.
 
 - [ ] **Step 3: Reentrancy test** — Frozen in Fear `EndOfTurn` forced effect
   suspends on its willpower test; after the test resolves, dispatch continues /


### PR DESCRIPTION
T5a of the Axis-B foundation (plan: `docs/superpowers/plans/2026-06-16-trigger-dispatch-t5-emit-event.md`; kickoff #327). **Behavior-preserving** chokepoint half of the semantic task; the iterative ordering loop is T5b.

## What
One `emit_event(cx, &TimingEvent)` chokepoint for forced + reaction trigger dispatch (#212). `TimingEvent` merges the two pre-existing binding-carrying dispatch keys — `ForcedTriggerPoint` + the event-driven `WindowKind` variants. `emit_event` queues the reaction window (phase 2) then fires forced (phase 1), preserving the prior per-site event order.

Migrated 9 of 10 sites:
- **EnemyDefeated dual** (queue `AfterEnemyDefeated` + fire forced `EnemyDefeated`, both at one point in `damage_enemy`) → one `emit_event`.
- 8 forced-only sites (act/agenda advance, phase-end, round-end, end-of-turn, entered-location, game-end) + the soak window → `emit_event`.

## Behavior-preserving facade
`emit_event` **delegates** to the existing `fire_forced_triggers` / `queue_reaction_window` — `forced_triggers.rs` stays unchanged (T5b rewrites the forced loop and absorbs it). It does **not** push log events (call sites keep emitting their own). Same forced order, same reject behavior.

## Deliberately deferred to T5b
The **successful-investigate** site is *not* migrated: its forced (Obscuring Fog, fired at `PostOnResolution`) and reaction (Dr. Milan, queued at `PostFollowUp`) fire at **different driver steps** today, so collapsing them into one `TimingEvent` would reorder them to RR-correct forced-first — a behavior change that belongs in T5b.

## Verification
Full strict gauntlet green; the existing suite (76 suites — defeat→Roland reaction + act-3 advance, soak→Guard Dog, round/phase-end forced) is the behavior-preserving gate.

Closes #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)