### PR TITLE
cards: Beat Cop 01018 + First Aid 01019 — close C5d (#239)

### DIFF
--- a/crates/cards/src/impls/beat_cop.rs
+++ b/crates/cards/src/impls/beat_cop.rs
@@ -1,0 +1,84 @@
+//! Beat Cop (Guardian ally asset, 01018).
+//!
+//! ```text
+//! You get +1 [combat].
+//! [fast] Discard Beat Cop: Deal 1 damage to an enemy at your location.
+//! ```
+//!
+//! Two abilities: a constant `+1 [combat]` while in play, and a `[fast]`
+//! ability whose cost discards the ally itself (`Cost::DiscardSelf`, #301)
+//! to deal 1 direct damage to a chosen enemy at the controller's location
+//! (`Effect::DealDamageToEnemy` over the keystone's
+//! `EnemyTarget::Chosen(At(your location))`, #349/#301). The activation
+//! pre-cost check rejects when no enemy is there, so the discard is never
+//! paid for nothing; 2+ enemies suspend for the controller's pick.
+//!
+//! The `sanity: 2` horror-soak the printed ally also carries is corpus
+//! metadata, not modeled as an ability (tracked in #44).
+
+use card_dsl::dsl::{
+    activated, constant, deal_damage_to_enemy, modify, Ability, Cost, EnemyTarget, ModifierScope,
+    Stat,
+};
+
+/// `ArkhamDB` code for Beat Cop (original-Core printing).
+pub const CODE: &str = "01018";
+
+/// Beat Cop's constant `+1 [combat]` and its `[fast]` discard-to-damage ability.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![
+        // You get +1 [combat] (while in play).
+        constant(modify(Stat::Combat, 1, ModifierScope::WhileInPlay)),
+        // [fast] Discard Beat Cop: Deal 1 damage to an enemy at your location.
+        activated(
+            0,
+            vec![Cost::DiscardSelf],
+            deal_damage_to_enemy(EnemyTarget::chosen_at_your_location(), 1),
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use card_dsl::dsl::{Choose, Effect, EntityScope, LocationSet, Trigger};
+
+    #[test]
+    fn abilities_are_constant_combat_plus_fast_discard_damage() {
+        let abilities = abilities();
+        assert_eq!(abilities.len(), 2);
+
+        // Index 0: constant +1 combat while in play.
+        assert_eq!(abilities[0].trigger, Trigger::Constant);
+        assert!(matches!(
+            abilities[0].effect,
+            Effect::Modify {
+                stat: Stat::Combat,
+                delta: 1,
+                scope: ModifierScope::WhileInPlay,
+            }
+        ));
+
+        // Index 1: [fast] (action_cost 0), DiscardSelf cost, deal 1 to a chosen
+        // enemy at your location.
+        assert_eq!(abilities[1].trigger, Trigger::Activated { action_cost: 0 });
+        assert_eq!(abilities[1].costs, vec![Cost::DiscardSelf]);
+        assert!(matches!(
+            abilities[1].effect,
+            Effect::DealDamageToEnemy {
+                target: EnemyTarget::Chosen(Choose {
+                    scope: EntityScope::At(LocationSet::Here),
+                }),
+                amount: 1,
+            }
+        ));
+    }
+
+    /// Catches a `pub mod` rename or a fat-fingered match arm in
+    /// `impls::abilities_for` — the registry must dispatch CODE here.
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(CODE), Some(abilities()));
+    }
+}

