### PR TITLE
cards: Flashlight 01087 — PR-7 of the choice-cluster completion

### DIFF
--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -694,6 +694,21 @@ pub enum Effect {
     /// for `CannotPlay`, `pending_action_surcharge` for `ExtraActionCost`);
     /// resolving it as an effect is a misuse and rejects.
     Restrict(Restriction),
+    /// Initiate an Investigate against the controller's current location,
+    /// applying `shroud_modifier` (resolved at eval) to that location's
+    /// shroud *difficulty* for this investigation — Flashlight 01087's
+    /// "-2 shroud for this investigation." The mirror of [`Fight`](Self::Fight):
+    /// the modifier adjusts the **location difficulty**, not the
+    /// investigator's total (which is `InFlightSkillTest.test_modifier`); the
+    /// reduced shroud clamps at 0. Reuses the base Investigate skill-test
+    /// follow-up, so on success it discovers a clue like the action does.
+    /// Inspectable (not `Native`) so the activation check can reject — before
+    /// any cost is paid — an investigation with no revealed location to test.
+    Investigate {
+        /// Shroud-difficulty modifier for this investigation, resolved
+        /// against state at eval (Flashlight: `-2`).
+        shroud_modifier: IntExpr,
+    },
 }
 
 // ---- stats and modifier scopes --------------------------------
@@ -1336,6 +1351,14 @@ pub fn fight(combat_modifier: IntExpr, extra_damage: u8) -> Effect {
         combat_modifier,
         extra_damage,
     }
+}
+
+/// Build an [`Effect::Investigate`] applying `shroud_modifier` to the
+/// controller's location difficulty for this investigation (Flashlight 01087:
+/// `investigate(IntExpr::Lit(-2))`).
+#[must_use]
+pub fn investigate(shroud_modifier: IntExpr) -> Effect {
+    Effect::Investigate { shroud_modifier }
 }
 
 /// Build an [`Effect::Restrict`] carrying a constant [`Restriction`].

--- a/crates/cards/src/impls/flashlight.rs
+++ b/crates/cards/src/impls/flashlight.rs
@@ -1,0 +1,77 @@
+//! Flashlight (neutral tool asset, 01087).
+//!
+//! ```text
+//! Uses (3 supplies).
+//! [action] Spend 1 supply: Investigate. Your location gets -2 shroud for
+//!   this investigation.
+//! ```
+//!
+//! One activated ability: an action paying 1 supply (`Cost::SpendUses`) to
+//! Investigate the controller's location with its shroud reduced by 2 for
+//! this investigation. The `-2` is an
+//! [`Effect::Investigate`](card_dsl::dsl::Effect::Investigate) `shroud_modifier`
+//! (#313) — the Investigate mirror of `Effect::Fight`: it lowers the
+//! location *difficulty* (clamped at 0), not the investigator's total, and
+//! reuses the base Investigate follow-up so a success discovers a clue. The
+//! `Uses (3 supplies)` pool and the depletion-discard are corpus metadata
+//! (`CardKind::Asset.uses` + `Uses.discard_when_empty`, pipeline-parsed) —
+//! `abilities()` declares only the action; the engine discards the asset when
+//! the last supply is spent.
+//!
+//! TODO(#361): activating this `[action]` while engaged with a ready enemy
+//! should provoke an attack of opportunity (RR p.5 — it is not a
+//! fight/evade/parley/resign ability). The engine fires no attack of
+//! opportunity on any activated ability today (a systemic gap, also
+//! affecting First Aid / Medical Texts); fixed engine-wide in #361.
+
+use card_dsl::card_data::UseKind;
+use card_dsl::dsl::{activated, investigate, Ability, Cost, IntExpr};
+
+/// `ArkhamDB` code for Flashlight (original-Core printing).
+pub const CODE: &str = "01087";
+
+/// Flashlight's `[action] Spend 1 supply: Investigate with -2 shroud` ability.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![activated(
+        1,
+        vec![Cost::SpendUses {
+            kind: UseKind::Supplies,
+            count: 1,
+        }],
+        investigate(IntExpr::Lit(-2)),
+    )]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use card_dsl::dsl::{Effect, Trigger};
+
+    #[test]
+    fn one_action_ability_spending_a_supply_to_investigate_minus_two_shroud() {
+        let abilities = abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(abilities[0].trigger, Trigger::Activated { action_cost: 1 });
+        assert_eq!(
+            abilities[0].costs,
+            vec![Cost::SpendUses {
+                kind: UseKind::Supplies,
+                count: 1,
+            }]
+        );
+        assert!(matches!(
+            abilities[0].effect,
+            Effect::Investigate {
+                shroud_modifier: IntExpr::Lit(-2),
+            }
+        ));
+    }
+
+    /// Catches a `pub mod` rename or a fat-fingered match arm in
+    /// `impls::abilities_for` — the registry must dispatch CODE here.
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(CODE), Some(abilities()));
+    }
+}

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -73,6 +73,7 @@ pub mod deduction;
 pub mod dr_milan_christopher;
 pub mod emergency_cache;
 pub mod first_aid;
