### PR TITLE
engine: fold setup Mulligan onto a Continuation frame + ResolveInput (#348 part 2c-iii-a)

### DIFF
--- a/crates/cards/tests/roster_seating.rs
+++ b/crates/cards/tests/roster_seating.rs
@@ -36,7 +36,13 @@ fn seats_roland_with_corpus_stats_and_payload_deck() {
         Action::Player(PlayerAction::StartScenario { roster }),
     );
 
-    assert_eq!(result.outcome, EngineOutcome::Done);
+    // StartScenario seats the roster and opens the setup mulligan prompt
+    // (AwaitingInput) for the first investigator (#348).
+    assert!(
+        matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),
+        "StartScenario opens the mulligan prompt, got {:?}",
+        result.outcome
+    );
     let inv = result
         .state
         .investigators

--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -136,30 +136,12 @@ pub enum PlayerAction {
         /// investigator.
         enemy: EnemyId,
     },
-    /// Setup-only redraw. Valid only when this investigator is the one
-    /// the `mulligan_pending` cursor points at — mulligans happen in
-    /// player order (Rules Reference p.16 / p.27). The cursor is seeded
-    /// at `StartScenario` and advances after each mulligan; when it
-    /// reaches `None` setup ends and the game begins.
-    ///
-    /// `indices_to_redraw` names zero-based positions in the hand to
-    /// redraw. An empty vec is a legal "keep my hand" signal that
-    /// still consumes the one-shot. Indices must be in bounds
-    /// (`< hand.len()`) and unique.
-    ///
-    /// On apply: named cards move hand → deck directly (per the
-    /// Rules Reference's "shuffles them back into his or her deck",
-    /// NOT via the discard pile), the deck is shuffled, and the
-    /// investigator draws replacement cards equal to the redraw
-    /// count. An empty mulligan skips both the shuffle and the
-    /// redraw — the deck stays untouched.
-    Mulligan {
-        /// Investigator mulliganing. Must be the investigator the
-        /// `mulligan_pending` cursor currently points at.
-        investigator: InvestigatorId,
-        /// Hand indices to redraw; empty = no-op-but-consumes.
-        indices_to_redraw: Vec<u8>,
-    },
+    // The setup mulligan is no longer a dedicated action (#348 part 2c-iii-a):
+    // it round-trips through `ResolveInput(PickMultiple)` against the top
+    // `Continuation::Mulligan` frame, like every other player-facing
+    // suspension. The acting investigator is the frame's `remaining[0]`; the
+    // `PickMultiple` selection carries the hand indices to redraw (empty =
+    // "keep my hand").
     /// Draw a card from the player deck. Standard turn-action:
     /// spends 1 action, draws 1 card.
     ///

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -325,12 +325,16 @@ pub(super) fn resume_mulligan(cx: &mut Cx, response: &InputResponse) -> EngineOu
     let indices: Vec<u32> = selected.iter().map(|o| o.0).collect();
 
     // ---- validate (state untouched on any failure) ----
