### PR TITLE
engine: fold in_flight_skill_test onto its SkillTest frame (#348 part 1)

### DIFF
--- a/crates/cards/tests/commit_cap.rs
+++ b/crates/cards/tests/commit_cap.rs
@@ -71,7 +71,7 @@ fn committing_over_the_cap_is_rejected() {
         r.outcome,
     );
     // Validate-first: the in-flight test is untouched, still awaiting commit.
-    assert!(r.state.in_flight_skill_test.is_some());
+    assert!(r.state.has_skill_test_in_flight());
 }
 
 /// Committing a single copy is within the cap and resolves normally.

--- a/crates/cards/tests/revelation_treacheries.rs
+++ b/crates/cards/tests/revelation_treacheries.rs
@@ -72,7 +72,7 @@ fn grasping_hands_deals_one_damage_per_point_failed_then_discards() {
             .contains(&CardCode::new("01162")),
         "the treachery discards after its suspended Revelation resolves",
     );
-    assert!(result.state.in_flight_skill_test.is_none());
+    assert!(!result.state.has_skill_test_in_flight());
     assert!(result.state.pending_revelation_discard.is_none());
 }
 

--- a/crates/game-core/src/engine/dispatch/choice.rs
+++ b/crates/game-core/src/engine/dispatch/choice.rs
@@ -129,7 +129,7 @@ pub(crate) fn resume_choice(cx: &mut Cx, response: &InputResponse) -> EngineOutc
     // Same reentrancy as the before-discover window's resume. A still-suspended
     // outcome (a further nested choice) returns as-is.
     if matches!(outcome, EngineOutcome::Done) {
-        if cx.state.in_flight_skill_test.is_some() {
+        if cx.state.has_skill_test_in_flight() {
             return super::skill_test::drive_skill_test(cx);
         }
         // A choice fired from inside a reaction window (Research Librarian

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -495,7 +495,7 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
     // suspensions of an in-flight test (Axis-B T4).
     if matches!(
         cx.state.continuations.last(),
-        Some(crate::state::Continuation::SkillTest)
+        Some(crate::state::Continuation::SkillTest(_))
     ) {
         return resume_skill_test_commit(cx, response);
     }

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -102,9 +102,7 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
     // While a skill test is paused at its commit window (no reaction
     // window open yet), only `ResolveInput` can advance the engine.
     // Mirrors the `mulligan_pending` guard above.
-    if cx.state.in_flight_skill_test.is_some()
-        && !matches!(action, PlayerAction::ResolveInput { .. })
-    {
+    if cx.state.has_skill_test_in_flight() && !matches!(action, PlayerAction::ResolveInput { .. }) {
         return EngineOutcome::Rejected {
             reason: "a skill test is paused at its commit window; submit a \
                      PlayerAction::ResolveInput with an InputResponse::CommitCards \

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -916,7 +916,7 @@ pub(super) fn close_reaction_window_at(cx: &mut Cx, idx: usize) -> EngineOutcome
     // window (no driver state to resume); this happens when a future
     // non-skill-test action queues a window — `Done` is the right
     // terminal outcome.
-    if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
+    if let Some(in_flight) = cx.state.current_skill_test() {
         if !matches!(in_flight.continuation, FinishContinuation::AwaitingCommit) {
             return super::skill_test::drive_skill_test(cx);
         }
@@ -962,7 +962,7 @@ pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) -> EngineOu
                 // adding a Mythos-phase Revelation that initiates a skill
                 // test must redesign the close-window + phase-transition
                 // ordering before this assertion fires.
-                if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
+                if let Some(in_flight) = cx.state.current_skill_test() {
                     unreachable!(
                         "MythosAfterDraws window closed while a skill test is in flight \
                      (continuation={:?}). Phase transition would strand the skill test \
@@ -980,7 +980,7 @@ pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) -> EngineOu
                 // Phase-transitioning continuation (4.2–4.6 then Upkeep→Mythos):
                 // cannot run while a skill test is in flight. Phase 4 has no
                 // Upkeep-phase skill-test source, so structurally unreachable.
-                if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
+                if let Some(in_flight) = cx.state.current_skill_test() {
                     unreachable!(
                         "UpkeepBegins window closed while a skill test is in flight \
                      (continuation={:?}). Phase 4 has no Upkeep-phase skill-test \
@@ -1000,7 +1000,7 @@ pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) -> EngineOu
                 // (e.g. a treachery-style "make an Agility test or take
                 // damage" attack ability) must redesign the window-close
                 // + phase-transition ordering before this assertion fires.
-                if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
+                if let Some(in_flight) = cx.state.current_skill_test() {
                     unreachable!(
                         "BeforeInvestigatorAttacked window closed while a \
                      skill test is in flight (continuation={:?}). Phase \
@@ -1045,7 +1045,7 @@ pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) -> EngineOu
                 after_enemy_phase_attacks(cx, investigator)
             }
             PhaseStep::AfterAllInvestigatorsAttacked => {
-                if let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() {
+                if let Some(in_flight) = cx.state.current_skill_test() {
                     unreachable!(
                         "AfterAllInvestigatorsAttacked window closed while a \
                      skill test is in flight (continuation={:?}). Phase \
@@ -1138,7 +1138,7 @@ fn resume_before_discover_window(
     if !cancelled {
         crate::engine::evaluator::perform_discovery(cx, location, count, investigator);
     }
-    if cx.state.in_flight_skill_test.is_some() {
+    if cx.state.has_skill_test_in_flight() {
         super::skill_test::drive_skill_test(cx)
     } else {
         EngineOutcome::Done

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -281,7 +281,7 @@ pub(super) fn finish_skill_test(cx: &mut Cx, indices: &[u32]) -> EngineOutcome {
     // immediately above and nothing has cleared it since.
     cx.state
         .current_skill_test_mut()
-        .expect("in_flight_skill_test was Some immediately above")
+        .expect("the SkillTest frame was present immediately above")
         .committed_by_active
         .clone_from(&indices_u8);
 
@@ -309,7 +309,7 @@ pub(super) fn finish_skill_test(cx: &mut Cx, indices: &[u32]) -> EngineOutcome {
     // safe. (C5a #236.)
     cx.state
         .current_skill_test_mut()
-        .expect("in_flight_skill_test was Some immediately above")
+        .expect("the SkillTest frame was present immediately above")
         .continuation = FinishContinuation::PostFollowUp { succeeded };
 
     if succeeded {
@@ -409,7 +409,7 @@ pub(super) fn drive_skill_test(cx: &mut Cx) -> EngineOutcome {
         let (continuation, investigator, indices_u8) = {
             let in_flight = cx.state.current_skill_test().unwrap_or_else(|| {
                 unreachable!(
-                    "drive_skill_test: in_flight_skill_test must exist while driver is active; \
+                    "drive_skill_test: the SkillTest frame must exist while driver is active; \
                      state-corruption invariant violation"
                 )
             });
@@ -431,14 +431,14 @@ pub(super) fn drive_skill_test(cx: &mut Cx) -> EngineOutcome {
                 fire_on_skill_test_resolution(cx, investigator, &indices_u8, succeeded);
                 cx.state
                     .current_skill_test_mut()
-                    .expect("in_flight_skill_test must persist across driver steps")
+                    .expect("the SkillTest frame must persist across driver steps")
                     .continuation = FinishContinuation::PostRetaliate { succeeded };
             }
             FinishContinuation::PostRetaliate { succeeded } => {
                 fire_retaliate_if_any(cx, investigator, succeeded);
                 cx.state
                     .current_skill_test_mut()
-                    .expect("in_flight_skill_test must persist across driver steps")
+                    .expect("the SkillTest frame must persist across driver steps")
                     .continuation = FinishContinuation::PostOnResolution { succeeded };
             }
             FinishContinuation::PostOnResolution { succeeded: _ } => {

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -67,7 +67,7 @@ pub(in crate::engine) fn start_skill_test(
             reason: format!("skill test: difficulty {difficulty} must be >= 0").into(),
         };
     }
-    if cx.state.in_flight_skill_test.is_some() {
+    if cx.state.has_skill_test_in_flight() {
         return EngineOutcome::Rejected {
             reason: "skill test: another skill test is already in flight; only one test \
                      may pause at a commit window at a time"
@@ -153,8 +153,7 @@ fn open_commit_window(cx: &mut Cx) -> EngineOutcome {
     let (investigator, skill, difficulty) = {
         let t = cx
             .state
-            .in_flight_skill_test
-            .as_ref()
+            .current_skill_test()
             .expect("open_commit_window: in-flight test must exist");
         (t.investigator, t.skill, t.difficulty)
     };
@@ -201,8 +200,7 @@ pub(in crate::engine) fn resume_substitution_choice(
         // separate and untouched.
         let t = cx
             .state
-            .in_flight_skill_test
-            .as_mut()
+            .current_skill_test_mut()
             .expect("resume_substitution_choice: in-flight test must exist");
         t.skill = SkillKind::Intellect;
         t.test_modifier = 0;
@@ -238,7 +236,7 @@ pub(in crate::engine) fn resume_substitution_choice(
 pub(super) fn finish_skill_test(cx: &mut Cx, indices: &[u32]) -> EngineOutcome {
     // Snapshot the in-flight record (Copy-able primitives only) so
     // later mutation paths can re-borrow state freely.
-    let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() else {
+    let Some(in_flight) = cx.state.current_skill_test() else {
         return EngineOutcome::Rejected {
             reason: "ResolveInput::CommitCards: no in-flight skill test to resume".into(),
         };
@@ -276,8 +274,7 @@ pub(super) fn finish_skill_test(cx: &mut Cx, indices: &[u32]) -> EngineOutcome {
     // replay clarity. Safe to expect: we read `in_flight_skill_test`
     // immediately above and nothing has cleared it since.
     cx.state
-        .in_flight_skill_test
-        .as_mut()
+        .current_skill_test_mut()
         .expect("in_flight_skill_test was Some immediately above")
         .committed_by_active
         .clone_from(&indices_u8);
@@ -305,8 +302,7 @@ pub(super) fn finish_skill_test(cx: &mut Cx, indices: &[u32]) -> EngineOutcome {
     // set follow_up=None), so running on_success after the follow-up is
     // safe. (C5a #236.)
     cx.state
-        .in_flight_skill_test
-        .as_mut()
+        .current_skill_test_mut()
         .expect("in_flight_skill_test was Some immediately above")
         .continuation = FinishContinuation::PostFollowUp { succeeded };
 
@@ -405,7 +401,7 @@ pub(super) fn drive_skill_test(cx: &mut Cx) -> EngineOutcome {
         }
 
         let (continuation, investigator, indices_u8) = {
-            let in_flight = cx.state.in_flight_skill_test.as_ref().unwrap_or_else(|| {
+            let in_flight = cx.state.current_skill_test().unwrap_or_else(|| {
                 unreachable!(
                     "drive_skill_test: in_flight_skill_test must exist while driver is active; \
                      state-corruption invariant violation"
@@ -428,16 +424,14 @@ pub(super) fn drive_skill_test(cx: &mut Cx) -> EngineOutcome {
             FinishContinuation::PostFollowUp { succeeded } => {
                 fire_on_skill_test_resolution(cx, investigator, &indices_u8, succeeded);
                 cx.state
-                    .in_flight_skill_test
-                    .as_mut()
+                    .current_skill_test_mut()
                     .expect("in_flight_skill_test must persist across driver steps")
                     .continuation = FinishContinuation::PostRetaliate { succeeded };
             }
             FinishContinuation::PostRetaliate { succeeded } => {
                 fire_retaliate_if_any(cx, investigator, succeeded);
                 cx.state
-                    .in_flight_skill_test
-                    .as_mut()
+                    .current_skill_test_mut()
                     .expect("in_flight_skill_test must persist across driver steps")
                     .continuation = FinishContinuation::PostOnResolution { succeeded };
             }
@@ -463,7 +457,7 @@ pub(super) fn drive_skill_test(cx: &mut Cx) -> EngineOutcome {
                 if let Some(code) = cx.state.pending_revelation_discard.take() {
                     cx.state.encounter_discard.push(code);
                 }
-                cx.state.in_flight_skill_test = None;
+                let _ = cx.state.take_skill_test();
                 // Remove this test's SkillTest resume-handle (Axis-B T4).
                 // Usually it is the top frame, but a player-window gate can
                 // legitimately sit above it (#69/#70/#71), so remove the
@@ -591,10 +585,7 @@ fn sum_skill_value(
     let pending_mod = pending_skill_modifier(state, investigator, skill);
     // One-shot modifier the initiating effect snapshotted (a weapon's
     // "+N for this attack"); 0 for player-action tests.
-    let test_mod = state
-        .in_flight_skill_test
-        .as_ref()
-        .map_or(0, |t| t.test_modifier);
+    let test_mod = state.current_skill_test().map_or(0, |t| t.test_modifier);
     base.saturating_add(constant_mod)
         .saturating_add(pending_mod)
         .saturating_add(icon_mod)
@@ -809,8 +800,7 @@ fn apply_skill_test_follow_up(
             // of resolution — so the accumulator is readable.
             let bonus = cx
                 .state
-                .in_flight_skill_test
-                .as_ref()
+                .current_skill_test()
                 .map_or(0, |t| t.bonus_attack_damage);
             super::combat::damage_enemy(
                 cx,
@@ -865,7 +855,7 @@ fn fire_retaliate_if_any(cx: &mut Cx, investigator: InvestigatorId, succeeded: b
     if succeeded {
         return;
     }
-    let follow_up = cx.state.in_flight_skill_test.as_ref().map(|t| t.follow_up);
+    let follow_up = cx.state.current_skill_test().map(|t| t.follow_up);
     let Some(SkillTestFollowUp::Fight { enemy, .. }) = follow_up else {
         return;
     };
@@ -1251,7 +1241,7 @@ mod tests {
             state.encounter_discard.contains(&CardCode("01162".into())),
             "suspended treachery flushed to encounter_discard at teardown"
         );
-        assert!(state.in_flight_skill_test.is_none());
+        assert!(!state.has_skill_test_in_flight());
         assert!(state.pending_revelation_discard.is_none());
     }
 
@@ -1376,7 +1366,7 @@ mod tests {
             matches!(out, EngineOutcome::AwaitingInput { .. }),
             "commit window"
         );
-        let t = state.in_flight_skill_test.as_ref().unwrap();
+        let t = state.current_skill_test().unwrap();
         assert_eq!(t.skill, SkillKind::Intellect, "now an intellect test");
         assert_eq!(t.kind, SkillTestKind::Fight, "still a Fight (damage)");
         assert_eq!(t.test_modifier, 0, "weapon combat bonus dropped");
@@ -1418,7 +1408,7 @@ mod tests {
             "commit window"
         );
         assert_eq!(
-            state.in_flight_skill_test.as_ref().unwrap().skill,
+            state.current_skill_test().unwrap().skill,
             SkillKind::Agility,
             "declined — keeps the printed skill",
         );
@@ -1453,9 +1443,6 @@ mod tests {
         };
         assert!(matches!(out, EngineOutcome::AwaitingInput { .. }));
         assert!(state.pending_substitution_prompt.is_none(), "no prompt");
-        assert_eq!(
-            state.in_flight_skill_test.as_ref().unwrap().skill,
-            SkillKind::Combat,
-        );
+        assert_eq!(state.current_skill_test().unwrap().skill, SkillKind::Combat,);
     }
 }

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -82,21 +82,29 @@ pub(in crate::engine) fn start_skill_test(
     // borrow from the validation block above is still live; reading
     // `current_location` here doesn't extend it past this line.
     let tested_location = inv.current_location;
-    cx.state.in_flight_skill_test = Some(InFlightSkillTest {
-        investigator,
-        skill,
-        kind,
-        difficulty,
-        committed_by_active: Vec::new(),
-        tested_location,
-        follow_up,
-        on_fail,
-        on_success,
-        source,
-        continuation: FinishContinuation::AwaitingCommit,
-        test_modifier,
-        bonus_attack_damage: 0,
-    });
+    // Push the SkillTest frame up front (carrying the test's data — #348), so the
+    // in-flight test has a home from test start. Safe: all validation precedes
+    // this point, and the only outcomes below are `AwaitingInput` (the
+    // Mind-over-Matter substitution prompt, or the commit window). During the
+    // substitution prompt this frame sits beneath `pending_substitution_prompt`,
+    // which the `resolve_input` cascade routes first.
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::SkillTest(InFlightSkillTest {
+            investigator,
+            skill,
+            kind,
+            difficulty,
+            committed_by_active: Vec::new(),
+            tested_location,
+            follow_up,
+            on_fail,
+            on_success,
+            source,
+            continuation: FinishContinuation::AwaitingCommit,
+            test_modifier,
+            bonus_attack_damage: 0,
+        }));
     cx.events.push(Event::SkillTestStarted {
         investigator,
         skill,
@@ -157,12 +165,10 @@ fn open_commit_window(cx: &mut Cx) -> EngineOutcome {
             .expect("open_commit_window: in-flight test must exist");
         (t.investigator, t.skill, t.difficulty)
     };
-    // Resume-handle on the one stack (Axis-B T4): the test parks at its commit
-    // window. Resolution (reaction/fast) frames push *above* this when a window
-    // opens mid-test; popped when the test fully resolves.
-    cx.state
-        .continuations
-        .push(crate::state::Continuation::SkillTest);
+    // The SkillTest frame (Axis-B T4) was already pushed at test start (#348);
+    // the test parks at its commit window. Resolution (reaction/fast) frames
+    // push *above* it when a window opens mid-test; it is popped when the test
+    // fully resolves.
     EngineOutcome::AwaitingInput {
         request: InputRequest::prompt(format!(
             "Commit cards from hand for {investigator:?}'s {skill:?} skill test \
@@ -393,7 +399,7 @@ pub(super) fn drive_skill_test(cx: &mut Cx) -> EngineOutcome {
             .state
             .continuations
             .iter()
-            .rposition(|c| matches!(c, crate::state::Continuation::SkillTest));
+            .rposition(|c| matches!(c, crate::state::Continuation::SkillTest(_)));
         if let Some(win_idx) = cx.state.top_reaction_window_index() {
             if skill_test_pos.is_none_or(|st| win_idx > st) {
                 return super::reaction_windows::open_queued_reaction_window(cx);
@@ -457,26 +463,16 @@ pub(super) fn drive_skill_test(cx: &mut Cx) -> EngineOutcome {
                 if let Some(code) = cx.state.pending_revelation_discard.take() {
                     cx.state.encounter_discard.push(code);
                 }
-                let _ = cx.state.take_skill_test();
-                // Remove this test's SkillTest resume-handle (Axis-B T4).
-                // Usually it is the top frame, but a player-window gate can
-                // legitimately sit above it (#69/#70/#71), so remove the
-                // (unique — no nesting today) SkillTest frame by position
-                // rather than popping the top.
-                let frame = cx
-                    .state
-                    .continuations
-                    .iter()
-                    .rposition(|c| matches!(c, crate::state::Continuation::SkillTest));
-                match frame {
-                    Some(pos) => {
-                        cx.state.continuations.remove(pos);
-                    }
-                    None => debug_assert!(
-                        false,
-                        "skill-test teardown: no SkillTest frame on the continuation stack",
-                    ),
-                }
+                // Tear down the test's SkillTest frame (Axis-B T4), which also
+                // carries the test data (#348). `take_skill_test` removes the
+                // (unique — no nesting today) frame by position, so a player-
+                // window gate legitimately sitting above it (#69/#70/#71) is
+                // unaffected.
+                let taken = cx.state.take_skill_test();
+                debug_assert!(
+                    taken.is_some(),
+                    "skill-test teardown: no SkillTest frame on the continuation stack",
+                );
                 return EngineOutcome::Done;
             }
         }
@@ -1095,24 +1091,26 @@ mod tests {
             .with_investigator(test_investigator(1))
             .with_enemy(enemy)
             .build();
-        state.in_flight_skill_test = Some(InFlightSkillTest {
-            investigator: inv,
-            skill: SkillKind::Combat,
-            kind: SkillTestKind::Fight,
-            difficulty: 2,
-            committed_by_active: Vec::new(),
-            tested_location: None,
-            follow_up: SkillTestFollowUp::Fight {
-                enemy: EnemyId(7),
-                extra_damage: 1,
-            },
-            on_fail: None,
-            on_success: None,
-            source: None,
-            continuation: FinishContinuation::AwaitingCommit,
-            test_modifier: 0,
-            bonus_attack_damage: 2,
-        });
+        state
+            .continuations
+            .push(crate::state::Continuation::SkillTest(InFlightSkillTest {
+                investigator: inv,
+                skill: SkillKind::Combat,
+                kind: SkillTestKind::Fight,
+                difficulty: 2,
+                committed_by_active: Vec::new(),
+                tested_location: None,
+                follow_up: SkillTestFollowUp::Fight {
+                    enemy: EnemyId(7),
+                    extra_damage: 1,
+                },
+                on_fail: None,
+                on_success: None,
+                source: None,
+                continuation: FinishContinuation::AwaitingCommit,
+                test_modifier: 0,
+                bonus_attack_damage: 2,
+            }));
         let mut events = Vec::new();
         let mut cx = Cx {
             state: &mut state,

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -1372,6 +1372,51 @@ mod tests {
     }
 
     #[test]
+    fn substitution_prompt_keeps_the_test_on_its_frame() {
+        // The substitution prompt suspends *before* the commit window — the one
+        // place test data exists pre-commit. Pin that it lives on a SkillTest
+        // frame (not a removed Option field) during that window (#348).
+        let inv = InvestigatorId(1);
+        let mut state = substitution_state(inv);
+        let mut events = Vec::new();
+        let out = {
+            let mut cx = Cx {
+                state: &mut state,
+                events: &mut events,
+            };
+            start_skill_test(
+                &mut cx,
+                inv,
+                SkillKind::Combat,
+                SkillTestKind::Fight,
+                3,
+                SkillTestFollowUp::None,
+                None,
+                None,
+                None,
+                0,
+            )
+        };
+        assert!(
+            matches!(out, EngineOutcome::AwaitingInput { .. }),
+            "substitution prompt should suspend",
+        );
+        assert_eq!(state.pending_substitution_prompt, Some(inv));
+        assert!(
+            state.current_skill_test().is_some(),
+            "the in-flight test must live on a SkillTest frame during the \
+             substitution prompt, not in a removed Option field",
+        );
+        assert!(
+            state
+                .continuations
+                .iter()
+                .any(|c| matches!(c, crate::state::Continuation::SkillTest(_))),
+            "a SkillTest frame is on the stack before the commit window",
+        );
+    }
+
+    #[test]
     fn substitution_choice_no_keeps_the_printed_skill() {
         let inv = InvestigatorId(1);
         let mut state = substitution_state(inv);

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -675,7 +675,7 @@ fn apply_attach_self_to_location(cx: &mut Cx) -> EngineOutcome {
 /// test. The Fight follow-up is the only reader, so this is inert for
 /// non-attack tests.
 fn boost_attack_damage_effect(cx: &mut Cx, amount: u8) -> EngineOutcome {
-    if let Some(test) = cx.state.in_flight_skill_test.as_mut() {
+    if let Some(test) = cx.state.current_skill_test_mut() {
         test.bonus_attack_damage = test.bonus_attack_damage.saturating_add(amount);
     }
     EngineOutcome::Done
@@ -952,7 +952,7 @@ fn eval_condition(
 ) -> Result<bool, String> {
     match condition {
         Condition::SkillTestKind(kind) => {
-            let t = state.in_flight_skill_test.as_ref().ok_or_else(|| {
+            let t = state.current_skill_test().ok_or_else(|| {
                 "Condition::SkillTestKind but no skill test is in flight".to_owned()
             })?;
             Ok(t.kind == *kind)
@@ -1772,8 +1772,7 @@ fn resolve_location_target(
              (ground_chosen_targets should run first)",
         ),
         LocationTarget::TestedLocation => state
-            .in_flight_skill_test
-            .as_ref()
+            .current_skill_test()
             .ok_or("LocationTarget::TestedLocation but no skill test is in flight")
             .and_then(|t| {
                 t.tested_location.ok_or(
@@ -2543,11 +2542,7 @@ mod tests {
             );
         }
         assert_eq!(
-            state
-                .in_flight_skill_test
-                .as_ref()
-                .unwrap()
-                .bonus_attack_damage,
+            state.current_skill_test().unwrap().bonus_attack_damage,
             2,
             "two BoostAttackDamage(1) applications should stack to 2"
         );

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -2462,21 +2462,25 @@ mod tests {
             .with_location(tested_loc)
             .with_location(elsewhere_loc)
             .build();
-        state.in_flight_skill_test = Some(crate::state::InFlightSkillTest {
-            investigator: InvestigatorId(1),
-            skill: SkillKind::Intellect,
-            kind: SkillTestKind::Investigate,
-            difficulty: 2,
-            committed_by_active: Vec::new(),
-            tested_location: Some(tested),
-            follow_up: crate::state::SkillTestFollowUp::Investigate,
-            on_fail: None,
-            on_success: None,
-            source: None,
-            continuation: crate::state::FinishContinuation::AwaitingCommit,
-            test_modifier: 0,
-            bonus_attack_damage: 0,
-        });
+        state
+            .continuations
+            .push(crate::state::Continuation::SkillTest(
+                crate::state::InFlightSkillTest {
+                    investigator: InvestigatorId(1),
+                    skill: SkillKind::Intellect,
+                    kind: SkillTestKind::Investigate,
+                    difficulty: 2,
+                    committed_by_active: Vec::new(),
+                    tested_location: Some(tested),
+                    follow_up: crate::state::SkillTestFollowUp::Investigate,
+                    on_fail: None,
+                    on_success: None,
+                    source: None,
+                    continuation: crate::state::FinishContinuation::AwaitingCommit,
+                    test_modifier: 0,
+                    bonus_attack_damage: 0,
+                },
+            ));
         let mut events = Vec::new();
 
         let outcome = apply_effect(
@@ -2515,21 +2519,25 @@ mod tests {
         );
         assert_eq!(outcome, EngineOutcome::Done);
 
-        state.in_flight_skill_test = Some(crate::state::InFlightSkillTest {
-            investigator: InvestigatorId(1),
-            skill: SkillKind::Combat,
-            kind: SkillTestKind::Fight,
-            difficulty: 3,
-            committed_by_active: Vec::new(),
-            tested_location: None,
-            follow_up: crate::state::SkillTestFollowUp::None,
-            on_fail: None,
-            on_success: None,
-            source: None,
-            continuation: crate::state::FinishContinuation::AwaitingCommit,
-            test_modifier: 0,
-            bonus_attack_damage: 0,
-        });
+        state
+            .continuations
+            .push(crate::state::Continuation::SkillTest(
+                crate::state::InFlightSkillTest {
+                    investigator: InvestigatorId(1),
+                    skill: SkillKind::Combat,
+                    kind: SkillTestKind::Fight,
+                    difficulty: 3,
+                    committed_by_active: Vec::new(),
+                    tested_location: None,
+                    follow_up: crate::state::SkillTestFollowUp::None,
+                    on_fail: None,
+                    on_success: None,
+                    source: None,
+                    continuation: crate::state::FinishContinuation::AwaitingCommit,
+                    test_modifier: 0,
+                    bonus_attack_damage: 0,
+                },
+            ));
 
         for _ in 0..2 {
             apply_effect(
@@ -2634,21 +2642,25 @@ mod tests {
                 l
             })
             .build();
-        state.in_flight_skill_test = Some(crate::state::InFlightSkillTest {
-            investigator: InvestigatorId(1),
-            skill: SkillKind::Intellect,
-            kind,
-            difficulty: 2,
-            committed_by_active: Vec::new(),
-            tested_location: Some(LocationId(10)),
-            follow_up: crate::state::SkillTestFollowUp::None,
-            on_fail: None,
-            on_success: None,
-            source: None,
-            continuation: crate::state::FinishContinuation::AwaitingCommit,
-            test_modifier: 0,
-            bonus_attack_damage: 0,
-        });
+        state
+            .continuations
+            .push(crate::state::Continuation::SkillTest(
+                crate::state::InFlightSkillTest {
+                    investigator: InvestigatorId(1),
+                    skill: SkillKind::Intellect,
+                    kind,
+                    difficulty: 2,
+                    committed_by_active: Vec::new(),
+                    tested_location: Some(LocationId(10)),
+                    follow_up: crate::state::SkillTestFollowUp::None,
+                    on_fail: None,
+                    on_success: None,
+                    source: None,
+                    continuation: crate::state::FinishContinuation::AwaitingCommit,
+                    test_modifier: 0,
+                    bonus_attack_damage: 0,
+                },
+            ));
         state
     }
 
@@ -2800,21 +2812,25 @@ mod tests {
         let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
-        state.in_flight_skill_test = Some(crate::state::InFlightSkillTest {
-            investigator: InvestigatorId(1),
-            skill: SkillKind::Willpower,
-            kind: SkillTestKind::Plain,
-            difficulty: 2,
-            committed_by_active: Vec::new(),
-            tested_location: None,
-            follow_up: crate::state::SkillTestFollowUp::None,
-            on_fail: None,
-            on_success: None,
-            source: None,
-            continuation: crate::state::FinishContinuation::AwaitingCommit,
-            test_modifier: 0,
-            bonus_attack_damage: 0,
-        });
+        state
+            .continuations
+            .push(crate::state::Continuation::SkillTest(
+                crate::state::InFlightSkillTest {
+                    investigator: InvestigatorId(1),
+                    skill: SkillKind::Willpower,
+                    kind: SkillTestKind::Plain,
+                    difficulty: 2,
+                    committed_by_active: Vec::new(),
+                    tested_location: None,
+                    follow_up: crate::state::SkillTestFollowUp::None,
+                    on_fail: None,
+                    on_success: None,
+                    source: None,
+                    continuation: crate::state::FinishContinuation::AwaitingCommit,
+                    test_modifier: 0,
+                    bonus_attack_damage: 0,
+                },
+            ));
         let mut events = Vec::new();
 
         let outcome = apply_effect(

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -505,7 +505,7 @@ mod tests {
             "skill test should pause at the commit window, got {:?}",
             paused.outcome,
         );
-        assert!(paused.state.in_flight_skill_test.is_some());
+        assert!(paused.state.has_skill_test_in_flight());
         let s1 = paused.state.clone();
 
         // Malformed response: commit window expects CommitCards; send Skip.
@@ -522,7 +522,7 @@ mod tests {
             "rejected ResolveInput rewinds to the pause state, not pre-action",
         );
         assert!(
-            result.state.in_flight_skill_test.is_some(),
+            result.state.has_skill_test_in_flight(),
             "suspension stays open"
         );
         assert!(result.events.is_empty());
@@ -4355,7 +4355,7 @@ mod tests {
         // resume path after the commit response arrives.
         assert_no_event!(result.events, Event::ChaosTokenRevealed { .. });
         assert!(
-            result.state.in_flight_skill_test.is_some(),
+            result.state.has_skill_test_in_flight(),
             "in_flight_skill_test must be populated while paused",
         );
     }
@@ -4397,7 +4397,7 @@ mod tests {
             Event::SkillTestEnded { investigator } if *investigator == id
         );
         assert!(
-            resumed.state.in_flight_skill_test.is_none(),
+            !resumed.state.has_skill_test_in_flight(),
             "in_flight_skill_test must clear after resolution",
         );
     }
@@ -4542,7 +4542,7 @@ mod tests {
         }
         // State stays paused (engine still in-flight) so a client
         // can submit a fixed-up response without re-initiating.
-        assert!(bad.state.in_flight_skill_test.is_some());
+        assert!(bad.state.has_skill_test_in_flight());
     }
 
     #[test]
@@ -4578,7 +4578,7 @@ mod tests {
         }
         // State stays paused so the client can submit a fixed-up
         // response without re-initiating the test.
-        assert!(bad.state.in_flight_skill_test.is_some());
+        assert!(bad.state.has_skill_test_in_flight());
     }
 
     #[test]
@@ -4612,7 +4612,7 @@ mod tests {
             other => panic!("expected Rejected, got {other:?}"),
         }
         // The pause must survive the rejected action.
-        assert!(rejected.state.in_flight_skill_test.is_some());
+        assert!(rejected.state.has_skill_test_in_flight());
     }
 
     #[test]
@@ -4638,7 +4638,7 @@ mod tests {
         );
         assert!(matches!(bad.outcome, EngineOutcome::Rejected { .. }));
         // Test still paused.
-        assert!(bad.state.in_flight_skill_test.is_some());
+        assert!(bad.state.has_skill_test_in_flight());
     }
 
     #[test]

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -94,8 +94,9 @@ pub struct ApplyResult {
 /// On [`EngineOutcome::AwaitingInput`], the returned state and event
 /// list reflect the work done up to the pause point — e.g. a
 /// `PerformSkillTest` apply that suspends at the commit window has
-/// already emitted [`Event::SkillTestStarted`] and populated
-/// [`GameState::in_flight_skill_test`]. The resume action
+/// already emitted [`Event::SkillTestStarted`] and pushed the
+/// [`SkillTest`](crate::state::Continuation::SkillTest) frame (read via
+/// [`GameState::current_skill_test`]). The resume action
 /// ([`PlayerAction::ResolveInput`](crate::action::PlayerAction::ResolveInput))
 /// drives the rest of resolution in a subsequent `apply` call. While
 /// paused, every non-`ResolveInput` player action rejects.
@@ -4425,9 +4426,16 @@ mod tests {
             EngineOutcome::AwaitingInput { .. }
         ));
         assert_eq!(
-            paused.state.continuations,
-            vec![crate::state::Continuation::SkillTest],
-            "parking at the commit window pushes exactly one SkillTest frame",
+            paused.state.continuations.len(),
+            1,
+            "parking at the commit window pushes exactly one frame",
+        );
+        assert!(
+            matches!(
+                paused.state.continuations.first(),
+                Some(crate::state::Continuation::SkillTest(_))
+            ),
+            "the single frame is the SkillTest frame carrying the in-flight test",
         );
 
         let resumed = apply(

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -4357,7 +4357,7 @@ mod tests {
         assert_no_event!(result.events, Event::ChaosTokenRevealed { .. });
         assert!(
             result.state.has_skill_test_in_flight(),
-            "in_flight_skill_test must be populated while paused",
+            "the SkillTest frame must be populated while paused",
         );
     }
 
@@ -4399,7 +4399,7 @@ mod tests {
         );
         assert!(
             !resumed.state.has_skill_test_in_flight(),
-            "in_flight_skill_test must clear after resolution",
+            "the SkillTest frame must clear after resolution",
         );
     }
 

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -270,7 +270,6 @@ impl GameStateBuilder {
             enemy_ids: Counter::new(),
             location_ids: Counter::new(),
             pending_skill_modifiers: Vec::new(),
-            in_flight_skill_test: None,
             // Builder-staged windows become `Resolution` frames on the one
             // continuation stack (Axis-B T3).
             continuations: self

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -1302,6 +1302,31 @@ impl GameState {
             .find(|w| !w.pending_triggers.is_empty())
     }
 
+    /// The skill test currently in flight, if any. Single source of truth for
+    /// "a test is mid-resolution"; `None` outside a test. (#348 moves the
+    /// payload onto the `Continuation::SkillTest` frame; this accessor hides
+    /// where it lives.)
+    #[must_use]
+    pub fn current_skill_test(&self) -> Option<&InFlightSkillTest> {
+        self.in_flight_skill_test.as_ref()
+    }
+
+    /// Mutable counterpart to [`Self::current_skill_test`].
+    pub fn current_skill_test_mut(&mut self) -> Option<&mut InFlightSkillTest> {
+        self.in_flight_skill_test.as_mut()
+    }
+
+    /// Remove and return the in-flight skill test (called at test teardown).
+    pub fn take_skill_test(&mut self) -> Option<InFlightSkillTest> {
+        self.in_flight_skill_test.take()
+    }
+
+    /// Whether a skill test is currently in flight.
+    #[must_use]
+    pub fn has_skill_test_in_flight(&self) -> bool {
+        self.in_flight_skill_test.is_some()
+    }
+
     /// Iterator over the open windows on the continuation stack, in stack
     /// order (bottom to top). The windows are `Continuation::Resolution`
     /// frames; non-window frames (Task 4+) are skipped.

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -1290,10 +1290,11 @@ impl GameState {
             .find(|w| !w.pending_triggers.is_empty())
     }
 
-    /// The skill test currently in flight, if any. Single source of truth for
-    /// "a test is mid-resolution"; `None` outside a test. (#348 moves the
-    /// payload onto the `Continuation::SkillTest` frame; this accessor hides
-    /// where it lives.)
+    /// The skill test currently in flight, if any; `None` outside a test. Reads
+    /// the topmost `Continuation::SkillTest` frame — the continuation stack is
+    /// the single source of truth for "a test is mid-resolution" (#348). Topmost
+    /// (not `.last()`) because a reaction window can sit above the test mid-
+    /// resolution; "topmost `SkillTest` = the in-flight test".
     #[must_use]
     pub fn current_skill_test(&self) -> Option<&InFlightSkillTest> {
         self.continuations.iter().rev().find_map(|c| match c {

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -121,22 +121,10 @@ pub struct GameState {
     /// [`ModifierScope::ThisSkillTest`]: crate::dsl::ModifierScope::ThisSkillTest
     /// [`Event::SkillTestEnded`]: crate::Event::SkillTestEnded
     pub pending_skill_modifiers: Vec<PendingSkillModifier>,
-    /// The skill test currently paused between [`SkillTestStarted`] and
-    /// [`ChaosTokenRevealed`] awaiting commit-window input from the
-    /// active investigator. `Some` whenever the engine has emitted
-    /// [`EngineOutcome::AwaitingInput`] for a commit window and is
-    /// waiting on a
-    /// [`PlayerAction::ResolveInput`](crate::action::PlayerAction::ResolveInput)
-    /// with a
-    /// [`CommitCards`](crate::action::InputResponse::CommitCards)
-    /// response. While set, every non-`ResolveInput` player action
-    /// rejects (mirrors the [`mulligan_pending`](Self::mulligan_pending)
-    /// guard).
-    ///
-    /// [`SkillTestStarted`]: crate::Event::SkillTestStarted
-    /// [`ChaosTokenRevealed`]: crate::Event::ChaosTokenRevealed
-    /// [`EngineOutcome::AwaitingInput`]: crate::EngineOutcome::AwaitingInput
-    pub in_flight_skill_test: Option<InFlightSkillTest>,
+    // The in-flight skill test now lives on its `Continuation::SkillTest(_)`
+    // frame (#348); read it via [`Self::current_skill_test`]. The former
+    // `in_flight_skill_test: Option<InFlightSkillTest>` field is removed —
+    // the continuation stack is the single source of truth.
     /// Stack of currently-open windows. The top (`last()`) is the
     /// most recently-opened; closing pops the top. Carries pending
     /// reaction triggers and the Fast-action gate for each window.
@@ -469,12 +457,12 @@ pub enum Continuation {
     /// player resolves its `pending_triggers` one at a time; see
     /// [`ResolutionFrame`].
     Resolution(ResolutionFrame),
-    /// A skill test is mid-resolution. A resume-handle only — the test's
-    /// data lives in the singleton [`GameState::in_flight_skill_test`]
-    /// field (read by many call sites; no nesting today), so this frame
-    /// carries no payload. Pushed when the test starts (parking at its
-    /// commit window) and popped when it fully resolves (Axis-B T4).
-    SkillTest,
+    /// A skill test is mid-resolution. Carries the in-flight test's data
+    /// directly (the former `GameState::in_flight_skill_test` singleton, folded
+    /// onto the frame — #348). Pushed at test start; popped when the test fully
+    /// resolves (Axis-B T4). At most one is ever on the stack (no nesting today);
+    /// [`GameState::current_skill_test`] returns the topmost one.
+    SkillTest(InFlightSkillTest),
     /// A controller choice is mid-resolution (Axis A): the effect tree is
     /// re-run from the top on each resume, replaying `decisions` to reach
     /// the next un-ground choice. See [`ChoiceFrame`].
@@ -514,7 +502,7 @@ impl Continuation {
     pub fn as_resolution(&self) -> Option<&ResolutionFrame> {
         match self {
             Continuation::Resolution(w) => Some(w),
-            Continuation::SkillTest | Continuation::Choice(_) => None,
+            Continuation::SkillTest(_) | Continuation::Choice(_) => None,
         }
     }
 
@@ -522,7 +510,7 @@ impl Continuation {
     pub fn as_resolution_mut(&mut self) -> Option<&mut ResolutionFrame> {
         match self {
             Continuation::Resolution(w) => Some(w),
-            Continuation::SkillTest | Continuation::Choice(_) => None,
+            Continuation::SkillTest(_) | Continuation::Choice(_) => None,
         }
     }
 }
@@ -1308,23 +1296,39 @@ impl GameState {
     /// where it lives.)
     #[must_use]
     pub fn current_skill_test(&self) -> Option<&InFlightSkillTest> {
-        self.in_flight_skill_test.as_ref()
+        self.continuations.iter().rev().find_map(|c| match c {
+            Continuation::SkillTest(t) => Some(t),
+            _ => None,
+        })
     }
 
     /// Mutable counterpart to [`Self::current_skill_test`].
     pub fn current_skill_test_mut(&mut self) -> Option<&mut InFlightSkillTest> {
-        self.in_flight_skill_test.as_mut()
+        self.continuations.iter_mut().rev().find_map(|c| match c {
+            Continuation::SkillTest(t) => Some(t),
+            _ => None,
+        })
     }
 
-    /// Remove and return the in-flight skill test (called at test teardown).
+    /// Remove and return the in-flight skill test (popping its frame off the
+    /// continuation stack). Called at test teardown.
     pub fn take_skill_test(&mut self) -> Option<InFlightSkillTest> {
-        self.in_flight_skill_test.take()
+        let pos = self
+            .continuations
+            .iter()
+            .rposition(|c| matches!(c, Continuation::SkillTest(_)))?;
+        match self.continuations.remove(pos) {
+            Continuation::SkillTest(t) => Some(t),
+            _ => unreachable!("rposition matched SkillTest"),
+        }
     }
 
     /// Whether a skill test is currently in flight.
     #[must_use]
     pub fn has_skill_test_in_flight(&self) -> bool {
-        self.in_flight_skill_test.is_some()
+        self.continuations
+            .iter()
+            .any(|c| matches!(c, Continuation::SkillTest(_)))
     }
 
     /// Iterator over the open windows on the continuation stack, in stack

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -187,7 +187,7 @@ fn resolve_commit_codes(codes: &[CardCode], state: &GameState, prompt: &str) -> 
     if codes.is_empty() {
         return Vec::new();
     }
-    let in_flight = state.in_flight_skill_test.as_ref().unwrap_or_else(|| {
+    let in_flight = state.current_skill_test().unwrap_or_else(|| {
         panic!(
             "ScriptedResolver::commit_cards: state has no in-flight skill test at \
              resolve time; prompt was: {prompt:?}",

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -463,21 +463,23 @@ mod tests {
         let mut inv = crate::test_support::test_investigator(1);
         inv.hand = hand.iter().map(|c| CardCode::new(*c)).collect();
         let mut state = GameStateBuilder::new().with_investigator(inv).build();
-        state.in_flight_skill_test = Some(InFlightSkillTest {
-            investigator: id,
-            skill: crate::state::SkillKind::Intellect,
-            kind: SkillTestKind::Plain,
-            difficulty: 1,
-            committed_by_active: Vec::new(),
-            tested_location: None,
-            follow_up: SkillTestFollowUp::None,
-            on_fail: None,
-            on_success: None,
-            source: None,
-            continuation: crate::state::FinishContinuation::AwaitingCommit,
-            test_modifier: 0,
-            bonus_attack_damage: 0,
-        });
+        state
+            .continuations
+            .push(crate::state::Continuation::SkillTest(InFlightSkillTest {
+                investigator: id,
+                skill: crate::state::SkillKind::Intellect,
+                kind: SkillTestKind::Plain,
+                difficulty: 1,
+                committed_by_active: Vec::new(),
+                tested_location: None,
+                follow_up: SkillTestFollowUp::None,
+                on_fail: None,
+                on_success: None,
+                source: None,
+                continuation: crate::state::FinishContinuation::AwaitingCommit,
+                test_modifier: 0,
+                bonus_attack_damage: 0,
+            }));
         state
     }
 

--- a/docs/superpowers/plans/2026-06-19-pr2a-fold-in-flight-skill-test-onto-frame.md
+++ b/docs/superpowers/plans/2026-06-19-pr2a-fold-in-flight-skill-test-onto-frame.md
@@ -1,0 +1,367 @@
+# PR 2a (#348, part 1) — Fold `in_flight_skill_test` onto its `SkillTest` frame — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Carry the in-flight skill test's data on its `Continuation::SkillTest(InFlightSkillTest)` frame instead of the parallel `GameState::in_flight_skill_test: Option<…>` field, making the continuation stack the single source of truth for "a test is in flight."
+
+**Architecture:** Same accessor-indirection strategy that worked for #345. Task 1 adds `current_skill_test()` / `current_skill_test_mut()` / `take_skill_test()` accessors on `GameState` (reading the *existing* `Option` field) and migrates every read/write site to them — pure refactor. Task 2 changes the `SkillTest` variant to carry the payload, pushes it early (at test start, replacing the `Option` set), drops the `Option` field, and points the accessors at the frame. Task 3 verifies the Mind-over-Matter substitution path (the one place test data exists before the commit window) still round-trips.
+
+**Tech Stack:** Rust, the `game-core` crate (this PR is entirely within `game-core`; no `cards`/`scenarios`/wire changes).
+
+This is **PR 2a of the #348 split** (2a = this; 2b = migrate `pending_*` modes onto frames + collapse both dispatch ladders; 2c = fold `Mulligan`/`DrawEncounterCard` into `InputResponse`). Spec: `docs/superpowers/specs/2026-06-19-continuation-stack-cleanup-design.md` §A. Series order (revised): #345 ✅ → **#348 (2a/2b/2c)** → #347 (tokens, clean on frames) → #380.
+
+## Global Constraints
+
+- **CI gauntlet, warnings-as-errors** (run all before pushing):
+  - `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo fmt --check`
+  - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
+  - `cargo build -p web --target wasm32-unknown-unknown`
+  - `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`
+- **No behavior change.** This is a representation refactor; every existing skill-test, reaction-window-mid-test, and Mind-over-Matter test must pass unchanged.
+- **`InFlightSkillTest` already derives** `Debug, Clone, PartialEq, Eq, Serialize, Deserialize` (it was a serialized field); it can move onto the `Continuation::SkillTest` variant, which is part of the serialized `continuations` Vec, with no new derives.
+- **No nesting today:** at most one `SkillTest` frame is ever on the stack. Accessors find the (unique) frame; if same-kind nesting ever lands, "innermost wins" = the topmost `SkillTest` frame (consistent with #345's binding rule).
+- **Branch:** new branch off fresh `main` — `engine/fold-in-flight-skill-test`. Commit per task; push only when the full gauntlet is green.
+
+---
+
+### Task 1: Accessor indirection over the `Option` field
+
+Add `GameState` accessors that locate the in-flight test, and migrate every site to them — while the data still lives in the `Option` field. Pure indirection; isolates the representation swap (Task 2) to the accessor bodies + the push/pop sites.
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (add accessor methods on `GameState`)
+- Modify: `crates/game-core/src/engine/dispatch/skill_test.rs` (the bulk of the read/write sites)
+- Modify: `crates/game-core/src/engine/mod.rs`, `crates/game-core/src/engine/dispatch/mod.rs`, and any other module that reads `in_flight_skill_test` (enumerated in Step 3)
+
+**Interfaces:**
+- Produces (methods on `GameState`):
+  - `fn current_skill_test(&self) -> Option<&InFlightSkillTest>`
+  - `fn current_skill_test_mut(&mut self) -> Option<&mut InFlightSkillTest>`
+  - `fn take_skill_test(&mut self) -> Option<InFlightSkillTest>` — clears the in-flight test (Task 1: `self.in_flight_skill_test.take()`; Task 2: pop the `SkillTest` frame and return its payload)
+  - `fn has_skill_test_in_flight(&self) -> bool` — convenience for the `.is_some()` guards
+
+- [ ] **Step 1: Add the accessors (reading the existing `Option` field)**
+
+In `crates/game-core/src/state/game_state.rs`, add to `impl GameState` (near the other continuation helpers like `top_reaction_window`):
+
+```rust
+/// The skill test currently in flight, if any. Single source of truth for
+/// "a test is mid-resolution"; `None` outside a test. (Task 2 moves the
+/// payload onto the `Continuation::SkillTest` frame; this accessor hides that.)
+#[must_use]
+pub fn current_skill_test(&self) -> Option<&InFlightSkillTest> {
+    self.in_flight_skill_test.as_ref()
+}
+
+/// Mutable counterpart to [`Self::current_skill_test`].
+pub fn current_skill_test_mut(&mut self) -> Option<&mut InFlightSkillTest> {
+    self.in_flight_skill_test.as_mut()
+}
+
+/// Remove and return the in-flight skill test (called at test teardown).
+pub fn take_skill_test(&mut self) -> Option<InFlightSkillTest> {
+    self.in_flight_skill_test.take()
+}
+
+/// Whether a skill test is currently in flight.
+#[must_use]
+pub fn has_skill_test_in_flight(&self) -> bool {
+    self.in_flight_skill_test.is_some()
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo build -p game-core`
+Expected: PASS (new methods unused for now).
+
+- [ ] **Step 3: Migrate every read/write site to the accessors**
+
+Enumerate the sites first so none is missed:
+
+```bash
+grep -rn "in_flight_skill_test" crates/game-core/src --include=*.rs | grep -v "fn current_skill_test\|fn take_skill_test\|fn has_skill_test_in_flight\|pub in_flight_skill_test"
+```
+
+Apply these mechanical transforms (one worked example each; apply to every matching site the grep lists, **including `#[cfg(test)]` code**):
+
+- `cx.state.in_flight_skill_test.is_some()` → `cx.state.has_skill_test_in_flight()`
+  - worked: `skill_test.rs:70` `if cx.state.in_flight_skill_test.is_some() {` → `if cx.state.has_skill_test_in_flight() {`
+- `state.in_flight_skill_test.is_none()` → `!state.has_skill_test_in_flight()`
+  - worked: `skill_test.rs:1254` `assert!(state.in_flight_skill_test.is_none());` → `assert!(!state.has_skill_test_in_flight());`
+- `…in_flight_skill_test.as_ref()` → `…current_skill_test()`
+  - worked: `skill_test.rs:241` `let Some(in_flight) = cx.state.in_flight_skill_test.as_ref() else {` → `let Some(in_flight) = cx.state.current_skill_test() else {`
+  - the `.as_ref().unwrap()` / `.as_ref().expect(...)` / `.as_ref().map(...)` forms become `current_skill_test().unwrap()` / `.expect(...)` / `.map(...)` (e.g. `skill_test.rs:868`, `:1379`, `:1421`, `:1457`)
+- `cx.state.in_flight_skill_test.as_mut()` → `cx.state.current_skill_test_mut()`
+- `cx.state.in_flight_skill_test = None;` → `let _ = cx.state.take_skill_test();` **only at the genuine teardown site** (`skill_test.rs:466`). See the note below — this is the one site whose meaning changes in Task 2.
+- `cx.state.in_flight_skill_test = Some(InFlightSkillTest { … })` (the push sites at `skill_test.rs:85` and the test-only `skill_test.rs:1108`): **leave as direct field writes for now** — Task 2 converts them to frame pushes. Mark each with a `// Task 2: becomes a SkillTest-frame push` comment so they are easy to find.
+
+For chained field reads like `cx.state.in_flight_skill_test.as_ref().expect(...).investigator`, rewrite to `cx.state.current_skill_test().expect(...).investigator`.
+
+- [ ] **Step 4: Full test suite — confirm pure-indirection (no behavior change)**
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: PASS.
+
+- [ ] **Step 5: Clippy + fmt**
+
+Run: `cargo clippy --all-targets --all-features -- -D warnings && cargo fmt --check`
+Expected: PASS. (Clippy may suggest collapsing `current_skill_test().map(...)` forms — apply its suggestions.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "engine: route in_flight_skill_test reads through GameState accessors
+
+Add current_skill_test / _mut / take_skill_test / has_skill_test_in_flight and
+migrate every read/write site to them. Pure indirection over the existing
+Option field — isolates the move onto the SkillTest frame (#348).
+
+Refs #348.
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Carry the payload on the `SkillTest` frame; drop the `Option` field
+
+Move the data onto `Continuation::SkillTest(InFlightSkillTest)`, push it early (at test start, replacing the `Option` set), repoint the accessors at the frame, and remove the field.
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (`Continuation::SkillTest` variant; accessor bodies; `as_resolution` match arms; remove the field)
+- Modify: `crates/game-core/src/engine/dispatch/skill_test.rs` (push site, `open_commit_window`, teardown, the `rposition` frame searches)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (`resolve_input` `SkillTest` match arm — now binds the payload)
+
+**Interfaces:**
+- Consumes: the Task-1 accessor names (signatures unchanged; only bodies change).
+- Produces: `Continuation::SkillTest(InFlightSkillTest)` (was a unit variant). `current_skill_test()` returns the topmost `SkillTest` frame's payload.
+
+- [ ] **Step 1: Change the variant to carry the payload**
+
+In `crates/game-core/src/state/game_state.rs`, the `Continuation` enum: change
+
+```rust
+    /// A skill test is mid-resolution. A resume-handle only — the test's
+    /// data lives in the singleton [`GameState::in_flight_skill_test`] …
+    SkillTest,
+```
+
+to
+
+```rust
+    /// A skill test is mid-resolution. Carries the in-flight test's data
+    /// directly (the former `GameState::in_flight_skill_test` singleton, folded
+    /// onto the frame — #348). Pushed at test start; popped when the test fully
+    /// resolves. At most one is ever on the stack (no nesting today).
+    SkillTest(InFlightSkillTest),
+```
+
+Update the two `Continuation::as_resolution` / `as_resolution_mut` match arms (`game_state.rs:516,524`) from `Continuation::SkillTest | Continuation::Choice(_) => None` to `Continuation::SkillTest(_) | Continuation::Choice(_) => None`.
+
+- [ ] **Step 2: Repoint the accessors at the frame; remove the field**
+
+Remove the `pub in_flight_skill_test: Option<InFlightSkillTest>` field from the `GameState` struct (and its doc-comment). Rewrite the Task-1 accessor bodies:
+
+```rust
+#[must_use]
+pub fn current_skill_test(&self) -> Option<&InFlightSkillTest> {
+    self.continuations.iter().rev().find_map(|c| match c {
+        Continuation::SkillTest(t) => Some(t),
+        _ => None,
+    })
+}
+
+pub fn current_skill_test_mut(&mut self) -> Option<&mut InFlightSkillTest> {
+    self.continuations.iter_mut().rev().find_map(|c| match c {
+        Continuation::SkillTest(t) => Some(t),
+        _ => None,
+    })
+}
+
+pub fn take_skill_test(&mut self) -> Option<InFlightSkillTest> {
+    let pos = self
+        .continuations
+        .iter()
+        .rposition(|c| matches!(c, Continuation::SkillTest(_)))?;
+    match self.continuations.remove(pos) {
+        Continuation::SkillTest(t) => Some(t),
+        _ => unreachable!("rposition matched SkillTest"),
+    }
+}
+
+#[must_use]
+pub fn has_skill_test_in_flight(&self) -> bool {
+    self.continuations
+        .iter()
+        .any(|c| matches!(c, Continuation::SkillTest(_)))
+}
+```
+
+(`rev().find_map` returns the *topmost* `SkillTest` frame — the innermost test under any reaction-window frames above it, matching the old singleton's "the current test" semantics.)
+
+- [ ] **Step 3: Push the frame early at test start (replacing the `Option` set)**
+
+In `skill_test.rs`, replace the `cx.state.in_flight_skill_test = Some(InFlightSkillTest { … });` block at line ~85 with a frame push of the same payload:
+
+```rust
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::SkillTest(InFlightSkillTest {
+            investigator,
+            skill,
+            kind,
+            difficulty,
+            committed_by_active: Vec::new(),
+            tested_location,
+            follow_up,
+            on_fail,
+            on_success,
+            source,
+            continuation: FinishContinuation::AwaitingCommit,
+            test_modifier,
+            bonus_attack_damage: 0,
+        }));
+```
+
+This is safe (all validation precedes line 85; the only post-85 outcomes are `AwaitingInput`). The Mind-over-Matter substitution path (line ~112) now runs with the `SkillTest` frame already on the stack and `pending_substitution_prompt` set above it — the `resolve_input` cascade routes substitution first (unchanged), and `resume_substitution_choice` rewrites the skill via `current_skill_test_mut()` (Task 1 already migrated it).
+
+- [ ] **Step 4: Stop pushing in `open_commit_window`**
+
+In `open_commit_window` (`skill_test.rs:152`), the frame is now already on the stack from Step 3. Remove the push:
+
+```rust
+    // before
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::SkillTest);
+    // after — (delete; the SkillTest frame was pushed at test start)
+```
+
+Keep the rest (it reads `current_skill_test()` for the prompt and returns the commit `AwaitingInput`).
+
+- [ ] **Step 5: Fix the teardown to a single pop**
+
+At the teardown (`skill_test.rs:466` region), the old code did `in_flight_skill_test = None;` *then* searched + removed the `SkillTest` frame via `rposition` (lines ~474-479). Both are now one operation. Replace the pair with:
+
+```rust
+    let _ = cx.state.take_skill_test();
+```
+
+Delete the now-redundant `rposition`/`remove` block that followed. (The other `rposition` for `SkillTest` at `skill_test.rs:398-400`, used to *locate* the frame mid-drive, becomes a `current_skill_test()` read or stays a `matches!(_, SkillTest(_))` position search — keep whichever the surrounding code needs; if it only checked presence, use `has_skill_test_in_flight()`.)
+
+- [ ] **Step 6: Update the `resolve_input` `SkillTest` arm**
+
+In `crates/game-core/src/engine/dispatch/mod.rs`, the match `Some(crate::state::Continuation::SkillTest)` (line ~500) becomes `Some(crate::state::Continuation::SkillTest(_))`.
+
+- [ ] **Step 7: Fix the test-only push site**
+
+`skill_test.rs:1108` (`state.in_flight_skill_test = Some(InFlightSkillTest { … })` in a `#[cfg(test)]`): replace with a `continuations.push(Continuation::SkillTest(InFlightSkillTest { … }))`. Likewise update the engine-unit-test fixture at `engine/mod.rs:4429` (`vec![crate::state::Continuation::SkillTest]` → `vec![Continuation::SkillTest(<payload>)]`) — construct a minimal `InFlightSkillTest` there; copy the field set from the production push in Step 3.
+
+- [ ] **Step 8: Compile + fix fallout**
+
+Run: `cargo build -p game-core --all-targets`
+Expected: errors only at remaining unit-variant `Continuation::SkillTest` matches/constructions (no payload). Fix each: `SkillTest` → `SkillTest(_)` in patterns, `SkillTest(payload)` in constructions. Re-run until clean.
+
+- [ ] **Step 9: Full suite**
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: PASS — every skill-test path (Investigate/Fight/Evade/`PerformSkillTest`), reaction-window-mid-test, and Mind-over-Matter substitution test unchanged.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add -A
+git commit -m "engine: carry in-flight skill test on its SkillTest frame
+
+Change Continuation::SkillTest to carry InFlightSkillTest; push it at test
+start (replacing the in_flight_skill_test Option set), point the accessors at
+the topmost SkillTest frame, single-pop at teardown, and remove the Option
+field. The continuation stack is now the only record of an in-flight test.
+
+Refs #348.
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Regression test — the substitution path round-trips through the frame
+
+The Mind-over-Matter prompt is the one place test data exists before the commit window; pin that it now lives on the frame and survives the substitution resume.
+
+**Files:**
+- Test: `crates/game-core/src/engine/dispatch/skill_test.rs` `#[cfg(test)]`
+
+**Interfaces:**
+- Consumes: `GameState::current_skill_test()`, `Continuation::SkillTest`.
+
+- [ ] **Step 1: Add the test**
+
+Locate the existing Mind-over-Matter substitution test in `skill_test.rs` (grep `substitution` in the test module). Add an assertion-style test alongside it that, after `start_skill_test` returns the substitution `AwaitingInput`, asserts the `SkillTest` frame already holds the payload:
+
+```rust
+#[test]
+fn substitution_prompt_keeps_the_test_on_its_frame() {
+    // Build a state where the active investigator has a Mind-over-Matter
+    // substitution covering the about-to-be-tested skill, then start the test.
+    // (Reuse the existing substitution-test setup helper in this module.)
+    let mut cx = /* the same Cx the neighboring substitution test builds */;
+    let outcome = start_skill_test(/* …Combat/Agility test args… */);
+    assert!(
+        matches!(outcome, EngineOutcome::AwaitingInput { .. }),
+        "substitution prompt should suspend",
+    );
+    assert!(
+        cx.state.current_skill_test().is_some(),
+        "the in-flight test must live on a SkillTest frame during the \
+         substitution prompt, not in a removed Option field",
+    );
+    assert!(
+        cx.state
+            .continuations
+            .iter()
+            .any(|c| matches!(c, crate::state::Continuation::SkillTest(_))),
+        "a SkillTest frame is on the stack before the commit window",
+    );
+}
+```
+
+Fill the `cx` / `start_skill_test` call from the neighboring substitution test's setup verbatim (the implementer reads that test for the exact builder calls — do not invent fixture APIs).
+
+- [ ] **Step 2: Run it**
+
+Run: `cargo test -p game-core substitution_prompt_keeps_the_test_on_its_frame`
+Expected: PASS.
+
+- [ ] **Step 3: Full CI gauntlet**
+
+Run all six commands from Global Constraints.
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "engine: test the in-flight test lives on its frame during substitution
+
+Refs #348.
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (spec §A — \"fold in_flight_skill_test onto its frame\"):**
+- `SkillTest(InFlightSkillTest)` payload + field removal → Task 2 Steps 1–2. ✓
+- `current_skill_test()` accessor finding the frame wherever it is (not `.last()`) → Task 2 Step 2 (`rev().find_map`). ✓
+- Innermost-wins if nesting ever appears → `rev()` returns topmost. ✓
+- No behavior change → Task 1 pure indirection; Task 2 preserves payload + ordering; Task 3 pins the one tricky path. ✓
+
+**Placeholder scan:** Task 3's `cx`/`start_skill_test` call is deliberately delegated to "copy the neighboring substitution test's setup" rather than inventing fixture APIs I haven't read — the implementer has the exact source adjacent. All other steps show complete code. The mechanical 57-site migration uses one worked example per access-pattern + the exact enumerating grep (DRY, as in #345 Task 1).
+
+**Type consistency:** accessor names (`current_skill_test`/`_mut`/`take_skill_test`/`has_skill_test_in_flight`) are identical across Task 1 (Option bodies) and Task 2 (frame bodies); `Continuation::SkillTest(InFlightSkillTest)` matches its construction (Task 2 Steps 3, 7) and patterns (Steps 1, 6, 8).
+
+**Out of scope (later sub-PRs):** `pending_*` mode migration + ladder collapse (2b), `Mulligan`/`DrawEncounterCard` → `InputResponse` (2c), tokens (#347), revelation disposal (#380).


### PR DESCRIPTION
## Summary

**Part 1 of the #348 split** (continuation-stack cleanup). Folds the in-flight skill test's data off the parallel `GameState::in_flight_skill_test: Option<InFlightSkillTest>` field and onto its existing `Continuation::SkillTest` frame, so the continuation stack is the single source of truth for "a test is mid-resolution." Spec §A: `docs/superpowers/specs/2026-06-19-continuation-stack-cleanup-design.md`.

Series order (revised): #345 ✅ → **#348 (2a this · 2b modes+ladders · 2c action fold)** → #347 (tokens) → #380.

## What changed

Three TDD commits + one review follow-up:

1. **Accessor indirection** — `GameState::current_skill_test()` / `current_skill_test_mut()` / `take_skill_test()` / `has_skill_test_in_flight()`; every read/write site migrated to them (Option still backing). Pure refactor.
2. **Payload on the frame** — `Continuation::SkillTest(InFlightSkillTest)` (was a unit variant). Pushed **early** at test start (replacing the `Option` set) so the test has a home before the Mind-over-Matter substitution prompt may suspend; accessors read the *topmost* `SkillTest` frame (a reaction window can sit above it mid-test); teardown is a single `take_skill_test()` pop; the `Option` field is removed.
3. **Regression test** — pins that the in-flight test lives on its frame during the substitution prompt (the one place test data exists pre-commit).
4. **Review follow-up** — reword `.expect()`/assert messages + a doc-comment that still named the removed field.

## Test notes

- New: `substitution_prompt_keeps_the_test_on_its_frame`. Existing skill-test / reaction-window-mid-test / Mind-over-Matter suites pass unchanged.
- No behavior change — pure representation refactor.
- Full gauntlet green locally: test / clippy / fmt / doc / wasm-build / wasm-clippy.
- Pre-push review: **ready to merge**, no Critical/Important; both Minors (stale field-name strings, doc tightening) folded in.
- Early-push safety verified by the reviewer: no rejection path exists between the push and the end of `start_skill_test`, so the frame cannot leak.

## Linked issues

Part of #348 (does not close it — 2b/2c follow).