+pub mod flashlight;
 pub mod guard_dog;
 pub mod guts;
 pub mod holy_rosary;
@@ -118,6 +119,7 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
         dr_milan_christopher::CODE => Some(dr_milan_christopher::abilities()),
         emergency_cache::CODE => Some(emergency_cache::abilities()),
         first_aid::CODE => Some(first_aid::abilities()),
+        flashlight::CODE => Some(flashlight::abilities()),
         guard_dog::CODE => Some(guard_dog::abilities()),
         guts::CODE => Some(guts::abilities()),
         holy_rosary::CODE => Some(holy_rosary::abilities()),

--- a/crates/cards/tests/flashlight.rs
+++ b/crates/cards/tests/flashlight.rs
@@ -1,0 +1,126 @@
+//! PR-7 (#313) integration: Flashlight 01087's `[action] Spend 1 supply:
+//! Investigate. Your location gets -2 shroud for this investigation.`
+//! end-to-end against the real `cards::REGISTRY`.
+//!
+//! Exercises the new `Effect::Investigate` shroud modifier: the -2 lowers
+//! the location difficulty (clamped at 0), the test reuses the base
+//! Investigate follow-up (so a success discovers a clue), and the
+//! activation rejects before spending a supply when there is no revealed
+//! location to investigate.
+//!
+//! Own process → installs `cards::REGISTRY`.
+
+use std::sync::Once;
+
+use game_core::engine::EngineOutcome;
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, InvestigatorId, LocationId, Phase,
+    SkillKind, TokenModifiers, UseKind,
+};
+use game_core::test_support::{
+    apply_no_commits, test_investigator, test_location, GameStateBuilder,
+};
+use game_core::{assert_event, Action, PlayerAction};
+
+const FLASHLIGHT: &str = "01087";
+const INV: InvestigatorId = InvestigatorId(1);
+const LOC: LocationId = LocationId(10);
+const TORCH_INST: CardInstanceId = CardInstanceId(0);
+
+static INSTALL: Once = Once::new();
+fn install() {
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// Board: Flashlight in play with 3 supplies; the active investigator at a
+/// revealed `shroud`-shroud location holding 1 clue, with `intellect`
+/// intellect. A `Numeric(0)` chaos bag makes the Investigate deterministic.
+fn board(intellect: i8, shroud: u8, revealed: bool) -> game_core::GameState {
+    install();
+    let mut inv = test_investigator(1);
+    inv.skills.intellect = intellect;
+    let mut torch = CardInPlay::enter_play(CardCode::new(FLASHLIGHT), TORCH_INST);
+    torch.uses.insert(UseKind::Supplies, 3);
+    inv.cards_in_play.push(torch);
+
+    let mut location = test_location(10, "Study");
+    location.shroud = shroud;
+    location.clues = 1;
+    location.revealed = revealed;
+
+    GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator_at(inv, LOC)
+        .with_location(location)
+        .with_active_investigator(INV)
+        .with_turn_order([INV])
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default())
+        .build()
+}
+
+fn supplies(state: &game_core::GameState) -> Option<u8> {
+    state.investigators[&INV]
+        .cards_in_play
+        .iter()
+        .find(|c| c.instance_id == TORCH_INST)
+        .map(|c| c.uses.get(&UseKind::Supplies).copied().unwrap_or(0))
+}
+
+fn activate(state: game_core::GameState) -> game_core::engine::ApplyResult {
+    apply_no_commits(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: INV,
+            instance_id: TORCH_INST,
+            ability_index: 0,
+        }),
+    )
+}
+
+#[test]
+fn minus_two_shroud_turns_a_failing_investigation_into_a_success() {
+    // Intellect 2 + 0 = 2. Base difficulty (shroud 4) would fail; the -2
+    // brings it to 2 → success by 0, discovering the location's clue.
+    let r = activate(board(2, 4, true));
+    assert_eq!(r.outcome, EngineOutcome::Done);
+    assert_event!(
+        r.events,
+        Event::SkillTestSucceeded { investigator, skill: SkillKind::Intellect, margin: 0 }
+            if *investigator == INV
+    );
+    assert_event!(r.events, Event::CluePlaced { investigator, .. } if *investigator == INV);
+    assert_eq!(r.state.investigators[&INV].clues, 1, "1 clue discovered");
+    assert_eq!(r.state.locations[&LOC].clues, 0, "clue left the location");
+    assert_eq!(supplies(&r.state), Some(2), "1 supply spent");
+}
+
+#[test]
+fn reduced_shroud_clamps_at_zero() {
+    // Shroud 1, -2 → difficulty (1 - 2).max(0) = 0, not -1 (which would
+    // reject as a negative difficulty). Intellect 0 + 0 = 0 ≥ 0 → success.
+    let r = activate(board(0, 1, true));
+    assert_eq!(r.outcome, EngineOutcome::Done);
+    assert_event!(
+        r.events,
+        Event::SkillTestSucceeded { investigator, skill: SkillKind::Intellect, margin: 0 }
+            if *investigator == INV
+    );
+    assert_eq!(supplies(&r.state), Some(2), "1 supply spent");
+}
+
+#[test]
+fn rejects_without_a_revealed_location_before_spending_a_supply() {
+    // Validate-first: an unrevealed location is not investigatable, so the
+    // activation rejects before the supply cost is paid.
+    let r = activate(board(2, 4, false));
+    assert!(matches!(r.outcome, EngineOutcome::Rejected { .. }));
+    assert_eq!(
+        supplies(&r.state),
+        Some(3),
+        "no supply spent on a rejected activation"
+    );
+}

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -1048,6 +1048,8 @@ fn effect_initiates_fight(effect: &crate::dsl::Effect) -> bool {
 ///   (Beat Cop can't pay its discard-self cost for no legal target). `amount` is
 ///   not consulted (a degenerate `amount: 0` ability — none in scope — would
 ///   still require a target here even though its handler is a no-op).
+/// - **`Investigate`:** needs the controller at a revealed location to test
+///   (Flashlight can't pay its supply cost with nothing to investigate).
 fn check_effect_target_available(
     state: &GameState,
     investigator: InvestigatorId,
@@ -1071,6 +1073,20 @@ fn check_effect_target_available(
             return Err(
                 "ActivateAbility: a 'deal damage to an enemy at your location' ability \
                  needs at least one enemy at your location"
+                    .into(),
+            );
+        }
+    }
+    if matches!(effect, crate::dsl::Effect::Investigate { .. }) {
+        let revealed_here = state
+            .investigators
+            .get(&investigator)
+            .and_then(|inv| inv.current_location)
+            .and_then(|loc| state.locations.get(&loc))
+            .is_some_and(|loc| loc.revealed);
+        if !revealed_here {
+            return Err(
+                "ActivateAbility: an Investigate ability needs a revealed location to investigate"
                     .into(),
             );
         }

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -354,6 +354,9 @@ fn apply_effect_inner(
         } => apply_fight(cx, &eval_ctx, combat_modifier, *extra_damage),
         Effect::BoostAttackDamage(amount) => boost_attack_damage_effect(cx, *amount),
         Effect::DrawCards { target, count } => draw_cards_effect(cx, eval_ctx, *target, *count),
+        Effect::Investigate { shroud_modifier } => {
+            apply_investigate(cx, &eval_ctx, shroud_modifier)
+        }
     }
 }
 