--- a/crates/cards/src/impls/first_aid.rs
+++ b/crates/cards/src/impls/first_aid.rs
@@ -1,0 +1,89 @@
+//! First Aid (Guardian item asset, 01019).
+//!
+//! ```text
+//! Uses (3 supplies). If First Aid has no supplies, discard it.
+//! [action] Spend 1 supply: Heal 1 damage or horror from an investigator
+//!   at your location.
+//! ```
+//!
+//! One activated ability: an action paying 1 supply (`Cost::SpendUses`) to
+//! heal 1 damage **or** horror from a chosen investigator at the controller's
+//! location. The damage-or-horror choice is an `Effect::ChooseOne` over the
+//! two `Effect::Heal` branches (#302), each targeting the keystone's
+//! `InvestigatorTarget::Chosen(At(your location))` (#349). The `Uses (3
+//! supplies)` pool and the "if no supplies, discard it" depletion-discard are
+//! corpus metadata (`CardKind::Asset.uses` + `Uses.discard_when_empty`,
+//! pipeline-parsed, #302) — `abilities()` declares only the action; the engine
+//! discards the asset automatically when the last supply is spent.
+
+use card_dsl::card_data::UseKind;
+use card_dsl::dsl::{activated, choose_one, heal, Ability, Cost, HarmKind, InvestigatorTarget};
+
+/// `ArkhamDB` code for First Aid (original-Core printing).
+pub const CODE: &str = "01019";
+
+/// First Aid's `[action] Spend 1 supply: heal 1 damage or horror` ability.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![activated(
+        1,
+        vec![Cost::SpendUses {
+            kind: UseKind::Supplies,
+            count: 1,
+        }],
+        choose_one([
+            heal(
+                HarmKind::Damage,
+                InvestigatorTarget::chosen_at_your_location(),
+                1,
+            ),
+            heal(
+                HarmKind::Horror,
+                InvestigatorTarget::chosen_at_your_location(),
+                1,
+            ),
+        ]),
+    )]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use card_dsl::dsl::{Effect, Trigger};
+
+    #[test]
+    fn one_action_ability_spending_a_supply_to_choose_a_heal() {
+        let abilities = abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(abilities[0].trigger, Trigger::Activated { action_cost: 1 });
+        assert_eq!(
+            abilities[0].costs,
+            vec![Cost::SpendUses {
+                kind: UseKind::Supplies,
+                count: 1,
+            }]
+        );
+        let Effect::ChooseOne(branches) = &abilities[0].effect else {
+            panic!("expected ChooseOne (damage or horror)");
+        };
+        assert_eq!(branches.len(), 2);
+        let expected_target = InvestigatorTarget::chosen_at_your_location();
+        assert_eq!(
+            branches[0],
+            heal(HarmKind::Damage, expected_target, 1),
+            "branch 0 heals 1 damage from an investigator at your location",
+        );
+        assert_eq!(
+            branches[1],
+            heal(HarmKind::Horror, expected_target, 1),
+            "branch 1 heals 1 horror from an investigator at your location",
+        );
+    }
+
+    /// Catches a `pub mod` rename or a fat-fingered match arm in
+    /// `impls::abilities_for` — the registry must dispatch CODE here.
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(CODE), Some(abilities()));
+    }
+}

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -67,10 +67,12 @@ pub mod agenda_01106;
 pub mod agenda_01107;
 pub mod attic;
 pub mod automatic_45;
+pub mod beat_cop;
 pub mod cellar;
 pub mod deduction;
 pub mod dr_milan_christopher;
 pub mod emergency_cache;
+pub mod first_aid;
 pub mod guard_dog;
 pub mod guts;
 pub mod holy_rosary;
@@ -108,10 +110,12 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
         agenda_01107::CODE => Some(agenda_01107::abilities()),
         attic::CODE => Some(attic::abilities()),
         automatic_45::CODE => Some(automatic_45::abilities()),
+        beat_cop::CODE => Some(beat_cop::abilities()),
         cellar::CODE => Some(cellar::abilities()),
         deduction::CODE => Some(deduction::abilities()),
         dr_milan_christopher::CODE => Some(dr_milan_christopher::abilities()),
         emergency_cache::CODE => Some(emergency_cache::abilities()),
+        first_aid::CODE => Some(first_aid::abilities()),
         guard_dog::CODE => Some(guard_dog::abilities()),
         guts::CODE => Some(guts::abilities()),
         holy_rosary::CODE => Some(holy_rosary::abilities()),

