### PR TITLE
engine: fold CommitCards/DiscardCards into InputResponse::PickMultiple (#348 part 3a)

### DIFF
--- a/crates/cards/tests/commit_cap.rs
+++ b/crates/cards/tests/commit_cap.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Once;
 
-use game_core::engine::EngineOutcome;
+use game_core::engine::{EngineOutcome, OptionId};
 use game_core::state::{
     CardCode, ChaosBag, ChaosToken, InvestigatorId, Phase, SkillKind, TokenModifiers,
 };
@@ -50,7 +50,9 @@ fn perform_test() -> Action {
 
 fn commit(indices: Vec<u32>) -> Action {
     Action::Player(PlayerAction::ResolveInput {
-        response: InputResponse::CommitCards { indices },
+        response: InputResponse::PickMultiple {
+            selected: indices.into_iter().map(OptionId).collect(),
+        },
     })
 }
 

--- a/crates/cards/tests/cover_up.rs
+++ b/crates/cards/tests/cover_up.rs
@@ -107,7 +107,7 @@ fn investigate_to_interrupt(state: GameState) -> (GameState, EngineOutcome) {
     let r = apply(
         r.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::CommitCards { indices: vec![] },
+            response: InputResponse::PickMultiple { selected: vec![] },
         }),
     );
     (r.state, r.outcome)

--- a/crates/cards/tests/dr_milan.rs
+++ b/crates/cards/tests/dr_milan.rs
@@ -53,7 +53,7 @@ fn board() -> GameState {
 
 fn commit_nothing() -> Action {
     Action::Player(PlayerAction::ResolveInput {
-        response: InputResponse::CommitCards { indices: vec![] },
+        response: InputResponse::PickMultiple { selected: vec![] },
     })
 }
 

--- a/crates/cards/tests/mind_over_matter.rs
+++ b/crates/cards/tests/mind_over_matter.rs
@@ -92,7 +92,9 @@ fn commit(state: game_core::GameState, indices: Vec<u32>) -> game_core::engine::
     apply(
         state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::CommitCards { indices },
+            response: InputResponse::PickMultiple {
+                selected: indices.into_iter().map(OptionId).collect(),
+            },
         }),
     )
 }

--- a/crates/cards/tests/neutral_cards.rs
+++ b/crates/cards/tests/neutral_cards.rs
@@ -12,7 +12,7 @@
 
 use std::sync::Once;
 
-use game_core::engine::EngineOutcome;
+use game_core::engine::{EngineOutcome, OptionId};
 use game_core::event::Event;
 use game_core::state::{
     CardCode, ChaosBag, ChaosToken, InvestigatorId, Phase, SkillKind, TokenModifiers,
@@ -86,7 +86,9 @@ fn perform_and_commit_guts(state: GameState) -> game_core::engine::ApplyResult {
     game_core::engine::apply(
         paused.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::CommitCards { indices: vec![0] },
+            response: InputResponse::PickMultiple {
+                selected: vec![OptionId(0)],
+            },
         }),
     )
 }

