### PR TITLE
cards: Medical Texts 01035 — PR-6 of the choice-cluster completion

### DIFF
--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -1179,6 +1179,28 @@ pub fn heal(kind: HarmKind, target: InvestigatorTarget, count: u8) -> Effect {
     }
 }
 
+/// Build an [`Effect::Heal`] healing `count` damage from `target` (the
+/// healing analogue of [`deal_damage`]).
+#[must_use]
+pub fn heal_damage(target: InvestigatorTarget, count: u8) -> Effect {
+    Effect::Heal {
+        kind: HarmKind::Damage,
+        target,
+        count,
+    }
+}
+
+/// Build an [`Effect::Heal`] healing `count` horror from `target` (the
+/// healing analogue of [`deal_horror`]).
+#[must_use]
+pub fn heal_horror(target: InvestigatorTarget, count: u8) -> Effect {
+    Effect::Heal {
+        kind: HarmKind::Horror,
+        target,
+        count,
+    }
+}
+
 /// Build an [`Effect::Deal`] dealing `amount` horror to `target`.
 #[must_use]
 pub fn deal_horror(target: InvestigatorTarget, amount: u8) -> Effect {

--- a/crates/cards/src/impls/first_aid.rs
+++ b/crates/cards/src/impls/first_aid.rs
@@ -17,7 +17,9 @@
 //! discards the asset automatically when the last supply is spent.
 
 use card_dsl::card_data::UseKind;
-use card_dsl::dsl::{activated, choose_one, heal, Ability, Cost, HarmKind, InvestigatorTarget};
+use card_dsl::dsl::{
+    activated, choose_one, heal_damage, heal_horror, Ability, Cost, InvestigatorTarget,
+};
 
 /// `ArkhamDB` code for First Aid (original-Core printing).
 pub const CODE: &str = "01019";
@@ -32,16 +34,8 @@ pub fn abilities() -> Vec<Ability> {
             count: 1,
         }],
         choose_one([
-            heal(
-                HarmKind::Damage,
-                InvestigatorTarget::chosen_at_your_location(),
-                1,
-            ),
-            heal(
-                HarmKind::Horror,
-                InvestigatorTarget::chosen_at_your_location(),
-                1,
-            ),
+            heal_damage(InvestigatorTarget::chosen_at_your_location(), 1),
+            heal_horror(InvestigatorTarget::chosen_at_your_location(), 1),
         ]),
     )]
 }
@@ -70,12 +64,12 @@ mod tests {
         let expected_target = InvestigatorTarget::chosen_at_your_location();
         assert_eq!(
             branches[0],
-            heal(HarmKind::Damage, expected_target, 1),
+            heal_damage(expected_target, 1),
             "branch 0 heals 1 damage from an investigator at your location",
         );
         assert_eq!(
             branches[1],
-            heal(HarmKind::Horror, expected_target, 1),
+            heal_horror(expected_target, 1),
             "branch 1 heals 1 horror from an investigator at your location",
         );
     }

