### PR TITLE
engine: serializable EvalContext with grouped bindings (#345)

### DIFF
--- a/crates/cards/src/impls/cover_up.rs
+++ b/crates/cards/src/impls/cover_up.rs
@@ -66,10 +66,10 @@ pub fn native_effect_for(tag: &str) -> Option<NativeEffectFn> {
 /// count (threaded via `clue_discovery_count`) from the firing instance.
 fn discard_clues(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
     debug_assert!(
-        ctx.clue_discovery_count.is_some(),
+        ctx.clue_discovery_count().is_some(),
         "cover_up discard: clue_discovery_count not threaded"
     );
-    let count = ctx.clue_discovery_count.unwrap_or(0);
+    let count = ctx.clue_discovery_count().unwrap_or(0);
     let Some(source) = ctx.source else {
         return EngineOutcome::Rejected {
             reason: "cover_up discard: no source instance".into(),

--- a/crates/cards/src/impls/crypt_chill.rs
+++ b/crates/cards/src/impls/crypt_chill.rs
@@ -70,7 +70,7 @@ fn crypt_chill_fail(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
     let assets = controlled_assets(cx, controller);
 
     // Resume: a pick was threaded in — re-enumerate and index by it.
-    if let Some(picked) = ctx.chosen_option {
+    if let Some(picked) = ctx.chosen_option() {
         let Some(&instance) = assets.get(picked.0 as usize) else {
             return EngineOutcome::Rejected {
                 reason: "01167 crypt-chill-fail: chosen_option out of range".into(),

--- a/crates/cards/src/impls/dynamite_blast.rs
+++ b/crates/cards/src/impls/dynamite_blast.rs
@@ -81,7 +81,7 @@ fn dynamite_blast(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
     let locations = candidate_locations(cx, controller);
 
     // Resume: a pick was threaded in — re-enumerate and index by it.
-    if let Some(picked) = ctx.chosen_option {
+    if let Some(picked) = ctx.chosen_option() {
         let Some(&loc) = locations.get(picked.0 as usize) else {
             return EngineOutcome::Rejected {
                 reason: "01024 blast: chosen_option out of range".into(),

--- a/crates/cards/src/impls/guard_dog.rs
+++ b/crates/cards/src/impls/guard_dog.rs
@@ -52,7 +52,7 @@ pub(crate) fn native_effect_for(tag: &str) -> Option<NativeEffectFn> {
 /// somehow absent we reject loudly (matching the card-effect error
 /// policy) rather than panic.
 fn retaliate(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
-    let Some(enemy) = ctx.attacking_enemy else {
+    let Some(enemy) = ctx.attacking_enemy() else {
         return EngineOutcome::Rejected {
             reason: "01021:retaliate fired without attacking_enemy bound — \
                      only the AfterEnemyAttackDamagedAsset window fires this \
@@ -123,7 +123,7 @@ mod tests {
         state.enemies.insert(eid, enemy);
 
         let mut ctx = EvalContext::for_controller(InvestigatorId(1));
-        ctx.attacking_enemy = Some(eid);
+        ctx.set_attacking_enemy(eid);
 
         let (out, events) = cx_apply(&mut state, &ctx, retaliate);
         assert_eq!(out, EngineOutcome::Done);

--- a/crates/game-core/src/engine/dispatch/choice.rs
+++ b/crates/game-core/src/engine/dispatch/choice.rs
@@ -63,8 +63,7 @@ pub(crate) fn suspend_for_choice(
             decisions,
             offered,
             effect,
-            controller: eval_ctx.controller,
-            source: eval_ctx.source,
+            context: eval_ctx,
         }));
     EngineOutcome::AwaitingInput {
         request: InputRequest::choice(prompt, options),
@@ -96,9 +95,9 @@ pub fn suspend_for_native_choice(
 }
 
 /// Resume a [`Continuation::Choice`]: validate the pick is in the offered
-/// set, append it to `decisions`, pop the frame, rebuild the
-/// [`EvalContext`] from the stored ingredients, and re-run the effect from
-/// the top (the evaluator replays `decisions`).
+/// set, append it to `decisions`, pop the frame, restore the snapshotted
+/// [`EvalContext`] (durable identity + any active window bindings), and re-run
+/// the effect from the top (the evaluator replays `decisions`).
 pub(crate) fn resume_choice(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
     let InputResponse::PickSingle(picked) = response else {
         return EngineOutcome::Rejected {
@@ -121,7 +120,7 @@ pub(crate) fn resume_choice(cx: &mut Cx, response: &InputResponse) -> EngineOutc
     };
     let mut decisions = frame.decisions;
     decisions.push(*picked);
-    let eval_ctx = EvalContext::for_controller_with_optional_source(frame.controller, frame.source);
+    let eval_ctx = frame.context;
     let outcome = apply_effect_with_decisions(cx, &frame.effect, eval_ctx, decisions);
 
     // If the choice completed an effect that was suspended *inside* a skill
@@ -163,5 +162,39 @@ mod tests {
     #[test]
     fn resolve_two_options_suspends() {
         assert!(matches!(resolve_choice_count(2), ChoiceResolution::Suspend));
+    }
+
+    #[test]
+    fn choice_frame_snapshots_active_skill_test_binding() {
+        use crate::state::InvestigatorId;
+        use crate::test_support::GameStateBuilder;
+
+        // A context carrying an active on_fail margin when a choice suspends.
+        let mut ctx = EvalContext::for_controller(InvestigatorId(1));
+        ctx.set_failed_by(2);
+
+        let mut state = GameStateBuilder::default().build();
+        let mut events = Vec::new();
+        let _ = suspend_for_choice(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            "pick",
+            vec!["a".into(), "b".into()],
+            Vec::new(),
+            crate::dsl::Effect::Seq(vec![]),
+            ctx,
+        );
+
+        let Some(Continuation::Choice(frame)) = state.continuations.last() else {
+            panic!("expected a Choice frame on the stack");
+        };
+        assert_eq!(
+            frame.context.failed_by(),
+            Some(2),
+            "the active skill-test margin must be snapshotted onto the ChoiceFrame, \
+             not dropped at suspend",
+        );
     }
 }

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -655,14 +655,14 @@ fn fire_pending_trigger(cx: &mut Cx, i: u32) -> EngineOutcome {
         .and_then(ResolutionFrame::kind)
     {
         Some(WindowKind::AfterEnemyAttackDamagedAsset { enemy, .. }) => {
-            eval_ctx.attacking_enemy = Some(enemy);
+            eval_ctx.set_attacking_enemy(enemy);
         }
         // For `BeforeDiscoverClues`, bind the would-be discovery count so the
         // replacement effect (Cover Up's "discard that many") discards the
         // right number. Mirrors `attacking_enemy`. TODO(#368): `count` is the
         // requested, not the capped, count.
         Some(WindowKind::BeforeDiscoverClues { count, .. }) => {
-            eval_ctx.clue_discovery_count = Some(count);
+            eval_ctx.set_clue_discovery_count(count);
         }
         _ => {}
     }

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -341,7 +341,7 @@ pub(super) fn finish_skill_test(cx: &mut Cx, indices: &[u32]) -> EngineOutcome {
         // effects (Deal / Native) run to completion;
         // a future suspending on_fail is #212 reentrancy work.
         let mut ctx = card_ctx(investigator);
-        ctx.failed_by = Some(failed_by);
+        ctx.set_failed_by(failed_by);
         let outcome = apply_effect(cx, effect, ctx);
         if matches!(outcome, EngineOutcome::AwaitingInput { .. }) {
             // on_fail suspended on a controller choice (Crypt Chill 01167's

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -185,6 +185,75 @@ impl EvalContext {
     }
 }
 
+impl EvalContext {
+    /// Just-resolved skill test's failure margin (bound only while running an
+    /// `on_fail` effect). See [`Effect::ForEachPointFailed`].
+    #[must_use]
+    pub fn failed_by(&self) -> Option<u8> {
+        self.failed_by
+    }
+    /// Clue count a before-discovery interrupt is replacing (bound only while
+    /// resolving a `WouldDiscoverClues` ability's effect).
+    #[must_use]
+    pub fn clue_discovery_count(&self) -> Option<u8> {
+        self.clue_discovery_count
+    }
+    /// Attacking enemy bound while resolving an `EnemyAttackDamagedSelf` reaction.
+    #[must_use]
+    pub fn attacking_enemy(&self) -> Option<crate::state::EnemyId> {
+        self.attacking_enemy
+    }
+    /// Investigator picked for an `InvestigatorTarget::Chosen`.
+    #[must_use]
+    pub fn chosen_investigator(&self) -> Option<crate::state::InvestigatorId> {
+        self.chosen_investigator
+    }
+    /// Location picked for a `LocationTarget::Chosen`.
+    #[must_use]
+    pub fn chosen_location(&self) -> Option<crate::state::LocationId> {
+        self.chosen_location
+    }
+    /// Enemy picked for an `EnemyTarget::Chosen`.
+    #[must_use]
+    pub fn chosen_enemy(&self) -> Option<crate::state::EnemyId> {
+        self.chosen_enemy
+    }
+    /// Option picked for a native leaf that suspended for a choice.
+    #[must_use]
+    pub fn chosen_option(&self) -> Option<crate::engine::OptionId> {
+        self.chosen_option
+    }
+
+    /// Bind the skill-test failure margin (see [`Self::failed_by`]).
+    pub fn set_failed_by(&mut self, margin: u8) {
+        self.failed_by = Some(margin);
+    }
+    /// Bind the before-discovery clue count (see [`Self::clue_discovery_count`]).
+    pub fn set_clue_discovery_count(&mut self, count: u8) {
+        self.clue_discovery_count = Some(count);
+    }
+    /// Bind the attacking enemy (see [`Self::attacking_enemy`]).
+    pub fn set_attacking_enemy(&mut self, enemy: crate::state::EnemyId) {
+        self.attacking_enemy = Some(enemy);
+    }
+    /// Bind the chosen investigator (see [`Self::chosen_investigator`]).
+    pub fn set_chosen_investigator(&mut self, id: crate::state::InvestigatorId) {
+        self.chosen_investigator = Some(id);
+    }
+    /// Bind the chosen location (see [`Self::chosen_location`]).
+    pub fn set_chosen_location(&mut self, id: crate::state::LocationId) {
+        self.chosen_location = Some(id);
+    }
+    /// Bind the chosen enemy (see [`Self::chosen_enemy`]).
+    pub fn set_chosen_enemy(&mut self, id: crate::state::EnemyId) {
+        self.chosen_enemy = Some(id);
+    }
+    /// Bind (or clear) the native-leaf chosen option (see [`Self::chosen_option`]).
+    pub fn set_chosen_option(&mut self, opt: Option<crate::engine::OptionId>) {
+        self.chosen_option = opt;
+    }
+}
+
 /// Apply an effect tree to the state.
 ///
 /// See module docs for the v0 scope and the validate-first
@@ -319,7 +388,7 @@ fn apply_effect_inner(
         Effect::AdvanceCurrentAct => apply_advance_current_act(cx),
         Effect::Native { tag } => apply_native(cx, tag, eval_ctx, cursor),
         Effect::ForEachPointFailed(body) => {
-            let n = eval_ctx.failed_by.unwrap_or(0);
+            let n = eval_ctx.failed_by().unwrap_or(0);
             for _ in 0..n {
                 match apply_effect_inner(cx, body, eval_ctx, cursor) {
                     EngineOutcome::Done => {}
@@ -1287,7 +1356,7 @@ fn apply_native(
     };
     let consumed_before = cursor.has_consumed();
     let mut eval_ctx = eval_ctx;
-    eval_ctx.chosen_option = cursor.take();
+    eval_ctx.set_chosen_option(cursor.take());
     let outcome = f(cx, &eval_ctx);
     debug_assert!(
         !(matches!(outcome, EngineOutcome::AwaitingInput { .. }) && consumed_before),
@@ -1420,7 +1489,7 @@ fn ground_chosen_targets(
         _ => None,
     };
     if let Some(InvestigatorTarget::Chosen(choose)) = inv_target {
-        if eval_ctx.chosen_investigator.is_none() {
+        if eval_ctx.chosen_investigator().is_none() {
             return ground_investigator_choice(cx, eval_ctx, cursor, choose.scope);
         }
     }
@@ -1430,7 +1499,7 @@ fn ground_chosen_targets(
         ..
     } = effect
     {
-        if eval_ctx.chosen_location.is_none() {
+        if eval_ctx.chosen_location().is_none() {
             return ground_location_choice(cx, eval_ctx, cursor, choose.scope);
         }
     }
@@ -1440,7 +1509,7 @@ fn ground_chosen_targets(
         ..
     } = effect
     {
-        if eval_ctx.chosen_enemy.is_none() {
+        if eval_ctx.chosen_enemy().is_none() {
             return ground_enemy_choice(cx, eval_ctx, cursor, choose.scope);
         }
     }
@@ -1464,7 +1533,7 @@ fn ground_investigator_choice(
     let candidates = investigator_candidates(cx.state, eval_ctx.controller, scope);
     let bind = |id| {
         let mut ctx = eval_ctx;
-        ctx.chosen_investigator = Some(id);
+        ctx.set_chosen_investigator(id);
         Ok(ctx)
     };
     match resolve_choice_count(candidates.len()) {
@@ -1505,7 +1574,7 @@ fn ground_location_choice(
     let candidates = location_candidates(cx.state, eval_ctx.controller, set);
     let bind = |id| {
         let mut ctx = eval_ctx;
-        ctx.chosen_location = Some(id);
+        ctx.set_chosen_location(id);
         Ok(ctx)
     };
     match resolve_choice_count(candidates.len()) {
@@ -1546,7 +1615,7 @@ fn ground_enemy_choice(
         crate::engine::dispatch::combat::enemies_in_scope(cx.state, eval_ctx.controller, scope);
     let bind = |id| {
         let mut ctx = eval_ctx;
-        ctx.chosen_enemy = Some(id);
+        ctx.set_chosen_enemy(id);
         Ok(ctx)
     };
     match resolve_choice_count(candidates.len()) {
@@ -1641,7 +1710,7 @@ fn resolve_investigator_target(
         InvestigatorTarget::Active => state
             .active_investigator
             .ok_or("InvestigatorTarget::Active but no active investigator (outside Investigation)"),
-        InvestigatorTarget::Chosen(_) => ctx.chosen_investigator.ok_or(
+        InvestigatorTarget::Chosen(_) => ctx.chosen_investigator().ok_or(
             "InvestigatorTarget::Chosen resolved before target-grounding bound it \
              (ground_chosen_targets should run first)",
         ),
@@ -1659,7 +1728,7 @@ fn resolve_location_target(
             .get(&ctx.controller)
             .and_then(|i| i.current_location)
             .ok_or("LocationTarget::YourLocation but the controller is between locations"),
-        LocationTarget::Chosen(_) => ctx.chosen_location.ok_or(
+        LocationTarget::Chosen(_) => ctx.chosen_location().ok_or(
             "LocationTarget::Chosen resolved before target-grounding bound it \
              (ground_chosen_targets should run first)",
         ),
@@ -1681,7 +1750,7 @@ fn resolve_enemy_target(
     target: EnemyTarget,
 ) -> Result<crate::state::EnemyId, &'static str> {
     match target {
-        EnemyTarget::Chosen(_) => ctx.chosen_enemy.ok_or(
+        EnemyTarget::Chosen(_) => ctx.chosen_enemy().ok_or(
             "EnemyTarget::Chosen resolved before target-grounding bound it \
              (ground_chosen_targets should run first)",
         ),
@@ -2056,7 +2125,7 @@ mod tests {
     #[test]
     fn eval_context_defaults_clue_discovery_count_to_none() {
         let ctx = EvalContext::for_controller(InvestigatorId(1));
-        assert_eq!(ctx.clue_discovery_count, None);
+        assert_eq!(ctx.clue_discovery_count(), None);
     }
 
     #[test]
@@ -4263,7 +4332,7 @@ mod tests {
         };
         // Margin 2 → run Deal{Damage,You,1} twice → 2 damage, 2 events.
         let mut eval_ctx = EvalContext::for_controller(InvestigatorId(1));
-        eval_ctx.failed_by = Some(2);
+        eval_ctx.set_failed_by(2);
         let outcome = apply_effect(
             &mut cx,
             &for_each_point_failed(deal_damage(InvestigatorTarget::You, 1)),

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -56,6 +56,8 @@
 //! change and no events pushed. The outer apply loop's belt-and-
 //! suspenders `events.clear()` on rejection backs this up.
 
+use serde::{Deserialize, Serialize};
+
 use crate::card_registry::CardRegistry;
 use crate::dsl::{
     Condition, Effect, EnemyTarget, HarmKind, IntExpr, InvestigatorTarget, LocationTarget,
@@ -67,6 +69,46 @@ use crate::state::{GameState, InvestigatorId, SkillKind};
 use super::outcome::EngineOutcome;
 use super::Cx;
 
+/// Failure margin of the just-resolved skill test (bound only while running an
+/// `on_fail` effect). Innermost-only: same-kind test nesting is carried by the
+/// per-frame snapshot stack, not multiple slots here (corpus-verified moot — no
+/// card reads a non-innermost margin; see the §1 cleanup spec §D).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillTestBinding {
+    /// Points the test was failed by.
+    pub failed_by: u8,
+}
+
+/// Clue count a before-discovery interrupt is replacing (bound only while
+/// resolving a `WouldDiscoverClues` ability's effect).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiscoveryBinding {
+    /// Clues the interrupt is replacing.
+    pub clue_discovery_count: u8,
+}
+
+/// Attacking enemy bound while resolving an `EnemyAttackDamagedSelf` reaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnemyAttackBinding {
+    /// The enemy whose attack is being reacted to.
+    pub attacking_enemy: crate::state::EnemyId,
+}
+
+/// Controller picks bound while grounding `*::Chosen` targets. Cohesive: the
+/// four `*::Chosen` kinds compose on one binding (a single effect may pick an
+/// investigator *and* a location). `Default` is all-`None`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ChoiceBinding {
+    /// `InvestigatorTarget::Chosen` pick.
+    pub investigator: Option<crate::state::InvestigatorId>,
+    /// `LocationTarget::Chosen` pick.
+    pub location: Option<crate::state::LocationId>,
+    /// `EnemyTarget::Chosen` pick.
+    pub enemy: Option<crate::state::EnemyId>,
+    /// Native-leaf option pick.
+    pub option: Option<crate::engine::OptionId>,
+}
+
 /// Per-evaluation context the effect needs to resolve targets and
 /// reference in-flight game state (current skill test, etc.).
 ///
@@ -76,7 +118,7 @@ use super::Cx;
 /// reaction-window context (for `OnEvent` triggers), etc. Keep the
 /// surface narrow and add fields only when an effect's evaluator
 /// actually reads them.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct EvalContext {
     /// The investigator whose card-effect we're resolving — the
@@ -91,36 +133,22 @@ pub struct EvalContext {
     /// originating from a specific in-play instance (events played
     /// from hand, scenario forced effects, …).
     pub source: Option<crate::state::CardInstanceId>,
-    /// The just-resolved skill test's failure margin, set only while the
-    /// skill-test driver runs an [`Effect::SkillTest`]'s `on_fail`. Read
-    /// by [`Effect::ForEachPointFailed`]. `None` outside that window.
-    pub failed_by: Option<u8>,
-    /// The clue count a before-timing discovery interrupt is replacing,
-    /// set only while resolving an `EventPattern::WouldDiscoverClues`
-    /// ability's effect (so the card-local "discard that many" Native
-    /// reads it). `None` outside that window. Mirrors `failed_by`.
-    pub clue_discovery_count: Option<u8>,
-    /// The attacking enemy bound while resolving an
-    /// `EnemyAttackDamagedSelf` reaction, so the card-local
-    /// `Effect::Native` retaliate can name it. `None` outside that
-    /// window. Mirrors `failed_by` / `clue_discovery_count`. (C5b #237.)
-    pub attacking_enemy: Option<crate::state::EnemyId>,
-    /// The investigator a controller picked for an
-    /// `InvestigatorTarget::Chosen`, bound by the evaluator's target-grounding
-    /// pass before the handler resolves the target. `None` outside a
-    /// grounded-choice evaluation. Mirrors `failed_by` (Axis A #334).
-    pub chosen_investigator: Option<crate::state::InvestigatorId>,
-    /// The location a controller picked for a `LocationTarget::Chosen`. The
-    /// location counterpart of `chosen_investigator`.
-    pub chosen_location: Option<crate::state::LocationId>,
-    /// The enemy a controller picked for an `EnemyTarget::Chosen`. The enemy
-    /// counterpart of `chosen_investigator` / `chosen_location`.
-    pub chosen_enemy: Option<crate::state::EnemyId>,
-    /// The option a controller picked for a native leaf that suspended for a
-    /// choice (Crypt Chill 01167). The native re-enumerates its candidates and
-    /// indexes by this id — the general native-pick primitive, mirroring
-    /// `clue_discovery_count`. `None` outside that re-invocation (Axis A #334).
-    pub chosen_option: Option<crate::engine::OptionId>,
+    /// Skill-test margin binding, bound only while running an `on_fail` effect.
+    /// Read via [`Self::failed_by`]. `None` outside that window.
+    pub skill_test: Option<SkillTestBinding>,
+    /// Before-discovery interrupt binding, bound only while resolving a
+    /// `WouldDiscoverClues` ability's effect. Read via
+    /// [`Self::clue_discovery_count`]. `None` outside that window.
+    pub discovery: Option<DiscoveryBinding>,
+    /// Enemy-attack reaction binding, bound only while resolving an
+    /// `EnemyAttackDamagedSelf` reaction. Read via [`Self::attacking_enemy`].
+    /// `None` outside that window. (C5b #237.)
+    pub enemy_attack: Option<EnemyAttackBinding>,
+    /// Grounded `*::Chosen` picks, bound during a grounded-choice evaluation
+    /// (Axis A #334). Read via [`Self::chosen_investigator`] /
+    /// [`Self::chosen_location`] / [`Self::chosen_enemy`] /
+    /// [`Self::chosen_option`]. `None` outside a grounded choice.
+    pub choice: Option<ChoiceBinding>,
 }
 
 impl EvalContext {
@@ -132,13 +160,10 @@ impl EvalContext {
         Self {
             controller,
             source: None,
-            failed_by: None,
-            clue_discovery_count: None,
-            attacking_enemy: None,
-            chosen_investigator: None,
-            chosen_location: None,
-            chosen_enemy: None,
-            chosen_option: None,
+            skill_test: None,
+            discovery: None,
+            enemy_attack: None,
+            choice: None,
         }
     }
 
@@ -154,13 +179,10 @@ impl EvalContext {
         Self {
             controller,
             source: Some(source),
-            failed_by: None,
-            clue_discovery_count: None,
-            attacking_enemy: None,
-            chosen_investigator: None,
-            chosen_location: None,
-            chosen_enemy: None,
-            chosen_option: None,
+            skill_test: None,
+            discovery: None,
+            enemy_attack: None,
+            choice: None,
         }
     }
 
@@ -190,67 +212,73 @@ impl EvalContext {
     /// `on_fail` effect). See [`Effect::ForEachPointFailed`].
     #[must_use]
     pub fn failed_by(&self) -> Option<u8> {
-        self.failed_by
+        self.skill_test.map(|b| b.failed_by)
     }
     /// Clue count a before-discovery interrupt is replacing (bound only while
     /// resolving a `WouldDiscoverClues` ability's effect).
     #[must_use]
     pub fn clue_discovery_count(&self) -> Option<u8> {
-        self.clue_discovery_count
+        self.discovery.map(|b| b.clue_discovery_count)
     }
     /// Attacking enemy bound while resolving an `EnemyAttackDamagedSelf` reaction.
     #[must_use]
     pub fn attacking_enemy(&self) -> Option<crate::state::EnemyId> {
-        self.attacking_enemy
+        self.enemy_attack.map(|b| b.attacking_enemy)
     }
     /// Investigator picked for an `InvestigatorTarget::Chosen`.
     #[must_use]
     pub fn chosen_investigator(&self) -> Option<crate::state::InvestigatorId> {
-        self.chosen_investigator
+        self.choice.and_then(|c| c.investigator)
     }
     /// Location picked for a `LocationTarget::Chosen`.
     #[must_use]
     pub fn chosen_location(&self) -> Option<crate::state::LocationId> {
-        self.chosen_location
+        self.choice.and_then(|c| c.location)
     }
     /// Enemy picked for an `EnemyTarget::Chosen`.
     #[must_use]
     pub fn chosen_enemy(&self) -> Option<crate::state::EnemyId> {
-        self.chosen_enemy
+        self.choice.and_then(|c| c.enemy)
     }
     /// Option picked for a native leaf that suspended for a choice.
     #[must_use]
     pub fn chosen_option(&self) -> Option<crate::engine::OptionId> {
-        self.chosen_option
+        self.choice.and_then(|c| c.option)
     }
 
     /// Bind the skill-test failure margin (see [`Self::failed_by`]).
     pub fn set_failed_by(&mut self, margin: u8) {
-        self.failed_by = Some(margin);
+        self.skill_test = Some(SkillTestBinding { failed_by: margin });
     }
     /// Bind the before-discovery clue count (see [`Self::clue_discovery_count`]).
     pub fn set_clue_discovery_count(&mut self, count: u8) {
-        self.clue_discovery_count = Some(count);
+        self.discovery = Some(DiscoveryBinding {
+            clue_discovery_count: count,
+        });
     }
     /// Bind the attacking enemy (see [`Self::attacking_enemy`]).
     pub fn set_attacking_enemy(&mut self, enemy: crate::state::EnemyId) {
-        self.attacking_enemy = Some(enemy);
+        self.enemy_attack = Some(EnemyAttackBinding {
+            attacking_enemy: enemy,
+        });
     }
     /// Bind the chosen investigator (see [`Self::chosen_investigator`]).
     pub fn set_chosen_investigator(&mut self, id: crate::state::InvestigatorId) {
-        self.chosen_investigator = Some(id);
+        self.choice
+            .get_or_insert_with(Default::default)
+            .investigator = Some(id);
     }
     /// Bind the chosen location (see [`Self::chosen_location`]).
     pub fn set_chosen_location(&mut self, id: crate::state::LocationId) {
-        self.chosen_location = Some(id);
+        self.choice.get_or_insert_with(Default::default).location = Some(id);
     }
     /// Bind the chosen enemy (see [`Self::chosen_enemy`]).
     pub fn set_chosen_enemy(&mut self, id: crate::state::EnemyId) {
-        self.chosen_enemy = Some(id);
+        self.choice.get_or_insert_with(Default::default).enemy = Some(id);
     }
     /// Bind (or clear) the native-leaf chosen option (see [`Self::chosen_option`]).
     pub fn set_chosen_option(&mut self, opt: Option<crate::engine::OptionId>) {
-        self.chosen_option = opt;
+        self.choice.get_or_insert_with(Default::default).option = opt;
     }
 }
 
@@ -2126,6 +2154,19 @@ mod tests {
     fn eval_context_defaults_clue_discovery_count_to_none() {
         let ctx = EvalContext::for_controller(InvestigatorId(1));
         assert_eq!(ctx.clue_discovery_count(), None);
+    }
+
+    #[test]
+    fn eval_context_round_trips_with_grouped_bindings() {
+        let mut ctx = EvalContext::for_controller(InvestigatorId(1));
+        ctx.set_failed_by(3);
+        ctx.set_chosen_investigator(InvestigatorId(2));
+        let json = serde_json::to_string(&ctx).expect("serialize");
+        let back: EvalContext = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.failed_by(), Some(3));
+        assert_eq!(back.chosen_investigator(), Some(InvestigatorId(2)));
+        assert_eq!(back.attacking_enemy(), None);
+        assert_eq!(back.chosen_option(), None);
     }
 
     #[test]

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -118,7 +118,7 @@ pub struct ChoiceBinding {
 /// reaction-window context (for `OnEvent` triggers), etc. Keep the
 /// surface narrow and add fields only when an effect's evaluator
 /// actually reads them.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct EvalContext {
     /// The investigator whose card-effect we're resolving — the
@@ -278,7 +278,18 @@ impl EvalContext {
     }
     /// Bind (or clear) the native-leaf chosen option (see [`Self::chosen_option`]).
     pub fn set_chosen_option(&mut self, opt: Option<crate::engine::OptionId>) {
-        self.choice.get_or_insert_with(Default::default).option = opt;
+        // Match the old flat-field semantics exactly: a `None` pick must NOT
+        // materialize an otherwise-empty `choice` binding (which would make
+        // `EvalContext` compare unequal to a never-touched one). Only create the
+        // binding to store a `Some`; otherwise clear an existing slot in place.
+        match opt {
+            Some(_) => self.choice.get_or_insert_with(Default::default).option = opt,
+            None => {
+                if let Some(choice) = self.choice.as_mut() {
+                    choice.option = None;
+                }
+            }
+        }
     }
 }
 

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -500,11 +500,12 @@ pub struct ChoiceFrame {
     pub offered: Vec<crate::engine::OptionId>,
     /// Root effect being (re-)resolved. A native leaf is just one node.
     pub effect: card_dsl::dsl::Effect,
-    /// [`EvalContext`](crate::engine::EvalContext)`.controller` ingredient.
-    pub controller: InvestigatorId,
-    /// [`EvalContext`](crate::engine::EvalContext)`.source` ingredient
-    /// (`None` for scenario / forced effects with no originating instance).
-    pub source: Option<CardInstanceId>,
+    /// The [`EvalContext`](crate::engine::EvalContext) captured at suspend —
+    /// durable identity (`controller`/`source`) **and** any active window
+    /// bindings (e.g. an `on_fail` margin). Snapshotting the whole context (vs.
+    /// re-storing ingredient tuples) means bindings survive the suspend; resume
+    /// re-runs the effect with this exact context. (#345.)
+    pub context: crate::engine::EvalContext,
 }
 
 impl Continuation {

--- a/crates/scenarios/src/test_fixtures/synth_cards.rs
+++ b/crates/scenarios/src/test_fixtures/synth_cards.rs
@@ -218,10 +218,10 @@ fn synth_cover_up_discard(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
     // The seam threads the replaced count via `clue_discovery_count`; a
     // missing value means a wiring regression, not a legal 0-clue discard.
     debug_assert!(
-        ctx.clue_discovery_count.is_some(),
+        ctx.clue_discovery_count().is_some(),
         "synth_cover_up_discard: clue_discovery_count not threaded"
     );
-    let count = ctx.clue_discovery_count.unwrap_or(0);
+    let count = ctx.clue_discovery_count().unwrap_or(0);
     let Some(source) = ctx.source else {
         return EngineOutcome::Rejected {
             reason: "synth_cover_up_discard: no source instance".into(),

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -115,15 +115,25 @@ Not rules bugs, but several simplify or de-risk the Tier-1 work — pull these i
 rather than deferring wholesale:
 
 - **§1 continuation-stack cleanup — the full #348 + #345 + #347 + #380, as one
-  designed pass. DO-FIRST, before the keystone.** #348 migrates the remaining
-  `pending_*` suspension modes (incl. `pending_enemy_attack`, `pending_end_turn`,
-  `clue_interrupt_pending`) onto the one continuation stack and collapses the
-  fragile `if pending_X.is_some()` `resolve_input` cascade; #345 makes
-  `EvalContext` serializable with a composable binding model so migrated frames
-  snapshot context instead of re-storing ingredient tuples; #347 makes resume
+  designed pass. DO-FIRST, before the keystone.** Designed in
+  `docs/superpowers/specs/2026-06-19-continuation-stack-cleanup-design.md`.
+  **Progress:** #345 shipped (PR #385); #347 → #348 → #380 follow as separate PRs.
+  #348 migrates the remaining
+  `pending_*` suspension modes (incl. `pending_enemy_attack`, `pending_end_turn`)
+  onto the one continuation stack and collapses the
+  fragile `if pending_X.is_some()` `resolve_input` cascade **and** the parallel
+  `apply_player_action` guard ladder into top-frame dispatch (folding
+  `Mulligan`/`DrawEncounterCard` into `ResolveInput` and `in_flight_skill_test`
+  onto its frame; `clue_interrupt_pending` is already a window); #345 makes
+  `EvalContext` serializable with **grouped optional bindings** snapshotted
+  per-frame (the Vec / per-frame-enum / global-stack alternatives were evaluated
+  and rejected — spec §D; innermost-only is corpus-moot, no TODO) so migrated
+  frames snapshot context instead of re-storing ingredient tuples; #347 makes resume
   **token-routed** (deterministic counter, stamped on the awaiting frame) so
   routing becomes token → frame → dispatch-on-variant, with stale/double-submit
-  rejection; #380 folds in. Designed together (they share the seam). The keystone
+  rejection; #380 removes the `pending_revelation_discard` side-channel by making
+  encounter-card resolution a frame whose framework teardown disposes of the card.
+  Designed together (they share the seam). The keystone
   adds attack-loop suspension, so this lands first and the keystone rides one
   clean stack. **Token-routing (#347b) also de-risks the browser surface** —
   #205's client can submit against a superseded prompt and be rejected cleanly,

--- a/docs/superpowers/plans/2026-06-19-pr1-eval-context-grouped-bindings.md
+++ b/docs/superpowers/plans/2026-06-19-pr1-eval-context-grouped-bindings.md
@@ -1,0 +1,556 @@
+# PR 1 (#345) — Serializable EvalContext with grouped bindings — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `EvalContext` serializable with cohesive grouped bindings, snapshotted whole onto suspended frames, killing the per-frame rebuild duplication and the latent cross-suspend binding-loss.
+
+**Architecture:** Three tasks, each compiles + passes CI. Task 1 introduces accessor/setter *indirection* over the current flat fields (pure refactor, zero behavior change). Task 2 swaps the internal representation to grouped `Option<…Binding>` sub-structs behind that indirection and derives serde. Task 3 makes `ChoiceFrame` snapshot the whole `EvalContext` instead of `controller`+`source`, fixing the latent binding-loss.
+
+**Tech Stack:** Rust, `serde`, the workspace's `game-core` / `cards` / `scenarios` crates.
+
+This is **PR 1 of 4** in the §1 continuation-stack cleanup (spec: `docs/superpowers/specs/2026-06-19-continuation-stack-cleanup-design.md`). It is foundational: it establishes the context-snapshot storage shape the later frame migration (#348) consumes. No behavior change for any in-scope card; the only observable new capability is that window bindings survive a choice suspend.
+
+## Global Constraints
+
+- **CI gauntlet, warnings-as-errors.** Before pushing, all must pass:
+  - `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo fmt --check`
+  - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
+  - `cargo build -p web --target wasm32-unknown-unknown`
+  - `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`
+- **Crate layering:** `game-core` never depends on `cards`/`scenarios`. The binding types live in `game-core` (`evaluator.rs`); `cards`/`scenarios` consume them through accessors only.
+- **`EvalContext` stays `Copy`.** All binding sub-structs are small (`u8` / id newtypes) and must derive `Copy`, so `EvalContext` remains `Copy` — many call sites pass it by value (`eval_ctx: EvalContext`).
+- **Single branch** `engine/continuation-stack-cleanup` (already created; the spec commit is on it). Commit per task; do not push until the full gauntlet is green.
+- **No `TODO` for same-kind nesting** — corpus-verified moot (see spec §D). Document innermost-only semantics as a plain fact in the doc-comment.
+
+---
+
+### Task 1: Accessor + setter indirection over the flat fields
+
+Introduce methods that read/write the window-bound fields, and migrate every call site to them — *without* changing the struct's representation yet. Pure refactor: after this task `EvalContext` still has the same flat fields, but no code outside `evaluator.rs` touches them directly. This isolates the representation swap (Task 2) to one file.
+
+**Files:**
+- Modify: `crates/game-core/src/engine/evaluator.rs` (add methods on `EvalContext`; migrate internal read/write sites)
+- Modify: `crates/game-core/src/engine/dispatch/skill_test.rs:344` (failed_by write)
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs:658,665` (attacking_enemy, clue_discovery_count writes)
+- Modify: `crates/cards/src/impls/cover_up.rs:69,72` (clue_discovery_count reads)
+- Modify: `crates/cards/src/impls/guard_dog.rs:55` (attacking_enemy read)
+- Modify: `crates/cards/src/impls/crypt_chill.rs:73` (chosen_option read)
+- Modify: `crates/cards/src/impls/dynamite_blast.rs:84` (chosen_option read)
+- Modify: `crates/scenarios/src/test_fixtures/synth_cards.rs:221,224` (clue_discovery_count reads)
+
+**Interfaces:**
+- Produces (methods on `EvalContext`, all `#[must_use]` on getters):
+  - `fn failed_by(&self) -> Option<u8>`
+  - `fn clue_discovery_count(&self) -> Option<u8>`
+  - `fn attacking_enemy(&self) -> Option<EnemyId>`
+  - `fn chosen_investigator(&self) -> Option<InvestigatorId>`
+  - `fn chosen_location(&self) -> Option<LocationId>`
+  - `fn chosen_enemy(&self) -> Option<EnemyId>`
+  - `fn chosen_option(&self) -> Option<OptionId>`
+  - `fn set_failed_by(&mut self, margin: u8)`
+  - `fn set_clue_discovery_count(&mut self, count: u8)`
+  - `fn set_attacking_enemy(&mut self, enemy: EnemyId)`
+  - `fn set_chosen_investigator(&mut self, id: InvestigatorId)`
+  - `fn set_chosen_location(&mut self, id: LocationId)`
+  - `fn set_chosen_enemy(&mut self, id: EnemyId)`
+  - `fn set_chosen_option(&mut self, opt: Option<OptionId>)`
+
+- [ ] **Step 1: Add the methods (reading/writing the existing flat fields)**
+
+In `crates/game-core/src/engine/evaluator.rs`, add a new `impl EvalContext` block immediately after the existing one (after `for_controller_with_optional_source`):
+
+```rust
+impl EvalContext {
+    /// Just-resolved skill test's failure margin (bound only while running an
+    /// `on_fail` effect). See [`Effect::ForEachPointFailed`].
+    #[must_use]
+    pub fn failed_by(&self) -> Option<u8> {
+        self.failed_by
+    }
+    /// Clue count a before-discovery interrupt is replacing (bound only while
+    /// resolving a `WouldDiscoverClues` ability's effect).
+    #[must_use]
+    pub fn clue_discovery_count(&self) -> Option<u8> {
+        self.clue_discovery_count
+    }
+    /// Attacking enemy bound while resolving an `EnemyAttackDamagedSelf` reaction.
+    #[must_use]
+    pub fn attacking_enemy(&self) -> Option<crate::state::EnemyId> {
+        self.attacking_enemy
+    }
+    /// Investigator picked for an `InvestigatorTarget::Chosen`.
+    #[must_use]
+    pub fn chosen_investigator(&self) -> Option<crate::state::InvestigatorId> {
+        self.chosen_investigator
+    }
+    /// Location picked for a `LocationTarget::Chosen`.
+    #[must_use]
+    pub fn chosen_location(&self) -> Option<crate::state::LocationId> {
+        self.chosen_location
+    }
+    /// Enemy picked for an `EnemyTarget::Chosen`.
+    #[must_use]
+    pub fn chosen_enemy(&self) -> Option<crate::state::EnemyId> {
+        self.chosen_enemy
+    }
+    /// Option picked for a native leaf that suspended for a choice.
+    #[must_use]
+    pub fn chosen_option(&self) -> Option<crate::engine::OptionId> {
+        self.chosen_option
+    }
+
+    pub fn set_failed_by(&mut self, margin: u8) {
+        self.failed_by = Some(margin);
+    }
+    pub fn set_clue_discovery_count(&mut self, count: u8) {
+        self.clue_discovery_count = Some(count);
+    }
+    pub fn set_attacking_enemy(&mut self, enemy: crate::state::EnemyId) {
+        self.attacking_enemy = Some(enemy);
+    }
+    pub fn set_chosen_investigator(&mut self, id: crate::state::InvestigatorId) {
+        self.chosen_investigator = Some(id);
+    }
+    pub fn set_chosen_location(&mut self, id: crate::state::LocationId) {
+        self.chosen_location = Some(id);
+    }
+    pub fn set_chosen_enemy(&mut self, id: crate::state::EnemyId) {
+        self.chosen_enemy = Some(id);
+    }
+    pub fn set_chosen_option(&mut self, opt: Option<crate::engine::OptionId>) {
+        self.chosen_option = opt;
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles (methods added, no sites migrated yet)**
+
+Run: `cargo build -p game-core`
+Expected: PASS (new methods, unused for now → may warn; that's fine pre-clippy).
+
+- [ ] **Step 3: Migrate the read sites to getters**
+
+Apply this exact transform (field access → method call) at each site. Worked example — `evaluator.rs:322`:
+
+```rust
+// before
+let n = eval_ctx.failed_by.unwrap_or(0);
+// after
+let n = eval_ctx.failed_by().unwrap_or(0);
+```
+
+Apply the same field→method rename at every read site:
+- `crates/game-core/src/engine/evaluator.rs:322` — `eval_ctx.failed_by` → `eval_ctx.failed_by()`
+- `crates/game-core/src/engine/evaluator.rs:1423` — `eval_ctx.chosen_investigator.is_none()` → `eval_ctx.chosen_investigator().is_none()`
+- `crates/game-core/src/engine/evaluator.rs:1433` — `eval_ctx.chosen_location.is_none()` → `eval_ctx.chosen_location().is_none()`
+- `crates/game-core/src/engine/evaluator.rs:1443` — `eval_ctx.chosen_enemy.is_none()` → `eval_ctx.chosen_enemy().is_none()`
+- `crates/game-core/src/engine/evaluator.rs:1644` — `ctx.chosen_investigator.ok_or(` → `ctx.chosen_investigator().ok_or(`
+- `crates/game-core/src/engine/evaluator.rs:1662` — `ctx.chosen_location.ok_or(` → `ctx.chosen_location().ok_or(`
+- `crates/game-core/src/engine/evaluator.rs:1684` — `ctx.chosen_enemy.ok_or(` → `ctx.chosen_enemy().ok_or(`
+- `crates/cards/src/impls/cover_up.rs:69` — `ctx.clue_discovery_count.is_some()` → `ctx.clue_discovery_count().is_some()`
+- `crates/cards/src/impls/cover_up.rs:72` — `ctx.clue_discovery_count.unwrap_or(0)` → `ctx.clue_discovery_count().unwrap_or(0)`
+- `crates/cards/src/impls/guard_dog.rs:55` — `ctx.attacking_enemy` → `ctx.attacking_enemy()`
+- `crates/cards/src/impls/crypt_chill.rs:73` — `ctx.chosen_option` → `ctx.chosen_option()`
+- `crates/cards/src/impls/dynamite_blast.rs:84` — `ctx.chosen_option` → `ctx.chosen_option()`
+- `crates/scenarios/src/test_fixtures/synth_cards.rs:221` — `ctx.clue_discovery_count.is_some()` → `ctx.clue_discovery_count().is_some()`
+- `crates/scenarios/src/test_fixtures/synth_cards.rs:224` — `ctx.clue_discovery_count.unwrap_or(0)` → `ctx.clue_discovery_count().unwrap_or(0)`
+
+- [ ] **Step 4: Migrate the write sites to setters**
+
+- `crates/game-core/src/engine/dispatch/skill_test.rs:344` — `ctx.failed_by = Some(failed_by);` → `ctx.set_failed_by(failed_by);`
+- `crates/game-core/src/engine/dispatch/reaction_windows.rs:658` — `eval_ctx.attacking_enemy = Some(enemy);` → `eval_ctx.set_attacking_enemy(enemy);`
+- `crates/game-core/src/engine/dispatch/reaction_windows.rs:665` — `eval_ctx.clue_discovery_count = Some(count);` → `eval_ctx.set_clue_discovery_count(count);`
+- `crates/game-core/src/engine/evaluator.rs:1290` — `eval_ctx.chosen_option = cursor.take();` → `eval_ctx.set_chosen_option(cursor.take());`
+- `crates/game-core/src/engine/evaluator.rs:1467` — in the `bind` closure, `ctx.chosen_investigator = Some(id);` → `ctx.set_chosen_investigator(id);`
+- `crates/game-core/src/engine/evaluator.rs:1508` — `ctx.chosen_location = Some(id);` → `ctx.set_chosen_location(id);`
+- `crates/game-core/src/engine/evaluator.rs:1549` — `ctx.chosen_enemy = Some(id);` → `ctx.set_chosen_enemy(id);`
+- `crates/game-core/src/engine/evaluator.rs:4266` (test) — `eval_ctx.failed_by = Some(2);` → `eval_ctx.set_failed_by(2);`
+
+- [ ] **Step 5: Run the full test suite to verify no behavior change**
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: PASS (identical behavior; this is pure indirection).
+
+- [ ] **Step 6: Clippy + fmt**
+
+Run: `cargo clippy --all-targets --all-features -- -D warnings && cargo fmt --check`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "engine: route EvalContext window bindings through accessors
+
+Introduce getter/setter methods over the flat window-bound fields and
+migrate every read/write site (game-core, cards, scenarios) to them. Pure
+indirection, no behavior change — isolates the representation swap (#345).
+
+Refs #345.
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Swap to grouped serializable bindings
+
+Replace the flat window-bound fields with cohesive `Option<…Binding>` sub-structs, behind the accessors from Task 1. Derive `Serialize`/`Deserialize` so frames can snapshot the whole context (used in Task 3).
+
+**Files:**
+- Modify: `crates/game-core/src/engine/evaluator.rs` (binding structs; `EvalContext` fields; constructors; accessor/setter bodies; add serde test)
+
+**Interfaces:**
+- Produces (public types in `game-core::engine::evaluator`, re-exported as needed):
+  - `struct SkillTestBinding { pub failed_by: u8 }`
+  - `struct DiscoveryBinding { pub clue_discovery_count: u8 }`
+  - `struct EnemyAttackBinding { pub attacking_enemy: EnemyId }`
+  - `struct ChoiceBinding { pub investigator: Option<InvestigatorId>, pub location: Option<LocationId>, pub enemy: Option<EnemyId>, pub option: Option<OptionId> }` (derives `Default`)
+  - `EvalContext` gains `Serialize, Deserialize` derives; window-bound fields replaced by `skill_test`, `discovery`, `enemy_attack`, `choice` (each `Option<…Binding>`).
+- Consumes: the accessor/setter method names from Task 1 (unchanged signatures).
+
+- [ ] **Step 1: Define the binding sub-structs**
+
+In `crates/game-core/src/engine/evaluator.rs`, immediately before `pub struct EvalContext`:
+
+```rust
+/// Failure margin of the just-resolved skill test (bound only while running an
+/// `on_fail` effect). Innermost-only: same-kind test nesting is carried by the
+/// per-frame snapshot stack, not multiple slots here (corpus-verified moot —
+/// no card reads a non-innermost margin; see the §1 cleanup spec §D).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillTestBinding {
+    /// Points the test was failed by.
+    pub failed_by: u8,
+}
+
+/// Clue count a before-discovery interrupt is replacing (bound only while
+/// resolving a `WouldDiscoverClues` ability's effect).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiscoveryBinding {
+    /// Clues the interrupt is replacing.
+    pub clue_discovery_count: u8,
+}
+
+/// Attacking enemy bound while resolving an `EnemyAttackDamagedSelf` reaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnemyAttackBinding {
+    /// The enemy whose attack is being reacted to.
+    pub attacking_enemy: crate::state::EnemyId,
+}
+
+/// Controller picks bound while grounding `*::Chosen` targets. Cohesive: the
+/// four `*::Chosen` kinds compose on one binding (a single effect may pick an
+/// investigator *and* a location). `Default` is all-`None`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ChoiceBinding {
+    /// `InvestigatorTarget::Chosen` pick.
+    pub investigator: Option<crate::state::InvestigatorId>,
+    /// `LocationTarget::Chosen` pick.
+    pub location: Option<crate::state::LocationId>,
+    /// `EnemyTarget::Chosen` pick.
+    pub enemy: Option<crate::state::EnemyId>,
+    /// Native-leaf option pick.
+    pub option: Option<crate::engine::OptionId>,
+}
+```
+
+- [ ] **Step 2: Restructure `EvalContext`**
+
+Replace the seven flat window-bound fields (`failed_by` … `chosen_option`) with the four grouped fields, and add serde derives. The `controller` + `source` durable fields are unchanged.
+
+```rust
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct EvalContext {
+    /// The investigator whose card-effect we're resolving — the "you" in card
+    /// text. Resolves `InvestigatorTarget::You` / `LocationTarget::YourLocation`.
+    pub controller: crate::state::InvestigatorId,
+    /// The in-play card-instance that triggered this effect, if any.
+    pub source: Option<crate::state::CardInstanceId>,
+    /// Skill-test margin binding (bound only during an `on_fail` effect).
+    pub skill_test: Option<SkillTestBinding>,
+    /// Before-discovery interrupt binding (bound only during `WouldDiscoverClues`).
+    pub discovery: Option<DiscoveryBinding>,
+    /// Enemy-attack reaction binding (bound only during `EnemyAttackDamagedSelf`).
+    pub enemy_attack: Option<EnemyAttackBinding>,
+    /// Grounded `*::Chosen` picks (bound during a grounded-choice evaluation).
+    pub choice: Option<ChoiceBinding>,
+}
+```
+
+- [ ] **Step 3: Update the three constructors**
+
+In `for_controller`, `for_controller_with_source`, and the `Some`/`None` arms of `for_controller_with_optional_source`, replace the seven `…: None,` field inits with:
+
+```rust
+            skill_test: None,
+            discovery: None,
+            enemy_attack: None,
+            choice: None,
+```
+
+(For `for_controller_with_optional_source`, the body delegates to the other two constructors, so no field inits there — leave it as-is.)
+
+- [ ] **Step 4: Update the accessor/setter bodies (from Task 1) to read/write the grouped fields**
+
+Replace the method bodies added in Task 1:
+
+```rust
+    #[must_use]
+    pub fn failed_by(&self) -> Option<u8> {
+        self.skill_test.map(|b| b.failed_by)
+    }
+    #[must_use]
+    pub fn clue_discovery_count(&self) -> Option<u8> {
+        self.discovery.map(|b| b.clue_discovery_count)
+    }
+    #[must_use]
+    pub fn attacking_enemy(&self) -> Option<crate::state::EnemyId> {
+        self.enemy_attack.map(|b| b.attacking_enemy)
+    }
+    #[must_use]
+    pub fn chosen_investigator(&self) -> Option<crate::state::InvestigatorId> {
+        self.choice.and_then(|c| c.investigator)
+    }
+    #[must_use]
+    pub fn chosen_location(&self) -> Option<crate::state::LocationId> {
+        self.choice.and_then(|c| c.location)
+    }
+    #[must_use]
+    pub fn chosen_enemy(&self) -> Option<crate::state::EnemyId> {
+        self.choice.and_then(|c| c.enemy)
+    }
+    #[must_use]
+    pub fn chosen_option(&self) -> Option<crate::engine::OptionId> {
+        self.choice.and_then(|c| c.option)
+    }
+
+    pub fn set_failed_by(&mut self, margin: u8) {
+        self.skill_test = Some(SkillTestBinding { failed_by: margin });
+    }
+    pub fn set_clue_discovery_count(&mut self, count: u8) {
+        self.discovery = Some(DiscoveryBinding {
+            clue_discovery_count: count,
+        });
+    }
+    pub fn set_attacking_enemy(&mut self, enemy: crate::state::EnemyId) {
+        self.enemy_attack = Some(EnemyAttackBinding {
+            attacking_enemy: enemy,
+        });
+    }
+    pub fn set_chosen_investigator(&mut self, id: crate::state::InvestigatorId) {
+        self.choice.get_or_insert_with(Default::default).investigator = Some(id);
+    }
+    pub fn set_chosen_location(&mut self, id: crate::state::LocationId) {
+        self.choice.get_or_insert_with(Default::default).location = Some(id);
+    }
+    pub fn set_chosen_enemy(&mut self, id: crate::state::EnemyId) {
+        self.choice.get_or_insert_with(Default::default).enemy = Some(id);
+    }
+    pub fn set_chosen_option(&mut self, opt: Option<crate::engine::OptionId>) {
+        self.choice.get_or_insert_with(Default::default).option = opt;
+    }
+```
+
+- [ ] **Step 5: Write the serde round-trip test (failing first)**
+
+Add to the `#[cfg(test)]` mod in `crates/game-core/src/engine/evaluator.rs`:
+
+```rust
+#[test]
+fn eval_context_round_trips_with_grouped_bindings() {
+    let mut ctx = EvalContext::for_controller(InvestigatorId(1));
+    ctx.set_failed_by(3);
+    ctx.set_chosen_investigator(InvestigatorId(2));
+    let json = serde_json::to_string(&ctx).expect("serialize");
+    let back: EvalContext = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back.failed_by(), Some(3));
+    assert_eq!(back.chosen_investigator(), Some(InvestigatorId(2)));
+    assert_eq!(back.attacking_enemy(), None);
+    assert_eq!(back.chosen_option(), None);
+}
+```
+
+- [ ] **Step 6: Run the new test + full suite**
+
+Run: `cargo test -p game-core eval_context_round_trips_with_grouped_bindings -- --nocapture`
+Expected: PASS.
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: PASS (accessors unchanged externally → cards/scenarios unaffected).
+
+- [ ] **Step 7: Clippy + fmt + doc**
+
+Run: `cargo clippy --all-targets --all-features -- -D warnings && cargo fmt --check && RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A
+git commit -m "engine: group EvalContext window bindings + derive serde
+
+Replace the flat Option fields with cohesive SkillTest/Discovery/EnemyAttack/
+Choice binding sub-structs behind the Task-1 accessors, and derive
+Serialize/Deserialize so frames can snapshot the whole context. Innermost-only
+per kind (corpus-moot; documented). No external API change.
+
+Refs #345.
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Snapshot the whole EvalContext on ChoiceFrame
+
+`ChoiceFrame` stores `controller` + `source` and rebuilds the context on resume (`choice.rs:124`), which silently drops any window binding active at suspend (the latent cross-suspend binding-loss). Replace those two fields with one `context: EvalContext` snapshot.
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs:495-508` (`ChoiceFrame` fields)
+- Modify: `crates/game-core/src/engine/dispatch/choice.rs:62-67` (build), `:124` (resume rebuild)
+- Test: `crates/game-core/src/engine/dispatch/choice.rs` `#[cfg(test)]` (binding-survives-suspend test)
+
+**Interfaces:**
+- Consumes: `EvalContext: Serialize + Clone + Copy` (Task 2).
+- Produces: `ChoiceFrame { decisions, offered, effect, context: EvalContext }` (replaces `controller` + `source`). `EvalContext` exposes `.controller` / `.source` directly, so any reader of the old fields reads `frame.context.controller` / `frame.context.source`.
+
+- [ ] **Step 1: Write the failing test — a skill-test binding survives a choice suspend**
+
+Add to `crates/game-core/src/engine/dispatch/choice.rs` `#[cfg(test)]` mod. This proves the binding is carried across the suspend on the frame (the latent-bug fix):
+
+```rust
+#[test]
+fn choice_frame_snapshots_active_skill_test_binding() {
+    use crate::engine::evaluator::EvalContext;
+    use crate::state::{Continuation, InvestigatorId};
+
+    // A context carrying an active on_fail margin when a choice suspends.
+    let mut ctx = EvalContext::for_controller(InvestigatorId(1));
+    ctx.set_failed_by(2);
+
+    let mut cx = crate::test_support::fixtures::test_cx_minimal();
+    let _ = suspend_for_choice(
+        &mut cx,
+        "pick",
+        vec!["a".into(), "b".into()],
+        Vec::new(),
+        crate::dsl::Effect::Seq(vec![]),
+        ctx,
+    );
+
+    let Some(Continuation::Choice(frame)) = cx.state.continuations.last() else {
+        panic!("expected a Choice frame on the stack");
+    };
+    assert_eq!(
+        frame.context.failed_by(),
+        Some(2),
+        "the active skill-test margin must be snapshotted onto the ChoiceFrame, \
+         not dropped at suspend",
+    );
+}
+```
+
+If `test_support::fixtures::test_cx_minimal()` does not exist, use the crate's existing minimal-`Cx` constructor (grep `fn .*Cx` in `crates/game-core/src/test_support/`); the assertion on `frame.context` is the load-bearing part.
+
+- [ ] **Step 2: Run it — expect a compile failure (field `context` missing)**
+
+Run: `cargo test -p game-core choice_frame_snapshots_active_skill_test_binding`
+Expected: FAIL to compile — `ChoiceFrame` has no field `context` (and `controller`/`source` still present).
+
+- [ ] **Step 3: Replace `ChoiceFrame`'s `controller`+`source` with `context`**
+
+In `crates/game-core/src/state/game_state.rs`, in `struct ChoiceFrame`, remove the `controller: InvestigatorId` and `source: Option<CardInstanceId>` fields and their doc-comments, and add:
+
+```rust
+    /// The [`EvalContext`](crate::engine::EvalContext) captured at suspend —
+    /// durable identity (`controller`/`source`) **and** any active window
+    /// bindings (e.g. an `on_fail` margin). Snapshotting the whole context (vs.
+    /// re-storing ingredient tuples) means bindings survive the suspend; resume
+    /// re-runs the effect with this exact context. (#345.)
+    pub context: crate::engine::EvalContext,
+```
+
+(`EvalContext` is re-exported at `crate::engine::EvalContext` — see `engine/mod.rs`. If `game_state.rs` cannot reference it without a cycle, use the fully-qualified `crate::engine::evaluator::EvalContext` path that `Continuation` doc-links already use.)
+
+- [ ] **Step 4: Update the `suspend_for_choice` builder**
+
+In `crates/game-core/src/engine/dispatch/choice.rs`, the `Continuation::Choice(ChoiceFrame { … })` literal currently sets `controller: eval_ctx.controller, source: eval_ctx.source`. Replace those two lines with:
+
+```rust
+            context: eval_ctx,
+```
+
+(`eval_ctx` is already the `EvalContext` argument; it is `Copy`, so this moves a copy onto the frame.)
+
+- [ ] **Step 5: Update the resume rebuild**
+
+In `crates/game-core/src/engine/dispatch/choice.rs:124`, replace:
+
+```rust
+    let eval_ctx = EvalContext::for_controller_with_optional_source(frame.controller, frame.source);
+```
+
+with:
+
+```rust
+    let eval_ctx = frame.context;
+```
+
+(Remove the now-unused `EvalContext` import if clippy flags it.)
+
+- [ ] **Step 6: Run the test — expect PASS**
+
+Run: `cargo test -p game-core choice_frame_snapshots_active_skill_test_binding`
+Expected: PASS.
+
+- [ ] **Step 7: Full suite — confirm no choice/Crypt-Chill/Dynamite-Blast regressions**
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: PASS. (Crypt Chill 01167 and Dynamite Blast 01024 exercise the choice-suspend path; their tests must still pass unchanged.)
+
+- [ ] **Step 8: Clippy + fmt + doc + wasm**
+
+Run:
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add -A
+git commit -m "engine: snapshot whole EvalContext on ChoiceFrame
+
+Replace ChoiceFrame's controller+source ingredient tuple with a full
+EvalContext snapshot, so window bindings (e.g. an on_fail margin) survive a
+choice suspend instead of being silently rebuilt away. Adds a regression test.
+
+Refs #345.
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (spec §D):**
+- "derive `Serialize`" → Task 2 Step 2. ✓
+- "grouped optional bindings" → Task 2 Steps 1–2. ✓
+- "frames snapshot the whole context" → Task 3 (ChoiceFrame; the only existing snapshot site — `InFlightSkillTest` folds in #348 per spec §A). ✓
+- "fixes the latent cross-suspend binding-loss" → Task 3 Step 1 test. ✓
+- "4 `chosen_*` collapse into one `ChoiceBinding`" → Task 2 Step 1. ✓
+- "innermost-only documented, no TODO" → Task 2 Step 1 doc-comment. ✓
+- Rejected alternatives / corpus-moot → recorded in the spec, not re-derived here. ✓
+
+**Placeholder scan:** none — every code step shows complete code; mechanical migrations give one worked example + the exact `file:line` site list (DRY for ~20 identical renames). The one conditional ("if `test_cx_minimal` doesn't exist…") names the exact grep to resolve it.
+
+**Type consistency:** accessor/setter names are identical in Task 1 (flat bodies) and Task 2 (grouped bodies); `ChoiceBinding` field names (`investigator`/`location`/`enemy`/`option`) match the `chosen_*` accessor bodies in Task 2 Step 4; `ChoiceFrame.context` (Task 3 Step 3) matches its reads in Task 3 Steps 1/5.
+
+**Out of scope (deferred to later PRs, per spec):** token plumbing (#347, PR 2), frame migration + `in_flight_skill_test` fold (#348, PR 3), revelation disposal (#380, PR 4).

--- a/docs/superpowers/specs/2026-06-19-continuation-stack-cleanup-design.md
+++ b/docs/superpowers/specs/2026-06-19-continuation-stack-cleanup-design.md
@@ -1,0 +1,303 @@
+# §1 continuation-stack cleanup — design
+
+**Date:** 2026-06-19
+**Issues:** #348 (umbrella) · #345 (serializable `EvalContext`) · #347 (token-routed resume) · #380 (revelation disposal)
+**Phase:** 7 — "the solo correctness gate", ordering step 2 (DO-FIRST, before the keystone)
+
+## Why this pass exists
+
+The trigger-dispatch umbrella (§1) decided on **one `Vec<Continuation>` suspend/resume
+stack**, migrated incrementally. Axis B put `Resolution` + `SkillTest` on it; Axis A added
+`Choice`. The remaining suspension modes still live as their own `Option<…>` fields on
+`GameState`, each wired three times (the field, a reject-guard in `apply_player_action`, a
+route in the `resolve_input` cascade). The cascade carries fragile hand-ordered priority
+reasoning ("X is an inner suspension of the test, route before Y") that grows per mode.
+
+The **keystone** (mid-action suspend/resume for attacks of opportunity, retaliate, soak, and
+attack-order — Phase 7 ordering step 3) *adds* suspension modes to the attack loop. Rather
+than build the Nth ad-hoc route on top of the mixed model, this pass migrates the existing
+modes onto the one stack first, so the keystone rides one clean stack.
+
+These four issues share the same seam and are designed together:
+
+- **#348** migrates the remaining suspension modes onto `Continuation` frames and collapses
+  both the `resolve_input` cascade and the `apply_player_action` guard ladder into a single
+  dispatch on the top frame.
+- **#345** makes `EvalContext` serializable with grouped bindings, so migrated frames
+  snapshot context instead of re-storing ad-hoc ingredient tuples.
+- **#347** makes resume **token-routed**: deterministic counter, stamped on the awaiting
+  frame, echoed at resume → stale-submit rejection + direct frame lookup.
+- **#380** removes the `pending_revelation_discard` side-channel by making encounter-card
+  resolution a continuation frame whose framework teardown disposes of the card.
+
+Motivated partly by Phase 8 (multiplayer) robustness and the Phase 7 browser surface
+(#205, token-routing gives clean stale-submit rejection); no single-player *behavior*
+depends on it today — this is a correctness-preserving structural pass.
+
+## The unifying model
+
+**The continuation stack is the single record of every suspended process.** Each frame
+declares how it resumes. Both ladders die: `apply_player_action`'s reject-guards and
+`resolve_input`'s priority cascade collapse into **one dispatch on the top frame**.
+
+The player-facing resume signal **unifies onto `ResolveInput`**. `PlayerAction::Mulligan` and
+`PlayerAction::DrawEncounterCard` fold into `InputResponse` variants and are **removed** as
+standalone actions. Setup emits `AwaitingInput { mulligan for X }` per investigator; Mythos
+step 1.4 emits `AwaitingInput { encounter draw for X }` per drawer.
+
+Two precision points:
+
+- "Everything is `ResolveInput`" governs the **resume/advance** signal. Fast-permitting
+  windows (reaction / player windows) still *additionally* admit `PlayCard` /
+  `ActivateAbility` for Fast cards — that dual intake stays.
+- Pure **internal-sequencing** frames (the Enemy-phase attack-loop *cursor* that advances
+  across investigators, driven to completion by its child windows closing) do **not** emit
+  `AwaitingInput` — they are not player-facing.
+
+The through-line for the whole pass: **co-locate state with the process it belongs to;
+delete global side-channels.** Folding `in_flight_skill_test` onto its frame, snapshotting
+bindings onto frames (#345), and making encounter-card disposal a frame teardown (#380) are
+the same move.
+
+## A. `Continuation` variants after migration (#348)
+
+Existing: `Resolution(ResolutionFrame)`, `Choice(ChoiceFrame)`, and `SkillTest`. Changes:
+
+- **Fold `in_flight_skill_test` onto its frame**: `SkillTest(InFlightSkillTest)` carries the
+  payload; the separate `GameState::in_flight_skill_test: Option<…>` field is removed. The
+  many call sites that read "the current test" use an accessor
+  `cx.state.current_skill_test()` that finds the (unique — no nesting today) `SkillTest`
+  frame *wherever it is on the stack* (a reaction window can sit above it mid-resolution, so
+  it is **not** `continuations.last()`). Innermost-wins if same-kind nesting ever appears.
+  *(This goes beyond #348's literal "`pending_*` fields" wording, but is the same
+  one-source-of-truth principle and removes a push-frame/set-field desync pair.)*
+
+- **Migrate the suspension modes** from `Option<…>` fields to typed frames carrying their
+  loop / payload state:
+
+  | Removed field | New `Continuation` variant |
+  |---|---|
+  | `mulligan_pending: Option<InvestigatorId>` | `Mulligan { remaining: Vec<InvestigatorId> }` |
+  | `mythos_draw_pending: Option<InvestigatorId>` | `EncounterDraw { remaining: Vec<InvestigatorId> }` |
+  | `hunter_move_pending: Option<HunterChoice>` | `HunterMove(HunterChoice)` |
+  | `spawn_engage_pending: Option<SpawnEngagePending>` | `SpawnEngage(SpawnEngagePending)` |
+  | `hand_size_discard_pending: Option<HandSizeDiscard>` | `HandSizeDiscard(HandSizeDiscard)` |
+  | `act_round_end_pending: Option<ActRoundEndPending>` | `ActRoundEnd(ActRoundEndPending)` |
+  | `pending_substitution_prompt: Option<InvestigatorId>` | `SubstitutionPrompt { investigator }` |
+  | `pending_enemy_attack: Option<PendingEnemyAttack>` | `EnemyAttack(PendingEnemyAttack)` |
+  | `pending_end_turn: Option<InvestigatorId>` | `EndTurn { investigator }` |
+
+  Loop modes (`Mulligan`, `EncounterDraw`) hold their `remaining` actor queue on the frame —
+  the head is the current actor; resume advances it; the frame pops when the queue drains.
+
+- **Stays a non-frame cursor:** `enemy_attack_pending` (the Enemy-phase 3.3 cursor across
+  investigators) is internal sequencing, not a player-facing input frame. It may move onto
+  the stack as a non-`AwaitingInput` driver frame when the keystone wants it; **out of scope
+  here**.
+
+- **Already retired:** `clue_interrupt_pending` (named in #348) is already a `Resolution`
+  window (Axis D) — nothing to do.
+
+## B. Router collapse (#348)
+
+Every frame variant gets a resume handler. The two ladders become one check each:
+
+```rust
+// apply_player_action: one guard
+if let Some(top) = cx.state.continuations.last() {
+    if !top.accepts(action) {            // ResolveInput always; + Fast plays for permissive windows
+        return Rejected { reason: top.expected_input_msg() };
+    }
+}
+
+// resolve_input: one dispatch (after token validation, §C)
+match top_frame_after_token_check(cx, token)? {
+    Continuation::Mulligan(_)       => resume_mulligan(cx, response),
+    Continuation::EncounterDraw(_)  => resume_encounter_draw(cx, response),
+    Continuation::HunterMove(_)     => resume_hunter_choice(cx, response),
+    // … one arm per variant …
+    Continuation::SkillTest(_)      => resume_skill_test_commit(cx, response),
+}
+```
+
+Routing order becomes **structural** (top of stack), retiring the hand-ordered
+`if pending_X.is_some()` priority cascade and its priority-reasoning comments. The
+`mutually-exclusive suspension modes` `debug_assert` is subsumed (frames stack rather than
+race for a shared slot).
+
+## C. Token-routed resume (#347, end-state **(b)**)
+
+- `GameState` gains `next_resume_token: u64` — a **deterministic counter** (NOT a nonce), so
+  replay from the action log reproduces tokens bit-for-bit.
+- Each suspend mints the next token and **stamps it on the awaiting frame**
+  (`ResolutionFrame` / `ChoiceFrame` / `SkillTest` / the new variants gain a `token`), and
+  returns it in `AwaitingInput { resume_token }`.
+- `PlayerAction::ResolveInput` gains `token: ResumeToken`; the host echoes the one it
+  received. **(Wire + replay-contract change.)**
+- `resolve_input` validates `submitted == top frame's token`; a mismatch rejects as
+  **stale** before dispatching on the frame variant.
+
+The token does double duty: it is the recorded "this frame is awaiting input" pointer
+**and** a staleness check. This replaces the **resume-path** re-derivation that today scans
+the stack top-down (`top_reaction_window` / `_index`) for the topmost frame with non-empty
+`pending_triggers`. Other uses of the window helpers (the open-window guard; locating where
+to enqueue a newly-triggered reaction) are separate concerns and may keep a window lookup —
+token-routing does **not** retire `top_reaction_window` wholesale.
+
+`ResumeToken` stops being vestigial (`pub(crate) u64`, currently always `ResumeToken(0)`).
+
+## D. Serializable `EvalContext` with grouped bindings (#345)
+
+`EvalContext` today is `controller` + `source` followed by a flat set of `Option<_>`
+window-bound fields, derives `Copy` only (not `Serialize`). Two problems: (A) illegal states
+are representable (e.g. `failed_by` + `attacking_enemy` coexisting, when they belong to
+disjoint windows — the invariant lives only in doc-comments); (B) not serializable, so
+suspended frames store ingredient tuples (`controller` + `source`) and rebuild — each new
+frame type re-implements the rebuild, and the rebuild **silently drops window-bound
+bindings** (a latent cross-suspend bug).
+
+**Decision: grouped optional bindings, snapshotted per-frame.**
+
+```rust
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct EvalContext {
+    // durable identity
+    pub controller: InvestigatorId,
+    pub source: Option<CardInstanceId>,
+    // window bindings — each cohesive, each optional
+    pub skill_test:   Option<SkillTestBinding>,   // { failed_by }
+    pub discovery:    Option<DiscoveryBinding>,    // { clue_discovery_count }
+    pub enemy_attack: Option<EnemyAttackBinding>,  // { attacking_enemy }
+    pub choice:       Option<ChoiceBinding>,       // { investigator, location, enemy, option }
+}
+```
+
+Frames **snapshot the whole `EvalContext`** instead of storing `controller` + `source`
+tuples. This fixes (B) — zero per-frame rebuild code — *and* the latent cross-suspend
+binding-loss (bindings survive the suspend because the whole context is captured). The four
+scattered `chosen_*` fields collapse into one cohesive `ChoiceBinding`.
+
+### Why grouped-Options, not a `Vec<Binding>`, a per-frame-type enum, or a global stack
+
+These were evaluated and rejected; recorded so a future author does not re-litigate:
+
+- **Per-frame-type enum** (`enum Binding { SkillTestFail{…}, Choice{…}, … }` tailored to the
+  frame): cannot express a binding *inherited* from an outer window the frame suspended
+  inside (an `on_fail` effect whose choice needs both `failed_by` and the pick). This is the
+  "layered, not one-of-N" footgun #345 warns about.
+- **`Vec<Binding>` inside `EvalContext`**: a *sibling* of grouped-Options (also per-frame,
+  also snapshotted, also desync-safe), but reads are scan-by-kind from scattered evaluator
+  sites (not LIFO), and it can hold two same-kind entries. Grouped-Options dominates it for
+  by-kind access: O(1) direct field read, cohesive, same nesting expressiveness.
+- **Global mutable binding-stack** (peek/pop across resume): breaks under the suspend-and-
+  replay re-run. The driver pushes `SkillTestFail` but the `ChoiceFrame` re-runs only the
+  effect subtree, not the driver scaffolding — so push/pop balance is split across the
+  suspend boundary and across two code paths, and bindings must persist on global state
+  invisibly to the replay mechanism. Per-frame snapshots cannot desync (captured once,
+  read-only) and are the existing grain of the code (`ChoiceFrame` already snapshots
+  `controller`+`source`).
+
+### Same-kind nesting: corpus-verified moot
+
+Grouped-Options holds the **innermost active** binding of each kind; same-kind *nesting* (a
+test inside a test) is handled by the per-frame snapshot stack (each level's binding frozen
+on its own frame), so a single context only ever needs the innermost value. The only thing
+it cannot do is **one effect reading two same-kind bindings simultaneously** — which would
+*also* need a DSL surface to name the non-innermost one (none exists).
+
+All 829 Core + Dunwich cards (the project's entire pinned card scope) were scanned: every
+`for each point` margin reference is a single innermost test; the multi-`test` cards are all
+commit/modifier cards or one test referenced twice (Liquid Courage 02024, Double or Nothing
+02026) — **none nests a test inside a test**. Discovery interrupts don't nest (#367);
+the attack loop is one-attacker-at-a-time; no card does nested same-target-kind choices.
+
+So this is moot for the corpus. **No `TODO`, no tracking issue** — a plain doc-comment states
+the innermost-only semantics as a fact. The grouped-Options → richer-binding change is
+localized and self-evident if a future cycle is ever pinned.
+
+## E. Revelation disposal: encounter-card resolution as a frame (#380)
+
+Discarding a one-shot treachery to the encounter discard after its Revelation resolves is
+**framework behavior, not card behavior** (RR default; persistent treacheries are the
+attaching exception, #235). Card authors must not opt into it. Today the framework handles it
+via `pending_revelation_discard: Option<CardCode>` — a global one-slot stash flushed by the
+**skill-test driver's** terminal teardown, which only understands "the Revelation suspended
+*into a skill test*." Since Axis A a Revelation can suspend on a **choice**, which this
+channel does not cover.
+
+**Decision: make encounter-card resolution a continuation frame whose framework teardown
+disposes of the card.**
+
+```rust
+Continuation::EncounterCard { card: CardCode }
+```
+
+(If teardown ever needs more than one resume point, add a small phase enum analogous to
+`FinishContinuation` — a single post-Revelation disposal step suffices for the four in-scope
+one-shot treacheries, so the frame starts payload-minimal.)
+
+- `resolve_encounter_card` pushes this frame, then runs the Revelation.
+- If the Revelation suspends — into a skill test, a choice, a nested effect, *anything* — the
+  `EncounterCard` frame sits on the stack **beneath** that suspension.
+- When the Revelation's whole sub-resolution completes and control pops back to the
+  `EncounterCard` frame, the **framework** runs the standard teardown: one-shot → discard to
+  `encounter_discard`; persistent → attach (#235). Then it pops.
+
+Properties: card authors write nothing (just the Revelation effect); suspension-reason-
+agnostic (rides the continuation mechanism, not a skill-test-specific flush); removes the
+global `pending_revelation_discard` slot **and** the skill-test driver's special teardown for
+it (the driver no longer knows treacheries exist). `pending_played_event` (the event-play
+analogue) is a sibling side-channel — *not* in scope here, but the same frame-teardown shape
+applies and is the natural follow-up.
+
+## Out of scope (explicitly)
+
+- The Enemy-phase `enemy_attack_pending` cursor (internal sequencing; keystone may fold it).
+- `pending_played_event` (event-play disposal analogue of #380 — same shape, separate issue).
+- The composable/Vec binding model and any same-kind-nesting support (corpus-moot).
+- `pending_cancellation`, `pending_skill_modifiers`, `skill_substitutions` (signals /
+  accumulators, not input-awaiting suspensions).
+- A pure enumerated-legal-actions `InputRequest` model (filed #384; needs its own brainstorm).
+- The keystone itself (mid-action attack suspend/resume — Phase 7 ordering step 3).
+
+## Consequences / migration notes
+
+- **Wire + action-log format break.** Removing `PlayerAction::Mulligan` /
+  `DrawEncounterCard` and adding `ResolveInput.token` means old serialized action logs do not
+  replay. Acceptable pre-1.0; flagged for the persistence layer (Phase 5).
+- **Test churn.** Every test that calls `Mulligan` / `DrawEncounterCard`, reads
+  `in_flight_skill_test`, or constructs `ResolveInput` without a token migrates. The
+  `test_support` resolver and fixtures update once; per-test call sites follow.
+- **No intended behavior change** for any in-scope card or scenario. The
+  revelation-treachery tests (`crates/cards/tests/revelation_treacheries.rs`) and Crypt
+  Chill's suspend path must hold unchanged; add a revelation-suspends-into-a-**choice** test.
+
+## Sequencing (PR decomposition)
+
+One spec, landed as reviewable PRs, each green on the full CI gauntlet:
+
+1. **#345** — serializable `EvalContext` + grouped bindings + per-frame snapshot. Foundational;
+   establishes the storage shape the migrated frames use.
+2. **#347** — token plumbing: `next_resume_token` counter, frame stamps, `ResolveInput.token`,
+   stale-reject. Wire change; establishes the router substrate.
+3. **#348** — migrate the suspension modes onto frames (incl. folding `in_flight_skill_test`);
+   collapse both ladders into top-frame dispatch; fold in `Mulligan` / `DrawEncounterCard` →
+   `InputResponse`. The bulk of the pass.
+4. **#380** — encounter-card-as-frame + framework disposal teardown; remove
+   `pending_revelation_discard`. Small; rides the clean stack.
+
+Rationale: bindings first (storage), then token (router substrate), then the migration
+(consumes both), then the side-channel cleanup.
+
+## What "done" looks like
+
+- `continuations: Vec<Continuation>` is the only suspension record; the listed `Option<…>`
+  `pending_*` / cursor fields and `in_flight_skill_test` are gone.
+- `apply_player_action` and `resolve_input` each dispatch on the top frame; no `pending_X`
+  cascade.
+- `ResolveInput` is token-validated; stale submits reject cleanly.
+- `EvalContext` is `Serialize`; frames snapshot it; bindings are grouped.
+- `pending_revelation_discard` is removed; revelations dispose via their `EncounterCard`
+  frame, for skill-test *and* choice suspensions.
+- Full CI gauntlet green; no behavior change for in-scope content.


### PR DESCRIPTION
## Summary

PR 1 of 4 in the **§1 continuation-stack cleanup** ([spec](docs/superpowers/specs/2026-06-19-continuation-stack-cleanup-design.md)). Makes `EvalContext` serializable with cohesive grouped bindings, snapshotted whole onto suspended frames — killing the per-frame rebuild duplication and a latent cross-suspend binding-loss. Foundational: establishes the context-snapshot storage shape the later frame migration (#348) consumes.

## What changed

Three commits, each green on the full CI gauntlet:

1. **Accessor indirection** — getter/setter methods over `EvalContext`'s window-bound fields; every read/write site (game-core, cards, scenarios) migrated to them. Pure refactor, isolates the representation swap to one file.
2. **Grouped serializable bindings** — the flat `Option<_>` window-bound fields become cohesive sub-structs (`SkillTestBinding`, `DiscoveryBinding`, `EnemyAttackBinding`, `ChoiceBinding`) behind those accessors; `EvalContext` derives `Serialize`/`Deserialize`/`PartialEq`/`Eq`. The four scattered `chosen_*` fields collapse into one `ChoiceBinding`. Innermost-only per kind (corpus-verified moot — see spec §D; no TODO).
3. **Whole-context snapshot on `ChoiceFrame`** — replaces the `controller`+`source` ingredient tuple with a full `EvalContext` snapshot, so window bindings (e.g. an `on_fail` margin) survive a choice suspend instead of being silently rebuilt away.

## Test notes

- New: `eval_context_round_trips_with_grouped_bindings` (serde) and `choice_frame_snapshots_active_skill_test_binding` (the latent-bug regression — a margin binding survives a choice suspend on the frame).
- No behavior change for in-scope content: the Crypt Chill 01167 / Dynamite Blast 01024 choice-suspend suites pass unchanged.
- Full gauntlet green locally: `test` / `clippy` / `fmt` / `doc` / `wasm-build` / `wasm-clippy`.
- Pre-push code review: **ready to merge**, no Critical/Important. One Minor folded in (`set_chosen_option(None)` now matches the old flat semantics exactly — no spurious `Some(default)` binding, which matters since `EvalContext` is now `PartialEq`).

Migration note (whole series, flagged in spec): later PRs change the `ResolveInput` wire format and remove `Mulligan`/`DrawEncounterCard` as standalone actions — old serialized action logs won't replay. Acceptable pre-1.0. This PR alone is behavior-preserving.

## Linked issues

Closes #345