-    let inv = cx.state.investigators.get(&investigator).unwrap_or_else(|| {
-        unreachable!(
+    let inv = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .unwrap_or_else(|| {
+            unreachable!(
             "resume_mulligan: prompted investigator {investigator:?} is not in the investigators \
              map; this is a state-corruption invariant violation"
         )
-    });
+        });
     let hand_len = inv.hand.len();
     for &idx in &indices {
         if idx as usize >= hand_len {

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -1,6 +1,7 @@
 //! Card-related dispatch handlers: deck management, drawing, mulligan,
 //! resource grants, and card play.
 
+use crate::action::InputResponse;
 use crate::card_data::CardType;
 use crate::card_registry;
 use crate::dsl::Trigger;
@@ -8,7 +9,7 @@ use crate::event::Event;
 use crate::state::{CardCode, InvestigatorId, Status, Zone};
 
 use super::super::evaluator::{apply_effect, EvalContext};
-use super::super::outcome::EngineOutcome;
+use super::super::outcome::{EngineOutcome, InputRequest, ResumeToken};
 use super::Cx;
 
 /// Starting hand size at scenario setup. Per the Rules Reference,
@@ -271,68 +272,85 @@ pub(super) fn draw(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
     EngineOutcome::Done
 }
 
-/// Handler for [`PlayerAction::Mulligan`].
+/// Push a [`Continuation::Mulligan`](crate::state::Continuation::Mulligan)
+/// frame over `remaining` and return the [`EngineOutcome::AwaitingInput`] that
+/// prompts `remaining[0]` to mulligan. Used by `start_scenario` (first prompt)
+/// and [`resume_mulligan`] (re-prompt after a queue pop). `remaining` must be
+/// non-empty; callers ensure this.
+pub(super) fn prompt_mulligan(cx: &mut Cx, remaining: Vec<InvestigatorId>) -> EngineOutcome {
+    let next = remaining[0];
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::Mulligan { remaining });
+    EngineOutcome::AwaitingInput {
+        request: InputRequest::prompt(format!(
+            "Setup mulligan: {next:?} may mulligan; submit InputResponse::PickMultiple with the \
+             hand indices (as option ids) to redraw (an empty selection keeps the hand).",
+        )),
+        resume_token: ResumeToken(0),
+    }
+}
+
+/// Resume the setup mulligan loop (#348), driving the top
+/// [`Continuation::Mulligan`](crate::state::Continuation::Mulligan) frame.
 ///
-/// Per the Rules Reference, the redrawn cards shuffle directly back
-/// into the deck (not via the discard pile). Validates that it is this
-/// investigator's turn to mulligan (`mulligan_pending == Some(investigator)`,
-/// Rules Reference p.16 player order) and that the redraw indices are in
-/// bounds and unique.
-///
-/// On success: move named hand cards to the deck, shuffle, draw the
-/// same count back, advance `mulligan_pending` to the next investigator
-/// in player order, emit `MulliganPerformed`. An empty `indices_to_redraw`
-/// is a legal "keep my hand" mulligan that consumes the turn without
-/// touching the deck.
-pub(super) fn mulligan(
-    cx: &mut Cx,
-    investigator: InvestigatorId,
-    indices_to_redraw: &[u8],
-) -> EngineOutcome {
-    // One check subsumes the three old ones: the cursor only ever holds
-    // an Active `turn_order` id, so a mismatch covers setup-over (`None`),
-    // wrong-player / too-early, and already-went (cursor moved past you).
-    if cx.state.mulligan_pending != Some(investigator) {
+/// The acting investigator is the frame's `remaining[0]` (Rules Reference p.16
+/// player order) — the response carries no investigator. Validates the
+/// `PickMultiple` redraw indices (each [`OptionId`](crate::engine::OptionId) is
+/// a hand index) are in bounds and unique. On success: move named hand cards
+/// directly back into the deck (not via the discard pile, per the rules),
+/// shuffle, draw the same count back, emit [`Event::MulliganPerformed`], then
+/// pop the queue front. When the queue drains, setup ends — "the game begins"
+/// (Rules Reference p.27): round 1 skips Mythos (p.24), so
+/// [`investigation_phase`](super::phases::investigation_phase) begins here.
+/// Otherwise re-prompt the next investigator. Rejections leave state and events
+/// untouched.
+pub(super) fn resume_mulligan(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
+    let Some(crate::state::Continuation::Mulligan { remaining }) = cx.state.continuations.last()
+    else {
+        unreachable!("resume_mulligan: no Mulligan frame on top of the stack")
+    };
+    let remaining = remaining.clone();
+    let investigator = remaining[0];
+
+    let InputResponse::PickMultiple { selected } = response else {
         return EngineOutcome::Rejected {
             reason: format!(
-                "Mulligan: it is not {investigator:?}'s turn to mulligan \
-                 (pending: {:?})",
-                cx.state.mulligan_pending,
+                "ResolveInput: setup mulligan expects InputResponse::PickMultiple, got {response:?}",
             )
             .into(),
         };
-    }
-    let inv = cx
-        .state
-        .investigators
-        .get(&investigator)
-        .unwrap_or_else(|| {
-            unreachable!(
-                "mulligan_pending {investigator:?} is not in the investigators map; \
-             this is a state-corruption invariant violation"
-            )
-        });
-    // Validate indices: each must be in bounds and unique.
+    };
+    // Each OptionId is a hand index to redraw.
+    let indices: Vec<u32> = selected.iter().map(|o| o.0).collect();
+
+    // ---- validate (state untouched on any failure) ----
+    let inv = cx.state.investigators.get(&investigator).unwrap_or_else(|| {
+        unreachable!(
+            "resume_mulligan: prompted investigator {investigator:?} is not in the investigators \
+             map; this is a state-corruption invariant violation"
+        )
+    });
     let hand_len = inv.hand.len();
-    for &idx in indices_to_redraw {
-        if usize::from(idx) >= hand_len {
+    for &idx in &indices {
+        if idx as usize >= hand_len {
             return EngineOutcome::Rejected {
                 reason: format!("Mulligan: hand_index {idx} out of bounds (hand size {hand_len})")
                     .into(),
             };
         }
     }
-    let mut sorted: Vec<usize> = indices_to_redraw.iter().map(|&i| usize::from(i)).collect();
+    let mut sorted: Vec<u32> = indices.clone();
     sorted.sort_unstable();
     if sorted.windows(2).any(|w| w[0] == w[1]) {
         return EngineOutcome::Rejected {
-            reason: format!("Mulligan: duplicate index in {indices_to_redraw:?}").into(),
+            reason: format!("Mulligan: duplicate index in {indices:?}").into(),
         };
     }
 
-    // Mutate.
-    let redrawn_count = u8::try_from(indices_to_redraw.len())
-        .expect("indices_to_redraw.len() <= hand.len() <= u8::MAX in practice");
+    // ---- mutate ----
+    let redrawn_count =
+        u8::try_from(indices.len()).expect("indices.len() <= hand.len() <= u8::MAX in practice");
     let inv_mut = cx
         .state
         .investigators
@@ -342,7 +360,7 @@ pub(super) fn mulligan(
     // we remove. Move named cards directly into the deck — they
     // shuffle back in per the rules, not through the discard pile.
     for &i in sorted.iter().rev() {
-        let card = inv_mut.hand.remove(i);
+        let card = inv_mut.hand.remove(i as usize);
         inv_mut.deck.push(card);
     }
     // If anything actually moved, shuffle the deck (which now contains
@@ -357,12 +375,27 @@ pub(super) fn mulligan(
         investigator,
         redrawn_count,
     });
-    // Advance to the next Active investigator in player order (or `None`
-    // when this was the last). The completion check in
-    // `apply_player_action` keys off `None` to end setup.
-    cx.state.mulligan_pending =
-        super::cursor::next_active_investigator_after(cx.state, investigator);
-    EngineOutcome::Done
+
+    // ---- advance the queue ----
+    let mut remaining = remaining;
+    remaining.remove(0);
+    // Pop the current Mulligan frame (validated above; it is the top frame).
+    cx.state.continuations.pop();
+    if remaining.is_empty() {
+        // Setup complete — "the game begins" (Rules Reference p.27). Round 1
+        // skips Mythos (p.24), so the first phase to begin is Investigation.
+        // Begin it HERE (the kickoff moved off `apply_player_action`): setup has
+        // "no action windows" (p.27), so the post-2.1 player window only opens
+        // now that mulligans are done. `investigation_phase` may leave an
+        // `InvestigationBegins` window open (a Fast-eligible play exists); we
+        // still return `Done`, so this is one of the few paths where `Done`
+        // accompanies a non-empty continuation stack — hosts present
+        // `ResolveInput::Skip` to close it, as for any phase-transition window.
+        super::phases::investigation_phase(cx);
+        EngineOutcome::Done
+    } else {
+        prompt_mulligan(cx, remaining)
+    }
 }
 
 /// Resolve the card's destination + abilities via the registry, or

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -59,22 +59,22 @@ pub(crate) mod threat_area;
 /// so callers and tests get a useful signal rather than a silent no-op.
 #[allow(clippy::too_many_lines)] // dispatcher: a guard ladder + one match arm per PlayerAction
 pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome {
-    // While a mulligan is pending (the setup mulligan cursor is `Some`),
-    // only Mulligan (and the already-rejected re-StartScenario) is valid.
-    // Per the Rules Reference, "after all players have completed their
-    // mulligans, the game begins" — the engine enforces that by gating
-    // other actions until every investigator has signaled their mulligan
-    // choice.
-    if cx.state.mulligan_pending.is_some()
-        && !matches!(
-            action,
-            PlayerAction::Mulligan { .. } | PlayerAction::StartScenario { .. }
-        )
+    // While the setup mulligan loop is in progress (a `Mulligan` frame is on
+    // top of the stack), only `ResolveInput` can advance the engine. Per the
+    // Rules Reference, "after all players have completed their mulligans, the
+    // game begins" — the engine enforces that by gating other actions until
+    // every investigator has submitted their mulligan choice. Setup-only;
+    // never coexists with the other suspension modes, so guard order is
+    // immaterial.
+    if matches!(
+        cx.state.continuations.last(),
+        Some(crate::state::Continuation::Mulligan { .. })
+    ) && !matches!(action, PlayerAction::ResolveInput { .. })
     {
         return EngineOutcome::Rejected {
-            reason: "a setup mulligan is pending; investigators must submit \
-                     PlayerAction::Mulligan (with an empty indices_to_redraw to \
-                     keep their hand) in player order before any other action"
+            reason: "a setup mulligan is pending; investigators must submit a \
+                     PlayerAction::ResolveInput with InputResponse::PickMultiple (the hand indices \
+                     to redraw, empty to keep their hand) in player order before any other action"
                 .into(),
         };
     }
@@ -101,7 +101,7 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
 
     // While a skill test is paused at its commit window (no reaction
     // window open yet), only `ResolveInput` can advance the engine.
-    // Mirrors the `mulligan_pending` guard above.
+    // Mirrors the `Mulligan`-frame guard above.
     if cx.state.has_skill_test_in_flight() && !matches!(action, PlayerAction::ResolveInput { .. }) {
         return EngineOutcome::Rejected {
             reason: "a skill test is paused at its commit window; submit a \
@@ -191,10 +191,14 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
             destination,
         } => actions::move_action(cx, *investigator, *destination),
         PlayerAction::Draw { investigator } => cards::draw(cx, *investigator),
-        PlayerAction::Mulligan {
-            investigator,
-            indices_to_redraw,
-        } => cards::mulligan(cx, *investigator, indices_to_redraw),
+        // The setup mulligan now resumes through `ResolveInput` (the top
+        // `Mulligan` frame); the dedicated action is removed in the next commit
+        // (#348 part 2c-iii-a, task a2). Until then, reject it loudly.
+        PlayerAction::Mulligan { .. } => EngineOutcome::Rejected {
+            reason: "PlayerAction::Mulligan is removed; submit a PlayerAction::ResolveInput \
+                     with InputResponse::PickMultiple (the hand indices to redraw) instead"
+                .into(),
+        },
         PlayerAction::Fight {
             investigator,
             enemy,
@@ -226,31 +230,10 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
         }
     };
 
-    // After a successful Mulligan, check whether every investigator
-    // has now mulliganed. If so, the cursor reaches `None` and normal
-    // play begins. Assumes `mulligan()` only ever returns `Done` or
-    // `Rejected` (never `AwaitingInput`) — if it ever grows an
-    // input-prompt path, this gate must be revisited so the cursor
-    // doesn't silently stay set across a partial mulligan.
-    if matches!(outcome, EngineOutcome::Done)
-        && matches!(action, PlayerAction::Mulligan { .. })
-        && cx.state.mulligan_pending.is_none()
-    {
-        // Setup complete — "the game begins" (Rules Reference p.27).
-        // Round 1 skips the Mythos phase (p.24), so the first phase to
-        // begin is Investigation. Kick off its driver HERE, not in
-        // start_scenario: setup has "no action windows" (p.27), so the
-        // post-2.1 player window must not open until mulligans are done.
-        //
-        // NOTE: investigation_phase may leave an InvestigationBegins
-        // window open (when a Fast-eligible play exists); this function
-        // still returns the Mulligan's `Done`. So this is one of the few
-        // paths where `Done` can accompany a non-empty `cx.state.open_windows`
-        // — hosts check `open_windows` and present `ResolveInput::Skip`
-        // to close it, exactly as for the phase-transition windows the
-        // void `*_phase` drivers open.
-        phases::investigation_phase(cx);
-    }
+    // The post-mulligan Investigation kickoff moved into `resume_mulligan`
+    // (#348): the mulligan loop now drains through `ResolveInput`, and
+    // `resume_mulligan` begins the Investigation phase itself once the last
+    // investigator has mulliganed. No outer-boundary kickoff remains here.
 
     // Reaction windows open at the step boundary inside the handler
     // that queued them (see `drive_skill_test`), not at this outer
@@ -438,6 +421,7 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
         Some(Continuation::SpawnEngage(_)) => hunters::resume_spawn_engage(cx, response),
         Some(Continuation::HandSizeDiscard(_)) => phases::resume_hand_size_discard(cx, response),
         Some(Continuation::ActRoundEnd(_)) => phases::resume_act_round_end_advance(cx, response),
+        Some(Continuation::Mulligan { .. }) => cards::resume_mulligan(cx, response),
         Some(Continuation::SkillTest(_)) => resume_skill_test_commit(cx, response),
         None => EngineOutcome::Rejected {
             reason: "ResolveInput: no AwaitingInput prompt is currently outstanding".into(),

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -191,14 +191,6 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
             destination,
         } => actions::move_action(cx, *investigator, *destination),
         PlayerAction::Draw { investigator } => cards::draw(cx, *investigator),
-        // The setup mulligan now resumes through `ResolveInput` (the top
-        // `Mulligan` frame); the dedicated action is removed in the next commit
-        // (#348 part 2c-iii-a, task a2). Until then, reject it loudly.
-        PlayerAction::Mulligan { .. } => EngineOutcome::Rejected {
-            reason: "PlayerAction::Mulligan is removed; submit a PlayerAction::ResolveInput \
-                     with InputResponse::PickMultiple (the hand indices to redraw) instead"
-                .into(),
-        },
         PlayerAction::Fight {
             investigator,
             enemy,

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -153,23 +153,23 @@ pub(super) fn start_scenario(cx: &mut Cx, roster: &[RosterEntry]) -> EngineOutco
     // shuffles to a no-op (no event).
     super::encounter::shuffle_encounter_deck(cx);
 
-    // Seed the mulligan cursor to the first Active investigator in
-    // player order. Each investigator submits a single
-    // `PlayerAction::Mulligan` in turn; the cursor advances after each
-    // and reaches `None` once all have gone (see `apply_player_action`),
-    // at which point setup ends. Other player actions are rejected while
-    // the cursor is `Some`. An empty/all-eliminated `turn_order` seeds
-    // `None` — the same degenerate no-op as the Mythos draw cursor.
-    cx.state.mulligan_pending = super::cursor::first_active_investigator(cx.state);
-
     // Round-1 action seed: round 1 skips Mythos, so there's no Upkeep 4.2
     // to grant the first round's actions. Every Active investigator → ACTIONS_PER_TURN.
     reset_actions(cx);
 
-    // NOTE: the Investigation phase is NOT begun here. Setup has no
-    // action windows (Rules Reference p.27); the phase begins after the
-    // mulligan cursor reaches `None` — see the kickoff in apply_player_action.
-    EngineOutcome::Done
+    // Begin the setup mulligan loop. Each Active investigator submits a single
+    // mulligan (a `ResolveInput(PickMultiple)`) in player order; the loop
+    // advances after each and drains once all have gone, at which point setup
+    // ends and the Investigation phase begins (see `resume_mulligan`). While
+    // the `Mulligan` frame is on the stack, every non-`ResolveInput` action is
+    // rejected. An empty/all-eliminated `turn_order` skips the loop entirely:
+    // setup ends immediately and we begin Investigation here.
+    let remaining = super::cursor::active_investigators_in_turn_order(cx.state);
+    if remaining.is_empty() {
+        investigation_phase(cx);
+        return EngineOutcome::Done;
+    }
+    super::cards::prompt_mulligan(cx, remaining)
 }
 
 pub(super) fn end_turn(cx: &mut Cx) -> EngineOutcome {
@@ -1039,7 +1039,11 @@ mod investigation_phase_tests {
             .build();
         state.turn_order = vec![InvestigatorId(1)];
         state.active_investigator = None;
-        state.mulligan_pending = Some(InvestigatorId(1));
+        state
+            .continuations
+            .push(crate::state::Continuation::Mulligan {
+                remaining: vec![InvestigatorId(1)],
+            });
 
         let mut events = Vec::new();
         let outcome = apply_player_action(
@@ -1047,16 +1051,16 @@ mod investigation_phase_tests {
                 state: &mut state,
                 events: &mut events,
             },
-            &PlayerAction::Mulligan {
-                investigator: InvestigatorId(1),
-                indices_to_redraw: vec![],
+            &PlayerAction::ResolveInput {
+                response: crate::action::InputResponse::PickMultiple { selected: vec![] },
             },
         );
 
         assert!(matches!(outcome, EngineOutcome::Done));
         assert_eq!(
-            state.mulligan_pending, None,
-            "mulligan cursor clears once every investigator has mulliganed"
+            state.current_mulligan(),
+            None,
+            "mulligan loop drains once every investigator has mulliganed"
         );
         assert_eq!(
             state.active_investigator,
@@ -3558,7 +3562,11 @@ mod start_scenario_tests {
             state,
             Action::Player(PlayerAction::StartScenario { roster: vec![] }),
         );
-        assert_eq!(result.outcome, EngineOutcome::Done);
+        // One Active investigator → StartScenario opens the mulligan prompt.
+        assert!(matches!(
+            result.outcome,
+            EngineOutcome::AwaitingInput { .. }
+        ));
         assert_eq!(result.state.round, 1);
     }
 
@@ -3590,7 +3598,10 @@ mod start_scenario_tests {
             Action::Player(PlayerAction::StartScenario { roster: vec![] }),
         );
 
-        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert!(matches!(
+            result.outcome,
+            EngineOutcome::AwaitingInput { .. }
+        ));
         crate::assert_event!(result.events, crate::event::Event::EncounterDeckShuffled);
         let mut after: Vec<&str> = result
             .state

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -293,18 +293,22 @@ mod tests {
             Action::Player(PlayerAction::StartScenario { roster: vec![] }),
         );
 
-        assert_eq!(start_result.outcome, EngineOutcome::Done);
+        assert!(
+            matches!(start_result.outcome, EngineOutcome::AwaitingInput { .. }),
+            "StartScenario opens the mulligan prompt (AwaitingInput), got {:?}",
+            start_result.outcome
+        );
         assert_eq!(start_result.state.round, 1);
         assert_eq!(start_result.state.phase, Phase::Investigation);
-        // Mulligan cursor is seeded — active investigator not yet set.
+        // The mulligan loop is in progress — active investigator not yet set.
         assert_eq!(
-            start_result.state.mulligan_pending,
+            start_result.state.current_mulligan(),
             Some(id),
-            "mulligan cursor must be seeded after StartScenario"
+            "mulligan loop must prompt the first investigator after StartScenario"
         );
         assert_eq!(
             start_result.state.active_investigator, None,
-            "active investigator is not set until the mulligan cursor clears"
+            "active investigator is not set until the mulligan loop drains"
         );
         assert_eq!(start_result.state.investigators[&id].actions_remaining, 3);
 
@@ -332,19 +336,19 @@ mod tests {
             }
         );
 
-        // After the sole investigator mulligans, the phase begins and the
-        // lead becomes active.
+        // After the sole investigator mulligans (an empty "keep my hand"
+        // PickMultiple), the phase begins and the lead becomes active.
         let mulligan_result = apply(
             start_result.state,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: id,
-                indices_to_redraw: vec![],
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::PickMultiple { selected: vec![] },
             }),
         );
         assert_eq!(mulligan_result.outcome, EngineOutcome::Done);
         assert_eq!(
-            mulligan_result.state.mulligan_pending, None,
-            "cursor must clear"
+            mulligan_result.state.current_mulligan(),
+            None,
+            "mulligan loop must drain"
         );
         assert_eq!(
             mulligan_result.state.active_investigator,
@@ -1140,9 +1144,9 @@ mod tests {
         assert_eq!(state.round, 1);
         assert_eq!(state.phase, Phase::Investigation);
         assert_eq!(
-            state.mulligan_pending,
+            state.current_mulligan(),
             Some(inv1),
-            "mulligan cursor must be seeded after StartScenario"
+            "mulligan loop must prompt the first investigator after StartScenario"
         );
         assert_eq!(
             state.active_investigator, None,
@@ -1150,26 +1154,17 @@ mod tests {
         );
         assert_eq!(state.investigators[&inv1].actions_remaining, 3);
 
-        // Mulligan past the window for both investigators (empty
-        // redraws = "keep my hand"). The engine requires every
-        // investigator to mulligan before non-Mulligan actions are
-        // accepted.
-        let state = apply(
-            state,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: inv1,
-                indices_to_redraw: vec![],
-            }),
-        )
-        .state;
-        let state = apply(
-            state,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: inv2,
-                indices_to_redraw: vec![],
-            }),
-        )
-        .state;
+        // Mulligan past the loop for both investigators (empty redraws =
+        // "keep my hand"), each via `ResolveInput(PickMultiple)`. The engine
+        // requires every investigator to mulligan before non-`ResolveInput`
+        // actions are accepted.
+        let empty_mulligan = || {
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::PickMultiple { selected: vec![] },
+            })
+        };
+        let state = apply(state, empty_mulligan()).state;
+        let state = apply(state, empty_mulligan()).state;
         // After the last mulligan, the Investigation phase begins and the
         // lead investigator becomes active.
         assert_eq!(
@@ -1272,12 +1267,11 @@ mod tests {
             "active investigator not set until mulligan window closes"
         );
 
-        // Mulligan past the setup window. After completion, lead becomes active.
+        // Mulligan past the setup loop. After completion, lead becomes active.
         let after_mulligan = apply(
             after_start,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: id,
-                indices_to_redraw: vec![],
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::PickMultiple { selected: vec![] },
             }),
         )
         .state;
@@ -1352,7 +1346,12 @@ mod tests {
             Action::Player(PlayerAction::StartScenario { roster: vec![] }),
         );
 
-        assert_eq!(result.outcome, EngineOutcome::Done);
+        // StartScenario deals hands, then opens the mulligan prompt
+        // (AwaitingInput) — the deal happens before the prompt.
+        assert!(matches!(
+            result.outcome,
+            EngineOutcome::AwaitingInput { .. }
+        ));
         assert_event!(
             result.events,
             Event::DeckShuffled { investigator } if *investigator == id
@@ -1388,7 +1387,10 @@ mod tests {
             Action::Player(PlayerAction::StartScenario { roster: vec![] }),
         );
 
-        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert!(matches!(
+            result.outcome,
+            EngineOutcome::AwaitingInput { .. }
+        ));
         // Empty-deck no-op shuffle: no event.
         assert_no_event!(result.events, Event::DeckShuffled { .. });
         // draw_cards still emits CardsDrawn { count: 0 } so consumers
@@ -1418,7 +1420,10 @@ mod tests {
             Action::Player(PlayerAction::StartScenario { roster: vec![] }),
         );
 
-        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert!(matches!(
+            result.outcome,
+            EngineOutcome::AwaitingInput { .. }
+        ));
         assert_event!(
             result.events,
             Event::CardsDrawn { investigator, count: 3 } if *investigator == id
@@ -3672,11 +3677,24 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // Mulligan tests (#85)
+    // Mulligan tests (#85; folded onto the `Mulligan` continuation frame +
+    // `ResolveInput(PickMultiple)` in #348 part 2c-iii-a)
     // ------------------------------------------------------------------
 
+    /// Submit a setup mulligan via `ResolveInput`: `indices` are the hand
+    /// indices to redraw (empty = keep the hand). The acting investigator is
+    /// the top `Mulligan` frame's `remaining[0]` — the response carries no
+    /// investigator id.
+    fn mulligan_resolve(indices: &[u32]) -> Action {
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickMultiple {
+                selected: indices.iter().copied().map(OptionId).collect(),
+            },
+        })
+    }
+
     /// Build a Mulligan scenario: one investigator with a known hand
-    /// of 5 cards + a remaining deck of 5, mulligan cursor seeded.
+    /// of 5 cards + a remaining deck of 5, the `Mulligan` frame staged.
     /// Bypasses `StartScenario` so tests can control the exact hand
     /// composition.
     fn mulligan_scenario() -> (InvestigatorId, GameState) {
@@ -3700,7 +3718,7 @@ mod tests {
             .with_investigator(inv)
             .with_rng_seed(2026)
             .with_turn_order([id])
-            .with_mulligan_pending(id)
+            .with_mulligan_remaining([id])
             .build();
         (id, state)
     }
@@ -3710,13 +3728,7 @@ mod tests {
         // Redraw indices [1, 3] → those two move to deck, deck
         // shuffles, two new cards come back.
         let (id, state) = mulligan_scenario();
-        let result = apply(
-            state,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: id,
-                indices_to_redraw: vec![1, 3],
-            }),
-        );
+        let result = apply(state, mulligan_resolve(&[1, 3]));
         assert_eq!(result.outcome, EngineOutcome::Done);
         assert_event!(
             result.events,
@@ -3740,13 +3752,7 @@ mod tests {
         let (id, state) = mulligan_scenario();
         let original_hand = state.investigators[&id].hand.clone();
         let original_deck = state.investigators[&id].deck.clone();
-        let result = apply(
-            state,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: id,
-                indices_to_redraw: vec![],
-            }),
-        );
+        let result = apply(state, mulligan_resolve(&[]));
         assert_eq!(result.outcome, EngineOutcome::Done);
         assert_event!(
             result.events,
@@ -3765,13 +3771,7 @@ mod tests {
     #[test]
     fn mulligan_redraw_all_replaces_entire_hand() {
         let (id, state) = mulligan_scenario();
-        let result = apply(
-            state,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: id,
-                indices_to_redraw: vec![0, 1, 2, 3, 4],
-            }),
-        );
+        let result = apply(state, mulligan_resolve(&[0, 1, 2, 3, 4]));
         assert_eq!(result.outcome, EngineOutcome::Done);
         assert_event!(
             result.events,
@@ -3801,48 +3801,42 @@ mod tests {
 
     #[test]
     fn mulligan_second_attempt_is_rejected() {
-        let (id, state) = mulligan_scenario();
-        let result = apply(
-            state,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: id,
-                indices_to_redraw: vec![0],
-            }),
-        );
+        // After the sole investigator mulligans, the frame drains and the
+        // Investigation phase begins (no further mulligan prompt outstanding).
+        // A second `ResolveInput` has no `Mulligan` frame to resume and is
+        // rejected.
+        let (_id, state) = mulligan_scenario();
+        let result = apply(state, mulligan_resolve(&[0]));
         assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_eq!(result.state.current_mulligan(), None);
         // Try again on the post-mulligan state.
-        let result2 = apply(
-            result.state,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: id,
-                indices_to_redraw: vec![0],
-            }),
-        );
+        let result2 = apply(result.state, mulligan_resolve(&[0]));
         assert!(matches!(result2.outcome, EngineOutcome::Rejected { .. }));
         assert!(result2.events.is_empty());
     }
 
     #[test]
-    fn mulligan_after_cursor_cleared_is_rejected() {
-        let (id, mut state) = mulligan_scenario();
-        state.mulligan_pending = None;
-        let result = apply(
-            state,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: id,
-                indices_to_redraw: vec![0],
-            }),
-        );
+    fn mulligan_resolve_with_no_frame_outstanding_is_rejected() {
+        // With no `Mulligan` frame on the stack (here: an empty continuation
+        // stack), a `ResolveInput(PickMultiple)` has nothing to resume and is
+        // rejected with state + events untouched. Replaces the former
+        // "mulligan after cursor cleared" test (the cursor is gone).
+        let (_id, mut state) = mulligan_scenario();
+        state.continuations.clear();
+        let result = apply(state, mulligan_resolve(&[0]));
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
         assert!(result.events.is_empty());
     }
 
     #[test]
