### PR TITLE
engine: fold PickLocation/PickInvestigator into PickSingle via structured options (#348 part 3b)

### DIFF
--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -367,9 +367,9 @@ pub enum InputResponse {
     /// Pick one option from a structured choice prompt
     /// ([`InputRequest::choice`](crate::engine::InputRequest::choice)),
     /// echoing back its [`OptionId`](crate::engine::OptionId). The
-    /// single-selection family (umbrella §3); [`PickLocation`](Self::PickLocation)
-    /// / [`PickInvestigator`](Self::PickInvestigator) consolidate into it in a
-    /// follow-up (2c-ii).
+    /// single-selection family (umbrella §3): the Axis-A choice machinery, and
+    /// the location/investigator-pick windows (hunter move/engage, spawn engage)
+    /// whose offered options index the candidate list.
     PickSingle(crate::engine::OptionId),
     /// Select a subset of the offered options, echoing back their
     /// [`OptionId`](crate::engine::OptionId)s (umbrella §3). The multi-selection
@@ -380,10 +380,6 @@ pub enum InputResponse {
         /// The chosen option ids (hand indices, for commit/discard windows).
         selected: Vec<crate::engine::OptionId>,
     },
-    /// Pick a specific investigator.
-    PickInvestigator(InvestigatorId),
-    /// Pick a specific location.
-    PickLocation(LocationId),
 }
 
 #[cfg(test)]

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -271,7 +271,7 @@ pub fn resolve_encounter_card(
 /// sole/best candidate); `Tie` suspends via
 /// [`SpawnEngagePending`](crate::state::SpawnEngagePending) and returns
 /// [`EngineOutcome::AwaitingInput`] for the lead investigator's
-/// `PickInvestigator`. When the spawn happens inside a Mythos
+/// `PickSingle`. When the spawn happens inside a Mythos
 /// encounter-draw chain, [`resume_spawn_engage`] re-enters
 /// [`run_mythos_draw_chain`] after the pick resolves.
 ///
@@ -398,7 +398,7 @@ pub(super) fn spawn_enemy_at(
     // 2. Resolve engagement-on-spawn (validate-first). The co-located
     //    set is narrowed by the enemy's `prey`; with `Prey::Default` a 2+
     //    set ties and suspends for the lead investigator's
-    //    `PickInvestigator` (option A).
+    //    `PickSingle` (option A).
     let candidates = super::cursor::active_investigators_at(cx.state, location_id);
 
     // 3. Mint and place (mutate-second). The enemy is inserted unengaged;

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -472,10 +472,13 @@ pub(super) fn spawn_enemy_at(
                     },
                 ));
             EngineOutcome::AwaitingInput {
-                request: InputRequest::prompt(format!(
-                    "Enemy {enemy_id:?} spawn engagement: lead investigator picks whom to \
-                     engage among {tied:?} (submit InputResponse::PickInvestigator)"
-                )),
+                request: InputRequest::choice(
+                    format!(
+                        "Enemy {enemy_id:?} spawn engagement: lead investigator picks whom to \
+                         engage among {tied:?}"
+                    ),
+                    super::hunters::candidate_options(&tied),
+                ),
                 resume_token: ResumeToken(0),
             }
         }
@@ -1690,13 +1693,13 @@ mod spawn_enemy_tests {
             Some(crate::state::Continuation::SpawnEngage(_))
         ));
 
