### PR TITLE
engine: Resource + Engage basic actions (+ Draw attack-of-opportunity fix)

### DIFF
--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -204,6 +204,28 @@ pub enum PlayerAction {
         /// investigator during the Investigation phase.
         investigator: InvestigatorId,
     },
+    /// Engage an enemy at the active investigator's location that the
+    /// investigator is not already engaged with (Rules Reference p.4).
+    /// Spends 1 action; the enemy becomes engaged with the investigator.
+    ///
+    /// Validate: Investigation phase, investigator is active and
+    /// `Status::Active`, `actions_remaining >= 1`, the enemy exists, is
+    /// at the investigator's `current_location`, and is not already
+    /// engaged with the investigator.
+    ///
+    /// Engage is NOT on the AoO-exempt list, so OTHER ready engaged
+    /// enemies make attacks of opportunity before the engagement
+    /// resolves (the target is not engaged at that point, so it does
+    /// not). The multiplayer "engage an enemy engaged with another
+    /// investigator" clause is latent (single `engaged_with` field).
+    Engage {
+        /// Investigator performing the action. Must be the active
+        /// investigator during the Investigation phase.
+        investigator: InvestigatorId,
+        /// The enemy to engage. Must be at the investigator's location
+        /// and not already engaged with the investigator.
+        enemy: EnemyId,
+    },
     /// Play a card from an investigator's hand. Spends no action
     /// point at this stage — play-cost gating (resource cost,
     /// action cost, "Fast" exemption) lives on the card and lands

--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -189,6 +189,21 @@ pub enum PlayerAction {
         /// investigator during the Investigation phase.
         investigator: InvestigatorId,
     },
+    /// Gain 1 resource (the basic "Resource" action, Rules Reference
+    /// Investigation step 2.2.1). Spends 1 action.
+    ///
+    /// Validate: Investigation phase, investigator is active and
+    /// `Status::Active`, `actions_remaining >= 1`.
+    ///
+    /// Resource is NOT on the AoO-exempt list (only Fight, Evade,
+    /// Parley, Resign are), so each ready engaged enemy makes an attack
+    /// of opportunity before the resource is gained; an AoO that
+    /// eliminates the investigator suppresses the gain.
+    Resource {
+        /// Investigator taking the action. Must be the active
+        /// investigator during the Investigation phase.
+        investigator: InvestigatorId,
+    },
     /// Play a card from an investigator's hand. Spends no action
     /// point at this stage — play-cost gating (resource cost,
     /// action cost, "Fast" exemption) lives on the card and lands

--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -195,9 +195,9 @@ pub enum PlayerAction {
     /// Validate: Investigation phase, investigator is active and
     /// `Status::Active`, `actions_remaining >= 1`.
     ///
-    /// Resource is NOT on the AoO-exempt list (only Fight, Evade,
+    /// Resource is NOT on the `AoO`-exempt list (only Fight, Evade,
     /// Parley, Resign are), so each ready engaged enemy makes an attack
-    /// of opportunity before the resource is gained; an AoO that
+    /// of opportunity before the resource is gained; an `AoO` that
     /// eliminates the investigator suppresses the gain.
     Resource {
         /// Investigator taking the action. Must be the active
@@ -213,7 +213,7 @@ pub enum PlayerAction {
     /// at the investigator's `current_location`, and is not already
     /// engaged with the investigator.
     ///
-    /// Engage is NOT on the AoO-exempt list, so OTHER ready engaged
+    /// Engage is NOT on the `AoO`-exempt list, so OTHER ready engaged
     /// enemies make attacks of opportunity before the engagement
     /// resolves (the target is not engaged at that point, so it does
     /// not). The multiplayer "engage an enemy engaged with another

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -216,6 +216,106 @@ pub(super) fn resource_action(cx: &mut Cx, investigator: InvestigatorId) -> Engi
     EngineOutcome::Done
 }
 
+/// Handler for [`PlayerAction::Engage`]. Engage an enemy at the
+/// investigator's location that they are not already engaged with
+/// (Rules Reference p.4) — it becomes engaged with the investigator.
+///
+/// Validate-first: Investigation phase, active + `Status::Active`,
+/// `actions_remaining >= 1`, enemy in state, enemy at the investigator's
+/// `current_location`, not already engaged with the investigator.
+/// Mutate-second: spend 1 action, fire attacks of opportunity (Engage is
+/// NOT AoO-exempt — the target is not engaged yet so it cannot AoO; only
+/// OTHER engaged ready enemies do), then — if the investigator survived —
+/// engage the enemy.
+pub(super) fn engage(
+    cx: &mut Cx,
+    investigator: InvestigatorId,
+    enemy_id: EnemyId,
+) -> EngineOutcome {
+    if cx.state.phase != Phase::Investigation {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Engage is only valid during the Investigation phase (was {:?})",
+                cx.state.phase
+            )
+            .into(),
+        };
+    }
+    if cx.state.active_investigator != Some(investigator) {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Engage: {investigator:?} is not the active investigator ({:?})",
+                cx.state.active_investigator,
+            )
+            .into(),
+        };
+    }
+    let inv = cx.state.investigators.get(&investigator).unwrap_or_else(|| {
+        unreachable!(
+            "Engage: active_investigator {investigator:?} is not in the investigators map; \
+             this is a state-corruption invariant violation"
+        )
+    });
+    if inv.status != Status::Active {
+        return EngineOutcome::Rejected {
+            reason: format!("Engage: {investigator:?} is not Active (status {:?})", inv.status)
+                .into(),
+        };
+    }
+    if inv.actions_remaining < 1 {
+        return EngineOutcome::Rejected {
+            reason: "Engage requires at least 1 action point".into(),
+        };
+    }
+    let inv_location = inv.current_location;
+    let Some(enemy) = cx.state.enemies.get(&enemy_id) else {
+        return EngineOutcome::Rejected {
+            reason: format!("Engage: enemy {enemy_id:?} is not in state").into(),
+        };
+    };
+    if enemy.engaged_with == Some(investigator) {
+        return EngineOutcome::Rejected {
+            reason: format!("Engage: {investigator:?} is already engaged with {enemy_id:?}").into(),
+        };
+    }
+    if enemy.current_location != inv_location {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Engage: enemy {enemy_id:?} (at {:?}) is not at {investigator:?}'s location ({:?})",
+                enemy.current_location, inv_location,
+            )
+            .into(),
+        };
+    }
+
+    // Mutate-second.
+    spend_one_action(cx, investigator);
+    super::combat::fire_attacks_of_opportunity(cx, investigator);
+
+    let inv_after = cx.state.investigators.get(&investigator).unwrap_or_else(|| {
+        unreachable!(
+            "Engage: investigator {investigator:?} disappeared between AoO and engagement; \
+             this is a state-corruption invariant violation"
+        )
+    });
+    if inv_after.status != Status::Active {
+        return EngineOutcome::Done;
+    }
+
+    let enemy_mut = cx.state.enemies.get_mut(&enemy_id).unwrap_or_else(|| {
+        unreachable!(
+            "Engage: enemy {enemy_id:?} disappeared between validation and engagement; \
+             this is a state-corruption invariant violation"
+        )
+    });
+    enemy_mut.engaged_with = Some(investigator);
+    cx.events.push(Event::EnemyEngaged {
+        enemy: enemy_id,
+        investigator,
+    });
+    EngineOutcome::Done
+}
+
 /// Handler for [`PlayerAction::Move`].
 ///
 /// Spends 1 action, then updates `current_location` to a connected

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -148,8 +148,8 @@ pub(super) fn investigate(cx: &mut Cx, investigator: InvestigatorId) -> EngineOu
 ///
 /// Validate-first: Investigation phase, `investigator` is active and
 /// `Status::Active`, `actions_remaining >= 1`. Mutate-second: spend 1
-/// action, fire attacks of opportunity (Resource is NOT AoO-exempt),
-/// then — if the investigator survived the AoO — gain 1 resource.
+/// action, fire attacks of opportunity (Resource is NOT `AoO`-exempt),
+/// then — if the investigator survived the `AoO` — gain 1 resource.
 pub(super) fn resource_action(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
     if cx.state.phase != Phase::Investigation {
         return EngineOutcome::Rejected {
@@ -169,16 +169,23 @@ pub(super) fn resource_action(cx: &mut Cx, investigator: InvestigatorId) -> Engi
             .into(),
         };
     }
-    let inv = cx.state.investigators.get(&investigator).unwrap_or_else(|| {
-        unreachable!(
-            "Resource: active_investigator {investigator:?} is not in the investigators map; \
+    let inv = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .unwrap_or_else(|| {
+            unreachable!(
+                "Resource: active_investigator {investigator:?} is not in the investigators map; \
              this is a state-corruption invariant violation"
-        )
-    });
+            )
+        });
     if inv.status != Status::Active {
         return EngineOutcome::Rejected {
-            reason: format!("Resource: {investigator:?} is not Active (status {:?})", inv.status)
-                .into(),
+            reason: format!(
+                "Resource: {investigator:?} is not Active (status {:?})",
+                inv.status
+            )
+            .into(),
         };
     }
     if inv.actions_remaining < 1 {
@@ -193,12 +200,16 @@ pub(super) fn resource_action(cx: &mut Cx, investigator: InvestigatorId) -> Engi
 
     // If AoO eliminated the investigator, the gain is suppressed; the
     // spent action + AoO events stay (mirrors `investigate`).
-    let inv_after = cx.state.investigators.get(&investigator).unwrap_or_else(|| {
-        unreachable!(
-            "Resource: investigator {investigator:?} disappeared between AoO and gain; \
+    let inv_after = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .unwrap_or_else(|| {
+            unreachable!(
+                "Resource: investigator {investigator:?} disappeared between AoO and gain; \
              this is a state-corruption invariant violation"
-        )
-    });
+            )
+        });
     if inv_after.status != Status::Active {
         return EngineOutcome::Done;
     }
@@ -224,8 +235,9 @@ pub(super) fn resource_action(cx: &mut Cx, investigator: InvestigatorId) -> Engi
 /// `actions_remaining >= 1`, enemy in state, enemy at the investigator's
 /// `current_location`, not already engaged with the investigator.
 /// Mutate-second: spend 1 action, fire attacks of opportunity (Engage is
-/// NOT AoO-exempt — the target is not engaged yet so it cannot AoO; only
-/// OTHER engaged ready enemies do), then — if the investigator survived —
+/// NOT `AoO`-exempt — the target is not engaged yet so it cannot `AoO`;
+/// only OTHER engaged ready enemies do), then — if the investigator
+/// survived —
 /// engage the enemy.
 pub(super) fn engage(
     cx: &mut Cx,
@@ -250,16 +262,23 @@ pub(super) fn engage(
             .into(),
         };
     }