-    fn mulligan_by_defeated_investigator_is_rejected() {
-        // The seed/advance helpers skip non-Active investigators, so the
-        // cursor never points at a defeated one. With inv1 Killed the
-        // cursor sits on inv2; a Mulligan from the defeated inv1 is
-        // rejected by the cursor mismatch.
+    fn start_scenario_mulligan_loop_skips_defeated_investigator() {
+        // The loop is seeded from `active_investigators_in_turn_order`, so a
+        // defeated investigator never enters the `remaining` queue: with inv1
+        // Killed, the loop prompts inv2 directly. (Replaces the former
+        // "defeated investigator mulligan rejected" test — the folded
+        // `ResolveInput` carries no investigator, so there is no
+        // wrong-investigator rejection path; the defeated investigator is
+        // instead structurally excluded from the queue.)
         let inv1 = InvestigatorId(1);
         let inv2 = InvestigatorId(2);
         let mut a = test_investigator(1);
@@ -3852,49 +3846,41 @@ mod tests {
             .with_investigator(a)
             .with_investigator(b)
             .with_turn_order([inv1, inv2])
-            .with_mulligan_pending(inv2)
             .build();
         let result = apply(
             state,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: inv1,
-                indices_to_redraw: vec![],
-            }),
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
         );
-        assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
-        assert!(result.events.is_empty());
+        assert!(
+            matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),
+            "StartScenario opens the mulligan prompt, got {:?}",
+            result.outcome
+        );
+        assert_eq!(
+            result.state.current_mulligan(),
+            Some(inv2),
+            "the defeated inv1 is skipped; the loop prompts inv2"
+        );
     }
 
     #[test]
     fn mulligan_with_out_of_bounds_index_is_rejected() {
-        let (id, state) = mulligan_scenario();
-        let result = apply(
-            state,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: id,
-                indices_to_redraw: vec![10],
-            }),
-        );
+        let (_id, state) = mulligan_scenario();
+        let result = apply(state, mulligan_resolve(&[10]));
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
         assert!(result.events.is_empty());
     }
 
     #[test]
     fn mulligan_with_duplicate_indices_is_rejected() {
-        let (id, state) = mulligan_scenario();
-        let result = apply(
-            state,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: id,
-                indices_to_redraw: vec![1, 1],
-            }),
-        );
+        let (_id, state) = mulligan_scenario();
+        let result = apply(state, mulligan_resolve(&[1, 1]));
         assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
         assert!(result.events.is_empty());
     }
 
     #[test]
-    fn start_scenario_seeds_mulligan_cursor() {
+    fn start_scenario_seeds_mulligan_loop() {
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
         inv.deck = make_test_deck(10);
@@ -3906,15 +3892,19 @@ mod tests {
             state,
             Action::Player(PlayerAction::StartScenario { roster: vec![] }),
         );
-        assert_eq!(result.outcome, EngineOutcome::Done);
-        assert_eq!(result.state.mulligan_pending, Some(id));
+        assert!(
+            matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),
+            "StartScenario opens the mulligan prompt, got {:?}",
+            result.outcome
+        );
+        assert_eq!(result.state.current_mulligan(), Some(id));
     }
 
     #[test]