@@ -447,6 +450,74 @@ fn apply_fight(
         None,
         eval_ctx.source,
         modifier,
+    )
+}
+
+/// Resolve [`Effect::Investigate`]: apply `shroud_modifier` to the
+/// controller's location difficulty and start an Investigate skill test
+/// (reusing the base Investigate follow-up, so success discovers a clue).
+/// The modifier adjusts the *location difficulty* (shroud), not the
+/// investigator's total — the reduced shroud clamps at 0 (RR p.4: game
+/// values can never be reduced below 0). The activation check has already
+/// confirmed a revealed location to test, so the missing/unrevealed cases
+/// here are defensive (state-shape) rejections.
+fn apply_investigate(
+    cx: &mut Cx,
+    eval_ctx: &EvalContext,
+    shroud_modifier: &IntExpr,
+) -> EngineOutcome {
+    let delta = match eval_int_expr(cx.state, eval_ctx.controller, shroud_modifier) {
+        Ok(d) => d,
+        Err(reason) => {
+            return EngineOutcome::Rejected {
+                reason: reason.into(),
+            }
+        }
+    };
+    let Some(location_id) = cx
+        .state
+        .investigators
+        .get(&eval_ctx.controller)
+        .and_then(|inv| inv.current_location)
+    else {
+        return EngineOutcome::Rejected {
+            reason: "Effect::Investigate: controller has no current location".into(),
+        };
+    };
+    let Some(location) = cx.state.locations.get(&location_id) else {
+        return EngineOutcome::Rejected {
+            reason: format!("Effect::Investigate: location {location_id:?} is not in state").into(),
+        };
+    };
+    if !location.revealed {
+        return EngineOutcome::Rejected {
+            reason: format!("Effect::Investigate: location {location_id:?} is not revealed").into(),
+        };
+    }
+    // Effective shroud folds in attachment modifiers (Obscuring Fog); fall
+    // back to the printed value with no registry (bare unit tests), matching
+    // the base Investigate action. Shroud is u8 in state but difficulty is
+    // i8; saturate the conversion (realistic shrouds are 0–6), apply the
+    // (negative) modifier, then clamp the reduced difficulty at 0.
+    let shroud = match crate::card_registry::current() {
+        Some(reg) => effective_shroud(reg, location),
+        None => location.shroud,
+    };
+    let difficulty = i8::try_from(shroud)
+        .unwrap_or(i8::MAX)
+        .saturating_add(delta)
+        .max(0);
+    crate::engine::dispatch::skill_test::start_skill_test(
+        cx,
+        eval_ctx.controller,
+        SkillKind::Intellect,
+        SkillTestKind::Investigate,
+        difficulty,
+        crate::state::SkillTestFollowUp::Investigate,
+        None,
+        None,
+        eval_ctx.source,
+        0,
     )
 }
 

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -163,7 +163,12 @@ when picked up.
   chosen co-located investigator; `heal_damage`/`heal_horror` DSL builders
   added) shipped: **✅ PR #360** (its choose-before-test ordering is exact
   in solo, deferred to #359 for multiplayer — mirrors Machete's #300).