-        // Investigator 3 is not among the co-located candidates.
+        // Option id 99 is out of the co-located candidate range.
         let outcome = super::super::hunters::resume_spawn_engage(
             &mut Cx {
                 state: &mut state,
                 events: &mut events,
             },
-            &InputResponse::PickInvestigator(InvestigatorId(3)),
+            &InputResponse::PickSingle(crate::engine::OptionId(99)),
         );
         assert!(
             matches!(outcome, EngineOutcome::Rejected { .. }),

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -299,7 +299,7 @@ fn engage_on_arrival(cx: &mut Cx, enemy_id: EnemyId) -> Option<HunterChoice> {
 /// not engage until readied) or has no location. On a prey `Tie` this
 /// engages the lead (`tied[0]`, which is `turn_order`-first because
 /// `active_investigators_at` is turn-order-ordered) rather than
-/// suspending for the lead's `PickInvestigator` — keeping every defeat
+/// suspending for the lead's `PickSingle` — keeping every defeat
 /// caller synchronous. TODO(#151): make the multiplayer tie an
 /// interactive lead choice when multiplayer lands.
 ///
@@ -499,7 +499,7 @@ pub(super) fn resume_hunter_choice(
 }
 
 /// Resume a suspended engagement-on-spawn choice (#128, option A) with
-/// the lead investigator's `PickInvestigator`, then continue the drawing
+/// the lead investigator's `PickSingle`, then continue the drawing
 /// investigator's Mythos encounter-draw chain.
 ///
 /// Validate-first: an invalid pick (wrong response shape, or a target
@@ -1165,7 +1165,7 @@ mod hunter_resume_tests {
     #[test]
     fn hunter_engage_tie_suspends_then_resumes_on_pick_investigator() {
         // Two investigators at B; hunter moves A->B; default prey -> tie ->
-        // PickInvestigator.
+        // PickSingle.
         let mut a = test_location(1, "A");
         let mut b = test_location(2, "B");
         a.connections = vec![LocationId(2)];

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -12,7 +12,7 @@ use crate::state::{
 
 use super::cursor;
 use super::Cx;
-use crate::engine::outcome::{EngineOutcome, InputRequest, ResumeToken};
+use crate::engine::outcome::{ChoiceOption, EngineOutcome, InputRequest, OptionId, ResumeToken};
 
 /// Result of narrowing a candidate investigator set by a prey
 /// instruction (Rules Reference p.12 / p.17).
@@ -381,24 +381,44 @@ pub(crate) fn drive_hunter_moves(cx: &mut Cx) -> EngineOutcome {
     EngineOutcome::Done
 }
 
-/// Store the pending hunter choice and return `AwaitingInput` for the
-/// lead investigator (#128, Task 7 wires the resume path).
+/// Build the offered options for a candidate list: option `i` is
+/// `candidates[i]`, label = its debug repr (#205 will make these human).
+pub(super) fn candidate_options<T: std::fmt::Debug>(candidates: &[T]) -> Vec<ChoiceOption> {
+    candidates
+        .iter()
+        .enumerate()
+        .map(|(i, c)| ChoiceOption {
+            id: OptionId(u32::try_from(i).expect("candidate count fits u32")),
+            label: format!("{c:?}"),
+        })
+        .collect()
+}
+
+/// Store the pending hunter choice and return `AwaitingInput` for the lead
+/// investigator: the candidates ride the request as structured options, and the
+/// resume comes back as `PickSingle(OptionId)` indexing the candidate list (#348).
 fn suspend_hunter_choice(cx: &mut Cx, choice: HunterChoice) -> EngineOutcome {
-    let prompt = match &choice {
-        HunterChoice::Move { enemy, candidates } => format!(
-            "Hunter {enemy:?} movement: lead investigator picks a destination among \
-             {candidates:?} (submit InputResponse::PickLocation)"
+    let (prompt, options) = match &choice {
+        HunterChoice::Move { enemy, candidates } => (
+            format!(
+                "Hunter {enemy:?} movement: lead investigator picks a destination among \
+                 {candidates:?}"
+            ),
+            candidate_options(candidates),
         ),
-        HunterChoice::Engage { enemy, candidates } => format!(
-            "Hunter {enemy:?} engagement: lead investigator picks whom to engage among \
-             {candidates:?} (submit InputResponse::PickInvestigator)"
+        HunterChoice::Engage { enemy, candidates } => (
+            format!(
+                "Hunter {enemy:?} engagement: lead investigator picks whom to engage among \
+                 {candidates:?}"
+            ),
+            candidate_options(candidates),
         ),
     };
     cx.state
         .continuations
         .push(crate::state::Continuation::HunterMove(choice));
     EngineOutcome::AwaitingInput {
-        request: InputRequest::prompt(prompt),
+        request: InputRequest::choice(prompt, options),
         resume_token: ResumeToken(0),
     }
 }
@@ -417,22 +437,29 @@ pub(super) fn resume_hunter_choice(
         unreachable!("resume_hunter_choice: called with no HunterMove frame on top of the stack")
     };
     let pending = pending.clone();
-    let current_enemy = match (&pending, response) {
-        (
-            HunterChoice::Move { enemy, candidates },
-            crate::action::InputResponse::PickLocation(loc),
-        ) => {
-            if !candidates.contains(loc) {
+    let crate::action::InputResponse::PickSingle(crate::engine::OptionId(i)) = response else {
+        return EngineOutcome::Rejected {
+            reason: format!(
+                "ResolveInput: hunter choice expects InputResponse::PickSingle, got {response:?}"
+            )
+            .into(),
+        };
+    };
+    let i = *i as usize;
+    let current_enemy = match &pending {
+        HunterChoice::Move { enemy, candidates } => {
+            let Some(&loc) = candidates.get(i) else {
                 return EngineOutcome::Rejected {
                     reason: format!(
-                        "ResolveInput: hunter move destination {loc:?} not among candidates {candidates:?}"
+                        "ResolveInput: hunter move option {i} out of range (0..{})",
+                        candidates.len()
                     )
                     .into(),
                 };
-            }
+            };
             // Pop the HunterMove frame we validated against (it is the top frame).
             cx.state.continuations.pop();
-            move_hunter_to(cx, *enemy, *loc);
+            move_hunter_to(cx, *enemy, loc);
             // After the move, attempt engage-on-arrival; that itself may
             // suspend on an engagement tie.
             if let Some(choice) = engage_on_arrival(cx, *enemy) {
@@ -440,38 +467,20 @@ pub(super) fn resume_hunter_choice(
             }
             *enemy
         }
-        (
-            HunterChoice::Engage { enemy, candidates },
-            crate::action::InputResponse::PickInvestigator(who),
-        ) => {
-            if !candidates.contains(who) {
+        HunterChoice::Engage { enemy, candidates } => {
+            let Some(&who) = candidates.get(i) else {
                 return EngineOutcome::Rejected {
                     reason: format!(
-                        "ResolveInput: hunter engage target {who:?} not among candidates {candidates:?}"
+                        "ResolveInput: hunter engage option {i} out of range (0..{})",
+                        candidates.len()
                     )
                     .into(),
                 };
-            }
+            };
             // Pop the HunterMove frame we validated against (it is the top frame).
             cx.state.continuations.pop();
-            engage_enemy_with(cx, *enemy, *who);
+            engage_enemy_with(cx, *enemy, who);
             *enemy
-        }
-        (HunterChoice::Move { .. }, other) => {
-            return EngineOutcome::Rejected {
-                reason: format!(
-                    "ResolveInput: hunter movement expects InputResponse::PickLocation, got {other:?}"
-                )
-                .into(),
-            };
-        }
-        (HunterChoice::Engage { .. }, other) => {
-            return EngineOutcome::Rejected {
-                reason: format!(
-                    "ResolveInput: hunter engagement expects InputResponse::PickInvestigator, got {other:?}"
-                )
-                .into(),
-            };
         }
     };
     // Continue with the next eligible hunter after the one we finished.
@@ -510,27 +519,26 @@ pub(super) fn resume_spawn_engage(
         unreachable!("resume_spawn_engage: called with no SpawnEngage frame on top of the stack")
     };
     let pending = pending.clone();
-    let crate::action::InputResponse::PickInvestigator(who) = response else {
+    let crate::action::InputResponse::PickSingle(crate::engine::OptionId(i)) = response else {
         return EngineOutcome::Rejected {
             reason: format!(
-                "ResolveInput: spawn engagement expects InputResponse::PickInvestigator, \
-                 got {response:?}"
+                "ResolveInput: spawn engagement expects InputResponse::PickSingle, got {response:?}"
             )
             .into(),
         };
     };
-    if !pending.candidates.contains(who) {
+    let Some(&who) = pending.candidates.get(*i as usize) else {
         return EngineOutcome::Rejected {
             reason: format!(
-                "ResolveInput: spawn engage target {who:?} not among candidates {:?}",
-                pending.candidates
+                "ResolveInput: spawn engage option {i} out of range (0..{})",
+                pending.candidates.len()
             )
             .into(),
         };
-    }
+    };
     // Pop the SpawnEngage frame we validated against (it is the top frame).
     cx.state.continuations.pop();
-    engage_enemy_with(cx, pending.enemy, *who);
+    engage_enemy_with(cx, pending.enemy, who);
 
     // Only re-enter the Mythos surge chain if the suspend happened
     // mid-chain (the drawing investigator is still the pending cursor).
@@ -1023,6 +1031,27 @@ mod hunter_resume_tests {
     use crate::assert_event;
     use crate::engine::Cx;
     use crate::state::{EnemyId, InvestigatorId, LocationId, Phase};
+
+    /// Build the `PickSingle` response selecting the offered option whose label
+    /// is `format!("{target:?}")`, from a suspended `AwaitingInput`'s options.
+    /// Panics if no option matches (a test-setup error).
+    fn pick(outcome: &EngineOutcome, target: impl std::fmt::Debug) -> crate::action::InputResponse {
+        let crate::engine::EngineOutcome::AwaitingInput { request, .. } = outcome else {
+            panic!("expected AwaitingInput, got {outcome:?}");
+        };
+        let label = format!("{target:?}");
+        let opt = request
+            .options
+            .iter()
+            .find(|o| o.label == label)
+            .unwrap_or_else(|| {
+                panic!(
+                    "no offered option labeled {label:?} in {:?}",
+                    request.options
+                )
+            });
+        crate::action::InputResponse::PickSingle(opt.id)
+    }
     use crate::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
 
     #[test]
@@ -1069,7 +1098,7 @@ mod hunter_resume_tests {
                 state: &mut state,
                 events: &mut ev2,
             },
-            &crate::action::InputResponse::PickLocation(LocationId(3)),
+            &pick(&outcome, LocationId(3)),
         );
         assert_eq!(resumed, EngineOutcome::Done);
         assert_eq!(
@@ -1115,13 +1144,13 @@ mod hunter_resume_tests {
             events: &mut events,
         });
         let mut ev2 = Vec::new();
-        // LocationId(4) is the destination, not a first-step candidate.
+        // Option id 99 is out of the candidate range -> rejected.
         let result = super::super::resolve_input(
             &mut crate::engine::Cx {
                 state: &mut state,
                 events: &mut ev2,
             },
-            &crate::action::InputResponse::PickLocation(LocationId(4)),
+            &crate::action::InputResponse::PickSingle(crate::engine::OptionId(99)),
         );
         assert!(matches!(result, EngineOutcome::Rejected { .. }));
         assert!(
@@ -1174,7 +1203,7 @@ mod hunter_resume_tests {
                 state: &mut state,
                 events: &mut ev2,
             },
-            &crate::action::InputResponse::PickInvestigator(InvestigatorId(2)),
+            &pick(&outcome, InvestigatorId(2)),
         );
         assert_eq!(resumed, EngineOutcome::Done);
         assert_eq!(
@@ -1284,7 +1313,7 @@ mod hunter_resume_tests {
                 state: &mut state,
                 events: &mut ev2,
             },
-            &crate::action::InputResponse::PickLocation(LocationId(2)),
+            &pick(&outcome, LocationId(2)),
         );
         assert_eq!(resumed, EngineOutcome::Done);
         assert_eq!(
@@ -1301,7 +1330,7 @@ mod hunter_resume_tests {
     fn hunter_move_tie_rejects_wrong_response_kind() {
         // Diamond A(1)-{B(2),C(3)}-D(4). Investigator at D; hunter at A,
         // default prey. Two equal first-steps (B, C) -> AwaitingInput on Move.
-        // Client submits PickInvestigator instead of PickLocation -> Rejected,
+        // Client submits a non-PickSingle response (Skip) -> Rejected,
         // pending preserved for retry.
         let mut loc_a = test_location(1, "A");
         let mut loc_b = test_location(2, "B");
@@ -1336,14 +1365,14 @@ mod hunter_resume_tests {
             state.continuations.last(),
             Some(crate::state::Continuation::HunterMove(_))
         ));
-        // Submit PickInvestigator when PickLocation is expected.
+        // Submit a non-PickSingle response (Skip).
         let mut ev2 = Vec::new();
         let result = super::super::resolve_input(
             &mut crate::engine::Cx {
                 state: &mut state,
                 events: &mut ev2,
             },
-            &crate::action::InputResponse::PickInvestigator(InvestigatorId(1)),
+            &crate::action::InputResponse::Skip,
         );
         assert!(
             matches!(result, EngineOutcome::Rejected { .. }),
@@ -1354,7 +1383,7 @@ mod hunter_resume_tests {
                 state.continuations.last(),
                 Some(crate::state::Continuation::HunterMove(_))
             ),
-            "pending preserved so client can retry with PickLocation"
+            "pending preserved so client can retry with PickSingle"
         );
     }
 
@@ -1362,7 +1391,7 @@ mod hunter_resume_tests {
     fn hunter_engage_tie_rejects_wrong_response_kind() {
         // Two investigators at B(2); hunter moves A(1)->B(2); default prey
         // -> engage tie -> AwaitingInput on Engage.
-        // Client submits PickLocation instead of PickInvestigator -> Rejected,
+        // Client submits a non-PickSingle response (Skip) -> Rejected,
         // pending preserved for retry.
         let mut loc_a = test_location(1, "A");
         let mut loc_b = test_location(2, "B");
@@ -1399,14 +1428,14 @@ mod hunter_resume_tests {
             state.continuations.last(),
             Some(crate::state::Continuation::HunterMove(_))
         ));
-        // Submit PickLocation when PickInvestigator is expected.
+        // Submit a non-PickSingle response (Skip).
         let mut ev2 = Vec::new();
         let result = super::super::resolve_input(
             &mut crate::engine::Cx {
                 state: &mut state,
                 events: &mut ev2,
             },
-            &crate::action::InputResponse::PickLocation(LocationId(1)),
+            &crate::action::InputResponse::Skip,
         );
         assert!(
             matches!(result, EngineOutcome::Rejected { .. }),
@@ -1417,7 +1446,7 @@ mod hunter_resume_tests {
                 state.continuations.last(),
                 Some(crate::state::Continuation::HunterMove(_))
             ),
-            "pending preserved so client can retry with PickInvestigator"
+            "pending preserved so client can retry with PickSingle"
         );
     }
 }

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -121,8 +121,7 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
     {
         return EngineOutcome::Rejected {
             reason: "a hunter-movement choice is pending; submit a PlayerAction::ResolveInput \
-                     with InputResponse::PickLocation (movement) or \
-                     InputResponse::PickInvestigator (engagement) before any other action"
+                     with InputResponse::PickSingle (an offered option id) before any other action"
                 .into(),
         };
     }
@@ -137,8 +136,8 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
     {
         return EngineOutcome::Rejected {
             reason: "an engagement-on-spawn choice is pending; submit a \
-                     PlayerAction::ResolveInput with InputResponse::PickInvestigator \
-                     before any other action"
+                     PlayerAction::ResolveInput with InputResponse::PickSingle \
+                     (an offered option id) before any other action"
                 .into(),
         };
     }

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -2469,12 +2469,22 @@ mod enemy_phase_tests {
         assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
         assert_eq!(state.phase, Phase::Enemy);
         let mut ev2 = Vec::new();
+        // Pick LocationId(2) by its offered option id (candidates ride the request).
+        let crate::engine::EngineOutcome::AwaitingInput { request, .. } = &outcome else {
+            unreachable!("asserted AwaitingInput above");
+        };
+        let pick = request
+            .options
+            .iter()
+            .find(|o| o.label == format!("{:?}", LocationId(2)))
+            .expect("LocationId(2) among offered options")
+            .id;
         let resumed = resolve_input(
             &mut crate::engine::Cx {
                 state: &mut state,
                 events: &mut ev2,
             },
-            &InputResponse::PickLocation(LocationId(2)),
+            &InputResponse::PickSingle(pick),
         );
         assert_eq!(resumed, EngineOutcome::Done);
         assert_event!(ev2, Event::WindowOpened { kind } if *kind == WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked));

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -1098,10 +1098,10 @@ pub enum PhaseStep {
 /// p.17).
 ///
 /// Two shapes because the two choice points need different input:
-/// movement is a `PickLocation` over a prey-filtered destination set
+/// movement is a `PickSingle` over a prey-filtered destination set
 /// (the chosen prey doesn't persist, so picking a location is
 /// outcome-equivalent to picking an investigator-then-path); engagement
-/// on arrival is a `PickInvestigator` over the co-located set.
+/// on arrival is a `PickSingle` over the co-located set.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum HunterChoice {
@@ -1125,7 +1125,7 @@ pub enum HunterChoice {
 
 /// A suspended engagement-on-spawn choice (#128, option A): a
 /// multi-investigator spawn tie awaiting the lead investigator's
-/// `PickInvestigator`. `investigator_to_draw` is the drawing
+/// `PickSingle`. `investigator_to_draw` is the drawing
 /// investigator whose Mythos encounter-draw chain resumes once the
 /// engagement is chosen.
 ///

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -89,6 +89,12 @@ enum ScriptedStep {
     /// skill test. A by-`CardCode` convenience over the real index-based
     /// commit flow (resolves codes to hand indices at replay time).
     CommitCards(Vec<CardCode>),
+    /// Pick the offered option whose label matches this string, resolved to
+    /// `PickSingle(option.id)` at replay time. A by-id convenience for the
+    /// location/investigator-pick windows, whose options are labeled with the
+    /// candidate's debug repr (`pick_location` / `pick_investigator` store
+    /// `format!("{id:?}")`).
+    PickByLabel(String),
 }
 
 impl ScriptedResolver {
@@ -118,14 +124,22 @@ impl ScriptedResolver {
         self.push(InputResponse::PickSingle(id))
     }
 
-    /// Respond with [`InputResponse::PickInvestigator`].
+    /// Pick the investigator `id` from a structured-choice window by matching
+    /// the offered option labeled `format!("{id:?}")` at replay time, yielding
+    /// [`InputResponse::PickSingle`].
     pub fn pick_investigator(&mut self, id: InvestigatorId) -> &mut Self {
-        self.push(InputResponse::PickInvestigator(id))
+        self.steps
+            .push_back(ScriptedStep::PickByLabel(format!("{id:?}")));
+        self
     }
 
-    /// Respond with [`InputResponse::PickLocation`].
+    /// Pick the location `id` from a structured-choice window by matching the
+    /// offered option labeled `format!("{id:?}")` at replay time, yielding
+    /// [`InputResponse::PickSingle`].
     pub fn pick_location(&mut self, id: LocationId) -> &mut Self {
-        self.push(InputResponse::PickLocation(id))
+        self.steps
+            .push_back(ScriptedStep::PickByLabel(format!("{id:?}")));
+        self
     }
 
     /// Commit cards (by code) from the in-flight skill test's
@@ -168,6 +182,20 @@ impl ChoiceResolver for ScriptedResolver {
                     .map(crate::engine::OptionId)
                     .collect(),
             },
+            ScriptedStep::PickByLabel(label) => {
+                let opt = request
+                    .options
+                    .iter()
+                    .find(|o| o.label == label)
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "ScriptedResolver::pick_*: no offered option labeled {label:?}; \
+                         prompt {:?}, options {:?}",
+                            request.prompt, request.options,
+                        )
+                    });
+                InputResponse::PickSingle(opt.id)
+            }
         }
     }
 }
@@ -407,7 +435,7 @@ mod tests {
     use super::*;
     use crate::action::{Action, InputResponse, PlayerAction};
     use crate::engine::{InputRequest, OptionId, ResumeToken};
-    use crate::state::{CardCode, InvestigatorId, LocationId, Phase};
+    use crate::state::{CardCode, InvestigatorId, Phase};
     use crate::test_support::{test_investigator, test_location, GameStateBuilder};
 
     fn empty_state() -> GameState {
@@ -423,22 +451,16 @@ mod tests {
         let mut r = ScriptedResolver::new();
         r.confirm()
             .skip()
-            .pick_investigator(InvestigatorId(2))
-            .pick_location(LocationId(99));
+            .pick_single(OptionId(2))
+            .pick_single(OptionId(5));
         assert_eq!(r.remaining(), 4);
 
         let state = empty_state();
         let p = req("pick");
         assert_eq!(r.next(&p, &state), InputResponse::Confirm);
         assert_eq!(r.next(&p, &state), InputResponse::Skip);
-        assert_eq!(
-            r.next(&p, &state),
-            InputResponse::PickInvestigator(InvestigatorId(2))
-        );
-        assert_eq!(
-            r.next(&p, &state),
-            InputResponse::PickLocation(LocationId(99))
-        );
+        assert_eq!(r.next(&p, &state), InputResponse::PickSingle(OptionId(2)));
+        assert_eq!(r.next(&p, &state), InputResponse::PickSingle(OptionId(5)));
         assert_eq!(r.remaining(), 0);
     }
 

--- a/crates/scenarios/tests/encounter_spawn.rs
+++ b/crates/scenarios/tests/encounter_spawn.rs
@@ -12,7 +12,7 @@
 //!   does NOT appear in `encounter_discard`.
 //! - Multi-investigator suspend: two investigators at the spawn
 //!   location → the spawn suspends (`AwaitingInput`) for the lead
-//!   investigator's `PickInvestigator` (#128, option A), leaving the
+//!   investigator's `PickSingle` (#128, option A), leaving the
 //!   enemy in play but unengaged until the pick resolves.
 //!
 //! Default-spawn and location-not-in-play coverage lives in
@@ -143,7 +143,7 @@ fn revealing_synth_enemy_with_two_investigators_at_loc_suspends_for_lead_pick() 
 
     assert!(
         matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),
-        "multi-investigator spawn now suspends for the lead's PickInvestigator, got {:?}",
+        "multi-investigator spawn now suspends for the lead's PickSingle, got {:?}",
         result.outcome,
     );
     assert!(matches!(

--- a/crates/scenarios/tests/hunter_movement.rs
+++ b/crates/scenarios/tests/hunter_movement.rs
@@ -1,6 +1,6 @@
 //! #128 integration: spawn-engagement tie resolved through the real
 //! registry + Mythos draw path (option A), plus hunter-movement replay
-//! equality across a `PickLocation` round-trip.
+//! equality across a `PickSingle` round-trip.
 
 use std::sync::Once;
 
@@ -41,7 +41,7 @@ fn multi_investigator_spawn_engagement_resolves_via_lead_pick() {
         .encounter_deck
         .push_back(game_core::state::CardCode(SYNTH_ENEMY_CODE.into()));
 
-    // 1) Drawing the enemy suspends for the lead's PickInvestigator.
+    // 1) Drawing the enemy suspends for the lead's PickSingle.
     let r1 = apply(state, Action::Player(PlayerAction::DrawEncounterCard));
     assert!(
         matches!(r1.outcome, EngineOutcome::AwaitingInput { .. }),

--- a/crates/scenarios/tests/hunter_movement.rs
+++ b/crates/scenarios/tests/hunter_movement.rs
@@ -5,7 +5,7 @@
 use std::sync::Once;
 
 use game_core::action::{InputResponse, PlayerAction};
-use game_core::engine::{apply, EngineOutcome};
+use game_core::engine::{apply, EngineOutcome, OptionId};
 use game_core::state::{EnemyId, InvestigatorId, LocationId, Phase};
 use game_core::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
 use game_core::Action;
@@ -58,11 +58,23 @@ fn multi_investigator_spawn_engagement_resolves_via_lead_pick() {
     let spawned = r1.state.enemies.values().next().expect("enemy placed");
     assert_eq!(spawned.engaged_with, None, "engagement deferred until pick");
 
-    // 2) Lead picks investigator 2; engagement resolves, draw chain ends.
+    // 2) Lead picks investigator 2 (by its offered option id); engagement
+    //    resolves, draw chain ends.
+    let pick = {
+        let EngineOutcome::AwaitingInput { request, .. } = &r1.outcome else {
+            unreachable!("asserted AwaitingInput above");
+        };
+        request
+            .options
+            .iter()
+            .find(|o| o.label == format!("{:?}", InvestigatorId(2)))
+            .expect("InvestigatorId(2) among offered options")
+            .id
+    };
     let r2 = apply(
         r1.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickInvestigator(InvestigatorId(2)),
+            response: InputResponse::PickSingle(pick),
         }),
     );
     assert_eq!(r2.outcome, EngineOutcome::Done);
@@ -103,10 +115,12 @@ fn hunter_movement_pick_location_replays_identically() {
             .build()
     }
 
+    // Candidates are the sorted first-steps toward D: [LocationId(2), LocationId(3)],
+    // so LocationId(3) is offered option id 1.
     let actions = [
         Action::Player(PlayerAction::EndTurn),
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickLocation(LocationId(3)),
+            response: InputResponse::PickSingle(OptionId(1)),
         }),
     ];
 

--- a/crates/scenarios/tests/mythos_phase.rs
+++ b/crates/scenarios/tests/mythos_phase.rs
@@ -236,7 +236,7 @@ fn mythos_phase_resolves_single_spawn_enemy() {
 fn mythos_phase_multi_investigator_spawn_suspends_then_resumes_chain() {
     // Two investigators co-located at the synth spawn location: the
     // drawn enemy ties under Prey::Default, so the draw suspends for the
-    // lead's PickInvestigator (#128, option A). Resolving the pick
+    // lead's PickSingle (#128, option A). Resolving the pick
     // engages the chosen investigator and resumes inv1's Mythos draw
     // chain — which, the enemy being non-surge, advances the cursor to
     // inv2 and stays in Mythos.

--- a/crates/scenarios/tests/mythos_phase.rs
+++ b/crates/scenarios/tests/mythos_phase.rs
@@ -304,12 +304,23 @@ fn mythos_phase_multi_investigator_spawn_suspends_then_resumes_chain() {
     // The cursor is unchanged — still mid-chain for inv1.
     assert_eq!(suspended.state.mythos_draw_pending, Some(InvestigatorId(1)));
 
-    // Lead picks inv2 → engage + resume the chain. The enemy is
-    // non-surge, so no further card draws; the chain advances to inv2.
+    // Lead picks inv2 (by its offered option id) → engage + resume the chain.
+    // The enemy is non-surge, so no further card draws; the chain advances to inv2.
+    let pick = {
+        let EngineOutcome::AwaitingInput { request, .. } = &suspended.outcome else {
+            unreachable!("asserted AwaitingInput above");
+        };
+        request
+            .options
+            .iter()
+            .find(|o| o.label == format!("{:?}", InvestigatorId(2)))
+            .expect("InvestigatorId(2) among offered options")
+            .id
+    };
     let resumed = apply(
         suspended.state,
         Action::Player(PlayerAction::ResolveInput {
-            response: InputResponse::PickInvestigator(InvestigatorId(2)),
+            response: InputResponse::PickSingle(pick),
         }),
     );
     assert_eq!(resumed.outcome, EngineOutcome::Done);

--- a/docs/superpowers/plans/2026-06-19-pr2c-ii-picksingle-location-investigator.md
+++ b/docs/superpowers/plans/2026-06-19-pr2c-ii-picksingle-location-investigator.md
@@ -1,0 +1,176 @@
+# PR 2c-ii (#348, part 3b) — `PickLocation`/`PickInvestigator` → `PickSingle` via structured options — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Retire `InputResponse::PickLocation` / `PickInvestigator` by migrating the three windows that use them (hunter-move, hunter-engage, spawn-engage) to the existing Axis-A structured-choice contract — the request carries the candidates as labeled `ChoiceOption`s and resume comes back as `PickSingle(OptionId)`. After this, `InputResponse` = `PickSingle · PickMultiple · Skip · Confirm`.
+
+**Architecture:** The three windows already hold their candidate lists on the suspended frame (`HunterChoice::{Move,Engage}.candidates`, `SpawnEngagePending.candidates`). The only new engine work is **emitting** those candidates as `ChoiceOption { id: OptionId(i), label: "{candidate:?}" }` at suspend, and **indexing** back (`candidates[i]`) at resume. Labels are debug reprs for now; **#205 owns turning them into human names + rendering the control** — this PR settles only the *data contract*. The web client has **no** production use of these variants (verified), so it is untouched.
+
+**Tech Stack:** Rust — `game-core` (engine + `test_support` resolver), scenario integration tests. No `web`/`cards`/`server` changes.
+
+This is **PR 2c-ii** (2c-i `PickMultiple` ✅; this; 2c-iii action fold). Umbrella §2–3 (structured request + `PickSingle` consolidation). Series: #345 ✅ → #348 (2a ✅ · 2b ✅ · 2c-i ✅ · **2c-ii** · 2c-iii) → #347 → #380.
+
+## Global Constraints
+
+- **CI gauntlet, warnings-as-errors** (all before pushing): test / clippy `--all-targets --all-features` / fmt / `RUSTDOCFLAGS="-D warnings" doc` / `wasm-build` / `wasm-clippy`.
+- **No behavior change.** `OptionId(i)` ⇒ `candidates[i]`; the move/engage/spawn-engage effects and their validation (candidate membership) are preserved — `contains(id)` becomes `i < candidates.len()` against the same list.
+- **Wire/replay break** (the two variants leave `InputResponse`). Acceptable pre-1.0.
+- **Branch:** `engine/input-picksingle-spatial` off fresh `main`. Commit per task; push only when the full gauntlet is green.
+
+## Surface (surveyed)
+
+- **Suspend sites:** `hunters.rs:~388-401` (`suspend_hunter_choice` — Move + Engage prompts) and `encounter.rs:~463-477` (spawn-engage). Both build `InputRequest::prompt(…)` today.
+- **Resume handlers:** `resume_hunter_choice` (`hunters.rs` — matches `(HunterChoice::Move, PickLocation)` / `(HunterChoice::Engage, PickInvestigator)`, validates `candidates.contains`) and `resume_spawn_engage` (`hunters.rs:~513` — `let PickInvestigator(who) = response`, validates `candidates.contains`).
+- **Guard/prompt/error strings naming the variants:** `mod.rs:124,140`; `hunters.rs:390,394,463,471,516`; `encounter.rs:477`.
+- **`ScriptedResolver`:** `pick_location` / `pick_investigator` helpers (`resolver.rs:121-129`) push the literal variant; the FIFO test (`:426-427,436,440`) uses them.
+- **Engine unit tests constructing the variants directly:** `hunters.rs:1072,1124,1177,1287,1346,1409`; `phases.rs:2477`; `encounter.rs:1699`.
+- **Integration tests (via the resolver):** `scenarios/tests/{hunter_movement,encounter_spawn,mythos_phase}.rs`.
+- **No web/src production use** (only docs/legacy-free).
+
+---
+
+### Task 1: Migrate the three windows to structured options + `PickSingle`
+
+Suspend emits candidates as options; resume reads `PickSingle`; rework the resolver; migrate all test sites. `PickLocation`/`PickInvestigator` become unused (removed in Task 2).
+
+**Files:** `hunters.rs`, `encounter.rs`, `mod.rs` (guard messages), `test_support/resolver.rs`, the unit-test sites above, and the three scenario integration tests.
+
+**Interfaces:**
+- Suspend produces `InputRequest::choice(prompt, candidates.iter().enumerate().map(|(i,c)| ChoiceOption { id: OptionId(i as u32), label: format!("{c:?}") }).collect())`.
+- Resume consumes `InputResponse::PickSingle(OptionId(i))` ⇒ `candidates[i as usize]`.
+- `ScriptedResolver`: `pick_location(LocationId)` / `pick_investigator(InvestigatorId)` keep their signatures but resolve at `next()` time to `PickSingle` by matching the request's option whose `label == format!("{id:?}")`.
+
+- [ ] **Step 1: Hunter suspend → structured options**
+
+In `suspend_hunter_choice` (`hunters.rs`), the prompt-build branches for `HunterChoice::Move { enemy, candidates }` and `Engage { enemy, candidates }`: replace the final `EngineOutcome::AwaitingInput { request: InputRequest::prompt(prompt), … }` with a `InputRequest::choice(prompt, opts)` where
+
+```rust
+let opts: Vec<ChoiceOption> = candidates
+    .iter()
+    .enumerate()
+    .map(|(i, c)| ChoiceOption {
+        id: OptionId(u32::try_from(i).expect("candidate count fits u32")),
+        label: format!("{c:?}"),
+    })
+    .collect();
+```
+
+(keep the existing human prompt text; import `ChoiceOption`, `OptionId`). Both Move and Engage candidate lists are `Vec<LocationId>` / `Vec<InvestigatorId>` — `format!("{c:?}")` gives `"LocationId(99)"` / `"InvestigatorId(2)"`.
+
+- [ ] **Step 2: `resume_hunter_choice` → `PickSingle`**
+
+Replace the two `match (&pending, response)` arms. Instead of matching `PickLocation(loc)` / `PickInvestigator(who)`, match `InputResponse::PickSingle(OptionId(i))` and resolve against the pending choice's candidates:
+
+```rust
+let current_enemy = match (&pending, response) {
+    (HunterChoice::Move { enemy, candidates }, InputResponse::PickSingle(OptionId(i))) => {
+        let Some(&loc) = candidates.get(*i as usize) else {
+            return EngineOutcome::Rejected {
+                reason: format!("ResolveInput: hunter move option {i} out of range (0..{})", candidates.len()).into(),
+            };
+        };
+        cx.state.continuations.pop(); // validated; pop the HunterMove frame
+        move_hunter_to(cx, *enemy, loc);
+        if let Some(choice) = engage_on_arrival(cx, *enemy) {
+            return suspend_hunter_choice(cx, choice);
+        }
+        *enemy
+    }
+    (HunterChoice::Engage { enemy, candidates }, InputResponse::PickSingle(OptionId(i))) => {
+        let Some(&who) = candidates.get(*i as usize) else {
+            return EngineOutcome::Rejected {
+                reason: format!("ResolveInput: hunter engage option {i} out of range (0..{})", candidates.len()).into(),
+            };
+        };
+        cx.state.continuations.pop();
+        engage_enemy_with(cx, *enemy, who);
+        *enemy
+    }
+    (_, other) => {
+        return EngineOutcome::Rejected {
+            reason: format!("ResolveInput: hunter choice expects InputResponse::PickSingle, got {other:?}").into(),
+        };
+    }
+};
+```
+
+(Preserves validate-first: pop only after the index is validated. The two prior shape-mismatch arms collapse into the one `(_ , other)` reject.)
+
+- [ ] **Step 3: Spawn-engage suspend + resume**
+
+`encounter.rs` spawn-engage suspend: same `InputRequest::choice` treatment over `tied` (the candidate list). `resume_spawn_engage` (`hunters.rs`): replace `let PickInvestigator(who) = response else {…}` + `candidates.contains` with the `PickSingle(OptionId(i))` → `pending.candidates.get(i)` form (mirror Step 2's Engage arm; pop after validation as 2b established).
+
+- [ ] **Step 4: Reword guard/prompt/error strings**
+
+`mod.rs:124,140` (guard messages), `hunters.rs:390,394` (prompts — though the prompt text is now paired with structured options, keep it human and drop the `submit InputResponse::PickLocation` clause), `hunters.rs:463,471,516`, `encounter.rs:477`: replace `PickLocation`/`PickInvestigator` references with `PickSingle`.
+
+- [ ] **Step 5: Rework `ScriptedResolver`**
+
+In `test_support/resolver.rs`: add a `ScriptedStep::PickByLabel(String)` variant. Change `pick_location` / `pick_investigator` to push `ScriptedStep::PickByLabel(format!("{id:?}"))` (keep their `&mut self`-chaining signatures). In `next()`, resolve it:
+
+```rust
+ScriptedStep::PickByLabel(label) => {
+    let opt = request.options.iter().find(|o| o.label == label).unwrap_or_else(|| {
+        panic!("ScriptedResolver::pick_*: no offered option labeled {label:?}; prompt {:?}, options {:?}", request.prompt, request.options)
+    });
+    InputResponse::PickSingle(opt.id)
+}
+```
+
+Update the resolver's own FIFO test (`:424-441`): the `pick_location`/`pick_investigator` lines now need an option-bearing request — simplest is to switch those two lines + their assertions to `pick_single(OptionId(..))` against `req("pick")` (the FIFO test only checks ordering, not window semantics; the label-matching path is covered by the integration tests).
+
+- [ ] **Step 6: Migrate the engine unit-test direct constructions**
+
+`hunters.rs:1072,1124,1177,1287,1346,1409`, `phases.rs:2477`, `encounter.rs:1699`: each constructs `&InputResponse::PickLocation(LocationId(n))` / `PickInvestigator(InvestigatorId(n))` and feeds it to a resume handler. Replace with `&InputResponse::PickSingle(OptionId(i))` where `i` is that location/investigator's **index in the test's candidate list**. Read each test's setup to determine the candidate order (the candidates are the equidistant-nearest locations / co-located investigators the test arranges); pick the index whose `candidates[i]` equals the id the test previously passed. Add a short `// candidates: [LocationId(2), LocationId(3)] → option 0 is LocationId(2)` comment where the ordering isn't obvious.
+
+- [ ] **Step 7: Build + fix + gauntlet**
+
+`cargo build -p game-core --all-targets` (fix stragglers); then full gauntlet. Integration tests (`hunter_movement`, `encounter_spawn`, `mythos_phase`) exercise the resolver's label-matching end-to-end. Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A
+git commit -m "engine: structured-options + PickSingle for hunter/spawn windows (#348)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Remove `PickLocation` / `PickInvestigator`
+
+**Files:** `crates/game-core/src/action.rs` (+ any doc-link fixups).
+
+- [ ] **Step 1: Remove the variants** from `InputResponse` (and their doc-comments). The `PickSingle` doc currently says they "consolidate into it in a follow-up (2c-ii)" — update it to drop that forward-reference (they're gone now).
+
+- [ ] **Step 2: Compile** — `cargo build -p game-core --all-targets` + `cargo build -p web --target wasm32-unknown-unknown`. Any error is a missed Task-1 site → fix to `PickSingle`.
+
+- [ ] **Step 3: Doc links** — grep `PickLocation`/`PickInvestigator` for surviving intra-doc `[\`…\`]` links (e.g. the `resolver.rs` `ScriptedResolver` helper-list doc) and repoint/reword. `RUSTDOCFLAGS="-D warnings" cargo doc` confirms.
+
+- [ ] **Step 4: Full gauntlet** — all six. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "engine: remove PickLocation/PickInvestigator (folded into PickSingle) (#348)
+
+InputResponse is now PickSingle / PickMultiple / Skip / Confirm.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec/umbrella coverage:** the three location/investigator-pick windows adopt the structured-choice contract (`InputRequest::choice` + `PickSingle`); `PickLocation`/`PickInvestigator` removed; `InputResponse` reaches the umbrella's `PickSingle · PickMultiple · Skip · Confirm`. The *data* contract (options + `PickSingle`) lands now; #205 inherits only human labels + client rendering (stated in Architecture). ✓
+
+**Placeholder scan:** Step 6 says "read each test's setup to determine the candidate order" rather than hard-coding indices, because the index depends on each test's board arrangement (the implementer must read the candidate list). All other steps show concrete code. The resolver label-match is fully specified.
+
+**Type consistency:** `OptionId(u32)` is the candidate index throughout (suspend builds it, resume `candidates.get(i as usize)`, resolver returns `opt.id`); `ChoiceOption { id, label }` matches the Axis-A type used by the choice/reaction windows.
+
+**Risk flag:** label-matching in the resolver couples to `format!("{id:?}")` equality between suspend and resolver. It's deterministic (both sides use the same `Debug`), but if a future window labels options differently, the resolver helper won't match — acceptable for test infra, and the panic message surfaces it loudly.
+
+**Out of scope:** human-readable labels + client rendering of these picks (#205); `Mulligan`/`DrawEncounterCard` action fold (2c-iii); tokens (#347); revelation disposal (#380).


### PR DESCRIPTION
## Summary

**Part 3b of the #348 split** — completes the umbrella's `InputResponse` taxonomy normalization (§2–3). Retires `PickLocation`/`PickInvestigator` by migrating the three windows that used them (hunter-move, hunter-engage, spawn-engage) to the existing Axis-A structured-choice contract. After this, **`InputResponse = PickSingle · PickMultiple · Skip · Confirm`.**

Series: #345 ✅ → #348 (2a ✅ · 2b ✅ · 2c-i ✅ · **2c-ii** · 2c-iii) → #347 → #380.

## What changed

Two commits:
1. **Structured options + `PickSingle`:** the three windows emit their candidate list (already on the suspended frame) as labeled `ChoiceOption`s (`id: OptionId(i)`, `label: "{candidate:?}"`); resume reads `PickSingle(OptionId(i))` → `candidates[i]` (validate-first: pop only after the index validates). A `candidate_options<T: Debug>` helper builds them. `ScriptedResolver::pick_location`/`pick_investigator` keep their id-based signatures, resolving to `PickSingle` by label-matching the request's options at `next()`. Guard/prompt/error strings reworded.
2. **Remove** `PickLocation`/`PickInvestigator`.

Labels are debug reprs for now; **#205 owns human names + client rendering** — this PR settles only the data contract (options + `PickSingle`), so #205 designs against a stable surface. Web client untouched (no production use — verified).

## Test notes

- No behavior change — `OptionId(i)` ⇒ `candidates[i]`; candidate-membership validation becomes index-range validation against the same list. Valid-pick tests select via the emitted options; invalid-pick tests use an out-of-range `OptionId`; the two former "wrong response kind" tests submit `Skip`.
- Full gauntlet green locally: test / clippy / fmt / doc / wasm-build / wasm-clippy.
- Pre-push review: **ready to merge**, no Critical/Important. One Minor (a forward-looking `PickInvestigator` mention in the phase-7 doc's #205 client-render note) is left for #205, which owns that surface.

## Linked issues

Part of #348 (does not close it — 2c-iii follows).