### PR TITLE
cards: Dynamite Blast 01024 — PR-8, closes the choice cluster

### DIFF
--- a/crates/cards/src/impls/dynamite_blast.rs
+++ b/crates/cards/src/impls/dynamite_blast.rs
@@ -1,0 +1,163 @@
+//! Dynamite Blast (Guardian event, 01024).
+//!
+//! ```text
+//! Choose either your location or a connecting location. Deal 3 damage to
+//!   each enemy and to each investigator at the chosen location.
+//! ```
+//!
+//! A card-local native (the #276 escape hatch), like agenda 01105 / Crypt
+//! Chill: it enumerates the controller's location and its connections, applies
+//! the choice convention (1 candidate → auto-target, 2+ → suspend via
+//! [`suspend_for_native_choice`]), and on resume deals 3 damage to every enemy
+//! ([`deal_damage_to_enemy`], which handles defeat → victory points / Roland's
+//! reaction) and every investigator ([`take_damage`] — the controller included
+//! if they blast their own location) at the chosen location.
+//!
+//! # Native, not a typed fan-out — on purpose
+//!
+//! A corpus audit found the only in-scope fan-out / area consumers are this card
+//! and agenda 01105 — two *different* shapes, with every other consumer in
+//! future Dunwich content. So a general `Effect::ForEach` / `EntityTarget`
+//! would be speculative today; both stay card-local natives until Dunwich's
+//! fan-out cards justify the abstraction. The deferred (and **not-yet-accepted**)
+//! design is captured in #363.
+//!
+//! Suspending from an `OnPlay` event relies on the played event being discarded
+//! on *completion* (`GameState.pending_played_event`, RR Appendix I step 4: the
+//! card is placed in discard "simultaneously with the completion" of its
+//! effect) — so it's discarded when the choice resolves, not stranded in hand.
+
+use card_dsl::dsl::{native, on_play, Ability};
+use game_core::card_registry::NativeEffectFn;
+use game_core::state::{EnemyId, InvestigatorId, LocationId};
+use game_core::{
+    deal_damage_to_enemy, resolve_choice_count, suspend_for_native_choice, take_damage,
+    ChoiceResolution, Cx, EngineOutcome, EvalContext,
+};
+
+/// `ArkhamDB` code for Dynamite Blast (original-Core printing).
+pub const CODE: &str = "01024";
+
+const BLAST: &str = "01024:blast";
+
+/// Damage dealt to each enemy and investigator at the chosen location.
+const DAMAGE: u8 = 3;
+
+/// Dynamite Blast's `OnPlay` area-of-effect.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![on_play(native(BLAST))]
+}
+
+/// Resolve this event's native-effect tag. Wired into the crate registry's
+/// `native_effect_for`.
+pub(crate) fn native_effect_for(tag: &str) -> Option<NativeEffectFn> {
+    (tag == BLAST).then_some(dynamite_blast as NativeEffectFn)
+}
+
+/// Candidate target locations: the controller's location followed by each
+/// connected location, connections sorted by id so an `OptionId` indexes the
+/// same location when the choice replays on resume.
+fn candidate_locations(cx: &Cx, controller: InvestigatorId) -> Vec<LocationId> {
+    let Some(here) = cx
+        .state
+        .investigators
+        .get(&controller)
+        .and_then(|inv| inv.current_location)
+    else {
+        return Vec::new();
+    };
+    let mut locations = vec![here];
+    if let Some(loc) = cx.state.locations.get(&here) {
+        let mut connections = loc.connections.clone();
+        connections.sort_unstable();
+        locations.extend(connections);
+    }
+    locations
+}
+
+fn dynamite_blast(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
+    let controller = ctx.controller;
+    let locations = candidate_locations(cx, controller);
+
+    // Resume: a pick was threaded in — re-enumerate and index by it.
+    if let Some(picked) = ctx.chosen_option {
+        let Some(&loc) = locations.get(picked.0 as usize) else {
+            return EngineOutcome::Rejected {
+                reason: "01024 blast: chosen_option out of range".into(),
+            };
+        };
+        return blast_location(cx, controller, loc);
+    }
+
+    match resolve_choice_count(locations.len()) {
+        // Controller is between locations — no legal target.
+        ChoiceResolution::Empty => EngineOutcome::Rejected {
+            reason: "01024 blast: controller has no location to target".into(),
+        },
+        // Exactly one (your location, no connections) → auto-target.
+        ChoiceResolution::Auto(i) => blast_location(cx, controller, locations[i]),
+        // 2+ → suspend for the controller's pick.
+        ChoiceResolution::Suspend => {
+            let labels = locations.iter().map(|id| format!("{id:?}")).collect();
+            suspend_for_native_choice(cx, "Choose a location to blast", labels, BLAST, ctx)
+        }
+    }
+}
+
+/// Deal [`DAMAGE`] to each enemy and each investigator at `loc`. Ids are
+/// snapshotted first (in `BTreeMap` order — deterministic for replay) because
+/// dealing damage can defeat enemies/investigators and mutate the maps mid-loop.
+/// Enemy damage is attributed to `controller` so a defeat counts as "you
+/// defeat" (victory points, Roland's reaction).
+fn blast_location(cx: &mut Cx, controller: InvestigatorId, loc: LocationId) -> EngineOutcome {
+    let enemies: Vec<EnemyId> = cx
+        .state
+        .enemies
+        .iter()
+        .filter(|(_, e)| e.current_location == Some(loc))
+        .map(|(id, _)| *id)
+        .collect();
+    for enemy in enemies {
+        deal_damage_to_enemy(cx, enemy, DAMAGE, Some(controller));
+    }
+
+    let investigators: Vec<InvestigatorId> = cx
+        .state
+        .investigators
+        .iter()
+        .filter(|(_, i)| i.current_location == Some(loc))
+        .map(|(id, _)| *id)
+        .collect();
+    for inv in investigators {
+        take_damage(cx, inv, DAMAGE);
+    }
+
+    EngineOutcome::Done
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use card_dsl::dsl::{Effect, Trigger};
+
+    #[test]
+    fn one_on_play_native_blast() {
+        let abilities = abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(abilities[0].trigger, Trigger::OnPlay);
+        assert!(
+            matches!(&abilities[0].effect, Effect::Native { tag } if tag == BLAST),
+            "OnPlay is the blast native",
+        );
+        assert!(native_effect_for(BLAST).is_some());
+        assert!(native_effect_for("nope").is_none());
+    }
+
+    /// Catches a `pub mod` rename or a fat-fingered match arm in
+    /// `impls::abilities_for` — the registry must dispatch CODE here.
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(CODE), Some(abilities()));
+    }
+}

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -71,6 +71,7 @@ pub mod beat_cop;
 pub mod cellar;
 pub mod deduction;
 pub mod dr_milan_christopher;