--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -364,18 +364,22 @@ pub enum InputResponse {
     Confirm,
     /// Decline / skip the prompted optional action.
     Skip,
-    /// Pick the option at the given zero-based index from the prompt's
-    /// option list. `u32` rather than `usize` for a stable wire format
-    /// independent of host pointer width.
-    PickIndex(u32),
     /// Pick one option from a structured choice prompt
     /// ([`InputRequest::choice`](crate::engine::InputRequest::choice)),
     /// echoing back its [`OptionId`](crate::engine::OptionId). The
-    /// single-selection family for the Axis-A choice machinery; the legacy
-    /// [`PickIndex`](Self::PickIndex) / [`PickLocation`](Self::PickLocation) /
-    /// [`PickInvestigator`](Self::PickInvestigator) stay on their existing
-    /// paths.
+    /// single-selection family (umbrella §3); [`PickLocation`](Self::PickLocation)
+    /// / [`PickInvestigator`](Self::PickInvestigator) consolidate into it in a
+    /// follow-up (2c-ii).
     PickSingle(crate::engine::OptionId),
+    /// Select a subset of the offered options, echoing back their
+    /// [`OptionId`](crate::engine::OptionId)s (umbrella §3). The multi-selection
+    /// family — the skill-test commit window and the upkeep hand-size discard
+    /// fold into this; min/exact-count constraints live on the request/frame,
+    /// not here. For those windows an `OptionId(i)` denotes hand index `i`.
+    PickMultiple {
+        /// The chosen option ids (hand indices, for commit/discard windows).
+        selected: Vec<crate::engine::OptionId>,
+    },
     /// Pick a specific investigator.
     PickInvestigator(InvestigatorId),
     /// Pick a specific location.
@@ -388,8 +392,7 @@ pub enum InputResponse {
     /// test's cleanup. Empty `indices` is a legal "commit nothing"
     /// signal.
     ///
-    /// `u32` rather than `u8` for wire-format symmetry with
-    /// [`PickIndex`](Self::PickIndex); hand sizes never approach `u8`
+    /// `u32` rather than `u8`; hand sizes never approach `u8`
     /// limits in practice, the field is downcast at validation time.
     CommitCards {
         /// Hand indices to commit.
@@ -402,8 +405,7 @@ pub enum InputResponse {
     /// count, a duplicate, or an out-of-bounds index is rejected.
     ///
     /// `u32` rather than `u8` for wire-format symmetry with
-    /// [`CommitCards`](Self::CommitCards) / [`PickIndex`](Self::PickIndex);
-    /// downcast at validation time.
+    /// [`CommitCards`](Self::CommitCards); downcast at validation time.
     DiscardCards {
         /// Hand indices to discard.
         indices: Vec<u32>,
@@ -430,9 +432,10 @@ mod input_response_tests {
     use super::*;
 
     #[test]
-    fn discard_cards_input_serde_roundtrip() {
-        let original = InputResponse::DiscardCards {
-            indices: vec![0, 3, 7],
+    fn pick_multiple_input_serde_roundtrip() {
+        use crate::engine::OptionId;
+        let original = InputResponse::PickMultiple {
+            selected: vec![OptionId(0), OptionId(3), OptionId(7)],
         };
         let json = serde_json::to_string(&original).expect("serialize");
         let back: InputResponse = serde_json::from_str(&json).expect("deserialize");

--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -384,32 +384,6 @@ pub enum InputResponse {
     PickInvestigator(InvestigatorId),
     /// Pick a specific location.
     PickLocation(LocationId),
-    /// Commit cards from hand to a skill test's commit window. Each
-    /// entry is a zero-based index into the active investigator's hand
-    /// at the moment of the prompt; the engine reads the matching
-    /// `CardCode`s, sums their printed skill icons (matching skill +
-    /// wild) into the test total, and discards them as part of the
-    /// test's cleanup. Empty `indices` is a legal "commit nothing"
-    /// signal.
-    ///
-    /// `u32` rather than `u8`; hand sizes never approach `u8`
-    /// limits in practice, the field is downcast at validation time.
-    CommitCards {
-        /// Hand indices to commit.
-        indices: Vec<u32>,
-    },
-    /// Discard cards from hand to satisfy the upkeep maximum-hand-size
-    /// step (Rules Reference p.25 step 4.5). Each entry is a zero-based index into
-    /// the prompted investigator's hand at the moment of the prompt. The
-    /// engine discards exactly the overflow (`hand.len() - 8`); any other
-    /// count, a duplicate, or an out-of-bounds index is rejected.
-    ///
-    /// `u32` rather than `u8` for wire-format symmetry with
-    /// [`CommitCards`](Self::CommitCards); downcast at validation time.
-    DiscardCards {
-        /// Hand indices to discard.
-        indices: Vec<u32>,
-    },
 }
 
 #[cfg(test)]

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -105,8 +105,8 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
     if cx.state.has_skill_test_in_flight() && !matches!(action, PlayerAction::ResolveInput { .. }) {
         return EngineOutcome::Rejected {
             reason: "a skill test is paused at its commit window; submit a \
-                     PlayerAction::ResolveInput with an InputResponse::CommitCards \
-                     (empty indices commits no cards) before any other action"
+                     PlayerAction::ResolveInput with an InputResponse::PickMultiple \
+                     (empty selection commits no cards) before any other action"
                 .into(),
         };
     }
@@ -352,11 +352,13 @@ fn resume_window(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
 }
 
 /// Resume a skill test parked at its commit window: the active investigator
-/// submits their commit list via [`InputResponse::CommitCards`].
+/// submits their commit list via [`InputResponse::PickMultiple`] (each
+/// [`OptionId`](crate::engine::OptionId) is a hand index).
 fn resume_skill_test_commit(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
     match response {
-        InputResponse::CommitCards { indices } => {
-            let outcome = skill_test::finish_skill_test(cx, indices);
+        InputResponse::PickMultiple { selected } => {
+            let indices: Vec<u32> = selected.iter().map(|o| o.0).collect();
+            let outcome = skill_test::finish_skill_test(cx, &indices);
             if matches!(outcome, EngineOutcome::Done) {
                 // The resolved test was a sibling fired by a forced run (2+
                 // simultaneous `EndOfTurn` forced — two Frozen in Fear copies,
@@ -385,7 +387,7 @@ fn resume_skill_test_commit(cx: &mut Cx, response: &InputResponse) -> EngineOutc
         }
         other => EngineOutcome::Rejected {
             reason: format!(
-                "ResolveInput: skill-test commit window expects InputResponse::CommitCards, \
+                "ResolveInput: skill-test commit window expects InputResponse::PickMultiple, \
                  got {other:?}",
             )
             .into(),

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -153,7 +153,7 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
     {
         return EngineOutcome::Rejected {
             reason: "a hand-size discard choice is pending; submit a PlayerAction::ResolveInput \
-                     with InputResponse::DiscardCards before any other action"
+                     with InputResponse::PickMultiple before any other action"
                 .into(),
         };
     }

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -879,7 +879,7 @@ fn check_hand_size(cx: &mut Cx) -> EngineOutcome {
 }
 
 /// Resume a parked upkeep hand-size discard (#111). Validates the
-/// `DiscardCards` response against the currently-prompted investigator
+/// `PickMultiple` response against the currently-prompted investigator
 /// (`remaining[0]`): the indices must be unique, in-bounds, and exactly
 /// `hand.len() - HAND_SIZE_LIMIT` in count. On success, discards the
 /// chosen cards (emitting [`Event::CardDiscarded`] per card), pops the
@@ -914,7 +914,7 @@ pub(super) fn resume_hand_size_discard(cx: &mut Cx, response: &InputResponse) ->
     if indices.len() != target {
         return EngineOutcome::Rejected {
             reason: format!(
-                "ResolveInput::DiscardCards: {current:?} must discard exactly {target} card(s) \
+                "hand-size discard: {current:?} must discard exactly {target} card(s) \
                  (hand {hand_len}, cap {HAND_SIZE_LIMIT}), got {}",
                 indices.len(),
             )
@@ -925,13 +925,13 @@ pub(super) fn resume_hand_size_discard(cx: &mut Cx, response: &InputResponse) ->
     for &i in &indices {
         if !seen.insert(i) {
             return EngineOutcome::Rejected {
-                reason: format!("ResolveInput::DiscardCards: duplicate hand index {i}").into(),
+                reason: format!("hand-size discard: duplicate hand index {i}").into(),
             };
         }
         if i as usize >= hand_len {
             return EngineOutcome::Rejected {
                 reason: format!(
-                    "ResolveInput::DiscardCards: hand index {i} out of bounds (hand size {hand_len})",
+                    "hand-size discard: hand index {i} out of bounds (hand size {hand_len})",
                 )
                 .into(),
             };

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -857,8 +857,8 @@ fn park_hand_size_discard(cx: &mut Cx, remaining: Vec<InvestigatorId>) -> Engine
     EngineOutcome::AwaitingInput {
         request: InputRequest::prompt(format!(
             "Upkeep step 4.5: {next:?} has more than {HAND_SIZE_LIMIT} cards in hand; \
-             submit InputResponse::DiscardCards with the hand indices to discard down to \
-             {HAND_SIZE_LIMIT}.",
+             submit InputResponse::PickMultiple with the hand indices (as option ids) to \
+             discard down to {HAND_SIZE_LIMIT}.",
         )),
         resume_token: ResumeToken(0),
     }
@@ -894,14 +894,16 @@ pub(super) fn resume_hand_size_discard(cx: &mut Cx, response: &InputResponse) ->
     let pending = pending.clone();
     let current = pending.remaining[0];
 
-    let InputResponse::DiscardCards { indices } = response else {
+    let InputResponse::PickMultiple { selected } = response else {
         return EngineOutcome::Rejected {
             reason: format!(
-                "ResolveInput: hand-size discard expects InputResponse::DiscardCards, got {response:?}",
+                "ResolveInput: hand-size discard expects InputResponse::PickMultiple, got {response:?}",
             )
             .into(),
         };
     };
+    // Each OptionId is a hand index.
+    let indices: Vec<u32> = selected.iter().map(|o| o.0).collect();
 
     // ---- validate (state untouched on any failure) ----
     let inv = cx.state.investigators.get(&current).unwrap_or_else(|| {
@@ -920,7 +922,7 @@ pub(super) fn resume_hand_size_discard(cx: &mut Cx, response: &InputResponse) ->
         };
     }
     let mut seen = std::collections::BTreeSet::new();
-    for &i in indices {
+    for &i in &indices {
         if !seen.insert(i) {
             return EngineOutcome::Rejected {
                 reason: format!("ResolveInput::DiscardCards: duplicate hand index {i}").into(),
@@ -2339,7 +2341,7 @@ mod upkeep_phase_tests {
                 state: &mut state,
                 events: &mut events,
             },
-            &InputResponse::DiscardCards { indices: vec![] },
+            &InputResponse::PickMultiple { selected: vec![] },
         );
         assert!(matches!(out, EngineOutcome::Rejected { .. }));
         assert!(
@@ -3138,6 +3140,7 @@ mod enemy_phase_tests {
 mod hand_size_tests {
     use super::*;
     use crate::assert_no_event;
+    use crate::engine::OptionId;
     use crate::state::{CardCode, InvestigatorId};
     use crate::test_support::{test_investigator, GameStateBuilder};
 
@@ -3276,8 +3279,8 @@ mod hand_size_tests {
                 state: &mut state,
                 events: &mut events,
             },
-            &InputResponse::DiscardCards {
-                indices: vec![0, 1],
+            &InputResponse::PickMultiple {
+                selected: vec![OptionId(0), OptionId(1)],
             },
         );
 
@@ -3334,7 +3337,9 @@ mod hand_size_tests {
                 state: &mut state,
                 events: &mut events,
             },
-            &InputResponse::DiscardCards { indices: vec![0] },
+            &InputResponse::PickMultiple {
+                selected: vec![OptionId(0)],
+            },
         );
 
         assert!(matches!(outcome, EngineOutcome::Rejected { .. }));
@@ -3378,8 +3383,8 @@ mod hand_size_tests {
                 state: &mut s1,
                 events: &mut e1,
             },
-            &InputResponse::DiscardCards {
-                indices: vec![0, 0],
+            &InputResponse::PickMultiple {
+                selected: vec![OptionId(0), OptionId(0)],
             },
         );
         assert!(matches!(o1, EngineOutcome::Rejected { .. }));
@@ -3393,8 +3398,8 @@ mod hand_size_tests {
                 state: &mut s2,
                 events: &mut e2,
             },
-            &InputResponse::DiscardCards {
-                indices: vec![0, 99],
+            &InputResponse::PickMultiple {
+                selected: vec![OptionId(0), OptionId(99)],
             },
         );
         assert!(matches!(o2, EngineOutcome::Rejected { .. }));
@@ -3426,7 +3431,9 @@ mod hand_size_tests {
                 state: &mut state,
                 events: &mut events,
             },
-            &InputResponse::DiscardCards { indices: vec![0] },
+            &InputResponse::PickMultiple {
+                selected: vec![OptionId(0)],
+            },
         );
         assert!(matches!(o1, EngineOutcome::AwaitingInput { .. }));
         assert_eq!(

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -249,13 +249,13 @@ pub(super) fn finish_skill_test(cx: &mut Cx, indices: &[u32]) -> EngineOutcome {
     // later mutation paths can re-borrow state freely.
     let Some(in_flight) = cx.state.current_skill_test() else {
         return EngineOutcome::Rejected {
-            reason: "ResolveInput::CommitCards: no in-flight skill test to resume".into(),
+            reason: "skill-test commit: no in-flight skill test to resume".into(),
         };
     };
     if !matches!(in_flight.continuation, FinishContinuation::AwaitingCommit) {
         return EngineOutcome::Rejected {
             reason: format!(
-                "ResolveInput::CommitCards: commit window already closed (continuation {:?}); \
+                "skill-test commit: commit window already closed (continuation {:?}); \
                  the engine is mid-resolution, not at the commit step",
                 in_flight.continuation,
             )
@@ -509,13 +509,15 @@ fn validate_commit_indices(
     for &i in indices {
         if !seen.insert(i) {
             return Err(EngineOutcome::Rejected {
-                reason: format!("CommitCards: duplicate hand index {i}").into(),
+                reason: format!("skill-test commit: duplicate hand index {i}").into(),
             });
         }
         if (i as usize) >= hand_len {
             return Err(EngineOutcome::Rejected {
-                reason: format!("CommitCards: hand index {i} out of bounds (hand size {hand_len})")
-                    .into(),
+                reason: format!(
+                    "skill-test commit: hand index {i} out of bounds (hand size {hand_len})"
+                )
+                .into(),
             });
         }
         indices_u8.push(
@@ -543,7 +545,7 @@ fn validate_commit_indices(
                 if count > limit {
                     return Err(EngineOutcome::Rejected {
                         reason: format!(
-                            "CommitCards: {code} allows at most {limit} committed per skill \
+                            "skill-test commit: {code} allows at most {limit} committed per skill \
                              test, but {count} were committed"
                         )
                         .into(),

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -174,7 +174,8 @@ fn open_commit_window(cx: &mut Cx) -> EngineOutcome {
     EngineOutcome::AwaitingInput {
         request: InputRequest::prompt(format!(
             "Commit cards from hand for {investigator:?}'s {skill:?} skill test \
-             (difficulty {difficulty}). Empty indices commits no cards.",
+             (difficulty {difficulty}); submit InputResponse::PickMultiple with the \
+             hand indices as option ids. Empty selection commits no cards.",
         )),
         resume_token: ResumeToken(0),
     }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -270,7 +270,7 @@ mod tests {
     };
     use crate::{assert_event, assert_event_count, assert_no_event};
 
-    use super::{apply, EngineOutcome};
+    use super::{apply, EngineOutcome, OptionId};
 
     #[test]
     fn start_scenario_advances_to_investigation_with_round_one() {
@@ -4383,7 +4383,7 @@ mod tests {
         let resumed = apply(
             paused.state,
             Action::Player(PlayerAction::ResolveInput {
-                response: InputResponse::CommitCards { indices: vec![] },
+                response: InputResponse::PickMultiple { selected: vec![] },
             }),
         );
 
@@ -4441,7 +4441,7 @@ mod tests {
         let resumed = apply(
             paused.state,
             Action::Player(PlayerAction::ResolveInput {
-                response: InputResponse::CommitCards { indices: vec![] },
+                response: InputResponse::PickMultiple { selected: vec![] },
             }),
         );
         assert_eq!(resumed.outcome, EngineOutcome::Done);
@@ -4473,8 +4473,8 @@ mod tests {
                 skill: SkillKind::Intellect,
                 difficulty: 3,
             }),
-            InputResponse::CommitCards {
-                indices: vec![0, 1],
+            InputResponse::PickMultiple {
+                selected: vec![OptionId(0), OptionId(1)],
             },
         );
 
@@ -4536,7 +4536,9 @@ mod tests {
         let bad = apply(
             paused.state,
             Action::Player(PlayerAction::ResolveInput {
-                response: InputResponse::CommitCards { indices: vec![5] },
+                response: InputResponse::PickMultiple {
+                    selected: vec![OptionId(5)],
+                },
             }),
         );
         match bad.outcome {
@@ -4573,8 +4575,8 @@ mod tests {
         let bad = apply(
             paused.state,
             Action::Player(PlayerAction::ResolveInput {
-                response: InputResponse::CommitCards {
-                    indices: vec![0, 0],
+                response: InputResponse::PickMultiple {
+                    selected: vec![OptionId(0), OptionId(0)],
                 },
             }),
         );
@@ -4657,7 +4659,7 @@ mod tests {
         let result = apply(
             state,
             Action::Player(PlayerAction::ResolveInput {
-                response: InputResponse::CommitCards { indices: vec![] },
+                response: InputResponse::PickMultiple { selected: vec![] },
             }),
         );
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -509,7 +509,7 @@ mod tests {
         assert!(paused.state.has_skill_test_in_flight());
         let s1 = paused.state.clone();
 
-        // Malformed response: commit window expects CommitCards; send Skip.
+        // Malformed response: commit window expects PickMultiple; send Skip.
         let result = apply(
             paused.state,
             Action::Player(PlayerAction::ResolveInput {
@@ -4363,7 +4363,7 @@ mod tests {
 
     #[test]
     fn resolve_input_with_empty_commits_resumes_the_test() {
-        // Pause → resume with `CommitCards { indices: [] }` →
+        // Pause → resume with `PickMultiple { selected: [] }` →
         // ChaosTokenRevealed and the rest of resolution fire on the
         // second apply.
         let id = InvestigatorId(1);

--- a/crates/game-core/src/engine/outcome.rs
+++ b/crates/game-core/src/engine/outcome.rs
@@ -137,7 +137,7 @@ mod tests {
 
     #[test]
     fn prompt_only_request_has_no_options() {
-        let req = InputRequest::prompt("Submit PickIndex");
+        let req = InputRequest::prompt("Submit a response");
         assert!(req.options.is_empty());
     }
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -674,8 +674,8 @@ pub struct InFlightSkillTest {
 ///   skill-test start. No resume; the next dispatch step is the
 ///   commit-window
 ///   [`ResolveInput`](crate::action::PlayerAction::ResolveInput)
-///   with a [`CommitCards`](crate::action::InputResponse::CommitCards)
-///   response.
+///   with a [`PickMultiple`](crate::action::InputResponse::PickMultiple)
+///   response (each `OptionId` a hand index).
 /// - [`PostFollowUp`](Self::PostFollowUp) — set by the commit-stage
 ///   entry once steps 1–2 have run. The next driver iteration runs
 ///   step 3.

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -113,11 +113,6 @@ impl ScriptedResolver {
         self.push(InputResponse::Skip)
     }
 
-    /// Respond with [`InputResponse::PickIndex`].
-    pub fn pick(&mut self, index: u32) -> &mut Self {
-        self.push(InputResponse::PickIndex(index))
-    }
-
     /// Respond with [`InputResponse::PickSingle`] (the Axis-A choice contract).
     pub fn pick_single(&mut self, id: crate::engine::OptionId) -> &mut Self {
         self.push(InputResponse::PickSingle(id))
@@ -425,16 +420,14 @@ mod tests {
         let mut r = ScriptedResolver::new();
         r.confirm()
             .skip()
-            .pick(7)
             .pick_investigator(InvestigatorId(2))
             .pick_location(LocationId(99));
-        assert_eq!(r.remaining(), 5);
+        assert_eq!(r.remaining(), 4);
 
         let state = empty_state();
         let p = req("pick");
         assert_eq!(r.next(&p, &state), InputResponse::Confirm);
         assert_eq!(r.next(&p, &state), InputResponse::Skip);
-        assert_eq!(r.next(&p, &state), InputResponse::PickIndex(7));
         assert_eq!(
             r.next(&p, &state),
             InputResponse::PickInvestigator(InvestigatorId(2))

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -18,12 +18,12 @@
 //!
 //! The first (and currently only) `AwaitingInput` site is the skill-
 //! test commit window (#63). When the engine prompts, the active
-//! investigator must reply with [`InputResponse::CommitCards`].
-//! [`ScriptedResolver::commit_cards`] is the ergonomic helper: tests
-//! pass card codes, the resolver translates them to hand indices using
-//! [`GameState`] at resolve time.
+//! investigator must reply with [`InputResponse::PickMultiple`] (each
+//! `OptionId` a hand index). [`ScriptedResolver::commit_cards`] is the
+//! ergonomic helper: tests pass card codes, the resolver translates them to
+//! hand indices using [`GameState`] at resolve time.
 //!
-//! [`InputResponse::CommitCards`]: crate::action::InputResponse::CommitCards
+//! [`InputResponse::PickMultiple`]: crate::action::InputResponse::PickMultiple
 //!
 //! # Example
 //!
@@ -68,7 +68,7 @@ pub trait ChoiceResolver {
 /// Replayable [`ChoiceResolver`] backed by a FIFO of pre-recorded steps.
 ///
 /// Build the script with the fluent helpers ([`confirm`](Self::confirm),
-/// [`skip`](Self::skip), [`pick`](Self::pick),
+/// [`skip`](Self::skip), [`pick_single`](Self::pick_single),
 /// [`pick_investigator`](Self::pick_investigator),
 /// [`pick_location`](Self::pick_location),
 /// [`commit_cards`](Self::commit_cards)). When the engine prompts and the

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -162,8 +162,11 @@ impl ChoiceResolver for ScriptedResolver {
         });
         match step {
             ScriptedStep::Response(r) => r,
-            ScriptedStep::CommitCards(codes) => InputResponse::CommitCards {
-                indices: resolve_commit_codes(&codes, state, &request.prompt),
+            ScriptedStep::CommitCards(codes) => InputResponse::PickMultiple {
+                selected: resolve_commit_codes(&codes, state, &request.prompt)
+                    .into_iter()
+                    .map(crate::engine::OptionId)
+                    .collect(),
             },
         }
     }
@@ -403,7 +406,7 @@ impl TestSession {
 mod tests {
     use super::*;
     use crate::action::{Action, InputResponse, PlayerAction};
-    use crate::engine::{InputRequest, ResumeToken};
+    use crate::engine::{InputRequest, OptionId, ResumeToken};
     use crate::state::{CardCode, InvestigatorId, LocationId, Phase};
     use crate::test_support::{test_investigator, test_location, GameStateBuilder};
 
@@ -484,7 +487,7 @@ mod tests {
         // with the engine's "empty commits is the no-op" semantics.
         let state = empty_state();
         let response = r.next(&req("commit"), &state);
-        assert_eq!(response, InputResponse::CommitCards { indices: vec![] });
+        assert_eq!(response, InputResponse::PickMultiple { selected: vec![] });
     }
 
     #[test]
@@ -495,8 +498,8 @@ mod tests {
         let response = r.next(&req("commit"), &state);
         assert_eq!(
             response,
-            InputResponse::CommitCards {
-                indices: vec![0, 1],
+            InputResponse::PickMultiple {
+                selected: vec![OptionId(0), OptionId(1)]
             }
         );
     }
@@ -509,8 +512,8 @@ mod tests {
         let response = r.next(&req("commit"), &state);
         assert_eq!(
             response,
-            InputResponse::CommitCards {
-                indices: vec![1, 3],
+            InputResponse::PickMultiple {
+                selected: vec![OptionId(1), OptionId(3)]
             }
         );
     }

--- a/crates/game-core/tests/commit_attack_buff.rs
+++ b/crates/game-core/tests/commit_attack_buff.rs
@@ -14,7 +14,7 @@ use std::sync::OnceLock;
 
 use game_core::card_data::{CardKind, CardMetadata, Class, SkillIcons};
 use game_core::dsl::{boost_attack_damage, on_commit, Ability};
-use game_core::engine::EngineOutcome;
+use game_core::engine::{EngineOutcome, OptionId};
 use game_core::event::Event;
 use game_core::state::{
     CardCode, ChaosBag, ChaosToken, EnemyId, InvestigatorId, Phase, TokenModifiers,
@@ -126,7 +126,9 @@ fn committing_vicious_blow_adds_one_attack_damage() {
     let result = game_core::engine::apply(
         paused.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::CommitCards { indices: vec![0] },
+            response: InputResponse::PickMultiple {
+                selected: vec![OptionId(0)],
+            },
         }),
     );
 
@@ -146,7 +148,7 @@ fn fight_without_commit_deals_base_damage() {
     let result = game_core::engine::apply(
         paused.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::CommitCards { indices: vec![] },
+            response: InputResponse::PickMultiple { selected: vec![] },
         }),
     );
 

--- a/crates/game-core/tests/reaction_windows.rs
+++ b/crates/game-core/tests/reaction_windows.rs
@@ -20,7 +20,7 @@ use game_core::dsl::{
     discover_clue, gain_resources, reaction_on_event, Ability, EventPattern, EventTiming,
     InvestigatorTarget, LocationTarget,
 };
-use game_core::engine::EngineOutcome;
+use game_core::engine::{EngineOutcome, OptionId};
 use game_core::event::Event;
 use game_core::state::{
     CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, EnemyId, FastActorScope,
@@ -183,7 +183,7 @@ fn fight_through_commit_window(state: game_core::GameState, action: Action) -> D
     let after = game_core::engine::apply(
         paused.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::CommitCards { indices: vec![] },
+            response: InputResponse::PickMultiple { selected: vec![] },
         }),
     );
     events.extend(after.events);
@@ -714,7 +714,9 @@ fn reaction_window_closes_before_on_skill_test_resolution_fires() {
     let paused_reaction = game_core::engine::apply(
         paused_commit.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::CommitCards { indices: vec![0] },
+            response: InputResponse::PickMultiple {
+                selected: vec![OptionId(0)],
+            },
         }),
     );
     assert!(
@@ -1134,7 +1136,7 @@ fn investigate_to_success_scenario(
 
 fn commit_nothing() -> Action {
     Action::Player(PlayerAction::ResolveInput {
-        response: InputResponse::CommitCards { indices: vec![] },
+        response: InputResponse::PickMultiple { selected: vec![] },
     })
 }
 

--- a/crates/scenarios/tests/closing_demo.rs
+++ b/crates/scenarios/tests/closing_demo.rs
@@ -101,7 +101,7 @@ fn won_walk_full_cycle_replays_identically() {
     // 1.4 -> DrawEncounterCard finishes Mythos -> round 2 Investigate
     // (4th clue, +commit) -> AdvanceAct x2 (act 0 -> 1 -> Won).
     let commit_nothing = Action::Player(PlayerAction::ResolveInput {
-        response: InputResponse::CommitCards { indices: vec![] },
+        response: InputResponse::PickMultiple { selected: vec![] },
     });
     let log = vec![
         Action::Player(PlayerAction::StartScenario { roster: vec![] }),

--- a/crates/scenarios/tests/closing_demo.rs
+++ b/crates/scenarios/tests/closing_demo.rs
@@ -44,7 +44,7 @@ fn apply_checked(state: GameState, action: &Action) -> (GameState, Vec<Event>) {
 }
 
 /// Apply `actions` in order from `initial`, concatenating all emitted
-/// events. The log includes explicit `ResolveInput { CommitCards }` steps
+/// events. The log includes explicit `ResolveInput { PickMultiple }` steps
 /// for each skill-test commit window. Each action is run through
 /// [`apply_checked`], so a `Rejected` step fails loudly.
 fn drive(mut state: GameState, actions: &[Action]) -> (GameState, Vec<Event>) {
@@ -96,7 +96,7 @@ fn won_walk_full_cycle_replays_identically() {
     let make_initial = scenarios::test_fixtures::synthetic::setup;
 
     // Round 1 (Mythos skipped): Investigate x3 (each followed by a
-    // CommitCards round-trip for the skill-test commit window) ->
+    // PickMultiple round-trip for the skill-test commit window) ->
     // EndTurn cascades through Enemy/Upkeep -> pauses at round-2 Mythos
     // 1.4 -> DrawEncounterCard finishes Mythos -> round 2 Investigate
     // (4th clue, +commit) -> AdvanceAct x2 (act 0 -> 1 -> Won).

--- a/crates/scenarios/tests/cover_up_interrupt.rs
+++ b/crates/scenarios/tests/cover_up_interrupt.rs
@@ -74,7 +74,7 @@ fn investigate_to_interrupt(state: GameState) -> (GameState, EngineOutcome) {
     let r = apply(
         r.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::CommitCards { indices: vec![] },
+            response: InputResponse::PickMultiple { selected: vec![] },
         }),
     );
     (r.state, r.outcome)

--- a/crates/scenarios/tests/the_gathering_resolutions.rs
+++ b/crates/scenarios/tests/the_gathering_resolutions.rs
@@ -227,7 +227,7 @@ fn act_progression_and_ghoul_priest_defeat_latches_won() {
     let result = apply(
         paused.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::CommitCards { indices: vec![] },
+            response: InputResponse::PickMultiple { selected: vec![] },
         }),
     );
 

--- a/crates/scenarios/tests/upkeep_hand_size.rs
+++ b/crates/scenarios/tests/upkeep_hand_size.rs
@@ -4,7 +4,7 @@
 //! `EndTurn`, padding the sole investigator's hand so that — after the
 //! step-4.4 draw — they hold more than the cap at step 4.5. The
 //! round-ending `EndTurn` must cascade into upkeep and pause with
-//! `AwaitingInput`; resolving the prompt with `DiscardCards` must land
+//! `AwaitingInput`; resolving the prompt with `PickMultiple` must land
 //! the hand at exactly the cap and let the round proceed.
 //!
 //! Lives in `crates/scenarios/tests/` for the same process-isolation /
@@ -115,7 +115,7 @@ fn upkeep_prompts_and_discards_down_to_eight() {
         "hand ({hand_at_check}) must be over the cap at 4.5"
     );
 
-    // Act 2: submit DiscardCards with exactly (hand_len - cap) indices.
+    // Act 2: submit PickMultiple with exactly (hand_len - cap) indices.
     let discard_count = hand_at_check - HAND_SIZE_LIMIT;
     let indices: Vec<u32> = (0..u32::try_from(discard_count).unwrap()).collect();
     let r4 = apply(
@@ -235,7 +235,7 @@ fn upkeep_hand_size_discard_replay_is_deterministic() {
     };
 
     // Replaying the same action sequence from the same initial state must
-    // reproduce identical state bit-for-bit — the DiscardCards path is
+    // reproduce identical state bit-for-bit — the PickMultiple discard path is
     // deterministic and must not drift between runs.
     assert_eq!(
         final_state, replayed_state,

--- a/crates/scenarios/tests/upkeep_hand_size.rs
+++ b/crates/scenarios/tests/upkeep_hand_size.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Once;
 
-use game_core::engine::{apply, EngineOutcome};
+use game_core::engine::{apply, EngineOutcome, OptionId};
 use game_core::state::{CardCode, InvestigatorId, Phase};
 use game_core::{Action, InputResponse, PlayerAction};
 use scenarios::test_fixtures::synth_cards::TEST_REGISTRY;
@@ -33,6 +33,7 @@ fn install_test_registry() {
 const HAND_SIZE_LIMIT: usize = 8;
 
 #[test]
+#[allow(clippy::too_many_lines)] // end-to-end upkeep walkthrough; length is inherent
 fn upkeep_prompts_and_discards_down_to_eight() {
     install_test_registry();
 
@@ -120,7 +121,9 @@ fn upkeep_prompts_and_discards_down_to_eight() {
     let r4 = apply(
         r3.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::DiscardCards { indices },
+            response: InputResponse::PickMultiple {
+                selected: indices.into_iter().map(OptionId).collect(),
+            },
         }),
     );
 
@@ -205,8 +208,8 @@ fn upkeep_hand_size_discard_replay_is_deterministic() {
         }),
         Action::Player(PlayerAction::EndTurn),
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::DiscardCards {
-                indices: indices.clone(),
+            response: InputResponse::PickMultiple {
+                selected: indices.iter().copied().map(OptionId).collect(),
             },
         }),
     ];

--- a/crates/server/tests/closing_demo.rs
+++ b/crates/server/tests/closing_demo.rs
@@ -105,7 +105,7 @@ async fn phase_5_closing_demo() {
     send(
         &mut actor,
         &submit(PlayerAction::ResolveInput {
-            response: InputResponse::CommitCards { indices: vec![] },
+            response: InputResponse::PickMultiple { selected: vec![] },
         }),
     )
     .await;

--- a/crates/server/tests/resume.rs
+++ b/crates/server/tests/resume.rs
@@ -110,7 +110,7 @@ async fn resolve_input_resumes_and_completes() {
         &mut a,
         &ClientMessage::Submit {
             action: PlayerAction::ResolveInput {
-                response: InputResponse::CommitCards { indices: vec![] },
+                response: InputResponse::PickMultiple { selected: vec![] },
             },
         },
     )

--- a/crates/web/src/input.rs
+++ b/crates/web/src/input.rs
@@ -1,13 +1,13 @@
 //! `AwaitingInput` resolution UI (P6.6, wasm-only). Renders the engine's
 //! pending prompt and a control to resolve it. Phase-6 scope is the
-//! skill-test commit window (`CommitCards`); other `InputResponse`
+//! skill-test commit window (`PickMultiple`); other `InputResponse`
 //! variants are deferred (spec S1, follow-up #205). Nothing renders when
 //! the latest outcome is not `AwaitingInput`.
 
 use std::collections::BTreeSet;
 
 use game_core::state::GameState;
-use game_core::{EngineOutcome, InputResponse, PlayerAction};
+use game_core::{EngineOutcome, InputResponse, OptionId, PlayerAction};
 use leptos::prelude::*;
 use protocol::ClientMessage;
 
@@ -63,11 +63,14 @@ pub fn AwaitingInputView() -> impl IntoView {
 
             let tx = tx.clone();
             let on_commit = move |_| {
-                let indices: Vec<u32> = selected.get().into_iter().collect();
+                let selected_ids: Vec<OptionId> =
+                    selected.get().into_iter().map(OptionId).collect();
                 if let Some(tx) = tx.clone() {
                     let _ = tx.unbounded_send(ClientMessage::Submit {
                         action: PlayerAction::ResolveInput {
-                            response: InputResponse::CommitCards { indices },
+                            response: InputResponse::PickMultiple {
+                                selected: selected_ids,
+                            },
                         },
                     });
                 }

--- a/crates/web/tests/input.rs
+++ b/crates/web/tests/input.rs
@@ -83,11 +83,11 @@ fn commit_indices(frame: ClientMessage) -> Vec<u32> {
         ClientMessage::Submit {
             action:
                 PlayerAction::ResolveInput {
-                    response: InputResponse::CommitCards { indices },
+                    response: InputResponse::PickMultiple { selected },
                 },
-        } => indices,
+        } => selected.into_iter().map(|o| o.0).collect(),
         other @ ClientMessage::Submit { .. } => {
-            panic!("expected ResolveInput/CommitCards, got {other:?}")
+            panic!("expected ResolveInput/PickMultiple, got {other:?}")
         }
     }
 }

--- a/docs/superpowers/plans/2026-06-19-pr2c-i-pickmultiple-consolidation.md
+++ b/docs/superpowers/plans/2026-06-19-pr2c-i-pickmultiple-consolidation.md
@@ -1,0 +1,222 @@
+# PR 2c-i (#348, part 3a) — `PickMultiple` consolidation + delete vestigial `PickIndex` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce the umbrella's `InputResponse::PickMultiple { selected: Vec<OptionId> }` and fold the legacy `CommitCards { indices }` / `DiscardCards { indices }` into it, and delete the vestigial `PickIndex` — moving `InputResponse` toward its standard `PickSingle · PickMultiple · Skip · Confirm` shape.
+
+**Architecture:** A wire-format change scoped to the *variant taxonomy*. `OptionId` wraps the hand index for these windows (so `selected: Vec<OptionId>` is the former `indices: Vec<u32>`); the commit/discard resume handlers read the ids back as indices; min/exact-count constraints stay where they already are (computed in the resume handlers / carried on the frame), **not** on the variant. Populating the *offered options* on the request (hand-as-`ChoiceOption`s, for client rendering) is **out of scope — deferred to #205**.
+
+**Tech Stack:** Rust — `game-core` (engine + `test_support`), `web` (client builds `CommitCards`), scenario/integration tests.
+
+This is **PR 2c-i**, the first of the reshaped-2c normalization (2c-i `PickMultiple`; 2c-ii `PickSingle` consolidation; 2c-iii action fold). Umbrella §3 (the standard `InputResponse` shape); spec: `docs/superpowers/specs/2026-06-19-continuation-stack-cleanup-design.md`. Series: #345 ✅ → #348 (2a ✅ · 2b ✅ · **2c-i/ii/iii**) → #347 → #380.
+
+## Global Constraints
+
+- **CI gauntlet, warnings-as-errors** (all before pushing): `RUSTFLAGS="-D warnings" cargo test --all --all-features`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo fmt --check`; `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`; `cargo build -p web --target wasm32-unknown-unknown`; `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`.
+- **No behavior change.** `OptionId(i)` for a commit/discard window means hand index `i`, exactly the old `indices` semantics; validation logic (count, duplicates, bounds, icon-sum) is unchanged — only the *carrier* changes.
+- **Wire/replay-contract change.** `CommitCards`/`DiscardCards`/`PickIndex` leave the serialized `InputResponse`; old action logs with them won't replay. Acceptable pre-1.0 (already flagged spec-wide).
+- **Branch:** `engine/input-pickmultiple` off fresh `main`. Commit per task; push only when the full gauntlet is green.
+
+## Surface (surveyed)
+
+- `CommitCards` — 37 sites: produced at `web/src/input.rs:70` + many tests; consumed in `resume_skill_test_commit` (`skill_test.rs`).
+- `DiscardCards` — 15 sites: consumed in `resume_hand_size_discard` (`phases.rs:897`) + tests; the prompt string at `phases.rs:860` names it.
+- `PickIndex` — 3 sites, **all test infra** (`outcome.rs:140` test prompt, `test_support/resolver.rs:116/118/437`). No production consumer → delete.
+
+---
+
+### Task 1: Add `PickMultiple`; delete `PickIndex`
+
+**Files:**
+- Modify: `crates/game-core/src/action.rs` (`InputResponse`: add `PickMultiple`, remove `PickIndex`; serde round-trip test)
+- Modify: `crates/game-core/src/test_support/resolver.rs` (drop the `PickIndex` helper + its test); `crates/game-core/src/engine/outcome.rs:140` (test prompt string)
+
+**Interfaces:**
+- Produces: `InputResponse::PickMultiple { selected: Vec<crate::engine::OptionId> }`. Removes `InputResponse::PickIndex(u32)`.
+
+- [ ] **Step 1: Add the variant + remove `PickIndex`**
+
+In `crates/game-core/src/action.rs` `enum InputResponse`, add:
+
+```rust
+    /// Select a subset of the offered options, echoing back their
+    /// [`OptionId`](crate::engine::OptionId)s (umbrella §3). The multi-selection
+    /// family — commit windows and the upkeep hand-size discard fold into this;
+    /// min/exact-count constraints live on the request/frame, not here. For
+    /// those windows an `OptionId(i)` denotes hand index `i`.
+    PickMultiple {
+        /// The chosen option ids (hand indices, for commit/discard windows).
+        selected: Vec<crate::engine::OptionId>,
+    },
+```
+
+Delete the `PickIndex(u32)` variant and its doc-comment.
+
+- [ ] **Step 2: Fix the `PickIndex` test-infra references**
+
+- `crates/game-core/src/test_support/resolver.rs`: delete the `pick_index` helper (around `:116-118`) and the `PickIndex(7)` assertion test (around `:437`).
+- `crates/game-core/src/engine/outcome.rs:140`: the test prompt string `"Submit PickIndex"` → `"Submit PickSingle"` (or delete if the test is `PickIndex`-specific — read it; if it only exercises `InputRequest::prompt`, just reword).
+
+- [ ] **Step 3: serde round-trip test for `PickMultiple`**
+
+Add to the `input_response_tests` mod in `action.rs` (mirror the existing `discard_cards_input_serde_roundtrip`):
+
+```rust
+#[test]
+fn pick_multiple_input_serde_roundtrip() {
+    use crate::engine::OptionId;
+    let original = InputResponse::PickMultiple {
+        selected: vec![OptionId(0), OptionId(3)],
+    };
+    let json = serde_json::to_string(&original).expect("serialize");
+    let back: InputResponse = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back, original);
+}
+```
+
+- [ ] **Step 4: Build + test + lint**
+
+Run: `cargo build -p game-core --all-targets` (expect errors only at the now-removed `PickIndex` sites if any were missed); then `RUSTFLAGS="-D warnings" cargo test -p game-core`; `cargo clippy --all-targets --all-features -- -D warnings && cargo fmt --check`.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "engine: add InputResponse::PickMultiple; delete vestigial PickIndex (#348)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Fold `CommitCards` into `PickMultiple` (skill-test commit window)
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/skill_test.rs` (`resume_skill_test_commit` reads `PickMultiple` instead of `CommitCards`; the commit-window prompt string)
+- Modify: `crates/web/src/input.rs:70` (client builds `PickMultiple` instead of `CommitCards`)
+- Modify: all test sites constructing `InputResponse::CommitCards { indices }`
+
+**Interfaces:**
+- Consumes: `InputResponse::PickMultiple` (Task 1).
+
+- [ ] **Step 1: Migrate the resume handler**
+
+In `resume_skill_test_commit` (`skill_test.rs`), replace the `let InputResponse::CommitCards { indices } = response else { … }` destructure with:
+
+```rust
+    let InputResponse::PickMultiple { selected } = response else {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "ResolveInput: skill-test commit expects InputResponse::PickMultiple, got {response:?}",
+            )
+            .into(),
+        };
+    };
+    // For the commit window, each OptionId is a hand index.
+    let indices: Vec<u32> = selected.iter().map(|o| o.0).collect();
+```
+
+Leave the downstream index validation (icon-sum, bounds) untouched — it consumes `indices` exactly as before.
+
+- [ ] **Step 2: Migrate the client**
+
+In `crates/web/src/input.rs:70`, build `InputResponse::PickMultiple { selected: indices.into_iter().map(OptionId).collect() }` instead of `CommitCards { indices }` (import `OptionId`). Read the surrounding code first — adapt the variable that held `indices` (it's `Vec<u32>` from the UI; wrap each in `OptionId`).
+
+- [ ] **Step 3: Migrate the test sites**
+
+Mechanical transform at every `InputResponse::CommitCards { indices: vec![a, b, …] }` (game-core unit tests, `test_support`, scenario/integration tests):
+
+```rust
+// before
+InputResponse::CommitCards { indices: vec![0, 2] }
+// after
+InputResponse::PickMultiple { selected: vec![OptionId(0), OptionId(2)] }
+```
+
+Enumerate with `grep -rn "InputResponse::CommitCards" crates --include=*.rs`. Where a `test_support` resolver helper wraps commit (e.g. `commit_cards(indices)`), update the helper body once and callers stay unchanged. Use the right path for `OptionId` per crate (`crate::engine::OptionId` internally, `game_core::engine::OptionId` in integration tests — match each file's existing imports).
+
+- [ ] **Step 4: Update the commit-window prompt string**
+
+In `open_commit_window` (`skill_test.rs`), the prompt mentions `CommitCards`; reword to `PickMultiple` (hand indices as option ids).
+
+- [ ] **Step 5: Gauntlet**
+
+`RUSTFLAGS="-D warnings" cargo test --all --all-features`; clippy; fmt; `cargo build -p web --target wasm32-unknown-unknown`; `cargo clippy -p web …`. Expected: PASS — every skill-test / commit test green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "engine: fold CommitCards into PickMultiple (#348)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Fold `DiscardCards` into `PickMultiple` (hand-size discard)
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/phases.rs` (`resume_hand_size_discard` reads `PickMultiple`; the discard prompt at `:860`)
+- Modify: all test sites constructing `InputResponse::DiscardCards { indices }` (game-core `phases.rs` tests; `crates/scenarios/tests/upkeep_hand_size.rs`)
+- Modify: `crates/web/src/*` only if it builds `DiscardCards` (grep to confirm; the survey showed the client builds `CommitCards` but check for `DiscardCards`)
+
+**Interfaces:**
+- Consumes: `InputResponse::PickMultiple` (Task 1).
+
+- [ ] **Step 1: Migrate the resume handler**
+
+In `resume_hand_size_discard` (`phases.rs:897`), replace the `InputResponse::DiscardCards { indices }` destructure with the `PickMultiple { selected }` form + `let indices: Vec<u32> = selected.iter().map(|o| o.0).collect();` (mirror Task 2 Step 1; message names hand-size discard). Downstream count/duplicate/bounds validation is unchanged.
+
+- [ ] **Step 2: Update the discard prompt string** (`phases.rs:860`) — `DiscardCards` → `PickMultiple`.
+
+- [ ] **Step 3: Migrate the test sites** — same mechanical transform as Task 2 Step 3, for `InputResponse::DiscardCards { indices: … }` → `PickMultiple { selected: … }`. Enumerate with `grep -rn "InputResponse::DiscardCards" crates --include=*.rs`. Includes `crates/scenarios/tests/upkeep_hand_size.rs` (game_core:: path).
+
+- [ ] **Step 4: Gauntlet** — full six commands. Expected: PASS (the #111 hand-size suite green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "engine: fold DiscardCards into PickMultiple (#348)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Remove the `CommitCards` / `DiscardCards` variants
+
+**Files:** `crates/game-core/src/action.rs` (remove both variants + their doc-comments + the `discard_cards_input_serde_roundtrip` test, or repoint it to `PickMultiple`).
+
+- [ ] **Step 1: Remove the variants**
+
+Delete `CommitCards { indices }` and `DiscardCards { indices }` from `InputResponse`. The existing `discard_cards_input_serde_roundtrip` test (`action.rs:433`) now references a removed variant — delete it (Task 1's `pick_multiple_input_serde_roundtrip` covers the multi-select serde).
+
+- [ ] **Step 2: Compile — confirm nothing still constructs them**
+
+`cargo build -p game-core --all-targets` then `cargo build -p web --target wasm32-unknown-unknown`. Any error is a missed Task-2/3 site; fix it (→ `PickMultiple`).
+
+- [ ] **Step 3: Full gauntlet** — all six. Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "engine: remove CommitCards/DiscardCards (folded into PickMultiple) (#348)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec/umbrella coverage:** `PickMultiple { Vec<OptionId> }` added (Task 1) and the two legacy index-variants folded (Tasks 2–4); `PickIndex` deleted (Task 1); constraints stay on the frame/handler (no variant change). Offered-options population explicitly deferred to #205 (stated in Architecture). ✓
+
+**Placeholder scan:** the client step (Task 2 Step 2) says "read the surrounding code first" because the exact UI variable wiring isn't surveyed line-by-line — the transform (wrap `Vec<u32>` indices in `OptionId`) is concrete. Mechanical test migrations give one worked example + the enumerating grep (DRY, as in 2a/2b).
+
+**Type consistency:** `PickMultiple { selected: Vec<OptionId> }` field name `selected` is used identically in the resume handlers (Tasks 2–3), the client (Task 2), and tests (Tasks 2–3). `OptionId(i).0` (the `u32`) is the hand index throughout.
+
+**Out of scope (later sub-PRs):** `PickSingle` consolidation of `PickLocation`/`PickInvestigator` (2c-ii); `Mulligan`/`DrawEncounterCard` action fold + mulligan/mythos cursors (2c-iii); offered-options population (#205); tokens (#347); revelation disposal (#380).


### PR DESCRIPTION
## Summary

**Part 3a of the #348 split** — first of the umbrella's `InputResponse` taxonomy normalization (§3 of the trigger-dispatch umbrella). Adds `InputResponse::PickMultiple { selected: Vec<OptionId> }`, folds the legacy `CommitCards`/`DiscardCards` index-variants into it, and deletes the vestigial `PickIndex`.

Series: #345 ✅ → #348 (2a ✅ · 2b ✅ · **2c-i** · 2c-ii · 2c-iii) → #347 → #380.

## What changed

Four commits:
1. Add `PickMultiple { selected: Vec<OptionId> }`; delete `PickIndex` (was only referenced by test infra).
2. Fold `CommitCards` → `PickMultiple` (skill-test commit window): `resume_skill_test_commit` + web client + ~13 test sites.
3. Fold `DiscardCards` → `PickMultiple` (upkeep hand-size discard): `resume_hand_size_discard` + tests.
4. Remove the `CommitCards`/`DiscardCards` variants.

For these two windows an `OptionId(i)` denotes hand index `i`, so `selected` is the former `indices`; resume handlers map back to `Vec<u32>` and feed the **unchanged** validation (count / duplicate / bounds / icon-sum). Populating the request's offered-options (hand-as-`ChoiceOption`s for client rendering) is **deferred to #205**.

End state: `InputResponse = PickSingle · PickMultiple · Skip · Confirm` + the still-present `PickLocation`/`PickInvestigator` (consolidated into `PickSingle` in 2c-ii).

## Test notes

- No behavior change — `OptionId(i)` == old hand index `i`; validation byte-for-byte unchanged.
- Wire/replay-contract change (the three removed variants leave the serialized enum) — acceptable pre-1.0, flagged spec-wide.
- Full gauntlet green locally: test / clippy / fmt / doc / wasm-build / wasm-clippy.
- Pre-push review: **ready to merge**, no Critical/Important; the stale error-string/comment names it flagged are folded in.

## Linked issues

Part of #348 (does not close it — 2c-ii/iii follow).