-    let inv = cx.state.investigators.get(&investigator).unwrap_or_else(|| {
-        unreachable!(
-            "Engage: active_investigator {investigator:?} is not in the investigators map; \
+    let inv = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .unwrap_or_else(|| {
+            unreachable!(
+                "Engage: active_investigator {investigator:?} is not in the investigators map; \
              this is a state-corruption invariant violation"
-        )
-    });
+            )
+        });
     if inv.status != Status::Active {
         return EngineOutcome::Rejected {
-            reason: format!("Engage: {investigator:?} is not Active (status {:?})", inv.status)
-                .into(),
+            reason: format!(
+                "Engage: {investigator:?} is not Active (status {:?})",
+                inv.status
+            )
+            .into(),
         };
     }
     if inv.actions_remaining < 1 {
@@ -292,12 +311,16 @@ pub(super) fn engage(
     spend_one_action(cx, investigator);
     super::combat::fire_attacks_of_opportunity(cx, investigator);
 
-    let inv_after = cx.state.investigators.get(&investigator).unwrap_or_else(|| {
-        unreachable!(
-            "Engage: investigator {investigator:?} disappeared between AoO and engagement; \
+    let inv_after = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .unwrap_or_else(|| {
+            unreachable!(
+                "Engage: investigator {investigator:?} disappeared between AoO and engagement; \
              this is a state-corruption invariant violation"
-        )
-    });
+            )
+        });
     if inv_after.status != Status::Active {
         return EngineOutcome::Done;
     }

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -4,8 +4,8 @@
 use crate::dsl::SkillTestKind;
 use crate::event::Event;
 use crate::state::{
-    Enemy, EnemyId, GameState, InvestigatorId, LocationId, Phase, SkillKind, SkillTestFollowUp,
-    Status,
+    Enemy, EnemyId, GameState, Investigator, InvestigatorId, LocationId, Phase, SkillKind,
+    SkillTestFollowUp, Status,
 };
 
 use super::super::outcome::EngineOutcome;
@@ -27,51 +27,12 @@ use super::Cx;
 ///
 /// [`Effect::DiscoverClue`]: crate::dsl::Effect::DiscoverClue
 pub(super) fn investigate(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
-    // Validate-first.
-    if cx.state.phase != Phase::Investigation {
-        return EngineOutcome::Rejected {
-            reason: format!(
-                "Investigate is only valid during the Investigation phase (was {:?})",
-                cx.state.phase
-            )
-            .into(),
-        };
-    }
-    if cx.state.active_investigator != Some(investigator) {
-        return EngineOutcome::Rejected {
-            reason: format!(
-                "Investigate: {investigator:?} is not the active investigator ({:?})",
-                cx.state.active_investigator,
-            )
-            .into(),
-        };
-    }
-    // Active-investigator + missing-from-map is a state-corruption
-    // invariant violation; panic rather than silently rejecting.
-    let inv = cx
-        .state
-        .investigators
-        .get(&investigator)
-        .unwrap_or_else(|| {
-            unreachable!(
-                "Investigate: active_investigator {investigator:?} is not in the investigators \
-             map; this is a state-corruption invariant violation"
-            )
-        });
-    if inv.status != Status::Active {
-        return EngineOutcome::Rejected {
-            reason: format!(
-                "Investigate: {investigator:?} is not Active (status {:?})",
-                inv.status,
-            )
-            .into(),
-        };
-    }
-    if inv.actions_remaining < 1 {
-        return EngineOutcome::Rejected {
-            reason: "Investigate requires at least 1 action point".into(),
-        };
-    }
+    // Validate-first (the shared basic-action prefix, then the
+    // location-specific checks).
+    let inv = match validate_basic_action(cx.state, "Investigate", investigator) {
+        Ok(inv) => inv,
+        Err(rejection) => return rejection,
+    };
     let Some(location_id) = inv.current_location else {
         return EngineOutcome::Rejected {
             reason: format!("Investigate: {investigator:?} has no current_location to investigate")
@@ -151,47 +112,8 @@ pub(super) fn investigate(cx: &mut Cx, investigator: InvestigatorId) -> EngineOu
 /// action, fire attacks of opportunity (Resource is NOT `AoO`-exempt),
 /// then — if the investigator survived the `AoO` — gain 1 resource.
 pub(super) fn resource_action(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
-    if cx.state.phase != Phase::Investigation {
-        return EngineOutcome::Rejected {
-            reason: format!(
-                "Resource is only valid during the Investigation phase (was {:?})",
-                cx.state.phase
-            )
-            .into(),
-        };
-    }
-    if cx.state.active_investigator != Some(investigator) {
-        return EngineOutcome::Rejected {
-            reason: format!(
-                "Resource: {investigator:?} is not the active investigator ({:?})",
-                cx.state.active_investigator,
-            )
-            .into(),
-        };
-    }
-    let inv = cx
-        .state
-        .investigators
-        .get(&investigator)
-        .unwrap_or_else(|| {
-            unreachable!(
-                "Resource: active_investigator {investigator:?} is not in the investigators map; \
-             this is a state-corruption invariant violation"
-            )
-        });
-    if inv.status != Status::Active {
-        return EngineOutcome::Rejected {
-            reason: format!(
-                "Resource: {investigator:?} is not Active (status {:?})",
-                inv.status
-            )
-            .into(),
-        };
-    }
-    if inv.actions_remaining < 1 {
-        return EngineOutcome::Rejected {
-            reason: "Resource requires at least 1 action point".into(),
-        };
+    if let Err(rejection) = validate_basic_action(cx.state, "Resource", investigator) {
+        return rejection;
     }
 
     // Mutate-second: spend the action, fire AoO, then gain the resource.
@@ -244,48 +166,10 @@ pub(super) fn engage(
     investigator: InvestigatorId,
     enemy_id: EnemyId,
 ) -> EngineOutcome {
-    if cx.state.phase != Phase::Investigation {
-        return EngineOutcome::Rejected {
-            reason: format!(
-                "Engage is only valid during the Investigation phase (was {:?})",
-                cx.state.phase
-            )
-            .into(),
-        };
-    }
-    if cx.state.active_investigator != Some(investigator) {
-        return EngineOutcome::Rejected {
-            reason: format!(
-                "Engage: {investigator:?} is not the active investigator ({:?})",
-                cx.state.active_investigator,
-            )
-            .into(),
-        };
-    }
-    let inv = cx
-        .state
-        .investigators
-        .get(&investigator)
-        .unwrap_or_else(|| {
-            unreachable!(
-                "Engage: active_investigator {investigator:?} is not in the investigators map; \
-             this is a state-corruption invariant violation"
-            )
-        });
-    if inv.status != Status::Active {
-        return EngineOutcome::Rejected {
-            reason: format!(
-                "Engage: {investigator:?} is not Active (status {:?})",
-                inv.status
-            )
-            .into(),
-        };
-    }
-    if inv.actions_remaining < 1 {
-        return EngineOutcome::Rejected {
-            reason: "Engage requires at least 1 action point".into(),
-        };
-    }
+    let inv = match validate_basic_action(cx.state, "Engage", investigator) {
+        Ok(inv) => inv,
+        Err(rejection) => return rejection,
+    };
     // A `None` location can't host an engage (matches `investigate`'s
     // guard); without it the `enemy.current_location != inv_location`
     // check below would let a locationless investigator engage a
@@ -525,27 +409,22 @@ pub(super) fn move_action(
     )
 }
 
-/// Validate the prefix shared by Fight and Evade: phase, active
-/// investigator, action point available, enemy exists, engaged with
-/// the named enemy. Returns the borrowed enemy so the caller can pick
-/// which difficulty (fight / evade) and read any other fields it
-/// needs.
+/// Validate the preconditions shared by every action-point-spending
+/// basic action: Investigation phase, `investigator` is the active
+/// investigator, `Status::Active`, and at least one action remaining.
+/// Returns the validated investigator. `action_name` is interpolated
+/// into rejection reasons; an active investigator missing from the map
+/// is a state-corruption invariant and panics.
 ///
-/// On `Err`, returns the rejection; the caller should propagate it
-/// without further state mutation. State-corruption invariants
-/// (active investigator missing from map) panic via `unreachable!`.
-///
-/// Does NOT validate the chosen difficulty is non-negative — the
-/// caller must do that after picking, because Fight and Evade each
-/// only care about one of the two values, and validating both
-/// upfront would reject legitimate states (an enemy with `fight: -1`
-/// the investigator only ever Evades).
-fn validate_engaged_action<'a>(
+/// Move / Fight / Evade defer the action-point check to `charge_action`
+/// (which folds in the Frozen-in-Fear surcharge), so `move_action` keeps
+/// its own prefix; Fight and Evade reach this via
+/// [`validate_engaged_action`], which then adds the enemy checks.
+pub(super) fn validate_basic_action<'a>(
     state: &'a GameState,
     action_name: &'static str,
     investigator: InvestigatorId,
-    enemy_id: EnemyId,
-) -> Result<&'a Enemy, EngineOutcome> {
+) -> Result<&'a Investigator, EngineOutcome> {
     if state.phase != Phase::Investigation {
         return Err(EngineOutcome::Rejected {
             reason: format!(
@@ -584,6 +463,31 @@ fn validate_engaged_action<'a>(
             reason: format!("{action_name} requires at least 1 action point").into(),
         });
     }
+    Ok(inv)
+}
+
+/// Validate the prefix shared by Fight and Evade: the basic-action
+/// preconditions (via [`validate_basic_action`]) plus enemy exists and
+/// engaged with the named enemy. Returns the borrowed enemy so the
+/// caller can pick which difficulty (fight / evade) and read any other
+/// fields it needs.
+///
+/// On `Err`, returns the rejection; the caller should propagate it
+/// without further state mutation. State-corruption invariants
+/// (active investigator missing from map) panic via `unreachable!`.
+///
+/// Does NOT validate the chosen difficulty is non-negative — the
+/// caller must do that after picking, because Fight and Evade each
+/// only care about one of the two values, and validating both
+/// upfront would reject legitimate states (an enemy with `fight: -1`
+/// the investigator only ever Evades).
+fn validate_engaged_action<'a>(
+    state: &'a GameState,
+    action_name: &'static str,
+    investigator: InvestigatorId,
+    enemy_id: EnemyId,
+) -> Result<&'a Enemy, EngineOutcome> {
+    validate_basic_action(state, action_name, investigator)?;
     let Some(enemy) = state.enemies.get(&enemy_id) else {
         return Err(EngineOutcome::Rejected {
             reason: format!("{action_name}: enemy {enemy_id:?} is not in state").into(),

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -106,8 +106,8 @@ pub(super) fn investigate(cx: &mut Cx, investigator: InvestigatorId) -> EngineOu
 
     // Mutate-second: spend the action, fire AoO, then resolve the
     // test. Investigate is NOT on the AoO-exempt list (only Fight,
-    // Evade, Parley, Engage, Resign are), so each ready engaged
-    // enemy attacks before the test resolves.
+    // Evade, Parley, Resign are), so each ready engaged enemy attacks
+    // before the test resolves.
     spend_one_action(cx, investigator);
     super::combat::fire_attacks_of_opportunity(cx, investigator);
 

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -143,6 +143,79 @@ pub(super) fn investigate(cx: &mut Cx, investigator: InvestigatorId) -> EngineOu
     )
 }
 
+/// Handler for [`PlayerAction::Resource`]. The basic "gain 1 resource"
+/// action (Rules Reference, Investigation step 2.2.1).
+///
+/// Validate-first: Investigation phase, `investigator` is active and
+/// `Status::Active`, `actions_remaining >= 1`. Mutate-second: spend 1
+/// action, fire attacks of opportunity (Resource is NOT AoO-exempt),
+/// then — if the investigator survived the AoO — gain 1 resource.
+pub(super) fn resource_action(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
+    if cx.state.phase != Phase::Investigation {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Resource is only valid during the Investigation phase (was {:?})",
+                cx.state.phase
+            )
+            .into(),
+        };
+    }
+    if cx.state.active_investigator != Some(investigator) {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Resource: {investigator:?} is not the active investigator ({:?})",
+                cx.state.active_investigator,
+            )
+            .into(),
+        };
+    }
+    let inv = cx.state.investigators.get(&investigator).unwrap_or_else(|| {
+        unreachable!(
+            "Resource: active_investigator {investigator:?} is not in the investigators map; \
+             this is a state-corruption invariant violation"
+        )
+    });
+    if inv.status != Status::Active {
+        return EngineOutcome::Rejected {
+            reason: format!("Resource: {investigator:?} is not Active (status {:?})", inv.status)
+                .into(),
+        };
+    }
+    if inv.actions_remaining < 1 {
+        return EngineOutcome::Rejected {
+            reason: "Resource requires at least 1 action point".into(),
+        };
+    }
+
+    // Mutate-second: spend the action, fire AoO, then gain the resource.
+    spend_one_action(cx, investigator);
+    super::combat::fire_attacks_of_opportunity(cx, investigator);
+
+    // If AoO eliminated the investigator, the gain is suppressed; the
+    // spent action + AoO events stay (mirrors `investigate`).
+    let inv_after = cx.state.investigators.get(&investigator).unwrap_or_else(|| {
+        unreachable!(
+            "Resource: investigator {investigator:?} disappeared between AoO and gain; \
+             this is a state-corruption invariant violation"
+        )
+    });
+    if inv_after.status != Status::Active {
+        return EngineOutcome::Done;
+    }
+
+    let inv_mut = cx
+        .state
+        .investigators
+        .get_mut(&investigator)
+        .expect("investigator existence checked above");
+    inv_mut.resources = inv_mut.resources.saturating_add(1);
+    cx.events.push(Event::ResourcesGained {
+        investigator,
+        amount: 1,
+    });
+    EngineOutcome::Done
+}
+
 /// Handler for [`PlayerAction::Move`].
 ///
 /// Spends 1 action, then updates `current_location` to a connected

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -286,7 +286,16 @@ pub(super) fn engage(
             reason: "Engage requires at least 1 action point".into(),
         };
     }