--- a/crates/cards/tests/beat_cop.rs
+++ b/crates/cards/tests/beat_cop.rs
@@ -1,0 +1,98 @@
+//! C5d (#239) integration: Beat Cop 01018's `[fast] Discard Beat Cop: Deal 1
+//! damage to an enemy at your location` end-to-end against the real
+//! `cards::REGISTRY`. The activated ability is at index 1 (index 0 is the
+//! constant `+1 [combat]`). Own process → installs `cards::REGISTRY`.
+
+use std::sync::Once;
+
+use game_core::engine::EngineOutcome;
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, CardInPlay, CardInstanceId, EnemyId, InvestigatorId, LocationId, Phase, Zone,
+};
+use game_core::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
+use game_core::{apply, assert_event, assert_no_event, Action, PlayerAction};
+
+const BEAT_COP: &str = "01018";
+const INV: InvestigatorId = InvestigatorId(1);
+const LOC: LocationId = LocationId(10);
+const ENEMY: EnemyId = EnemyId(100);
+const COP_INST: CardInstanceId = CardInstanceId(0);
+
+static INSTALL: Once = Once::new();
+fn install() {
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// Board: Beat Cop in play, the active investigator at `LOC`, and (when
+/// `enemy_present`) a 3-health enemy co-located at `LOC`.
+fn board(enemy_present: bool) -> game_core::GameState {
+    install();
+    let mut inv = test_investigator(1);
+    inv.cards_in_play
+        .push(CardInPlay::enter_play(CardCode::new(BEAT_COP), COP_INST));
+
+    let mut builder = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator_at(inv, LOC)
+        .with_location(test_location(10, "Study"))
+        .with_active_investigator(INV)
+        .with_turn_order([INV]);
+    if enemy_present {
+        let mut enemy = test_enemy(100, "Ghoul");
+        enemy.max_health = 3;
+        enemy.current_location = Some(LOC);
+        builder = builder.with_enemy(enemy);
+    }
+    builder.build()
+}
+
+fn activate_fast(state: game_core::GameState) -> game_core::engine::ApplyResult {
+    apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: INV,
+            instance_id: COP_INST,
+            ability_index: 1, // index 1 = the [fast] discard-damage ability
+        }),
+    )
+}
+
+#[test]
+fn discards_self_and_deals_one_damage_to_the_co_located_enemy() {
+    let r = activate_fast(board(true));
+    assert_eq!(r.outcome, EngineOutcome::Done);
+    assert_event!(r.events, Event::EnemyDamaged { amount: 1, .. });
+    assert_eq!(r.state.enemies[&ENEMY].damage, 1);
+    // Beat Cop paid its own discard as the cost.
+    assert_event!(
+        r.events,
+        Event::CardDiscarded {
+            from: Zone::InPlay,
+            ..
+        }
+    );
+    assert!(
+        r.state.investigators[&INV].cards_in_play.is_empty(),
+        "Beat Cop discarded itself",
+    );
+    assert_eq!(
+        r.state.investigators[&INV].discard,
+        vec![CardCode::new(BEAT_COP)],
+    );
+}
+
+#[test]
+fn rejects_with_no_enemy_at_location_and_keeps_beat_cop_in_play() {
+    let r = activate_fast(board(false));
+    assert!(matches!(r.outcome, EngineOutcome::Rejected { .. }));
+    // Pre-cost target check (#301) rejects before paying ⇒ Beat Cop survives.
+    assert_no_event!(r.events, Event::CardDiscarded { .. });
+    assert_eq!(
+        r.state.investigators[&INV].cards_in_play.len(),
+        1,
+        "Beat Cop not discarded for a no-target activation",
+    );
+}