--- a/crates/cards/src/impls/medical_texts.rs
+++ b/crates/cards/src/impls/medical_texts.rs
@@ -1,0 +1,111 @@
+//! Medical Texts (Seeker item asset, 01035).
+//!
+//! ```text
+//! [action] Choose an investigator at your location and test [intellect] (2).
+//!   If you succeed, heal 1 damage from that investigator. If you fail, deal
+//!   1 damage to that investigator.
+//! ```
+//!
+//! One `[action]` ability (no exhaust, no uses): an
+//! [`Effect::SkillTest`](card_dsl::dsl::Effect::SkillTest) (#286) against
+//! intellect (2), branching on the controller's result —
+//! `on_success` heals 1 damage, `on_fail` deals 1 damage, each to the chosen
+//! investigator at the controller's location
+//! ([`InvestigatorTarget::chosen_at_your_location`], #349). Composed entirely
+//! from existing primitives — no native effect, no engine work. The first
+//! `Effect::SkillTest` initiated from an *activated* ability (every prior
+//! caller is a Revelation/forced effect); `activate_ability` ends in
+//! `apply_effect`, so the test suspends at the commit window and resumes
+//! through the same `drive_skill_test` path regardless of origin.
+//!
+//! # The target is chosen *inside* the post-test branch — exact in solo
+//!
+//! The printed card chooses the target **before** the test ("Choose … and
+//! test"); this impl chooses inside whichever branch runs (`on_success` /
+//! `on_fail`). **Exact under today's solo engine:** with one investigator at
+//! your location the `Chosen` choice auto-binds (count 1, no suspend), so
+//! choosing before vs. after the test is indistinguishable. The divergence
+//! only appears with 2+ investigators at your location (multiplayer), where a
+//! post-test choice would let the player pick the target after seeing the
+//! result — strictly more information than the card grants.
+//!
+//! TODO(#359): bind the chosen investigator before the test (needs the
+//! binding to survive the `Effect::SkillTest` suspend/resume) once
+//! multiplayer makes the ordering observable. Mirrors Machete's #300
+//! deferral.
+
+use card_dsl::card_data::SkillKind;
+use card_dsl::dsl::{activated, deal_damage, heal_damage, skill_test, Ability, InvestigatorTarget};
+
+/// `ArkhamDB` code for Medical Texts (original-Core printing).
+pub const CODE: &str = "01035";
+
+/// Medical Texts' `[action]` intellect(2) test: heal 1 damage on success,
+/// deal 1 damage on failure, to a chosen investigator at your location.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![activated(
+        1,
+        vec![],
+        skill_test(
+            SkillKind::Intellect,
+            2,
+            Some(heal_damage(
+                InvestigatorTarget::chosen_at_your_location(),
+                1,
+            )),
+            Some(deal_damage(
+                InvestigatorTarget::chosen_at_your_location(),
+                1,
+            )),
+        ),
+    )]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use card_dsl::dsl::{Effect, Trigger};
+
+    #[test]
+    fn one_action_intellect_test_branching_heal_or_damage() {
+        let abilities = abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(abilities[0].trigger, Trigger::Activated { action_cost: 1 });
+        assert!(
+            abilities[0].costs.is_empty(),
+            "Medical Texts' action has no exhaust/uses cost",
+        );
+
+        let Effect::SkillTest {
+            skill,
+            difficulty,
+            on_success,
+            on_fail,
+        } = &abilities[0].effect
+        else {
+            panic!("expected Effect::SkillTest");
+        };
+        assert_eq!(*skill, SkillKind::Intellect);
+        assert_eq!(*difficulty, 2);
+
+        let target = InvestigatorTarget::chosen_at_your_location();
+        assert_eq!(
+            on_success.as_deref(),
+            Some(&heal_damage(target, 1)),
+            "success heals 1 damage from the chosen investigator",
+        );
+        assert_eq!(
+            on_fail.as_deref(),
+            Some(&deal_damage(target, 1)),
+            "failure deals 1 damage to the chosen investigator",
+        );
+    }
+
+    /// Catches a `pub mod` rename or a fat-fingered match arm in
+    /// `impls::abilities_for` — the registry must dispatch CODE here.
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(CODE), Some(abilities()));
+    }
+}

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -81,6 +81,7 @@ pub mod knife;
 pub mod machete;
 pub mod magnifying_glass;
 pub mod manual_dexterity;
+pub mod medical_texts;
 pub mod overpower;
 pub mod perception;
 pub mod physical_training;
@@ -125,6 +126,7 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
         machete::CODE => Some(machete::abilities()),
         magnifying_glass::CODE => Some(magnifying_glass::abilities()),
         manual_dexterity::CODE => Some(manual_dexterity::abilities()),