-    let inv_location = inv.current_location;
+    // A `None` location can't host an engage (matches `investigate`'s
+    // guard); without it the `enemy.current_location != inv_location`
+    // check below would let a locationless investigator engage a
+    // locationless enemy (`None != None == false`).
+    let Some(inv_location) = inv.current_location else {
+        return EngineOutcome::Rejected {
+            reason: format!("Engage: {investigator:?} has no current_location to engage from")
+                .into(),
+        };
+    };
     let Some(enemy) = cx.state.enemies.get(&enemy_id) else {
         return EngineOutcome::Rejected {
             reason: format!("Engage: enemy {enemy_id:?} is not in state").into(),
@@ -297,11 +306,11 @@ pub(super) fn engage(
             reason: format!("Engage: {investigator:?} is already engaged with {enemy_id:?}").into(),
         };
     }
-    if enemy.current_location != inv_location {
+    if enemy.current_location != Some(inv_location) {
         return EngineOutcome::Rejected {
             reason: format!(
-                "Engage: enemy {enemy_id:?} (at {:?}) is not at {investigator:?}'s location ({:?})",
-                enemy.current_location, inv_location,
+                "Engage: enemy {enemy_id:?} (at {:?}) is not at {investigator:?}'s location ({inv_location:?})",
+                enemy.current_location,
             )
             .into(),
         };

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -5,7 +5,7 @@ use crate::card_data::CardType;
 use crate::card_registry;
 use crate::dsl::Trigger;
 use crate::event::Event;
-use crate::state::{CardCode, InvestigatorId, Phase, Status, Zone};
+use crate::state::{CardCode, InvestigatorId, Status, Zone};
 
 use super::super::evaluator::{apply_effect, EvalContext};
 use super::super::outcome::EngineOutcome;
@@ -244,47 +244,8 @@ pub(super) fn draw_one_with_deckout(cx: &mut Cx, investigator: InvestigatorId) {
 ///
 /// The draw logic itself is delegated to [`draw_one_with_deckout`].
 pub(super) fn draw(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
-    if cx.state.phase != Phase::Investigation {
-        return EngineOutcome::Rejected {
-            reason: format!(
-                "Draw is only valid during the Investigation phase (was {:?})",
-                cx.state.phase
-            )
-            .into(),
-        };
-    }
-    if cx.state.active_investigator != Some(investigator) {
-        return EngineOutcome::Rejected {
-            reason: format!(
-                "Draw: {investigator:?} is not the active investigator ({:?})",
-                cx.state.active_investigator,
-            )
-            .into(),
-        };
-    }
-    let inv = cx
-        .state
-        .investigators
-        .get(&investigator)
-        .unwrap_or_else(|| {
-            unreachable!(
-                "Draw: active_investigator {investigator:?} is not in the investigators map; \
-             this is a state-corruption invariant violation"
-            )
-        });
-    if inv.status != Status::Active {
-        return EngineOutcome::Rejected {
-            reason: format!(
-                "Draw: {investigator:?} is not Active (status {:?})",
-                inv.status,
-            )
-            .into(),
-        };
-    }
-    if inv.actions_remaining < 1 {
-        return EngineOutcome::Rejected {
-            reason: "Draw requires at least 1 action point".into(),
-        };
+    if let Err(rejection) = super::actions::validate_basic_action(cx.state, "Draw", investigator) {
+        return rejection;
     }
 
     // Mutate.

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -289,6 +289,23 @@ pub(super) fn draw(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
 
     // Mutate.
     super::actions::spend_one_action(cx, investigator);
+
+    // Draw is NOT on the AoO-exempt list (only Fight, Evade, Parley,
+    // Resign are), so each ready engaged enemy attacks before the card
+    // is drawn (RR p.5).
+    super::combat::fire_attacks_of_opportunity(cx, investigator);
+
+    // If the AoO eliminated the investigator, suppress the draw (the
+    // spent action + AoO events stay), mirroring `investigate`.
+    let still_active = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .is_some_and(|inv| inv.status == Status::Active);
+    if !still_active {
+        return EngineOutcome::Done;
+    }
+
     draw_one_with_deckout(cx, investigator);
     EngineOutcome::Done
 }

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -176,6 +176,7 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
             difficulty,
         } => skill_test::perform_skill_test(cx, *investigator, *skill, *difficulty),
         PlayerAction::Investigate { investigator } => actions::investigate(cx, *investigator),
+        PlayerAction::Resource { investigator } => actions::resource_action(cx, *investigator),
         PlayerAction::Move {
             investigator,
             destination,

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -177,6 +177,10 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
         } => skill_test::perform_skill_test(cx, *investigator, *skill, *difficulty),
         PlayerAction::Investigate { investigator } => actions::investigate(cx, *investigator),
         PlayerAction::Resource { investigator } => actions::resource_action(cx, *investigator),
+        PlayerAction::Engage {
+            investigator,
+            enemy,
+        } => actions::engage(cx, *investigator, *enemy),
         PlayerAction::Move {
             investigator,
             destination,

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -2738,6 +2738,44 @@ mod tests {
     }
 
     #[test]
+    fn draw_action_fires_aoo_from_ready_engaged_enemy() {
+        let inv_id = InvestigatorId(1);
+        let loc = crate::state::LocationId(10);
+        let mut enemy = test_enemy(200, "Engaged Ghoul");
+        enemy.current_location = Some(loc);
+        enemy.engaged_with = Some(inv_id);
+        enemy.attack_damage = 1;
+        let state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .with_location(test_location(10, "Study"))
+            .with_investigator({
+                let mut i = test_investigator(1);
+                i.current_location = Some(loc);
+                // Give the deck a card so the draw itself succeeds without
+                // the empty-deck horror path muddying the AoO assertion.
+                i.deck = vec![CardCode::new("_test_card_1")];
+                i
+            })
+            .with_active_investigator(inv_id)
+            .with_enemy(enemy)
+            .build();
+
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Draw {
+                investigator: inv_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_eq!(result.state.investigators[&inv_id].damage, 1);
+        assert_event!(
+            result.events,
+            Event::DamageTaken { investigator, amount: 1 } if *investigator == inv_id
+        );
+    }
+
+    #[test]
     fn move_with_unengaged_enemy_at_origin_leaves_enemy_behind() {
         let (inv_id, a, b, _, mut state) = move_scenario_with_engaged_enemy();
         // Convert the engagement into a non-engagement: enemy is at A

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -2541,6 +2541,69 @@ mod tests {
     }
 
     #[test]
+    fn resource_action_rejects_when_not_active_status() {
+        let inv_id = InvestigatorId(1);
+        let state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .with_investigator({
+                let mut i = test_investigator(1);
+                i.status = Status::Killed;
+                i
+            })
+            .with_active_investigator(inv_id)
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Resource {
+                investigator: inv_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert_eq!(result.state.investigators[&inv_id].resources, 5);
+        assert_eq!(result.state.investigators[&inv_id].actions_remaining, 3);
+    }
+
+    #[test]
+    fn resource_action_aoo_that_eliminates_suppresses_the_gain() {
+        // A lethal AoO (attack_damage == max_health) defeats the
+        // investigator before the resource is gained; the gain is
+        // suppressed (no ResourcesGained event) while the AoO damage
+        // still lands.
+        let inv_id = InvestigatorId(1);
+        let loc = crate::state::LocationId(10);
+        let mut enemy = test_enemy(200, "Lethal Ghoul");
+        enemy.current_location = Some(loc);
+        enemy.engaged_with = Some(inv_id);
+        enemy.attack_damage = 8; // == test_investigator max_health
+        let state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .with_location(test_location(10, "Study"))
+            .with_investigator({
+                let mut i = test_investigator(1);
+                i.current_location = Some(loc);
+                i
+            })
+            .with_active_investigator(inv_id)
+            .with_enemy(enemy)
+            .build();
+
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Resource {
+                investigator: inv_id,
+            }),
+        );
+
+        // Lethal AoO landed.
+        assert_event!(
+            result.events,
+            Event::DamageTaken { investigator, amount: 8 } if *investigator == inv_id
+        );
+        // ...but the resource gain was suppressed.
+        assert_no_event!(result.events, Event::ResourcesGained { .. });
+    }
+
+    #[test]
     fn engage_action_engages_unengaged_enemy_at_location() {
         let inv_id = InvestigatorId(1);
         let loc = crate::state::LocationId(10);
@@ -2735,6 +2798,37 @@ mod tests {
         );
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
         assert_eq!(result.state.enemies[&enemy_id].engaged_with, None);
+    }
+
+    #[test]
+    fn engage_action_rejects_when_not_active_status() {
+        let inv_id = InvestigatorId(1);
+        let loc = crate::state::LocationId(10);
+        let enemy_id = EnemyId(300);
+        let mut enemy = test_enemy(300, "Ghoul");
+        enemy.current_location = Some(loc);
+        let state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .with_location(test_location(10, "Study"))
+            .with_investigator({
+                let mut i = test_investigator(1);
+                i.current_location = Some(loc);
+                i.status = Status::Insane;
+                i
+            })
+            .with_active_investigator(inv_id)
+            .with_enemy(enemy)
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Engage {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert_eq!(result.state.enemies[&enemy_id].engaged_with, None);
+        assert_eq!(result.state.investigators[&inv_id].actions_remaining, 3);
     }
 
     #[test]

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -2541,6 +2541,203 @@ mod tests {
     }
 
     #[test]
+    fn engage_action_engages_unengaged_enemy_at_location() {
+        let inv_id = InvestigatorId(1);
+        let loc = crate::state::LocationId(10);
+        let enemy_id = EnemyId(300);
+        let mut enemy = test_enemy(300, "Aloof Ghoul");
+        enemy.current_location = Some(loc);
+        enemy.engaged_with = None;
+        let state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .with_location(test_location(10, "Study"))
+            .with_investigator({
+                let mut i = test_investigator(1);
+                i.current_location = Some(loc);
+                i
+            })
+            .with_active_investigator(inv_id)
+            .with_enemy(enemy)
+            .build();
+
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Engage {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_eq!(result.state.enemies[&enemy_id].engaged_with, Some(inv_id));
+        assert_eq!(result.state.investigators[&inv_id].actions_remaining, 2);
+        assert_event!(
+            result.events,
+            Event::EnemyEngaged { enemy, investigator }
+                if *enemy == enemy_id && *investigator == inv_id
+        );
+    }
+
+    #[test]
+    fn engage_action_provokes_aoo_from_other_engaged_enemy_not_the_target() {
+        let inv_id = InvestigatorId(1);
+        let loc = crate::state::LocationId(10);
+        let target_id = EnemyId(300);
+        let mut target = test_enemy(300, "Target Ghoul"); // not engaged yet
+        target.current_location = Some(loc);
+        let mut other = test_enemy(301, "Already-Engaged Ghoul");
+        other.current_location = Some(loc);
+        other.engaged_with = Some(inv_id);
+        other.attack_damage = 1;
+        let state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .with_location(test_location(10, "Study"))
+            .with_investigator({
+                let mut i = test_investigator(1);
+                i.current_location = Some(loc);
+                i
+            })
+            .with_active_investigator(inv_id)
+            .with_enemy(target)
+            .with_enemy(other)
+            .build();
+
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Engage {
+                investigator: inv_id,
+                enemy: target_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        // The OTHER engaged enemy made the AoO; the target (not engaged at
+        // AoO time) did not. Target ends engaged; investigator took 1 damage.
+        assert_eq!(result.state.investigators[&inv_id].damage, 1);
+        assert_eq!(result.state.enemies[&target_id].engaged_with, Some(inv_id));
+        assert_event!(
+            result.events,
+            Event::DamageTaken { investigator, amount: 1 } if *investigator == inv_id
+        );
+    }
+
+    #[test]
+    fn engage_action_rejects_enemy_not_at_location() {
+        let inv_id = InvestigatorId(1);
+        let here = crate::state::LocationId(10);
+        let there = crate::state::LocationId(11);
+        let enemy_id = EnemyId(300);
+        let mut enemy = test_enemy(300, "Distant Ghoul");
+        enemy.current_location = Some(there);
+        let state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .with_location(test_location(10, "Study"))
+            .with_location(test_location(11, "Hallway"))
+            .with_investigator({
+                let mut i = test_investigator(1);
+                i.current_location = Some(here);
+                i
+            })
+            .with_active_investigator(inv_id)
+            .with_enemy(enemy)
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Engage {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert_eq!(result.state.enemies[&enemy_id].engaged_with, None);
+        assert_eq!(result.state.investigators[&inv_id].actions_remaining, 3);
+    }
+
+    #[test]
+    fn engage_action_rejects_already_engaged_enemy() {
+        let inv_id = InvestigatorId(1);
+        let loc = crate::state::LocationId(10);
+        let enemy_id = EnemyId(300);
+        let mut enemy = test_enemy(300, "Engaged Ghoul");
+        enemy.current_location = Some(loc);
+        enemy.engaged_with = Some(inv_id);
+        let state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .with_location(test_location(10, "Study"))
+            .with_investigator({
+                let mut i = test_investigator(1);
+                i.current_location = Some(loc);
+                i
+            })
+            .with_active_investigator(inv_id)
+            .with_enemy(enemy)
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Engage {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert_eq!(result.state.investigators[&inv_id].actions_remaining, 3);
+    }
+
+    #[test]
+    fn engage_action_rejects_unknown_enemy() {
+        let inv_id = InvestigatorId(1);
+        let loc = crate::state::LocationId(10);
+        let state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .with_location(test_location(10, "Study"))
+            .with_investigator({
+                let mut i = test_investigator(1);
+                i.current_location = Some(loc);
+                i
+            })
+            .with_active_investigator(inv_id)
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Engage {
+                investigator: inv_id,
+                enemy: EnemyId(999),
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    }
+
+    #[test]
+    fn engage_action_rejects_no_actions_remaining() {
+        let inv_id = InvestigatorId(1);
+        let loc = crate::state::LocationId(10);
+        let enemy_id = EnemyId(300);
+        let mut enemy = test_enemy(300, "Ghoul");
+        enemy.current_location = Some(loc);
+        let state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .with_location(test_location(10, "Study"))
+            .with_investigator({
+                let mut i = test_investigator(1);
+                i.current_location = Some(loc);
+                i.actions_remaining = 0;
+                i
+            })
+            .with_active_investigator(inv_id)
+            .with_enemy(enemy)
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Engage {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert_eq!(result.state.enemies[&enemy_id].engaged_with, None);
+    }
+
+    #[test]
     fn move_with_unengaged_enemy_at_origin_leaves_enemy_behind() {
         let (inv_id, a, b, _, mut state) = move_scenario_with_engaged_enemy();
         // Convert the engagement into a non-engagement: enemy is at A

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -2412,6 +2412,135 @@ mod tests {
     }
 
     #[test]
+    fn resource_action_spends_action_and_gains_one_resource() {
+        let inv_id = InvestigatorId(1);
+        let loc = crate::state::LocationId(10);
+        let state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .with_location(test_location(10, "Study"))
+            .with_investigator({
+                let mut i = test_investigator(1);
+                i.current_location = Some(loc);
+                i.resources = 5;
+                i
+            })
+            .with_active_investigator(inv_id)
+            .build();
+
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Resource {
+                investigator: inv_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_eq!(result.state.investigators[&inv_id].resources, 6);
+        assert_eq!(result.state.investigators[&inv_id].actions_remaining, 2);
+        assert_event!(
+            result.events,
+            Event::ResourcesGained { investigator, amount: 1 } if *investigator == inv_id
+        );
+    }
+
+    #[test]
+    fn resource_action_fires_aoo_from_ready_engaged_enemy() {
+        let inv_id = InvestigatorId(1);
+        let loc = crate::state::LocationId(10);
+        let mut enemy = test_enemy(200, "Engaged Ghoul");
+        enemy.current_location = Some(loc);
+        enemy.engaged_with = Some(inv_id);
+        enemy.attack_damage = 1;
+        let state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .with_location(test_location(10, "Study"))
+            .with_investigator({
+                let mut i = test_investigator(1);
+                i.current_location = Some(loc);
+                i
+            })
+            .with_active_investigator(inv_id)
+            .with_enemy(enemy)
+            .build();
+
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Resource {
+                investigator: inv_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        // AoO fired: investigator took 1 damage, but the resource is still gained.
+        assert_eq!(result.state.investigators[&inv_id].damage, 1);
+        assert_eq!(result.state.investigators[&inv_id].resources, 6);
+        assert_event!(
+            result.events,
+            Event::DamageTaken { investigator, amount: 1 } if *investigator == inv_id
+        );
+    }
+
+    #[test]
+    fn resource_action_rejects_wrong_phase() {
+        let inv_id = InvestigatorId(1);
+        let state = GameStateBuilder::new()
+            .with_phase(Phase::Mythos)
+            .with_investigator(test_investigator(1))
+            .with_active_investigator(inv_id)
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Resource {
+                investigator: inv_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert_eq!(result.state.investigators[&inv_id].resources, 5);
+        assert_eq!(result.state.investigators[&inv_id].actions_remaining, 3);
+    }
+
+    #[test]
+    fn resource_action_rejects_when_not_active_investigator() {
+        let inv_id = InvestigatorId(1);
+        let other = InvestigatorId(2);
+        let state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .with_investigator(test_investigator(1))
+            .with_investigator(test_investigator(2))
+            .with_active_investigator(other)
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Resource {
+                investigator: inv_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    }
+
+    #[test]
+    fn resource_action_rejects_with_no_actions_remaining() {
+        let inv_id = InvestigatorId(1);
+        let state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .with_investigator({
+                let mut i = test_investigator(1);
+                i.actions_remaining = 0;
+                i
+            })
+            .with_active_investigator(inv_id)
+            .build();
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Resource {
+                investigator: inv_id,
+            }),
+        );
+        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+        assert_eq!(result.state.investigators[&inv_id].resources, 5);
+    }
+
+    #[test]
     fn move_with_unengaged_enemy_at_origin_leaves_enemy_behind() {
         let (inv_id, a, b, _, mut state) = move_scenario_with_engaged_enemy();
         // Convert the engagement into a non-engagement: enemy is at A

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -33,10 +33,17 @@ here.
 
 ### Tier 1 — the work
 
-**A. Missing basic actions** (no `PlayerAction` variant exists today):
-- [#141](https://github.com/talelburg/eldritch/issues/141) — Resource action (gain 1; Investigation step 2.2.1).
-- [#77](https://github.com/talelburg/eldritch/issues/77) — Engage (+ Parley). Engage is core; Parley pairs with Lita.
-- [#258](https://github.com/talelburg/eldritch/issues/258) (Resign only) — the Resign action; the rest of #258 is optional content.
+**A. Missing basic actions** — ✅ **shipped (PR #383).** `PlayerAction::Resource`
+([#141](https://github.com/talelburg/eldritch/issues/141), closed) + the
+basic-action half of [#77](https://github.com/talelburg/eldritch/issues/77)
+(`PlayerAction::Engage`). Both fire attacks of opportunity (RR p.5 exempts only
+fight/evade/parley/resign); the pre-existing **Draw** AoO gap was fixed alongside,
+and the shared five-check prologue extracted into `validate_basic_action`.
+**Resign and Parley are NOT basic actions** (verified RR p.5: "Activate, Play,
+Resign, and Parley are not basic actions") — they are action *types* granted only
+by card/location abilities, so they live with the optional content in
+[#258](https://github.com/talelburg/eldritch/issues/258) (the Parlor's Resign,
+Lita's Parley), **not** the gate. #77 stays open for its Parley half.
 
 **B. Attacks of opportunity + non-enemy-phase attack windows** — one cluster,
 one shared mechanism (mid-action park/resume; see the keystone note):
@@ -66,7 +73,7 @@ clue" is stubbed; needs the dynamic skill-test-modifier DSL surface
 
 ### Ordering, dependencies, simplifications
 
-1. **Basic actions first** (#141, #77, Resign) — small, independent; Engage also unblocks #300's condition.
+1. ~~**Basic actions first** (#141, #77)~~ — ✅ shipped (PR #383); Engage also unblocks #300's condition. (Resign/Parley aren't basic actions — see Tier-1 A.)
 2. **§1 continuation-stack cleanup before the keystone** — the full #348 + #345 + #347 + #380 as one designed pass (see Refactor triage). The keystone *adds* suspension modes, so migrate the existing `pending_*` onto the one stack (with serializable context + token-routed resume) first rather than building the Nth ad-hoc route on top.
 3. **The keystone: mid-action suspend/resume.** Tier-1 B **and** C all hinge on `drive_attack_loop` being able to park the triggering action, open a window, and resume. Build it once and #293/#379/#361/#378/#143/#44 collapse into a single attack-loop arc — the highest-leverage item in the phase. Fold #119 in for #44's soak (symmetric token storage).
 4. **Skill-test windows** (#374 + #64) — one reaction-window work-stream.
@@ -161,7 +168,10 @@ from the Move/Investigate handlers) and `fire_retaliate_if_any` call
 `EnemyAttackSource::AttackOfOpportunity` is the reserved-unconstructed variant
 the fix wires up.** Exhaust rules differ by source: enemy-phase always
 exhausts (cancelled too — RR p.6/p.25); AoO never (RR p.7); Retaliate never
-(RR p.18). Activating an ability or playing an event fire no AoO today.
+(RR p.18). **Every non-exempt basic action — Draw, Resource, Move, Investigate,
+Engage (PR #383) — already calls `fire_attacks_of_opportunity` (window-less),
+so the keystone's window-upgrade must cover all of them uniformly**; activating
+an ability or playing an event fire no AoO yet (#361/#378).
 
 **Trigger spine.** `emit_event` is the one dispatch chokepoint (two-phase
 forced-then-reaction, RR p.2). Simultaneous triggers resolve through the

--- a/docs/superpowers/plans/2026-06-19-resource-engage-basic-actions.md
+++ b/docs/superpowers/plans/2026-06-19-resource-engage-basic-actions.md
@@ -1,0 +1,819 @@
+# Resource + Engage Basic Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the two missing basic actions — Resource (gain 1 resource) and Engage (engage an enemy at your location) — both firing attacks of opportunity per the Rules Reference, and fix the pre-existing Draw AoO gap.
+
+**Architecture:** Two new `PlayerAction` variants dispatched to handlers in `engine/dispatch/actions.rs`, each following the established validate-first / mutate-second basic-action shape (the `investigate` handler is the canonical model): validate every precondition, then `spend_one_action` → `combat::fire_attacks_of_opportunity` → if the investigator survived the AoO, apply the effect. Draw gets the same `fire_attacks_of_opportunity` call it currently lacks.
+
+**Tech Stack:** Rust, `game-core` kernel crate. Tests are `#[cfg(test)]` engine unit tests using the `TestGame`/`GameStateBuilder` builder + `test_investigator`/`test_enemy`/`test_location` fixtures + the `assert_event!` / `assert_no_event!` macros.
+
+## Global Constraints
+
+- **Validate-first / mutate-second:** every handler checks all preconditions and returns `EngineOutcome::Rejected { reason }` with state + events unchanged before any mutation.
+- **AoO-exempt actions are fight / evade / parley / resign ONLY** (RR p.5). Draw, Resource, Move, Investigate, Engage all provoke an AoO.
+- **AoO can eliminate the investigator;** after `fire_attacks_of_opportunity`, re-read status and suppress the action's primary effect (return `EngineOutcome::Done`) if `status != Status::Active` — exactly as `investigate` does (`actions.rs:118-130`).
+- **State-corruption invariants panic** via `unreachable!` (active investigator missing from map); user-facing precondition failures return `Rejected`.
+- **CI gauntlet (run before the final commit / push):**
+  ```sh
+  cargo fmt --check
+  cargo clippy --all-targets --all-features -- -D warnings
+  RUSTFLAGS="-D warnings" cargo test --all --all-features
+  RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+  ```
+- Tests live in `crates/game-core/src/engine/mod.rs` alongside the existing basic-action tests (`move_with_ready_engaged_enemy_fires_aoo_and_enemy_follows` et al.). Fixtures: `test_investigator(id)` → `resources: 5, actions_remaining: 3, status: Active, current_location: None`; `test_enemy(id, name)` → `attack_damage: 1, attack_horror: 0, current_location: None, exhausted: false, engaged_with: None`.
+
+---
+
+### Task 1: Resource action (#141)
+
+**Files:**
+- Modify: `crates/game-core/src/action.rs` (add `Resource` variant to `PlayerAction`)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (add dispatch arm)
+- Modify: `crates/game-core/src/engine/dispatch/actions.rs` (add `resource_action` handler)
+- Test: `crates/game-core/src/engine/mod.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Produces: `pub(super) fn resource_action(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome`
+- Consumes (existing): `spend_one_action`, `combat::fire_attacks_of_opportunity`, `Event::ResourcesGained { investigator, amount }`.
+
+- [ ] **Step 1: Write the failing happy-path + AoO tests**
+
+In `crates/game-core/src/engine/mod.rs` test module, add:
+
+```rust
+#[test]
+fn resource_action_spends_action_and_gains_one_resource() {
+    let inv_id = InvestigatorId(1);
+    let loc = crate::state::LocationId(10);
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_location(test_location(10, "Study"))
+        .with_investigator({
+            let mut i = test_investigator(1);
+            i.current_location = Some(loc);
+            i.resources = 5;
+            i
+        })
+        .with_active_investigator(inv_id)
+        .build();
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::Resource { investigator: inv_id }),
+    );
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_eq!(result.state.investigators[&inv_id].resources, 6);
+    assert_eq!(result.state.investigators[&inv_id].actions_remaining, 2);
+    assert_event!(
+        result.events,
+        Event::ResourcesGained { investigator, amount: 1 } if *investigator == inv_id
+    );
+}
+
+#[test]
+fn resource_action_fires_aoo_from_ready_engaged_enemy() {
+    let inv_id = InvestigatorId(1);
+    let loc = crate::state::LocationId(10);
+    let mut enemy = test_enemy(200, "Engaged Ghoul");
+    enemy.current_location = Some(loc);
+    enemy.engaged_with = Some(inv_id);
+    enemy.attack_damage = 1;
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_location(test_location(10, "Study"))
+        .with_investigator({
+            let mut i = test_investigator(1);
+            i.current_location = Some(loc);
+            i
+        })
+        .with_active_investigator(inv_id)
+        .with_enemy(enemy)
+        .build();
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::Resource { investigator: inv_id }),
+    );
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    // AoO fired: investigator took 1 damage, but the resource is still gained.
+    assert_eq!(result.state.investigators[&inv_id].damage, 1);
+    assert_eq!(result.state.investigators[&inv_id].resources, 6);
+    assert_event!(
+        result.events,
+        Event::DamageTaken { investigator, amount: 1 } if *investigator == inv_id
+    );
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p game-core resource_action 2>&1 | tail -20`
+Expected: FAIL — `no variant named Resource found for enum PlayerAction` (compile error).
+
+- [ ] **Step 3: Add the `Resource` variant to `PlayerAction`**
+
+In `crates/game-core/src/action.rs`, add to the `PlayerAction` enum (after `Investigate`):
+
+```rust
+    /// Gain 1 resource (the basic "Resource" action, Rules Reference
+    /// Investigation step 2.2.1). Spends 1 action.
+    ///
+    /// Validate: Investigation phase, investigator is active and
+    /// `Status::Active`, `actions_remaining >= 1`.
+    ///
+    /// Resource is NOT on the AoO-exempt list (only Fight, Evade,
+    /// Parley, Resign are), so each ready engaged enemy makes an attack
+    /// of opportunity before the resource is gained; an AoO that
+    /// eliminates the investigator suppresses the gain.
+    Resource {
+        /// Investigator taking the action. Must be the active
+        /// investigator during the Investigation phase.
+        investigator: InvestigatorId,
+    },
+```
+
+- [ ] **Step 4: Add the dispatch arm**
+
+In `crates/game-core/src/engine/dispatch/mod.rs`, in the `apply_player_action` match (after the `Investigate` arm):
+
+```rust
+        PlayerAction::Resource { investigator } => actions::resource_action(cx, *investigator),
+```
+
+- [ ] **Step 5: Implement the `resource_action` handler**
+
+In `crates/game-core/src/engine/dispatch/actions.rs`, add:
+
+```rust
+/// Handler for [`PlayerAction::Resource`]. The basic "gain 1 resource"
+/// action (Rules Reference, Investigation step 2.2.1).
+///
+/// Validate-first: Investigation phase, `investigator` is active and
+/// `Status::Active`, `actions_remaining >= 1`. Mutate-second: spend 1
+/// action, fire attacks of opportunity (Resource is NOT AoO-exempt),
+/// then — if the investigator survived the AoO — gain 1 resource.
+pub(super) fn resource_action(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
+    if cx.state.phase != Phase::Investigation {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Resource is only valid during the Investigation phase (was {:?})",
+                cx.state.phase
+            )
+            .into(),
+        };
+    }
+    if cx.state.active_investigator != Some(investigator) {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Resource: {investigator:?} is not the active investigator ({:?})",
+                cx.state.active_investigator,
+            )
+            .into(),
+        };
+    }
+    let inv = cx.state.investigators.get(&investigator).unwrap_or_else(|| {
+        unreachable!(
+            "Resource: active_investigator {investigator:?} is not in the investigators map; \
+             this is a state-corruption invariant violation"
+        )
+    });
+    if inv.status != Status::Active {
+        return EngineOutcome::Rejected {
+            reason: format!("Resource: {investigator:?} is not Active (status {:?})", inv.status)
+                .into(),
+        };
+    }
+    if inv.actions_remaining < 1 {
+        return EngineOutcome::Rejected {
+            reason: "Resource requires at least 1 action point".into(),
+        };
+    }
+
+    // Mutate-second: spend the action, fire AoO, then gain the resource.
+    spend_one_action(cx, investigator);
+    super::combat::fire_attacks_of_opportunity(cx, investigator);
+
+    // If AoO eliminated the investigator, the gain is suppressed; the
+    // spent action + AoO events stay (mirrors `investigate`).
+    let inv_after = cx.state.investigators.get(&investigator).unwrap_or_else(|| {
+        unreachable!(
+            "Resource: investigator {investigator:?} disappeared between AoO and gain; \
+             this is a state-corruption invariant violation"
+        )
+    });
+    if inv_after.status != Status::Active {
+        return EngineOutcome::Done;
+    }
+
+    let inv_mut = cx
+        .state
+        .investigators
+        .get_mut(&investigator)
+        .expect("investigator existence checked above");
+    inv_mut.resources = inv_mut.resources.saturating_add(1);
+    cx.events.push(Event::ResourcesGained {
+        investigator,
+        amount: 1,
+    });
+    EngineOutcome::Done
+}
+```
+
+- [ ] **Step 6: Add the rejection tests**
+
+In the same test module:
+
+```rust
+#[test]
+fn resource_action_rejects_wrong_phase() {
+    let inv_id = InvestigatorId(1);
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Mythos)
+        .with_investigator(test_investigator(1))
+        .with_active_investigator(inv_id)
+        .build();
+    let result = apply(state, Action::Player(PlayerAction::Resource { investigator: inv_id }));
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert_eq!(result.state.investigators[&inv_id].resources, 5);
+    assert_eq!(result.state.investigators[&inv_id].actions_remaining, 3);
+}
+
+#[test]
+fn resource_action_rejects_when_not_active_investigator() {
+    let inv_id = InvestigatorId(1);
+    let other = InvestigatorId(2);
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(test_investigator(1))
+        .with_investigator(test_investigator(2))
+        .with_active_investigator(other)
+        .build();
+    let result = apply(state, Action::Player(PlayerAction::Resource { investigator: inv_id }));
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+}
+
+#[test]
+fn resource_action_rejects_with_no_actions_remaining() {
+    let inv_id = InvestigatorId(1);
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator({
+            let mut i = test_investigator(1);
+            i.actions_remaining = 0;
+            i
+        })
+        .with_active_investigator(inv_id)
+        .build();
+    let result = apply(state, Action::Player(PlayerAction::Resource { investigator: inv_id }));
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert_eq!(result.state.investigators[&inv_id].resources, 5);
+}
+```
+
+- [ ] **Step 7: Run all Resource tests to verify they pass**
+
+Run: `cargo test -p game-core resource_action 2>&1 | tail -20`
+Expected: PASS (5 tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/game-core/src/action.rs crates/game-core/src/engine/dispatch/mod.rs crates/game-core/src/engine/dispatch/actions.rs crates/game-core/src/engine/mod.rs
+git commit -m "engine: Resource basic action (gain 1 resource, fires AoO)
+
+Adds PlayerAction::Resource — the basic gain-1-resource action
+(Investigation step 2.2.1). Fires attacks of opportunity (not on the
+RR p.5 exempt list of fight/evade/parley/resign); an AoO that
+eliminates the investigator suppresses the gain. Part of #141.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Engage action (#77)
+
+**Files:**
+- Modify: `crates/game-core/src/action.rs` (add `Engage` variant)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (add dispatch arm)
+- Modify: `crates/game-core/src/engine/dispatch/actions.rs` (add `engage` handler)
+- Test: `crates/game-core/src/engine/mod.rs`
+
+**Interfaces:**
+- Produces: `pub(super) fn engage(cx: &mut Cx, investigator: InvestigatorId, enemy_id: EnemyId) -> EngineOutcome`
+- Consumes (existing): `spend_one_action`, `combat::fire_attacks_of_opportunity`, `Event::EnemyEngaged { enemy, investigator }`, `Enemy.{current_location, engaged_with}`.
+
+- [ ] **Step 1: Write the failing happy-path + AoO tests**
+
+```rust
+#[test]
+fn engage_action_engages_unengaged_enemy_at_location() {
+    let inv_id = InvestigatorId(1);
+    let loc = crate::state::LocationId(10);
+    let enemy_id = EnemyId(300);
+    let mut enemy = test_enemy(300, "Aloof Ghoul");
+    enemy.current_location = Some(loc);
+    enemy.engaged_with = None;
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_location(test_location(10, "Study"))
+        .with_investigator({
+            let mut i = test_investigator(1);
+            i.current_location = Some(loc);
+            i
+        })
+        .with_active_investigator(inv_id)
+        .with_enemy(enemy)
+        .build();
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::Engage { investigator: inv_id, enemy: enemy_id }),
+    );
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_eq!(result.state.enemies[&enemy_id].engaged_with, Some(inv_id));
+    assert_eq!(result.state.investigators[&inv_id].actions_remaining, 2);
+    assert_event!(
+        result.events,
+        Event::EnemyEngaged { enemy, investigator }
+            if *enemy == enemy_id && *investigator == inv_id
+    );
+}
+
+#[test]
+fn engage_action_provokes_aoo_from_other_engaged_enemy_not_the_target() {
+    let inv_id = InvestigatorId(1);
+    let loc = crate::state::LocationId(10);
+    let target_id = EnemyId(300);
+    let other_id = EnemyId(301);
+    let mut target = test_enemy(300, "Target Ghoul"); // not engaged yet
+    target.current_location = Some(loc);
+    let mut other = test_enemy(301, "Already-Engaged Ghoul");
+    other.current_location = Some(loc);
+    other.engaged_with = Some(inv_id);
+    other.attack_damage = 1;
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_location(test_location(10, "Study"))
+        .with_investigator({
+            let mut i = test_investigator(1);
+            i.current_location = Some(loc);
+            i
+        })
+        .with_active_investigator(inv_id)
+        .with_enemy(target)
+        .with_enemy(other)
+        .build();
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::Engage { investigator: inv_id, enemy: target_id }),
+    );
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    // The OTHER engaged enemy made the AoO; the target (not engaged at
+    // AoO time) did not. Target ends engaged; investigator took 1 damage.
+    assert_eq!(result.state.investigators[&inv_id].damage, 1);
+    assert_eq!(result.state.enemies[&target_id].engaged_with, Some(inv_id));
+    assert_event!(
+        result.events,
+        Event::DamageTaken { investigator, amount: 1 } if *investigator == inv_id
+    );
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p game-core engage_action 2>&1 | tail -20`
+Expected: FAIL — `no variant named Engage found for enum PlayerAction`.
+
+- [ ] **Step 3: Add the `Engage` variant to `PlayerAction`**
+
+In `crates/game-core/src/action.rs`, after the `Resource` variant:
+
+```rust
+    /// Engage an enemy at the active investigator's location that the
+    /// investigator is not already engaged with (Rules Reference p.4).
+    /// Spends 1 action; the enemy becomes engaged with the investigator.
+    ///
+    /// Validate: Investigation phase, investigator is active and
+    /// `Status::Active`, `actions_remaining >= 1`, the enemy exists, is
+    /// at the investigator's `current_location`, and is not already
+    /// engaged with the investigator.
+    ///
+    /// Engage is NOT on the AoO-exempt list, so OTHER ready engaged
+    /// enemies make attacks of opportunity before the engagement
+    /// resolves (the target is not engaged at that point, so it does
+    /// not). The multiplayer "engage an enemy engaged with another
+    /// investigator" clause is latent (single `engaged_with` field).
+    Engage {
+        /// Investigator performing the action. Must be the active
+        /// investigator during the Investigation phase.
+        investigator: InvestigatorId,
+        /// The enemy to engage. Must be at the investigator's location
+        /// and not already engaged with the investigator.
+        enemy: EnemyId,
+    },
+```
+
+- [ ] **Step 4: Add the dispatch arm**
+
+In `crates/game-core/src/engine/dispatch/mod.rs`, after the `Resource` arm:
+
+```rust
+        PlayerAction::Engage {
+            investigator,
+            enemy,
+        } => actions::engage(cx, *investigator, *enemy),
+```
+
+- [ ] **Step 5: Implement the `engage` handler**
+
+In `crates/game-core/src/engine/dispatch/actions.rs`:
+
+```rust
+/// Handler for [`PlayerAction::Engage`]. Engage an enemy at the
+/// investigator's location that they are not already engaged with
+/// (Rules Reference p.4) — it becomes engaged with the investigator.
+///
+/// Validate-first: Investigation phase, active + `Status::Active`,
+/// `actions_remaining >= 1`, enemy in state, enemy at the investigator's
+/// `current_location`, not already engaged with the investigator.
+/// Mutate-second: spend 1 action, fire attacks of opportunity (Engage is
+/// NOT AoO-exempt — the target is not engaged yet so it cannot AoO; only
+/// OTHER engaged ready enemies do), then — if the investigator survived —
+/// engage the enemy.
+pub(super) fn engage(
+    cx: &mut Cx,
+    investigator: InvestigatorId,
+    enemy_id: EnemyId,
+) -> EngineOutcome {
+    if cx.state.phase != Phase::Investigation {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Engage is only valid during the Investigation phase (was {:?})",
+                cx.state.phase
+            )
+            .into(),
+        };
+    }
+    if cx.state.active_investigator != Some(investigator) {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Engage: {investigator:?} is not the active investigator ({:?})",
+                cx.state.active_investigator,
+            )
+            .into(),
+        };
+    }
+    let inv = cx.state.investigators.get(&investigator).unwrap_or_else(|| {
+        unreachable!(
+            "Engage: active_investigator {investigator:?} is not in the investigators map; \
+             this is a state-corruption invariant violation"
+        )
+    });
+    if inv.status != Status::Active {
+        return EngineOutcome::Rejected {
+            reason: format!("Engage: {investigator:?} is not Active (status {:?})", inv.status)
+                .into(),
+        };
+    }
+    if inv.actions_remaining < 1 {
+        return EngineOutcome::Rejected {
+            reason: "Engage requires at least 1 action point".into(),
+        };
+    }
+    let inv_location = inv.current_location;
+    let Some(enemy) = cx.state.enemies.get(&enemy_id) else {
+        return EngineOutcome::Rejected {
+            reason: format!("Engage: enemy {enemy_id:?} is not in state").into(),
+        };
+    };
+    if enemy.engaged_with == Some(investigator) {
+        return EngineOutcome::Rejected {
+            reason: format!("Engage: {investigator:?} is already engaged with {enemy_id:?}").into(),
+        };
+    }
+    if enemy.current_location != inv_location {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "Engage: enemy {enemy_id:?} (at {:?}) is not at {investigator:?}'s location ({:?})",
+                enemy.current_location, inv_location,
+            )
+            .into(),
+        };
+    }
+
+    // Mutate-second.
+    spend_one_action(cx, investigator);
+    super::combat::fire_attacks_of_opportunity(cx, investigator);
+
+    let inv_after = cx.state.investigators.get(&investigator).unwrap_or_else(|| {
+        unreachable!(
+            "Engage: investigator {investigator:?} disappeared between AoO and engagement; \
+             this is a state-corruption invariant violation"
+        )
+    });
+    if inv_after.status != Status::Active {
+        return EngineOutcome::Done;
+    }
+
+    let enemy_mut = cx.state.enemies.get_mut(&enemy_id).unwrap_or_else(|| {
+        unreachable!(
+            "Engage: enemy {enemy_id:?} disappeared between validation and engagement; \
+             this is a state-corruption invariant violation"
+        )
+    });
+    enemy_mut.engaged_with = Some(investigator);
+    cx.events.push(Event::EnemyEngaged {
+        enemy: enemy_id,
+        investigator,
+    });
+    EngineOutcome::Done
+}
+```
+
+- [ ] **Step 6: Add the rejection tests**
+
+```rust
+#[test]
+fn engage_action_rejects_enemy_not_at_location() {
+    let inv_id = InvestigatorId(1);
+    let here = crate::state::LocationId(10);
+    let there = crate::state::LocationId(11);
+    let enemy_id = EnemyId(300);
+    let mut enemy = test_enemy(300, "Distant Ghoul");
+    enemy.current_location = Some(there);
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_location(test_location(10, "Study"))
+        .with_location(test_location(11, "Hallway"))
+        .with_investigator({
+            let mut i = test_investigator(1);
+            i.current_location = Some(here);
+            i
+        })
+        .with_active_investigator(inv_id)
+        .with_enemy(enemy)
+        .build();
+    let result = apply(state, Action::Player(PlayerAction::Engage { investigator: inv_id, enemy: enemy_id }));
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert_eq!(result.state.enemies[&enemy_id].engaged_with, None);
+    assert_eq!(result.state.investigators[&inv_id].actions_remaining, 3);
+}
+
+#[test]
+fn engage_action_rejects_already_engaged_enemy() {
+    let inv_id = InvestigatorId(1);
+    let loc = crate::state::LocationId(10);
+    let enemy_id = EnemyId(300);
+    let mut enemy = test_enemy(300, "Engaged Ghoul");
+    enemy.current_location = Some(loc);
+    enemy.engaged_with = Some(inv_id);
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_location(test_location(10, "Study"))
+        .with_investigator({
+            let mut i = test_investigator(1);
+            i.current_location = Some(loc);
+            i
+        })
+        .with_active_investigator(inv_id)
+        .with_enemy(enemy)
+        .build();
+    let result = apply(state, Action::Player(PlayerAction::Engage { investigator: inv_id, enemy: enemy_id }));
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert_eq!(result.state.investigators[&inv_id].actions_remaining, 3);
+}
+
+#[test]
+fn engage_action_rejects_unknown_enemy() {
+    let inv_id = InvestigatorId(1);
+    let loc = crate::state::LocationId(10);
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_location(test_location(10, "Study"))
+        .with_investigator({
+            let mut i = test_investigator(1);
+            i.current_location = Some(loc);
+            i
+        })
+        .with_active_investigator(inv_id)
+        .build();
+    let result = apply(state, Action::Player(PlayerAction::Engage { investigator: inv_id, enemy: EnemyId(999) }));
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+}
+
+#[test]
+fn engage_action_rejects_no_actions_remaining() {
+    let inv_id = InvestigatorId(1);
+    let loc = crate::state::LocationId(10);
+    let enemy_id = EnemyId(300);
+    let mut enemy = test_enemy(300, "Ghoul");
+    enemy.current_location = Some(loc);
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_location(test_location(10, "Study"))
+        .with_investigator({
+            let mut i = test_investigator(1);
+            i.current_location = Some(loc);
+            i.actions_remaining = 0;
+            i
+        })
+        .with_active_investigator(inv_id)
+        .with_enemy(enemy)
+        .build();
+    let result = apply(state, Action::Player(PlayerAction::Engage { investigator: inv_id, enemy: enemy_id }));
+    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert_eq!(result.state.enemies[&enemy_id].engaged_with, None);
+}
+```
+
+- [ ] **Step 7: Run all Engage tests to verify they pass**
+
+Run: `cargo test -p game-core engage_action 2>&1 | tail -20`
+Expected: PASS (6 tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/game-core/src/action.rs crates/game-core/src/engine/dispatch/mod.rs crates/game-core/src/engine/dispatch/actions.rs crates/game-core/src/engine/mod.rs
+git commit -m "engine: Engage basic action (engage enemy at your location)
+
+Adds PlayerAction::Engage (RR p.4): engage an enemy at your location not
+already engaged with you; it becomes engaged. Fires attacks of
+opportunity from OTHER ready engaged enemies (the target isn't engaged
+yet). Multiplayer 'engage an enemy engaged with another investigator'
+clause is latent. Part of #77.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Draw AoO fix + exempt-list comment fix
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/cards.rs` (`draw` handler — add AoO)
+- Modify: `crates/game-core/src/engine/dispatch/actions.rs:108` (fix the exempt-list comment)
+- Test: `crates/game-core/src/engine/mod.rs`
+
+**Interfaces:**
+- Consumes (existing): `combat::fire_attacks_of_opportunity`, the `draw` handler's existing structure.
+
+- [ ] **Step 1: Write the failing Draw-AoO test**
+
+```rust
+#[test]
+fn draw_action_fires_aoo_from_ready_engaged_enemy() {
+    let inv_id = InvestigatorId(1);
+    let loc = crate::state::LocationId(10);
+    let mut enemy = test_enemy(200, "Engaged Ghoul");
+    enemy.current_location = Some(loc);
+    enemy.engaged_with = Some(inv_id);
+    enemy.attack_damage = 1;
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_location(test_location(10, "Study"))
+        .with_investigator({
+            let mut i = test_investigator(1);
+            i.current_location = Some(loc);
+            // Give the deck a card so the draw itself succeeds without
+            // the empty-deck horror path muddying the AoO assertion.
+            i.deck = vec![CardCode::new("_test_card_1")];
+            i
+        })
+        .with_active_investigator(inv_id)
+        .with_enemy(enemy)
+        .build();
+
+    let result = apply(state, Action::Player(PlayerAction::Draw { investigator: inv_id }));
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_eq!(result.state.investigators[&inv_id].damage, 1);
+    assert_event!(
+        result.events,
+        Event::DamageTaken { investigator, amount: 1 } if *investigator == inv_id
+    );
+}
+```
+
+> Note: confirm the `CardCode` constructor used elsewhere in this test module (`CardCode::new(...)` vs `CardCode("...".into())`) and match it; both appear in the codebase — use whichever the surrounding tests use.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p game-core draw_action_fires_aoo 2>&1 | tail -20`
+Expected: FAIL — `investigators[&inv_id].damage` is `0` (no AoO fired) / `DamageTaken event missing`.
+
+- [ ] **Step 3: Add the AoO call to the `draw` handler**
+
+In `crates/game-core/src/engine/dispatch/cards.rs`, in `draw`, immediately after `super::actions::spend_one_action(cx, investigator);` and before the deck-draw logic, insert:
+
+```rust
+    // Draw is NOT on the AoO-exempt list (only Fight, Evade, Parley,
+    // Resign are), so each ready engaged enemy attacks before the card
+    // is drawn (RR p.5).
+    super::combat::fire_attacks_of_opportunity(cx, investigator);
+
+    // If the AoO eliminated the investigator, suppress the draw (the
+    // spent action + AoO events stay), mirroring `investigate`.
+    if cx
+        .state
+        .investigators
+        .get(&investigator)
+        .is_none_or(|inv| inv.status != Status::Active)
+    {
+        return EngineOutcome::Done;
+    }
+```
+
+> If `Status` / `EngineOutcome` are not already imported in `cards.rs`, add the imports the surrounding code uses (the file already references `Status` for the `Draw` validation, so it is in scope). Verify `is_none_or` is acceptable under the crate's MSRV; if clippy/compile rejects it, use `.map_or(true, |inv| inv.status != Status::Active)`.
+
+- [ ] **Step 4: Fix the exempt-list comment**
+
+In `crates/game-core/src/engine/dispatch/actions.rs` (the `investigate` handler, ~line 108), change:
+
+```rust
+    // test. Investigate is NOT on the AoO-exempt list (only Fight,
+    // Evade, Parley, Engage, Resign are), so each ready engaged
+    // enemy attacks before the test resolves.
+```
+
+to:
+
+```rust
+    // test. Investigate is NOT on the AoO-exempt list (only Fight,
+    // Evade, Parley, Resign are), so each ready engaged enemy attacks
+    // before the test resolves.
+```
+
+- [ ] **Step 5: Run the Draw-AoO test + the full draw test group to verify**
+
+Run: `cargo test -p game-core draw 2>&1 | tail -20`
+Expected: PASS — the new AoO test plus all existing `draw` tests still green (the empty-deck-horror tests use no engaged enemy, so AoO is a no-op there).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/cards.rs crates/game-core/src/engine/dispatch/actions.rs crates/game-core/src/engine/mod.rs
+git commit -m "engine: Draw action fires attacks of opportunity
+
+Draw is not on the RR p.5 AoO-exempt list (fight/evade/parley/resign),
+but the handler never fired AoO — fixed, with the same elimination guard
+the other basic actions use. Also corrects the actions.rs exempt-list
+comment that wrongly included Engage.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Final gauntlet + phase-doc update
+
+**Files:**
+- Modify: `docs/phases/phase-7-the-gathering.md` (mark #141/#77 progress)
+
+- [ ] **Step 1: Run the full CI gauntlet**
+
+```sh
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+```
+Expected: all green. Fix any clippy/fmt/doc issues before proceeding.
+
+- [ ] **Step 2: Update the phase doc**
+
+In `docs/phases/phase-7-the-gathering.md`, Tier-1 group A: note #141 (Resource) and #77 (Engage's basic-action half) as shipped (cite the PR once open), and record the discovered/fixed Draw-AoO gap + the corrected exempt-list. Add a Decisions/Architecture note only if load-bearing for future work (the "all non-exempt actions fire `fire_attacks_of_opportunity`; the keystone upgrades them to open windows" point is worth one line). Defer this commit until the PR is otherwise ready (per the phase-doc workflow).
+
+- [ ] **Step 3: Commit the doc update**
+
+```bash
+git add docs/phases/phase-7-the-gathering.md
+git commit -m "docs: phase-7 — Resource + Engage basic actions shipped
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- Resource action (#141) → Task 1. ✓
+- Engage action (#77) → Task 2. ✓
+- Both fire AoO (not exempt), with elimination guard → Tasks 1 & 2 mutate steps. ✓
+- Draw AoO fix (folded in, option b) → Task 3. ✓
+- Exempt-list comment fix → Task 3 Step 4. ✓
+- Validate-first/mutate-second, panics for state-corruption → handler code follows `investigate`. ✓
+- Out of scope (AoO windows #293/#379, attack-order #143, Engage multiplayer clause, Parley/Resign #258) → not implemented; noted in variant doc-comments. ✓
+- Testing per action (happy / rejections / AoO) → Tasks 1, 2, 3 test steps. ✓
+
+**Placeholder scan:** No "TBD"/"add validation"/"write tests for the above" — every handler and test step carries complete code. Two flagged verification notes (CardCode constructor form, `is_none_or` MSRV) are explicit fallbacks, not placeholders. ✓
+
+**Type consistency:** `resource_action(cx, investigator)`, `engage(cx, investigator, enemy_id)` match their dispatch arms; `Event::ResourcesGained { investigator, amount }` and `Event::EnemyEngaged { enemy, investigator }` match the `event.rs` definitions; `Enemy.{current_location, engaged_with}`, `Status::Active`, `spend_one_action`, `combat::fire_attacks_of_opportunity` all verified against source. ✓

--- a/docs/superpowers/specs/2026-06-19-resource-engage-basic-actions-design.md
+++ b/docs/superpowers/specs/2026-06-19-resource-engage-basic-actions-design.md
@@ -1,0 +1,123 @@
+# Resource + Engage basic actions (+ Draw AoO fix)
+
+Phase 7 — solo correctness gate, Tier-1 item A (missing basic actions).
+Closes #141 (Resource) and #77 (Engage's basic-action half; Parley defers to
+#258). Folds in a fix to the pre-existing Draw attack-of-opportunity gap found
+during design.
+
+## Background
+
+The Rules Reference (vendored PDF, p.4/p.5) lists the **basic actions**:
+*Draw, Resource, Move, Investigate, Fight, Engage, Evade*. The engine's
+`PlayerAction` enum has Draw, Move, Investigate, Fight, Evade — but **no
+Resource and no Engage**, so a solo player cannot take either. This adds them.
+
+**Attack-of-opportunity rule (RR p.5, verbatim):** "Each time an investigator
+is engaged with one or more ready enemies and takes an action other than to
+fight, to evade, or to activate a parley or resign ability, each of those
+enemies makes an attack of opportunity against the investigator, in the order
+of the investigator's choosing." So the exempt actions are **fight / evade /
+parley / resign only** — Draw, Resource, Move, Investigate, and **Engage** all
+provoke an AoO. Today Move and Investigate fire `fire_attacks_of_opportunity`;
+Draw does **not** (a latent gap); a comment in `actions.rs` wrongly lists Engage
+as exempt.
+
+## Scope
+
+In: the Resource and Engage actions, both firing AoO; the Draw AoO fix; the
+stale exempt-list comment. Out: the AoO *reaction windows* (soak/cancel) — the
+keystone cluster (#293/#379/#361/#378) upgrades **all** AoO sites uniformly
+later; this work uses the existing window-less `fire_attacks_of_opportunity` and
+stays consistent with Move/Investigate. Also out: Engage's multiplayer
+"engage an enemy engaged with another investigator" clause (single
+`Enemy.engaged_with` field; latent in 1p) and Parley/Resign (card/location-
+granted action types, not basic actions → #258).
+
+## Design
+
+Both handlers live in `engine/dispatch/actions.rs` and follow the established
+**validate-first / mutate-second** basic-action shape (cf. `move_action`,
+`investigate`), reusing `spend_one_action` and `combat::fire_attacks_of_opportunity`.
+
+### Resource action (#141)
+
+`PlayerAction::Resource { investigator }`.
+
+- **Validate** (all preconditions before any mutation): phase is
+  `Investigation`; `investigator` is the active investigator; status is
+  `Active`; `actions_remaining >= 1`.
+- **Mutate**: `spend_one_action` → `fire_attacks_of_opportunity(cx, investigator)`
+  (Resource is not exempt) → **if the investigator is still `Active`** (AoO can
+  defeat/eliminate them), `resources = resources.saturating_add(1)` and emit
+  `Event::ResourcesGained { investigator, amount: 1 }`. If AoO eliminated them,
+  the resource is not gained — the spent action + AoO events stay (mirrors the
+  Move/Investigate "primary effect suppressed by AoO" guard).
+
+### Engage action (#77)
+
+`PlayerAction::Engage { investigator, enemy }`.
+
+- **Validate**: phase is `Investigation`; `investigator` is active; status is
+  `Active`; `actions_remaining >= 1`; `enemy` exists in state; the enemy is at
+  the investigator's `current_location`; the investigator is **not already
+  engaged** with that enemy (`enemy.engaged_with != Some(investigator)` — RR:
+  "cannot engage an enemy he or she is already engaged with").
+- **Mutate**: `spend_one_action` →
+  `fire_attacks_of_opportunity(cx, investigator)` (from *other* already-engaged
+  ready enemies; the target is not engaged yet, so it is correctly not in the
+  AoO set) → **if still `Active`**, set `enemy.engaged_with = Some(investigator)`
+  and emit `Event::EnemyEngaged { … }`. AoO-elimination suppresses the
+  engagement, same guard as Resource.
+
+### Draw AoO fix (folded in)
+
+Add `fire_attacks_of_opportunity(cx, investigator)` to the `Draw` handler
+(`engine/dispatch/cards.rs`), after `spend_one_action` and before the card is
+drawn, with the same "if still `Active`" guard around the draw. Draw is not
+AoO-exempt; this brings it in line with Move/Investigate and the two new
+actions.
+
+### Comment fix
+
+Correct the `actions.rs` exempt-list comment (currently "only Fight, Evade,
+Parley, Engage, Resign are [exempt]") to the rules-accurate set: **fight /
+evade / parley / resign**.
+
+## Dispatch wiring
+
+Add the two variants to `PlayerAction` (`action.rs`, with doc-comments stating
+the validation + AoO behavior), and two arms to the `apply_player_action`
+match (`engine/dispatch/mod.rs`) delegating to the new `actions.rs` handlers.
+`#[non_exhaustive]` is already on the enum.
+
+## Testing
+
+Engine unit tests (`actions.rs` `#[cfg(test)]`) using the `TestGame` builder +
+event-assertion macros:
+
+- **Resource**: happy path (action spent, +1 resource, `ResourcesGained`
+  emitted); rejections — wrong phase, not active investigator, not `Active`
+  status, `actions_remaining == 0`; AoO path — engaged with a ready enemy →
+  AoO fires (damage dealt) and the resource is still gained when the
+  investigator survives.
+- **Engage**: happy path (action spent, target `engaged_with` set,
+  `EnemyEngaged` emitted); rejections — wrong phase / not active / not `Active`
+  / no actions / enemy not in state / enemy not at the investigator's location /
+  already engaged with that enemy; AoO path — a *second* already-engaged ready
+  enemy makes an AoO when the first is engaged (2-enemy fixture), and the target
+  enemy does **not** AoO (it wasn't engaged yet).
+- **Draw**: extend the existing Draw tests with an AoO case (engaged ready enemy
+  → AoO fires on Draw).
+
+No integration test needed (no card data); these are pure engine actions.
+
+## Out-of-scope follow-ups (already tracked / noted)
+
+- AoO **reaction windows** (Guard Dog soak, Dodge cancel) on these sites —
+  keystone #293/#379; this work uses the window-less mechanism, consistent with
+  the existing AoO callers.
+- **Engage attack-order** when multiple other enemies are engaged — RR "in the
+  order of the investigator's choosing" is #143 (player-picked AoO order);
+  today `fire_attacks_of_opportunity` uses a fixed deterministic order.
+- Engage's **multiplayer** clause (engage an enemy engaged with another
+  investigator) — needs multi-investigator engagement, deferred.


### PR DESCRIPTION
Phase-7 solo-correctness-gate, Tier-1 item A (missing basic actions).

## Summary

Adds the two basic actions the engine was missing and fixes a related latent bug. Per Rules Reference p.5, the **only** AoO-exempt actions are fight/evade/parley/resign — so Draw, Resource, Move, Investigate, and Engage all provoke an attack of opportunity.

- **`PlayerAction::Resource`** (#141) — the basic gain-1-resource action (Investigation step 2.2.1). Validate-first → spend action → fire AoO → gain 1 resource if the investigator survived.
- **`PlayerAction::Engage`** (#77, Engage half) — engage an enemy at your location not already engaged with you (RR p.4); it becomes engaged. AoO fires from *other* already-engaged ready enemies (the target isn't engaged yet, so it can't attack).
- **Draw AoO fix** — the `Draw` handler never fired AoO despite Draw not being exempt; fixed, with the same elimination guard the other actions use.
- **Comment fix** — corrected the `actions.rs` comment that wrongly listed Engage on the AoO-exempt list.

All three handlers mirror the canonical `investigate` shape: an AoO that eliminates the investigator suppresses the action's primary effect (`Done`, action + AoO events kept).

## Scope

`#77` is **not fully closed** — its Engage half ships here; **Parley** is an action *type* granted only by card/location abilities (RR p.5: "Activate, Play, Resign, and Parley are not basic actions"), tracked under #258 (Lita/Parlor). Out of scope (tracked): AoO reaction windows (#293/#379), player-chosen AoO attack order (#143), Engage's multiplayer "engage an enemy engaged with another investigator" clause.

## Design / plan

`docs/superpowers/specs/2026-06-19-resource-engage-basic-actions-design.md`, `docs/superpowers/plans/2026-06-19-resource-engage-basic-actions.md`.

## Test plan

14 new engine unit tests (7 Resource, 7 Engage) + a Draw-AoO test: happy paths, every rejection branch (incl. Engage's not-at-location / already-engaged / not-Active), the AoO interaction (other-enemy-only for Engage), and the AoO-eliminates-suppression guard. Full gauntlet green locally: fmt, clippy `-D warnings`, `RUSTFLAGS=-D warnings test --all --all-features`, doc, wasm-build, wasm-clippy.

A pre-push review (APPROVE) flagged two minors, both addressed: an explicit None-location guard on Engage, and tests for the not-Active + AoO-elimination branches.

Closes #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)