-    fn non_mulligan_action_while_mulligan_pending_is_rejected() {
-        // Non-Mulligan player actions are gated by the mulligan
-        // cursor: the engine refuses Move/Investigate/etc. until
-        // every investigator has signaled their mulligan choice.
+    fn non_resolve_input_action_while_mulligan_pending_is_rejected() {
+        // Non-`ResolveInput` player actions are gated by the `Mulligan` frame:
+        // the engine refuses Move/Investigate/etc. until every investigator
+        // has submitted their mulligan choice.
         let id = InvestigatorId(1);
         let a = crate::state::LocationId(10);
         let b = crate::state::LocationId(11);
@@ -3930,7 +3920,7 @@ mod tests {
             .with_phase(Phase::Investigation)
             .with_active_investigator(id)
             .with_turn_order([id])
-            .with_mulligan_pending(id)
+            .with_mulligan_remaining([id])
             .build();
         let result = apply(
             state,
@@ -3944,25 +3934,19 @@ mod tests {
     }
 
     #[test]
-    fn solo_mulligan_clears_the_cursor() {
+    fn solo_mulligan_drains_the_loop() {
         // Single-investigator scenario: as soon as that one
         // investigator mulligans (empty redraw counts), all
-        // investigators have mulliganed and the cursor clears.
-        let (id, state) = mulligan_scenario();
-        let result = apply(
-            state,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: id,
-                indices_to_redraw: vec![],
-            }),
-        );
+        // investigators have mulliganed and the loop drains.
+        let (_id, state) = mulligan_scenario();
+        let result = apply(state, mulligan_resolve(&[]));
         assert_eq!(result.outcome, EngineOutcome::Done);
-        assert_eq!(result.state.mulligan_pending, None);
+        assert_eq!(result.state.current_mulligan(), None);
     }
 
     #[test]
-    fn multi_investigator_mulligan_advances_cursor_in_player_order() {
-        // Two investigators; the cursor advances inv1 → inv2 → None as
+    fn multi_investigator_mulligan_advances_in_player_order() {
+        // Two investigators; the loop advances inv1 → inv2 → drained as
         // each mulligans in player order.
         let inv1 = InvestigatorId(1);
         let inv2 = InvestigatorId(2);
@@ -3974,68 +3958,26 @@ mod tests {
             .with_investigator(a)
             .with_investigator(b)
             .with_turn_order([inv1, inv2])
-            .with_mulligan_pending(inv1)
+            .with_mulligan_remaining([inv1, inv2])
             .build();
 
-        let after_first = apply(
-            state,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: inv1,
-                indices_to_redraw: vec![],
-            }),
+        let after_first = apply(state, mulligan_resolve(&[]));
+        assert!(
+            matches!(after_first.outcome, EngineOutcome::AwaitingInput { .. }),
+            "after inv1 mulligans, the loop re-prompts inv2 (AwaitingInput), got {:?}",
+            after_first.outcome
         );
-        assert_eq!(after_first.outcome, EngineOutcome::Done);
-        assert_eq!(after_first.state.mulligan_pending, Some(inv2));
+        assert_eq!(after_first.state.current_mulligan(), Some(inv2));
 
-        let after_second = apply(
-            after_first.state,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: inv2,
-                indices_to_redraw: vec![],
-            }),
-        );
+        let after_second = apply(after_first.state, mulligan_resolve(&[]));
         assert_eq!(after_second.outcome, EngineOutcome::Done);
-        assert_eq!(after_second.state.mulligan_pending, None);
-    }
-
-    #[test]
-    fn multi_investigator_mulligan_out_of_order_is_rejected() {
-        // Cursor is on inv1 (first in turn_order). inv2 trying to
-        // mulligan out of turn is rejected, and the cursor is unmoved
-        // (Rules Reference p.16: mulligans in player order).
-        let inv1 = InvestigatorId(1);
-        let inv2 = InvestigatorId(2);
-        let mut a = test_investigator(1);
-        let mut b = test_investigator(2);
-        a.hand = vec![CardCode::new("a-0")];
-        b.hand = vec![CardCode::new("b-0")];
-        let state = GameStateBuilder::new()
-            .with_investigator(a)
-            .with_investigator(b)
-            .with_turn_order([inv1, inv2])
-            .with_mulligan_pending(inv1)
-            .build();
-
-        let out_of_order = apply(
-            state,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: inv2,
-                indices_to_redraw: vec![],
-            }),
-        );
-        assert!(matches!(
-            out_of_order.outcome,
-            EngineOutcome::Rejected { .. }
-        ));
-        assert!(out_of_order.events.is_empty());
-        assert_eq!(out_of_order.state.mulligan_pending, Some(inv1));
+        assert_eq!(after_second.state.current_mulligan(), None);
     }
 
     #[test]
     fn multi_investigator_real_redraw_plus_empty_mulligan_combo() {
         // One investigator does a real redraw, the other keeps their
-        // hand. Both signal Mulligan; window closes after the
-        // second.
+        // hand. Both mulligan; the loop drains after the second.
         let inv1 = InvestigatorId(1);
         let inv2 = InvestigatorId(2);
         let mut a = test_investigator(1);
@@ -4056,21 +3998,19 @@ mod tests {
             .with_investigator(a)
             .with_investigator(b)
             .with_turn_order([inv1, inv2])
-            .with_mulligan_pending(inv1)
+            .with_mulligan_remaining([inv1, inv2])
             .with_rng_seed(99)
             .build();
 
         // inv1 redraws indices [0, 2] → those two go to deck, deck
         // shuffles, two new cards come back.
-        let after_inv1 = apply(
-            state,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: inv1,
-                indices_to_redraw: vec![0, 2],
-            }),
+        let after_inv1 = apply(state, mulligan_resolve(&[0, 2]));
+        assert!(
+            matches!(after_inv1.outcome, EngineOutcome::AwaitingInput { .. }),
+            "after inv1 mulligans, the loop re-prompts inv2, got {:?}",
+            after_inv1.outcome
         );
-        assert_eq!(after_inv1.outcome, EngineOutcome::Done);
-        assert_eq!(after_inv1.state.mulligan_pending, Some(inv2)); // inv2 hasn't yet
+        assert_eq!(after_inv1.state.current_mulligan(), Some(inv2)); // inv2 hasn't yet
         let inv1_after = &after_inv1.state.investigators[&inv1];
         assert_eq!(inv1_after.hand.len(), 3);
         assert_eq!(inv1_after.deck.len(), 3);
@@ -4080,18 +4020,12 @@ mod tests {
                 if *investigator == inv1
         );
 
-        // inv2 keeps hand (empty redraw). Window now closes.
+        // inv2 keeps hand (empty redraw). The loop drains.
         let original_inv2_hand = after_inv1.state.investigators[&inv2].hand.clone();
         let original_inv2_deck = after_inv1.state.investigators[&inv2].deck.clone();
-        let after_inv2 = apply(
-            after_inv1.state,
-            Action::Player(PlayerAction::Mulligan {
-                investigator: inv2,
-                indices_to_redraw: vec![],
-            }),
-        );
+        let after_inv2 = apply(after_inv1.state, mulligan_resolve(&[]));
         assert_eq!(after_inv2.outcome, EngineOutcome::Done);
-        assert_eq!(after_inv2.state.mulligan_pending, None);
+        assert_eq!(after_inv2.state.current_mulligan(), None);
         assert_event!(
             after_inv2.events,
             Event::MulliganPerformed { investigator, redrawn_count: 0 }

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -54,7 +54,7 @@ pub struct GameStateBuilder {
     active_investigator: Option<InvestigatorId>,
     turn_order: Vec<InvestigatorId>,
     rng: RngState,
-    mulligan_pending: Option<InvestigatorId>,
+    mulligan_remaining: Option<Vec<InvestigatorId>>,
     hand_size_discard_pending: Option<HandSizeDiscard>,
     open_windows: Vec<ResolutionFrame>,
     scenario_id: Option<ScenarioId>,
@@ -77,7 +77,7 @@ impl GameStateBuilder {
             active_investigator: None,
             turn_order: Vec::new(),
             rng: RngState::new(0),
-            mulligan_pending: None,
+            mulligan_remaining: None,
             hand_size_discard_pending: None,
             open_windows: Vec::new(),
             scenario_id: None,
@@ -202,14 +202,19 @@ impl GameStateBuilder {
         self
     }
 
-    /// Seed the mulligan cursor to `id`. By default the cursor is
-    /// `None` so tests don't accidentally exercise Mulligan paths; opt
-    /// in when a test wants to fire the Mulligan action directly
-    /// without going through `StartScenario`. The investigator must be
-    /// in `turn_order` (set via [`with_turn_order`](Self::with_turn_order))
-    /// for the cursor to advance correctly after the mulligan.
-    pub fn with_mulligan_pending(mut self, id: InvestigatorId) -> Self {
-        self.mulligan_pending = Some(id);
+    /// Stage a pending setup mulligan over the given player-order queue
+    /// (front = currently prompted). By default no mulligan is staged so
+    /// tests don't accidentally exercise Mulligan paths; opt in when a test
+    /// wants to resume the mulligan loop directly via `ResolveInput` without
+    /// going through `StartScenario`. The queue must list the investigators in
+    /// `turn_order` (set via [`with_turn_order`](Self::with_turn_order)) so the
+    /// loop advances correctly. Stages a [`Continuation::Mulligan`] frame at
+    /// [`build`](Self::build).
+    pub fn with_mulligan_remaining(
+        mut self,
+        remaining: impl IntoIterator<Item = InvestigatorId>,
+    ) -> Self {
+        self.mulligan_remaining = Some(remaining.into_iter().collect());
         self
     }
 
@@ -262,6 +267,12 @@ impl GameStateBuilder {
         if let Some(hsd) = self.hand_size_discard_pending {
             continuations.push(Continuation::HandSizeDiscard(hsd));
         }
+        // A staged setup mulligan becomes a `Mulligan` frame (#348). Setup and
+        // upkeep are disjoint phases, so this never coexists with a staged
+        // hand-size discard; push order is immaterial.
+        if let Some(remaining) = self.mulligan_remaining {
+            continuations.push(Continuation::Mulligan { remaining });
+        }
         GameState {
             investigators: self.investigators,
             locations: self.locations,
@@ -276,7 +287,6 @@ impl GameStateBuilder {
             active_investigator: self.active_investigator,
             turn_order: self.turn_order,
             rng: self.rng,
-            mulligan_pending: self.mulligan_pending,
             card_instance_ids: Counter::new(),
             enemy_ids: Counter::new(),
             location_ids: Counter::new(),

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -86,22 +86,11 @@ pub struct GameState {
     /// underlying [`rand_chacha::ChaCha8Rng`] is reconstructed on
     /// demand by [`RngState`] methods.
     pub rng: RngState,
-    /// The investigator whose setup mulligan is pending, processed in
-    /// player order (Rules Reference p.16 / p.27: "each player, in
-    /// player order, may mulligan once"). Mirror of
-    /// [`mythos_draw_pending`](Self::mythos_draw_pending):
-    ///
-    /// - Seeded to the first [`Status::Active`](crate::state::Status::Active)
-    ///   investigator in [`turn_order`](Self::turn_order) at
-    ///   [`PlayerAction::StartScenario`](crate::action::PlayerAction::StartScenario).
-    /// - A [`PlayerAction::Mulligan`](crate::action::PlayerAction::Mulligan)
-    ///   is valid only when `mulligan_pending == Some(that investigator)`;
-    ///   on success the cursor advances to the next Active investigator
-    ///   in `turn_order`.
-    /// - `None` once every investigator has mulliganed — at which point
-    ///   setup ends and the Investigation phase begins. While `Some`,
-    ///   the engine rejects every non-Mulligan player action.
-    pub mulligan_pending: Option<InvestigatorId>,
+    // The setup mulligan loop now lives on its `Continuation::Mulligan`
+    // frame (#348); read the prompted investigator via
+    // [`Self::current_mulligan`]. The former `mulligan_pending:
+    // Option<InvestigatorId>` cursor is removed — the continuation stack is the
+    // single source of truth (mirroring the `in_flight_skill_test` fold).
     /// Allocator for [`CardInstanceId`]s, minted when cards enter play.
     /// Deterministic across replays; serializes as a bare `u32`.
     pub card_instance_ids: Counter<CardInstanceId>,
@@ -471,6 +460,20 @@ pub enum Continuation {
         /// The investigator taking the test.
         investigator: InvestigatorId,
     },
+    /// The setup mulligan loop (Rules Reference p.27), migrated off the former
+    /// `GameState::mulligan_pending` cursor field (#348). `remaining[0]` is the
+    /// investigator currently prompted to mulligan; the queue is the Active
+    /// investigators in [`turn_order`](GameState::turn_order). Pushed by
+    /// `start_scenario`, advanced by `resume_mulligan` as each investigator
+    /// submits their `PickMultiple` redraw indices, popped when drained — at
+    /// which point setup ends and the Investigation phase begins. While present,
+    /// the engine rejects every non-`ResolveInput` action. Read the prompted
+    /// investigator via [`GameState::current_mulligan`].
+    Mulligan {
+        /// Active investigators yet to mulligan, in player order; front =
+        /// currently prompted.
+        remaining: Vec<InvestigatorId>,
+    },
 }
 
 /// A controller choice paused mid-resolution (umbrella §3, Axis A).
@@ -512,7 +515,8 @@ impl Continuation {
             | Continuation::SpawnEngage(_)
             | Continuation::HandSizeDiscard(_)
             | Continuation::ActRoundEnd(_)
-            | Continuation::SubstitutionPrompt { .. } => None,
+            | Continuation::SubstitutionPrompt { .. }
+            | Continuation::Mulligan { .. } => None,
         }
     }
 
@@ -526,7 +530,8 @@ impl Continuation {
             | Continuation::SpawnEngage(_)
             | Continuation::HandSizeDiscard(_)
             | Continuation::ActRoundEnd(_)
-            | Continuation::SubstitutionPrompt { .. } => None,
+            | Continuation::SubstitutionPrompt { .. }
+            | Continuation::Mulligan { .. } => None,
         }
     }
 }
@@ -1337,6 +1342,20 @@ impl GameState {
         match self.continuations.remove(pos) {
             Continuation::SkillTest(t) => Some(t),
             _ => unreachable!("rposition matched SkillTest"),
+        }
+    }
+
+    /// The investigator currently prompted to mulligan, if a setup mulligan is
+    /// in progress; `None` otherwise. Reads the top
+    /// [`Continuation::Mulligan`] frame's `remaining[0]` — the continuation
+    /// stack is the single source of truth for "a mulligan is pending" (#348,
+    /// replacing the former `mulligan_pending` cursor). The frame is only ever
+    /// the top during setup, so `.last()` (not a topmost search) is correct.
+    #[must_use]
+    pub fn current_mulligan(&self) -> Option<InvestigatorId> {
+        match self.continuations.last() {
+            Some(Continuation::Mulligan { remaining }) => remaining.first().copied(),
+            _ => None,
         }
     }
 

--- a/crates/scenarios/tests/closing_demo.rs
+++ b/crates/scenarios/tests/closing_demo.rs
@@ -105,9 +105,8 @@ fn won_walk_full_cycle_replays_identically() {
     });
     let log = vec![
         Action::Player(PlayerAction::StartScenario { roster: vec![] }),
-        Action::Player(PlayerAction::Mulligan {
-            investigator: inv,
-            indices_to_redraw: vec![],
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickMultiple { selected: vec![] },
         }),
         Action::Player(PlayerAction::Investigate { investigator: inv }),
         commit_nothing.clone(), // commit window for investigate 1
@@ -174,9 +173,8 @@ fn lost_walk_spawn_attack_doom_replays_identically() {
     // realized action log so the round-trip replays exactly what ran.
     let mut log = vec![
         Action::Player(PlayerAction::StartScenario { roster: vec![] }),
-        Action::Player(PlayerAction::Mulligan {
-            investigator: inv,
-            indices_to_redraw: vec![],
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickMultiple { selected: vec![] },
         }),
     ];
     let (mut state, mut events) = drive(make_initial(), &log);

--- a/crates/scenarios/tests/mythos_phase.rs
+++ b/crates/scenarios/tests/mythos_phase.rs
@@ -63,16 +63,14 @@ fn drive(
 /// Returns the state after `EndTurn` has ticked through all phases
 /// and landed in Mythos with `mythos_draw_pending = Some(InvestigatorId(1))`.
 fn setup_at_mythos_draw(state: game_core::state::GameState) -> game_core::state::GameState {
-    let inv1 = InvestigatorId(1);
     let (state, _) = drive(
         state,
         vec![
             // Round 1 begins; mulligan window opens.
             Action::Player(PlayerAction::StartScenario { roster: vec![] }),
             // Close mulligan window (empty redraw = keep hand).
-            Action::Player(PlayerAction::Mulligan {
-                investigator: inv1,
-                indices_to_redraw: vec![],
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::PickMultiple { selected: vec![] },
             }),
             // Sole investigator ends their turn → auto-advance through
             // Investigation → Enemy → Upkeep → Mythos (round 2).
@@ -258,13 +256,11 @@ fn mythos_phase_multi_investigator_spawn_suspends_then_resumes_chain() {
         base,
         vec![
             Action::Player(PlayerAction::StartScenario { roster: vec![] }),
-            Action::Player(PlayerAction::Mulligan {
-                investigator: InvestigatorId(1),
-                indices_to_redraw: vec![],
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::PickMultiple { selected: vec![] },
             }),
-            Action::Player(PlayerAction::Mulligan {
-                investigator: InvestigatorId(2),
-                indices_to_redraw: vec![],
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::PickMultiple { selected: vec![] },
             }),
             Action::Player(PlayerAction::EndTurn),
             Action::Player(PlayerAction::EndTurn),
@@ -381,13 +377,11 @@ fn mythos_phase_multi_investigator_player_order() {
         base,
         vec![
             Action::Player(PlayerAction::StartScenario { roster: vec![] }),
-            Action::Player(PlayerAction::Mulligan {
-                investigator: inv1,
-                indices_to_redraw: vec![],
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::PickMultiple { selected: vec![] },
             }),
-            Action::Player(PlayerAction::Mulligan {
-                investigator: inv2,
-                indices_to_redraw: vec![],
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::PickMultiple { selected: vec![] },
             }),
             // inv1 ends turn → rotates to inv2.
             Action::Player(PlayerAction::EndTurn),
@@ -484,13 +478,11 @@ fn mythos_phase_multi_investigator_surge_does_not_spill() {
         base,
         vec![
             Action::Player(PlayerAction::StartScenario { roster: vec![] }),
-            Action::Player(PlayerAction::Mulligan {
-                investigator: inv1,
-                indices_to_redraw: vec![],
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::PickMultiple { selected: vec![] },
             }),
-            Action::Player(PlayerAction::Mulligan {
-                investigator: inv2,
-                indices_to_redraw: vec![],
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::PickMultiple { selected: vec![] },
             }),
             // inv1 ends turn → rotates to inv2.
             Action::Player(PlayerAction::EndTurn),

--- a/crates/scenarios/tests/synthetic_resolution.rs
+++ b/crates/scenarios/tests/synthetic_resolution.rs
@@ -21,7 +21,7 @@ use game_core::engine::apply;
 use game_core::event::Event;
 use game_core::scenario::Resolution;
 use game_core::state::{GameState, InvestigatorId, Phase};
-use game_core::{assert_event, Action, PlayerAction};
+use game_core::{assert_event, Action, InputResponse, PlayerAction};
 use scenarios::test_fixtures::synth_cards::TEST_REGISTRY;
 use scenarios::REGISTRY;
 
@@ -62,9 +62,8 @@ fn synthetic_scenario_resolves_won_via_act_advance() {
         state,
         vec![
             Action::Player(PlayerAction::StartScenario { roster: vec![] }),
-            Action::Player(PlayerAction::Mulligan {
-                investigator: inv,
-                indices_to_redraw: vec![],
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::PickMultiple { selected: vec![] },
             }),
         ],
     );
@@ -90,7 +89,6 @@ fn synthetic_scenario_resolves_won_via_act_advance() {
 #[test]
 fn synthetic_scenario_resolves_lost_via_doom() {
     install_registry();
-    let inv = InvestigatorId(1);
     let mut base = scenarios::test_fixtures::synthetic::setup();
     base.encounter_discard.clear();
 
@@ -99,9 +97,8 @@ fn synthetic_scenario_resolves_lost_via_doom() {
         base,
         vec![
             Action::Player(PlayerAction::StartScenario { roster: vec![] }),
-            Action::Player(PlayerAction::Mulligan {
-                investigator: inv,
-                indices_to_redraw: vec![],
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::PickMultiple { selected: vec![] },
             }),
         ],
     );

--- a/crates/scenarios/tests/the_gathering.rs
+++ b/crates/scenarios/tests/the_gathering.rs
@@ -12,7 +12,7 @@ use game_core::state::{CardCode, InvestigatorId, LocationId, Phase};
 use game_core::test_support::{
     fire_forced_on_enter, test_investigator, test_location, GameStateBuilder,
 };
-use game_core::{Action, PlayerAction};
+use game_core::{Action, InputResponse, PlayerAction};
 use scenarios::{the_gathering, REGISTRY};
 
 static INSTALL: Once = Once::new();
@@ -40,7 +40,6 @@ fn apply_checked(
 
 /// Seat solo Roland (01001, empty deck) and close the mulligan window.
 fn setup_and_seat() -> game_core::state::GameState {
-    let inv = InvestigatorId(1);
     let mut state = the_gathering::setup();
     for a in [
         Action::Player(PlayerAction::StartScenario {
@@ -49,9 +48,8 @@ fn setup_and_seat() -> game_core::state::GameState {
                 deck: vec![],
             }],
         }),
-        Action::Player(PlayerAction::Mulligan {
-            investigator: inv,
-            indices_to_redraw: vec![],
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickMultiple { selected: vec![] },
         }),
     ] {
         state = apply_checked(state, &a);

--- a/crates/scenarios/tests/the_gathering_resolutions.rs
+++ b/crates/scenarios/tests/the_gathering_resolutions.rs
@@ -45,19 +45,22 @@ fn seated_roland() -> GameState {
         investigator: CardCode::new(ROLAND),
         deck: vec![CardCode::new("01088"); 8],
     }];
-    // StartScenario completes (Done) with the mulligan cursor seeded; each
-    // investigator then submits a single Mulligan action before the turn's
-    // actions begin.
+    // StartScenario opens the mulligan prompt (AwaitingInput); each
+    // investigator then submits a single mulligan (ResolveInput) before the
+    // turn's actions begin.
     let started = apply(
         state,
         Action::Player(PlayerAction::StartScenario { roster }),
     );
-    assert_eq!(started.outcome, EngineOutcome::Done);
+    assert!(
+        matches!(started.outcome, EngineOutcome::AwaitingInput { .. }),
+        "StartScenario opens the mulligan prompt, got {:?}",
+        started.outcome
+    );
     let after_mulligan = apply(
         started.state,
-        Action::Player(PlayerAction::Mulligan {
-            investigator: INV,
-            indices_to_redraw: vec![],
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickMultiple { selected: vec![] },
         }),
     );
     assert_eq!(after_mulligan.outcome, EngineOutcome::Done);

--- a/crates/scenarios/tests/upkeep_hand_size.rs
+++ b/crates/scenarios/tests/upkeep_hand_size.rs
@@ -53,13 +53,16 @@ fn upkeep_prompts_and_discards_down_to_eight() {
         base,
         Action::Player(PlayerAction::StartScenario { roster: vec![] }),
     );
-    assert_eq!(r1.outcome, EngineOutcome::Done);
+    assert!(
+        matches!(r1.outcome, EngineOutcome::AwaitingInput { .. }),
+        "StartScenario opens the mulligan prompt, got {:?}",
+        r1.outcome
+    );
 
     let r2 = apply(
         r1.state,
-        Action::Player(PlayerAction::Mulligan {
-            investigator: inv1,
-            indices_to_redraw: vec![],
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickMultiple { selected: vec![] },
         }),
     );
     assert_eq!(r2.outcome, EngineOutcome::Done);
@@ -202,9 +205,8 @@ fn upkeep_hand_size_discard_replay_is_deterministic() {
 
     let actions = vec![
         Action::Player(PlayerAction::StartScenario { roster: vec![] }),
-        Action::Player(PlayerAction::Mulligan {
-            investigator: inv1,
-            indices_to_redraw: vec![],
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickMultiple { selected: vec![] },
         }),
         Action::Player(PlayerAction::EndTurn),
         Action::Player(PlayerAction::ResolveInput {

--- a/crates/scenarios/tests/upkeep_phase.rs
+++ b/crates/scenarios/tests/upkeep_phase.rs
@@ -16,7 +16,7 @@ use std::sync::Once;
 
 use game_core::engine::{apply, EngineOutcome};
 use game_core::state::{CardCode, CardInPlay, CardInstanceId, InvestigatorId, Phase};
-use game_core::{Action, PlayerAction};
+use game_core::{Action, InputResponse, PlayerAction};
 use scenarios::test_fixtures::synth_cards::TEST_REGISTRY;
 use scenarios::test_fixtures::synthetic;
 
@@ -57,13 +57,16 @@ fn upkeep_full_round_draws_and_grants_then_pauses_at_mythos() {
         base,
         Action::Player(PlayerAction::StartScenario { roster: vec![] }),
     );
-    assert_eq!(r1.outcome, EngineOutcome::Done);
+    assert!(
+        matches!(r1.outcome, EngineOutcome::AwaitingInput { .. }),
+        "StartScenario opens the mulligan prompt, got {:?}",
+        r1.outcome
+    );
 
     let r2 = apply(
         r1.state,
-        Action::Player(PlayerAction::Mulligan {
-            investigator: inv1,
-            indices_to_redraw: vec![],
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickMultiple { selected: vec![] },
         }),
     );
     assert_eq!(r2.outcome, EngineOutcome::Done);
@@ -127,14 +130,11 @@ fn upkeep_round_replay_is_deterministic() {
         base
     };
 
-    let inv1 = InvestigatorId(1);
-
     // --- First pass: drive and collect the action log. ---
     let actions = vec![
         Action::Player(PlayerAction::StartScenario { roster: vec![] }),
-        Action::Player(PlayerAction::Mulligan {
-            investigator: inv1,
-            indices_to_redraw: vec![],
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickMultiple { selected: vec![] },
         }),
         Action::Player(PlayerAction::EndTurn),
     ];

--- a/crates/server/tests/ws.rs
+++ b/crates/server/tests/ws.rs
@@ -66,9 +66,10 @@ async fn accepted_action_broadcasts_applied_to_all_clients() {
                 assert!(!matches!(outcome, EngineOutcome::Rejected { .. }));
                 assert!(!events.is_empty(), "StartScenario emits events");
                 // The broadcast carries the authoritative post-action
-                // state: StartScenario seeds the mulligan cursor, which
-                // was None in the pre-action Hello.
-                assert_eq!(state.mulligan_pending, Some(InvestigatorId(1)));
+                // state: StartScenario opens the setup mulligan loop, so the
+                // first investigator is prompted (it was None in the
+                // pre-action Hello).
+                assert_eq!(state.current_mulligan(), Some(InvestigatorId(1)));
             }
             other => panic!("expected Applied, got {other:?}"),
         }

--- a/crates/web/src/controls.rs
+++ b/crates/web/src/controls.rs
@@ -2,10 +2,9 @@
 //! toy scenario's actions, each `disabled` per the P6.6 legality helper
 //! ([`enabled_controls`](crate::legality::enabled_controls)) — a UX
 //! affordance, not a correctness gate (the server stays authoritative).
-//! Move/PlayCard use inline pickers; Mulligan has its own multi-select.
+//! Move/PlayCard use inline pickers; the setup mulligan is an `AwaitingInput`
+//! handled by `AwaitingInputView` (input.rs), not a dedicated control here.
 //! `board.rs` stays read-only — all interactivity lives here.
-
-use std::collections::BTreeSet;
 
 use game_core::state::{EnemyId, GameState, InvestigatorId};
 use game_core::PlayerAction;
@@ -203,75 +202,11 @@ fn enemy_picker(
     view! { <div class=format!("{class}-picker")>{buttons}</div> }
 }
 
-/// Mulligan multi-select: setup-only (gated on the `mulligan_pending`
-/// cursor via the legality helper). Toggling a card flips its index in
-/// `selected`; submitting sends the selected indices (empty = legal "keep
-/// my hand"). Kept separate from the P6.6 commit window — the shapes
-/// diverge (see the design spec). The cursor's investigator owns the
-/// redraw, not necessarily the active one.
-fn mulligan_picker(
-    game: &GameState,
-    legal: bool,
-    selected: RwSignal<BTreeSet<u32>>,
-    tx: Option<&OutboundTx>,
-) -> impl IntoView {
-    if !legal {
-        return ().into_any();
-    }
-    let cursor = game.mulligan_pending;
-    let hand: Vec<String> = cursor
-        .and_then(|id| game.investigators.get(&id))
-        .map(|inv| inv.hand.iter().map(ToString::to_string).collect())
-        .unwrap_or_default();
-    let cards: Vec<_> = hand
-        .into_iter()
-        .enumerate()
-        .map(|(idx, code)| {
-            let i = u32::try_from(idx).expect("hand fits in u32");
-            view! {
-                <li>
-                    <button
-                        class="mull-card"
-                        class:selected=move || selected.get().contains(&i)
-                        on:click=move |_| selected.update(|s| {
-                            if !s.remove(&i) {
-                                s.insert(i);
-                            }
-                        })
-                    >
-                        {code}
-                    </button>
-                </li>
-            }
-        })
-        .collect();
-    let tx = tx.cloned();
-    let on_submit = move |_| {
-        if let Some(inv) = cursor {
-            let indices: Vec<u8> = selected
-                .get()
-                .into_iter()
-                .map(|i| u8::try_from(i).expect("hand fits in u8"))
-                .collect();
-            if let Some(tx) = tx.clone() {
-                let _ = tx.unbounded_send(ClientMessage::Submit {
-                    action: PlayerAction::Mulligan {
-                        investigator: inv,
-                        indices_to_redraw: indices,
-                    },
-                });
-            }
-        }
-        selected.set(BTreeSet::new());
-    };
-    view! {
-        <section class="mulligan">
-            <ul>{cards}</ul>
-            <button class="mulligan-submit" on:click=on_submit>"Mulligan"</button>
-        </section>
-    }
-    .into_any()
-}
+// The dedicated setup-mulligan picker is gone (#348 part 2c-iii-a): the
+// mulligan is now an `AwaitingInput`, so it flows through `AwaitingInputView`
+// (input.rs), which builds the `ResolveInput(PickMultiple)` from the prompted
+// investigator's selected hand cards — the same multi-select shape. Prompt
+// text / labeling polish is deferred to #205.
 
 /// All core-loop action controls. Reads the store reactively; nothing
 /// renders until both a `game` and an `outcome` are present.
@@ -279,9 +214,6 @@ fn mulligan_picker(
 pub fn ActionControls() -> impl IntoView {
     let store = use_store();
     let tx = use_context::<OutboundTx>();
-    // Mulligan's own selection signal — component-lived so it survives the
-    // reactive re-render and is cleared on submit.
-    let mulligan_sel = RwSignal::new(BTreeSet::<u32>::new());
 
     view! {
         {move || {
@@ -353,12 +285,6 @@ pub fn ActionControls() -> impl IntoView {
                     {play_picker(&game, active, has(ActionControl::PlayCard), tx.as_ref())}
                     {enemy_picker(&game, active, has(ActionControl::Fight), "fight-target", "Fight", fight_action, tx.as_ref())}
                     {enemy_picker(&game, active, has(ActionControl::Evade), "evade-target", "Evade", evade_action, tx.as_ref())}
-                    {mulligan_picker(
-                        &game,
-                        has(ActionControl::Mulligan),
-                        mulligan_sel,
-                        tx.as_ref(),
-                    )}
                 </section>
             }
             .into_any()

--- a/crates/web/src/input.rs
+++ b/crates/web/src/input.rs
@@ -89,8 +89,13 @@ pub fn AwaitingInputView() -> impl IntoView {
     }
 }
 
-/// The active investigator's hand as card-code strings (empty when there
-/// is no active investigator).
+/// The prompted investigator's hand as card-code strings (empty when no
+/// investigator is being prompted).
+///
+/// Falls back to the setup mulligan's prompted investigator
+/// ([`GameState::current_mulligan`]) when there is no active investigator:
+/// during the setup mulligan loop `active_investigator` is not yet set, but
+/// the `PickMultiple` redraw still targets that investigator's hand (#348).
 ///
 /// Solo-scope assumption: the skill-test performer equals
 /// `active_investigator`. The authoritative "whose hand commits" is
@@ -99,6 +104,7 @@ pub fn AwaitingInputView() -> impl IntoView {
 /// #205.
 fn active_hand(game: &GameState) -> Vec<String> {
     game.active_investigator
+        .or_else(|| game.current_mulligan())
         .and_then(|id| game.investigators.get(&id))
         .map(|inv| inv.hand.iter().map(ToString::to_string).collect())
         .unwrap_or_default()

--- a/crates/web/src/legality.rs
+++ b/crates/web/src/legality.rs
@@ -16,7 +16,6 @@ pub enum ActionControl {
     Investigate,
     PlayCard,
     EndTurn,
-    Mulligan,
     DrawEncounter,
     AdvanceAct,
     Fight,
@@ -38,10 +37,13 @@ pub enum ActionControl {
 /// 2. `round == 0` is the pre-start state straight from a scenario
 ///    `setup()` (the engine bumps to round 1 at `StartScenario` and only
 ///    ever increments), so `StartScenario` is the sole legal action — it
-///    seeds hands and the mulligan cursor.
-/// 3. The setup cursors dominate their windows: `mulligan_pending` ⇒ only
-///    `Mulligan`; `mythos_draw_pending` ⇒ only `DrawEncounter`. These are
-///    state facts, not phase, so they're checked before the phase table.
+///    seeds hands and opens the setup mulligan loop. The mulligan itself is
+///    an `AwaitingInput` (case 1 above), so it needs no dedicated control —
+///    it flows through the `ResolveInput` prompt UI like every other
+///    suspension.
+/// 3. The `mythos_draw_pending` setup cursor dominates its window
+///    (⇒ only `DrawEncounter`). A state fact, not phase, so it's checked
+///    before the phase table.
 /// 4. Otherwise, the controls the current `Phase` permits.
 ///
 /// Finer checks (resources, action budget, clue presence) are
@@ -49,8 +51,8 @@ pub enum ActionControl {
 #[must_use]
 pub fn enabled_controls(game: &GameState, outcome: &EngineOutcome) -> BTreeSet<ActionControl> {
     use ActionControl::{
-        AdvanceAct, Draw, DrawEncounter, EndTurn, Evade, Fight, Investigate, Move, Mulligan,
-        PlayCard, StartScenario,
+        AdvanceAct, Draw, DrawEncounter, EndTurn, Evade, Fight, Investigate, Move, PlayCard,
+        StartScenario,
     };
 
     if game.resolution.is_some() {
@@ -61,9 +63,6 @@ pub fn enabled_controls(game: &GameState, outcome: &EngineOutcome) -> BTreeSet<A
     }
     if game.round == 0 {
         return BTreeSet::from([StartScenario]);
-    }
-    if game.mulligan_pending.is_some() {
-        return BTreeSet::from([Mulligan]);
     }
     if game.mythos_draw_pending.is_some() {
         return BTreeSet::from([DrawEncounter]);
@@ -128,15 +127,10 @@ mod tests {
         assert_eq!(enabled_controls(&game, &out), BTreeSet::new());
     }
 
-    #[test]
-    fn mulligan_pending_enables_only_mulligan() {
-        let mut game = investigation_game();
-        game.mulligan_pending = Some(InvestigatorId(1));
-        assert_eq!(
-            enabled_controls(&game, &EngineOutcome::Done),
-            BTreeSet::from([ActionControl::Mulligan])
-        );
-    }
+    // The former `mulligan_pending_enables_only_mulligan` test is gone: the
+    // setup mulligan is now an `AwaitingInput`, so it is covered by
+    // `awaiting_input_disables_everything` (the mulligan prompt flows through
+    // the `ResolveInput` UI, not a dedicated control). #348 part 2c-iii-a.
 
     #[test]
     fn mythos_draw_pending_enables_only_draw_encounter() {

--- a/crates/web/tests/controls.rs
+++ b/crates/web/tests/controls.rs
@@ -266,68 +266,9 @@ async fn play_picker_submits_play_card_by_hand_index() {
     }
 }
 
-/// A setup game where investigator 1 is on the mulligan cursor with a
-/// two-card hand.
-fn mulligan_game() -> game_core::state::GameState {
-    let mut inv = test_investigator(1);
-    inv.hand = vec![
-        CardCode::new("_synth_event_a"),
-        CardCode::new("_synth_event_b"),
-    ];
-    GameStateBuilder::new()
-        .with_investigator(inv)
-        .with_active_investigator(InvestigatorId(1))
-        .with_phase(Phase::Investigation)
-        .with_round(1)
-        .with_mulligan_pending(InvestigatorId(1))
-        .build()
-}
-
-#[wasm_bindgen_test]
-async fn mulligan_submits_selected_indices() {
-    let mut rx = mount(mulligan_game(), EngineOutcome::Done).await;
-    let controls = last_controls();
-    // Select the first card, then submit.
-    let cards = controls.query_selector_all(".mull-card").expect("query");
-    cards
-        .item(0)
-        .expect("first mull-card")
-        .dyn_into::<web_sys::HtmlElement>()
-        .expect("HtmlElement")
-        .click();
-    leptos::task::tick().await;
-    click_in(&controls, ".mulligan-submit");
-    leptos::task::tick().await;
-    let frame = rx.try_recv().expect("a frame after tick");
-    match submit_action(frame) {
-        PlayerAction::Mulligan {
-            investigator,
-            indices_to_redraw,
-        } => {
-            assert_eq!(investigator, InvestigatorId(1));
-            assert_eq!(indices_to_redraw, vec![0]);
-        }
-        other => panic!("expected Mulligan, got {other:?}"),
-    }
-}
-
-#[wasm_bindgen_test]
-async fn mulligan_with_no_selection_keeps_hand() {
-    let mut rx = mount(mulligan_game(), EngineOutcome::Done).await;
-    click_in(&last_controls(), ".mulligan-submit");
-    leptos::task::tick().await;
-    let frame = rx.try_recv().expect("a frame after tick");
-    match submit_action(frame) {
-        PlayerAction::Mulligan {
-            investigator,
-            indices_to_redraw,
-        } => {
-            assert_eq!(investigator, InvestigatorId(1));
-            assert_eq!(indices_to_redraw, Vec::<u8>::new());
-        }
-        other => panic!("expected Mulligan, got {other:?}"),
-    }
-}
+// The dedicated mulligan-picker tests are gone (#348 part 2c-iii-a): the setup
+// mulligan is now an `AwaitingInput` handled by `AwaitingInputView`, covered by
+// the mulligan tests in tests/input.rs.
 
 /// An Investigation-phase game with one enemy (id 7) engaged with the
 /// active investigator (id 1).

--- a/crates/web/tests/input.rs
+++ b/crates/web/tests/input.rs
@@ -130,3 +130,50 @@ async fn commit_after_selecting_submits_that_index() {
         .expect("a frame after tick — did tick flush the click handler?");
     assert_eq!(commit_indices(frame), vec![0]);
 }
+
+// ---- Setup mulligan via AwaitingInputView (#348 part 2c-iii-a) ----
+//
+// The setup mulligan is now an `AwaitingInput` routed through this same view
+// (its dedicated picker was removed). The wrinkle vs. the commit window:
+// during the mulligan loop there is no active investigator yet, so the view
+// must fall back to the mulligan-prompted investigator's hand.
+
+/// A setup-mulligan state: investigator 1 is on the mulligan loop with a
+/// two-card hand and **no active investigator** (as the engine leaves it
+/// during setup).
+fn mulligan_game() -> game_core::state::GameState {
+    let mut inv = test_investigator(1);
+    inv.hand = vec![
+        CardCode::new("_synth_event_a"),
+        CardCode::new("_synth_event_b"),
+    ];
+    GameStateBuilder::new()
+        .with_investigator(inv)
+        .with_mulligan_remaining([InvestigatorId(1)])
+        .build()
+}
+
+#[wasm_bindgen_test]
+async fn mulligan_renders_prompted_hand_without_active_investigator() {
+    // active_investigator is None during the mulligan loop; the view falls
+    // back to current_mulligan() so the redraw hand still renders.
+    let _rx = mount(mulligan_game()).await;
+    let section = last_section();
+    let html = section.inner_html();
+    assert!(html.contains("_synth_event_a"), "card a missing: {html}");
+    assert!(html.contains("_synth_event_b"), "card b missing: {html}");
+}
+
+#[wasm_bindgen_test]
+async fn mulligan_submits_selected_redraw_index() {
+    let mut rx = mount(mulligan_game()).await;
+    let section = last_section();
+    click_in(&section, ".hand-card", 0); // redraw index 0
+    leptos::task::tick().await;
+    click_in(&section, ".commit", 0);
+    leptos::task::tick().await;
+    let frame = rx
+        .try_recv()
+        .expect("a frame after tick — did tick flush the click handler?");
+    assert_eq!(commit_indices(frame), vec![0]);
+}

--- a/docs/superpowers/plans/2026-06-19-pr2c-iii-fold-mulligan-drawencounter.md
+++ b/docs/superpowers/plans/2026-06-19-pr2c-iii-fold-mulligan-drawencounter.md
@@ -84,3 +84,27 @@ This is **PR 2c-iii** (2c-i `PickMultiple` ✅, 2c-ii `PickSingle` ✅; this). S
 **Risk flags:** (1) `StartScenario`/Mythos-entry returning `AwaitingInput` is a broad test-shape change — most of the churn. (2) The surge-chain + spawn-engage re-entry is the one place logic (not just protocol) is delicate; pin it with the existing `mythos_phase` surge + spawn-engage integration tests (`scenarios/tests/{mythos_phase,encounter_spawn}.rs`), which must pass unchanged in behavior. (3) `server`/`web` removing two actions — confirm no client UI path still constructs them (the web client builds `DrawEncounterCard`? grep `crates/web/src` — if so it migrates to a Confirm control).
 
 **Out of scope:** tokens (#347), revelation disposal (#380), human option labels + client rendering (#205), `enemy_attack_pending` cursor.
+
+---
+
+## Execution notes (from a first pass on 2c-iii-a, reverted clean)
+
+A first execution of **2c-iii-a** got the engine half done cleanly but was reverted before finishing the test surface (end of a long session). What it surfaced — bake these into the next run:
+
+- **The engine half is straightforward** and worked: `Continuation::Mulligan { remaining }` + classifier arms; `cards::prompt_mulligan` + `resume_mulligan` (reads `PickMultiple { selected }` → redraw hand indices, drives `remaining`, `investigation_phase` on drain); `start_scenario` pushes the frame and returns `prompt_mulligan` (so its outcome is `AwaitingInput`, or `Done` straight to `investigation_phase` when no active investigators); the `mulligan_pending` guard in `apply_player_action` → a `Mulligan`-frame guard; remove the `Mulligan` dispatch arm + the post-mulligan kickoff block; add `Some(Continuation::Mulligan { .. }) => cards::resume_mulligan` to `resolve_input`; remove the `mulligan_pending` field.
+
+- **Add a `GameState::current_mulligan() -> Option<InvestigatorId>` accessor** (reads the top `Mulligan` frame's `remaining[0]`). It makes the test read-site migration a clean rename: `state.mulligan_pending` → `state.current_mulligan()`.
+
+- **Builder:** keep a staging field but the helper must stage the *full* remaining queue, not one id — replace `with_mulligan_pending(id)` with `with_mulligan_remaining(impl IntoIterator<Item = InvestigatorId>)`, pushing `Continuation::Mulligan { remaining }` in `build()`. The single-id form breaks the multi-investigator advance tests.
+
+- **Obsolete test (remove it):** the "out-of-order mulligan rejected" unit test (`engine/mod.rs`) tested that `Mulligan { investigator: wrong }` rejects on cursor mismatch. The folded action carries **no** investigator (the frame's `remaining[0]` is the actor), so that rejection path no longer exists — delete the test rather than port it.
+
+- **`StartScenario` now returns `AwaitingInput`:** every test doing `StartScenario → (assert Done) → Mulligan` becomes `StartScenario → (assert AwaitingInput) → ResolveInput(PickMultiple)`. Dropping the action's `investigator` field leaves unused `inv`/`id` bindings in some tests (`_`-prefix or remove).
+
+- **Mechanical action-fold transform** (worked across ~19 files with one perl in the first pass): `PlayerAction::Mulligan { investigator: _, indices_to_redraw: vec![a, b] }` → `PlayerAction::ResolveInput { response: InputResponse::PickMultiple { selected: vec![OptionId(a), OptionId(b)] } }` (empty → `vec![]`). Then add `InputResponse`/`OptionId` imports where the compiler flags (`scenarios/tests/{synthetic_resolution,upkeep_phase,the_gathering,...}.rs`).
+
+- **`server`:** `ws.rs` asserts on `state.mulligan_pending` → `state.current_mulligan()`.
+
+- **`web` client — remove the dead dedicated mulligan UI.** `enabled_controls` already short-circuits to empty on `AwaitingInput` (`legality.rs`), and mulligan is now an `AwaitingInput`, so the `mulligan_pending` legality branch, `ActionControl::Mulligan`, and the `mulligan_picker` component (+ its `mulligan_sel` signal and `web/tests/controls.rs` cases) are all unreachable. Remove them; the mulligan now flows through `input.rs`'s `AwaitingInputView`, which already builds `PickMultiple` from selected hand cards — functionally correct. The prompt-text/labeling polish is **#205**.
+
+The same shape applies to **2c-iii-b** (`DrawEncounterCard` → `Confirm`): expect a `current_encounter_drawer()` accessor, a `with_mythos_draw_remaining` builder helper, `mythos_phase` returning `AwaitingInput`, the analogous server/web touchpoints, and the surge/spawn-engage re-entry rewire called out in the design above.

--- a/docs/superpowers/plans/2026-06-19-pr2c-iii-fold-mulligan-drawencounter.md
+++ b/docs/superpowers/plans/2026-06-19-pr2c-iii-fold-mulligan-drawencounter.md
@@ -1,0 +1,86 @@
+# PR 2c-iii (#348, part 3c) — Fold `Mulligan` / `DrawEncounterCard` into `ResolveInput`; cursors → frames — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (or subagent-driven-development) to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the last two non-standard `PlayerAction`s (`Mulligan`, `DrawEncounterCard`) by turning the setup-mulligan loop and the Mythos-step-1.4 draw loop into `AwaitingInput`-driven `Continuation` frames resumed via `ResolveInput`. After this, every player-facing suspension resumes through `ResolveInput`, and the `mulligan_pending` / `mythos_draw_pending` cursors are gone.
+
+**Architecture:** This is **control-flow**, not a wire rename. Two independent halves, **each its own PR** (a: Mulligan, b: DrawEncounterCard):
+- A loop becomes a `Continuation` frame holding `remaining: Vec<InvestigatorId>` (turn order; head = current actor). The phase driver that *set the cursor* now **pushes the frame + returns `AwaitingInput`** for `remaining[0]`. The old dedicated-action handler becomes a `resume_*` that advances `remaining` and either re-emits `AwaitingInput` for the next actor or, when drained, pops the frame and runs the phase tail.
+- The two actions leave `PlayerAction`; `resolve_input` gains a dispatch arm per frame; the per-cursor guards/arms in `apply_player_action` collapse into top-frame dispatch.
+
+**Tech Stack:** Rust — `game-core` (engine), `server`, `web`, and tests across the workspace. **Wire + replay-log contract change** (two actions removed) → touches `server`/`web` more than any prior sub-PR.
+
+This is **PR 2c-iii** (2c-i `PickMultiple` ✅, 2c-ii `PickSingle` ✅; this). Spec §A–B (Tier-C cursors + the action fold). Series: #345 ✅ → #348 (2a ✅ · 2b ✅ · 2c-i ✅ · 2c-ii ✅ · **2c-iii-a · 2c-iii-b**) → #347 → #380.
+
+## Global Constraints
+
+- **CI gauntlet, warnings-as-errors** (all six jobs) before every push.
+- **No behavior change** to the *game logic* — only the *protocol* changes: setup and Mythos draw now round-trip through `AwaitingInput`/`ResolveInput` instead of dedicated actions. The mulligan redraw / encounter-draw / surge-chain effects are byte-for-byte preserved.
+- **`StartScenario` and the Mythos-phase entry now return `AwaitingInput`** (the first mulligan / first draw prompt) where they previously returned `Done` with a cursor set. Every test that did `StartScenario → (assert Done) → Mulligan` becomes `StartScenario → (assert AwaitingInput) → ResolveInput(PickMultiple)`. This is the largest test-shape change in the series.
+- **Branches:** `engine/fold-mulligan` (PR a) then `engine/fold-draw-encounter` (PR b), each off fresh `main`. Commit per task; push only when green.
+
+---
+
+## PR 2c-iii-a — `Mulligan` → `ResolveInput(PickMultiple)`; `mulligan_pending` → `Mulligan` frame
+
+### Surface
+- `PlayerAction::Mulligan { investigator, indices_to_redraw }` (`action.rs:156`).
+- `apply_player_action` (`mod.rs`): the mulligan guard (`:68-80`), the `Mulligan` dispatch arm (`:194`), and the post-mulligan `investigation_phase` kickoff (`:230-248`).
+- `cards::mulligan` (`cards.rs:287-366`) — validates indices, redraws, advances `mulligan_pending` via `next_active_investigator_after`.
+- `phases.rs:163` (`start_scenario` sets `mulligan_pending = first_active_investigator`).
+- `mulligan_pending` field (`game_state.rs`) + builder `with_mulligan_pending` + builder init.
+- ~19 files constructing `PlayerAction::Mulligan`.
+
+### Design
+- New `Continuation::Mulligan { remaining: Vec<InvestigatorId> }` (+ classify in the two `as_resolution`/`as_resolution_mut` arms). `remaining[0]` is the current mulliganer; turn order, Active only.
+- A shared `fn prompt_mulligan(cx) -> EngineOutcome`: read the top `Mulligan` frame's `remaining[0]`, return `AwaitingInput { request: choice("…mulligan… submit PickMultiple with hand indices to redraw (empty = keep)", hand-as-options-OR-prompt) }`. (Per 2c-i, offered-options population for the hand is deferred to #205; for now `OptionId(i)` = hand index, request may stay a prompt or carry minimal options — match the commit-window decision in 2c-i.)
+- `start_scenario` (`phases.rs:163`): replace `mulligan_pending = …` with: push `Continuation::Mulligan { remaining: active_investigators_in_turn_order(state) }`; if `remaining` is empty (no active investigators — degenerate) fall straight through to `investigation_phase`; else `return prompt_mulligan(cx)`. **`start_scenario`'s outcome becomes `AwaitingInput`.**
+- `cards::mulligan` → `resume_mulligan(cx, response)`: destructure `PickMultiple { selected }` → `indices: Vec<u8>` (the redraw hand indices, `o.0 as u8`); run the **unchanged** validation + redraw + `MulliganPerformed` event against the frame's `remaining[0]`; then `remaining.remove(0)`; if empty → pop the `Mulligan` frame and call `investigation_phase` (the post-mulligan kickoff moves here from `apply_player_action`); else `prompt_mulligan(cx)` for the next.
+- `apply_player_action`: delete the mulligan guard, the `Mulligan` arm, and the post-mulligan-kickoff block. Add `Continuation::Mulligan(_)` to `resolve_input`'s top-frame match → `resume_mulligan`. (Note: `Mulligan` is the only frame that can be top *during setup before the mulligan completes* — top-frame dispatch handles it; the old "reject everything but Mulligan/StartScenario" guard is replaced by the generic input-awaiting reject for frame-suspensions.)
+- Remove `PlayerAction::Mulligan`, `mulligan_pending` field, `GameStateBuilder::with_mulligan_pending` (or repoint it to stage a `Mulligan` frame — check callers; a `with_mulligan_remaining([ids])` staging the frame is the natural replacement).
+
+### Tasks
+- [ ] **a1 — `Mulligan` frame + `prompt_mulligan` + `resume_mulligan`; `start_scenario` emits `AwaitingInput`.** Add the variant + classifier; add `prompt_mulligan`; convert `cards::mulligan` into `resume_mulligan` (reads `PickMultiple`, drives `remaining`, kicks off `investigation_phase` on drain); rewire `start_scenario`. Keep `PlayerAction::Mulligan` + `mulligan_pending` *temporarily* unused-ish so the build stays green is NOT possible here (the flows are entangled) — so a1 also: delete the guard/arm/kickoff, add the `resolve_input` arm, remove the field + builder helper, and migrate the in-crate engine tests. Big task; the compiler + the exhaustive `as_resolution` match guide it.
+- [ ] **a2 — Fold `PlayerAction::Mulligan` → `ResolveInput(PickMultiple)` at all call sites + remove the action.** Mechanical: `Mulligan { investigator, indices_to_redraw: vec![a,b] }` → `ResolveInput { response: PickMultiple { selected: vec![OptionId(a), OptionId(b)] } }` (empty redraw → `selected: vec![]`). The `investigator` is dropped (the frame's `remaining[0]` is the actor). Update `StartScenario`-then-`Mulligan` test shapes (`StartScenario` now returns `AwaitingInput`). Covers `server`/`web` + ~19 test files. Then delete `PlayerAction::Mulligan`. Full gauntlet.
+
+---
+
+## PR 2c-iii-b — `DrawEncounterCard` → `ResolveInput(Confirm)`; `mythos_draw_pending` → `EncounterDraw` frame
+
+### Surface
+- `PlayerAction::DrawEncounterCard` (`action.rs:288`); its dispatch arm (`mod.rs:215`).
+- `draw_encounter_card` (`encounter.rs:608`) → `mythos_draw_for` → `run_mythos_draw_chain` (surge loop) → `advance_mythos_draw_pending` (`encounter.rs:771`).
+- `phases.rs:387` (`mythos_phase` sets `mythos_draw_pending = first_active`; `None` ⇒ skip to the after-draws window).
+- `resume_spawn_engage` (`hunters.rs:552`) re-enters the surge chain when `mythos_draw_pending == investigator_to_draw`.
+- `mythos_draw_pending` field + ~13 files constructing `DrawEncounterCard`.
+
+### Design
+- New `Continuation::EncounterDraw { remaining: Vec<InvestigatorId> }` (+ classify). `remaining[0]` = current drawer.
+- `fn prompt_encounter_draw(cx) -> EngineOutcome`: `AwaitingInput { request: prompt("Mythos 1.4: {remaining[0]:?} draws an encounter card; submit ResolveInput::Confirm") }`. (No options — `Confirm` is a binary proceed.)
+- `mythos_phase` (`phases.rs:387`): push `EncounterDraw { remaining: active_in_turn_order }`; if empty → the existing `MythosAfterDraws` path; else `return prompt_encounter_draw(cx)`. **Mythos entry now returns `AwaitingInput`** (it's reached from the upkeep→Mythos cascade and from round-1… trace the callers; the cascade currently runs `mythos_phase` inline and returns its outcome — confirm it propagates `AwaitingInput`).
+- `draw_encounter_card` → `resume_encounter_draw(cx, response)`: require `Confirm`; run `run_mythos_draw_chain(cx, remaining[0], 0, true)` (unchanged surge logic; it may suspend on a spawn-engage `SpawnEngage` frame — see below); on the chain's `Done`, `remaining.remove(0)`; if empty → pop the `EncounterDraw` frame + open the `MythosAfterDraws` window (what `advance_mythos_draw_pending`→`None` did); else `prompt_encounter_draw` for the next.
+- **Surge / spawn-engage interplay (the tricky bit):** today `resume_spawn_engage` re-enters the chain when `mythos_draw_pending == investigator_to_draw`. Replace that read with "the top non-`SpawnEngage` frame is an `EncounterDraw` whose `remaining[0] == investigator_to_draw`" — i.e. the drawer is still mid-Mythos-draw. The `SpawnEngage` frame sits **above** the `EncounterDraw` frame; when it resolves it re-drives the chain for the same drawer. `advance_mythos_draw_pending` is absorbed into `resume_encounter_draw`'s `remaining.remove(0)`.
+- `apply_player_action`: delete the `DrawEncounterCard` arm. Add `Continuation::EncounterDraw(_)` → `resume_encounter_draw` in `resolve_input`.
+- Remove `PlayerAction::DrawEncounterCard`, `mythos_draw_pending` field.
+
+### Tasks
+- [ ] **b1 — `EncounterDraw` frame + `prompt`/`resume`; `mythos_phase` emits `AwaitingInput`; rewire surge + spawn-engage re-entry.** Add variant + classifier; `prompt_encounter_draw`; convert `draw_encounter_card`→`resume_encounter_draw` driving `remaining`; rewire `mythos_phase`; repoint `resume_spawn_engage`'s re-entry condition + `advance_mythos_draw_pending`'s removal onto the frame. Delete the `DrawEncounterCard` arm; add the `resolve_input` arm; remove the field; migrate in-crate engine tests (the `mythos_draw_pending` reads/sets in `encounter.rs`/`phases.rs` tests → inspect/stage the `EncounterDraw` frame).
+- [ ] **b2 — Fold `PlayerAction::DrawEncounterCard` → `ResolveInput(Confirm)` at all call sites + remove the action.** Mechanical: `DrawEncounterCard` → `ResolveInput { response: Confirm }`. Update the Mythos-entry test shapes (now `AwaitingInput`). Covers `server`/`web` + ~13 test files. Delete the action. Full gauntlet.
+
+---
+
+## Cross-cutting (do in whichever PR lands second)
+
+- **Spec correction (owed):** update `docs/superpowers/specs/2026-06-19-continuation-stack-cleanup-design.md` — its "Sequencing" still lists the old `#347`-before-`#348` order (now `#345 → #348 → #347 → #380`), and re-add the `InputResponse` normalization (2c-i/ii/iii) to the §1 scope (it was dropped from the original spec). Also note the `PickLocation`/`PickInvestigator` consolidation landed in 2c-ii (not deferred to #205 as the spec's earlier text implied — only the *labels/rendering* defer).
+- **Phase-7 doc:** flip the §1 progress line; the `#205` client-render note still lists `PickInvestigator`/`DiscardCards` (now `PickSingle`/`PickMultiple`) — reword.
+- After 2c-iii: the engine's only player-input channel is `ResolveInput`; `PlayerAction` is the turn-action set + `StartScenario` + `ResolveInput`. The §1 cleanup's router/taxonomy goals are met; remaining series work is **#347** (token-route `ResolveInput`, now trivial on the unified channel) and **#380** (revelation disposal).
+
+## Self-Review
+
+**Spec/§B coverage:** both actions fold into `ResolveInput` (`PickMultiple` / `Confirm`); `mulligan_pending`/`mythos_draw_pending` become loop frames; setup + Mythos emit `AwaitingInput`; cursors removed. ✓ Tier-C from the spec's §A table is done; `enemy_attack_pending` stays a cursor (it's framework-sequencing, not player-facing — unchanged). ✓
+
+**Placeholder scan:** the mulligan/draw prompt's offered-options population is explicitly deferred to #205 (consistent with 2c-i); the surge/spawn-engage re-entry condition is described precisely (top non-`SpawnEngage` frame is the `EncounterDraw` for the drawer) but the implementer must read `run_mythos_draw_chain` + `resume_spawn_engage` to wire it — flagged as the task's known-tricky point. Mechanical action-site folds give the exact transformation + the file count.
+
+**Risk flags:** (1) `StartScenario`/Mythos-entry returning `AwaitingInput` is a broad test-shape change — most of the churn. (2) The surge-chain + spawn-engage re-entry is the one place logic (not just protocol) is delicate; pin it with the existing `mythos_phase` surge + spawn-engage integration tests (`scenarios/tests/{mythos_phase,encounter_spawn}.rs`), which must pass unchanged in behavior. (3) `server`/`web` removing two actions — confirm no client UI path still constructs them (the web client builds `DrawEncounterCard`? grep `crates/web/src` — if so it migrates to a Confirm control).
+
+**Out of scope:** tokens (#347), revelation disposal (#380), human option labels + client rendering (#205), `enemy_attack_pending` cursor.


### PR DESCRIPTION
## Summary

Migrates the setup mulligan off its bespoke `GameState::mulligan_pending` cursor onto a `Continuation::Mulligan { remaining }` frame, resumed through `ResolveInput(PickMultiple)` like every other player-facing suspension. After this, the engine's only player-input channel is `ResolveInput` (the last non-standard player action, `DrawEncounterCard`, follows in 2c-iii-b).

This is **PR 2c-iii-a** of #348's continuation-stack cleanup (2c-i `PickMultiple` ✅, 2c-ii `PickSingle` ✅).

## What changed

**Engine (commit a1):**
- New `Continuation::Mulligan { remaining: Vec<InvestigatorId> }` (+ classifier arms) and `GameState::current_mulligan()` reading the prompted investigator off the stack.
- `start_scenario` now pushes the frame and returns `AwaitingInput` (the first mulligan prompt) — or `Done` straight into `investigation_phase` when no Active investigator exists.
- `cards::mulligan` → `cards::resume_mulligan` (driven by the top frame's `remaining[0]`, not a submitted investigator id) + `cards::prompt_mulligan`. The post-mulligan Investigation kickoff moves out of `apply_player_action` into `resume_mulligan`'s drain path.
- `apply_player_action`'s `mulligan_pending` guard becomes a `Mulligan`-frame guard; `resolve_input` gains a `Mulligan` arm. Builder: `with_mulligan_pending(id)` → `with_mulligan_remaining(ids)`.

**Workspace fold (commit a2):**
- Delete `PlayerAction::Mulligan`; fold every call site onto `ResolveInput(PickMultiple { selected })` (each `OptionId` = a hand index to redraw, empty = keep).
- `server`: `ws.rs` reads `current_mulligan()`.
- `web`: remove the now-dead dedicated mulligan UI (`mulligan_picker`, `mulligan_sel`, the `mulligan_pending` legality branch, `ActionControl::Mulligan`). The mulligan now flows through `AwaitingInputView`; `active_hand()` falls back to `current_mulligan()` so the redraw hand renders during setup (when no active investigator is set).

## Test notes

- `StartScenario` now returns `AwaitingInput` instead of `Done`-with-cursor — the largest test-shape change; updated across game-core/scenarios/cards/server tests.
- The out-of-order / wrong-investigator mulligan rejection tests are dropped (the folded response carries no investigator) and replaced with a structural "loop skips defeated investigator" test.
- New `crates/web/tests/input.rs` wasm tests cover the mulligan-through-`AwaitingInputView` path (including the no-active-investigator hand fallback).
- Full CI gauntlet run locally (all 7 jobs): fmt, test, clippy, doc, wasm-build, wasm-test (headless Firefox), wasm-clippy — all green.

## Linked issues

Part of #348 (2c-iii-b and #347/#380 remain).