+        medical_texts::CODE => Some(medical_texts::abilities()),
         overpower::CODE => Some(overpower::abilities()),
         perception::CODE => Some(perception::abilities()),
         physical_training::CODE => Some(physical_training::abilities()),

--- a/crates/cards/tests/medical_texts.rs
+++ b/crates/cards/tests/medical_texts.rs
@@ -1,0 +1,108 @@
+//! PR-6 (#321) integration: Medical Texts 01035's `[action] Choose an
+//! investigator at your location and test [intellect] (2). If you succeed,
+//! heal 1 damage from that investigator. If you fail, deal 1 damage to that
+//! investigator.` end-to-end against the real `cards::REGISTRY`.
+//!
+//! Exercises the first `Effect::SkillTest` initiated from an *activated*
+//! ability: the test suspends at the commit window (driven by
+//! `apply_no_commits`) and resumes through `drive_skill_test`, then the
+//! outcome branch heals or deals 1 damage to the chosen co-located
+//! investigator. In solo the choice auto-binds to the controller (one
+//! candidate at the location), so no choice suspend occurs.
+//!
+//! Own process → installs `cards::REGISTRY`.
+
+use std::sync::Once;
+
+use game_core::dsl::HarmKind;
+use game_core::engine::EngineOutcome;
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, InvestigatorId, LocationId, Phase,
+    TokenModifiers,
+};
+use game_core::test_support::{
+    apply_no_commits, test_investigator, test_location, GameStateBuilder,
+};
+use game_core::{assert_event, Action, PlayerAction};
+
+const MEDICAL_TEXTS: &str = "01035";
+const INV: InvestigatorId = InvestigatorId(1);
+const LOC: LocationId = LocationId(10);
+const BOOK_INST: CardInstanceId = CardInstanceId(0);
+
+static INSTALL: Once = Once::new();
+fn install() {
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// Board: Medical Texts in play; the active investigator with `intellect`
+/// intellect and `damage` damage, alone at `LOC`. A `Numeric(0)` chaos bag
+/// makes the intellect(2) test deterministic — intellect 3 succeeds, 1 fails,
+/// both off the difficulty boundary.
+fn board(intellect: i8, damage: u8) -> game_core::GameState {
+    install();
+    let mut inv = test_investigator(1);
+    inv.skills.intellect = intellect;
+    inv.damage = damage;
+    inv.cards_in_play.push(CardInPlay::enter_play(
+        CardCode::new(MEDICAL_TEXTS),
+        BOOK_INST,
+    ));
+
+    GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator_at(inv, LOC)
+        .with_location(test_location(10, "Study"))
+        .with_active_investigator(INV)
+        .with_turn_order([INV])
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default())
+        .build()
+}
+
+fn activate(state: game_core::GameState) -> game_core::engine::ApplyResult {
+    apply_no_commits(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: INV,
+            instance_id: BOOK_INST,
+            ability_index: 0,
+        }),
+    )
+}
+
+#[test]
+fn success_heals_one_damage_from_the_chosen_investigator() {
+    // intellect 3 + 0 = 3 >= difficulty 2 → success → heal 1 damage.
+    let r = activate(board(3, 2));
+    assert_eq!(r.outcome, EngineOutcome::Done);
+    assert_event!(r.events, Event::SkillTestSucceeded { .. });
+    assert_event!(
+        r.events,
+        Event::Healed {
+            kind: HarmKind::Damage,
+            amount: 1,
+            ..
+        }
+    );
+    assert_eq!(r.state.investigators[&INV].damage, 1, "1 damage healed");
+}
+
+#[test]
+fn failure_deals_one_damage_to_the_chosen_investigator() {
+    // intellect 1 + 0 = 1 < difficulty 2 → failure → deal 1 damage.
+    let r = activate(board(1, 0));
+    assert_eq!(r.outcome, EngineOutcome::Done);
+    assert_event!(r.events, Event::SkillTestFailed { .. });
+    assert_event!(
+        r.events,
+        Event::DamageTaken {
+            investigator: INV,
+            amount: 1,
+        }
+    );
+    assert_eq!(r.state.investigators[&INV].damage, 1, "1 damage dealt");
+}

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -158,8 +158,12 @@ when picked up.
   sub-slice). The orthogonal #354 (`DealDamage`/`DealHorror` → `Effect::Deal`
   consolidation) also shipped (PR #356). PR-5 (#312 — Knife 01086, two
   `[action]` Fight abilities on existing primitives + `Cost::DiscardSelf`)