-  Remaining cluster PRs: #313 (Flashlight), #306 (Dynamite).
+  PR-7 (#313 — Flashlight 01087, the new `Effect::Investigate { shroud_modifier }`
+  primitive: the Investigate mirror of `Effect::Fight`, lowering location
+  difficulty -2 clamped at 0 and reusing the base Investigate follow-up)
+  shipped: **✅ PR #362** (AoO on activated abilities — RR p.5 — is a systemic
+  engine gap also affecting First Aid / Medical Texts, carved to #361).
+  Remaining cluster PR: #306 (Dynamite).
   Slice 1's `fire_forced_triggers` is a forward-compatible subset Axis B
   replaces. **Note:** #213's "one mixed pool" framing was corrected to
   RR-accurate two-phase (forced-all-before-reaction, RR p.2; issue text


### PR DESCRIPTION
## Summary

Implements **Flashlight (01087)** — PR-7 of the Phase-7 choice-cluster completion. Infra + content: adds the `Effect::Investigate` primitive and the card.

Card text (verbatim from `data/arkhamdb-snapshot/pack/core/core.json`):

> `Uses (3 supplies).`
> `[action] Spend 1 supply: Investigate. Your location gets -2 shroud for this investigation.`

## New primitive: `Effect::Investigate { shroud_modifier: IntExpr }`

The Investigate mirror of `Effect::Fight`:

- Initiates an Investigate against the controller's current location, applying `shroud_modifier` to that location's **difficulty** (shroud) for this investigation — *not* the investigator's total (which is `InFlightSkillTest.test_modifier`).
- The reduced shroud **clamps at 0** (RR p.4: game values never reduce below 0; also required since `start_skill_test` rejects negative difficulty).
- The −2 folds into the snapshotted skill-test `difficulty` at start, exactly like the base Investigate action folds in `effective_shroud` — **no new `InFlightSkillTest` field**.
- Reuses `SkillTestFollowUp::Investigate`, so a success discovers a clue like the action does.
- Typed (not `Native`) so the activation check can reject — **before the supply cost is paid** — an investigation with no revealed location (`check_effect_target_available`, mirroring Fight's pre-cost target check).

## Flashlight impl

`activated(1, vec![Cost::SpendUses { Supplies, 1 }], investigate(IntExpr::Lit(-2)))`. The `Uses (3 supplies)` pool + depletion-discard come from corpus metadata, same as First Aid.

## ⚠️ Attack of opportunity — carved to #361

Per RR p.5, activating an `[action]` ability while engaged with a ready enemy provokes an attack of opportunity (it's not a fight/evade/parley/resign ability). The engine fires **no** AoO on any activated ability today — a pre-existing systemic gap also affecting the shipped First Aid (01019) and Medical Texts (01035). Fixing it requires classifying ability "kinds" at the `activate_ability` layer, well outside this primitive's scope. Filed as **#361** (with the RR citation) and TODO'd in Flashlight's impl. Flashlight ships with the same AoO behavior as its sibling assets.

## Testing

- DSL: card structure unit test asserts `Effect::Investigate { shroud_modifier: IntExpr::Lit(-2) }`.
- **Integration tests** (`crates/cards/tests/flashlight.rs`, real registry + skill-test driver):
  - −2 turns a shroud-4 investigation that would fail (intellect 2) into a success → clue discovered + 1 supply spent.
  - reduced shroud **clamps at 0** (shroud 1 → difficulty 0, not −1).
  - **pre-cost reject** on an unrevealed location → no supply spent.
- Full CI gauntlet green locally (fmt, test, clippy, doc, wasm-build, wasm-clippy).

Closes #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)