+pub mod dynamite_blast;
 pub mod emergency_cache;
 pub mod first_aid;
 pub mod flashlight;
@@ -117,6 +118,7 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
         cellar::CODE => Some(cellar::abilities()),
         deduction::CODE => Some(deduction::abilities()),
         dr_milan_christopher::CODE => Some(dr_milan_christopher::abilities()),
+        dynamite_blast::CODE => Some(dynamite_blast::abilities()),
         emergency_cache::CODE => Some(emergency_cache::abilities()),
         first_aid::CODE => Some(first_aid::abilities()),
         flashlight::CODE => Some(flashlight::abilities()),
@@ -159,6 +161,7 @@ pub fn native_effect_for(tag: &str) -> Option<game_core::card_registry::NativeEf
         .or_else(|| agenda_01105::native_effect_for(tag))
         .or_else(|| agenda_01106::native_effect_for(tag))
         .or_else(|| agenda_01107::native_effect_for(tag))
+        .or_else(|| dynamite_blast::native_effect_for(tag))
         .or_else(|| guard_dog::native_effect_for(tag))
         .or_else(|| treachery_01007::native_effect_for(tag))
         .or_else(|| treachery_01166::native_effect_for(tag))

--- a/crates/cards/tests/dynamite_blast.rs
+++ b/crates/cards/tests/dynamite_blast.rs
@@ -1,0 +1,182 @@
+//! PR-8 (#306) integration: Dynamite Blast 01024's `Choose either your
+//! location or a connecting location. Deal 3 damage to each enemy and to each
+//! investigator at the chosen location.` end-to-end against the real
+//! `cards::REGISTRY`.
+//!
+//! Exercises (a) the location choice — auto when there's one candidate, a
+//! suspend/resume `Continuation::Choice` when there are 2+; (b) the area
+//! damage over both enemies and investigators at the chosen location (and *not* the other
+//! location); (c) self-damage when blasting your own location; (d) the
+//! played-event being discarded on *completion* of a suspending `OnPlay`
+//! (`pending_played_event`, RR Appendix I step 4) rather than stranded in hand.
+//!
+//! Own process → installs `cards::REGISTRY`.
+
+use std::sync::Once;
+
+use game_core::engine::EngineOutcome;
+use game_core::state::{CardCode, EnemyId, InvestigatorId, LocationId, Phase};
+use game_core::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
+use game_core::{apply, Action, InputResponse, OptionId, PlayerAction};
+
+const DYNAMITE: &str = "01024";
+const INV: InvestigatorId = InvestigatorId(1);
+const INV2: InvestigatorId = InvestigatorId(2);
+const LOC_A: LocationId = LocationId(10);
+const LOC_B: LocationId = LocationId(11);
+const ENEMY_A: EnemyId = EnemyId(100);
+const ENEMY_B: EnemyId = EnemyId(101);
+
+static INSTALL: Once = Once::new();
+fn install() {
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+fn play(state: game_core::GameState) -> game_core::engine::ApplyResult {
+    apply(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: INV,
+            hand_index: 0,
+        }),
+    )
+}
+
+fn pick(state: game_core::GameState, option: u32) -> game_core::engine::ApplyResult {
+    apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickSingle(OptionId(option)),
+        }),
+    )
+}
+
+/// Two connected locations. The controller (Dynamite in hand) and a 3-health
+/// enemy sit at `LOC_A`; a second investigator and a 5-health enemy sit at the
+/// connecting `LOC_B`.
+fn board() -> game_core::GameState {
+    install();
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(LOC_A);
+    inv.hand = vec![CardCode::new(DYNAMITE)];
+
+    let mut inv2 = test_investigator(2);
+    inv2.current_location = Some(LOC_B);
+
+    let mut loc_a = test_location(10, "Cellar");
+    loc_a.connections = vec![LOC_B];
+    let mut loc_b = test_location(11, "Hallway");
+    loc_b.connections = vec![LOC_A];
+
+    let mut enemy_a = test_enemy(100, "Ghoul A");
+    enemy_a.current_location = Some(LOC_A);
+    enemy_a.max_health = 3; // 3 damage defeats it
+    let mut enemy_b = test_enemy(101, "Ghoul B");
+    enemy_b.current_location = Some(LOC_B);
+    enemy_b.max_health = 5; // survives, to assert it's untouched
+
+    GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(inv)
+        .with_investigator(inv2)
+        .with_location(loc_a)
+        .with_location(loc_b)
+        .with_enemy(enemy_a)
+        .with_enemy(enemy_b)
+        .with_active_investigator(INV)
+        .with_turn_order([INV])
+        .build()
+}
+
+#[test]
+fn blasts_only_the_chosen_location_then_discards_the_event() {
+    // Two candidates (your location + the connection) → suspend.
+    let r = play(board());
+    assert!(
+        matches!(r.outcome, EngineOutcome::AwaitingInput { .. }),
+        "2 candidate locations → choice suspends",
+    );
+    // The event has left hand ("commences being played") but isn't discarded yet.
+    assert!(
+        r.state.investigators[&INV].hand.is_empty(),
+        "event left hand"
+    );
+    assert!(
+        r.state.investigators[&INV].discard.is_empty(),
+        "not discarded until the effect completes",
+    );
+    assert!(r.state.pending_played_event.is_some(), "event mid-play");
+
+    // candidate_locations = [LOC_A, LOC_B] → OptionId(0) blasts LOC_A.
+    let r = pick(r.state, 0);
+    assert_eq!(r.outcome, EngineOutcome::Done);
+
+    // LOC_A: enemy defeated (3 dmg ≥ 3 health), controller took 3 (self-damage).
+    assert!(
+        !r.state.enemies.contains_key(&ENEMY_A),
+        "enemy at the blasted location was defeated and removed",
+    );
+    assert_eq!(
+        r.state.investigators[&INV].damage, 3,
+        "the controller blasted its own location and took 3",
+    );
+    // LOC_B (not chosen): untouched.
+    assert_eq!(
+        r.state.enemies[&ENEMY_B].damage, 0,
+        "enemy at LOC_B untouched"
+    );
+    assert_eq!(
+        r.state.investigators[&INV2].damage, 0,
+        "investigator at LOC_B untouched",
+    );
+
+    // Discard-on-completion (RR Appendix I step 4): the event is now discarded.
+    assert_eq!(
+        r.state.investigators[&INV].discard,
+        vec![CardCode::new(DYNAMITE)],
+        "event discarded when its effect completed",
+    );
+    assert!(
+        r.state.pending_played_event.is_none(),
+        "pending played-event flushed",
+    );
+}
+
+#[test]
+fn auto_targets_and_discards_when_your_location_is_the_only_candidate() {
+    // A single location with no connections → one candidate → auto, no suspend.
+    install();
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(LOC_A);
+    inv.hand = vec![CardCode::new(DYNAMITE)];
+
+    let loc_a = test_location(10, "Cellar"); // no connections
+    let mut enemy_a = test_enemy(100, "Ghoul A");
+    enemy_a.current_location = Some(LOC_A);
+    enemy_a.max_health = 5; // survives, to assert the 3-damage amount
+
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(inv)
+        .with_location(loc_a)
+        .with_enemy(enemy_a)
+        .with_active_investigator(INV)
+        .with_turn_order([INV])
+        .build();
+
+    let r = play(state);
+    assert_eq!(
+        r.outcome,
+        EngineOutcome::Done,
+        "single candidate → no suspend"
+    );
+    assert_eq!(r.state.enemies[&ENEMY_A].damage, 3, "enemy took 3");
+    assert_eq!(r.state.investigators[&INV].damage, 3, "controller took 3");
+    assert_eq!(
+        r.state.investigators[&INV].discard,
+        vec![CardCode::new(DYNAMITE)],
+        "event discarded",
+    );
+}

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -542,6 +542,22 @@ pub(super) fn play_card(
         investigator,
         code: code.clone(),
     });
