### PR TITLE
docs: phase-7 — defer #117 trigger index, close Axis-B as substantively done

### DIFF
--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -126,15 +126,17 @@ when picked up.
   + [Axis-B foundation](../superpowers/specs/2026-06-16-trigger-dispatch-rework-axis-b-foundation-design.md)
   specs ([Axis-B plan](../superpowers/plans/2026-06-16-trigger-dispatch-axis-b-foundation.md)).
   Five axes: **B** trigger-dispatch spine (one continuation stack +
-  two-phase forced-then-reaction `emit_event` + #117 index; tasks
-  [#328](https://github.com/talelburg/eldritch/issues/328)–[#333](https://github.com/talelburg/eldritch/issues/333)).
-  **T1–T5 shipped** (#328–#332): the `emit_event` chokepoint + `TimingEvent`
-  closed #212; the iterative lead-ordered forced run + reentrancy + the
-  forced-before-reaction investigate collapse closed #213 (T5b, PR #343).
-  **T6** (#333 / #117 event-keyed index) is the remaining Axis-B task.
-  #294 was re-examined and **kept open** (its multi-soak-window state is
-  unconstructible in scope — see Decisions), not closed by Axis B. **A**
-  interactive choice
+  two-phase forced-then-reaction `emit_event`; tasks
+  [#328](https://github.com/talelburg/eldritch/issues/328)–[#332](https://github.com/talelburg/eldritch/issues/332)).
+  **Substantive work done** — T1–T5 (#328–#332) shipped: the `emit_event`
+  chokepoint + `TimingEvent` closed #212; the iterative lead-ordered forced
+  run + reentrancy + the forced-before-reaction investigate collapse closed
+  #213 (T5b, PR #343). The #117 **event-keyed trigger index is deferred** to
+  Phase 4+ (zero perf return at Slice-1 board sizes vs. real index-invariant
+  carrying cost; tracked in #117, plan recorded there) — its Axis-B task
+  wrapper #333 was closed as redundant. #294 was re-examined and **kept open**
+  (its multi-soak-window state is unconstructible in scope — see Decisions),
+  not closed by Axis B. **A** interactive choice
   ([#334](https://github.com/talelburg/eldritch/issues/334)), **C**
   reaction-event-play ([#335](https://github.com/talelburg/eldritch/issues/335)),
   **D** cancellation/replacement ([#336](https://github.com/talelburg/eldritch/issues/336)),


### PR DESCRIPTION
## Summary

Bookkeeping after the Axis-B review: the trigger-dispatch spine (T1–T5) is shipped and the #117 event-keyed trigger index is deferred, so the phase-7 north-star bullet is updated to match and the redundant Axis-B task #333 is closed.

## What changed

- phase-7 doc: Axis-B marked **substantively done** — T1–T5 (#328–#332) shipped (#212 emit_event chokepoint + #213 iterative forced ordering / reentrancy / investigate collapse, PR #343). The #117 index is **deferred to Phase 4+** (zero perf return at Slice-1 board sizes vs. the real index-invariant carrying cost); #333 (its task wrapper) closed as redundant since #117 carries the feature context.

## Why defer #117

Per the issue's own guidance — the reaction-window scan isn't a hot path until Phase 4+ decks grow. The index would add standing invariant cost: a serialized `EventPattern`-keyed index kept consistent across every board mutation, including the many tests/builders that push to `cards_in_play`/`threat_area` directly (rebuild-in-`build()` + cross-check, or the debug oracle fails). Safe to build but not worth it now; the implementation plan is recorded on #117 for when boards make the scan hot.

## Test notes

Docs-only; no code change.

## Linked issues

(No `Closes` — #117 stays open/deferred; #333 already closed as redundant. Bookkeeping only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)