### PR TITLE
engine: consolidate DealDamage + DealHorror into Effect::Deal { kind } (#354)

### DIFF
--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -539,17 +539,12 @@ pub enum Effect {
     /// investigator. (Caller responsibility: validate the location
     /// has clues and the investigator can hold them.)
     DiscoverClue { from: LocationTarget, count: u8 },
-    /// Deal `amount` damage to the resolved target investigator,
-    /// applying defeat if the new total reaches their max health.
-    /// `amount == 0` is a no-op (no event, no target resolution).
-    DealDamage {
-        target: InvestigatorTarget,
-        amount: u8,
-    },
-    /// Deal `amount` horror to the resolved target investigator,
-    /// applying defeat if the new total reaches their max sanity.
-    /// `amount == 0` is a no-op.
-    DealHorror {
+    /// Deal `amount` of `kind` (damage or horror) to the resolved target
+    /// investigator, applying defeat if the new total reaches their max health
+    /// (damage) or max sanity (horror). `amount == 0` is a no-op (no event, no
+    /// target resolution). Built via the [`deal_damage`] / [`deal_horror`] sugar.
+    Deal {
+        kind: HarmKind,
         target: InvestigatorTarget,
         amount: u8,
     },
@@ -559,7 +554,7 @@ pub enum Effect {
     /// before any cost is paid. `amount == 0` is a no-op.
     DealDamageToEnemy { target: EnemyTarget, amount: u8 },
     /// Heal `count` of `kind` (damage or horror) from the resolved target
-    /// investigator — the inverse of `DealDamage`/`DealHorror` (no defeat
+    /// investigator — the inverse of [`Effect::Deal`] (no defeat
     /// interaction). Heals at most the current amount (saturating at 0).
     /// `count == 0`, or a target with nothing to heal, is a no-op.
     Heal {
@@ -704,8 +699,8 @@ pub enum Effect {
 // ---- stats and modifier scopes --------------------------------
 
 /// Which health track a heal or harm acts on — physical (`Damage`, on health)
-/// or mental (`Horror`, on sanity). Shared by [`Effect::Heal`]; the
-/// `DealDamage`/`DealHorror` consolidation (#354) adopts it.
+/// or mental (`Horror`, on sanity). Shared by [`Effect::Heal`] and
+/// [`Effect::Deal`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum HarmKind {
     /// Physical damage (reduces remaining health).
@@ -1164,10 +1159,14 @@ pub fn discover_clue(from: LocationTarget, count: u8) -> Effect {
     Effect::DiscoverClue { from, count }
 }
 
-/// Build an [`Effect::DealDamage`] against `target` for `amount`.
+/// Build an [`Effect::Deal`] dealing `amount` damage to `target`.
 #[must_use]
 pub fn deal_damage(target: InvestigatorTarget, amount: u8) -> Effect {
-    Effect::DealDamage { target, amount }
+    Effect::Deal {
+        kind: HarmKind::Damage,
+        target,
+        amount,
+    }
 }
 
 /// Build an [`Effect::Heal`].
@@ -1180,10 +1179,14 @@ pub fn heal(kind: HarmKind, target: InvestigatorTarget, count: u8) -> Effect {
     }
 }
 
-/// Build an [`Effect::DealHorror`] against `target` for `amount`.
+/// Build an [`Effect::Deal`] dealing `amount` horror to `target`.
 #[must_use]
 pub fn deal_horror(target: InvestigatorTarget, amount: u8) -> Effect {
-    Effect::DealHorror { target, amount }
+    Effect::Deal {
+        kind: HarmKind::Horror,
+        target,
+        amount,
+    }
 }
 
 /// Build an [`Effect::DealDamageToEnemy`].
@@ -1619,6 +1622,32 @@ mod tests {
         );
         let json = serde_json::to_string(&e).unwrap();
         assert_eq!(serde_json::from_str::<Effect>(&json).unwrap(), e);
+    }
+
+    #[test]
+    fn deal_builders_produce_the_kinded_effect_and_round_trip() {
+        let dmg = deal_damage(InvestigatorTarget::You, 2);
+        let hor = deal_horror(InvestigatorTarget::You, 3);
+        assert_eq!(
+            dmg,
+            Effect::Deal {
+                kind: HarmKind::Damage,
+                target: InvestigatorTarget::You,
+                amount: 2,
+            }
+        );
+        assert_eq!(
+            hor,
+            Effect::Deal {
+                kind: HarmKind::Horror,
+                target: InvestigatorTarget::You,
+                amount: 3,
+            }
+        );
+        for e in [dmg, hor] {
+            let json = serde_json::to_string(&e).unwrap();
+            assert_eq!(serde_json::from_str::<Effect>(&json).unwrap(), e);
+        }
     }
 
     #[test]

--- a/crates/cards/src/impls/agenda_01105.rs
+++ b/crates/cards/src/impls/agenda_01105.rs
@@ -72,7 +72,7 @@ fn random_discard_each(cx: &mut Cx, _ctx: &EvalContext) -> EngineOutcome {
 
 #[cfg(test)]
 mod tests {
-    use card_dsl::dsl::{Effect, EventPattern, EventTiming, Trigger};
+    use card_dsl::dsl::{Effect, EventPattern, EventTiming, HarmKind, Trigger};
 
     #[test]
     fn abilities_are_one_forced_on_advance_choose_one() {
@@ -97,7 +97,8 @@ mod tests {
         assert!(
             matches!(
                 &branches[1],
-                Effect::DealHorror {
+                Effect::Deal {
+                    kind: HarmKind::Horror,
                     target: card_dsl::dsl::InvestigatorTarget::You,
                     amount: 2
                 }

--- a/crates/cards/src/impls/attic.rs
+++ b/crates/cards/src/impls/attic.rs
@@ -30,7 +30,7 @@ pub fn abilities() -> Vec<Ability> {
 
 #[cfg(test)]
 mod tests {
-    use card_dsl::dsl::{Effect, EventPattern, EventTiming, InvestigatorTarget, Trigger};
+    use card_dsl::dsl::{Effect, EventPattern, EventTiming, HarmKind, InvestigatorTarget, Trigger};
 
     #[test]
     fn abilities_are_one_forced_enter_horror() {
@@ -46,7 +46,8 @@ mod tests {
         );
         assert!(matches!(
             abilities[0].effect,
-            Effect::DealHorror {
+            Effect::Deal {
+                kind: HarmKind::Horror,
                 target: InvestigatorTarget::You,
                 amount: 1,
             }

--- a/crates/cards/src/impls/cellar.rs
+++ b/crates/cards/src/impls/cellar.rs
@@ -28,7 +28,7 @@ pub fn abilities() -> Vec<Ability> {
 
 #[cfg(test)]
 mod tests {
-    use card_dsl::dsl::{Effect, EventPattern, EventTiming, InvestigatorTarget, Trigger};
+    use card_dsl::dsl::{Effect, EventPattern, EventTiming, HarmKind, InvestigatorTarget, Trigger};
 
     #[test]
     fn abilities_are_one_forced_enter_damage() {
@@ -44,7 +44,8 @@ mod tests {
         );
         assert!(matches!(
             abilities[0].effect,
-            Effect::DealDamage {
+            Effect::Deal {
+                kind: HarmKind::Damage,
                 target: InvestigatorTarget::You,
                 amount: 1,
             }

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -39,9 +39,9 @@
 //!   `Effect::Fight` (flat +1 combat, +1 damage; conditional-damage caveat
 //!   in the impl, TODO(#300)).
 //! - Attic (01113) — `Trigger::OnEvent` (`EnteredLocation`, `After`) +
-//!   `DealHorror(You, 1)`.
+//!   `deal_horror(You, 1)`.
 //! - Cellar (01114) — `Trigger::OnEvent` (`EnteredLocation`, `After`) +
-//!   `DealDamage(You, 1)`.
+//!   `deal_damage(You, 1)`.
 //! - Deduction (01039) — `Trigger::OnSkillTestResolution` (Success-
 //!   gated) + `If(SkillTestKind(Investigate), DiscoverClue@TestedLocation)`.
 //! - Roland Banks (01001) — investigator. `Trigger::OnEvent`

--- a/crates/cards/src/impls/treachery_01162.rs
+++ b/crates/cards/src/impls/treachery_01162.rs
@@ -31,7 +31,7 @@ pub fn abilities() -> Vec<Ability> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use card_dsl::dsl::Effect;
+    use card_dsl::dsl::{Effect, HarmKind};
 
     #[test]
     fn revelation_tests_agility_3_then_damage_per_point() {
@@ -52,7 +52,7 @@ mod tests {
         assert!(matches!(
             on_fail.as_deref(),
             Some(Effect::ForEachPointFailed(b))
-                if matches!(**b, Effect::DealDamage { amount: 1, .. })
+                if matches!(**b, Effect::Deal { kind: HarmKind::Damage, amount: 1, .. })
         ));
     }
 }

--- a/crates/cards/src/impls/treachery_01163.rs
+++ b/crates/cards/src/impls/treachery_01163.rs
@@ -31,7 +31,7 @@ pub fn abilities() -> Vec<Ability> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use card_dsl::dsl::Effect;
+    use card_dsl::dsl::{Effect, HarmKind};
 
     #[test]
     fn revelation_tests_willpower_3_then_horror_per_point() {
@@ -52,7 +52,7 @@ mod tests {
         assert!(matches!(
             on_fail.as_deref(),
             Some(Effect::ForEachPointFailed(b))
-                if matches!(**b, Effect::DealHorror { amount: 1, .. })
+                if matches!(**b, Effect::Deal { kind: HarmKind::Horror, amount: 1, .. })
         ));
     }
 }

--- a/crates/game-core/src/engine/dispatch/elimination.rs
+++ b/crates/game-core/src/engine/dispatch/elimination.rs
@@ -189,8 +189,8 @@ pub(crate) fn take_horror(cx: &mut Cx, investigator: InvestigatorId, amount: u8)
 
 /// Apply `amount` damage to `investigator` via the numeric helper,
 /// then apply defeat (cause [`DefeatCause::Damage`]) if it was lethal.
-/// The single-source-damage twin of `take_horror` — the first such
-/// caller is `Effect::DealDamage`'s evaluator.
+/// The single-source-damage twin of `take_horror` — called by
+/// `Effect::Deal`'s evaluator (the `HarmKind::Damage` arm).
 ///
 /// Re-exported at `game_core::take_damage` so card-local native effects
 /// (#276) can deal damage without re-implementing the defeat check — the

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -250,7 +250,7 @@ pub(super) fn finish_skill_test(cx: &mut Cx, indices: &[u32]) -> EngineOutcome {
         // Margin-keyed failure branch of a treachery-Revelation test
         // (`Effect::SkillTest`). The failure margin is threaded so
         // `Effect::ForEachPointFailed` can scale. In-scope on_fail
-        // effects (DealDamage / DealHorror / Native) run to completion;
+        // effects (Deal / Native) run to completion;
         // a future suspending on_fail is #212 reentrancy work.
         let mut ctx = card_ctx(investigator);
         ctx.failed_by = Some(failed_by);
@@ -967,8 +967,8 @@ pub(super) fn peril_check(
 /// Apply a resolved symbol token's side effects to the testing
 /// investigator: `immediate` effects always, `on_fail` effects only when
 /// the test failed. Routes through the same elimination paths as
-/// `Effect::DealDamage` / `Effect::DealHorror`, so defeat handling and
-/// the `DamageTaken` / `HorrorTaken` events are reused.
+/// `Effect::Deal`, so defeat handling and the `DamageTaken` /
+/// `HorrorTaken` events are reused.
 fn apply_symbol_outcome(
     cx: &mut Cx,
     investigator: InvestigatorId,

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -274,8 +274,11 @@ fn apply_effect_inner(
     match effect {
         Effect::GainResources { target, amount } => gain_resources(cx, eval_ctx, *target, *amount),
         Effect::DiscoverClue { from, count } => discover_clue(cx, eval_ctx, *from, *count),
-        Effect::DealDamage { target, amount } => deal_damage_effect(cx, eval_ctx, *target, *amount),
-        Effect::DealHorror { target, amount } => deal_horror_effect(cx, eval_ctx, *target, *amount),
+        Effect::Deal {
+            kind,
+            target,
+            amount,
+        } => deal_effect(cx, eval_ctx, *kind, *target, *amount),
         Effect::DealDamageToEnemy { target, amount } => {
             deal_damage_to_enemy_effect(cx, eval_ctx, *target, *amount)
         }
@@ -906,9 +909,13 @@ pub(crate) fn perform_discovery(
     });
 }
 
-fn deal_damage_effect(
+/// Resolve [`Effect::Deal`]: ground the target investigator and apply `amount`
+/// of `kind` (damage or horror) via the elimination helpers (which run the
+/// matching defeat check). `amount == 0` is a no-op.
+fn deal_effect(
     cx: &mut Cx,
     eval_ctx: EvalContext,
+    kind: HarmKind,
     target: InvestigatorTarget,
     amount: u8,
 ) -> EngineOutcome {
@@ -925,10 +932,17 @@ fn deal_damage_effect(
     };
     if !cx.state.investigators.contains_key(&target_id) {
         return EngineOutcome::Rejected {
-            reason: format!("DealDamage: investigator {target_id:?} is not in the state").into(),
+            reason: format!("Deal: investigator {target_id:?} is not in the state").into(),
         };
     }
-    crate::engine::dispatch::elimination::take_damage(cx, target_id, amount);
+    match kind {
+        HarmKind::Damage => {
+            crate::engine::dispatch::elimination::take_damage(cx, target_id, amount);
+        }
+        HarmKind::Horror => {
+            crate::engine::dispatch::elimination::take_horror(cx, target_id, amount);
+        }
+    }
     EngineOutcome::Done
 }
 
@@ -1001,32 +1015,6 @@ fn heal_effect(
             amount: healed,
         });
     }
-    EngineOutcome::Done
-}
-
-fn deal_horror_effect(
-    cx: &mut Cx,
-    eval_ctx: EvalContext,
-    target: InvestigatorTarget,
-    amount: u8,
-) -> EngineOutcome {
-    if amount == 0 {
-        return EngineOutcome::Done;
-    }
-    let target_id = match resolve_investigator_target(cx.state, eval_ctx, target) {
-        Ok(id) => id,
-        Err(reason) => {
-            return EngineOutcome::Rejected {
-                reason: reason.into(),
-            }
-        }
-    };
-    if !cx.state.investigators.contains_key(&target_id) {
-        return EngineOutcome::Rejected {
-            reason: format!("DealHorror: investigator {target_id:?} is not in the state").into(),
-        };
-    }
-    crate::engine::dispatch::elimination::take_horror(cx, target_id, amount);
     EngineOutcome::Done
 }
 
@@ -1184,8 +1172,7 @@ fn ground_chosen_targets(
 ) -> Result<EvalContext, EngineOutcome> {
     let inv_target = match effect {
         Effect::GainResources { target, .. }
-        | Effect::DealDamage { target, .. }
-        | Effect::DealHorror { target, .. }
+        | Effect::Deal { target, .. }
         | Effect::Heal { target, .. }
         | Effect::DrawCards { target, .. } => Some(target),
         _ => None,
@@ -3888,7 +3875,7 @@ mod tests {
             state: &mut state,
             events: &mut events,
         };
-        // Margin 2 → run DealDamage{You,1} twice → 2 damage, 2 events.
+        // Margin 2 → run Deal{Damage,You,1} twice → 2 damage, 2 events.
         let mut eval_ctx = EvalContext::for_controller(InvestigatorId(1));
         eval_ctx.failed_by = Some(2);
         let outcome = apply_effect(
@@ -3950,7 +3937,7 @@ mod tests {
     #[test]
     fn deal_damage_at_max_health_defeats_investigator() {
         // Build an investigator with a known low max_health (3), then
-        // apply exactly 3 damage via Effect::DealDamage and assert the
+        // apply exactly 3 damage via Effect::Deal and assert the
         // investigator is Killed and InvestigatorDefeated is emitted.
         use crate::state::Status;
         let id = InvestigatorId(1);


### PR DESCRIPTION
## Summary

Folds the two near-identical damage effects into one `HarmKind`-parameterized `Effect::Deal { kind, target, amount }`, reusing the `HarmKind` introduced in #302. Behavior-preserving cleanup.

## What changed

- **`card-dsl`:** `Effect::{DealDamage, DealHorror}` → `Effect::Deal { kind: HarmKind, target, amount }`. The `deal_damage` / `deal_horror` builders stay as thin sugar (so the ~20 call sites are unchanged).
- **evaluator:** `deal_damage_effect` + `deal_horror_effect` → one `deal_effect` dispatching on `kind` (calls `take_damage`/`take_horror`); the match arm and `ground_chosen_targets` arms collapse to one each.
- **5 test assertions** matching the old variants + a handful of doc-comments updated to `Effect::Deal`.

## Why no behavior change

Nothing about damage/horror resolution changes — same elimination paths, same events, same defeat handling. The existing damage/horror card + engine tests pass unchanged (they go through the unchanged builders), which is the safety net. Added one serde/shape test for the new variant.

## Test notes

Full strict gauntlet green (test/clippy/fmt/doc, `-D warnings`). No `DealDamage`/`DealHorror` variant references remain (outside `DealDamageToEnemy`, which is unrelated).

## Linked issues

Closes #354