+    // RR Appendix I, step 3: an event "commences being played" — it leaves
+    // hand now and is placed in discard on *completion* of its effect (step 4),
+    // flushed from `pending_played_event` by the apply loop on `Done`. Stashing
+    // it before running OnPlay means a suspending effect (Dynamite Blast's
+    // location choice) discards the event when it resumes rather than stranding
+    // it in hand. (An asset enters play after its OnPlay effect, below.)
+    if let super::PlayDestination::Discard = destination {
+        let card = cx
+            .state
+            .investigators
+            .get_mut(&investigator)
+            .expect("checked")
+            .hand
+            .remove(idx);
+        cx.state.pending_played_event = Some((investigator, card));
+    }
     let eval_ctx = EvalContext::for_controller(investigator);
     for ability in abilities.iter().filter(|a| a.trigger == Trigger::OnPlay) {
         let outcome = apply_effect(cx, &ability.effect, eval_ctx);
@@ -549,42 +565,47 @@ pub(super) fn play_card(
             return outcome;
         }
     }
-    match destination {
-        super::PlayDestination::InPlay => {
-            // Remove the card from hand, then mint + seed its in-play
-            // instance via the shared constructor (mints the id, seeds the
-            // asset uses-pool) and push it into the play area.
-            let played = cx
-                .state
-                .investigators
-                .get_mut(&investigator)
-                .expect("checked")
-                .hand
-                .remove(idx);
-            let in_play = super::threat_area::new_in_play_instance(cx, played);
-            cx.state
-                .investigators
-                .get_mut(&investigator)
-                .expect("checked")
-                .cards_in_play
-                .push(in_play);
-        }
-        super::PlayDestination::Discard => {
-            let inv_mut = cx
-                .state
-                .investigators
-                .get_mut(&investigator)
-                .expect("checked");
-            let card = inv_mut.hand.remove(idx);
-            inv_mut.discard.push(card.clone());
-            cx.events.push(Event::CardDiscarded {
-                investigator,
-                code: card,
-                from: Zone::Hand,
-            });
-        }
+    if let super::PlayDestination::InPlay = destination {
+        // Remove the card from hand, then mint + seed its in-play instance via
+        // the shared constructor (mints the id, seeds the asset uses-pool) and
+        // push it into the play area.
+        let played = cx
+            .state
+            .investigators
+            .get_mut(&investigator)
+            .expect("checked")
+            .hand
+            .remove(idx);
+        let in_play = super::threat_area::new_in_play_instance(cx, played);
+        cx.state
+            .investigators
+            .get_mut(&investigator)
+            .expect("checked")
+            .cards_in_play
+            .push(in_play);
     }
     EngineOutcome::Done
+}
+
+/// Flush a [`pending_played_event`](crate::state::GameState::pending_played_event)
+/// to its owner's discard pile, emitting [`Event::CardDiscarded`] (`from:
+/// Zone::Hand`). Called by the apply loop when an action completes (`Done`):
+/// per RR Appendix I step 4, an event is placed in discard "simultaneously with
+/// the completion" of its effect — so this fires immediately for a normal event
+/// and on resume for one whose `OnPlay` suspended (Dynamite Blast 01024). A
+/// no-op when no event is mid-play.
+pub(in crate::engine) fn flush_pending_played_event(cx: &mut Cx) {
+    let Some((investigator, code)) = cx.state.pending_played_event.take() else {
+        return;
+    };
+    if let Some(inv) = cx.state.investigators.get_mut(&investigator) {
+        inv.discard.push(code.clone());
+    }
+    cx.events.push(Event::CardDiscarded {
+        investigator,
+        code,
+        from: Zone::Hand,
+    });
 }
 
 #[cfg(test)]

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -152,14 +152,24 @@ pub fn apply_with_scenario_registry(
             // State half is restored after this block (the `cx` borrow on
             // `state` releases at the block close).
             cx.events.clear();
-        } else if !resolution_already_fired {
-            // A dispatch site may have latched a resolution this apply (act/
-            // agenda resolution point, or no-remaining-players elimination).
-            // Fire the module hook exactly once, on the None->Some transition.
-            // Runs on Done AND AwaitingInput — a resolution can latch during
-            // an apply that pauses (e.g. doom crosses the threshold in Mythos
-            // 1.3 before the 1.4 draw pause).
-            fire_scenario_resolution(&mut cx, registry);
+        } else {
+            // An event completes its play here (RR Appendix I, step 4): flush
+            // the pending played-event to its owner's discard on Done, before
+            // the resolution hook. A suspending OnPlay event (Dynamite Blast)
+            // resumes to Done on a later apply and is discarded then;
+            // AwaitingInput leaves it mid-play (still "being played").
+            if matches!(outcome, EngineOutcome::Done) {
+                dispatch::cards::flush_pending_played_event(&mut cx);
+            }
+            if !resolution_already_fired {
+                // A dispatch site may have latched a resolution this apply (act/
+                // agenda resolution point, or no-remaining-players elimination).
+                // Fire the module hook exactly once, on the None->Some transition.
+                // Runs on Done AND AwaitingInput — a resolution can latch during
+                // an apply that pauses (e.g. doom crosses the threshold in Mythos
+                // 1.3 before the 1.4 draw pause).
+                fire_scenario_resolution(&mut cx, registry);
+            }
         }
         outcome
         // `cx` drops here, releasing borrows on `state` and `events`.

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -289,6 +289,7 @@ impl GameStateBuilder {
             clue_interrupt_pending: None,
             pending_enemy_attack: None,
             pending_revelation_discard: None,
+            pending_played_event: None,
             encounter_deck: VecDeque::new(),
             encounter_discard: Vec::new(),
             agenda_deck: Vec::new(),

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -243,6 +243,17 @@ pub struct GameState {
     /// TODO(#212): generalize beyond skill-test-suspended revelations
     /// once `ChooseOne` can suspend mid-resolution.
     pub pending_revelation_discard: Option<CardCode>,
+    /// An event card mid-play: it has left hand ("commences being played",
+    /// RR Appendix I step 3) but is not yet in discard. The apply loop
+    /// flushes it to the owner's discard pile on `Done` (step 4: the event is
+    /// placed in discard "simultaneously with the completion" of its effect),
+    /// so an `OnPlay` effect that suspends — Dynamite Blast 01024's location
+    /// choice — discards the event when it resumes rather than stranding it in
+    /// hand. The player-event analogue of
+    /// [`pending_revelation_discard`](Self::pending_revelation_discard). `None`
+    /// outside an in-flight event play.
+    #[serde(default)]
+    pub pending_played_event: Option<(InvestigatorId, CardCode)>,
     /// Shared encounter deck (top = front). Built at scenario setup
     /// from encounter-set codes; drawn from during Mythos. When the
     /// deck runs out, `draw_encounter_top` (in `engine::dispatch`)

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -168,7 +168,16 @@ when picked up.
   difficulty -2 clamped at 0 and reusing the base Investigate follow-up)
   shipped: **✅ PR #362** (AoO on activated abilities — RR p.5 — is a systemic
   engine gap also affecting First Aid / Medical Texts, carved to #361).
-  Remaining cluster PR: #306 (Dynamite).
+  PR-8 (#306 — Dynamite Blast 01024) shipped: **✅ PR #364**, **closing the
+  choice cluster**. A card-local native (location choice +
+  enemy/investigator AoE) rather than a general fan-out: a corpus audit found
+  the only in-scope fan-out consumers are this card + agenda 01105 (different
+  shapes; the rest are Dunwich), so a general `Effect::ForEach` / `EntityTarget`
+  stays deferred and not-yet-designed in #363. Its engine prereq — a played
+  event leaves hand at play-start (`pending_played_event`) and is discarded on
+  *completion* (RR Appendix I step 4), so a suspending `OnPlay` event isn't
+  stranded — also shipped in #364.
+  **The choice-cluster completion sub-slice is done — all 8 PRs merged.**
   Slice 1's `fire_forced_triggers` is a forward-compatible subset Axis B
   replaces. **Note:** #213's "one mixed pool" framing was corrected to
   RR-accurate two-phase (forced-all-before-reaction, RR p.2; issue text


### PR DESCRIPTION
## Summary

Implements **Dynamite Blast (01024)** — PR-8, the **final** card of the Phase-7 choice-cluster completion.

Card text (verbatim from `data/arkhamdb-snapshot/pack/core/core.json`):

> `Choose either your location or a connecting location. Deal 3 damage to each enemy and to each investigator at the chosen location.`

A Guardian **event** with an `OnPlay` area-of-effect.

## Approach: card-local native (no new DSL primitive)

A corpus audit (Core + Dunwich) found the only in-scope fan-out / area consumers are **this card and agenda 01105** — two *different* shapes (investigator-all + random-discard vs. mixed-kind + damage), with **every other consumer in future Dunwich content**. So a general `Effect::ForEach` / `EntityTarget` would be speculative today; Dynamite is a card-local native (the `Effect::Native` escape hatch, like agenda 01105 / Crypt Chill), and the deferred — **not-yet-accepted** — general design is captured in **#363**.

The native: enumerates `{your location} ∪ connections`, applies the choice convention (1 → auto-target, 2+ → `suspend_for_native_choice`), and on resume deals 3 to each enemy (`deal_damage_to_enemy`, attributed to the controller so defeats count as "you defeat" → victory points / Roland's reaction) and each investigator (`take_damage` — the controller included if it blasts its own location) at the chosen location.

## Engine prereq: suspending `OnPlay` events (RR-faithful)

Dynamite is the first **played-from-hand event whose `OnPlay` suspends** (the location choice). Previously `play_card` ran `OnPlay` and only discarded the event *after* — so a suspend returned before the discard, and `resume_choice` re-runs only the effect, never `play_card`'s tail → the event would be **stranded in hand**.

Fixed per the Rules Reference (Appendix I, Initiation Sequence):
> step 3: "The card **commences being played**." step 4: "… the card is regarded as played (and placed in play, or in its owner's discard pile if it's an event) … **simultaneously with the completion of this step**."

So a played event now leaves hand at play-start into `GameState.pending_played_event`, and the apply loop discards it **on `Done`** (immediately for a normal event, on resume for a suspending one). This is the player-event analogue of the existing `pending_revelation_discard`. Bonus: the `Rejected` snapshot rollback now also unwinds the pending event, so a mid-resolution reject leaves no partial state (improving the caveat noted in CLAUDE.md). Asset `OnPlay` keeps its current order (no in-scope asset suspends on play). Observable event order is unchanged for non-suspending events (`CardPlayed → [effect events] → CardDiscarded`).

## Testing

- Unit test: the single `OnPlay` native ability + native-tag / registry dispatch.
- **Integration tests** (`crates/cards/tests/dynamite_blast.rs`, real registry):
  - two connected locations → choice **suspends**; pick → blasts only the chosen location (enemy defeated, controller self-damaged 3), the other location untouched; **event discarded on completion** + `pending_played_event` flushed.
  - single candidate (no connections) → **auto-targets** with no suspend, deals 3, discards.
- Full CI gauntlet green locally (fmt, test, clippy, doc, wasm-build, wasm-clippy).

Closes #306. With this, the choice-cluster completion sub-slice is **done** (PRs 1–8 all merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)