### PR TITLE
engine: Axis C reaction-event-play — Evidence! 01022

### DIFF
--- a/crates/cards/src/impls/evidence.rs
+++ b/crates/cards/src/impls/evidence.rs
@@ -1,0 +1,81 @@
+//! Evidence! (Neutral event, 01022).
+//!
+//! Card text (verbatim, `data/arkhamdb-snapshot/pack/core/core.json`):
+//!
+//! ```text
+//! Fast. Play after you defeat an enemy.
+//! Discover 1 clue at your location.
+//! ```
+//!
+//! # Scope
+//!
+//! Evidence! is Roland Banks 01001's `[reaction]` ("After you defeat an
+//! enemy: Discover 1 clue at your location.") sourced from hand instead of
+//! from play — the identical [`Trigger::OnEvent`] declaration, minus Roland's
+//! once-per-round [`UsageLimit`]. Per Rules Reference p.11, a Fast event with
+//! a "Play after …" instruction plays "as if the described timing point were a
+//! triggering condition", so the play-timing predicate IS the `OnEvent`
+//! pattern (Axis C, #335 / #304). The Fast/cost/Insight metadata comes from
+//! the generated corpus.
+//!
+//! [`Trigger::OnEvent`]: card_dsl::dsl::Trigger::OnEvent
+//! [`UsageLimit`]: card_dsl::dsl::UsageLimit
+
+use card_dsl::dsl::{
+    discover_clue, reaction_on_event, Ability, EventPattern, EventTiming, LocationTarget,
+};
+
+/// `ArkhamDB` code for the original-Core printing.
+pub const CODE: &str = "01022";
+
+/// Evidence!'s "Play after you defeat an enemy. / Discover 1 clue at your
+/// location." — Roland 01001's reaction without the usage limit.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![reaction_on_event(
+        EventPattern::EnemyDefeated {
+            by_controller: true,
+            code: None,
+        },
+        EventTiming::After,
+        discover_clue(LocationTarget::YourLocation, 1),
+    )]
+}
+
+#[cfg(test)]
+mod tests {
+    use card_dsl::dsl::{Effect, EventPattern, EventTiming, LocationTarget, Trigger, TriggerKind};
+
+    #[test]
+    fn abilities_are_one_after_defeat_reaction_discovering_one_clue() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(
+            abilities[0].trigger,
+            Trigger::OnEvent {
+                pattern: EventPattern::EnemyDefeated {
+                    by_controller: true,
+                    code: None,
+                },
+                timing: EventTiming::After,
+                kind: TriggerKind::Reaction,
+            },
+        );
+        assert!(matches!(
+            abilities[0].effect,
+            Effect::DiscoverClue {
+                from: LocationTarget::YourLocation,
+                count: 1,
+            },
+        ));
+        assert!(
+            abilities[0].usage_limit.is_none(),
+            "Evidence! is a one-shot event — no per-round usage limit",
+        );
+    }
+
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(super::CODE), Some(super::abilities()));
+    }
+}

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -73,6 +73,7 @@ pub mod deduction;
 pub mod dr_milan_christopher;
 pub mod dynamite_blast;
 pub mod emergency_cache;
+pub mod evidence;
 pub mod first_aid;
 pub mod flashlight;
 pub mod guard_dog;
@@ -120,6 +121,7 @@ pub fn abilities_for(code: &str) -> Option<Vec<Ability>> {
         dr_milan_christopher::CODE => Some(dr_milan_christopher::abilities()),
         dynamite_blast::CODE => Some(dynamite_blast::abilities()),
         emergency_cache::CODE => Some(emergency_cache::abilities()),
+        evidence::CODE => Some(evidence::abilities()),
         first_aid::CODE => Some(first_aid::abilities()),
         flashlight::CODE => Some(flashlight::abilities()),
         guard_dog::CODE => Some(guard_dog::abilities()),

--- a/crates/cards/tests/dr_milan.rs
+++ b/crates/cards/tests/dr_milan.rs
@@ -85,7 +85,7 @@ fn dr_milan_plus_one_intellect_succeeds_then_reaction_gains_resource() {
     let resumed = game_core::engine::apply(
         paused_reaction.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
     assert_eq!(resumed.outcome, EngineOutcome::Done);
@@ -168,7 +168,7 @@ fn obscuring_fog_forced_discard_precedes_dr_milan_reaction_window() {
     let resumed = game_core::engine::apply(
         paused_reaction.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
     assert_eq!(resumed.outcome, EngineOutcome::Done);

--- a/crates/cards/tests/evidence.rs
+++ b/crates/cards/tests/evidence.rs
@@ -1,0 +1,108 @@
+//! End-to-end tests for Evidence! 01022 (Axis C reaction-event-play, #304)
+//! against the real `cards::REGISTRY`.
+//!
+//! Card text (verbatim, `data/arkhamdb-snapshot/pack/core/core.json`):
+//!
+//! > Fast. Play after you defeat an enemy.
+//! > Discover 1 clue at your location.
+//!
+//! Lives at `crates/cards/tests/` so it can install [`cards::REGISTRY`] in its
+//! own integration-test process.
+
+use std::sync::Once;
+
+use game_core::engine::EngineOutcome;
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, ChaosBag, ChaosToken, EnemyId, InvestigatorId, LocationId, Phase, TokenModifiers,
+    WindowKind,
+};
+use game_core::test_support::{
+    drive, test_enemy, test_investigator, test_location, GameStateBuilder, ScriptedResolver,
+};
+use game_core::{assert_event, assert_no_event, Action, PlayerAction};
+
+/// `ArkhamDB` code for original-Core Evidence!.
+const EVIDENCE: &str = "01022";
+
+fn install_real_registry() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// Solo investigator (NOT Roland — no in-play reaction) engaged with a 1-HP
+/// enemy at a location with `location_clues` clues, holding Evidence! in hand.
+/// A successful Combat test defeats the enemy and opens the after-defeat
+/// window.
+fn investigator_with_evidence_and_enemy(
+    location_clues: u8,
+) -> (InvestigatorId, EnemyId, LocationId, game_core::GameState) {
+    install_real_registry();
+    let inv_id = InvestigatorId(1);
+    let enemy_id = EnemyId(100);
+    let loc_id = LocationId(10);
+
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(loc_id);
+    inv.skills.combat = 4;
+    inv.hand.push(CardCode::new(EVIDENCE));
+
+    let mut enemy = test_enemy(100, "Mock Ghoul");
+    enemy.fight = 1;
+    enemy.max_health = 1;
+    enemy.damage = 0;
+    enemy.engaged_with = Some(inv_id);
+
+    let mut loc = test_location(10, "Study");
+    loc.clues = location_clues;
+
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_round(0)
+        .with_active_investigator(inv_id)
+        .with_turn_order([inv_id])
+        .with_investigator(inv)
+        .with_enemy(enemy)
+        .with_location(loc)
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default())
+        .build();
+    (inv_id, enemy_id, loc_id, state)
+}
+
+fn fight_action(inv: InvestigatorId, enemy: EnemyId) -> Action {
+    Action::Player(PlayerAction::Fight {
+        investigator: inv,
+        enemy,
+    })
+}
+
+#[test]
+fn after_defeat_window_opens_and_offers_evidence_with_no_in_play_reaction() {
+    let (inv_id, enemy_id, loc_id, state) = investigator_with_evidence_and_enemy(2);
+
+    // Commit nothing to the Fight test, then SKIP the reaction window (the
+    // option is offered here; playing it is exercised in the next test).
+    let mut resolver = ScriptedResolver::new();
+    resolver.commit_cards(&[]).skip();
+    let result = drive(state, fight_action(inv_id, enemy_id), resolver);
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    // The window opens even though no in-play card reacts — the hand match
+    // alone opens it.
+    assert_event!(
+        result.events,
+        Event::WindowOpened {
+            kind: WindowKind::AfterEnemyDefeated { enemy: e, .. },
+        } if *e == enemy_id
+    );
+    // Skipped → no clue discovered, Evidence! still in hand.
+    assert_no_event!(result.events, Event::CluePlaced { .. });
+    assert_eq!(result.state.locations[&loc_id].clues, 2);
+    assert!(result.state.investigators[&inv_id]
+        .hand
+        .iter()
+        .any(|c| c.as_str() == EVIDENCE));
+}

--- a/crates/cards/tests/evidence.rs
+++ b/crates/cards/tests/evidence.rs
@@ -20,7 +20,7 @@ use game_core::state::{
 use game_core::test_support::{
     drive, test_enemy, test_investigator, test_location, GameStateBuilder, ScriptedResolver,
 };
-use game_core::{assert_event, assert_no_event, Action, PlayerAction};
+use game_core::{apply, assert_event, assert_no_event, Action, PlayerAction};
 
 /// `ArkhamDB` code for original-Core Evidence!.
 const EVIDENCE: &str = "01022";
@@ -105,6 +105,40 @@ fn after_defeat_window_opens_and_offers_evidence_with_no_in_play_reaction() {
         .hand
         .iter()
         .any(|c| c.as_str() == EVIDENCE));
+}
+
+#[test]
+fn evidence_cannot_be_played_as_a_standalone_action() {
+    // #304 acceptance: Evidence! is illegal outside its named window. Playing
+    // it via the ordinary PlayCard action (here, during the turn with no defeat)
+    // must reject — otherwise it would run no OnPlay effect and silently fizzle.
+    let (inv_id, _enemy_id, loc_id, state) = investigator_with_evidence_and_enemy(2);
+    assert_eq!(
+        state.investigators[&inv_id].hand[0].as_str(),
+        EVIDENCE,
+        "fixture invariant: Evidence! is the only hand card, at index 0",
+    );
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::PlayCard {
+            investigator: inv_id,
+            hand_index: 0,
+        }),
+    );
+
+    assert!(
+        matches!(result.outcome, EngineOutcome::Rejected { .. }),
+        "Evidence! must be illegal as a standalone play; got {:?}",
+        result.outcome,
+    );
+    // State unchanged: still in hand, not discarded, no clue moved.
+    assert!(result.state.investigators[&inv_id]
+        .hand
+        .iter()
+        .any(|c| c.as_str() == EVIDENCE));
+    assert!(result.state.investigators[&inv_id].discard.is_empty());
+    assert_eq!(result.state.locations[&loc_id].clues, 2);
 }
 
 #[test]

--- a/crates/cards/tests/evidence.rs
+++ b/crates/cards/tests/evidence.rs
@@ -11,11 +11,11 @@
 
 use std::sync::Once;
 
-use game_core::engine::EngineOutcome;
+use game_core::engine::{EngineOutcome, OptionId};
 use game_core::event::Event;
 use game_core::state::{
     CardCode, ChaosBag, ChaosToken, EnemyId, InvestigatorId, LocationId, Phase, TokenModifiers,
-    WindowKind,
+    WindowKind, Zone,
 };
 use game_core::test_support::{
     drive, test_enemy, test_investigator, test_location, GameStateBuilder, ScriptedResolver,
@@ -105,4 +105,98 @@ fn after_defeat_window_opens_and_offers_evidence_with_no_in_play_reaction() {
         .hand
         .iter()
         .any(|c| c.as_str() == EVIDENCE));
+}
+
+#[test]
+fn picking_evidence_plays_it_and_discovers_a_clue() {
+    let (inv_id, enemy_id, loc_id, state) = investigator_with_evidence_and_enemy(2);
+
+    // Commit nothing, then pick the single offered option (OptionId(0) = the
+    // hand Evidence! play; there is no in-play trigger).
+    let mut resolver = ScriptedResolver::new();
+    resolver.commit_cards(&[]).pick_single(OptionId(0));
+    let result = drive(state, fight_action(inv_id, enemy_id), resolver);
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::CardPlayed { investigator, code } if *investigator == inv_id && code.as_str() == EVIDENCE
+    );
+    assert_event!(
+        result.events,
+        Event::CluePlaced { investigator, count: 1 } if *investigator == inv_id
+    );
+    assert_event!(
+        result.events,
+        Event::CardDiscarded { investigator, code, from: Zone::Hand }
+            if *investigator == inv_id && code.as_str() == EVIDENCE
+    );
+    assert_event!(
+        result.events,
+        Event::WindowClosed {
+            kind: WindowKind::AfterEnemyDefeated { enemy: e, .. },
+        } if *e == enemy_id
+    );
+
+    // 1 clue moved from the Study to the investigator; Evidence! is in discard.
+    assert_eq!(result.state.locations[&loc_id].clues, 1);
+    assert_eq!(result.state.investigators[&inv_id].clues, 1);
+    let inv = &result.state.investigators[&inv_id];
+    assert!(!inv.hand.iter().any(|c| c.as_str() == EVIDENCE));
+    assert!(inv.discard.iter().any(|c| c.as_str() == EVIDENCE));
+}
+
+#[test]
+fn window_offers_both_in_play_reaction_and_hand_evidence() {
+    use game_core::state::{CardInPlay, CardInstanceId};
+    install_real_registry();
+    let inv_id = InvestigatorId(1);
+    let enemy_id = EnemyId(100);
+    let loc_id = LocationId(10);
+
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(loc_id);
+    inv.skills.combat = 4;
+    inv.hand.push(CardCode::new(EVIDENCE));
+    // Roland's investigator card in play → his after-defeat reaction also matches.
+    inv.cards_in_play.push(CardInPlay::enter_play(
+        CardCode::new("01001"),
+        CardInstanceId(1),
+    ));
+
+    let mut enemy = test_enemy(100, "Mock Ghoul");
+    enemy.fight = 1;
+    enemy.max_health = 1;
+    enemy.damage = 0;
+    enemy.engaged_with = Some(inv_id);
+
+    let mut loc = test_location(10, "Study");
+    loc.clues = 2;
+
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_round(0)
+        .with_active_investigator(inv_id)
+        .with_turn_order([inv_id])
+        .with_investigator(inv)
+        .with_enemy(enemy)
+        .with_location(loc)
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default())
+        .build();
+
+    // Two options: OptionId(0) = Roland's in-play reaction, OptionId(1) = hand
+    // Evidence!. Pick the hand play, then skip the remaining reaction.
+    let mut resolver = ScriptedResolver::new();
+    resolver.commit_cards(&[]).pick_single(OptionId(1)).skip();
+    let result = drive(state, fight_action(inv_id, enemy_id), resolver);
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::CardPlayed { investigator, code } if *investigator == inv_id && code.as_str() == EVIDENCE
+    );
+    // Evidence! discovered its clue; Roland's reaction was skipped.
+    assert_event!(result.events, Event::CluePlaced { investigator, count: 1 } if *investigator == inv_id);
+    assert_eq!(result.state.investigators[&inv_id].clues, 1);
 }