--- a/crates/cards/tests/first_aid.rs
+++ b/crates/cards/tests/first_aid.rs
@@ -1,0 +1,143 @@
+//! C5d (#239) integration: First Aid 01019's `[action] Spend 1 supply: Heal 1
+//! damage or horror from an investigator at your location` end-to-end against
+//! the real `cards::REGISTRY`. The damage-or-horror choice is a `ChooseOne`
+//! that suspends; resume picks the branch. The `Uses (3 supplies)` pool and
+//! the "if no supplies, discard it" depletion-discard come from corpus
+//! metadata (#302). Own process → installs `cards::REGISTRY`.
+
+use std::sync::Once;
+
+use game_core::dsl::HarmKind;
+use game_core::engine::EngineOutcome;
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, CardInPlay, CardInstanceId, InvestigatorId, LocationId, Phase, UseKind,
+};
+use game_core::test_support::{test_investigator, test_location, GameStateBuilder};
+use game_core::{apply, assert_event, Action, InputResponse, OptionId, PlayerAction};
+
+const FIRST_AID: &str = "01019";
+const INV: InvestigatorId = InvestigatorId(1);
+const LOC: LocationId = LocationId(10);
+const KIT_INST: CardInstanceId = CardInstanceId(0);
+
+static INSTALL: Once = Once::new();
+fn install() {
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// Board: First Aid in play with `supplies` supplies; the active investigator
+/// at `LOC` carrying 2 damage and 2 horror to heal from.
+fn board(supplies: u8) -> game_core::GameState {
+    install();
+    let mut inv = test_investigator(1);
+    inv.damage = 2;
+    inv.horror = 2;
+    let mut kit = CardInPlay::enter_play(CardCode::new(FIRST_AID), KIT_INST);
+    kit.uses.insert(UseKind::Supplies, supplies);
+    inv.cards_in_play.push(kit);
+
+    GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator_at(inv, LOC)
+        .with_location(test_location(10, "Study"))
+        .with_active_investigator(INV)
+        .with_turn_order([INV])
+        .build()
+}
+
+fn supplies(state: &game_core::GameState) -> Option<u8> {
+    state.investigators[&INV]
+        .cards_in_play
+        .iter()
+        .find(|c| c.instance_id == KIT_INST)
+        .map(|c| c.uses.get(&UseKind::Supplies).copied().unwrap_or(0))
+}
+
+fn activate(state: game_core::GameState) -> game_core::engine::ApplyResult {
+    apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: INV,
+            instance_id: KIT_INST,
+            ability_index: 0,
+        }),
+    )
+}
+
+fn pick(state: game_core::GameState, branch: u32) -> game_core::engine::ApplyResult {
+    apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickSingle(OptionId(branch)),
+        }),
+    )
+}
+
+#[test]
+fn spends_a_supply_and_heals_one_damage_when_the_damage_branch_is_chosen() {
+    // Activate → suspends on the damage-or-horror choice.
+    let r = activate(board(3));
+    assert!(matches!(r.outcome, EngineOutcome::AwaitingInput { .. }));
+    assert_eq!(supplies(&r.state), Some(2), "1 supply spent on activation");
+
+    // Branch 0 = heal damage; the sole co-located investigator (the controller)
+    // auto-binds, so this completes.
+    let r = pick(r.state, 0);
+    assert_eq!(r.outcome, EngineOutcome::Done);
+    assert_eq!(r.state.investigators[&INV].damage, 1, "1 damage healed");
+    assert_eq!(r.state.investigators[&INV].horror, 2, "horror untouched");
+    assert_event!(
+        r.events,
+        Event::Healed {
+            kind: HarmKind::Damage,
+            amount: 1,
+            ..
+        }
+    );
+}
+
+#[test]
+fn heals_one_horror_when_the_horror_branch_is_chosen() {
+    let r = activate(board(3));
+    assert!(matches!(r.outcome, EngineOutcome::AwaitingInput { .. }));
+
+    // Branch 1 = heal horror.
+    let r = pick(r.state, 1);
+    assert_eq!(r.outcome, EngineOutcome::Done);
+    assert_eq!(r.state.investigators[&INV].horror, 1, "1 horror healed");
+    assert_eq!(r.state.investigators[&INV].damage, 2, "damage untouched");
+    assert_event!(
+        r.events,
+        Event::Healed {
+            kind: HarmKind::Horror,
+            amount: 1,
+            ..
+        }
+    );
+}
+
+#[test]
+fn spending_the_last_supply_discards_first_aid() {
+    // 1 supply: the activation's SpendUses empties the pool, so the
+    // depletion-discard (#302) fires during cost payment — First Aid is gone
+    // before the heal's choice even suspends.
+    let r = activate(board(1));
+    assert!(matches!(r.outcome, EngineOutcome::AwaitingInput { .. }));
+    assert!(
+        r.state.investigators[&INV].cards_in_play.is_empty(),
+        "First Aid discarded when its last supply was spent",
+    );
+    assert_eq!(
+        r.state.investigators[&INV].discard,
+        vec![CardCode::new(FIRST_AID)],
+    );
+
+    // The heal still resolves (the ability continues even though its source
+    // left play).
+    let r = pick(r.state, 0);
+    assert_eq!(r.outcome, EngineOutcome::Done);
+    assert_eq!(r.state.investigators[&INV].damage, 1, "heal still applied");
+}

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -85,7 +85,7 @@ root dependency; C7 is the playable Won/Lost gate; #212 lands after C.
 | C5b | [#237](https://github.com/talelburg/eldritch/issues/237) | Guard Dog reaction + enemy-attack soak mechanic | ✅ PR #292 |
 | — | [#295](https://github.com/talelburg/eldritch/issues/295) | infra: weapon support — ammo/uses (`Cost::SpendUses`) + inspectable `Effect::Fight` (`IntExpr` modifier + bonus damage) (prerequisite for C5c's .38 Special) | ✅ PR #297 |
 | C5c | [#238](https://github.com/talelburg/eldritch/issues/238) | .38 Special signature + Cover Up content | ✅ PR #298 |
-| C5d | [#239](https://github.com/talelburg/eldritch/issues/239) | Guardian L0 assets — **3 engine-free shipped** (.45 Automatic, Physical Training, Machete); Beat Cop + First Aid deferred to [#301](https://github.com/talelburg/eldritch/issues/301) / [#302](https://github.com/talelburg/eldritch/issues/302); Guard Dog already in C5b | 🛠️ PR #303 (partial; #239 open) |
+| C5d | [#239](https://github.com/talelburg/eldritch/issues/239) | Guardian L0 assets — .45 Automatic, Physical Training, Machete (PR #303); Guard Dog (C5b); **Beat Cop + First Aid** (PR #357, on the #301/#302 prereqs) | ✅ PR #303 + #357 |
 | — | [#307](https://github.com/talelburg/eldritch/issues/307) | infra: `Trigger::OnCommit` firing + `Effect::BoostAttackDamage` / `InFlightSkillTest.bonus_attack_damage` (prerequisite for C5e's Vicious Blow) | ✅ PR #308 |
 | C5e | [#240](https://github.com/talelburg/eldritch/issues/240) | Guardian L0 events + skill (×4) — **only Vicious Blow 01025 was implementable; shipped (PR #309).** Engine prereq landed (PR #308); Evidence! ([#304](https://github.com/talelburg/eldritch/issues/304), reaction-event-play), Dodge ([#305](https://github.com/talelburg/eldritch/issues/305), attack-cancellation), Dynamite Blast ([#306](https://github.com/talelburg/eldritch/issues/306), location-choice = #212/#213) carved to follow-ups | ✅ PR #309 |
 | C6a | [#241](https://github.com/talelburg/eldritch/issues/241) | Dr. Milan after-investigate window | ✅ PR #318 |
@@ -153,7 +153,11 @@ when picked up.
   PR-2 (#301 — `Cost::DiscardSelf` + the enemy variety + `Effect::DealDamageToEnemy`,
   Beat Cop's engine prereqs) shipped: **✅ PR #352**.
   PR-3 (#302 — `Effect::Heal` + uses-depletion auto-discard, First Aid's engine
-  prereqs) shipped: **✅ PR #355**.
+  prereqs) shipped: **✅ PR #355**. PR-4 (#239 — the Beat Cop + First Aid
+  *cards*) shipped: **✅ PR #357**, **closing C5d** (the last open Group-C
+  sub-slice). The orthogonal #354 (`DealDamage`/`DealHorror` → `Effect::Deal`
+  consolidation) also shipped (PR #356). Remaining cluster PRs: #312 (Knife,
+  on #301), #321 (Medical Texts, on #302), #313 (Flashlight), #306 (Dynamite).
   Slice 1's `fire_forced_triggers` is a forward-compatible subset Axis B
   replaces. **Note:** #213's "one mixed pool" framing was corrected to
   RR-accurate two-phase (forced-all-before-reaction, RR p.2; issue text


### PR DESCRIPTION
## Summary

The last two Guardian L0 assets (C5d), composing the now-merged #301 / #302 / #349 primitives. The other four (.45 Automatic, Physical Training, Machete, Guard Dog) already shipped, so this closes C5d.

## What changed

- **Beat Cop 01018** — `constant(modify(Combat, +1, WhileInPlay))` + `[fast] activated(0, [Cost::DiscardSelf], deal_damage_to_enemy(EnemyTarget::chosen_at_your_location(), 1))`. Verbatim: *"You get +1 [combat]. / [fast] Discard Beat Cop: Deal 1 damage to an enemy at your location."*
- **First Aid 01019** — `[action] activated(1, [Cost::SpendUses{Supplies,1}], ChooseOne([heal(Damage, chosen_at_your_location, 1), heal(Horror, …, 1)]))`. The `Uses (3 supplies)` pool + the "if no supplies, discard it" depletion-discard are corpus metadata (#302), not in `abilities()`. Verbatim: *"Uses (3 supplies). If First Aid has no supplies, discard it. / [action] Spend 1 supply: Heal 1 damage or horror from an investigator at your location."*
- Registered both in `impls/mod.rs`.

> Note: the #239 issue body's "Beat Cop after-enemy-defeated reaction" is **stale** — the verbatim text has no reaction; implemented per the snapshot (the fast discard-damage ability that #301 was built for).

## Test notes

- Per-card shape tests + the `registry_dispatches_to_this_modules_abilities` guard.
- Real-registry integration tests (`crates/cards/tests/`): Beat Cop discards-self + deals 1 to a co-located enemy, and the no-enemy activation rejects with the source intact (#301 pre-cost check); First Aid's heal round-trip (suspend → `PickSingle` → heal) for both damage and horror branches, and the **last-supply spend discards it** end-to-end (#302 depletion).
- Full strict gauntlet green; code-reviewed (verbatim text verified against the snapshot + corpus; no Critical/Important).

## Linked issues

Closes #239