-  shipped: **✅ PR #358**. Remaining cluster PRs: #321 (Medical Texts,
-  on #302), #313 (Flashlight), #306 (Dynamite).
+  shipped: **✅ PR #358**. PR-6 (#321 — Medical Texts 01035, the first
+  `Effect::SkillTest` from an activated ability, branching heal/deal on a
+  chosen co-located investigator; `heal_damage`/`heal_horror` DSL builders
+  added) shipped: **✅ PR #360** (its choose-before-test ordering is exact
+  in solo, deferred to #359 for multiplayer — mirrors Machete's #300).
+  Remaining cluster PRs: #313 (Flashlight), #306 (Dynamite).
   Slice 1's `fire_forced_triggers` is a forward-compatible subset Axis B
   replaces. **Note:** #213's "one mixed pool" framing was corrected to
   RR-accurate two-phase (forced-all-before-reaction, RR p.2; issue text


### PR DESCRIPTION
## Summary

Implements **Medical Texts (01035)** — PR-6 of the Phase-7 choice-cluster completion. Content reusing existing primitives; no new engine variants.

Card text (verbatim from `data/arkhamdb-snapshot/pack/core/core.json`):

> `[action] Choose an investigator at your location and test [intellect] (2). If you succeed, heal 1 damage from that investigator. If you fail, deal 1 damage to that investigator.`

One `Activated { action_cost: 1 }` ability (no exhaust/uses — the printed text is a bare `[action]`):

```rust
activated(1, vec![], skill_test(
    SkillKind::Intellect, 2,
    Some(heal_damage(InvestigatorTarget::chosen_at_your_location(), 1)),  // on success
    Some(deal_damage(InvestigatorTarget::chosen_at_your_location(), 1)),  // on failure
))
```

Reuses `Effect::SkillTest` (#286), `Effect::Heal` (#302), `deal_damage` (existing), and the `chosen_at_your_location` investigator choice (#349).

## Design notes

- **First `Effect::SkillTest` initiated from an activated ability** (every prior caller is a Revelation/forced effect). `activate_ability` ends in `apply_effect`, so the test suspends at the commit window and resumes through the same `drive_skill_test` path regardless of origin. Verified behaviorally — see the integration test.
- **Target chosen inside the post-test branch — exact in solo.** The printed card commits the target *before* the test; this impl chooses inside whichever branch runs. With one co-located investigator the `Chosen` choice auto-binds (count 1, no suspend), so the orderings are indistinguishable. The divergence appears only with 2+ investigators at your location (multiplayer), tracked in **#359** (mirrors Machete's #300). Binding-before-test would need new engine machinery (a binding that survives the SkillTest suspend/resume), out of content-only scope.

## Incidental cleanup

Adds `heal_damage` / `heal_horror` DSL builders mirroring `deal_damage` / `deal_horror`, and refactors **First Aid 01019** to use them (its `Effect::Heal` output is unchanged).

## Testing

- Unit test: the ability's trigger/cost/SkillTest tree (skill, difficulty, both branches) + registry-dispatch guard.
- **Integration test** (`crates/cards/tests/medical_texts.rs`, real registry + skill-test driver): a `Numeric(0)` chaos bag drives intellect 3 → **success heals 1 damage** and intellect 1 → **failure deals 1 damage** to the chosen investigator.
- Full CI gauntlet green locally (fmt, test, clippy, doc, wasm-build, wasm-clippy).

Closes #321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)