--- a/crates/cards/tests/guard_dog_soak.rs
+++ b/crates/cards/tests/guard_dog_soak.rs
@@ -165,7 +165,7 @@ fn enemy_attack_soaks_onto_guard_dog_then_retaliate_damages_attacker() {
     let result = apply(
         state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
     state = result.state;
@@ -371,7 +371,7 @@ fn only_guard_dogs_reaction_is_offered_not_another_controlled_soaker() {
     let result = apply(
         state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
     state = result.state;
@@ -444,7 +444,7 @@ fn two_attackers_suspend_on_first_soak_then_resume_second_attacker() {
     let result = apply(
         state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
     state = result.state;
@@ -480,7 +480,7 @@ fn two_attackers_suspend_on_first_soak_then_resume_second_attacker() {
     let result = apply(
         state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
     state = result.state;

--- a/crates/cards/tests/persistent_treachery.rs
+++ b/crates/cards/tests/persistent_treachery.rs
@@ -363,7 +363,11 @@ fn two_frozen_in_fear_end_of_turn_tests_both_resolve_then_turn_resumes() {
     // Order the first forced, commit nothing to its test; order the second,
     // commit nothing to its test.
     let mut resolver = ScriptedResolver::new();
-    resolver.pick(0).commit_cards(&[]).pick(0).commit_cards(&[]);
+    resolver
+        .pick_single(game_core::engine::OptionId(0))
+        .commit_cards(&[])
+        .pick_single(game_core::engine::OptionId(0))
+        .commit_cards(&[]);
     let r = drive(state, Action::Player(PlayerAction::EndTurn), resolver);
 
     assert_eq!(r.outcome, EngineOutcome::Done);

--- a/crates/cards/tests/roland_banks.rs
+++ b/crates/cards/tests/roland_banks.rs
@@ -100,9 +100,11 @@ fn fight_action(inv: InvestigatorId, enemy: EnemyId) -> Action {
 fn reaction_fires_after_roland_defeats_enemy_and_discovers_clue() {
     let (inv_id, enemy_id, loc_id, state) = roland_at_location_with_enemy(2, 0);
 
-    // Empty commit, then PickIndex(0) for the reaction window.
+    // Empty commit, then PickSingle(OptionId(0)) for the reaction window.
     let mut resolver = ScriptedResolver::new();
-    resolver.commit_cards(&[]).pick(0);
+    resolver
+        .commit_cards(&[])
+        .pick_single(game_core::engine::OptionId(0));
     let result = drive(state, fight_action(inv_id, enemy_id), resolver);
 
     assert_eq!(result.outcome, EngineOutcome::Done);
@@ -201,7 +203,9 @@ fn lazy_round_reset_re_enables_reaction_in_a_later_round() {
     }
 
     let mut resolver = ScriptedResolver::new();
-    resolver.commit_cards(&[]).pick(0);
+    resolver
+        .commit_cards(&[])
+        .pick_single(game_core::engine::OptionId(0));
     let result = drive(state, fight_action(inv_id, enemy_id), resolver);
 
     assert_eq!(result.outcome, EngineOutcome::Done);

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -537,26 +537,16 @@ pub(super) fn play_card(
         .hand[idx]
         .clone();
 
-    // Mutate.
-    cx.events.push(Event::CardPlayed {
-        investigator,
-        code: code.clone(),
-    });
-    // RR Appendix I, step 3: an event "commences being played" — it leaves
-    // hand now and is placed in discard on *completion* of its effect (step 4),
-    // flushed from `pending_played_event` by the apply loop on `Done`. Stashing
-    // it before running OnPlay means a suspending effect (Dynamite Blast's
-    // location choice) discards the event when it resumes rather than stranding
-    // it in hand. (An asset enters play after its OnPlay effect, below.)
-    if let super::PlayDestination::Discard = destination {
-        let card = cx
-            .state
-            .investigators
-            .get_mut(&investigator)
-            .expect("checked")
-            .hand
-            .remove(idx);
-        cx.state.pending_played_event = Some((investigator, card));
+    // Mutate. An event commences being played (`CardPlayed` + leaves hand +
+    // stashed for discard-on-completion) via the shared `begin_event_play`;
+    // an asset emits `CardPlayed` now and enters play after its OnPlay effect
+    // (below).
+    match destination {
+        super::PlayDestination::Discard => begin_event_play(cx, investigator, idx),
+        super::PlayDestination::InPlay => cx.events.push(Event::CardPlayed {
+            investigator,
+            code: code.clone(),
+        }),
     }
     let eval_ctx = EvalContext::for_controller(investigator);
     for ability in abilities.iter().filter(|a| a.trigger == Trigger::OnPlay) {
@@ -585,6 +575,42 @@ pub(super) fn play_card(
             .push(in_play);
     }
     EngineOutcome::Done
+}
+
+/// Commence playing an event from `investigator`'s hand at `hand_index` (RR
+/// Appendix I, step 3): emit [`Event::CardPlayed`], remove the card from hand,
+/// and stash it in
+/// [`pending_played_event`](crate::state::GameState::pending_played_event) so
+/// it is placed in discard on *completion* of its effect (step 4), flushed by
+/// the apply loop on `Done`. Stashing before the effect runs means a
+/// suspending effect (Dynamite Blast 01024's location choice) discards the
+/// event when it resumes rather than stranding it in hand.
+///
+/// Shared by [`play_card`]'s event branch and the Axis-C reaction-event play
+/// (`reaction_windows::play_fast_event`). The caller runs the event's
+/// effect(s) after this returns; neither path charges a resource cost (Slice 1
+/// does not model play-cost resources). The caller guarantees `investigator`
+/// exists and `hand_index` is in bounds.
+pub(super) fn begin_event_play(cx: &mut Cx, investigator: InvestigatorId, hand_index: usize) {
+    let code = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .expect("begin_event_play: caller guarantees investigator exists")
+        .hand[hand_index]
+        .clone();
+    cx.events.push(Event::CardPlayed {
+        investigator,
+        code: code.clone(),
+    });
+    let card = cx
+        .state
+        .investigators
+        .get_mut(&investigator)
+        .expect("begin_event_play: caller guarantees investigator exists")
+        .hand
+        .remove(hand_index);
+    cx.state.pending_played_event = Some((investigator, card));
 }
 
 /// Flush a [`pending_played_event`](crate::state::GameState::pending_played_event)

--- a/crates/game-core/src/engine/dispatch/choice.rs
+++ b/crates/game-core/src/engine/dispatch/choice.rs
@@ -121,10 +121,7 @@ pub(crate) fn resume_choice(cx: &mut Cx, response: &InputResponse) -> EngineOutc
     };
     let mut decisions = frame.decisions;
     decisions.push(*picked);
-    let eval_ctx = match frame.source {
-        Some(src) => EvalContext::for_controller_with_source(frame.controller, src),
-        None => EvalContext::for_controller(frame.controller),
-    };
+    let eval_ctx = EvalContext::for_controller_with_optional_source(frame.controller, frame.source);
     let outcome = apply_effect_with_decisions(cx, &frame.effect, eval_ctx, decisions);
 
     // If the choice completed an effect that was suspended *inside* a skill

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -8,7 +8,8 @@
 use crate::card_registry;
 use crate::dsl::{EventPattern, EventTiming, Trigger};
 use crate::state::{
-    CardCode, CardInstanceId, InvestigatorId, LocationId, Phase, ResolutionCandidate,
+    CandidateSource, CardCode, CardInstanceId, InvestigatorId, LocationId, Phase,
+    ResolutionCandidate,
 };
 
 use super::super::evaluator::{apply_effect, EvalContext};
@@ -351,7 +352,12 @@ fn push_matching(
                     controller,
                     ability_index: u8::try_from(idx)
                         .expect("ability_index fits u8 — abilities vecs are tiny"),
-                    source,
+                    // Forced hits are in-play instances or scenario board
+                    // cards — never hand events.
+                    source: match source {
+                        Some(id) => CandidateSource::InPlay(id),
+                        None => CandidateSource::Board,
+                    },
                 });
             }
         }
@@ -375,8 +381,14 @@ fn resolve_one(cx: &mut Cx, hit: &ResolutionCandidate) -> EngineOutcome {
     };
     let effect = abilities[usize::from(hit.ability_index)].effect.clone();
     let ctx = match hit.source {
-        Some(src) => EvalContext::for_controller_with_source(hit.controller, src),
-        None => EvalContext::for_controller(hit.controller),
+        CandidateSource::InPlay(src) => {
+            EvalContext::for_controller_with_source(hit.controller, src)
+        }
+        CandidateSource::Board => EvalContext::for_controller(hit.controller),
+        CandidateSource::Hand => unreachable!(
+            "fire_forced_triggers: a forced run never holds a Hand candidate \
+             (hand Fast events are reaction-window plays, not forced)"
+        ),
     };
     apply_effect(cx, &effect, ctx)
 }

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -380,15 +380,9 @@ fn resolve_one(cx: &mut Cx, hit: &ResolutionCandidate) -> EngineOutcome {
         };
     };
     let effect = abilities[usize::from(hit.ability_index)].effect.clone();
-    let ctx = match hit.source {
-        CandidateSource::InPlay(src) => {
-            EvalContext::for_controller_with_source(hit.controller, src)
-        }
-        CandidateSource::Board => EvalContext::for_controller(hit.controller),
-        CandidateSource::Hand => unreachable!(
-            "fire_forced_triggers: a forced run never holds a Hand candidate \
-             (hand Fast events are reaction-window plays, not forced)"
-        ),
-    };
+    // A forced run holds only in-play / board candidates (`Hand` ⇒ `None` is
+    // harmless — hand Fast events are reaction-window plays, never forced).
+    let ctx =
+        EvalContext::for_controller_with_optional_source(hit.controller, hit.source.instance());
     apply_effect(cx, &effect, ctx)
 }

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -89,8 +89,8 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
     {
         return EngineOutcome::Rejected {
             reason: "a reaction window is open; submit a \
-                     PlayerAction::ResolveInput with an InputResponse::PickIndex \
-                     to fire a pending trigger, or InputResponse::Skip to close \
+                     PlayerAction::ResolveInput with an InputResponse::PickSingle(OptionId) \
+                     to resolve an option, or InputResponse::Skip to close \
                      the window (rejected if forced triggers remain) before any \
                      other action"
                 .into(),

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -3043,6 +3043,7 @@ mod enemy_phase_tests {
             .continuations
             .push(crate::state::Continuation::Resolution(ResolutionFrame {
                 pending_triggers: Vec::new(),
+                fast_plays: Vec::new(),
                 kind: crate::state::ResolutionKind::Window(crate::state::WindowBinding {
                     kind: WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked),
                     fast_actors: FastActorScope::Any,

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -3043,7 +3043,6 @@ mod enemy_phase_tests {
             .continuations
             .push(crate::state::Continuation::Resolution(ResolutionFrame {
                 pending_triggers: Vec::new(),
-                fast_plays: Vec::new(),
                 kind: crate::state::ResolutionKind::Window(crate::state::WindowBinding {
                     kind: WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked),
                     fast_actors: FastActorScope::Any,

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -17,7 +17,7 @@ use crate::card_registry;
 use crate::dsl::{EventPattern, EventTiming, Trigger};
 use crate::event::Event;
 use crate::state::{
-    CardCode, CardInstanceId, Continuation, FastActorScope, FastEventCandidate, FinishContinuation,
+    CandidateSource, CardCode, CardInstanceId, Continuation, FastActorScope, FinishContinuation,
     ForcedContinuation, GameState, InvestigatorId, Phase, PhaseStep, ResolutionCandidate,
     ResolutionFrame, ResolutionKind, Status, WindowBinding, WindowKind,
 };
@@ -26,15 +26,21 @@ use super::super::evaluator::{apply_effect, EvalContext};
 use super::super::outcome::{ChoiceOption, EngineOutcome, InputRequest, OptionId, ResumeToken};
 use super::Cx;
 
-/// Queue a reaction window of the given `kind` if any in-play card
-/// has a matching `Trigger::OnEvent` ability. No-op when the registry
-/// isn't installed or no card matches.
+/// Queue a reaction window of the given `kind` if any candidate matches —
+/// an in-play card with a matching `Trigger::OnEvent` ability *or* (Axis C,
+/// #335) a Fast event in hand whose play-instruction matches. No-op when the
+/// registry isn't installed or nothing matches.
 ///
 /// Emits [`Event::WindowOpened`] before pushing onto
 /// [`GameState::open_windows`] so reaction-window observability is
 /// symmetric with the Fast-window path ([`open_fast_window`]).
-/// If no triggers are pending the function returns early without
+/// If no candidate matches the function returns early without
 /// emitting anything — the window never opens.
+///
+/// The hand events are appended *after* the in-play triggers in the single
+/// `pending_triggers` list, so they are offered as options after the
+/// triggers; each carries [`CandidateSource::Hand`] so the fire path *plays*
+/// it rather than firing an in-play ability.
 ///
 /// The window suspends the surrounding driver
 /// (today, [`drive_skill_test`]) at its next step boundary: after the
@@ -48,12 +54,13 @@ use super::Cx;
 /// rather than silent stacking — multi-window queueing lands when a
 /// multi-defeat effect arrives.
 pub(super) fn queue_reaction_window(cx: &mut Cx, kind: WindowKind) {
-    let pending_triggers = scan_pending_triggers(cx.state, kind);
+    let mut pending_triggers = scan_pending_triggers(cx.state, kind);
     // Axis C (#335): the window also opens for a matching Fast event in hand,
     // so a defeat with Evidence! in hand (and no in-play reaction) still opens
-    // the after-defeat window.
-    let fast_plays = scan_hand_fast_events(cx.state, kind);
-    if pending_triggers.is_empty() && fast_plays.is_empty() {
+    // the after-defeat window. Hand plays are offered after the in-play
+    // triggers.
+    pending_triggers.extend(scan_hand_fast_events(cx.state, kind));
+    if pending_triggers.is_empty() {
         return;
     }
     cx.events.push(Event::WindowOpened { kind });
@@ -64,7 +71,6 @@ pub(super) fn queue_reaction_window(cx: &mut Cx, kind: WindowKind) {
         .continuations
         .push(Continuation::Resolution(ResolutionFrame {
             pending_triggers,
-            fast_plays,
             kind: ResolutionKind::Window(WindowBinding {
                 kind,
                 fast_actors: FastActorScope::Any,
@@ -88,8 +94,6 @@ pub(super) fn open_forced_resolution(
         .continuations
         .push(Continuation::Resolution(ResolutionFrame {
             pending_triggers: candidates,
-            // The forced run admits no Fast plays (RR p.2).
-            fast_plays: Vec::new(),
             kind: ResolutionKind::Forced(continuation),
         }));
     open_queued_reaction_window(cx)
@@ -165,7 +169,7 @@ fn scan_pending_triggers(state: &GameState, kind: WindowKind) -> Vec<ResolutionC
                     code: card.code.clone(),
                     controller: id,
                     ability_index,
-                    source: Some(card.instance_id),
+                    source: CandidateSource::InPlay(card.instance_id),
                 });
             }
         }
@@ -180,10 +184,10 @@ fn scan_pending_triggers(state: &GameState, kind: WindowKind) -> Vec<ResolutionC
 /// timing point were a triggering condition", so a hand Fast event is its
 /// in-play twin sourced from hand.
 ///
-/// Returns candidates in active-investigator-first / turn-order order, like
-/// [`scan_pending_triggers`]. Empty when the registry isn't installed (tests
-/// that don't touch card data) or nothing matches.
-fn scan_hand_fast_events(state: &GameState, kind: WindowKind) -> Vec<FastEventCandidate> {
+/// Returns [`CandidateSource::Hand`] candidates in active-investigator-first
+/// / turn-order order, like [`scan_pending_triggers`]. Empty when the registry
+/// isn't installed (tests that don't touch card data) or nothing matches.
+fn scan_hand_fast_events(state: &GameState, kind: WindowKind) -> Vec<ResolutionCandidate> {
     let Some(reg) = card_registry::current() else {
         return Vec::new();
     };
@@ -224,10 +228,11 @@ fn scan_hand_fast_events(state: &GameState, kind: WindowKind) -> Vec<FastEventCa
                 }
                 let ability_index = u8::try_from(idx)
                     .expect("abilities vec exceeds u8::MAX — card-impl bug, abilities are tiny");
-                plays.push(FastEventCandidate {
-                    controller: id,
+                plays.push(ResolutionCandidate {
                     code: code.clone(),
+                    controller: id,
                     ability_index,
+                    source: CandidateSource::Hand,
                 });
                 // One option per card: a card with two matching abilities is
                 // still offered once. No in-scope card has two.
@@ -340,6 +345,31 @@ fn trigger_matches(
     }
 }
 
+/// Build the structured option list for a resolution frame: one
+/// [`ChoiceOption`] per pending candidate, in `pending_triggers` order.
+/// `OptionId(i)` is the index into the returned list — the Axis-A convention
+/// shared with [`super::choice`]. The label distinguishes a hand Fast-event
+/// play ([`CandidateSource::Hand`]) from an in-play reaction.
+fn build_resolution_options(frame: &ResolutionFrame) -> Vec<ChoiceOption> {
+    frame
+        .pending_triggers
+        .iter()
+        .enumerate()
+        .map(|(i, cand)| {
+            let label = match cand.source {
+                CandidateSource::Hand => format!("Play {} from hand", cand.code),
+                CandidateSource::InPlay(_) | CandidateSource::Board => {
+                    format!("Resolve reaction: {}", cand.code)
+                }
+            };
+            ChoiceOption {
+                id: OptionId(u32::try_from(i).expect("option count fits in u32")),
+                label,
+            }
+        })
+        .collect()
+}
+
 /// Return [`AwaitingInput`] for the already-open reaction window at
 /// the top of [`GameState::open_windows`]. Called by [`drive_skill_test`]
 /// at a step boundary when an earlier step queued a window via
@@ -348,30 +378,6 @@ fn trigger_matches(
 /// [`Event::WindowOpened`] is emitted by [`queue_reaction_window`]
 /// (not here) so the event appears at queue time and is symmetric with
 /// the [`open_fast_window`] path.
-/// Build the structured option list for a resolution frame: one
-/// [`ChoiceOption`] per pending in-play trigger, in `pending_triggers`
-/// order. `OptionId(i)` is the index into the returned list — the Axis-A
-/// convention shared with [`super::choice`]. Axis C (Task 4) appends the
-/// frame's hand Fast-event plays after the triggers.
-fn build_resolution_options(frame: &ResolutionFrame) -> Vec<ChoiceOption> {
-    let triggers = frame
-        .pending_triggers
-        .iter()
-        .map(|cand| format!("Resolve reaction: {}", cand.code));
-    let plays = frame
-        .fast_plays
-        .iter()
-        .map(|play| format!("Play {} from hand", play.code));
-    triggers
-        .chain(plays)
-        .enumerate()
-        .map(|(i, label)| ChoiceOption {
-            id: OptionId(u32::try_from(i).expect("option count fits in u32")),
-            label,
-        })
-        .collect()
-}
-
 pub(super) fn open_queued_reaction_window(cx: &mut Cx) -> EngineOutcome {
     let window = cx
         .state
@@ -414,28 +420,10 @@ pub(super) fn open_queued_reaction_window(cx: &mut Cx) -> EngineOutcome {
 /// returns [`Done`].
 pub(super) fn resume_reaction_window(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
     match response {
-        InputResponse::PickSingle(OptionId(i)) => {
-            // Options are `pending_triggers` then `fast_plays` (see
-            // `build_resolution_options`): an id within the trigger count fires
-            // an in-play trigger; the rest play a hand Fast-event (Axis C).
-            let window_idx = cx
-                .state
-                .top_reaction_window_index()
-                .expect("resume_reaction_window: caller checked is_some");
-            let trigger_count = u32::try_from(
-                cx.state.continuations[window_idx]
-                    .as_resolution()
-                    .expect("top_reaction_window_index points at a Resolution frame")
-                    .pending_triggers
-                    .len(),
-            )
-            .expect("pending_triggers length fits in u32");
-            if *i < trigger_count {
-                fire_pending_trigger(cx, *i)
-            } else {
-                play_fast_event_in_window(cx, window_idx, (*i - trigger_count) as usize)
-            }
-        }
+        // `OptionId(i)` indexes the single `pending_triggers` list (see
+        // `build_resolution_options`); `fire_pending_trigger` dispatches on
+        // the candidate's source (in-play ability vs. Axis-C hand play).
+        InputResponse::PickSingle(OptionId(i)) => fire_pending_trigger(cx, *i),
         InputResponse::Skip => {
             // Resolve the active reaction-window index up-front so the
             // close path operates on the same window the driver had
@@ -507,6 +495,20 @@ fn fire_pending_trigger(cx: &mut Cx, i: u32) -> EngineOutcome {
         (window.pending_triggers[idx].clone(), idx)
     };
 
+    // Axis C (#335): a hand candidate is *played*, not fired in place. Remove
+    // it from the run first (so a suspending play resumes the remaining
+    // siblings, not this one again — mirrors the in-play path below), then
+    // play it.
+    if trigger.source == CandidateSource::Hand {
+        {
+            let window = cx.state.continuations[window_idx]
+                .as_resolution_mut()
+                .expect("fire_pending_trigger: window_idx is a Resolution frame");
+            window.pending_triggers.remove(pending_idx);
+        }
+        return play_fast_event(cx, window_idx, &trigger);
+    }
+
     // Look up the ability fresh from the registry. The card may have
     // changed state between scan and fire (exhausted, used, …) but
     // its ability list is static, so registry lookup is sufficient.
@@ -540,10 +542,15 @@ fn fire_pending_trigger(cx: &mut Cx, i: u32) -> EngineOutcome {
     // Thread the source instance (if any) into the EvalContext so effects
     // that self-reference (`DiscardSelf`) or push source-attributed state
     // resolve against the firing card. Board-card candidates (act / agenda)
-    // have no source.
+    // have no source; hand candidates were handled above.
     let mut eval_ctx = match trigger.source {
-        Some(src) => EvalContext::for_controller_with_source(trigger.controller, src),
-        None => EvalContext::for_controller(trigger.controller),
+        CandidateSource::InPlay(src) => {
+            EvalContext::for_controller_with_source(trigger.controller, src)
+        }
+        CandidateSource::Board => EvalContext::for_controller(trigger.controller),
+        CandidateSource::Hand => {
+            unreachable!("fire_pending_trigger: Hand candidates are played above, not fired")
+        }
     };
     // For `AfterEnemyAttackDamagedAsset` windows, bind the attacking
     // enemy into the context so Guard Dog's native retaliate
@@ -597,43 +604,27 @@ fn fire_pending_trigger(cx: &mut Cx, i: u32) -> EngineOutcome {
     }
 }
 
-/// Play the `fast_play_idx`-th hand Fast-event of the resolution frame at
-/// `window_idx` (Axis C, #335). Emits [`Event::CardPlayed`], stashes the event
-/// in [`GameState::pending_played_event`] (RR Appendix I step 3 — leaves hand
-/// at play-start), runs the matched `OnEvent` ability's effect, then advances
-/// the run. The apply loop flushes the event to discard on completion (RR
-/// Appendix I step 4) — the suspending-event path Dynamite Blast 01024 uses.
+/// Play the hand Fast-event `candidate` from the resolution run at
+/// `window_idx` (Axis C, #335) — the [`CandidateSource::Hand`] resolution of
+/// [`fire_pending_trigger`]. Commences the play via the shared
+/// [`super::cards::begin_event_play`] (emit [`Event::CardPlayed`], leave hand,
+/// stash in [`GameState::pending_played_event`] — RR Appendix I step 3), runs
+/// the matched `OnEvent` ability's effect, then advances the run. The apply
+/// loop flushes the event to discard on completion (step 4) — the
+/// suspending-event path Dynamite Blast 01024 uses.
 ///
 /// Charges no resource cost, matching [`super::cards::play_card`] (Slice 1
-/// does not model play-cost resources). Mirrors [`fire_pending_trigger`]'s
-/// snapshot-then-apply borrow discipline: the candidate is removed from the
-/// frame *before* its effect resolves, so a suspending effect's resume drives
-/// the remaining options, not this one again.
-fn play_fast_event_in_window(
+/// does not model play-cost resources). The caller has already removed the
+/// candidate from the run, so a suspending effect's resume drives the
+/// remaining siblings, not this play again.
+fn play_fast_event(
     cx: &mut Cx,
     window_idx: usize,
-    fast_play_idx: usize,
+    candidate: &ResolutionCandidate,
 ) -> EngineOutcome {
-    let candidate = {
-        let frame = cx.state.continuations[window_idx]
-            .as_resolution_mut()
-            .expect("play_fast_event_in_window: window_idx is a Resolution frame");
-        if fast_play_idx >= frame.fast_plays.len() {
-            return EngineOutcome::Rejected {
-                reason: format!(
-                    "ResolveInput: PickSingle hand-play index {fast_play_idx} out of bounds \
-                     (fast_plays size {})",
-                    frame.fast_plays.len(),
-                )
-                .into(),
-            };
-        }
-        frame.fast_plays.remove(fast_play_idx)
-    };
-
+    let controller = candidate.controller;
     // Find the event in the controller's hand by code (first match — copies
     // are fungible; resolving by code avoids stale indices after a prior play).
-    let controller = candidate.controller;
     let hand_idx = cx
         .state
         .investigators
@@ -641,34 +632,22 @@ fn play_fast_event_in_window(
         .and_then(|inv| inv.hand.iter().position(|c| *c == candidate.code))
         .unwrap_or_else(|| {
             unreachable!(
-                "play_fast_event_in_window: candidate {candidate:?} vanished from \
+                "play_fast_event: candidate {candidate:?} vanished from \
                  {controller:?}'s hand between scan and play"
             )
         });
-
-    cx.events.push(Event::CardPlayed {
-        investigator: controller,
-        code: candidate.code.clone(),
-    });
-    let card = cx
-        .state
-        .investigators
-        .get_mut(&controller)
-        .expect("controller exists (located the hand index above)")
-        .hand
-        .remove(hand_idx);
-    cx.state.pending_played_event = Some((controller, card));
+    super::cards::begin_event_play(cx, controller, hand_idx);
 
     // Run the matched OnEvent ability's effect under the playing investigator.
     let reg = card_registry::current().unwrap_or_else(|| {
         unreachable!(
-            "play_fast_event_in_window: registry installed at scan time is now missing; \
+            "play_fast_event: registry installed at scan time is now missing; \
              the OnceLock contract guarantees once-set-stays-set"
         )
     });
     let abilities = (reg.abilities_for)(&candidate.code).unwrap_or_else(|| {
         unreachable!(
-            "play_fast_event_in_window: registry lost abilities for {:?} between scan and play",
+            "play_fast_event: registry lost abilities for {:?} between scan and play",
             candidate.code,
         )
     });
@@ -676,7 +655,7 @@ fn play_fast_event_in_window(
         .get(usize::from(candidate.ability_index))
         .unwrap_or_else(|| {
             unreachable!(
-                "play_fast_event_in_window: ability_index {} out of range for {:?}",
+                "play_fast_event: ability_index {} out of range for {:?}",
                 candidate.ability_index, candidate.code,
             )
         })
@@ -704,10 +683,10 @@ pub(super) fn advance_resolution(cx: &mut Cx, window_idx: usize) -> EngineOutcom
     let window = cx.state.continuations[window_idx]
         .as_resolution()
         .expect("advance_resolution: window_idx is a Resolution frame");
-    // Close only when no option remains — a pending in-play trigger *or* a
-    // hand Fast-event play (Axis C). A window with only a remaining hand play
-    // stays open so the player can still play it.
-    if !window.has_pending_options() {
+    // Close when no candidate remains. Hand Fast-event plays (Axis C) ride
+    // `pending_triggers` alongside in-play triggers, so this single check
+    // keeps a window with only a remaining hand play open.
+    if window.pending_triggers.is_empty() {
         return close_reaction_window_at(cx, window_idx);
     }
     let skip_hint = if window.is_forced() {
@@ -745,13 +724,13 @@ pub(super) fn advance_resolution(cx: &mut Cx, window_idx: usize) -> EngineOutcom
 fn bump_usage_counter(state: &mut GameState, trigger: &ResolutionCandidate) {
     let current_round = state.round;
     // Only usage-limited abilities reach here, and those are on in-play
-    // instances (reactions) — so `source` is always `Some`.
-    let instance_id = trigger.source.unwrap_or_else(|| {
+    // instances (reactions) — so the source is always `InPlay`.
+    let CandidateSource::InPlay(instance_id) = trigger.source else {
         unreachable!(
-            "bump_usage_counter: a usage-limited candidate must have a source instance \
-             (board cards carry no usage limits); candidate {trigger:?}"
+            "bump_usage_counter: a usage-limited candidate must be an in-play instance \
+             (board / hand candidates carry no usage limits); candidate {trigger:?}"
         )
-    });
+    };
     let inv = state
         .investigators
         .get_mut(&trigger.controller)
@@ -1122,8 +1101,6 @@ pub(super) fn open_fast_window(cx: &mut Cx, kind: WindowKind) -> EngineOutcome {
         .continuations
         .push(Continuation::Resolution(ResolutionFrame {
             pending_triggers,
-            // Framework Fast window (out of Axis-C scope): no hand-event options.
-            fast_plays: Vec::new(),
             kind: ResolutionKind::Window(WindowBinding {
                 kind,
                 fast_actors: FastActorScope::Any,

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -1176,6 +1176,27 @@ pub(super) fn check_play_card(
                 unreachable!("resolve_play_target returned non-Rejected outcome: {other:?}")
             }
         };
+    // Reaction-event gate (Axis C, #335 / #304): a Fast event whose play
+    // instruction is a triggering condition is modeled as an `OnEvent` ability
+    // (e.g. Evidence! 01022's "Play after you defeat an enemy"). RR p.11: such
+    // an event "may be played any time its play instructions specify" — i.e.
+    // ONLY in its matching reaction window, where Axis C offers it as a
+    // `PickSingle` option (the window path runs `play_fast_event`, bypassing
+    // this gate). It is never a free-timing standalone play, so reject it from
+    // the `PlayCard` action — otherwise `play_card` would run only its (absent)
+    // `OnPlay` abilities and silently discard it for no effect.
+    if card_type == CardType::Event
+        && abilities
+            .iter()
+            .any(|a| matches!(a.trigger, Trigger::OnEvent { .. }))
+    {
+        return Err(format!(
+            "PlayCard: {code} is a reaction event — it may only be played in response \
+             to its triggering condition (its reaction window), not as a standalone \
+             action (RR p.11)."
+        )
+        .into());
+    }
     // Timing gate — see play_card doc-comment "# Timing gate" section.
     let active_during_investigation =
         state.phase == Phase::Investigation && state.active_investigator == Some(investigator);

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -414,7 +414,28 @@ pub(super) fn open_queued_reaction_window(cx: &mut Cx) -> EngineOutcome {
 /// returns [`Done`].
 pub(super) fn resume_reaction_window(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
     match response {
-        InputResponse::PickSingle(OptionId(i)) => fire_pending_trigger(cx, *i),
+        InputResponse::PickSingle(OptionId(i)) => {
+            // Options are `pending_triggers` then `fast_plays` (see
+            // `build_resolution_options`): an id within the trigger count fires
+            // an in-play trigger; the rest play a hand Fast-event (Axis C).
+            let window_idx = cx
+                .state
+                .top_reaction_window_index()
+                .expect("resume_reaction_window: caller checked is_some");
+            let trigger_count = u32::try_from(
+                cx.state.continuations[window_idx]
+                    .as_resolution()
+                    .expect("top_reaction_window_index points at a Resolution frame")
+                    .pending_triggers
+                    .len(),
+            )
+            .expect("pending_triggers length fits in u32");
+            if *i < trigger_count {
+                fire_pending_trigger(cx, *i)
+            } else {
+                play_fast_event_in_window(cx, window_idx, (*i - trigger_count) as usize)
+            }
+        }
         InputResponse::Skip => {
             // Resolve the active reaction-window index up-front so the
             // close path operates on the same window the driver had
@@ -573,6 +594,103 @@ fn fire_pending_trigger(cx: &mut Cx, i: u32) -> EngineOutcome {
             }
             advance_resolution(cx, window_idx)
         }
+    }
+}
+
+/// Play the `fast_play_idx`-th hand Fast-event of the resolution frame at
+/// `window_idx` (Axis C, #335). Emits [`Event::CardPlayed`], stashes the event
+/// in [`GameState::pending_played_event`] (RR Appendix I step 3 — leaves hand
+/// at play-start), runs the matched `OnEvent` ability's effect, then advances
+/// the run. The apply loop flushes the event to discard on completion (RR
+/// Appendix I step 4) — the suspending-event path Dynamite Blast 01024 uses.
+///
+/// Charges no resource cost, matching [`super::cards::play_card`] (Slice 1
+/// does not model play-cost resources). Mirrors [`fire_pending_trigger`]'s
+/// snapshot-then-apply borrow discipline: the candidate is removed from the
+/// frame *before* its effect resolves, so a suspending effect's resume drives
+/// the remaining options, not this one again.
+fn play_fast_event_in_window(
+    cx: &mut Cx,
+    window_idx: usize,
+    fast_play_idx: usize,
+) -> EngineOutcome {
+    let candidate = {
+        let frame = cx.state.continuations[window_idx]
+            .as_resolution_mut()
+            .expect("play_fast_event_in_window: window_idx is a Resolution frame");
+        if fast_play_idx >= frame.fast_plays.len() {
+            return EngineOutcome::Rejected {
+                reason: format!(
+                    "ResolveInput: PickSingle hand-play index {fast_play_idx} out of bounds \
+                     (fast_plays size {})",
+                    frame.fast_plays.len(),
+                )
+                .into(),
+            };
+        }
+        frame.fast_plays.remove(fast_play_idx)
+    };
+
+    // Find the event in the controller's hand by code (first match — copies
+    // are fungible; resolving by code avoids stale indices after a prior play).
+    let controller = candidate.controller;
+    let hand_idx = cx
+        .state
+        .investigators
+        .get(&controller)
+        .and_then(|inv| inv.hand.iter().position(|c| *c == candidate.code))
+        .unwrap_or_else(|| {
+            unreachable!(
+                "play_fast_event_in_window: candidate {candidate:?} vanished from \
+                 {controller:?}'s hand between scan and play"
+            )
+        });
+
+    cx.events.push(Event::CardPlayed {
+        investigator: controller,
+        code: candidate.code.clone(),
+    });
+    let card = cx
+        .state
+        .investigators
+        .get_mut(&controller)
+        .expect("controller exists (located the hand index above)")
+        .hand
+        .remove(hand_idx);
+    cx.state.pending_played_event = Some((controller, card));
+
+    // Run the matched OnEvent ability's effect under the playing investigator.
+    let reg = card_registry::current().unwrap_or_else(|| {
+        unreachable!(
+            "play_fast_event_in_window: registry installed at scan time is now missing; \
+             the OnceLock contract guarantees once-set-stays-set"
+        )
+    });
+    let abilities = (reg.abilities_for)(&candidate.code).unwrap_or_else(|| {
+        unreachable!(
+            "play_fast_event_in_window: registry lost abilities for {:?} between scan and play",
+            candidate.code,
+        )
+    });
+    let effect = abilities
+        .get(usize::from(candidate.ability_index))
+        .unwrap_or_else(|| {
+            unreachable!(
+                "play_fast_event_in_window: ability_index {} out of range for {:?}",
+                candidate.ability_index, candidate.code,
+            )
+        })
+        .effect
+        .clone();
+    let eval_ctx = EvalContext::for_controller(controller);
+
+    match apply_effect(cx, &effect, eval_ctx) {
+        EngineOutcome::Rejected { reason } => unreachable!(
+            "Fast-event play: effect for {:?} rejected unexpectedly: {reason}",
+            candidate.code,
+        ),
+        suspended @ EngineOutcome::AwaitingInput { .. } => suspended,
+        EngineOutcome::Done => advance_resolution(cx, window_idx),
     }
 }
 

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -23,7 +23,7 @@ use crate::state::{
 };
 
 use super::super::evaluator::{apply_effect, EvalContext};
-use super::super::outcome::{EngineOutcome, InputRequest, ResumeToken};
+use super::super::outcome::{ChoiceOption, EngineOutcome, InputRequest, OptionId, ResumeToken};
 use super::Cx;
 
 /// Queue a reaction window of the given `kind` if any in-play card
@@ -276,6 +276,23 @@ fn trigger_matches(
 /// [`Event::WindowOpened`] is emitted by [`queue_reaction_window`]
 /// (not here) so the event appears at queue time and is symmetric with
 /// the [`open_fast_window`] path.
+/// Build the structured option list for a resolution frame: one
+/// [`ChoiceOption`] per pending in-play trigger, in `pending_triggers`
+/// order. `OptionId(i)` is the index into the returned list — the Axis-A
+/// convention shared with [`super::choice`]. Axis C (Task 4) appends the
+/// frame's hand Fast-event plays after the triggers.
+fn build_resolution_options(frame: &ResolutionFrame) -> Vec<ChoiceOption> {
+    frame
+        .pending_triggers
+        .iter()
+        .enumerate()
+        .map(|(i, cand)| ChoiceOption {
+            id: OptionId(u32::try_from(i).expect("option count fits in u32")),
+            label: format!("Resolve reaction: {}", cand.code),
+        })
+        .collect()
+}
+
 pub(super) fn open_queued_reaction_window(cx: &mut Cx) -> EngineOutcome {
     let window = cx
         .state
@@ -286,12 +303,16 @@ pub(super) fn open_queued_reaction_window(cx: &mut Cx) -> EngineOutcome {
     } else {
         ", or InputResponse::Skip to close"
     };
+    let options = build_resolution_options(window);
     EngineOutcome::AwaitingInput {
-        request: InputRequest::prompt(format!(
-            "Resolution window: {} candidate(s) pending. \
-             Submit InputResponse::PickIndex to resolve one{skip_hint}.",
-            window.pending_triggers.len(),
-        )),
+        request: InputRequest::choice(
+            format!(
+                "Resolution window: {} option(s). \
+                 Submit InputResponse::PickSingle(OptionId) to resolve one{skip_hint}.",
+                options.len(),
+            ),
+            options,
+        ),
         // No multi-window state to disambiguate — routing keys off
         // the top of `state.open_windows`. Conventional 0 like the
         // commit-window's resume token.
@@ -301,8 +322,8 @@ pub(super) fn open_queued_reaction_window(cx: &mut Cx) -> EngineOutcome {
 
 /// Resume an open reaction window with the player's response.
 ///
-/// - [`InputResponse::PickIndex(i)`]: fires the i-th pending trigger
-///   via the evaluator. After firing, removes the entry. If pending
+/// - [`InputResponse::PickSingle(OptionId(i))`]: fires the i-th pending
+///   trigger via the evaluator. After firing, removes the entry. If pending
 ///   triggers remain, re-emits [`AwaitingInput`]; else closes the
 ///   window.
 /// - [`InputResponse::Skip`]: closes the window provided no forced
@@ -314,7 +335,7 @@ pub(super) fn open_queued_reaction_window(cx: &mut Cx) -> EngineOutcome {
 /// returns [`Done`].
 pub(super) fn resume_reaction_window(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
     match response {
-        InputResponse::PickIndex(i) => fire_pending_trigger(cx, *i),
+        InputResponse::PickSingle(OptionId(i)) => fire_pending_trigger(cx, *i),
         InputResponse::Skip => {
             // Resolve the active reaction-window index up-front so the
             // close path operates on the same window the driver had
@@ -333,7 +354,8 @@ pub(super) fn resume_reaction_window(cx: &mut Cx, response: &InputResponse) -> E
             {
                 return EngineOutcome::Rejected {
                     reason: "ResolveInput::Skip: forced abilities are mandatory; submit \
-                             InputResponse::PickIndex to resolve one (the lead orders them)"
+                             InputResponse::PickSingle(OptionId) to resolve one (the lead \
+                             orders them)"
                         .into(),
                 };
             }
@@ -341,7 +363,7 @@ pub(super) fn resume_reaction_window(cx: &mut Cx, response: &InputResponse) -> E
         }
         other => EngineOutcome::Rejected {
             reason: format!(
-                "ResolveInput: reaction window expects InputResponse::PickIndex \
+                "ResolveInput: reaction window expects InputResponse::PickSingle(OptionId) \
                  or InputResponse::Skip, got {other:?}",
             )
             .into(),
@@ -374,7 +396,7 @@ fn fire_pending_trigger(cx: &mut Cx, i: u32) -> EngineOutcome {
             _ => {
                 return EngineOutcome::Rejected {
                     reason: format!(
-                        "ResolveInput: reaction-window PickIndex({i}) out of bounds \
+                        "ResolveInput: reaction-window PickSingle(OptionId({i})) out of bounds \
                          (pending size {})",
                         window.pending_triggers.len(),
                     )
@@ -493,12 +515,16 @@ pub(super) fn advance_resolution(cx: &mut Cx, window_idx: usize) -> EngineOutcom
     } else {
         ", or InputResponse::Skip to close"
     };
-    let pending_len = window.pending_triggers.len();
+    let options = build_resolution_options(window);
     EngineOutcome::AwaitingInput {
-        request: InputRequest::prompt(format!(
-            "Resolution window: {pending_len} candidate(s) pending. \
-             Submit InputResponse::PickIndex to resolve one{skip_hint}.",
-        )),
+        request: InputRequest::choice(
+            format!(
+                "Resolution window: {} option(s). \
+                 Submit InputResponse::PickSingle(OptionId) to resolve one{skip_hint}.",
+                options.len(),
+            ),
+            options,
+        ),
         resume_token: ResumeToken(0),
     }
 }

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -60,6 +60,8 @@ pub(super) fn queue_reaction_window(cx: &mut Cx, kind: WindowKind) {
         .continuations
         .push(Continuation::Resolution(ResolutionFrame {
             pending_triggers,
+            // Axis C (Task 4) scans the hand here; no hand plays yet.
+            fast_plays: Vec::new(),
             kind: ResolutionKind::Window(WindowBinding {
                 kind,
                 fast_actors: FastActorScope::Any,
@@ -83,6 +85,8 @@ pub(super) fn open_forced_resolution(
         .continuations
         .push(Continuation::Resolution(ResolutionFrame {
             pending_triggers: candidates,
+            // The forced run admits no Fast plays (RR p.2).
+            fast_plays: Vec::new(),
             kind: ResolutionKind::Forced(continuation),
         }));
     open_queued_reaction_window(cx)
@@ -922,6 +926,8 @@ pub(super) fn open_fast_window(cx: &mut Cx, kind: WindowKind) -> EngineOutcome {
         .continuations
         .push(Continuation::Resolution(ResolutionFrame {
             pending_triggers,
+            // Framework Fast window (out of Axis-C scope): no hand-event options.
+            fast_plays: Vec::new(),
             kind: ResolutionKind::Window(WindowBinding {
                 kind,
                 fast_actors: FastActorScope::Any,

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -17,9 +17,9 @@ use crate::card_registry;
 use crate::dsl::{EventPattern, EventTiming, Trigger};
 use crate::event::Event;
 use crate::state::{
-    CardCode, CardInstanceId, Continuation, FastActorScope, FinishContinuation, ForcedContinuation,
-    GameState, InvestigatorId, Phase, PhaseStep, ResolutionCandidate, ResolutionFrame,
-    ResolutionKind, Status, WindowBinding, WindowKind,
+    CardCode, CardInstanceId, Continuation, FastActorScope, FastEventCandidate, FinishContinuation,
+    ForcedContinuation, GameState, InvestigatorId, Phase, PhaseStep, ResolutionCandidate,
+    ResolutionFrame, ResolutionKind, Status, WindowBinding, WindowKind,
 };
 
 use super::super::evaluator::{apply_effect, EvalContext};
@@ -49,7 +49,11 @@ use super::Cx;
 /// multi-defeat effect arrives.
 pub(super) fn queue_reaction_window(cx: &mut Cx, kind: WindowKind) {
     let pending_triggers = scan_pending_triggers(cx.state, kind);
-    if pending_triggers.is_empty() {
+    // Axis C (#335): the window also opens for a matching Fast event in hand,
+    // so a defeat with Evidence! in hand (and no in-play reaction) still opens
+    // the after-defeat window.
+    let fast_plays = scan_hand_fast_events(cx.state, kind);
+    if pending_triggers.is_empty() && fast_plays.is_empty() {
         return;
     }
     cx.events.push(Event::WindowOpened { kind });
@@ -60,8 +64,7 @@ pub(super) fn queue_reaction_window(cx: &mut Cx, kind: WindowKind) {
         .continuations
         .push(Continuation::Resolution(ResolutionFrame {
             pending_triggers,
-            // Axis C (Task 4) scans the hand here; no hand plays yet.
-            fast_plays: Vec::new(),
+            fast_plays,
             kind: ResolutionKind::Window(WindowBinding {
                 kind,
                 fast_actors: FastActorScope::Any,
@@ -168,6 +171,71 @@ fn scan_pending_triggers(state: &GameState, kind: WindowKind) -> Vec<ResolutionC
         }
     }
     pending
+}
+
+/// Scan every window-eligible investigator's hand for Fast **events** whose
+/// `Trigger::OnEvent` ability matches `kind` (Axis C, #335). The play-timing
+/// predicate is the same [`trigger_matches`] used for in-play reactions — per
+/// Rules Reference p.11 a Fast reaction event plays "as if the described
+/// timing point were a triggering condition", so a hand Fast event is its
+/// in-play twin sourced from hand.
+///
+/// Returns candidates in active-investigator-first / turn-order order, like
+/// [`scan_pending_triggers`]. Empty when the registry isn't installed (tests
+/// that don't touch card data) or nothing matches.
+fn scan_hand_fast_events(state: &GameState, kind: WindowKind) -> Vec<FastEventCandidate> {
+    let Some(reg) = card_registry::current() else {
+        return Vec::new();
+    };
+    let mut order: Vec<InvestigatorId> = Vec::with_capacity(state.turn_order.len());
+    if let Some(active) = state.active_investigator {
+        order.push(active);
+    }
+    for id in &state.turn_order {
+        if Some(*id) != state.active_investigator {
+            order.push(*id);
+        }
+    }
+
+    let mut plays = Vec::new();
+    for id in order {
+        let Some(inv) = state.investigators.get(&id) else {
+            continue;
+        };
+        for code in &inv.hand {
+            let Some(meta) = (reg.metadata_for)(code) else {
+                continue;
+            };
+            if !meta.is_fast() || meta.card_type() != CardType::Event {
+                continue;
+            }
+            let Some(abilities) = (reg.abilities_for)(code) else {
+                continue;
+            };
+            for (idx, ability) in abilities.iter().enumerate() {
+                let Trigger::OnEvent {
+                    pattern, timing, ..
+                } = &ability.trigger
+                else {
+                    continue;
+                };
+                if !trigger_matches(kind, pattern, *timing, id) {
+                    continue;
+                }
+                let ability_index = u8::try_from(idx)
+                    .expect("abilities vec exceeds u8::MAX — card-impl bug, abilities are tiny");
+                plays.push(FastEventCandidate {
+                    controller: id,
+                    code: code.clone(),
+                    ability_index,
+                });
+                // One option per card: a card with two matching abilities is
+                // still offered once. No in-scope card has two.
+                break;
+            }
+        }
+    }
+    plays
 }
 
 /// Returns whether an [`Trigger::OnEvent`] ability with the given
@@ -286,13 +354,20 @@ fn trigger_matches(
 /// convention shared with [`super::choice`]. Axis C (Task 4) appends the
 /// frame's hand Fast-event plays after the triggers.
 fn build_resolution_options(frame: &ResolutionFrame) -> Vec<ChoiceOption> {
-    frame
+    let triggers = frame
         .pending_triggers
         .iter()
+        .map(|cand| format!("Resolve reaction: {}", cand.code));
+    let plays = frame
+        .fast_plays
+        .iter()
+        .map(|play| format!("Play {} from hand", play.code));
+    triggers
+        .chain(plays)
         .enumerate()
-        .map(|(i, cand)| ChoiceOption {
+        .map(|(i, label)| ChoiceOption {
             id: OptionId(u32::try_from(i).expect("option count fits in u32")),
-            label: format!("Resolve reaction: {}", cand.code),
+            label,
         })
         .collect()
 }
@@ -511,7 +586,10 @@ pub(super) fn advance_resolution(cx: &mut Cx, window_idx: usize) -> EngineOutcom
     let window = cx.state.continuations[window_idx]
         .as_resolution()
         .expect("advance_resolution: window_idx is a Resolution frame");
-    if window.pending_triggers.is_empty() {
+    // Close only when no option remains — a pending in-play trigger *or* a
+    // hand Fast-event play (Axis C). A window with only a remaining hand play
+    // stays open so the player can still play it.
+    if !window.has_pending_options() {
         return close_reaction_window_at(cx, window_idx);
     }
     let skip_hint = if window.is_forced() {

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -543,15 +543,10 @@ fn fire_pending_trigger(cx: &mut Cx, i: u32) -> EngineOutcome {
     // that self-reference (`DiscardSelf`) or push source-attributed state
     // resolve against the firing card. Board-card candidates (act / agenda)
     // have no source; hand candidates were handled above.
-    let mut eval_ctx = match trigger.source {
-        CandidateSource::InPlay(src) => {
-            EvalContext::for_controller_with_source(trigger.controller, src)
-        }
-        CandidateSource::Board => EvalContext::for_controller(trigger.controller),
-        CandidateSource::Hand => {
-            unreachable!("fire_pending_trigger: Hand candidates are played above, not fired")
-        }
-    };
+    let mut eval_ctx = EvalContext::for_controller_with_optional_source(
+        trigger.controller,
+        trigger.source.instance(),
+    );
     // For `AfterEnemyAttackDamagedAsset` windows, bind the attacking
     // enemy into the context so Guard Dog's native retaliate
     // (`Effect::Native("01021:retaliate")`) can name the attacker via

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -204,9 +204,8 @@ pub(super) fn finish_skill_test(cx: &mut Cx, indices: &[u32]) -> EngineOutcome {
     // Build the eval context for the success/failure card effects,
     // threading the firing instance (`source`) so `Effect::DiscardSelf`
     // can find itself across the suspend/resume boundary.
-    let card_ctx = |investigator: InvestigatorId| match source {
-        Some(src) => EvalContext::for_controller_with_source(investigator, src),
-        None => EvalContext::for_controller(investigator),
+    let card_ctx = |investigator: InvestigatorId| {
+        EvalContext::for_controller_with_optional_source(investigator, source)
     };
 
     // Pre-advance the continuation to PostFollowUp BEFORE running the

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -163,6 +163,26 @@ impl EvalContext {
             chosen_option: None,
         }
     }
+
+    /// Construct a context for `controller`, threading `source` when present.
+    /// The common shape where a candidate / pending suspension carries an
+    /// *optional* firing instance (in-play reaction or weapon ⇒ `Some`;
+    /// scenario board card or hand-played event ⇒ `None`). Collapses the
+    /// `match source { Some => with_source, None => for_controller }` repeated
+    /// at the skill-test, choice-resume, forced-run, and reaction-window
+    /// dispatch sites. Pair with
+    /// [`CandidateSource::instance`](crate::state::CandidateSource::instance)
+    /// when the source is a `CandidateSource`.
+    #[must_use]
+    pub fn for_controller_with_optional_source(
+        controller: crate::state::InvestigatorId,
+        source: Option<crate::state::CardInstanceId>,
+    ) -> Self {
+        match source {
+            Some(src) => Self::for_controller_with_source(controller, src),
+            None => Self::for_controller(controller),
+        }
+    }
 }
 
 /// Apply an effect tree to the state.

--- a/crates/game-core/src/engine/outcome.rs
+++ b/crates/game-core/src/engine/outcome.rs
@@ -63,10 +63,10 @@ pub struct ChoiceOption {
 /// A prompt the engine emits when it needs player input.
 ///
 /// Carries free-form [`prompt`](Self::prompt) text plus, for the
-/// single-selection choice contract (Axis A), a structured
-/// [`options`](Self::options) list. Legacy prompt-only callers (the
-/// reaction-window `PickIndex` path, commit windows) leave `options` empty
-/// via [`InputRequest::prompt`].
+/// single-selection choice contract (Axis A + the Axis-C reaction-window
+/// migration), a structured [`options`](Self::options) list. Remaining
+/// prompt-only callers (commit windows, hand-size discard) leave `options`
+/// empty via [`InputRequest::prompt`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct InputRequest {

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -1207,26 +1207,26 @@ pub struct PendingSkillModifier {
 }
 
 impl GameState {
-    /// The topmost open window that has unresolved reaction triggers,
-    /// if any. Used by the dispatcher's "is reaction work pending?"
-    /// guards. Pure Fast-gating windows (empty `pending_triggers`)
-    /// are skipped — they don't block dispatch.
+    /// The topmost open window that has an unresolved option — a pending
+    /// in-play trigger *or* a hand Fast-event play (Axis C). Used by the
+    /// dispatcher's "is reaction work pending?" guards. Pure Fast-gating
+    /// framework windows (no triggers and no hand plays) are skipped — they
+    /// don't block dispatch.
     #[must_use]
     pub fn top_reaction_window(&self) -> Option<&ResolutionFrame> {
-        self.windows()
-            .rev()
-            .find(|w| !w.pending_triggers.is_empty())
+        self.windows().rev().find(|w| w.has_pending_options())
     }
 
     /// Mutable counterpart to `top_reaction_window`. Same skip rule
-    /// applies: windows with empty `pending_triggers` are skipped —
-    /// phase-gate-only windows are not exposed as reaction-work.
+    /// applies: windows with no pending option (no triggers and no hand
+    /// plays) are skipped — phase-gate-only windows are not exposed as
+    /// reaction-work.
     pub fn top_reaction_window_mut(&mut self) -> Option<&mut ResolutionFrame> {
         self.continuations
             .iter_mut()
             .rev()
             .filter_map(Continuation::as_resolution_mut)
-            .find(|w| !w.pending_triggers.is_empty())
+            .find(|w| w.has_pending_options())
     }
 
     /// Iterator over the open windows on the continuation stack, in stack
@@ -1276,7 +1276,7 @@ impl GameState {
     pub fn top_reaction_window_index(&self) -> Option<usize> {
         self.continuations.iter().rposition(|c| {
             c.as_resolution()
-                .is_some_and(|w| !w.pending_triggers.is_empty())
+                .is_some_and(ResolutionFrame::has_pending_options)
         })
     }
 

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -1129,6 +1129,20 @@ pub enum CandidateSource {
     Hand,
 }
 
+impl CandidateSource {
+    /// The firing in-play instance, if any — `Some` for [`InPlay`](Self::InPlay),
+    /// `None` for [`Board`](Self::Board) (scenario card) and [`Hand`](Self::Hand)
+    /// (event not yet in play). Feeds
+    /// [`EvalContext::for_controller_with_optional_source`](crate::engine::EvalContext::for_controller_with_optional_source).
+    #[must_use]
+    pub fn instance(self) -> Option<CardInstanceId> {
+        match self {
+            CandidateSource::InPlay(id) => Some(id),
+            CandidateSource::Board | CandidateSource::Hand => None,
+        }
+    }
+}
+
 /// A single pending ability/play waiting to resolve in a
 /// [`Continuation::Resolution`] frame.
 ///

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -764,12 +764,6 @@ pub struct ResolutionFrame {
     /// lead orders. Empty is permitted — framework windows opened for
     /// phase/timing reasons gate Fast actions with no pending candidates.
     pub pending_triggers: Vec<ResolutionCandidate>,
-    /// Fast events in hand that match this window's event (Axis C, #335),
-    /// offered as `PickSingle` options *after* `pending_triggers`. Empty for
-    /// the forced run (it admits no Fast plays) and for windows opened before
-    /// the hand scan (`queue_reaction_window` populates it from
-    /// `scan_hand_fast_events`).
-    pub fast_plays: Vec<FastEventCandidate>,
     /// What this resolution run *is*: either a reaction / fast / framework
     /// [`Window`](ResolutionKind::Window) (carrying its kind + Fast-action
     /// scope), or the mandatory **forced run**
@@ -850,17 +844,8 @@ impl ResolutionFrame {
     pub fn new_empty(kind: WindowKind, fast_actors: FastActorScope) -> Self {
         Self {
             pending_triggers: Vec::new(),
-            fast_plays: Vec::new(),
             kind: ResolutionKind::Window(WindowBinding { kind, fast_actors }),
         }
-    }
-
-    /// True while this frame still has an option to offer — a pending in-play
-    /// trigger or a hand Fast-event play (Axis C). The close condition for a
-    /// resolution run is the negation of this.
-    #[must_use]
-    pub fn has_pending_options(&self) -> bool {
-        !self.pending_triggers.is_empty() || !self.fast_plays.is_empty()
     }
 
     /// The [`WindowKind`] if this frame is a window; `None` for the forced
@@ -1121,62 +1106,54 @@ pub struct HandSizeDiscard {
     pub remaining: Vec<InvestigatorId>,
 }
 
-/// A single pending [`Trigger::OnEvent`](crate::dsl::Trigger::OnEvent)
-/// ability waiting to resolve in a [`Continuation::Resolution`] frame.
+/// Where a [`ResolutionCandidate`] comes from — which decides how it
+/// *resolves* when picked.
 ///
-/// The **unified candidate** for both the forced run and a reaction window
-/// (Axis-B T5b): abilities resolve by `code` (registry lookup), so the same
-/// shape serves in-play instances *and* scenario board cards (act / agenda)
-/// that have no instance. Whether a candidate is mandatory vs. optional is a
-/// property of the *frame* (`can_skip`), not the candidate — forced and
-/// reaction are separate resolution runs.
+/// `InPlay` and `Board` candidates **fire an ability's effect**; a `Hand`
+/// candidate (Axis C, #335) is a Fast event **played** from hand (RR
+/// Appendix I — `CardPlayed`, run the matched ability's effect, discard),
+/// not fired in place. Replacing the former `source: Option<CardInstanceId>`
+/// with this enum lets one `pending_triggers` list carry hand events
+/// alongside in-play reactions: `None` (board) and "from hand" are distinct
+/// origins, so a bare `Option` could not tell them apart.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum CandidateSource {
+    /// An ability on an in-play / threat-area instance (reaction trigger,
+    /// weapon, …). The instance id drives `Effect::DiscardSelf`, usage-limit
+    /// bumping, and the soak self-binding.
+    InPlay(CardInstanceId),
+    /// A scenario board card (act / agenda) — no instance; fires by `code`.
+    Board,
+    /// A Fast event in the controller's hand (Axis C) — *played* rather than
+    /// fired. No instance until it would enter play (events never do).
+    Hand,
+}
+
+/// A single pending ability/play waiting to resolve in a
+/// [`Continuation::Resolution`] frame.
+///
+/// The **unified candidate** for the forced run, a reaction window's in-play
+/// triggers, *and* (Axis C) a Fast event playable from hand: abilities resolve
+/// by `code` (registry lookup), so the same shape serves in-play instances,
+/// scenario board cards (act / agenda), and hand events. How a picked
+/// candidate resolves is decided by its [`source`](Self::source)
+/// ([`CandidateSource`]). Whether a candidate is mandatory vs. optional is a
+/// property of the *frame*, not the candidate — forced and reaction are
+/// separate resolution runs.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ResolutionCandidate {
-    /// Printed code of the card whose ability fires. Abilities are looked
-    /// up by code, so this resolves both in-play instances and board cards.
+    /// Printed code of the card whose ability fires (or which is played, for
+    /// a [`CandidateSource::Hand`] event). Abilities are looked up by code.
     pub code: CardCode,
-    /// The investigator the effect resolves under (controller).
+    /// The investigator the effect resolves under (controller / player).
     pub controller: InvestigatorId,
     /// Zero-based index into the card's
-    /// [`abilities`](crate::dsl::Ability) vec — which ability fires.
+    /// [`abilities`](crate::dsl::Ability) vec — which ability fires / runs.
     pub ability_index: u8,
-    /// The firing card instance, when there is one (in-play asset,
-    /// threat-area, attachment, reaction trigger) — used for
-    /// `Effect::DiscardSelf`, usage-limit bumping, and the soak
-    /// self-binding. `None` for scenario board cards (act / agenda).
-    pub source: Option<CardInstanceId>,
-}
-
-/// One Fast event playable from hand that matches an open reaction window's
-/// event (Axis C, #335). The window offers it as a `PickSingle` option
-/// alongside in-play [`ResolutionCandidate`]s; picking it plays the event
-/// and runs ability `ability_index`'s effect. Sourced from hand, so there is
-/// no in-play instance id (unlike [`ResolutionCandidate::source`]).
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[non_exhaustive]
-pub struct FastEventCandidate {
-    /// The investigator whose hand holds the event and who plays it.
-    pub controller: InvestigatorId,
-    /// Printed code of the Fast event in hand.
-    pub code: CardCode,
-    /// Index into the card's [`abilities`](crate::dsl::Ability) vec — the
-    /// `OnEvent` ability whose pattern matched this window and whose effect
-    /// resolves on play.
-    pub ability_index: u8,
-}
-
-impl FastEventCandidate {
-    /// Construct a candidate. Provided so integration tests outside the
-    /// crate can build one despite the `#[non_exhaustive]` attribute.
-    #[must_use]
-    pub fn new(controller: InvestigatorId, code: CardCode, ability_index: u8) -> Self {
-        Self {
-            controller,
-            code,
-            ability_index,
-        }
-    }
+    /// Where the candidate comes from, deciding how it resolves — see
+    /// [`CandidateSource`].
+    pub source: CandidateSource,
 }
 
 /// A queued [`ModifierScope::ThisSkillTest`] contribution waiting to
@@ -1207,26 +1184,27 @@ pub struct PendingSkillModifier {
 }
 
 impl GameState {
-    /// The topmost open window that has an unresolved option — a pending
-    /// in-play trigger *or* a hand Fast-event play (Axis C). Used by the
-    /// dispatcher's "is reaction work pending?" guards. Pure Fast-gating
-    /// framework windows (no triggers and no hand plays) are skipped — they
-    /// don't block dispatch.
+    /// The topmost open window that has unresolved candidates, if any. Used
+    /// by the dispatcher's "is reaction work pending?" guards. A candidate is
+    /// an in-play trigger *or* a hand Fast-event play (Axis C) — both ride
+    /// `pending_triggers`. Pure Fast-gating framework windows (empty
+    /// `pending_triggers`) are skipped — they don't block dispatch.
     #[must_use]
     pub fn top_reaction_window(&self) -> Option<&ResolutionFrame> {
-        self.windows().rev().find(|w| w.has_pending_options())
+        self.windows()
+            .rev()
+            .find(|w| !w.pending_triggers.is_empty())
     }
 
     /// Mutable counterpart to `top_reaction_window`. Same skip rule
-    /// applies: windows with no pending option (no triggers and no hand
-    /// plays) are skipped — phase-gate-only windows are not exposed as
-    /// reaction-work.
+    /// applies: windows with empty `pending_triggers` are skipped —
+    /// phase-gate-only windows are not exposed as reaction-work.
     pub fn top_reaction_window_mut(&mut self) -> Option<&mut ResolutionFrame> {
         self.continuations
             .iter_mut()
             .rev()
             .filter_map(Continuation::as_resolution_mut)
-            .find(|w| w.has_pending_options())
+            .find(|w| !w.pending_triggers.is_empty())
     }
 
     /// Iterator over the open windows on the continuation stack, in stack
@@ -1276,7 +1254,7 @@ impl GameState {
     pub fn top_reaction_window_index(&self) -> Option<usize> {
         self.continuations.iter().rposition(|c| {
             c.as_resolution()
-                .is_some_and(ResolutionFrame::has_pending_options)
+                .is_some_and(|w| !w.pending_triggers.is_empty())
         })
     }
 
@@ -1379,7 +1357,6 @@ mod open_window_tests {
     fn open_window_serde_roundtrip() {
         let window = ResolutionFrame {
             pending_triggers: Vec::new(),
-            fast_plays: Vec::new(),
             kind: ResolutionKind::Window(WindowBinding {
                 kind: WindowKind::AfterEnemyDefeated {
                     enemy: EnemyId(7),
@@ -1402,23 +1379,17 @@ mod open_window_tests {
     }
 
     #[test]
-    fn new_empty_frame_has_no_fast_plays_and_no_pending_options() {
-        let frame = ResolutionFrame::new_empty(
-            WindowKind::AfterEnemyDefeated {
-                enemy: EnemyId(1),
-                by: Some(InvestigatorId(1)),
-            },
-            FastActorScope::Any,
-        );
-        assert!(frame.fast_plays.is_empty());
-        assert!(!frame.has_pending_options());
-    }
-
-    #[test]
-    fn fast_event_candidate_serde_round_trips() {
-        let candidate = FastEventCandidate::new(InvestigatorId(1), CardCode::new("01022"), 0);
+    fn hand_candidate_serde_round_trips() {
+        // A Fast event playable from hand (Axis C) rides ResolutionCandidate
+        // with a `Hand` source — distinct from a board card's `None`/`Board`.
+        let candidate = ResolutionCandidate {
+            code: CardCode::new("01022"),
+            controller: InvestigatorId(1),
+            ability_index: 0,
+            source: CandidateSource::Hand,
+        };
         let json = serde_json::to_string(&candidate).expect("serialize");
-        let back: FastEventCandidate = serde_json::from_str(&json).expect("deserialize");
+        let back: ResolutionCandidate = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, candidate);
     }
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -764,6 +764,12 @@ pub struct ResolutionFrame {
     /// lead orders. Empty is permitted — framework windows opened for
     /// phase/timing reasons gate Fast actions with no pending candidates.
     pub pending_triggers: Vec<ResolutionCandidate>,
+    /// Fast events in hand that match this window's event (Axis C, #335),
+    /// offered as `PickSingle` options *after* `pending_triggers`. Empty for
+    /// the forced run (it admits no Fast plays) and for windows opened before
+    /// the hand scan (`queue_reaction_window` populates it from
+    /// `scan_hand_fast_events`).
+    pub fast_plays: Vec<FastEventCandidate>,
     /// What this resolution run *is*: either a reaction / fast / framework
     /// [`Window`](ResolutionKind::Window) (carrying its kind + Fast-action
     /// scope), or the mandatory **forced run**
@@ -844,8 +850,17 @@ impl ResolutionFrame {
     pub fn new_empty(kind: WindowKind, fast_actors: FastActorScope) -> Self {
         Self {
             pending_triggers: Vec::new(),
+            fast_plays: Vec::new(),
             kind: ResolutionKind::Window(WindowBinding { kind, fast_actors }),
         }
+    }
+
+    /// True while this frame still has an option to offer — a pending in-play
+    /// trigger or a hand Fast-event play (Axis C). The close condition for a
+    /// resolution run is the negation of this.
+    #[must_use]
+    pub fn has_pending_options(&self) -> bool {
+        !self.pending_triggers.is_empty() || !self.fast_plays.is_empty()
     }
 
     /// The [`WindowKind`] if this frame is a window; `None` for the forced
@@ -1133,6 +1148,37 @@ pub struct ResolutionCandidate {
     pub source: Option<CardInstanceId>,
 }
 
+/// One Fast event playable from hand that matches an open reaction window's
+/// event (Axis C, #335). The window offers it as a `PickSingle` option
+/// alongside in-play [`ResolutionCandidate`]s; picking it plays the event
+/// and runs ability `ability_index`'s effect. Sourced from hand, so there is
+/// no in-play instance id (unlike [`ResolutionCandidate::source`]).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct FastEventCandidate {
+    /// The investigator whose hand holds the event and who plays it.
+    pub controller: InvestigatorId,
+    /// Printed code of the Fast event in hand.
+    pub code: CardCode,
+    /// Index into the card's [`abilities`](crate::dsl::Ability) vec — the
+    /// `OnEvent` ability whose pattern matched this window and whose effect
+    /// resolves on play.
+    pub ability_index: u8,
+}
+
+impl FastEventCandidate {
+    /// Construct a candidate. Provided so integration tests outside the
+    /// crate can build one despite the `#[non_exhaustive]` attribute.
+    #[must_use]
+    pub fn new(controller: InvestigatorId, code: CardCode, ability_index: u8) -> Self {
+        Self {
+            controller,
+            code,
+            ability_index,
+        }
+    }
+}
+
 /// A queued [`ModifierScope::ThisSkillTest`] contribution waiting to
 /// apply to a skill test.
 ///
@@ -1333,6 +1379,7 @@ mod open_window_tests {
     fn open_window_serde_roundtrip() {
         let window = ResolutionFrame {
             pending_triggers: Vec::new(),
+            fast_plays: Vec::new(),
             kind: ResolutionKind::Window(WindowBinding {
                 kind: WindowKind::AfterEnemyDefeated {
                     enemy: EnemyId(7),
@@ -1352,6 +1399,27 @@ mod open_window_tests {
         let json = serde_json::to_string(&kind).expect("serialize");
         let back: WindowKind = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, kind);
+    }
+
+    #[test]
+    fn new_empty_frame_has_no_fast_plays_and_no_pending_options() {
+        let frame = ResolutionFrame::new_empty(
+            WindowKind::AfterEnemyDefeated {
+                enemy: EnemyId(1),
+                by: Some(InvestigatorId(1)),
+            },
+            FastActorScope::Any,
+        );
+        assert!(frame.fast_plays.is_empty());
+        assert!(!frame.has_pending_options());
+    }
+
+    #[test]
+    fn fast_event_candidate_serde_round_trips() {
+        let candidate = FastEventCandidate::new(InvestigatorId(1), CardCode::new("01022"), 0);
+        let json = serde_json::to_string(&candidate).expect("serialize");
+        let back: FastEventCandidate = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, candidate);
     }
 }
 

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -24,8 +24,8 @@ pub use counter::Counter;
 pub(crate) use counter::define_id;
 pub use enemy::{Enemy, EnemyId};
 pub use game_state::{
-    Act, ActRoundEndPending, Agenda, ChoiceFrame, ClueInterruptPending, Continuation,
-    EnemyAttackSource, FastActorScope, FastEventCandidate, FinishContinuation, ForcedContinuation,
+    Act, ActRoundEndPending, Agenda, CandidateSource, ChoiceFrame, ClueInterruptPending,
+    Continuation, EnemyAttackSource, FastActorScope, FinishContinuation, ForcedContinuation,
     GameState, HandSizeDiscard, HunterChoice, InFlightSkillTest, PendingEnemyAttack,
     PendingSkillModifier, PhaseStep, ResolutionCandidate, ResolutionFrame, ResolutionKind,
     RoundEndAdvance, SkillTestFollowUp, SpawnEngagePending, WindowBinding, WindowKind,

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -26,10 +26,9 @@ pub use enemy::{Enemy, EnemyId};
 pub use game_state::{
     Act, ActRoundEndPending, Agenda, ChoiceFrame, ClueInterruptPending, Continuation,
     EnemyAttackSource, FastActorScope, FastEventCandidate, FinishContinuation, ForcedContinuation,
-    GameState,
-    HandSizeDiscard, HunterChoice, InFlightSkillTest, PendingEnemyAttack, PendingSkillModifier,
-    PhaseStep, ResolutionCandidate, ResolutionFrame, ResolutionKind, RoundEndAdvance,
-    SkillTestFollowUp, SpawnEngagePending, WindowBinding, WindowKind,
+    GameState, HandSizeDiscard, HunterChoice, InFlightSkillTest, PendingEnemyAttack,
+    PendingSkillModifier, PhaseStep, ResolutionCandidate, ResolutionFrame, ResolutionKind,
+    RoundEndAdvance, SkillTestFollowUp, SpawnEngagePending, WindowBinding, WindowKind,
 };
 pub use investigator::{DefeatCause, Investigator, InvestigatorId, Status};
 pub use location::{Location, LocationId};

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -25,7 +25,8 @@ pub(crate) use counter::define_id;
 pub use enemy::{Enemy, EnemyId};
 pub use game_state::{
     Act, ActRoundEndPending, Agenda, ChoiceFrame, ClueInterruptPending, Continuation,
-    EnemyAttackSource, FastActorScope, FinishContinuation, ForcedContinuation, GameState,
+    EnemyAttackSource, FastActorScope, FastEventCandidate, FinishContinuation, ForcedContinuation,
+    GameState,
     HandSizeDiscard, HunterChoice, InFlightSkillTest, PendingEnemyAttack, PendingSkillModifier,
     PhaseStep, ResolutionCandidate, ResolutionFrame, ResolutionKind, RoundEndAdvance,
     SkillTestFollowUp, SpawnEngagePending, WindowBinding, WindowKind,

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -704,7 +704,7 @@ fn two_simultaneous_forced_triggers_resolved_in_lead_chosen_order() {
     let after_first = apply(
         paused.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
     // One forced resolved; the second is still pending (another choice or
@@ -722,7 +722,7 @@ fn two_simultaneous_forced_triggers_resolved_in_lead_chosen_order() {
     let done = apply(
         after_first.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
     assert_eq!(done.outcome, EngineOutcome::Done);

--- a/crates/game-core/tests/reaction_windows.rs
+++ b/crates/game-core/tests/reaction_windows.rs
@@ -261,7 +261,7 @@ fn matching_reaction_opens_window_and_suspends() {
 
 #[test]
 fn pick_index_fires_pending_trigger_and_closes_window() {
-    // Open the window, then PickIndex(0) → effect fires (clue
+    // Open the window, then PickSingle(OptionId(0)) → effect fires (clue
     // discovered), the entry drains, the window closes, and the
     // engine returns Done.
     let (inv_id, enemy_id, loc_id, state) = fight_to_defeat_scenario(&[(ROLAND_REACTION, 1)]);
@@ -274,7 +274,7 @@ fn pick_index_fires_pending_trigger_and_closes_window() {
     let resumed = game_core::engine::apply(
         paused.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
 
@@ -426,7 +426,7 @@ fn unqualified_pattern_matches_any_defeat() {
     let resumed = game_core::engine::apply(
         paused.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
     assert_eq!(resumed.outcome, EngineOutcome::Done);
@@ -450,7 +450,7 @@ fn pick_index_out_of_bounds_rejects_window_stays_open() {
     let bad = game_core::engine::apply(
         paused.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(99),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(99)),
         }),
     );
     match bad.outcome {
@@ -496,8 +496,8 @@ fn non_resolve_input_action_rejects_while_window_open() {
 #[test]
 fn multiple_pending_triggers_resolve_one_at_a_time() {
     // TWO_REACTIONS exposes two OnEvent abilities. The window opens
-    // with both pending; PickIndex(0) fires the first (clue), engine
-    // re-emits AwaitingInput with one entry remaining; PickIndex(0)
+    // with both pending; PickSingle(OptionId(0)) fires the first (clue), engine
+    // re-emits AwaitingInput with one entry remaining; PickSingle(OptionId(0))
     // again fires the second (resource); window closes.
     let (inv_id, enemy_id, loc_id, state) = fight_to_defeat_scenario(&[(TWO_REACTIONS, 1)]);
     let paused = fight_through_commit_window(state, fight_action(inv_id, enemy_id));
@@ -518,7 +518,7 @@ fn multiple_pending_triggers_resolve_one_at_a_time() {
     let after_first = game_core::engine::apply(
         paused.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
     assert!(
@@ -544,7 +544,7 @@ fn multiple_pending_triggers_resolve_one_at_a_time() {
     let after_second = game_core::engine::apply(
         after_first.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
     assert_eq!(after_second.outcome, EngineOutcome::Done);
@@ -597,7 +597,7 @@ fn fight_event_sequence_pins_window_between_enemy_defeated_and_skill_test_ended(
     let resumed = game_core::engine::apply(
         paused.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
     assert_eq!(resumed.outcome, EngineOutcome::Done);
@@ -725,7 +725,7 @@ fn reaction_window_closes_before_on_skill_test_resolution_fires() {
     let resumed = game_core::engine::apply(
         paused_reaction.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
     assert_eq!(resumed.outcome, EngineOutcome::Done);
@@ -834,7 +834,7 @@ fn pending_triggers_order_active_investigator_first_then_turn_order() {
 
 #[test]
 fn skip_after_firing_one_drops_remaining_optionals() {
-    // TWO_REACTIONS has two optional triggers. Fire PickIndex(0)
+    // TWO_REACTIONS has two optional triggers. Fire PickSingle(OptionId(0))
     // (consuming the first), then Skip. The second optional must NOT
     // fire — its effect (gain 1 resource) leaves resources unchanged
     // from the post-first-fire baseline. The window closes cleanly.
@@ -857,7 +857,7 @@ fn skip_after_firing_one_drops_remaining_optionals() {
     let after_first = game_core::engine::apply(
         paused.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
     assert!(
@@ -1022,7 +1022,7 @@ fn close_reaction_window_at_removes_reaction_window_not_empty_phase_gate_on_top(
 fn pick_index_fires_threat_area_reaction_and_closes_window() {
     // ROLAND_REACTION is seated in the investigator's threat_area
     // (instance id 7). The scan already finds it there; now verify
-    // the fire path also resolves it: PickIndex(0) discovers 1 clue,
+    // the fire path also resolves it: PickSingle(OptionId(0)) discovers 1 clue,
     // the window closes, and Done is returned.
     install_mock_registry();
     let inv_id = InvestigatorId(1);
@@ -1064,7 +1064,7 @@ fn pick_index_fires_threat_area_reaction_and_closes_window() {
     let resumed = game_core::engine::apply(
         paused.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
 
@@ -1156,7 +1156,7 @@ fn after_successful_investigate_fires_in_play_reaction() {
     let resumed = game_core::engine::apply(
         paused_reaction.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
     assert_eq!(resumed.outcome, EngineOutcome::Done);

--- a/crates/game-core/tests/reaction_windows.rs
+++ b/crates/game-core/tests/reaction_windows.rs
@@ -255,7 +255,10 @@ fn matching_reaction_opens_window_and_suspends() {
     );
     assert_eq!(window.pending_triggers.len(), 1);
     assert_eq!(window.pending_triggers[0].controller, inv_id);
-    assert_eq!(window.pending_triggers[0].source, Some(CardInstanceId(1)));
+    assert_eq!(
+        window.pending_triggers[0].source,
+        game_core::state::CandidateSource::InPlay(CardInstanceId(1))
+    );
     assert_eq!(window.pending_triggers[0].ability_index, 0);
 }
 
@@ -824,12 +827,18 @@ fn pending_triggers_order_active_investigator_first_then_turn_order() {
         window.pending_triggers[0].controller, active,
         "active investigator's trigger must come first",
     );
-    assert_eq!(window.pending_triggers[0].source, Some(CardInstanceId(1)));
+    assert_eq!(
+        window.pending_triggers[0].source,
+        game_core::state::CandidateSource::InPlay(CardInstanceId(1))
+    );
     assert_eq!(
         window.pending_triggers[1].controller, other,
         "non-active investigator's trigger comes after, in turn order",
     );
-    assert_eq!(window.pending_triggers[1].source, Some(CardInstanceId(2)));
+    assert_eq!(
+        window.pending_triggers[1].source,
+        game_core::state::CandidateSource::InPlay(CardInstanceId(2))
+    );
 }
 
 #[test]
@@ -941,7 +950,10 @@ fn reaction_trigger_in_threat_area_opens_window() {
         .expect("threat-area reaction must populate the window");
     assert_eq!(window.pending_triggers.len(), 1);
     assert_eq!(window.pending_triggers[0].controller, inv_id);
-    assert_eq!(window.pending_triggers[0].source, Some(CardInstanceId(7)));
+    assert_eq!(
+        window.pending_triggers[0].source,
+        game_core::state::CandidateSource::InPlay(CardInstanceId(7))
+    );
 }
 
 #[test]

--- a/crates/game-core/tests/round_ended.rs
+++ b/crates/game-core/tests/round_ended.rs
@@ -146,7 +146,7 @@ fn two_round_end_forced_suspend_then_resume_the_upkeep_tail() {
     let after_first = apply(
         paused.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
     assert!(
@@ -166,7 +166,7 @@ fn two_round_end_forced_suspend_then_resume_the_upkeep_tail() {
     let done = apply(
         after_first.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickIndex(0),
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
     assert_eq!(done.outcome, EngineOutcome::Done);

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -140,9 +140,14 @@ when picked up.
   ([#334](https://github.com/talelburg/eldritch/issues/334)) — **✅ PR #350**:
   `Effect::ChooseOne` + `Location`/`Investigator::ChosenByController` + native-leaf
   picks on a `Continuation::Choice` frame (agenda 01105 + Crypt Chill 01167
-  upgraded; see Decisions). **C**
-  reaction-event-play ([#335](https://github.com/talelburg/eldritch/issues/335)),
-  **D** cancellation/replacement ([#336](https://github.com/talelburg/eldritch/issues/336)),
+  upgraded; see Decisions). **C** reaction-event-play
+  ([#335](https://github.com/talelburg/eldritch/issues/335)) — **✅ PR #365**:
+  a Fast event in hand (Evidence! 01022, #304) rides the reaction window's one
+  candidate list and is *played* when picked; reaction/forced windows migrated
+  to `PickSingle(OptionId)`; reaction events are window-only at the play gate
+  (see Decisions).
+  **D** cancellation/replacement ([#336](https://github.com/talelburg/eldritch/issues/336)) —
+  still open; Dodge 01023 (#305) needs it plus Axis C.
   **E** orthogonal card prereqs (#301/#302/#306/#312/#313/#319/#320/#322/#323).
   The reachable subset of E (the six cards unblocked by Axes A+B) is sequenced
   as the **choice-cluster completion** sub-slice — 8 PRs mapped to existing
@@ -246,6 +251,8 @@ Devourer Below, campaign log + `Fact` enum) is **Phase 9**, not Phase 7.
 - **`Cost::DiscardSelf` discards the source asset in play (sole source-cost, paid last); `Effect::DealDamageToEnemy` is typed for a pre-cost target check (#301, PR #352).** `DiscardSelf` removes the source from `cards_in_play` → owner's discard (`CardDiscarded { InPlay }`), reusing the defeat-discard path; combining it with `Exhaust`/`SpendUses` is a loud reject (`reject_incompatible_costs`) and a missing source at payment is a loud `unreachable!`. The enemy variety ships as `EnemyTarget::Chosen(Choose<EntityScope>)`, reusing the keystone's `EntityScope::At`; `chosen_enemy` binds it; `combat::enemies_in_scope` is shared by the evaluator's grounding and the activation pre-cost check (`check_effect_target_available`, folded with the Fight check), which rejects 0-enemies-in-scope **before** paying — the reason `DealDamageToEnemy` is typed, not `Native` (Beat Cop can't pay its discard-self cost for no legal target). `≥1` proceeds; `2+` suspends via the Choose resolver. Beat Cop's content (PR-4 #239) and Knife's discard-self cost (PR-5 #312) are now unblocked.
 
 - **`Effect::Heal` (the engine's first heal, reusing `InvestigatorTarget::Chosen`) + uses-depletion auto-discard via a pipeline-parsed `Uses.discard_when_empty` flag (#302, PR #355).** `Heal { kind: HarmKind, target, count }` saturating-reduces damage/horror (`Event::Healed`, only when something heals); First Aid's "damage or horror" is `ChooseOne([Heal{Damage}, Heal{Horror}])`. `HarmKind { Damage, Horror }` is shared — the `DealDamage`/`DealHorror` consolidation reusing it is **#354**. `Uses.discard_when_empty` is parsed from the templated `If <name> has no <kind>, discard it` clause (RR p.27; true for First Aid 01019 / Forbidden Knowledge 01058 / Grotesque Statue 01071); the depletion-discard checks at `SpendUses` payment via a `discard_card_from_play` helper shared with `Cost::DiscardSelf`. **First-Aid-correct; rules-precise post-resolution timing + effect-depletion cards (Forbidden Knowledge depletes via *effect*, not cost) + the mid-payment source-removal hazard are deferred to #353.** First Aid (PR-4 #239) and Medical Texts' heal (PR-6 #321) are now unblocked.
+
+- **Axis C reaction-event-play: a Fast event is a reaction sourced from hand, carried on the *one* candidate list, and window-only (#335 / #304, PR #365).** Evidence! 01022 is Roland 01001's after-defeat reaction minus the usage limit; the play-timing predicate is the existing `trigger_matches`/`OnEvent` pattern (RR p.11), not a new field. Hand events ride `pending_triggers: Vec<ResolutionCandidate>` distinguished by `source: CandidateSource { InPlay(id), Board, Hand }` (replacing `source: Option<CardInstanceId>` — `None` already meant "board card", so it couldn't also mean "from hand"); `fire_pending_trigger` dispatches `Hand ⇒ play (via the shared `cards::begin_event_play`), else fire`. Reaction/forced windows now resume via `PickSingle(OptionId)` (the legacy `PickIndex` reaction path is retired; the variant survives for other callers). **A reaction event is window-only: `check_play_card` rejects a standalone `PlayCard` of any event with an `OnEvent` ability** — otherwise `play_card`'s `OnPlay`-only loop would silently discard it for no effect. **A future reaction event (Dodge 01023, #305) reuses this exact path; it adds only Axis D (cancellation, #336).** **Fast assets are *not* offered in reaction windows by rules** (RR p.11/p.22: they play in framework *player* windows = `WindowKind::PlayerWindow`/`open_fast_window`, not in reaction to a triggering condition) — not a deferral.
 
 ## Open questions
 

--- a/docs/superpowers/plans/2026-06-18-phase-7-axis-c-reaction-event-play.md
+++ b/docs/superpowers/plans/2026-06-18-phase-7-axis-c-reaction-event-play.md
@@ -1,0 +1,1066 @@
+# Axis C — Reaction-Event-Play (Evidence! 01022) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a Fast event in hand (Evidence! 01022) be offered and played as an option inside the after-defeat reaction window, by migrating the reaction-window resume contract to the structured `PickSingle(OptionId)` surface.
+
+**Architecture:** A reaction window's offered options become `{in-play pending triggers} ∪ {matching hand Fast-event plays}`, each a `ChoiceOption` resolved by `PickSingle(OptionId)`. The play-timing predicate is the *existing* `trigger_matches` `EventPattern` check — Evidence! is Roland 01001's after-defeat reaction, sourced from hand instead of from play. A picked hand-event option emits `CardPlayed`, runs the matched ability's effect, and discards via the existing `pending_played_event` flush.
+
+**Tech Stack:** Rust workspace (`game-core` kernel, `cards` content, `card-dsl` types). Event-sourced `apply(state, action) -> ApplyResult`. Reaction windows live on the `Continuation::Resolution` stack (Axis B). Tests: in-crate unit tests + `crates/cards/tests/` integration tests (own process each, so `card_registry::install` is safe).
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-06-18-phase-7-axis-c-reaction-event-play-design.md`.
+- **Issues:** closes #335 (Axis C) and #304 (Evidence!).
+- **CI gauntlet (all must pass, warnings-as-errors), run from repo root before pushing:**
+  - `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo fmt --check`
+  - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
+  - `cargo build -p web --target wasm32-unknown-unknown`
+  - `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`
+- **Validate-first / mutate-second** handler contract holds for every new path.
+- **Never hand-edit** `crates/cards/src/generated/cards.rs` (Evidence!'s metadata comes from the corpus; only `abilities()` is hand-written).
+- **Card text is verbatim** from `data/arkhamdb-snapshot/pack/core/core.json`: Evidence! 01022 = "Fast. Play after you defeat an enemy.\nDiscover 1 clue at your location." (`type_code: event`, `traits: Insight.`, `cost: 1`).
+- **Branch:** `engine/axis-c-reaction-event-play`. Commit subjects use `scope: description`. The spec file (already written) and the phase-doc update both ride this branch; the phase-doc commit is the **final** commit after CI is green (per `docs/phases/README.md`).
+- **Out of scope:** the framework `open_fast_window` non-paused Fast-play path; Fast assets / Fast 0-action abilities as window options; Axis D cancellation (Dodge); any new DSL primitive; charging the event's resource cost (existing `play_card` does not — stay consistent).
+
+---
+
+### Task 0: Branch setup
+
+- [ ] **Step 1: Create the feature branch**
+
+Run from repo root:
+```bash
+git checkout -b engine/axis-c-reaction-event-play
+git add docs/superpowers/specs/2026-06-18-phase-7-axis-c-reaction-event-play-design.md
+git commit -m "docs: Axis C reaction-event-play design spec
+
+Spec for #335 / #304. Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+(The spec file already exists in the working tree from the brainstorming step.)
+
+---
+
+### Task 1: Evidence! 01022 card + registration
+
+Evidence! is Roland 01001's reaction minus the once-per-round limit (verified against `crates/cards/src/impls/roland_banks.rs` and the snapshot). It is wired into the registry so later tasks can scan it from hand. (The card is inert until Axis C machinery lands — `PlayCard` from hand outside a window is already gated by phase/timing, and no window offers it yet.)
+
+**Files:**
+- Create: `crates/cards/src/impls/evidence.rs`
+- Modify: `crates/cards/src/impls/mod.rs` (module decl ~line 91 region; `abilities_for` match arm ~line 122, alphabetical between `emergency_cache` and `first_aid`)
+
+**Interfaces:**
+- Produces: `evidence::CODE: &str = "01022"`, `evidence::abilities() -> Vec<Ability>`.
+
+- [ ] **Step 1: Write the failing card test**
+
+Create `crates/cards/src/impls/evidence.rs`:
+```rust
+//! Evidence! (Neutral event, 01022).
+//!
+//! Card text (verbatim, `data/arkhamdb-snapshot/pack/core/core.json`):
+//!
+//! ```text
+//! Fast. Play after you defeat an enemy.
+//! Discover 1 clue at your location.
+//! ```
+//!
+//! # Scope
+//!
+//! Evidence! is Roland Banks 01001's `[reaction]` ("After you defeat an
+//! enemy: Discover 1 clue at your location.") sourced from hand instead of
+//! from play — the identical [`Trigger::OnEvent`] declaration, minus Roland's
+//! once-per-round [`UsageLimit`]. Per Rules Reference p.11, a Fast event with
+//! a "Play after …" instruction plays "as if the described timing point were a
+//! triggering condition", so the play-timing predicate IS the `OnEvent`
+//! pattern (Axis C, #335 / #304). The Fast/cost/Insight metadata comes from
+//! the generated corpus.
+
+use card_dsl::dsl::{
+    discover_clue, reaction_on_event, Ability, EventPattern, EventTiming, LocationTarget,
+};
+
+/// `ArkhamDB` code for the original-Core printing.
+pub const CODE: &str = "01022";
+
+/// Evidence!'s "Play after you defeat an enemy. / Discover 1 clue at your
+/// location." — Roland 01001's reaction without the usage limit.
+#[must_use]
+pub fn abilities() -> Vec<Ability> {
+    vec![reaction_on_event(
+        EventPattern::EnemyDefeated {
+            by_controller: true,
+            code: None,
+        },
+        EventTiming::After,
+        discover_clue(LocationTarget::YourLocation, 1),
+    )]
+}
+
+#[cfg(test)]
+mod tests {
+    use card_dsl::dsl::{
+        Effect, EventPattern, EventTiming, LocationTarget, Trigger, TriggerKind,
+    };
+
+    #[test]
+    fn abilities_are_one_after_defeat_reaction_discovering_one_clue() {
+        let abilities = super::abilities();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(
+            abilities[0].trigger,
+            Trigger::OnEvent {
+                pattern: EventPattern::EnemyDefeated {
+                    by_controller: true,
+                    code: None,
+                },
+                timing: EventTiming::After,
+                kind: TriggerKind::Reaction,
+            },
+        );
+        assert!(matches!(
+            abilities[0].effect,
+            Effect::DiscoverClue {
+                from: LocationTarget::YourLocation,
+                count: 1,
+            },
+        ));
+        assert!(
+            abilities[0].usage_limit.is_none(),
+            "Evidence! is a one-shot event — no per-round usage limit",
+        );
+    }
+
+    #[test]
+    fn registry_dispatches_to_this_modules_abilities() {
+        assert_eq!(crate::abilities_for(super::CODE), Some(super::abilities()));
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p cards evidence`
+Expected: FAIL to compile — `evidence` module not declared / `abilities_for` returns `None` for `"01022"`.
+
+- [ ] **Step 3: Register the module**
+
+In `crates/cards/src/impls/mod.rs`, add the module declaration alongside the others (alphabetical, near the `emergency_cache` / `first_aid` neighbours):
+```rust
+pub mod evidence;
+```
+And add the `abilities_for` match arm (alphabetical, between `emergency_cache` and `first_aid`):
+```rust
+        evidence::CODE => Some(evidence::abilities()),
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p cards evidence`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cards/src/impls/evidence.rs crates/cards/src/impls/mod.rs
+git commit -m "cards: Evidence! 01022 abilities + registration
+
+Roland 01001's after-defeat reaction sourced from hand, minus the usage
+limit. Inert until Axis C machinery (#335) offers it in a window.
+Part of #304. Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Migrate the reaction/forced-window resume contract to `PickSingle(OptionId)`
+
+Behavior-preserving refactor: the window emits structured `options` (one per pending in-play trigger) and resumes via `PickSingle(OptionId)` instead of `PickIndex`. No hand events yet. This task's "test" is the existing reaction/forced-window suite staying green after migrating its `pick(n)` calls to `pick_single(OptionId(n))`.
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (`open_queued_reaction_window`, `advance_resolution`, `resume_reaction_window`; add a private `build_resolution_options` helper)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (the apply-pause guard message at ~line 87-92 referencing `PickIndex`)
+- Modify (test migration): `crates/cards/tests/roland_banks.rs`, `crates/cards/tests/dr_milan.rs`, `crates/cards/tests/guard_dog_soak.rs`, `crates/cards/tests/persistent_treachery.rs`, and any in-crate `reaction_windows.rs` / `mod.rs` test submitting `PickIndex` to a reaction window.
+
+**Interfaces:**
+- Consumes: `ChoiceOption`, `OptionId`, `InputRequest::choice` (from `engine/outcome.rs`); `ScriptedResolver::pick_single(OptionId)` (already exists in `test_support/resolver.rs`).
+- Produces: `build_resolution_options(state, frame) -> Vec<ChoiceOption>` (private to `reaction_windows.rs`); reaction/forced windows now answer `InputResponse::PickSingle(OptionId)`.
+
+- [ ] **Step 1: Migrate one existing test to the new contract (failing test)**
+
+In `crates/cards/tests/roland_banks.rs`, change the two `resolver.commit_cards(&[]).pick(0)` calls (lines ~105, ~204) to:
+```rust
+    resolver.commit_cards(&[]).pick_single(game_core::engine::OptionId(0));
+```
+Add the import if needed (the test already imports from `game_core::engine`; reference `game_core::engine::OptionId` inline as shown).
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p cards --test roland_banks reaction_fires_after_roland_defeats_enemy_and_discovers_clue`
+Expected: FAIL — the reaction window still expects `PickIndex`; a `PickSingle` response hits `resume_reaction_window`'s `other => Rejected` arm.
+
+- [ ] **Step 3: Add the option-builder + migrate the window emit/resume**
+
+In `crates/game-core/src/engine/dispatch/reaction_windows.rs`:
+
+Add the imports `ChoiceOption`, `OptionId` to the existing `use crate::engine::...` group (they live in `crate::engine`).
+
+Add the private helper:
+```rust
+/// Build the structured option list for a resolution frame: one
+/// [`ChoiceOption`] per pending in-play trigger, in `pending_triggers`
+/// order. `OptionId(i)` is the index into the returned list (the Axis-A
+/// convention). Task 4 appends the frame's hand Fast-event plays after the
+/// triggers.
+fn build_resolution_options(_state: &GameState, frame: &ResolutionFrame) -> Vec<ChoiceOption> {
+    let mut options = Vec::new();
+    let mut next_id = 0u32;
+    for cand in &frame.pending_triggers {
+        options.push(ChoiceOption {
+            id: OptionId(next_id),
+            label: format!("Resolve reaction: {}", cand.code),
+        });
+        next_id += 1;
+    }
+    options
+}
+```
+
+Rewrite `open_queued_reaction_window`'s `AwaitingInput` to use `choice`:
+```rust
+pub(super) fn open_queued_reaction_window(cx: &mut Cx) -> EngineOutcome {
+    let window = cx
+        .state
+        .top_reaction_window()
+        .expect("open_queued_reaction_window: caller checked is_some");
+    let skip_hint = if window.is_forced() {
+        " (forced — cannot skip; the lead orders them)"
+    } else {
+        ", or InputResponse::Skip to close"
+    };
+    let prompt = format!(
+        "Resolution window: {} option(s). Submit InputResponse::PickSingle(OptionId){skip_hint}.",
+        window.pending_triggers.len(),
+    );
+    let options = build_resolution_options(cx.state, window);
+    EngineOutcome::AwaitingInput {
+        request: InputRequest::choice(prompt, options),
+        resume_token: ResumeToken(0),
+    }
+}
+```
+
+Rewrite `advance_resolution`'s re-prompt arm the same way (keep the close branch):
+```rust
+pub(super) fn advance_resolution(cx: &mut Cx, window_idx: usize) -> EngineOutcome {
+    let window = cx.state.continuations[window_idx]
+        .as_resolution()
+        .expect("advance_resolution: window_idx is a Resolution frame");
+    if window.pending_triggers.is_empty() {
+        return close_reaction_window_at(cx, window_idx);
+    }
+    let skip_hint = if window.is_forced() {
+        " (forced — cannot skip)"
+    } else {
+        ", or InputResponse::Skip to close"
+    };
+    let prompt = format!(
+        "Resolution window: {} option(s). Submit InputResponse::PickSingle(OptionId){skip_hint}.",
+        window.pending_triggers.len(),
+    );
+    let options = build_resolution_options(cx.state, window);
+    EngineOutcome::AwaitingInput {
+        request: InputRequest::choice(prompt, options),
+        resume_token: ResumeToken(0),
+    }
+}
+```
+
+Rewrite `resume_reaction_window`'s match (the `PickIndex` arm becomes `PickSingle`; `Skip` unchanged; update the `other` message). `fire_pending_trigger` already takes a `u32` index into `pending_triggers`, so route the `OptionId`'s inner value through it after a bounds check:
+```rust
+pub(super) fn resume_reaction_window(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
+    match response {
+        InputResponse::PickSingle(OptionId(i)) => fire_pending_trigger(cx, *i),
+        InputResponse::Skip => {
+            let idx = cx
+                .state
+                .top_reaction_window_index()
+                .expect("resume_reaction_window: caller checked is_some");
+            if cx.state.continuations[idx]
+                .as_resolution()
+                .is_some_and(ResolutionFrame::is_forced)
+            {
+                return EngineOutcome::Rejected {
+                    reason: "ResolveInput::Skip: forced abilities are mandatory; submit \
+                             InputResponse::PickSingle(OptionId) to resolve one (the lead orders them)"
+                        .into(),
+                };
+            }
+            close_reaction_window_at(cx, idx)
+        }
+        other => EngineOutcome::Rejected {
+            reason: format!(
+                "ResolveInput: reaction window expects InputResponse::PickSingle(OptionId) \
+                 or InputResponse::Skip, got {other:?}",
+            )
+            .into(),
+        },
+    }
+}
+```
+
+Update `fire_pending_trigger`'s out-of-bounds reject message (line ~377) from `PickIndex({i})` to `PickSingle(OptionId({i}))` for consistency, and update its doc-comment bullet that references `InputResponse::PickIndex(i)` to `PickSingle`.
+
+In `crates/game-core/src/engine/dispatch/mod.rs`, update the apply-pause guard message (~line 92) that says `InputResponse::PickIndex` to read `InputResponse::PickSingle(OptionId)`.
+
+- [ ] **Step 4: Run the migrated test to verify it passes**
+
+Run: `cargo test -p cards --test roland_banks`
+Expected: PASS once Step 5's sibling-test migrations are also applied (the file shares the contract). If only the one test was migrated in Step 1, migrate the remaining `pick(n)` calls in this file now (see Step 5) and re-run.
+
+- [ ] **Step 5: Migrate the remaining reaction/forced-window test call sites**
+
+Replace every `.pick(N)` that drives a reaction or forced window, and every raw `InputResponse::PickIndex(N)` submitted to one, with `pick_single(OptionId(N))` / `InputResponse::PickSingle(OptionId(N))`:
+- `crates/cards/tests/roland_banks.rs` (remaining `pick` calls)
+- `crates/cards/tests/dr_milan.rs` (raw `PickIndex`)
+- `crates/cards/tests/guard_dog_soak.rs` (raw `PickIndex`)
+- `crates/cards/tests/persistent_treachery.rs` (`.pick(`)
+- Any `#[cfg(test)]` cases in `crates/game-core/src/engine/dispatch/reaction_windows.rs` and `crates/game-core/src/engine/dispatch/mod.rs` that submit `PickIndex` to a reaction/forced window.
+
+Find them all:
+```bash
+grep -rn '\.pick(\|PickIndex' crates/cards/tests crates/scenarios/tests crates/game-core/src | grep -v 'resolver.rs\|action.rs'
+```
+For each hit that targets a reaction/forced window, switch to the `PickSingle`/`pick_single` form. Leave any `PickIndex` use that targets a *different* (non-reaction-window) prompt untouched — none should exist after Axis B, but verify each hit's context.
+
+- [ ] **Step 6: Run the full workspace test suite**
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: PASS. If a forced-run test (e.g. `crates/scenarios/tests/the_gathering_resolutions.rs`, `the_gathering.rs`) drove a window via `pick`/`PickIndex`, it is now migrated and green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "engine: migrate reaction/forced windows to PickSingle(OptionId)
+
+Behavior-preserving: windows emit structured ChoiceOption lists (one per
+pending trigger) and resume via PickSingle instead of PickIndex, aligning
+the reaction-window contract with Axis A. Retires the PickIndex-while-paused
+reaction-window path. Part of #335.
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `FastEventCandidate` type + `ResolutionFrame.fast_plays` field
+
+Add the data the hand-event option needs. Pure state types, unit-tested without a registry.
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (new `FastEventCandidate` struct near `ResolutionCandidate` ~line 1120; new `fast_plays` field on `ResolutionFrame` ~line 760; `new_empty` ~line 844; `has_pending_options` helper)
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (every `ResolutionFrame { … }` literal gains `fast_plays: Vec::new()`: `open_fast_window` ~line 897, `open_forced_resolution` ~line 84)
+
+**Interfaces:**
+- Produces:
+  - `pub struct FastEventCandidate { pub controller: InvestigatorId, pub code: CardCode, pub ability_index: u8 }`
+  - `ResolutionFrame.fast_plays: Vec<FastEventCandidate>`
+  - `ResolutionFrame::has_pending_options(&self) -> bool` (`!pending_triggers.is_empty() || !fast_plays.is_empty()`)
+
+- [ ] **Step 1: Write the failing unit test**
+
+In `game_state.rs`'s test module (or the nearest `#[cfg(test)] mod` covering `ResolutionFrame`), add:
+```rust
+#[test]
+fn new_empty_frame_has_no_fast_plays_and_no_pending_options() {
+    let frame = ResolutionFrame::new_empty(
+        WindowKind::AfterEnemyDefeated { enemy: EnemyId(1), by: Some(InvestigatorId(1)) },
+        FastActorScope::Any,
+    );
+    assert!(frame.fast_plays.is_empty());
+    assert!(!frame.has_pending_options());
+}
+
+#[test]
+fn fast_event_candidate_serde_round_trips() {
+    let c = FastEventCandidate {
+        controller: InvestigatorId(1),
+        code: CardCode::new("01022"),
+        ability_index: 0,
+    };
+    let json = serde_json::to_string(&c).expect("serialize");
+    let back: FastEventCandidate = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back, c);
+}
+```
+(Use the imports already present in that test module; add `FastActorScope`, `EnemyId`, `FastEventCandidate` if missing.)
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p game-core new_empty_frame_has_no_fast_plays_and_no_pending_options fast_event_candidate_serde_round_trips`
+Expected: FAIL — `FastEventCandidate` / `fast_plays` / `has_pending_options` undefined.
+
+- [ ] **Step 3: Add the type, field, and helper**
+
+Near `ResolutionCandidate` (~line 1120) in `game_state.rs`:
+```rust
+/// One Fast event playable from hand that matches an open reaction
+/// window's event (Axis C, #335). The window offers it as a `PickSingle`
+/// option alongside in-play [`ResolutionCandidate`]s; picking it plays the
+/// event and runs ability `ability_index`'s effect. Sourced from hand, so
+/// there is no in-play instance id (unlike `ResolutionCandidate.source`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct FastEventCandidate {
+    /// The investigator whose hand holds the event and who plays it.
+    pub controller: InvestigatorId,
+    /// Printed code of the Fast event in hand.
+    pub code: CardCode,
+    /// Index into the card's abilities — the `OnEvent` ability whose
+    /// pattern matched this window and whose effect resolves on play.
+    pub ability_index: u8,
+}
+
+impl FastEventCandidate {
+    /// Construct a candidate (mirrors the struct fields; provided so
+    /// external integration tests can build one despite `#[non_exhaustive]`).
+    #[must_use]
+    pub fn new(controller: InvestigatorId, code: CardCode, ability_index: u8) -> Self {
+        Self { controller, code, ability_index }
+    }
+}
+```
+
+Add the field to `ResolutionFrame` (~line 766, after `pending_triggers`):
+```rust
+    /// Fast events in hand that match this window's event (Axis C). Empty
+    /// for the forced run and for windows opened before Axis C scanned
+    /// hands. Offered as `PickSingle` options after `pending_triggers`.
+    pub fast_plays: Vec<FastEventCandidate>,
+```
+
+Update `new_empty` (~line 844) to initialise it:
+```rust
+    pub fn new_empty(kind: WindowKind, fast_actors: FastActorScope) -> Self {
+        Self {
+            pending_triggers: Vec::new(),
+            fast_plays: Vec::new(),
+            kind: ResolutionKind::Window(WindowBinding { kind, fast_actors }),
+        }
+    }
+```
+
+Add the helper in `impl ResolutionFrame`:
+```rust
+    /// True while this frame still has an option to offer — a pending
+    /// in-play trigger or a hand Fast-event play. The close condition for
+    /// a resolution run is the negation.
+    #[must_use]
+    pub fn has_pending_options(&self) -> bool {
+        !self.pending_triggers.is_empty() || !self.fast_plays.is_empty()
+    }
+```
+
+In `reaction_windows.rs`, add `fast_plays: Vec::new()` to the two remaining `ResolutionFrame { … }` literals (`open_fast_window`, `open_forced_resolution`). `queue_reaction_window`'s literal is updated in Task 4.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p game-core new_empty_frame_has_no_fast_plays_and_no_pending_options fast_event_candidate_serde_round_trips`
+Expected: PASS.
+
+- [ ] **Step 5: Run the workspace suite (no behavior change yet)**
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "engine: FastEventCandidate + ResolutionFrame.fast_plays field
+
+The data a hand Fast-event option carries (controller + code + matched
+ability index) and where it rides on the resolution frame. No behavior yet.
+Part of #335. Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Scan hand for matching Fast events; open the window on a hand match; offer them as options
+
+The after-defeat window now opens when *either* an in-play trigger or a hand Fast-event matches, and offers the hand events as options after the triggers. No play yet — `Skip` closes without discovering.
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (`scan_hand_fast_events`; `queue_reaction_window`; `build_resolution_options`; `advance_resolution` close condition)
+- Create: `crates/cards/tests/evidence.rs` (integration test)
+
+**Interfaces:**
+- Consumes: `trigger_matches` (existing), `card_registry::current()`, `metadata.is_fast()` / `metadata.card_type()`.
+- Produces: `scan_hand_fast_events(state: &GameState, kind: WindowKind) -> Vec<FastEventCandidate>` (private).
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `crates/cards/tests/evidence.rs`:
+```rust
+//! End-to-end tests for Evidence! 01022 (Axis C reaction-event-play, #304)
+//! against the real `cards::REGISTRY`.
+//!
+//! Card text (verbatim, `data/arkhamdb-snapshot/pack/core/core.json`):
+//! > Fast. Play after you defeat an enemy.
+//! > Discover 1 clue at your location.
+
+use std::sync::Once;
+
+use game_core::engine::{EngineOutcome, OptionId};
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, ChaosBag, ChaosToken, EnemyId, InvestigatorId, LocationId, Phase, TokenModifiers,
+    WindowKind,
+};
+use game_core::test_support::{
+    drive, test_enemy, test_investigator, test_location, GameStateBuilder, ScriptedResolver,
+};
+use game_core::{assert_event, assert_no_event, Action, PlayerAction};
+
+const EVIDENCE: &str = "01022";
+
+fn install_real_registry() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// Solo investigator (NOT Roland — no in-play reaction) engaged with a
+/// 1-HP enemy at a location with `location_clues` clues, holding Evidence!
+/// in hand. A successful Combat test defeats the enemy and opens the
+/// after-defeat window.
+fn investigator_with_evidence_and_enemy(
+    location_clues: u8,
+) -> (InvestigatorId, EnemyId, LocationId, game_core::GameState) {
+    install_real_registry();
+    let inv_id = InvestigatorId(1);
+    let enemy_id = EnemyId(100);
+    let loc_id = LocationId(10);
+
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(loc_id);
+    inv.skills.combat = 4;
+    inv.hand.push(CardCode::new(EVIDENCE));
+
+    let mut enemy = test_enemy(100, "Mock Ghoul");
+    enemy.fight = 1;
+    enemy.max_health = 1;
+    enemy.damage = 0;
+    enemy.engaged_with = Some(inv_id);
+
+    let mut loc = test_location(10, "Study");
+    loc.clues = location_clues;
+
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_round(0)
+        .with_active_investigator(inv_id)
+        .with_turn_order([inv_id])
+        .with_investigator(inv)
+        .with_enemy(enemy)
+        .with_location(loc)
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default())
+        .build();
+    (inv_id, enemy_id, loc_id, state)
+}
+
+fn fight_action(inv: InvestigatorId, enemy: EnemyId) -> Action {
+    Action::Player(PlayerAction::Fight { investigator: inv, enemy })
+}
+
+#[test]
+fn after_defeat_window_opens_and_offers_evidence_with_no_in_play_reaction() {
+    let (inv_id, enemy_id, loc_id, state) = investigator_with_evidence_and_enemy(2);
+
+    // Commit nothing to the Fight test, then SKIP the reaction window
+    // (Task 4: the option is offered but playing it lands in Task 5).
+    let mut resolver = ScriptedResolver::new();
+    resolver.commit_cards(&[]).skip();
+    let result = drive(state, fight_action(inv_id, enemy_id), resolver);
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    // The window opens even though no in-play card reacts — the hand match
+    // alone opens it.
+    assert_event!(
+        result.events,
+        Event::WindowOpened {
+            kind: WindowKind::AfterEnemyDefeated { enemy: e, .. },
+        } if *e == enemy_id
+    );
+    // Skipped → no clue discovered, Evidence! still in hand.
+    assert_no_event!(result.events, Event::CluePlaced { .. });
+    assert_eq!(result.state.locations[&loc_id].clues, 2);
+    assert!(result.state.investigators[&inv_id]
+        .hand
+        .iter()
+        .any(|c| c.as_str() == EVIDENCE));
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p cards --test evidence after_defeat_window_opens_and_offers_evidence_with_no_in_play_reaction`
+Expected: FAIL — no `WindowOpened` (defeating the enemy with no in-play reaction queues no window today: `queue_reaction_window` bails on empty `pending_triggers`).
+
+- [ ] **Step 3: Add the hand scan and the open-on-hand-match logic**
+
+In `reaction_windows.rs`, add the scan (mirrors `scan_pending_triggers`' investigator ordering and registry fallback):
+```rust
+/// Scan every window-eligible investigator's hand for Fast **events**
+/// carrying an `OnEvent` ability whose pattern matches `kind` (Axis C,
+/// #335). The play-timing predicate is the same `trigger_matches` used for
+/// in-play reactions — a Fast reaction event is its in-play twin sourced
+/// from hand (RR p.11). Returns active-investigator-first / turn-order
+/// order, like `scan_pending_triggers`. Empty when no registry is installed.
+fn scan_hand_fast_events(state: &GameState, kind: WindowKind) -> Vec<FastEventCandidate> {
+    let Some(reg) = card_registry::current() else {
+        return Vec::new();
+    };
+    let mut order: Vec<InvestigatorId> = Vec::with_capacity(state.turn_order.len());
+    if let Some(active) = state.active_investigator {
+        order.push(active);
+    }
+    for id in &state.turn_order {
+        if Some(*id) != state.active_investigator {
+            order.push(*id);
+        }
+    }
+
+    let mut plays = Vec::new();
+    for id in order {
+        let Some(inv) = state.investigators.get(&id) else {
+            continue;
+        };
+        for code in &inv.hand {
+            let Some(meta) = (reg.metadata_for)(code) else {
+                continue;
+            };
+            if !meta.is_fast() || meta.card_type() != CardType::Event {
+                continue;
+            }
+            let Some(abilities) = (reg.abilities_for)(code) else {
+                continue;
+            };
+            for (idx, ability) in abilities.iter().enumerate() {
+                let Trigger::OnEvent { pattern, timing, .. } = &ability.trigger else {
+                    continue;
+                };
+                if !trigger_matches(kind, pattern, *timing, id) {
+                    continue;
+                }
+                let ability_index = u8::try_from(idx)
+                    .expect("abilities vec exceeds u8::MAX — card-impl bug, abilities are tiny");
+                plays.push(FastEventCandidate { controller: id, code: code.clone(), ability_index });
+                // One option per card: a card with two matching abilities is
+                // still played once. No in-scope card has two.
+                break;
+            }
+        }
+    }
+    plays
+}
+```
+Add `CardType` and `FastEventCandidate` to the `use` lists at the top of the file as needed.
+
+Update `queue_reaction_window` to scan both sources and store `fast_plays`:
+```rust
+pub(super) fn queue_reaction_window(cx: &mut Cx, kind: WindowKind) {
+    let pending_triggers = scan_pending_triggers(cx.state, kind);
+    let fast_plays = scan_hand_fast_events(cx.state, kind);
+    if pending_triggers.is_empty() && fast_plays.is_empty() {
+        return;
+    }
+    cx.events.push(Event::WindowOpened { kind });
+    cx.state
+        .continuations
+        .push(Continuation::Resolution(ResolutionFrame {
+            pending_triggers,
+            fast_plays,
+            kind: ResolutionKind::Window(WindowBinding {
+                kind,
+                fast_actors: FastActorScope::Any,
+            }),
+        }));
+}
+```
+
+Extend `build_resolution_options` to append the hand plays after the triggers:
+```rust
+    for play in &frame.fast_plays {
+        options.push(ChoiceOption {
+            id: OptionId(next_id),
+            label: format!("Play {} from hand", play.code),
+        });
+        next_id += 1;
+    }
+    options
+```
+
+Update `advance_resolution`'s close condition to use the helper (so a window with only a remaining hand play stays open):
+```rust
+    if !window.has_pending_options() {
+        return close_reaction_window_at(cx, window_idx);
+    }
+```
+And update both `open_queued_reaction_window` and `advance_resolution` prompt counts from `window.pending_triggers.len()` to `build_resolution_options(cx.state, window).len()` (so the prompt reflects all offered options).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p cards --test evidence after_defeat_window_opens_and_offers_evidence_with_no_in_play_reaction`
+Expected: PASS — the window opens on the hand match and `Skip` closes it without discovering.
+
+- [ ] **Step 5: Run the workspace suite (regression)**
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: PASS. Roland's tests still pass: with Roland in play the window already opened; now `build_resolution_options` includes his trigger plus any hand events (none in those fixtures).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "engine: open reaction window on a matching hand Fast-event
+
+queue_reaction_window now scans hands for Fast events whose OnEvent pattern
+matches the window (reusing trigger_matches) and opens when either an in-play
+trigger or a hand event matches; hand events are offered as PickSingle options
+after the triggers. Playing them lands next. Part of #335 / #304.
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Play a picked hand Fast-event option
+
+Route a `PickSingle` whose id falls past the in-play triggers to playing the event: emit `CardPlayed`, run the matched ability's effect, discard via `pending_played_event`.
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (`resume_reaction_window` id-splitting; new `play_fast_event_in_window`)
+- Modify: `crates/cards/tests/evidence.rs` (add the play test + the both-sources test)
+
+**Interfaces:**
+- Consumes: `apply_effect` (evaluator), `EvalContext::for_controller`, `pending_played_event` slot, `advance_resolution`.
+- Produces: `play_fast_event_in_window(cx, window_idx, fast_play_idx) -> EngineOutcome` (private).
+
+- [ ] **Step 1: Write the failing play test**
+
+In `crates/cards/tests/evidence.rs`, add:
+```rust
+#[test]
+fn picking_evidence_plays_it_and_discovers_a_clue() {
+    let (inv_id, enemy_id, loc_id, state) = investigator_with_evidence_and_enemy(2);
+
+    // Commit nothing, then pick the single offered option (OptionId(0) =
+    // the hand Evidence! play; there is no in-play trigger).
+    let mut resolver = ScriptedResolver::new();
+    resolver.commit_cards(&[]).pick_single(OptionId(0));
+    let result = drive(state, fight_action(inv_id, enemy_id), resolver);
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::CardPlayed { investigator, code } if *investigator == inv_id && code.as_str() == EVIDENCE
+    );
+    assert_event!(
+        result.events,
+        Event::CluePlaced { investigator, count: 1 } if *investigator == inv_id
+    );
+    assert_event!(
+        result.events,
+        Event::CardDiscarded { investigator, code, from: game_core::state::Zone::Hand }
+            if *investigator == inv_id && code.as_str() == EVIDENCE
+    );
+    assert_event!(
+        result.events,
+        Event::WindowClosed {
+            kind: WindowKind::AfterEnemyDefeated { enemy: e, .. },
+        } if *e == enemy_id
+    );
+
+    // 1 clue moved from the Study to the investigator; Evidence! is in discard.
+    assert_eq!(result.state.locations[&loc_id].clues, 1);
+    assert_eq!(result.state.investigators[&inv_id].clues, 1);
+    let inv = &result.state.investigators[&inv_id];
+    assert!(!inv.hand.iter().any(|c| c.as_str() == EVIDENCE));
+    assert!(inv.discard.iter().any(|c| c.as_str() == EVIDENCE));
+}
+```
+(Import `game_core::state::Zone` if the `from:` matcher needs it — add to the `use game_core::state::{…}` group.)
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p cards --test evidence picking_evidence_plays_it_and_discovers_a_clue`
+Expected: FAIL — `OptionId(0)` routes to `fire_pending_trigger(0)`, but `pending_triggers` is empty, so it rejects out-of-bounds (no in-play trigger). The hand play isn't wired.
+
+- [ ] **Step 3: Split the id in `resume_reaction_window` and add the play routine**
+
+In `resume_reaction_window`, replace the `PickSingle` arm with id-splitting against the active frame's `pending_triggers.len()`:
+```rust
+        InputResponse::PickSingle(OptionId(i)) => {
+            let window_idx = cx
+                .state
+                .top_reaction_window_index()
+                .expect("resume_reaction_window: caller checked is_some");
+            let trigger_count = u32::try_from(
+                cx.state.continuations[window_idx]
+                    .as_resolution()
+                    .expect("top_reaction_window_index points at a Resolution frame")
+                    .pending_triggers
+                    .len(),
+            )
+            .expect("pending_triggers length fits in u32");
+            if *i < trigger_count {
+                fire_pending_trigger(cx, *i)
+            } else {
+                play_fast_event_in_window(cx, window_idx, (*i - trigger_count) as usize)
+            }
+        }
+```
+
+Add the play routine (mirrors `fire_pending_trigger`'s snapshot-then-apply shape and `play_card`'s `pending_played_event` discard; charges no resource cost, matching `play_card`):
+```rust
+/// Play the `fast_play_idx`-th hand Fast-event in the resolution frame at
+/// `window_idx`: emit `CardPlayed`, stash the event in `pending_played_event`
+/// (RR Appendix I step 3 — leaves hand at play-start), run the matched
+/// ability's effect, then advance the run (close → the apply loop flushes the
+/// event to discard on completion, RR Appendix I step 4). Mirrors the
+/// suspending-event discard path Dynamite Blast 01024 already uses.
+fn play_fast_event_in_window(
+    cx: &mut Cx,
+    window_idx: usize,
+    fast_play_idx: usize,
+) -> EngineOutcome {
+    // Snapshot + remove the candidate before resolving, so a suspending
+    // effect's resume drives the remaining options, not this one again.
+    let candidate = {
+        let frame = cx.state.continuations[window_idx]
+            .as_resolution_mut()
+            .expect("play_fast_event_in_window: window_idx is a Resolution frame");
+        if fast_play_idx >= frame.fast_plays.len() {
+            return EngineOutcome::Rejected {
+                reason: format!(
+                    "ResolveInput: PickSingle hand-play index {fast_play_idx} out of bounds \
+                     (fast_plays size {})",
+                    frame.fast_plays.len(),
+                )
+                .into(),
+            };
+        }
+        frame.fast_plays.remove(fast_play_idx)
+    };
+
+    // Find the event in the controller's hand by code (first match — copies
+    // are fungible; this avoids stale hand indices after a prior play).
+    let controller = candidate.controller;
+    let hand_idx = cx
+        .state
+        .investigators
+        .get(&controller)
+        .and_then(|inv| inv.hand.iter().position(|c| *c == candidate.code))
+        .unwrap_or_else(|| {
+            unreachable!(
+                "play_fast_event_in_window: Evidence-style candidate {candidate:?} vanished \
+                 from {controller:?}'s hand between scan and play",
+            )
+        });
+
+    cx.events.push(Event::CardPlayed {
+        investigator: controller,
+        code: candidate.code.clone(),
+    });
+    let card = cx
+        .state
+        .investigators
+        .get_mut(&controller)
+        .expect("controller exists (checked above)")
+        .hand
+        .remove(hand_idx);
+    cx.state.pending_played_event = Some((controller, card));
+
+    // Run the matched OnEvent ability's effect under the playing investigator.
+    let reg = card_registry::current().unwrap_or_else(|| {
+        unreachable!("play_fast_event_in_window: registry installed at scan time is now missing")
+    });
+    let abilities = (reg.abilities_for)(&candidate.code).unwrap_or_else(|| {
+        unreachable!("play_fast_event_in_window: registry lost abilities for {:?}", candidate.code)
+    });
+    let effect = abilities
+        .get(usize::from(candidate.ability_index))
+        .expect("ability_index validated at scan time")
+        .effect
+        .clone();
+    let eval_ctx = EvalContext::for_controller(controller);
+
+    match apply_effect(cx, &effect, eval_ctx) {
+        EngineOutcome::Rejected { reason } => unreachable!(
+            "Fast-event play: effect for {:?} rejected unexpectedly: {reason}",
+            candidate.code,
+        ),
+        suspended @ EngineOutcome::AwaitingInput { .. } => suspended,
+        EngineOutcome::Done => advance_resolution(cx, window_idx),
+    }
+}
+```
+Add any missing imports (`EvalContext`, `apply_effect` — both already used elsewhere in this file).
+
+- [ ] **Step 4: Run the play test to verify it passes**
+
+Run: `cargo test -p cards --test evidence picking_evidence_plays_it_and_discovers_a_clue`
+Expected: PASS — Evidence! plays, 1 clue discovered, event discarded, window closed.
+
+- [ ] **Step 5: Add the both-sources test**
+
+In `crates/cards/tests/evidence.rs`, add a fixture variant that ALSO puts Roland 01001 in play (so the window offers two options: his in-play trigger at `OptionId(0)` and the hand Evidence! at `OptionId(1)`), then pick the Evidence! option:
+```rust
+#[test]
+fn window_offers_both_in_play_reaction_and_hand_evidence() {
+    use game_core::state::{CardInPlay, CardInstanceId};
+    install_real_registry();
+    let inv_id = InvestigatorId(1);
+    let enemy_id = EnemyId(100);
+    let loc_id = LocationId(10);
+
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(loc_id);
+    inv.skills.combat = 4;
+    inv.hand.push(CardCode::new(EVIDENCE));
+    // Roland's investigator card in play → his after-defeat reaction also matches.
+    inv.cards_in_play
+        .push(CardInPlay::enter_play(CardCode::new("01001"), CardInstanceId(1)));
+
+    let mut enemy = test_enemy(100, "Mock Ghoul");
+    enemy.fight = 1;
+    enemy.max_health = 1;
+    enemy.damage = 0;
+    enemy.engaged_with = Some(inv_id);
+
+    let mut loc = test_location(10, "Study");
+    loc.clues = 2;
+
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_round(0)
+        .with_active_investigator(inv_id)
+        .with_turn_order([inv_id])
+        .with_investigator(inv)
+        .with_enemy(enemy)
+        .with_location(loc)
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default())
+        .build();
+
+    // Two options: OptionId(0) = Roland's in-play reaction, OptionId(1) =
+    // hand Evidence!. Pick the hand play, then skip the remaining reaction.
+    let mut resolver = ScriptedResolver::new();
+    resolver.commit_cards(&[]).pick_single(OptionId(1)).skip();
+    let result = drive(state, fight_action(inv_id, enemy_id), resolver);
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(
+        result.events,
+        Event::CardPlayed { investigator, code } if *investigator == inv_id && code.as_str() == EVIDENCE
+    );
+    // Evidence! discovered its clue; Roland's reaction was skipped.
+    assert_event!(result.events, Event::CluePlaced { investigator, count: 1 } if *investigator == inv_id);
+    assert_eq!(result.state.investigators[&inv_id].clues, 1);
+}
+```
+
+- [ ] **Step 6: Run the play tests + workspace suite**
+
+Run: `cargo test -p cards --test evidence`
+Expected: PASS (all three).
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "engine: play a picked hand Fast-event in a reaction window
+
+A PickSingle id past the in-play triggers routes to play_fast_event_in_window:
+emit CardPlayed, run the matched ability's effect, discard via
+pending_played_event. Closes Evidence! 01022 (#304) and the Axis C
+reaction-event-play machinery (#335).
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Full gauntlet, PR, and phase-doc update
+
+**Files:**
+- Modify: `docs/phases/phase-7-the-gathering.md` (final commit, after CI green)
+
+- [ ] **Step 1: Run the complete CI gauntlet locally**
+
+```bash
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+Expected: all green. Fix any clippy/doc/fmt issues with follow-up edits (e.g. intra-doc links for new items; `cargo fmt` to format).
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+git push -u origin engine/axis-c-reaction-event-play
+gh pr create --fill
+```
+PR body: summarise the contract migration + the hand-event option + Evidence!; note the scope boundary (framework `open_fast_window` untouched; Fast assets/abilities not offered; Axis D deferred). Include `Closes #335` and `Closes #304`. End the body with the Claude Code attribution line.
+
+- [ ] **Step 3: Watch CI**
+
+```bash
+gh pr checks <PR#> --watch
+```
+Fix failures with follow-up commits to the same branch (no force-push).
+
+- [ ] **Step 4: Update the phase doc as the FINAL commit (only once CI is green)**
+
+In `docs/phases/phase-7-the-gathering.md`, in the "Future slices" → Axis C area / the Group-C breakdown:
+- Mark Axis C (#335) and Evidence! (#304) shipped (`✅ PR #<n>`).
+- Add a **Decisions made** entry capturing only what a future PR-author would choose differently without it. Candidates (keep to the load-bearing ones):
+  - "A Fast reaction event is its in-play-reaction twin sourced from hand; the play-timing predicate is the existing `OnEvent`/`trigger_matches` match, not a new field (RR p.11). Evidence! reuses Roland 01001's declaration minus the usage limit."
+  - "Reaction/forced windows resolve via `PickSingle(OptionId)`; options = `{in-play triggers} ∪ {matching hand Fast-events}`. The `PickIndex`-while-paused reaction-window path is retired (variant kept for other callers). A window opens when *either* source matches."
+  - "Scope boundary: the framework `open_fast_window` non-paused Fast-play path and Fast-asset/Fast-ability window options are deferred — no Slice-1 card needs them. Dodge 01023 still needs Axis D (cancellation, #336)."
+- Remove any now-settled open question this PR closes.
+
+```bash
+git add docs/phases/phase-7-the-gathering.md
+git commit -m "docs: phase-7 — Axis C reaction-event-play + Evidence! shipped
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+git push
+```
+
+- [ ] **Step 5: Merge only after explicit user approval**
+
+```bash
+gh pr merge <PR#> --squash --delete-branch
+```
+Then confirm #335 / #304 auto-closed and `git checkout main && git pull`.
+
+---
+
+## Notes for the implementer
+
+- **Why no new predicate language:** Evidence! and Roland 01001 compile to the same `OnEvent { EnemyDefeated { by_controller: true, code: None }, After, Reaction }` + `discover_clue(YourLocation, 1)`. The only difference is the source zone; the engine already matches that pattern via `trigger_matches`.
+- **Why `pending_played_event` (not immediate discard):** Evidence!'s `DiscoverClue` can itself suspend (a Cover-Up-style `WouldDiscoverClues` interrupt), so the event must discard on *completion*, not at play-start. The single-slot `pending_played_event` + the apply loop's flush-on-`Done` is the existing mechanism (Dynamite Blast 01024).
+- **Why find-by-code in `play_fast_event_in_window` (not a stored hand index):** playing one event shifts later hand indices; resolving the card by code keeps a second queued play (exotic; two Evidence! copies) correct without index bookkeeping.
+- **Borrow discipline:** mirror `fire_pending_trigger` — snapshot/remove from the frame first, then mutate `state`/run `apply_effect`; `apply_effect` pushes no continuations, so `window_idx` stays valid across it.
+- **Registry-dependent behavior is integration-tested** in `crates/cards/tests/evidence.rs` (own process → `install` is safe); pure logic (`trigger_matches`, frame helpers) is unit-tested in-crate.
+```

--- a/docs/superpowers/specs/2026-06-18-phase-7-axis-c-reaction-event-play-design.md
+++ b/docs/superpowers/specs/2026-06-18-phase-7-axis-c-reaction-event-play-design.md
@@ -1,0 +1,251 @@
+# Phase 7 — Axis C: reaction-event-play (Evidence! 01022)
+
+**Status:** design approved 2026-06-18, ready for implementation plan.
+**Issues:** #335 (Axis C tracker), #304 (Evidence! 01022).
+**Umbrella:** [trigger-dispatch rework](2026-06-16-trigger-dispatch-rework-umbrella-design.md) §4 Axis C.
+**Predecessors shipped:** Axis B (#212/#213, `emit_event` + the `Continuation::Resolution`
+stack) and Axis A (#334/#349, `PickSingle(OptionId)` + `ChoiceOption` + `InputRequest::choice`).
+
+## Why this exists
+
+The choice-cluster completion sub-slice closed every Gathering card reachable on
+Axes A+B. The remaining carved cards need new dispatch machinery. **Axis C** is
+the smallest of those: it admits a **Fast event played from hand** as an option
+inside a reaction window. It unblocks **Evidence! 01022** (this spec's only card)
+and is a hard prerequisite for Dodge 01023 (Axis D).
+
+Evidence! 01022, verbatim from `data/arkhamdb-snapshot/pack/core/core.json`:
+
+> Fast. Play after you defeat an enemy.
+> Discover 1 clue at your location.
+
+(`type_code: event`, `traits: Insight.`, `cost: 1`.)
+
+## The core insight: Evidence! is Roland's reaction, sourced from hand
+
+Roland Banks 01001's investigator reaction (`crates/cards/src/impls/roland_banks.rs`)
+is, verbatim: "After you defeat an enemy: Discover 1 clue at your location."
+It compiles to:
+
+```rust
+reaction_on_event(
+    EventPattern::EnemyDefeated { by_controller: true, code: None },
+    EventTiming::After,
+    discover_clue(LocationTarget::YourLocation, 1),
+)
+```
+
+Evidence!'s play instruction ("Play after you defeat an enemy") and effect
+("Discover 1 clue at your location") are the **identical declaration** — Evidence!
+merely omits Roland's once-per-round `UsageLimit`. Per RR p.11, a Fast event with
+a when/after instruction plays "as if the described timing point were a triggering
+condition." So Evidence! *is* the same `OnEvent` reaction; the only difference is
+the **source zone**: Roland's ability rides a card in play (scanned today by
+`scan_pending_triggers` over `controlled_card_instances()`); Evidence!'s rides an
+Event in hand and resolves by **playing the card**.
+
+**Consequence: no new play-timing predicate language.** The predicate is the
+existing `trigger_matches(pattern, kind)` in
+`crates/game-core/src/engine/dispatch/reaction_windows.rs`. Axis C extends *where*
+the engine scans for matches (hand, not just play) and *how* a hand match resolves
+(play the event vs. fire an in-play ability).
+
+## Current architecture (what the rework changes)
+
+A reaction window today (`reaction_windows.rs`):
+
+1. `emit_event` (`dispatch/emit.rs`) calls `queue_reaction_window(cx, kind)` for a
+   reaction-capable `TimingEvent` (e.g. `EnemyDefeated` → `WindowKind::AfterEnemyDefeated`).
+2. `queue_reaction_window` runs `scan_pending_triggers` over every investigator's
+   in-play cards. **If the result is empty, it returns without opening a window**
+   (`reaction_windows.rs:52`). Otherwise it pushes a `Continuation::Resolution`
+   frame holding the matched in-play candidates and `fast_actors: FastActorScope::Any`.
+3. `open_queued_reaction_window` emits `AwaitingInput` with a **prompt-only**
+   `InputRequest::prompt(...)` (empty `options`), expecting `InputResponse::PickIndex(i)`
+   / `Skip`.
+4. `resume_reaction_window` accepts `PickIndex(i)` (fire in-play trigger `i` via
+   `fire_pending_trigger`) or `Skip`; **all other variants reject**.
+
+Two gaps for Evidence!:
+
+- **The window never opens.** If Evidence! is in hand but no in-play card reacts
+  (Roland not in play, or already used his limit), step 2 finds zero in-play
+  candidates and skips the window — Evidence! is never offered.
+- **No way to play it.** Even with the window open (Roland in play too), the
+  engine is paused; `apply` (`engine/mod.rs:100`) rejects every non-`ResolveInput`
+  action, so a parallel `PlayCard` is impossible, and `resume_reaction_window`
+  rejects everything but `PickIndex`/`Skip`. The Fast event play must arrive as a
+  **structured option** in the window's `ResolveInput` set.
+
+(Note: the framework `open_fast_window` path returns `Done` and does *not* pause —
+the active player plays Fast cards there via an ordinary `PlayCard`. That is a
+separate interaction model; see Scope boundary.)
+
+## The design
+
+### 1. Open the window when a hand Fast-event matches (not just an in-play trigger)
+
+`queue_reaction_window` gains a second source. After `scan_pending_triggers`
+(in-play matches), scan each **window-eligible** investigator's hand for Fast
+**Events** carrying an `OnEvent` ability whose `(pattern, timing, kind: Reaction)`
+matches the window's `WindowKind`/event, reusing `trigger_matches`. The window
+opens/suspends when **either** source is non-empty. The empty-bail at
+`reaction_windows.rs:52` becomes "bail only when *both* sources are empty."
+
+The hand scan is controller-scoped by the pattern itself: `EnemyDefeated {
+by_controller: true }` matches only the investigator credited with the defeat
+(the window's `by`), so Evidence! is offered to exactly that investigator. (Solo
+Slice-1: the active investigator. The scan order mirrors `scan_pending_triggers`:
+active investigator first, then turn order.)
+
+### 2. Unified `OptionId` option list
+
+The window's offered options become the union, in a stable order:
+
+```
+options = [ in-play pending triggers ... ] ++ [ matching hand Fast-event plays ... ]
+```
+
+Each becomes a `ChoiceOption { id: OptionId(i), label }` (the Axis-A type in
+`engine/outcome.rs`). `OptionId(i)` is the index into the offered list (the
+existing Axis-A convention). The window frame must record enough to map each
+`OptionId` back to its origin on resume — which in-play candidate, or which
+investigator + hand index. The exact frame representation (extend
+`ResolutionFrame`, or carry a parallel offered-options vector mirroring
+`ChoiceFrame.offered`) is settled in the plan against the borrow constraints;
+the contract is: **resume validates `OptionId` membership against the offered set
+and dispatches by origin.**
+
+### 3. Resume contract migration: `PickIndex` → `PickSingle(OptionId)`
+
+- `open_queued_reaction_window` emits `InputRequest::choice(prompt, options)`
+  instead of `InputRequest::prompt(...)`.
+- `resume_reaction_window` accepts `InputResponse::PickSingle(OptionId)` instead
+  of `PickIndex(u32)`:
+  - id resolves to an **in-play trigger** → existing `fire_pending_trigger` (by its
+    index within the trigger sub-list);
+  - id resolves to a **hand Fast-event** → **play it** (see §4);
+  - out-of-membership id → reject, window stays open (mirrors today's
+    out-of-bounds `PickIndex` behavior).
+- `InputResponse::Skip` is unchanged (close the window; still rejected while a
+  forced run is open).
+
+This retires the legacy `PickIndex`-while-paused reaction-window contract in
+favor of the structured single-selection one, narrowing the input-contract split
+flagged in #347/#348. `PickIndex` itself is not deleted here (other callers /
+wire-format stability); only the reaction-window path moves off it.
+
+### 4. Resolving a hand Fast-event option = playing the card
+
+A picked hand-event option routes through the existing **play path** rather than a
+parallel implementation. Reuse `play_card`'s body
+(`dispatch/cards.rs`): emit `Event::CardPlayed`, stash the event in
+`pending_played_event` (RR Appendix I step 3 — leaves hand at play-start), run the
+event's effect through the evaluator, and let the apply loop flush
+`pending_played_event` to discard on completion (RR Appendix I step 4 — the path
+Dynamite Blast 01024 already uses for a suspending event).
+
+The effect run is the **matched `OnEvent` ability's effect** (Evidence!'s
+`discover_clue(YourLocation, 1)`). Evidence! has no separate `Trigger::OnPlay`
+ability; its sole ability is the reaction. The plan decides whether the
+window-play path runs "the matched reaction ability's effect" specifically or
+"all of the event's play-resolved abilities" — for Evidence! (one ability) the two
+coincide; the former is the precise reading of "the timing point is the triggering
+condition" and is preferred unless reuse of `play_card`'s loop makes the latter
+cleaner. `EvalContext` for the effect binds `controller = the playing investigator`
+(the defeat's `by`), so `LocationTarget::YourLocation` resolves to that
+investigator's location.
+
+### 5. `fast_actors` scope
+
+`FastActorScope::Any` (and `WindowBinding.fast_actors`) stays as the coarse
+actor-eligibility gate used by `check_play_card` / `check_activate_ability`. The
+umbrella's "tighten the `Any` blanket" concern is satisfied structurally: a Fast
+event is now **offered** only when its `OnEvent` pattern matches the window (a
+per-card, controller-scoped predicate), so the blanket is no longer the thing
+deciding whether Evidence! is playable here. We document this and do not remove
+`fast_actors` (it remains the multiplayer-relevant "who may act" gate).
+
+## Scope boundary
+
+- **Framework `open_fast_window` windows are out of scope.** They return `Done`
+  (engine not paused) and admit Fast plays via an ordinary non-paused `PlayCard`
+  (`check_play_card`'s permissive-window branch) — a different interaction model
+  from the paused, structured after-event reaction window. Axis C migrates only
+  the after-event reaction-window resume path that Evidence!/Dodge need. Unifying
+  the framework fast-window path onto the same `OptionId` surface is a follow-up,
+  not required by any Slice-1 card. (Filed as a follow-up at plan time.)
+- **Fast assets / Fast 0-action abilities as window options are out of scope.**
+  Evidence! is a Fast *event*; the hand scan is Event-only. `any_fast_play_eligible`
+  already covers the broader set for the framework path; widening the structured
+  option list to assets/abilities waits for a card that needs it.
+- **Axis D (cancellation) is out of scope.** Dodge 01023 needs both Axis C and a
+  Before-timing cancel/replacement signal (#336); only the reaction-event-play
+  half lands here.
+- **No new DSL primitive.** Evidence! reuses `EventPattern::EnemyDefeated`,
+  `discover_clue`, `LocationTarget::YourLocation`, and `reaction_on_event` verbatim
+  from the existing surface.
+
+## Evidence! 01022 card
+
+`crates/cards/src/impls/evidence_01022.rs`:
+
+```rust
+pub const CODE: &str = "01022";
+
+pub fn abilities() -> Vec<Ability> {
+    vec![reaction_on_event(
+        EventPattern::EnemyDefeated { by_controller: true, code: None },
+        EventTiming::After,
+        discover_clue(LocationTarget::YourLocation, 1),
+    )]
+}
+```
+
+(No `UsageLimit` — Evidence! has no per-round limit; it is a one-shot event
+discarded on play.) Wire into the registry (`impls::abilities_for`) and the module
+list. The metadata (Fast, cost 1, Insight, event) comes from the generated corpus —
+not hand-typed.
+
+## Testing
+
+1. **Card test** (`evidence_01022.rs`): `abilities()` is one `OnEvent` reaction with
+   the `EnemyDefeated { by_controller: true, code: None }` / `After` / `Reaction`
+   trigger and `discover_clue(YourLocation, 1)` effect; registry dispatches `CODE`.
+2. **Engine unit tests** (`reaction_windows.rs`):
+   - The after-defeat window **opens** when a matching hand Fast-event exists and
+     *no* in-play trigger does (the empty-in-play-but-hand-match case).
+   - The offered option list is the union (in-play triggers ++ hand events) with
+     stable `OptionId`s; `PickSingle` of an out-of-membership id rejects and leaves
+     the window open.
+   - `PickSingle` of the hand-event option plays it (asserts `CardPlayed`,
+     the effect's events, `CardDiscarded { from: Hand }`), then closes the window.
+   - The non-credited investigator is **not** offered Evidence! (pattern scoping).
+3. **Integration test** (`crates/cards/tests/`, real registry): solo Roland (or a
+   fixture with Evidence! in hand) defeats an enemy → the after-defeat window
+   offers Evidence! → `PickSingle` it → 1 clue discovered at the location, Evidence!
+   in discard, window closed. Cover the both-sources case (Roland in play *and*
+   Evidence! in hand → two options).
+4. **Regression:** existing reaction-window tests (Roland 01001, Dr. Milan 01033,
+   Guard Dog soak) migrate from `PickIndex` to `PickSingle(OptionId)` and stay green.
+
+## Decisions made (to fold into the phase doc when the PR lands)
+
+- **Evidence!'s play-timing predicate is the existing `OnEvent`/`trigger_matches`
+  match, not a new "play window" field — a Fast reaction event is its in-play-
+  reaction twin sourced from hand (RR p.11).** Evidence! reuses Roland 01001's exact
+  declaration minus the usage limit.
+- **Reaction windows move from the prompt-only `PickIndex` contract to the
+  structured `PickSingle(OptionId)` contract (Axis-A's `ChoiceOption` surface);
+  options are `{in-play triggers} ∪ {matching hand Fast-events}`.** A hand-event
+  option resolves through the existing `play_card` path (`pending_played_event`
+  discard). The legacy `PickIndex` reaction-window path is retired; `PickIndex` the
+  variant survives for other callers.
+- **A reaction window opens when *either* an in-play trigger or a hand Fast-event
+  matches** — `queue_reaction_window`'s empty-bail now requires both sources empty.
+- **`fast_actors` is not tightened/removed; offering is pattern-gated instead.**
+  The blanket `Any` no longer decides Fast-event playability in a window.
+- **Framework `open_fast_window` fast-play unification is deferred** (separate
+  non-paused `PlayCard` model; no Slice-1 card needs it).
+</content>
+</invoke>

--- a/docs/superpowers/specs/2026-06-18-phase-7-axis-c-reaction-event-play-design.md
+++ b/docs/superpowers/specs/2026-06-18-phase-7-axis-c-reaction-event-play-design.md
@@ -175,6 +175,20 @@ per-card, controller-scoped predicate), so the blanket is no longer the thing
 deciding whether Evidence! is playable here. We document this and do not remove
 `fast_actors` (it remains the multiplayer-relevant "who may act" gate).
 
+### 6. Reaction-event play gate (the enforcement half of #304's acceptance)
+
+Offering Evidence! in its window is only half the contract — #304 also requires
+it to be **illegal outside** that window. A reaction event is window-only: its
+play instruction *is* a triggering condition (modeled as the `OnEvent` ability),
+and RR p.11 says such an event "may be played any time its play instructions
+specify" — i.e. only then. So `check_play_card` rejects a `PlayCard` of an
+event whose abilities contain any `Trigger::OnEvent` (the standalone-action
+path). The window play (`play_fast_event`) bypasses `check_play_card`, so the
+reaction route is unaffected. Without this gate `play_card` would run only the
+event's (absent) `OnPlay` abilities and silently discard Evidence! for no
+effect — a `no-silent-approximation` violation. The gate generalizes to Dodge
+01023 (also `OnEvent`, also window-only).
+
 ## Scope boundary
 
 - **Framework `open_fast_window` windows are out of scope.** They return `Done`
@@ -245,11 +259,19 @@ not hand-typed.
    offers Evidence! → `PickSingle` it → 1 clue discovered at the location, Evidence!
    in discard, window closed. Cover the both-sources case (Roland in play *and*
    Evidence! in hand → two options).
-4. **Regression:** existing reaction-window tests (Roland 01001, Dr. Milan 01033,
+4. **Play-gate test** (`crates/cards/tests/evidence.rs`): a `PlayCard` of Evidence!
+   as a standalone action (no defeat window open) **rejects** and leaves state
+   unchanged (still in hand, no clue) — #304's "illegal outside its window."
+5. **Regression:** existing reaction-window tests (Roland 01001, Dr. Milan 01033,
    Guard Dog soak) migrate from `PickIndex` to `PickSingle(OptionId)` and stay green.
 
 ## Decisions made (to fold into the phase doc when the PR lands)
 
+- **A reaction event is window-only: `check_play_card` rejects a `PlayCard` of an
+  event with any `Trigger::OnEvent` ability** (the standalone-action path), so
+  Evidence! is illegal outside its window (#304 acceptance) and can't silently
+  fizzle through `play_card`'s `OnPlay`-only loop. The window play (`play_fast_event`)
+  bypasses the gate. Generalizes to Dodge.
 - **Evidence!'s play-timing predicate is the existing `OnEvent`/`trigger_matches`
   match, not a new "play window" field — a Fast reaction event is its in-play-
   reaction twin sourced from hand (RR p.11).** Evidence! reuses Roland 01001's exact

--- a/docs/superpowers/specs/2026-06-18-phase-7-axis-c-reaction-event-play-design.md
+++ b/docs/superpowers/specs/2026-06-18-phase-7-axis-c-reaction-event-play-design.md
@@ -98,23 +98,30 @@ by_controller: true }` matches only the investigator credited with the defeat
 Slice-1: the active investigator. The scan order mirrors `scan_pending_triggers`:
 active investigator first, then turn order.)
 
-### 2. Unified `OptionId` option list
+### 2. One candidate list, an origin discriminant (not a parallel vec)
 
-The window's offered options become the union, in a stable order:
+A hand Fast-event play is just another candidate in the window's existing
+`pending_triggers: Vec<ResolutionCandidate>` — appended after the in-play
+triggers, in a stable order:
 
 ```
-options = [ in-play pending triggers ... ] ++ [ matching hand Fast-event plays ... ]
+pending_triggers = [ in-play triggers ... ] ++ [ matching hand Fast-event plays ... ]
 ```
 
-Each becomes a `ChoiceOption { id: OptionId(i), label }` (the Axis-A type in
-`engine/outcome.rs`). `OptionId(i)` is the index into the offered list (the
-existing Axis-A convention). The window frame must record enough to map each
-`OptionId` back to its origin on resume — which in-play candidate, or which
-investigator + hand index. The exact frame representation (extend
-`ResolutionFrame`, or carry a parallel offered-options vector mirroring
-`ChoiceFrame.offered`) is settled in the plan against the borrow constraints;
-the contract is: **resume validates `OptionId` membership against the offered set
-and dispatches by origin.**
+`ResolutionCandidate` already carries `code` + `controller` + `ability_index`;
+the only thing that differs is *how it resolves*. So `source: Option<CardInstanceId>`
+(which distinguished an in-play instance from a `None` scenario board card)
+becomes a three-way `CandidateSource { InPlay(CardInstanceId), Board, Hand }`.
+A bare `Option` can't express "from hand" — `None` already means "board card"
+— so the enum is what lets one list carry both without a parallel vector or a
+near-duplicate struct.
+
+`build_resolution_options` maps the list to `ChoiceOption { id: OptionId(i), label }`
+(the Axis-A type), `OptionId(i)` = index into `pending_triggers`. Resume is
+then just `fire_pending_trigger(i)` — no id arithmetic — and `fire_pending_trigger`
+dispatches on `candidate.source`: `Hand` ⇒ play the event (§4); `InPlay`/`Board`
+⇒ fire the ability (the existing path). The label distinguishes the two
+(`"Play X from hand"` vs `"Resolve reaction: X"`).
 
 ### 3. Resume contract migration: `PickIndex` → `PickSingle(OptionId)`
 
@@ -137,23 +144,25 @@ wire-format stability); only the reaction-window path moves off it.
 
 ### 4. Resolving a hand Fast-event option = playing the card
 
-A picked hand-event option routes through the existing **play path** rather than a
-parallel implementation. Reuse `play_card`'s body
-(`dispatch/cards.rs`): emit `Event::CardPlayed`, stash the event in
-`pending_played_event` (RR Appendix I step 3 — leaves hand at play-start), run the
-event's effect through the evaluator, and let the apply loop flush
-`pending_played_event` to discard on completion (RR Appendix I step 4 — the path
-Dynamite Blast 01024 already uses for a suspending event).
+A `Hand` candidate routes through the play path, sharing `play_card`'s
+mechanics. The duplicated "commence playing an event" steps — emit
+`Event::CardPlayed`, remove the card from hand, stash it in
+`pending_played_event` (RR Appendix I step 3 — leaves hand at play-start) — are
+extracted into a `begin_event_play(cx, investigator, hand_index)` helper in
+`dispatch/cards.rs`, called by both `play_card`'s event branch and the
+reaction-window play path. The apply loop then flushes `pending_played_event`
+to discard on completion (RR Appendix I step 4 — the path Dynamite Blast 01024
+already uses for a suspending event).
 
-The effect run is the **matched `OnEvent` ability's effect** (Evidence!'s
-`discover_clue(YourLocation, 1)`). Evidence! has no separate `Trigger::OnPlay`
-ability; its sole ability is the reaction. The plan decides whether the
-window-play path runs "the matched reaction ability's effect" specifically or
-"all of the event's play-resolved abilities" — for Evidence! (one ability) the two
-coincide; the former is the precise reading of "the timing point is the triggering
-condition" and is preferred unless reuse of `play_card`'s loop makes the latter
-cleaner. `EvalContext` for the effect binds `controller = the playing investigator`
-(the defeat's `by`), so `LocationTarget::YourLocation` resolves to that
+What stays caller-side is the **effect that runs**, because that is the genuine
+difference: `play_card` runs the event's `Trigger::OnPlay` abilities; the
+reaction path runs the **matched `OnEvent` ability's effect** (Evidence!'s
+`discover_clue(YourLocation, 1)`). Evidence! has no `OnPlay` ability — its sole
+ability is the reaction whose pattern gated the play — so running `OnPlay`
+abilities (as `play_card` does) would discover no clue; running the matched
+`OnEvent` effect is the precise reading of "the timing point is the triggering
+condition." `EvalContext` binds `controller = the playing investigator` (the
+defeat's `by`), so `LocationTarget::YourLocation` resolves to that
 investigator's location.
 
 ### 5. `fast_actors` scope
@@ -175,10 +184,20 @@ deciding whether Evidence! is playable here. We document this and do not remove
   the after-event reaction-window resume path that Evidence!/Dodge need. Unifying
   the framework fast-window path onto the same `OptionId` surface is a follow-up,
   not required by any Slice-1 card. (Filed as a follow-up at plan time.)
-- **Fast assets / Fast 0-action abilities as window options are out of scope.**
-  Evidence! is a Fast *event*; the hand scan is Event-only. `any_fast_play_eligible`
-  already covers the broader set for the framework path; widening the structured
-  option list to assets/abilities waits for a card that needs it.
+- **Fast assets / Fast 0-action abilities are correctly *not* offered here —
+  this is rules-precise, not a deferral.** RR p.11 splits the two by timing
+  surface: a *Fast event* "may be played any time its play instructions
+  specify… as if the described timing point were a triggering condition" — so
+  Evidence! reacts to the *defeat triggering condition* (this window). A *Fast
+  asset* "may be played during any **player window** on his or her turn," and
+  RR p.22 defines player windows as the framework windows in the timing chart
+  ("The red boxes are player windows"). An after-defeat reaction window is
+  *not* one of those framework player windows, so a Fast asset is not playable
+  in reaction to a defeat; it is played in the surrounding framework player
+  window, which the engine models separately as `WindowKind::PlayerWindow` via
+  `open_fast_window`. The two `WindowKind` families already mirror this split,
+  so the hand scan being Event-only is the rules-correct behavior. (A Fast
+  asset offered in the after-defeat window would be a rules *bug*.)
 - **Axis D (cancellation) is out of scope.** Dodge 01023 needs both Axis C and a
   Before-timing cancel/replacement signal (#336); only the reaction-event-play
   half lands here.
@@ -236,16 +255,28 @@ not hand-typed.
   reaction twin sourced from hand (RR p.11).** Evidence! reuses Roland 01001's exact
   declaration minus the usage limit.
 - **Reaction windows move from the prompt-only `PickIndex` contract to the
-  structured `PickSingle(OptionId)` contract (Axis-A's `ChoiceOption` surface);
-  options are `{in-play triggers} ∪ {matching hand Fast-events}`.** A hand-event
-  option resolves through the existing `play_card` path (`pending_played_event`
-  discard). The legacy `PickIndex` reaction-window path is retired; `PickIndex` the
-  variant survives for other callers.
+  structured `PickSingle(OptionId)` contract (Axis-A's `ChoiceOption` surface).**
+  The legacy `PickIndex` reaction-window path is retired; `PickIndex` the variant
+  survives for other callers.
+- **Hand Fast-events ride the *one* `pending_triggers` list as `ResolutionCandidate`s,
+  distinguished by `source: CandidateSource { InPlay(id), Board, Hand }`** (replacing
+  `source: Option<CardInstanceId>`, where `None` already meant "board card" and so
+  could not also mean "from hand"). `fire_pending_trigger` dispatches on the source:
+  `Hand` ⇒ play the event, else fire the ability. No parallel `fast_plays` vec, no
+  second candidate struct, no `OptionId` arithmetic in resume.
+- **A hand event is played via a shared `begin_event_play` helper** (CardPlayed +
+  leave hand + stash `pending_played_event`), extracted from `play_card` and reused
+  by the reaction path; the matched `OnEvent` effect runs caller-side (the genuine
+  difference from `play_card`'s `OnPlay` loop).
 - **A reaction window opens when *either* an in-play trigger or a hand Fast-event
-  matches** — `queue_reaction_window`'s empty-bail now requires both sources empty.
+  matches** — `queue_reaction_window` appends the hand scan to `pending_triggers`
+  and bails only when the combined list is empty.
 - **`fast_actors` is not tightened/removed; offering is pattern-gated instead.**
   The blanket `Any` no longer decides Fast-event playability in a window.
 - **Framework `open_fast_window` fast-play unification is deferred** (separate
   non-paused `PlayCard` model; no Slice-1 card needs it).
-</content>
-</invoke>
+- **Fast assets/abilities are *not* offered in the reaction window by rules, not
+  scope** — Fast events play in reaction to a triggering condition (RR p.11);
+  Fast assets play in framework player windows (RR p.22), which the engine models
+  as `WindowKind::PlayerWindow`/`open_fast_window`. Offering a Fast asset in the
+  after-defeat window would be a rules bug.


### PR DESCRIPTION
## Summary

Axis C — **reaction-event-play**: a Fast event in hand (Evidence! 01022) is offered and played as an option inside the after-defeat reaction window. Closes the Axis-C machinery (#335) and Evidence! (#304).

Evidence! 01022 is Roland 01001's after-defeat reaction sourced from hand instead of from play — the identical `OnEvent { EnemyDefeated { by_controller: true }, After, Reaction }` + `discover_clue(YourLocation, 1)`, minus the usage limit. Per RR p.11 a Fast event with a when/after instruction plays "as if the described timing point were a triggering condition", so the play-timing predicate is the existing `trigger_matches` — no new predicate language.

## What changed

- **Contract migration:** reaction/forced windows resume via `PickSingle(OptionId)` (Axis-A's `ChoiceOption` surface) instead of the prompt-only `PickIndex`; all reaction/forced-window test call sites migrated. The `PickIndex` variant survives for other callers.
- **One candidate list:** hand Fast-events ride the existing `pending_triggers: Vec<ResolutionCandidate>`, distinguished by `source: CandidateSource { InPlay(id), Board, Hand }` (replacing `source: Option<CardInstanceId>`, where `None` already meant "board card"). `fire_pending_trigger` dispatches on source — no parallel vec, no second struct, no `OptionId` arithmetic.
- **Window opens** when *either* an in-play trigger or a matching hand Fast-event exists (`queue_reaction_window` appends the hand scan).
- **Play path reuse:** `begin_event_play` (CardPlayed + leave hand + stash `pending_played_event`) is shared by `play_card`'s event branch and the reaction-window play; the matched `OnEvent` effect runs caller-side.
- **Play gate (#304 acceptance):** `check_play_card` rejects a standalone `PlayCard` of any event with an `OnEvent` ability — a reaction event is window-only, so it can't silently fizzle through the `OnPlay`-only loop.
- **Shared constructor:** `EvalContext::for_controller_with_optional_source` collapses the `match source { Some => with_source, None => for_controller }` shape repeated at four dispatch sites.

## Scope boundary

- **Fast assets / 0-cost abilities are correctly *not* offered here** — RR p.11/p.22: Fast assets play in framework *player windows* (the timing-chart red boxes, modeled as `WindowKind::PlayerWindow`/`open_fast_window`), not in reaction to a triggering condition. Offering one in the after-defeat window would be a rules bug, not a missing feature.
- **Axis D (cancellation) deferred** — Dodge 01023 needs both Axis C and the Before-timing cancel/replacement signal (#336); only the reaction-event-play half lands here.
- No new DSL primitive.

## Testing

Per-card test, engine unit tests, and `crates/cards/tests/evidence.rs` integration tests: window opens for a hand match with no in-play reaction; `PickSingle` plays Evidence! (clue discovered, event discarded, window closed); both-sources case (Roland + Evidence! → two options); standalone-play rejection. Existing reaction/forced-window suites migrated to `PickSingle` and green. Full gauntlet (test/clippy/fmt/doc/wasm-build/wasm-clippy) passes locally.

Design: `docs/superpowers/specs/2026-06-18-phase-7-axis-c-reaction-event-play-design.md`.

Closes #335
Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)
