### PR TITLE
engine: migrate Tier-A suspension modes onto Continuation frames (#348 part 2)

### DIFF
--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -1657,7 +1657,7 @@ mod spawn_enemy_tests {
     #[test]
     fn resume_spawn_engage_rejects_bad_pick_and_preserves_pending() {
         // Validate-first: a pick outside the stored candidate set rejects
-        // and leaves `spawn_engage_pending` intact for retry, with the
+        // and leaves the SpawnEngage frame intact for retry, with the
         // enemy still unengaged.
         use crate::action::InputResponse;
         let mut loc = test_location(1, "Hall");

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -460,13 +460,17 @@ pub(super) fn spawn_enemy_at(
             // stored value to the live chain position before returning the
             // `AwaitingInput` (the single-draw `EncounterCardRevealed` path
             // has no chain, so 0 is correct there).
-            cx.state.spawn_engage_pending = Some(SpawnEngagePending {
-                enemy: enemy_id,
-                investigator_to_draw: investigator,
-                candidates: tied.clone(),
-                surge: metadata.surge(),
-                chain_count: 0,
-            });
+            cx.state
+                .continuations
+                .push(crate::state::Continuation::SpawnEngage(
+                    SpawnEngagePending {
+                        enemy: enemy_id,
+                        investigator_to_draw: investigator,
+                        candidates: tied.clone(),
+                        surge: metadata.surge(),
+                        chain_count: 0,
+                    },
+                ));
             EngineOutcome::AwaitingInput {
                 request: InputRequest::prompt(format!(
                     "Enemy {enemy_id:?} spawn engagement: lead investigator picks whom to \
@@ -739,7 +743,9 @@ pub(super) fn run_mythos_draw_chain(
                 // A mid-chain spawn engagement tie suspended. Record the
                 // live chain position so the resume keeps counting toward
                 // the cap rather than restarting its budget.
-                if let Some(pending) = cx.state.spawn_engage_pending.as_mut() {
+                if let Some(crate::state::Continuation::SpawnEngage(pending)) =
+                    cx.state.continuations.last_mut()
+                {
                     pending.chain_count = chain_count;
                 }
                 return outcome;
@@ -1640,7 +1646,10 @@ mod spawn_enemy_tests {
             &metadata,
         );
         assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
-        assert!(state.spawn_engage_pending.is_some());
+        assert!(matches!(
+            state.continuations.last(),
+            Some(crate::state::Continuation::SpawnEngage(_))
+        ));
         let spawned = state.enemies.values().next().expect("one enemy");
         assert_eq!(spawned.engaged_with, None);
     }
@@ -1676,7 +1685,10 @@ mod spawn_enemy_tests {
             CardCode("_synth_enemy".into()),
             &metadata,
         );
-        assert!(state.spawn_engage_pending.is_some());
+        assert!(matches!(
+            state.continuations.last(),
+            Some(crate::state::Continuation::SpawnEngage(_))
+        ));
 
         // Investigator 3 is not among the co-located candidates.
         let outcome = super::super::hunters::resume_spawn_engage(
@@ -1691,7 +1703,10 @@ mod spawn_enemy_tests {
             "{outcome:?}"
         );
         assert!(
-            state.spawn_engage_pending.is_some(),
+            matches!(
+                state.continuations.last(),
+                Some(crate::state::Continuation::SpawnEngage(_))
+            ),
             "pending must survive a rejected pick for retry",
         );
         let enemy = state.enemies.values().next().expect("enemy still placed");

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -394,7 +394,9 @@ fn suspend_hunter_choice(cx: &mut Cx, choice: HunterChoice) -> EngineOutcome {
              {candidates:?} (submit InputResponse::PickInvestigator)"
         ),
     };
-    cx.state.hunter_move_pending = Some(choice);
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::HunterMove(choice));
     EngineOutcome::AwaitingInput {
         request: InputRequest::prompt(prompt),
         resume_token: ResumeToken(0),
@@ -410,9 +412,11 @@ pub(super) fn resume_hunter_choice(
     cx: &mut Cx,
     response: &crate::action::InputResponse,
 ) -> EngineOutcome {
-    let pending = cx.state.hunter_move_pending.clone().unwrap_or_else(|| {
-        unreachable!("resume_hunter_choice: called with no pending hunter choice")
-    });
+    let Some(crate::state::Continuation::HunterMove(pending)) = cx.state.continuations.last()
+    else {
+        unreachable!("resume_hunter_choice: called with no HunterMove frame on top of the stack")
+    };
+    let pending = pending.clone();
     let current_enemy = match (&pending, response) {
         (
             HunterChoice::Move { enemy, candidates },
@@ -426,7 +430,8 @@ pub(super) fn resume_hunter_choice(
                     .into(),
                 };
             }
-            cx.state.hunter_move_pending = None;
+            // Pop the HunterMove frame we validated against (it is the top frame).
+            cx.state.continuations.pop();
             move_hunter_to(cx, *enemy, *loc);
             // After the move, attempt engage-on-arrival; that itself may
             // suspend on an engagement tie.
@@ -447,7 +452,8 @@ pub(super) fn resume_hunter_choice(
                     .into(),
                 };
             }
-            cx.state.hunter_move_pending = None;
+            // Pop the HunterMove frame we validated against (it is the top frame).
+            cx.state.continuations.pop();
             engage_enemy_with(cx, *enemy, *who);
             *enemy
         }
@@ -1050,7 +1056,10 @@ mod hunter_resume_tests {
             events: &mut events,
         });
         assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
-        assert!(state.hunter_move_pending.is_some());
+        assert!(matches!(
+            state.continuations.last(),
+            Some(crate::state::Continuation::HunterMove(_))
+        ));
         // Resume by picking C.
         let mut ev2 = Vec::new();
         let resumed = super::super::resolve_input(
@@ -1065,7 +1074,10 @@ mod hunter_resume_tests {
             state.enemies[&EnemyId(1)].current_location,
             Some(LocationId(3))
         );
-        assert!(state.hunter_move_pending.is_none());
+        assert!(!matches!(
+            state.continuations.last(),
+            Some(crate::state::Continuation::HunterMove(_))
+        ));
         assert_event!(ev2, Event::EnemyMoved { enemy, to } if *enemy == EnemyId(1) && *to == LocationId(3));
     }
 
@@ -1111,7 +1123,10 @@ mod hunter_resume_tests {
         );
         assert!(matches!(result, EngineOutcome::Rejected { .. }));
         assert!(
-            state.hunter_move_pending.is_some(),
+            matches!(
+                state.continuations.last(),
+                Some(crate::state::Continuation::HunterMove(_))
+            ),
             "pending stays open on invalid pick"
         );
     }
@@ -1164,7 +1179,10 @@ mod hunter_resume_tests {
             state.enemies[&EnemyId(1)].engaged_with,
             Some(InvestigatorId(2))
         );
-        assert!(state.hunter_move_pending.is_none());
+        assert!(!matches!(
+            state.continuations.last(),
+            Some(crate::state::Continuation::HunterMove(_))
+        ));
     }
 
     #[test]
@@ -1312,7 +1330,10 @@ mod hunter_resume_tests {
             events: &mut events,
         });
         assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
-        assert!(state.hunter_move_pending.is_some());
+        assert!(matches!(
+            state.continuations.last(),
+            Some(crate::state::Continuation::HunterMove(_))
+        ));
         // Submit PickInvestigator when PickLocation is expected.
         let mut ev2 = Vec::new();
         let result = super::super::resolve_input(
@@ -1327,7 +1348,10 @@ mod hunter_resume_tests {
             "wrong response kind should be rejected"
         );
         assert!(
-            state.hunter_move_pending.is_some(),
+            matches!(
+                state.continuations.last(),
+                Some(crate::state::Continuation::HunterMove(_))
+            ),
             "pending preserved so client can retry with PickLocation"
         );
     }
@@ -1369,7 +1393,10 @@ mod hunter_resume_tests {
             Some(LocationId(2))
         );
         assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
-        assert!(state.hunter_move_pending.is_some());
+        assert!(matches!(
+            state.continuations.last(),
+            Some(crate::state::Continuation::HunterMove(_))
+        ));
         // Submit PickLocation when PickInvestigator is expected.
         let mut ev2 = Vec::new();
         let result = super::super::resolve_input(
@@ -1384,7 +1411,10 @@ mod hunter_resume_tests {
             "wrong response kind should be rejected"
         );
         assert!(
-            state.hunter_move_pending.is_some(),
+            matches!(
+                state.continuations.last(),
+                Some(crate::state::Continuation::HunterMove(_))
+            ),
             "pending preserved so client can retry with PickInvestigator"
         );
     }

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -406,7 +406,7 @@ fn suspend_hunter_choice(cx: &mut Cx, choice: HunterChoice) -> EngineOutcome {
 /// Resume a suspended Hunter-movement choice with the lead
 /// investigator's response, then continue driving remaining hunters.
 /// Validates the response against the stored candidate set; on an
-/// invalid pick, rejects and leaves `hunter_move_pending` untouched so
+/// invalid pick, rejects and leaves the `HunterMove` frame on the stack so
 /// the client can retry. (#128)
 pub(super) fn resume_hunter_choice(
     cx: &mut Cx,
@@ -494,8 +494,7 @@ pub(super) fn resume_hunter_choice(
 /// investigator's Mythos encounter-draw chain.
 ///
 /// Validate-first: an invalid pick (wrong response shape, or a target
-/// outside the stored candidate set) rejects and leaves
-/// `spawn_engage_pending` untouched so the client can retry.
+/// outside the stored candidate set) rejects and leaves the `SpawnEngage` frame on the stack so the client can retry.
 ///
 /// The chain only resumes when the suspension arose mid-Mythos-draw —
 /// i.e. the drawing investigator is still the pending cursor. The
@@ -537,7 +536,7 @@ pub(super) fn resume_spawn_engage(
     // mid-chain (the drawing investigator is still the pending cursor).
     // The `EncounterCardRevealed` single-draw path resolves to `Done`.
     //
-    // Invariant: while `spawn_engage_pending` is set, the apply guard
+    // Invariant: while a SpawnEngage frame is on the stack, the apply guard
     // (line 129) rejects every non-`ResolveInput` action, so nothing can
     // retarget the Mythos cursor between suspend and resume. Hence
     // `mythos_draw_pending == Some(investigator_to_draw)` reliably means

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -506,9 +506,11 @@ pub(super) fn resume_spawn_engage(
     cx: &mut Cx,
     response: &crate::action::InputResponse,
 ) -> EngineOutcome {
-    let pending = cx.state.spawn_engage_pending.clone().unwrap_or_else(|| {
-        unreachable!("resume_spawn_engage: called with no pending spawn engagement")
-    });
+    let Some(crate::state::Continuation::SpawnEngage(pending)) = cx.state.continuations.last()
+    else {
+        unreachable!("resume_spawn_engage: called with no SpawnEngage frame on top of the stack")
+    };
+    let pending = pending.clone();
     let crate::action::InputResponse::PickInvestigator(who) = response else {
         return EngineOutcome::Rejected {
             reason: format!(
@@ -527,7 +529,8 @@ pub(super) fn resume_spawn_engage(
             .into(),
         };
     }
-    cx.state.spawn_engage_pending = None;
+    // Pop the SpawnEngage frame we validated against (it is the top frame).
+    cx.state.continuations.pop();
     engage_enemy_with(cx, pending.enemy, *who);
 
     // Only re-enter the Mythos surge chain if the suspend happened

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -146,8 +146,10 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
     // A pending upkeep hand-size discard (#111) blocks every action but
     // `ResolveInput`. Upkeep-phase only; never coexists with the other
     // suspension modes, so guard order is immaterial.
-    if cx.state.hand_size_discard_pending.is_some()
-        && !matches!(action, PlayerAction::ResolveInput { .. })
+    if matches!(
+        cx.state.continuations.last(),
+        Some(crate::state::Continuation::HandSizeDiscard(_))
+    ) && !matches!(action, PlayerAction::ResolveInput { .. })
     {
         return EngineOutcome::Rejected {
             reason: "a hand-size discard choice is pending; submit a PlayerAction::ResolveInput \
@@ -450,18 +452,6 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
     // Hunter movement, spawn engagement, and hand-size discard are three
     // mutually exclusive suspension modes (different phases). Route to the
     // right resume handler before the reaction-window and skill-test checks.
-    debug_assert!(
-        [
-            cx.state.hand_size_discard_pending.is_some(),
-            cx.state.act_round_end_pending.is_some(),
-        ]
-        .iter()
-        .filter(|b| **b)
-        .count()
-            <= 1,
-        "hand-size discard and act round-end advance are \
-         mutually exclusive suspension modes (different phases)",
-    );
     if matches!(
         cx.state.continuations.last(),
         Some(crate::state::Continuation::HunterMove(_))
@@ -481,7 +471,10 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
     // Upkeep step-4.5 hand-size discard (#111) is its own suspension mode;
     // route it before the reaction-window check (it arises in Upkeep, not
     // mid-skill-test, so the two never coexist).
-    if cx.state.hand_size_discard_pending.is_some() {
+    if matches!(
+        cx.state.continuations.last(),
+        Some(crate::state::Continuation::HandSizeDiscard(_))
+    ) {
         return phases::resume_hand_size_discard(cx, response);
     }
 

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -114,8 +114,10 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
     // Hunter movement is Enemy-phase only; it can't coexist with an open
     // reaction window or an in-flight skill test, so order among the guards
     // is immaterial — but a pending hunter choice still blocks other actions.
-    if cx.state.hunter_move_pending.is_some()
-        && !matches!(action, PlayerAction::ResolveInput { .. })
+    if matches!(
+        cx.state.continuations.last(),
+        Some(crate::state::Continuation::HunterMove(_))
+    ) && !matches!(action, PlayerAction::ResolveInput { .. })
     {
         return EngineOutcome::Rejected {
             reason: "a hunter-movement choice is pending; submit a PlayerAction::ResolveInput \
@@ -448,7 +450,6 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
     // right resume handler before the reaction-window and skill-test checks.
     debug_assert!(
         [
-            cx.state.hunter_move_pending.is_some(),
             cx.state.spawn_engage_pending.is_some(),
             cx.state.hand_size_discard_pending.is_some(),
             cx.state.act_round_end_pending.is_some(),
@@ -457,10 +458,13 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
         .filter(|b| **b)
         .count()
             <= 1,
-        "hunter movement, spawn engagement, hand-size discard, and act round-end advance are \
+        "spawn engagement, hand-size discard, and act round-end advance are \
          mutually exclusive suspension modes (different phases)",
     );
-    if cx.state.hunter_move_pending.is_some() {
+    if matches!(
+        cx.state.continuations.last(),
+        Some(crate::state::Continuation::HunterMove(_))
+    ) {
         return hunters::resume_hunter_choice(cx, response);
     }
 

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -130,8 +130,10 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
     // A pending engagement-on-spawn choice (#128) likewise blocks every
     // action but `ResolveInput`. Mirrors the hunter guard above; the two
     // never coexist (different phases), so guard order is immaterial.
-    if cx.state.spawn_engage_pending.is_some()
-        && !matches!(action, PlayerAction::ResolveInput { .. })
+    if matches!(
+        cx.state.continuations.last(),
+        Some(crate::state::Continuation::SpawnEngage(_))
+    ) && !matches!(action, PlayerAction::ResolveInput { .. })
     {
         return EngineOutcome::Rejected {
             reason: "an engagement-on-spawn choice is pending; submit a \
@@ -450,7 +452,6 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
     // right resume handler before the reaction-window and skill-test checks.
     debug_assert!(
         [
-            cx.state.spawn_engage_pending.is_some(),
             cx.state.hand_size_discard_pending.is_some(),
             cx.state.act_round_end_pending.is_some(),
         ]
@@ -458,7 +459,7 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
         .filter(|b| **b)
         .count()
             <= 1,
-        "spawn engagement, hand-size discard, and act round-end advance are \
+        "hand-size discard and act round-end advance are \
          mutually exclusive suspension modes (different phases)",
     );
     if matches!(
@@ -470,7 +471,10 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
 
     // Engagement-on-spawn suspension (#128, option A) is a distinct mode
     // from hunter movement: its resume re-enters the Mythos draw chain.
-    if cx.state.spawn_engage_pending.is_some() {
+    if matches!(
+        cx.state.continuations.last(),
+        Some(crate::state::Continuation::SpawnEngage(_))
+    ) {
         return hunters::resume_spawn_engage(cx, response);
     }
 

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -427,10 +427,13 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
     //   suspension, so it resumes LAST (below), after the legacy mid-test modes
     //   (hand-size discard, act round-end) — inner suspensions of the flow.
     // Mind over Matter (#322): a skill test paused on its "use X in place of
-    // Y?" prompt at initiation. Set only between the prompt and the commit
-    // window, so it unambiguously owns the next input — route it first (it can
-    // sit above a forced-run / window frame, e.g. a treachery agility test).
-    if cx.state.pending_substitution_prompt.is_some() {
+    // Y?" prompt at initiation. Its `SubstitutionPrompt` frame is pushed *above*
+    // the `SkillTest` frame, so top-frame dispatch routes it before the commit
+    // window — no special-case ordering needed (#348).
+    if matches!(
+        cx.state.continuations.last(),
+        Some(crate::state::Continuation::SubstitutionPrompt { .. })
+    ) {
         return skill_test::resume_substitution_choice(cx, response);
     }
 

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -160,8 +160,10 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
 
     // A pending act round-end advance (#275) blocks every action but
     // `ResolveInput`. Upkeep-phase only; never coexists with the others.
-    if cx.state.act_round_end_pending.is_some()
-        && !matches!(action, PlayerAction::ResolveInput { .. })
+    if matches!(
+        cx.state.continuations.last(),
+        Some(crate::state::Continuation::ActRoundEnd(_))
+    ) && !matches!(action, PlayerAction::ResolveInput { .. })
     {
         return EngineOutcome::Rejected {
             reason:
@@ -481,7 +483,10 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
     // Act round-end clue-spend window (#275): its own suspension mode,
     // arising only in Upkeep (never mid-skill-test), so route it before the
     // reaction-window check like hand-size discard.
-    if cx.state.act_round_end_pending.is_some() {
+    if matches!(
+        cx.state.continuations.last(),
+        Some(crate::state::Continuation::ActRoundEnd(_))
+    ) {
         return phases::resume_act_round_end_advance(cx, response);
     }
 

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -419,97 +419,27 @@ fn resume_skill_test_commit(cx: &mut Cx, response: &InputResponse) -> EngineOutc
 /// index. This covers the `MythosAfterDraws` window after all Fast
 /// plays have been made and the player is done.
 pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
-    // Continuation router (umbrella §1 / Axis-B), split by frame priority:
-    //
-    // - An open **window** (`Resolution`) nests above everything — a reaction
-    //   window mid-skill-test, a Fast window — so it resumes FIRST.
-    // - The **skill-test commit** frame (`SkillTest`) is the *outermost* test
-    //   suspension, so it resumes LAST (below), after the legacy mid-test modes
-    //   (hand-size discard, act round-end) — inner suspensions of the flow.
-    // Mind over Matter (#322): a skill test paused on its "use X in place of
-    // Y?" prompt at initiation. Its `SubstitutionPrompt` frame is pushed *above*
-    // the `SkillTest` frame, so top-frame dispatch routes it before the commit
-    // window — no special-case ordering needed (#348).
-    if matches!(
-        cx.state.continuations.last(),
-        Some(crate::state::Continuation::SubstitutionPrompt { .. })
-    ) {
-        return skill_test::resume_substitution_choice(cx, response);
-    }
-
-    if matches!(
-        cx.state.continuations.last(),
-        Some(crate::state::Continuation::Resolution(_))
-    ) {
-        return resume_window(cx, response);
-    }
-
-    // A `Continuation::Choice` (Axis A) nests above whatever it suspended
-    // within (a Forced run, a skill test), so it resumes before the legacy
-    // mid-test modes below.
-    if matches!(
-        cx.state.continuations.last(),
-        Some(crate::state::Continuation::Choice(_))
-    ) {
-        return choice::resume_choice(cx, response);
-    }
-
-    // Hunter movement, spawn engagement, and hand-size discard are three
-    // mutually exclusive suspension modes (different phases). Route to the
-    // right resume handler before the reaction-window and skill-test checks.
-    if matches!(
-        cx.state.continuations.last(),
-        Some(crate::state::Continuation::HunterMove(_))
-    ) {
-        return hunters::resume_hunter_choice(cx, response);
-    }
-
-    // Engagement-on-spawn suspension (#128, option A) is a distinct mode
-    // from hunter movement: its resume re-enters the Mythos draw chain.
-    if matches!(
-        cx.state.continuations.last(),
-        Some(crate::state::Continuation::SpawnEngage(_))
-    ) {
-        return hunters::resume_spawn_engage(cx, response);
-    }
-
-    // Upkeep step-4.5 hand-size discard (#111) is its own suspension mode;
-    // route it before the reaction-window check (it arises in Upkeep, not
-    // mid-skill-test, so the two never coexist).
-    if matches!(
-        cx.state.continuations.last(),
-        Some(crate::state::Continuation::HandSizeDiscard(_))
-    ) {
-        return phases::resume_hand_size_discard(cx, response);
-    }
-
-    // Act round-end clue-spend window (#275): its own suspension mode,
-    // arising only in Upkeep (never mid-skill-test), so route it before the
-    // reaction-window check like hand-size discard.
-    if matches!(
-        cx.state.continuations.last(),
-        Some(crate::state::Continuation::ActRoundEnd(_))
-    ) {
-        return phases::resume_act_round_end_advance(cx, response);
-    }
-
-    // Open windows (reaction + pure-Fast) are `Continuation::Resolution`
-    // frames, handled by the continuation router at the top of this function
-    // (umbrella §1 / Axis-B T3) — so no window check is needed here. The
-    // before-discover clue interrupt (Cover Up 01007) is one such window now
-    // (Axis D #336), not a bespoke mid-test mode.
-
-    // The skill-test commit window (`Continuation::SkillTest` frame) resumes
-    // here — *after* the legacy mid-test modes above, which are inner
-    // suspensions of an in-flight test (Axis-B T4).
-    if matches!(
-        cx.state.continuations.last(),
-        Some(crate::state::Continuation::SkillTest(_))
-    ) {
-        return resume_skill_test_commit(cx, response);
-    }
-
-    EngineOutcome::Rejected {
-        reason: "ResolveInput: no AwaitingInput prompt is currently outstanding".into(),
+    // Top-frame dispatch (umbrella §1 / #348): every suspension is a
+    // `Continuation` frame, and the frame awaiting input is always the top of
+    // the stack (each suspension pushes above whatever it suspended within — a
+    // `SubstitutionPrompt` above its `SkillTest`, a reaction `Resolution` above
+    // a mid-test commit, etc.). So routing is "dispatch on the top frame's
+    // variant"; the former hand-ordered `if pending_X.is_some()` priority
+    // cascade is gone.
+    use crate::state::Continuation;
+    match cx.state.continuations.last() {
+        Some(Continuation::SubstitutionPrompt { .. }) => {
+            skill_test::resume_substitution_choice(cx, response)
+        }
+        Some(Continuation::Resolution(_)) => resume_window(cx, response),
+        Some(Continuation::Choice(_)) => choice::resume_choice(cx, response),
+        Some(Continuation::HunterMove(_)) => hunters::resume_hunter_choice(cx, response),
+        Some(Continuation::SpawnEngage(_)) => hunters::resume_spawn_engage(cx, response),
+        Some(Continuation::HandSizeDiscard(_)) => phases::resume_hand_size_discard(cx, response),
+        Some(Continuation::ActRoundEnd(_)) => phases::resume_act_round_end_advance(cx, response),
+        Some(Continuation::SkillTest(_)) => resume_skill_test_commit(cx, response),
+        None => EngineOutcome::Rejected {
+            reason: "ResolveInput: no AwaitingInput prompt is currently outstanding".into(),
+        },
     }
 }

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -703,7 +703,9 @@ pub(super) fn upkeep_after_round_ended(cx: &mut Cx) -> EngineOutcome {
              InputResponse::Confirm to spend and advance, or Skip to decline.",
             pending.threshold,
         );
-        cx.state.act_round_end_pending = Some(pending);
+        cx.state
+            .continuations
+            .push(crate::state::Continuation::ActRoundEnd(pending));
         return EngineOutcome::AwaitingInput {
             request: InputRequest::prompt(prompt),
             resume_token: ResumeToken(0),
@@ -737,11 +739,11 @@ fn round_end_advance_window(state: &GameState) -> Option<ActRoundEndPending> {
 /// act; Skip declines; either way the round closes (Upkeep→Mythos). A wrong
 /// response kind rejects with state untouched.
 pub(super) fn resume_act_round_end_advance(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
-    let pending = cx
-        .state
-        .act_round_end_pending
-        .clone()
-        .unwrap_or_else(|| unreachable!("resume_act_round_end_advance: no pending window"));
+    let Some(crate::state::Continuation::ActRoundEnd(pending)) = cx.state.continuations.last()
+    else {
+        unreachable!("resume_act_round_end_advance: no ActRoundEnd frame on top of the stack")
+    };
+    let pending = pending.clone();
     match response {
         InputResponse::Confirm => {
             let contributors =
@@ -754,14 +756,14 @@ pub(super) fn resume_act_round_end_advance(cx: &mut Cx, response: &InputResponse
                 };
             }
             super::act_agenda::spend_clues_from(cx.state, &contributors, pending.threshold);
-            cx.state.act_round_end_pending = None;
+            cx.state.continuations.pop();
             // The round-end-advance act (01109) is non-terminal (resolution
             // None) — advance the cursor to the next act.
             super::act_agenda::advance_act(cx);
             step_phase(cx)
         }
         InputResponse::Skip => {
-            cx.state.act_round_end_pending = None;
+            cx.state.continuations.pop();
             step_phase(cx)
         }
         other => EngineOutcome::Rejected {
@@ -2242,7 +2244,10 @@ mod upkeep_phase_tests {
             events: &mut events,
         });
         assert!(matches!(out, EngineOutcome::AwaitingInput { .. }));
-        assert!(state.act_round_end_pending.is_some());
+        assert!(matches!(
+            state.continuations.last(),
+            Some(crate::state::Continuation::ActRoundEnd(_))
+        ));
         assert_eq!(state.phase, Phase::Upkeep, "parked: did not transition");
         assert_no_event!(
             events,
@@ -2261,7 +2266,10 @@ mod upkeep_phase_tests {
             events: &mut events,
         });
         assert_eq!(out, EngineOutcome::Done);
-        assert!(state.act_round_end_pending.is_none());
+        assert!(!matches!(
+            state.continuations.last(),
+            Some(crate::state::Continuation::ActRoundEnd(_))
+        ));
         assert_eq!(state.phase, Phase::Mythos, "no window → straight to Mythos");
     }
 
@@ -2284,7 +2292,10 @@ mod upkeep_phase_tests {
         assert_eq!(out, EngineOutcome::Done);
         assert_eq!(state.act_index, 1, "advanced act 2 -> act 3");
         assert_eq!(state.investigators[&inv].clues, 0, "spent 3 clues");
-        assert!(state.act_round_end_pending.is_none());
+        assert!(!matches!(
+            state.continuations.last(),
+            Some(crate::state::Continuation::ActRoundEnd(_))
+        ));
         assert_eq!(state.phase, Phase::Mythos);
     }
 
@@ -2307,7 +2318,10 @@ mod upkeep_phase_tests {
         assert_eq!(out, EngineOutcome::Done);
         assert_eq!(state.act_index, 0, "no advance on Skip");
         assert_eq!(state.investigators[&inv].clues, 3, "no clues spent");
-        assert!(state.act_round_end_pending.is_none());
+        assert!(!matches!(
+            state.continuations.last(),
+            Some(crate::state::Continuation::ActRoundEnd(_))
+        ));
         assert_eq!(state.phase, Phase::Mythos);
     }
 
@@ -2328,7 +2342,13 @@ mod upkeep_phase_tests {
             &InputResponse::DiscardCards { indices: vec![] },
         );
         assert!(matches!(out, EngineOutcome::Rejected { .. }));
-        assert!(state.act_round_end_pending.is_some(), "still pending");
+        assert!(
+            matches!(
+                state.continuations.last(),
+                Some(crate::state::Continuation::ActRoundEnd(_))
+            ),
+            "still pending"
+        );
         assert_eq!(state.phase, Phase::Upkeep);
     }
 
@@ -2353,7 +2373,10 @@ mod upkeep_phase_tests {
             events: &mut events,
         });
         assert_eq!(out, EngineOutcome::Done, "unaffordable by Hallway alone");
-        assert!(state.act_round_end_pending.is_none());
+        assert!(!matches!(
+            state.continuations.last(),
+            Some(crate::state::Continuation::ActRoundEnd(_))
+        ));
     }
 }
 

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -224,7 +224,7 @@ pub(super) fn end_turn(cx: &mut Cx) -> EngineOutcome {
     // - **a single** suspending hit has no run frame; record the active
     //   investigator in `pending_end_turn` so the skill-test commit-resume
     //   path re-enters [`resume_end_turn`] once the test resolves (C4c, #235
-    //   — mirrors `spawn_engage_pending`).
+    //   — mirrors the SpawnEngage frame).
     //
     // A `Rejected` propagates as-is.
     let end_of_turn = super::emit::emit_event(
@@ -841,7 +841,7 @@ pub(super) fn over_cap_investigators(state: &GameState) -> Vec<InvestigatorId> {
         .collect()
 }
 
-/// Stores `remaining` as `hand_size_discard_pending` and returns the
+/// Pushes a `HandSizeDiscard(remaining)` frame and returns the
 /// [`EngineOutcome::AwaitingInput`] that prompts `remaining[0]` to discard.
 /// Used by both [`check_hand_size`] (first suspension) and
 /// [`resume_hand_size_discard`] (re-prompt after a queue pop).

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -847,7 +847,11 @@ pub(super) fn over_cap_investigators(state: &GameState) -> Vec<InvestigatorId> {
 /// `remaining` must be non-empty; callers ensure this before calling.
 fn park_hand_size_discard(cx: &mut Cx, remaining: Vec<InvestigatorId>) -> EngineOutcome {
     let next = remaining[0];
-    cx.state.hand_size_discard_pending = Some(HandSizeDiscard { remaining });
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::HandSizeDiscard(
+            HandSizeDiscard { remaining },
+        ));
     EngineOutcome::AwaitingInput {
         request: InputRequest::prompt(format!(
             "Upkeep step 4.5: {next:?} has more than {HAND_SIZE_LIMIT} cards in hand; \
@@ -881,11 +885,11 @@ fn check_hand_size(cx: &mut Cx) -> EngineOutcome {
 /// — when the queue drains — runs [`upkeep_phase_end`] (4.6 + transition
 /// to Mythos). Rejections leave state and events untouched.
 pub(super) fn resume_hand_size_discard(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
-    let pending = cx
-        .state
-        .hand_size_discard_pending
-        .clone()
-        .unwrap_or_else(|| unreachable!("resume_hand_size_discard: no pending discard"));
+    let Some(crate::state::Continuation::HandSizeDiscard(pending)) = cx.state.continuations.last()
+    else {
+        unreachable!("resume_hand_size_discard: no HandSizeDiscard frame on top of the stack")
+    };
+    let pending = pending.clone();
     let current = pending.remaining[0];
 
     let InputResponse::DiscardCards { indices } = response else {
@@ -960,8 +964,9 @@ pub(super) fn resume_hand_size_discard(cx: &mut Cx, response: &InputResponse) ->
     // ---- advance the queue ----
     let mut remaining = pending.remaining;
     remaining.remove(0);
+    // Pop the current HandSizeDiscard frame (validated above; it is the top frame).
+    cx.state.continuations.pop();
     if remaining.is_empty() {
-        cx.state.hand_size_discard_pending = None;
         upkeep_phase_end(cx) // 4.6 + transition (may open the act round-end window)
     } else {
         park_hand_size_discard(cx, remaining)
@@ -3155,10 +3160,10 @@ mod hand_size_tests {
             "over-cap investigator must suspend; got {outcome:?}"
         );
         assert_eq!(
-            state
-                .hand_size_discard_pending
-                .as_ref()
-                .map(|p| p.remaining.clone()),
+            state.continuations.iter().rev().find_map(|c| match c {
+                crate::state::Continuation::HandSizeDiscard(p) => Some(p.remaining.clone()),
+                _ => None,
+            }),
             Some(vec![id]),
         );
     }
@@ -3181,7 +3186,10 @@ mod hand_size_tests {
         });
 
         assert_eq!(outcome, EngineOutcome::Done);
-        assert!(state.hand_size_discard_pending.is_none());
+        assert!(!matches!(
+            state.continuations.last(),
+            Some(crate::state::Continuation::HandSizeDiscard(_))
+        ));
     }
 
     #[test]
@@ -3207,7 +3215,10 @@ mod hand_size_tests {
         });
 
         assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
-        assert!(state.hand_size_discard_pending.is_some());
+        assert!(matches!(
+            state.continuations.last(),
+            Some(crate::state::Continuation::HandSizeDiscard(_))
+        ));
         assert_eq!(
             state.phase,
             Phase::Upkeep,
@@ -3248,7 +3259,10 @@ mod hand_size_tests {
         );
 
         assert_eq!(outcome, EngineOutcome::Done);
-        assert!(state.hand_size_discard_pending.is_none());
+        assert!(!matches!(
+            state.continuations.last(),
+            Some(crate::state::Continuation::HandSizeDiscard(_))
+        ));
         assert_eq!(state.investigators[&id].hand.len(), 8);
         assert_eq!(state.investigators[&id].discard.len(), 2);
         assert_eq!(
@@ -3307,7 +3321,10 @@ mod hand_size_tests {
             "rejected: hand untouched"
         );
         assert!(
-            state.hand_size_discard_pending.is_some(),
+            matches!(
+                state.continuations.last(),
+                Some(crate::state::Continuation::HandSizeDiscard(_))
+            ),
             "rejected: still pending"
         );
         assert!(events.is_empty(), "rejected: no events");
@@ -3390,10 +3407,10 @@ mod hand_size_tests {
         );
         assert!(matches!(o1, EngineOutcome::AwaitingInput { .. }));
         assert_eq!(
-            state
-                .hand_size_discard_pending
-                .as_ref()
-                .map(|p| p.remaining.clone()),
+            state.continuations.iter().rev().find_map(|c| match c {
+                crate::state::Continuation::HandSizeDiscard(p) => Some(p.remaining.clone()),
+                _ => None,
+            }),
             Some(vec![inv2]),
         );
         assert_eq!(state.phase, Phase::Upkeep);
@@ -3430,7 +3447,10 @@ mod hand_size_tests {
             "rejected: hand untouched"
         );
         assert!(
-            state.hand_size_discard_pending.is_some(),
+            matches!(
+                state.continuations.last(),
+                Some(crate::state::Continuation::HandSizeDiscard(_))
+            ),
             "rejected: still pending"
         );
         assert!(events.is_empty(), "rejected: no events");

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -86,8 +86,8 @@ pub(in crate::engine) fn start_skill_test(
     // in-flight test has a home from test start. Safe: all validation precedes
     // this point, and the only outcomes below are `AwaitingInput` (the
     // Mind-over-Matter substitution prompt, or the commit window). During the
-    // substitution prompt this frame sits beneath `pending_substitution_prompt`,
-    // which the `resolve_input` cascade routes first.
+    // substitution prompt this frame sits beneath the `SubstitutionPrompt`
+    // frame, which top-frame dispatch routes first.
     cx.state
         .continuations
         .push(crate::state::Continuation::SkillTest(InFlightSkillTest {
@@ -116,9 +116,11 @@ pub(in crate::engine) fn start_skill_test(
     // substitution active, offer the choice BEFORE the commit window — the
     // test type is fixed here (per the card's FAQ). The in-flight record (just
     // created) is the parking; `resume_substitution_choice` rewrites its skill
-    // on "yes". Routed via `pending_substitution_prompt`.
+    // on "yes". Routed via a `SubstitutionPrompt` frame above the `SkillTest`.
     if substitution_covers(cx.state, investigator, skill) {
-        cx.state.pending_substitution_prompt = Some(investigator);
+        cx.state
+            .continuations
+            .push(crate::state::Continuation::SubstitutionPrompt { investigator });
         let use_skill = SkillKind::Intellect; // sole substitution in scope
         return EngineOutcome::AwaitingInput {
             request: InputRequest::choice(
@@ -197,7 +199,9 @@ pub(in crate::engine) fn resume_substitution_choice(
             reason: format!("substitution prompt: PickSingle({opt}) out of range (0|1)").into(),
         };
     }
-    cx.state.pending_substitution_prompt = None;
+    // Pop the SubstitutionPrompt frame we validated against (it is the top
+    // frame, above the SkillTest frame the mutation below reaches).
+    cx.state.continuations.pop();
     if *opt == 0 {
         // Use Intellect: the test becomes an Intellect test (base / icons /
         // bonuses all key off `skill`), and a weapon's combat bonus
@@ -1351,7 +1355,9 @@ mod tests {
             )
         };
         assert!(matches!(out, EngineOutcome::AwaitingInput { .. }), "prompt");
-        assert_eq!(state.pending_substitution_prompt, Some(inv));
+        assert!(
+            matches!(state.continuations.last(), Some(crate::state::Continuation::SubstitutionPrompt { investigator }) if *investigator == inv)
+        );
 
         let out = {
             let mut cx = Cx {
@@ -1368,7 +1374,10 @@ mod tests {
         assert_eq!(t.skill, SkillKind::Intellect, "now an intellect test");
         assert_eq!(t.kind, SkillTestKind::Fight, "still a Fight (damage)");
         assert_eq!(t.test_modifier, 0, "weapon combat bonus dropped");
-        assert!(state.pending_substitution_prompt.is_none());
+        assert!(!matches!(
+            state.continuations.last(),
+            Some(crate::state::Continuation::SubstitutionPrompt { .. })
+        ));
     }
 
     #[test]
@@ -1401,7 +1410,9 @@ mod tests {
             matches!(out, EngineOutcome::AwaitingInput { .. }),
             "substitution prompt should suspend",
         );
-        assert_eq!(state.pending_substitution_prompt, Some(inv));
+        assert!(
+            matches!(state.continuations.last(), Some(crate::state::Continuation::SubstitutionPrompt { investigator }) if *investigator == inv)
+        );
         assert!(
             state.current_skill_test().is_some(),
             "the in-flight test must live on a SkillTest frame during the \
@@ -1485,7 +1496,13 @@ mod tests {
             )
         };
         assert!(matches!(out, EngineOutcome::AwaitingInput { .. }));
-        assert!(state.pending_substitution_prompt.is_none(), "no prompt");
+        assert!(
+            !matches!(
+                state.continuations.last(),
+                Some(crate::state::Continuation::SubstitutionPrompt { .. })
+            ),
+            "no prompt"
+        );
         assert_eq!(state.current_skill_test().unwrap().skill, SkillKind::Combat,);
     }
 }

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -280,7 +280,6 @@ impl GameStateBuilder {
             scenario_id: self.scenario_id,
             mythos_draw_pending: None,
             enemy_attack_pending: None,
-            hunter_move_pending: None,
             spawn_engage_pending: None,
             pending_end_turn: None,
             hand_size_discard_pending: self.hand_size_discard_pending,

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -251,6 +251,17 @@ impl GameStateBuilder {
 
     /// Materialize the configured [`GameState`].
     pub fn build(self) -> GameState {
+        // Builder-staged windows become `Resolution` frames on the one
+        // continuation stack (Axis-B T3); a staged hand-size discard becomes a
+        // `HandSizeDiscard` frame on top of them (#348).
+        let mut continuations: Vec<Continuation> = self
+            .open_windows
+            .into_iter()
+            .map(Continuation::Resolution)
+            .collect();
+        if let Some(hsd) = self.hand_size_discard_pending {
+            continuations.push(Continuation::HandSizeDiscard(hsd));
+        }
         GameState {
             investigators: self.investigators,
             locations: self.locations,
@@ -270,18 +281,11 @@ impl GameStateBuilder {
             enemy_ids: Counter::new(),
             location_ids: Counter::new(),
             pending_skill_modifiers: Vec::new(),
-            // Builder-staged windows become `Resolution` frames on the one
-            // continuation stack (Axis-B T3).
-            continuations: self
-                .open_windows
-                .into_iter()
-                .map(Continuation::Resolution)
-                .collect(),
+            continuations,
             scenario_id: self.scenario_id,
             mythos_draw_pending: None,
             enemy_attack_pending: None,
             pending_end_turn: None,
-            hand_size_discard_pending: self.hand_size_discard_pending,
             act_round_end_pending: None,
             pending_enemy_attack: None,
             pending_cancellation: false,

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -291,7 +291,6 @@ impl GameStateBuilder {
             pending_revelation_discard: None,
             pending_played_event: None,
             skill_substitutions: Vec::new(),
-            pending_substitution_prompt: None,
             encounter_deck: VecDeque::new(),
             encounter_discard: Vec::new(),
             agenda_deck: Vec::new(),

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -286,7 +286,6 @@ impl GameStateBuilder {
             mythos_draw_pending: None,
             enemy_attack_pending: None,
             pending_end_turn: None,
-            act_round_end_pending: None,
             pending_enemy_attack: None,
             pending_cancellation: false,
             pending_revelation_discard: None,

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -280,7 +280,6 @@ impl GameStateBuilder {
             scenario_id: self.scenario_id,
             mythos_draw_pending: None,
             enemy_attack_pending: None,
-            spawn_engage_pending: None,
             pending_end_turn: None,
             hand_size_discard_pending: self.hand_size_discard_pending,
             act_round_end_pending: None,

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -202,10 +202,6 @@ pub struct GameState {
     /// phase-end once the test resolves. Defaults to `None`.
     #[serde(default)]
     pub pending_end_turn: Option<InvestigatorId>,
-    /// Suspended act round-end clue-spend window (#275). `Some` only while
-    /// awaiting the group's Confirm/Skip at the end of the round. See
-    /// [`ActRoundEndPending`].
-    pub act_round_end_pending: Option<ActRoundEndPending>,
     /// `Some` while an enemy-attack loop is suspended on a soak reaction
     /// window (C5b #237). Mirror of [`pending_end_turn`](Self::pending_end_turn).
     #[serde(default)]
@@ -469,6 +465,9 @@ pub enum Continuation {
     /// A suspended upkeep hand-size discard (#111), migrated off the former
     /// `GameState::hand_size_discard_pending` field (#348).
     HandSizeDiscard(HandSizeDiscard),
+    /// A suspended act round-end clue-spend window (#275), migrated off the
+    /// former `GameState::act_round_end_pending` field (#348).
+    ActRoundEnd(ActRoundEndPending),
 }
 
 /// A controller choice paused mid-resolution (umbrella §3, Axis A).
@@ -508,7 +507,8 @@ impl Continuation {
             | Continuation::Choice(_)
             | Continuation::HunterMove(_)
             | Continuation::SpawnEngage(_)
-            | Continuation::HandSizeDiscard(_) => None,
+            | Continuation::HandSizeDiscard(_)
+            | Continuation::ActRoundEnd(_) => None,
         }
     }
 
@@ -520,7 +520,8 @@ impl Continuation {
             | Continuation::Choice(_)
             | Continuation::HunterMove(_)
             | Continuation::SpawnEngage(_)
-            | Continuation::HandSizeDiscard(_) => None,
+            | Continuation::HandSizeDiscard(_)
+            | Continuation::ActRoundEnd(_) => None,
         }
     }
 
@@ -537,7 +538,8 @@ impl Continuation {
             | Continuation::SkillTest(_)
             | Continuation::HunterMove(_)
             | Continuation::SpawnEngage(_)
-            | Continuation::HandSizeDiscard(_) => true,
+            | Continuation::HandSizeDiscard(_)
+            | Continuation::ActRoundEnd(_) => true,
         }
     }
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -242,12 +242,6 @@ pub struct GameState {
     /// round boundary ("until the end of the round").
     #[serde(default)]
     pub skill_substitutions: Vec<SkillSubstitution>,
-    /// Set while a skill test is paused on its "use X in place of Y?" prompt at
-    /// initiation (Mind over Matter 01036). Routes the next `ResolveInput` to
-    /// `resume_substitution_choice`; holds the test's investigator. `None`
-    /// otherwise.
-    #[serde(default)]
-    pub pending_substitution_prompt: Option<InvestigatorId>,
     /// Shared encounter deck (top = front). Built at scenario setup
     /// from encounter-set codes; drawn from during Mythos. When the
     /// deck runs out, `draw_encounter_top` (in `engine::dispatch`)
@@ -468,6 +462,15 @@ pub enum Continuation {
     /// A suspended act round-end clue-spend window (#275), migrated off the
     /// former `GameState::act_round_end_pending` field (#348).
     ActRoundEnd(ActRoundEndPending),
+    /// A skill test paused on its Mind-over-Matter "use X in place of Y?" prompt
+    /// at initiation (#322), migrated off the former
+    /// `GameState::pending_substitution_prompt` field (#348). Pushed *above* the
+    /// `SkillTest` frame, so top-frame dispatch routes it before the commit
+    /// window; resumed by [`resume_substitution_choice`](crate::engine).
+    SubstitutionPrompt {
+        /// The investigator taking the test.
+        investigator: InvestigatorId,
+    },
 }
 
 /// A controller choice paused mid-resolution (umbrella §3, Axis A).
@@ -508,7 +511,8 @@ impl Continuation {
             | Continuation::HunterMove(_)
             | Continuation::SpawnEngage(_)
             | Continuation::HandSizeDiscard(_)
-            | Continuation::ActRoundEnd(_) => None,
+            | Continuation::ActRoundEnd(_)
+            | Continuation::SubstitutionPrompt { .. } => None,
         }
     }
 
@@ -521,7 +525,8 @@ impl Continuation {
             | Continuation::HunterMove(_)
             | Continuation::SpawnEngage(_)
             | Continuation::HandSizeDiscard(_)
-            | Continuation::ActRoundEnd(_) => None,
+            | Continuation::ActRoundEnd(_)
+            | Continuation::SubstitutionPrompt { .. } => None,
         }
     }
 
@@ -539,7 +544,8 @@ impl Continuation {
             | Continuation::HunterMove(_)
             | Continuation::SpawnEngage(_)
             | Continuation::HandSizeDiscard(_)
-            | Continuation::ActRoundEnd(_) => true,
+            | Continuation::ActRoundEnd(_)
+            | Continuation::SubstitutionPrompt { .. } => true,
         }
     }
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -195,10 +195,6 @@ pub struct GameState {
     /// [`Status::Insane`]: crate::state::Status::Insane
     /// [`Status::Resigned`]: crate::state::Status::Resigned
     pub enemy_attack_pending: Option<InvestigatorId>,
-    /// Suspended Hunter-movement choice (#128), `Some` only while the
-    /// Enemy phase is paused on a lead-investigator tie; cleared once
-    /// resolved. See [`HunterChoice`].
-    pub hunter_move_pending: Option<HunterChoice>,
     /// Suspended engagement-on-spawn choice (#128). See [`SpawnEngagePending`].
     pub spawn_engage_pending: Option<SpawnEngagePending>,
     /// Suspended end-of-turn continuation (C4c, #235): `Some(active)` while
@@ -467,6 +463,10 @@ pub enum Continuation {
     /// re-run from the top on each resume, replaying `decisions` to reach
     /// the next un-ground choice. See [`ChoiceFrame`].
     Choice(ChoiceFrame),
+    /// A suspended Hunter-movement / engagement choice (#128), migrated off the
+    /// former `GameState::hunter_move_pending` field (#348). Resumed by
+    /// [`resume_hunter_choice`](crate::engine) via `ResolveInput`.
+    HunterMove(HunterChoice),
 }
 
 /// A controller choice paused mid-resolution (umbrella §3, Axis A).
@@ -502,7 +502,9 @@ impl Continuation {
     pub fn as_resolution(&self) -> Option<&ResolutionFrame> {
         match self {
             Continuation::Resolution(w) => Some(w),
-            Continuation::SkillTest(_) | Continuation::Choice(_) => None,
+            Continuation::SkillTest(_) | Continuation::Choice(_) | Continuation::HunterMove(_) => {
+                None
+            }
         }
     }
 
@@ -510,7 +512,9 @@ impl Continuation {
     pub fn as_resolution_mut(&mut self) -> Option<&mut ResolutionFrame> {
         match self {
             Continuation::Resolution(w) => Some(w),
-            Continuation::SkillTest(_) | Continuation::Choice(_) => None,
+            Continuation::SkillTest(_) | Continuation::Choice(_) | Continuation::HunterMove(_) => {
+                None
+            }
         }
     }
 
@@ -524,7 +528,8 @@ impl Continuation {
         match self {
             Continuation::Resolution(_)
             | Continuation::Choice(_)
-            | Continuation::SkillTest(_) => true,
+            | Continuation::SkillTest(_)
+            | Continuation::HunterMove(_) => true,
         }
     }
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -195,8 +195,6 @@ pub struct GameState {
     /// [`Status::Insane`]: crate::state::Status::Insane
     /// [`Status::Resigned`]: crate::state::Status::Resigned
     pub enemy_attack_pending: Option<InvestigatorId>,
-    /// Suspended engagement-on-spawn choice (#128). See [`SpawnEngagePending`].
-    pub spawn_engage_pending: Option<SpawnEngagePending>,
     /// Suspended end-of-turn continuation (C4c, #235): `Some(active)` while
     /// `end_turn` is paused on a suspending `EndOfTurn` forced effect
     /// (Frozen in Fear 01164's willpower test). The skill-test commit-resume
@@ -467,6 +465,9 @@ pub enum Continuation {
     /// former `GameState::hunter_move_pending` field (#348). Resumed by
     /// [`resume_hunter_choice`](crate::engine) via `ResolveInput`.
     HunterMove(HunterChoice),
+    /// A suspended engagement-on-spawn choice (#128), migrated off the former
+    /// `GameState::spawn_engage_pending` field (#348).
+    SpawnEngage(SpawnEngagePending),
 }
 
 /// A controller choice paused mid-resolution (umbrella §3, Axis A).
@@ -502,9 +503,10 @@ impl Continuation {
     pub fn as_resolution(&self) -> Option<&ResolutionFrame> {
         match self {
             Continuation::Resolution(w) => Some(w),
-            Continuation::SkillTest(_) | Continuation::Choice(_) | Continuation::HunterMove(_) => {
-                None
-            }
+            Continuation::SkillTest(_)
+            | Continuation::Choice(_)
+            | Continuation::HunterMove(_)
+            | Continuation::SpawnEngage(_) => None,
         }
     }
 
@@ -512,9 +514,10 @@ impl Continuation {
     pub fn as_resolution_mut(&mut self) -> Option<&mut ResolutionFrame> {
         match self {
             Continuation::Resolution(w) => Some(w),
-            Continuation::SkillTest(_) | Continuation::Choice(_) | Continuation::HunterMove(_) => {
-                None
-            }
+            Continuation::SkillTest(_)
+            | Continuation::Choice(_)
+            | Continuation::HunterMove(_)
+            | Continuation::SpawnEngage(_) => None,
         }
     }
 
@@ -529,7 +532,8 @@ impl Continuation {
             Continuation::Resolution(_)
             | Continuation::Choice(_)
             | Continuation::SkillTest(_)
-            | Continuation::HunterMove(_) => true,
+            | Continuation::HunterMove(_)
+            | Continuation::SpawnEngage(_) => true,
         }
     }
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -202,8 +202,6 @@ pub struct GameState {
     /// phase-end once the test resolves. Defaults to `None`.
     #[serde(default)]
     pub pending_end_turn: Option<InvestigatorId>,
-    /// Suspended upkeep hand-size discard (#111). See [`HandSizeDiscard`].
-    pub hand_size_discard_pending: Option<HandSizeDiscard>,
     /// Suspended act round-end clue-spend window (#275). `Some` only while
     /// awaiting the group's Confirm/Skip at the end of the round. See
     /// [`ActRoundEndPending`].
@@ -468,6 +466,9 @@ pub enum Continuation {
     /// A suspended engagement-on-spawn choice (#128), migrated off the former
     /// `GameState::spawn_engage_pending` field (#348).
     SpawnEngage(SpawnEngagePending),
+    /// A suspended upkeep hand-size discard (#111), migrated off the former
+    /// `GameState::hand_size_discard_pending` field (#348).
+    HandSizeDiscard(HandSizeDiscard),
 }
 
 /// A controller choice paused mid-resolution (umbrella §3, Axis A).
@@ -506,7 +507,8 @@ impl Continuation {
             Continuation::SkillTest(_)
             | Continuation::Choice(_)
             | Continuation::HunterMove(_)
-            | Continuation::SpawnEngage(_) => None,
+            | Continuation::SpawnEngage(_)
+            | Continuation::HandSizeDiscard(_) => None,
         }
     }
 
@@ -517,7 +519,8 @@ impl Continuation {
             Continuation::SkillTest(_)
             | Continuation::Choice(_)
             | Continuation::HunterMove(_)
-            | Continuation::SpawnEngage(_) => None,
+            | Continuation::SpawnEngage(_)
+            | Continuation::HandSizeDiscard(_) => None,
         }
     }
 
@@ -533,7 +536,8 @@ impl Continuation {
             | Continuation::Choice(_)
             | Continuation::SkillTest(_)
             | Continuation::HunterMove(_)
-            | Continuation::SpawnEngage(_) => true,
+            | Continuation::SpawnEngage(_)
+            | Continuation::HandSizeDiscard(_) => true,
         }
     }
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -529,25 +529,6 @@ impl Continuation {
             | Continuation::SubstitutionPrompt { .. } => None,
         }
     }
-
-    /// Whether this frame is resumed by a player
-    /// [`ResolveInput`](crate::action::PlayerAction::ResolveInput). Every
-    /// current variant is — but Tier-B framework-resumed suspensions (added
-    /// with the keystone) will return `false`. The exhaustive `match` forces
-    /// each new variant to be classified here (#348).
-    #[must_use]
-    pub fn awaits_resolve_input(&self) -> bool {
-        match self {
-            Continuation::Resolution(_)
-            | Continuation::Choice(_)
-            | Continuation::SkillTest(_)
-            | Continuation::HunterMove(_)
-            | Continuation::SpawnEngage(_)
-            | Continuation::HandSizeDiscard(_)
-            | Continuation::ActRoundEnd(_)
-            | Continuation::SubstitutionPrompt { .. } => true,
-        }
-    }
 }
 
 /// A skill test paused mid-resolution at the commit window.

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -513,6 +513,20 @@ impl Continuation {
             Continuation::SkillTest(_) | Continuation::Choice(_) => None,
         }
     }
+
+    /// Whether this frame is resumed by a player
+    /// [`ResolveInput`](crate::action::PlayerAction::ResolveInput). Every
+    /// current variant is — but Tier-B framework-resumed suspensions (added
+    /// with the keystone) will return `false`. The exhaustive `match` forces
+    /// each new variant to be classified here (#348).
+    #[must_use]
+    pub fn awaits_resolve_input(&self) -> bool {
+        match self {
+            Continuation::Resolution(_)
+            | Continuation::Choice(_)
+            | Continuation::SkillTest(_) => true,
+        }
+    }
 }
 
 /// A skill test paused mid-resolution at the commit window.

--- a/crates/game-core/tests/act_round_end.rs
+++ b/crates/game-core/tests/act_round_end.rs
@@ -47,10 +47,14 @@ fn parked_window_state(clues: u8) -> GameState {
         },
     ];
     state.act_index = 0;
-    state.act_round_end_pending = Some(ActRoundEndPending {
-        contributor_location: LocationId(2),
-        threshold: 3,
-    });
+    state
+        .continuations
+        .push(game_core::state::Continuation::ActRoundEnd(
+            ActRoundEndPending {
+                contributor_location: LocationId(2),
+                threshold: 3,
+            },
+        ));
     state
 }
 
@@ -62,7 +66,13 @@ fn pending_window_blocks_non_resolve_actions() {
         matches!(r.outcome, EngineOutcome::Rejected { .. }),
         "the guard blocks non-ResolveInput actions while a window is pending"
     );
-    assert!(r.state.act_round_end_pending.is_some(), "still pending");
+    assert!(
+        matches!(
+            r.state.continuations.last(),
+            Some(game_core::state::Continuation::ActRoundEnd(_))
+        ),
+        "still pending"
+    );
 }
 
 #[test]
@@ -81,5 +91,8 @@ fn resolve_confirm_routes_to_resume_and_advances() {
         0,
         "spent 3"
     );
-    assert!(r.state.act_round_end_pending.is_none());
+    assert!(!matches!(
+        r.state.continuations.last(),
+        Some(game_core::state::Continuation::ActRoundEnd(_))
+    ));
 }

--- a/crates/scenarios/tests/encounter_spawn.rs
+++ b/crates/scenarios/tests/encounter_spawn.rs
@@ -146,7 +146,10 @@ fn revealing_synth_enemy_with_two_investigators_at_loc_suspends_for_lead_pick() 
         "multi-investigator spawn now suspends for the lead's PickInvestigator, got {:?}",
         result.outcome,
     );
-    assert!(result.state.spawn_engage_pending.is_some());
+    assert!(matches!(
+        result.state.continuations.last(),
+        Some(game_core::state::Continuation::SpawnEngage(_))
+    ));
     let enemy = result.state.enemies.values().next().expect("enemy placed");
     assert_eq!(
         enemy.engaged_with, None,

--- a/crates/scenarios/tests/hunter_movement.rs
+++ b/crates/scenarios/tests/hunter_movement.rs
@@ -49,7 +49,10 @@ fn multi_investigator_spawn_engagement_resolves_via_lead_pick() {
         r1.outcome,
     );
     assert!(
-        r1.state.spawn_engage_pending.is_some(),
+        matches!(
+            r1.state.continuations.last(),
+            Some(game_core::state::Continuation::SpawnEngage(_))
+        ),
         "spawn engagement tie should be pending for the lead's pick",
     );
     let spawned = r1.state.enemies.values().next().expect("enemy placed");
@@ -63,7 +66,10 @@ fn multi_investigator_spawn_engagement_resolves_via_lead_pick() {
         }),
     );
     assert_eq!(r2.outcome, EngineOutcome::Done);
-    assert!(r2.state.spawn_engage_pending.is_none());
+    assert!(!matches!(
+        r2.state.continuations.last(),
+        Some(game_core::state::Continuation::SpawnEngage(_))
+    ));
     let enemy = r2.state.enemies.values().next().expect("enemy in play");
     assert_eq!(enemy.engaged_with, Some(InvestigatorId(2)));
 }

--- a/crates/scenarios/tests/mythos_phase.rs
+++ b/crates/scenarios/tests/mythos_phase.rs
@@ -290,7 +290,10 @@ fn mythos_phase_multi_investigator_spawn_suspends_then_resumes_chain() {
         "spawn tie must suspend, got {:?}",
         suspended.outcome,
     );
-    assert!(suspended.state.spawn_engage_pending.is_some());
+    assert!(matches!(
+        suspended.state.continuations.last(),
+        Some(game_core::state::Continuation::SpawnEngage(_))
+    ));
     let enemy = suspended
         .state
         .enemies
@@ -310,7 +313,10 @@ fn mythos_phase_multi_investigator_spawn_suspends_then_resumes_chain() {
         }),
     );
     assert_eq!(resumed.outcome, EngineOutcome::Done);
-    assert!(resumed.state.spawn_engage_pending.is_none());
+    assert!(!matches!(
+        resumed.state.continuations.last(),
+        Some(game_core::state::Continuation::SpawnEngage(_))
+    ));
     let enemy = resumed
         .state
         .enemies

--- a/crates/scenarios/tests/the_gathering.rs
+++ b/crates/scenarios/tests/the_gathering.rs
@@ -110,7 +110,10 @@ fn drives_act_1_then_act_2_via_round_end_window() {
         "round end opens the act-2 clue-spend window, got {:?}",
         r.outcome,
     );
-    assert!(r.state.act_round_end_pending.is_some());
+    assert!(matches!(
+        r.state.continuations.last(),
+        Some(game_core::state::Continuation::ActRoundEnd(_))
+    ));
 
     // Spend the clues as a group: act 2 advances to act 3.
     let r = apply(

--- a/crates/scenarios/tests/the_gathering_resolutions.rs
+++ b/crates/scenarios/tests/the_gathering_resolutions.rs
@@ -162,7 +162,10 @@ fn act_progression_and_ghoul_priest_defeat_latches_won() {
         "EndTurn should open the act-2 round-end window, got {:?}",
         round_end.outcome,
     );
-    assert!(round_end.state.act_round_end_pending.is_some());
+    assert!(matches!(
+        round_end.state.continuations.last(),
+        Some(game_core::state::Continuation::ActRoundEnd(_))
+    ));
     let after_confirm = apply(
         round_end.state,
         Action::Player(PlayerAction::ResolveInput {

--- a/crates/scenarios/tests/upkeep_hand_size.rs
+++ b/crates/scenarios/tests/upkeep_hand_size.rs
@@ -79,7 +79,10 @@ fn upkeep_prompts_and_discards_down_to_eight() {
     let hand_before_end = state.investigators[&inv1].hand.len();
     let discard_pile_before = state.investigators[&inv1].discard.len();
     assert!(
-        state.hand_size_discard_pending.is_none(),
+        !matches!(
+            state.continuations.last(),
+            Some(game_core::state::Continuation::HandSizeDiscard(_))
+        ),
         "no discard should be pending before the round-ending EndTurn"
     );
 
@@ -94,7 +97,10 @@ fn upkeep_prompts_and_discards_down_to_eight() {
         r3.outcome,
     );
     assert!(
-        r3.state.hand_size_discard_pending.is_some(),
+        matches!(
+            r3.state.continuations.last(),
+            Some(game_core::state::Continuation::HandSizeDiscard(_))
+        ),
         "hand_size_discard_pending must be set while awaiting the discard"
     );
     let hand_at_check = r3.state.investigators[&inv1].hand.len();
@@ -134,7 +140,10 @@ fn upkeep_prompts_and_discards_down_to_eight() {
         "discarded cards must move to the investigator's discard pile"
     );
     assert!(
-        r4.state.hand_size_discard_pending.is_none(),
+        !matches!(
+            r4.state.continuations.last(),
+            Some(game_core::state::Continuation::HandSizeDiscard(_))
+        ),
         "discard-pending must be cleared once the queue drains"
     );
 

--- a/crates/scenarios/tests/upkeep_hand_size.rs
+++ b/crates/scenarios/tests/upkeep_hand_size.rs
@@ -101,7 +101,7 @@ fn upkeep_prompts_and_discards_down_to_eight() {
             r3.state.continuations.last(),
             Some(game_core::state::Continuation::HandSizeDiscard(_))
         ),
-        "hand_size_discard_pending must be set while awaiting the discard"
+        "a HandSizeDiscard frame must be on the stack while awaiting the discard"
     );
     let hand_at_check = r3.state.investigators[&inv1].hand.len();
     assert_eq!(

--- a/docs/superpowers/plans/2026-06-19-pr2b-migrate-tier-a-modes-onto-frames.md
+++ b/docs/superpowers/plans/2026-06-19-pr2b-migrate-tier-a-modes-onto-frames.md
@@ -1,0 +1,260 @@
+# PR 2b (#348, part 2) — Migrate the Tier-A suspension modes onto Continuation frames — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task (fresh subagent per task + review between tasks). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the five cleanly-`ResolveInput`-resumed suspension modes off their `Option<…>` fields on `GameState` and onto typed `Continuation` frames, collapsing their `resolve_input` cascade arms and `apply_player_action` guard-ladder entries into uniform top-frame dispatch.
+
+**Architecture:** Task 1 introduces a frame-aware dispatch skeleton (`resolve_input` dispatches on `continuations.last()`) and a unified guard, both covering the *existing* frame variants (`Resolution`/`Choice`/`SkillTest`) with no behavior change. Each of Tasks 2–6 then migrates one mode end-to-end (new variant, suspend→push, resume→pop-from-frame, dispatch arm, and removal of the field + old cascade arm + old guard entry), leaving the build green. Task 7 removes the emptied cascade scaffolding.
+
+**Tech Stack:** Rust, the `game-core` crate. No `cards`/`scenarios`/wire changes (these five modes are engine-internal; their `InputResponse` variants already exist).
+
+This is **PR 2b of the #348 split.** Scope decision (recorded): **Tier A only** — `hunter_move_pending`, `spawn_engage_pending`, `hand_size_discard_pending`, `act_round_end_pending`, `pending_substitution_prompt`. **Tier B** (`pending_enemy_attack`, `pending_end_turn` — framework-resumed via continuation-close paths) is deferred to the **keystone** (Phase-7 step 3), which rebuilds that machinery. **Tier C** (`mulligan_pending`, `mythos_draw_pending`) is **2c** (the `Mulligan`/`DrawEncounterCard`→`InputResponse` fold); `enemy_attack_pending` stays a cursor per the spec. Spec §A: `docs/superpowers/specs/2026-06-19-continuation-stack-cleanup-design.md`. Series order: #345 ✅ → #348 (2a ✅ · **2b** · 2c) → #347 → #380.
+
+## Global Constraints
+
+- **CI gauntlet, warnings-as-errors** (all before pushing):
+  - `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo fmt --check`
+  - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
+  - `cargo build -p web --target wasm32-unknown-unknown`
+  - `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`
+- **No behavior change.** Pure suspension-storage refactor. Every Hunter-movement, spawn-engagement, hand-size-discard, act-round-end, and Mind-over-Matter test must pass unchanged.
+- **Frames push ABOVE what they suspend within.** Each mode is pushed when its suspension begins and is the top frame while active, so `continuations.last()`-based dispatch routes it correctly. `pending_substitution_prompt` in particular pushes **above** the `SkillTest` frame (which 2a guarantees exists from test start) — top-frame dispatch then routes the substitution prompt before the commit window, replacing the old "route substitution first" special-case.
+- **Tier B / Tier C untouched.** `pending_enemy_attack`, `pending_end_turn`, `mulligan_pending`, `mythos_draw_pending`, `enemy_attack_pending` stay as `Option` fields with their existing guards/handling. The unified guard (Task 1) covers only frame-based input-awaiting suspensions; the mulligan/mythos cursor guards remain separate.
+- **Branch:** `engine/migrate-tier-a-suspensions` off fresh `main`. Commit per task; push only when the full gauntlet is green.
+
+## Per-mode reference table
+
+| Mode (field) | Payload type | New variant | Suspend site | Resume fn | Resume `InputResponse` |
+|---|---|---|---|---|---|
+| `hunter_move_pending` | `HunterChoice` | `HunterMove(HunterChoice)` | `hunters.rs:397` | `hunters::resume_hunter_choice` | `PickLocation` / `PickInvestigator` |
+| `spawn_engage_pending` | `SpawnEngagePending` | `SpawnEngage(SpawnEngagePending)` | `encounter.rs:463` | `hunters::resume_spawn_engage` | `PickInvestigator` |
+| `hand_size_discard_pending` | `HandSizeDiscard` | `HandSizeDiscard(HandSizeDiscard)` | `phases.rs:850` (+ builder staging `builder.rs:222`) | `phases::resume_hand_size_discard` | `DiscardCards` |
+| `act_round_end_pending` | `ActRoundEndPending` | `ActRoundEnd(ActRoundEndPending)` | `phases.rs:706` | `phases::resume_act_round_end_advance` | `Confirm` / `Skip` |
+| `pending_substitution_prompt` | `InvestigatorId` | `SubstitutionPrompt { investigator: InvestigatorId }` | `skill_test.rs` (the `pending_substitution_prompt = Some(...)` line) | `skill_test::resume_substitution_choice` | `PickSingle` |
+
+---
+
+### Task 1: Frame-aware dispatch skeleton + unified guard (no behavior change)
+
+Make `resolve_input` dispatch on `continuations.last()` and add a unified "input-awaiting frame" guard, both covering only the existing variants (`Resolution`/`Choice`/`SkillTest`) for now. This is the seam Tasks 2–6 extend.
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (add `Continuation::awaits_resolve_input`)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (`resolve_input` head; `apply_player_action` guard)
+
+**Interfaces:**
+- Produces: `Continuation::awaits_resolve_input(&self) -> bool` — true for frames whose resume is a player `ResolveInput`. (Window frames return true; they additionally admit Fast plays handled by the existing window guard.)
+
+- [ ] **Step 1: Add the classifier**
+
+In `game_state.rs`, on `impl Continuation`:
+
+```rust
+/// Whether this frame is resumed by a player [`ResolveInput`](crate::action::PlayerAction::ResolveInput).
+/// Every current variant is — but Tier-B framework-resumed suspensions (added
+/// with the keystone) will return `false`.
+#[must_use]
+pub fn awaits_resolve_input(&self) -> bool {
+    match self {
+        Continuation::Resolution(_)
+        | Continuation::Choice(_)
+        | Continuation::SkillTest(_) => true,
+    }
+}
+```
+
+(The `match` is exhaustive so each Task 2–6 variant addition forces a compile error here until classified — a deliberate tripwire.)
+
+- [ ] **Step 2: Verify**
+
+Run: `cargo build -p game-core` → PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "engine: add Continuation::awaits_resolve_input classifier (#348)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Tasks 2–6: Migrate each mode (one task per mode)
+
+**These five tasks are structurally identical.** The recipe below is the exemplar for **Task 2 (`HunterMove`)**; Tasks 3–6 apply the same recipe with the row's values from the per-mode table. Each task is its own subagent dispatch + review, and each must leave the full gauntlet green.
+
+#### Recipe (worked for `hunter_move_pending` → `HunterMove(HunterChoice)`)
+
+**Files:** `game_state.rs` (variant + classifier), the mode's suspend-site file, its resume-handler file, `dispatch/mod.rs` (dispatch arm + guard/cascade removal).
+
+- [ ] **Step 1: Add the variant**
+
+In `game_state.rs` `enum Continuation`, add:
+
+```rust
+    /// A suspended Hunter-movement choice (#128), migrated off the former
+    /// `GameState::hunter_move_pending` field (#348). Resumed by
+    /// [`resume_hunter_choice`](crate::engine) via `ResolveInput`.
+    HunterMove(HunterChoice),
+```
+
+- [ ] **Step 2: Classify it**
+
+Add `| Continuation::HunterMove(_)` to the `true` arm of `awaits_resolve_input` (Task 1). (Compile error here until done — the tripwire.)
+
+- [ ] **Step 3: Migrate the suspend site** (`hunters.rs:397`)
+
+```rust
+// before
+cx.state.hunter_move_pending = Some(choice);
+// after
+cx.state
+    .continuations
+    .push(crate::state::Continuation::HunterMove(choice));
+```
+
+(Leave the `AwaitingInput { … }` return that follows unchanged.)
+
+- [ ] **Step 4: Migrate the resume handler** (`hunters::resume_hunter_choice`)
+
+Replace the `cx.state.hunter_move_pending.take()` (or `.as_ref()`) read at the top of the handler with a pop of the `HunterMove` frame:
+
+```rust
+let choice = match cx.state.continuations.last() {
+    Some(crate::state::Continuation::HunterMove(_)) => {
+        match cx.state.continuations.pop() {
+            Some(crate::state::Continuation::HunterMove(c)) => c,
+            _ => unreachable!("checked HunterMove on top"),
+        }
+    }
+    _ => {
+        return EngineOutcome::Rejected {
+            reason: "resume_hunter_choice: no HunterMove frame on top of the stack".into(),
+        }
+    }
+};
+```
+
+(Match the handler's existing validation/early-return style; if it pops late after validating the response, keep that ordering — pop only once the response is accepted, to preserve validate-first. Read the existing handler body and adapt: the rule is *the payload now comes from the frame, and the frame is removed exactly where the field was previously cleared*.)
+
+- [ ] **Step 5: Add the dispatch arm; remove the old cascade arm**
+
+In `resolve_input` (`dispatch/mod.rs`), the routing is now top-frame. Add to the dispatch:
+
+```rust
+    if let Some(crate::state::Continuation::HunterMove(_)) = cx.state.continuations.last() {
+        return hunters::resume_hunter_choice(cx, response);
+    }
+```
+
+and **delete** the old `if cx.state.hunter_move_pending.is_some() { return hunters::resume_hunter_choice(cx, response); }` cascade arm.
+
+- [ ] **Step 6: Remove the guard-ladder entry**
+
+Delete the `if cx.state.hunter_move_pending.is_some() && !matches!(action, PlayerAction::ResolveInput { .. }) { return Rejected … }` block in `apply_player_action`. It is now covered by the unified frame guard — confirm that guard exists (add it in Task 2 if not yet present):
+
+```rust
+    // Unified: any frame awaiting a ResolveInput blocks every other action
+    // (Fast plays during reaction windows are admitted by the window guard above).
+    if cx
+        .state
+        .continuations
+        .last()
+        .is_some_and(crate::state::Continuation::awaits_resolve_input)
+        && !matches!(action, PlayerAction::ResolveInput { .. })
+    {
+        return EngineOutcome::Rejected {
+            reason: "an input-awaiting suspension is on the stack; submit a \
+                     PlayerAction::ResolveInput before any other action"
+                .into(),
+        };
+    }
+```
+
+Place this guard **after** the existing mulligan and reaction-window guards (those stay). The first migrated mode (Task 2) introduces it; later tasks just delete their per-field guard entry.
+
+- [ ] **Step 7: Remove the field**
+
+Delete `pub hunter_move_pending: Option<HunterChoice>,` from `GameState` and its `builder.rs` initializer. Fix the mutual-exclusion `debug_assert!` in `resolve_input` (`dispatch/mod.rs:451`) by dropping the `hunter_move_pending` term (Task 6 removes the assert entirely once all four of its terms are gone).
+
+- [ ] **Step 8: Compile, test, lint**
+
+```bash
+cargo build -p game-core --all-targets   # fix any remaining unit-field references
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings && cargo fmt --check
+```
+Expected: PASS — the Hunter-movement tests (`hunters.rs` `#[cfg(test)]`, the #128 suite) unchanged.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add -A
+git commit -m "engine: migrate hunter_move_pending onto a HunterMove frame (#348)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+#### Task 3 — `spawn_engage_pending` → `SpawnEngage(SpawnEngagePending)`
+Apply the recipe with the table row. Suspend site `encounter.rs:463`; resume `hunters::resume_spawn_engage`; tests: the #128 spawn-engage suite (`encounter.rs:1649` `resume_spawn_engage_rejects_bad_pick_and_preserves_pending` — update its `spawn_engage_pending` assertions to inspect the `SpawnEngage` frame instead). Commit subject: `engine: migrate spawn_engage_pending onto a SpawnEngage frame (#348)`.
+
+#### Task 4 — `hand_size_discard_pending` → `HandSizeDiscard(HandSizeDiscard)`
+Apply the recipe. **Two** suspend sites: the production one (`phases.rs:850`) **and** a builder staging helper (`builder.rs:222`, used to stage a paused upkeep state — convert it to push the frame onto the builder's `continuations`, or read how the builder stages other frames and mirror that). Resume `phases::resume_hand_size_discard`; tests: the #111 hand-size suite (`phases.rs` `resume_hand_size_discard_*`). Commit: `engine: migrate hand_size_discard_pending onto a HandSizeDiscard frame (#348)`.
+
+#### Task 5 — `act_round_end_pending` → `ActRoundEnd(ActRoundEndPending)`
+Apply the recipe. Suspend `phases.rs:706`; resume `phases::resume_act_round_end_advance`; tests: the #275 act-round-end suite (`phases.rs` `resume_confirm_*` / `resume_skip_*`). Commit: `engine: migrate act_round_end_pending onto an ActRoundEnd frame (#348)`.
+
+#### Task 6 — `pending_substitution_prompt` → `SubstitutionPrompt { investigator }`
+Apply the recipe, with two specifics:
+- **Push above the `SkillTest` frame.** At the suspend site in `skill_test.rs` (the `pending_substitution_prompt = Some(investigator)` line), push `Continuation::SubstitutionPrompt { investigator }` — it lands on top of the already-present `SkillTest` frame (2a). `resume_substitution_choice` pops it, then calls `open_commit_window` as today.
+- **Delete the substitution-first special-case.** Remove the `if cx.state.pending_substitution_prompt.is_some() { return resume_substitution_choice(…) }` block at the **head** of `resolve_input` — top-frame dispatch now handles ordering (the `SubstitutionPrompt` frame is on top, so it routes first by construction). Add the normal dispatch arm instead.
+- Tests: the Mind-over-Matter suite (`skill_test.rs` `combat_test_with_substitution_*`, `substitution_choice_no_*`, and the 2a `substitution_prompt_keeps_the_test_on_its_frame`) — update any `pending_substitution_prompt` assertions to inspect the `SubstitutionPrompt` frame.
+Commit: `engine: migrate pending_substitution_prompt onto a SubstitutionPrompt frame (#348)`.
+
+---
+
+### Task 7: Remove the emptied cascade scaffolding
+
+After Tasks 2–6, the old per-field cascade arms and guard entries are gone. Clean up the remnants.
+
+**Files:** `crates/game-core/src/engine/dispatch/mod.rs`
+
+- [ ] **Step 1: Remove the mutual-exclusion `debug_assert!`**
+
+The `debug_assert!` that asserted hunter/spawn/hand-size/act-round are mutually exclusive (`dispatch/mod.rs:451`) referenced fields that no longer exist. Delete it — top-frame dispatch makes the ordering structural; mutual exclusion is no longer a routing concern.
+
+- [ ] **Step 2: Tidy `resolve_input`**
+
+Confirm `resolve_input` is now a flat sequence of `if let Some(Continuation::X(_)) = last() { return resume_x(…) }` arms (one per frame variant) followed by the terminal `Rejected`. Collapse to a single `match cx.state.continuations.last() { … }` if it reads more cleanly. Confirm the head no longer has the substitution special-case.
+
+- [ ] **Step 3: Full gauntlet**
+
+Run all six commands from Global Constraints. Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "engine: collapse resolve_input cascade to top-frame dispatch (#348)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (spec §A — migrate `pending_*` suspension modes; collapse the cascade + guard ladder):**
+- 5 Tier-A modes → frames → Tasks 2–6. ✓
+- Cascade arms + guard entries collapsed to top-frame dispatch → Tasks 1, 2 (guard), 7. ✓
+- Substitution-first special-case retired via top-frame ordering → Task 6. ✓
+- Tier B deferred to keystone, Tier C to 2c, `enemy_attack_pending` stays → recorded in scope. ✓
+
+**Placeholder scan:** the recipe's Step 4 deliberately says "read the existing handler body and adapt" for the pop placement (validate-first ordering varies per handler — the subagent must preserve each handler's existing reject-before-mutate shape rather than blindly pop first). Every other step is concrete. The five modes share one recipe (DRY) + a per-mode parameter table; this mirrors the accepted approach in the 2a plan.
+
+**Type consistency:** variant names (`HunterMove`/`SpawnEngage`/`HandSizeDiscard`/`ActRoundEnd`/`SubstitutionPrompt`) match the table, the `awaits_resolve_input` arms, and the dispatch arms. Payload types match the `pub struct` declarations surveyed (`HunterChoice`, `SpawnEngagePending`, `HandSizeDiscard`, `ActRoundEndPending`, `InvestigatorId`).
+
+**Subagent-driven note:** Tasks are ordered so each leaves a green build. Task 1 is the seam; Tasks 2–6 are independent migrations (any order, but the guard is introduced in the first one run); Task 7 is terminal cleanup. Give each implementer subagent explicit git guardrails: stay on `engine/migrate-tier-a-suspensions`, never switch branches, never touch `main`; verify branch + `git log` after each task.


### PR DESCRIPTION
## Summary

**Part 2 of the #348 split.** Migrates the five cleanly-`ResolveInput`-resumed suspension modes off their `Option<…>` fields on `GameState` onto typed `Continuation` frames, and collapses the `resolve_input` cascade into a single top-frame `match`. Spec §A: `docs/superpowers/specs/2026-06-19-continuation-stack-cleanup-design.md`.

Series order: #345 ✅ → #348 (2a ✅ · **2b this** · 2c) → #347 → #380.

## What changed

Eight commits (T1 seam → one per mode → collapse → cleanups):

- **5 modes → frames:** `hunter_move_pending`→`HunterMove`, `spawn_engage_pending`→`SpawnEngage`, `hand_size_discard_pending`→`HandSizeDiscard`, `act_round_end_pending`→`ActRoundEnd`, `pending_substitution_prompt`→`SubstitutionPrompt { investigator }`. Each: variant + suspend-push + resume-pop (validate-first: popped only on the accepted path) + frame-check guard + removed field/builder-init.
- **`SubstitutionPrompt` pushes above the `SkillTest` frame** (2a guarantees it), so top-frame dispatch routes it before the commit window — retiring the substitution-first special-case at the head of `resolve_input`. The pre-existing `has_skill_test_in_flight()` guard already covers it.
- **`resolve_input` collapsed** to one `match cx.state.continuations.last()`; the hand-ordered priority cascade and its mutual-exclusion `debug_assert` are gone.
- **Builder** stages a `HandSizeDiscard` frame at `build()`.

## Scope

**In:** Tier A (the 5 above). **Out (unchanged `Option` fields):** Tier B `pending_enemy_attack`/`pending_end_turn` (framework-resumed — deferred to the keystone, which rebuilds that machinery); Tier C `mulligan_pending`/`mythos_draw_pending` (2c, the action fold); `enemy_attack_pending` cursor stays.

## Test notes

- No behavior change — pure suspension-storage refactor. ~25 test assertions migrated from field reads to frame checks.
- Full gauntlet green locally: test / clippy / fmt / doc / wasm-build / wasm-clippy.
- Pre-push review: **ready to merge**, no Critical/Important. Verified validate-first in all five resume handlers, top-of-stack pop soundness, substitution ordering, match completeness, and Tier-B/C isolation. The seven stale-field-name comment/message references it flagged are folded in.

## Linked issues

Part of #348 (does not close it — 2c follows).