### PR TITLE
cards: Knife 01086 — PR-5 of the choice-cluster completion

### DIFF
--- a/crates/cards/src/impls/knife.rs
+++ b/crates/cards/src/impls/knife.rs
@@ -1,0 +1,90 @@
+//! Knife (neutral melee weapon asset, 01086).
+//!
+//! ```text
+//! [action]: Fight. You get +1 [combat] for this attack.
+//! [action] Discard Knife: Fight. You get +2 [combat] for this attack.
+//!   This attack deals +1 damage.
+//! ```
+//!
+//! Two `[action]` Fight abilities, both pure compositions of existing
+//! primitives:
+//!
+//! - **Ability 0** — a bare `[action]` Fight (no cost) with a `+1` combat
+//!   modifier, dealing the base `1` damage (`extra_damage: 0`). The same
+//!   shape as [`machete`](super::machete) minus the bonus damage.
+//! - **Ability 1** — discards Knife itself ([`Cost::DiscardSelf`], #301) for
+//!   a `+2` combat modifier and `+1` damage, dealing `1 + 1` on success.
+//!
+//! Both fight through the inspectable [`Effect::Fight`](card_dsl::dsl::Effect::Fight),
+//! which auto-targets the single engaged enemy and rejects a fight with ≠1
+//! engaged enemy **before** any cost is paid — so ability 1's discard is
+//! never spent for nothing. The two abilities are at vec indices 0 and 1;
+//! `ActivateAbility.ability_index` selects between them
+//! (`resolve_activated_ability` indexes the raw abilities vec and rejects
+//! any non-`Activated` trigger).
+
+use card_dsl::dsl::{activated, fight, Ability, Cost, IntExpr};
+
+/// `ArkhamDB` code for Knife (original-Core printing).
+pub const CODE: &str = "01086";
+
+/// Knife's two `[action]` Fight abilities: the basic `+1 [combat]` fight and
+/// the discard-self `+2 [combat]` / `+1` damage fight.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![
+        // [action]: Fight. You get +1 [combat] for this attack.
+        activated(1, vec![], fight(IntExpr::Lit(1), 0)),
+        // [action] Discard Knife: Fight. You get +2 [combat] for this attack.
+        // This attack deals +1 damage.
+        activated(1, vec![Cost::DiscardSelf], fight(IntExpr::Lit(2), 1)),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use card_dsl::dsl::{Effect, Trigger};
+
+    #[test]
+    fn two_action_fight_abilities() {
+        let abilities = abilities();
+        assert_eq!(abilities.len(), 2);
+
+        // Index 0: bare [action] Fight, +1 combat, base damage.
+        assert_eq!(abilities[0].trigger, Trigger::Activated { action_cost: 1 });
+        assert!(
+            abilities[0].costs.is_empty(),
+            "the basic Fight has no cost beyond the action",
+        );
+        let Effect::Fight {
+            combat_modifier,
+            extra_damage,
+        } = &abilities[0].effect
+        else {
+            panic!("expected Effect::Fight at index 0");
+        };
+        assert_eq!(*combat_modifier, IntExpr::Lit(1));
+        assert_eq!(*extra_damage, 0);
+
+        // Index 1: [action] Discard Knife Fight, +2 combat, +1 damage.
+        assert_eq!(abilities[1].trigger, Trigger::Activated { action_cost: 1 });
+        assert_eq!(abilities[1].costs, vec![Cost::DiscardSelf]);
+        let Effect::Fight {
+            combat_modifier,
+            extra_damage,
+        } = &abilities[1].effect
+        else {
+            panic!("expected Effect::Fight at index 1");
+        };
+        assert_eq!(*combat_modifier, IntExpr::Lit(2));
+        assert_eq!(*extra_damage, 1);
+    }
+
+    /// Catches a `pub mod` rename or a fat-fingered match arm in
+    /// `impls::abilities_for` — the registry must dispatch CODE here.
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(CODE), Some(abilities()));
+    }
+}

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -77,6 +77,7 @@ pub mod guard_dog;
 pub mod guts;
 pub mod holy_rosary;
 pub mod hyperawareness;
+pub mod knife;
 pub mod machete;
 pub mod magnifying_glass;
 pub mod manual_dexterity;
@@ -120,6 +121,7 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
         guts::CODE => Some(guts::abilities()),
         holy_rosary::CODE => Some(holy_rosary::abilities()),
         hyperawareness::CODE => Some(hyperawareness::abilities()),
+        knife::CODE => Some(knife::abilities()),
         machete::CODE => Some(machete::abilities()),
         magnifying_glass::CODE => Some(magnifying_glass::abilities()),
         manual_dexterity::CODE => Some(manual_dexterity::abilities()),

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -156,8 +156,10 @@ when picked up.
   prereqs) shipped: **✅ PR #355**. PR-4 (#239 — the Beat Cop + First Aid
   *cards*) shipped: **✅ PR #357**, **closing C5d** (the last open Group-C
   sub-slice). The orthogonal #354 (`DealDamage`/`DealHorror` → `Effect::Deal`
-  consolidation) also shipped (PR #356). Remaining cluster PRs: #312 (Knife,
-  on #301), #321 (Medical Texts, on #302), #313 (Flashlight), #306 (Dynamite).
+  consolidation) also shipped (PR #356). PR-5 (#312 — Knife 01086, two
+  `[action]` Fight abilities on existing primitives + `Cost::DiscardSelf`)
+  shipped: **✅ PR #358**. Remaining cluster PRs: #321 (Medical Texts,
+  on #302), #313 (Flashlight), #306 (Dynamite).
   Slice 1's `fire_forced_triggers` is a forward-compatible subset Axis B
   replaces. **Note:** #213's "one mixed pool" framing was corrected to
   RR-accurate two-phase (forced-all-before-reaction, RR p.2; issue text


### PR DESCRIPTION
## Summary

Implements **Knife (01086)** — PR-5 of the Phase-7 choice-cluster completion sub-slice ([decomposition](../blob/main/docs/superpowers/specs/2026-06-17-phase-7-choice-cluster-completion-decomposition-design.md)). Pure content reusing existing primitives; no engine changes.

Card text (verbatim from `data/arkhamdb-snapshot/pack/core/core.json`):

> `[action]: Fight. You get +1 [combat] for this attack.`
> `[action] Discard Knife: Fight. You get +2 [combat] for this attack. This attack deals +1 damage.`

Two `Activated { action_cost: 1 }` abilities:

| idx | DSL | Damage |
|---|---|---|
| 0 | `activated(1, vec![], fight(Lit(1), 0))` | 1 |
| 1 | `activated(1, vec![Cost::DiscardSelf], fight(Lit(2), 1))` | 2 |

## Design notes

- **No new engine work** — same shape as Machete (01020) / .45 Automatic (01016), plus `Cost::DiscardSelf` (#301, already proven on Beat Cop). `Effect::Fight` auto-targets the single engaged enemy and rejects a fight with ≠1 engaged enemy *before* any cost is paid, so ability 1's discard is never spent for nothing.
- **Two activated abilities on one card** dispatch via `ActivateAbility.ability_index` — `resolve_activated_ability` indexes the raw abilities vec and rejects non-`Activated` triggers, so indices 0/1 select cleanly.
- Metadata (Hand slot, cost 1, combat 1) comes from the generated corpus; `is_playable` flips on automatically once `abilities_for` matches.

## Testing

- New per-card unit tests assert both abilities' triggers/costs/effects and the registry-dispatch guard.
- Full CI gauntlet green locally (fmt, test, clippy, doc, wasm-build, wasm-clippy).

Closes #312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)