### PR TITLE
engine: fold Mythos encounter draw onto a Continuation frame + ResolveInput (#348 part 2c-iii-b)

### DIFF
--- a/crates/cards/tests/dodge.rs
+++ b/crates/cards/tests/dodge.rs
@@ -53,6 +53,13 @@ fn dodge_state() -> (GameState, InvestigatorId, EnemyId) {
     let mut inv = test_investigator(1);
     inv.current_location = Some(loc_id);
     inv.hand = vec![CardCode::new(DODGE)];
+    // A spare deck card so the round-ending cascade's upkeep step-4.4 draw has
+    // something to draw. Without it, the empty deck reshuffles the discard —
+    // and since a played Dodge is discarded the instant its effect completes
+    // (RR Appendix I step 4, now flushed at completion rather than the apply
+    // boundary — #348), the reshuffle would draw Dodge straight back into hand,
+    // obscuring the "Dodge went to discard" assertion.
+    inv.deck = vec![CardCode::new("01088")];
 
     let state = game_core::test_support::GameStateBuilder::new()
         .with_phase(Phase::Investigation)

--- a/crates/cards/tests/guard_dog_soak.rs
+++ b/crates/cards/tests/guard_dog_soak.rs
@@ -206,10 +206,15 @@ fn attack_reaching_printed_health_defeats_guard_dog_with_no_reaction_window() {
     state = result.state;
 
     // Guard Dog left play (discarded), so no soak window suspended the loop;
-    // the enemy phase cascaded onward.
+    // the enemy phase cascaded onward, all the way through Upkeep into the
+    // round-ending Mythos step-1.4 encounter-draw prompt (#348). The
+    // definitive "no soak window opened" proof is the event-stream assertion
+    // below; reaching the Mythos draw prompt confirms the loop was not parked.
     assert!(
-        !matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),
-        "no soak window should park the loop when Guard Dog is defeated: {:?}",
+        matches!(result.outcome, EngineOutcome::AwaitingInput { .. })
+            && state.phase == Phase::Mythos
+            && state.current_encounter_drawer().is_some(),
+        "the loop cascaded onward to the Mythos draw prompt (not a soak park): {:?}",
         result.outcome
     );
     assert!(

--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -259,15 +259,13 @@ pub enum PlayerAction {
         /// `Activated`-triggered ability.
         ability_index: u8,
     },
-    /// Resolve one Mythos-phase encounter draw for the acting
-    /// investigator. Valid only during `Phase::Mythos` when
-    /// `state.mythos_draw_pending == Some(acting_investigator)`.
-    /// Resolves the per-card 5-step sub-sequence from Rules
-    /// Reference p.24 step 1.4 inline (including surge re-draws);
-    /// advances `mythos_draw_pending` to the next-in-turn-order
-    /// drawer, or opens the `MythosAfterDraws` window if this was
-    /// the last drawer.
-    DrawEncounterCard,
+    // The Mythos step-1.4 encounter draw is no longer a dedicated action
+    // (#348 part 2c-iii-b): it round-trips through `ResolveInput(Confirm)`
+    // against the top `Continuation::EncounterDraw` frame, like every other
+    // player-facing suspension. The acting drawer is the frame's `remaining[0]`;
+    // the per-card 5-step sub-sequence (RR p.24 step 1.4, including surge
+    // re-draws) resolves on `Confirm`, then the loop advances to the next
+    // drawer or opens the `MythosAfterDraws` window.
     /// Respond to an `AwaitingInput` prompt the engine emitted. The
     /// shape of `response` is dictated by the active prompt. (The
     /// `EngineOutcome::AwaitingInput` variant lands in a later PR.)

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -1,11 +1,13 @@
 //! Encounter-deck draw, spawn, and Mythos draw chain handlers.
 
+use crate::action::InputResponse;
 use crate::card_data::{CardKind, CardMetadata, CardType, HealthValue, Spawn, SpawnLocation};
 use crate::card_registry;
 use crate::dsl::Trigger;
 use crate::event::Event;
 use crate::state::{
-    CardCode, Enemy, InvestigatorId, LocationId, Phase, PhaseStep, SpawnEngagePending, WindowKind,
+    CardCode, Continuation, Enemy, InvestigatorId, LocationId, PhaseStep, SpawnEngagePending,
+    Status, WindowKind,
 };
 
 use super::super::evaluator::{apply_effect, EvalContext};
@@ -603,56 +605,66 @@ pub(super) fn draw_encounter_top(cx: &mut Cx) -> Option<CardCode> {
     cx.state.encounter_deck.pop_front()
 }
 
-/// Handler for [`PlayerAction::DrawEncounterCard`]. Validates phase
-/// + cursor; delegates to [`mythos_draw_for`] on success.
-pub(super) fn draw_encounter_card(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
-    if cx.state.phase != Phase::Mythos {
+/// Push the prompt for the topmost [`Continuation::EncounterDraw`] frame's
+/// current drawer (`remaining[0]`): an [`EngineOutcome::AwaitingInput`] whose
+/// response is a binary [`Confirm`](InputResponse::Confirm) (the draw carries
+/// no choice). Used by `mythos_phase` (first prompt) and
+/// [`advance_encounter_draw`] (re-prompt after a queue pop). The frame must
+/// already be on the stack; callers ensure this.
+pub(super) fn prompt_encounter_draw(cx: &Cx) -> EngineOutcome {
+    let drawer = cx
+        .state
+        .current_encounter_drawer()
+        .expect("prompt_encounter_draw: no EncounterDraw frame on the stack");
+    EngineOutcome::AwaitingInput {
+        request: InputRequest::prompt(format!(
+            "Mythos step 1.4: {drawer:?} draws an encounter card; submit InputResponse::Confirm.",
+        )),
+        resume_token: ResumeToken(0),
+    }
+}
+
+/// Resume the Mythos step-1.4 encounter-draw loop (#348), driving the topmost
+/// [`Continuation::EncounterDraw`] frame.
+///
+/// The acting drawer is the frame's `remaining[0]` (Rules Reference p.24
+/// player order) — the response is a binary [`Confirm`](InputResponse::Confirm)
+/// (the draw carries no choice). Runs that investigator's full surge chain via
+/// [`run_mythos_draw_chain`]; the chain may suspend on a mid-chain
+/// spawn-engagement tie (pushing a [`SpawnEngage`](Continuation::SpawnEngage)
+/// frame above this one), in which case its `AwaitingInput` propagates and
+/// [`resume_spawn_engage`](super::hunters::resume_spawn_engage) re-enters the
+/// chain. On chain completion the loop advances ([`advance_encounter_draw`]):
+/// re-prompt the next drawer, or — when drained — pop the frame and open the
+/// post-1.4 `MythosAfterDraws` window. Rejections leave state untouched.
+///
+/// # Mid-chain rejection caveat
+///
+/// Follows the same pattern as `play_card` (CLAUDE.md documents it): if
+/// [`resolve_encounter_card`] rejects mid-chain — e.g. [`spawn_enemy`]
+/// rejecting because the drawing investigator has no location — the card has
+/// already been drawn from `encounter_deck` by [`draw_encounter_top`], and the
+/// apply loop's `events.clear()` on `Rejected` wipes the event stream but does
+/// **not** roll back the state mutation. The card is silently lost. Out of
+/// Phase-4 scope (the synthetic fixture gives every investigator a location at
+/// setup).
+pub(super) fn resume_encounter_draw(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
+    let Some(Continuation::EncounterDraw { remaining }) = cx.state.continuations.last() else {
+        unreachable!("resume_encounter_draw: no EncounterDraw frame on top of the stack")
+    };
+    let drawer = remaining[0];
+    if !matches!(response, InputResponse::Confirm) {
         return EngineOutcome::Rejected {
             reason: format!(
-                "DrawEncounterCard: only valid during Mythos phase, got {:?}",
-                cx.state.phase,
+                "ResolveInput: Mythos encounter draw expects InputResponse::Confirm, got {response:?}",
             )
             .into(),
         };
     }
-    match cx.state.mythos_draw_pending {
-        None => EngineOutcome::Rejected {
-            reason: "DrawEncounterCard: no draw pending (all investigators have drawn)".into(),
-        },
-        Some(expected) if expected != investigator => EngineOutcome::Rejected {
-            reason: format!(
-                "DrawEncounterCard: out of order; expected {expected:?}, got {investigator:?}",
-            )
-            .into(),
-        },
-        Some(_) => mythos_draw_for(cx, investigator),
-    }
-}
-
-/// Resolves one investigator's full Mythos encounter draw — the
-/// per-card 5-step sub-sequence from Rules Reference p.24, with
-/// surge re-draws looping until the chain ends.
-///
-/// Called by [`draw_encounter_card`] with the pending-drawer's id.
-/// Returns Done on success (chain completed, `mythos_draw_pending`
-/// advanced).
-///
-/// # Mid-chain rejection caveat
-///
-/// `mythos_draw_for` follows the same pattern as `play_card` (CLAUDE.md
-/// documents it): if [`resolve_encounter_card`] rejects mid-chain — e.g.
-/// [`spawn_enemy`] rejecting because the drawing investigator has no
-/// location — the card has already been drawn from `encounter_deck` by
-/// [`draw_encounter_top`], and the apply loop's `events.clear()` on
-/// `Rejected` wipes the event stream but does **not** roll back the state
-/// mutation. The card is silently lost from the encounter deck. In Phase 4
-/// scope this can't happen because the synthetic fixture ensures every
-/// investigator has a location at scenario start; revisit if a future
-/// scenario lets investigators reach a location-less state during play.
-fn mythos_draw_for(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
-    // Fresh chain: count starts at 0 and the loop draws at least one
-    // card (`draw_more = true`).
-    run_mythos_draw_chain(cx, investigator, 0, true)
+    // Fresh chain: count starts at 0 and the loop draws at least one card
+    // (`draw_more = true`). On completion the chain calls
+    // `advance_encounter_draw` itself (see `run_mythos_draw_chain`'s tail).
+    run_mythos_draw_chain(cx, drawer, 0, true)
 }
 
 /// The Mythos surge-draw loop, shared by the initial draw
@@ -760,23 +772,46 @@ pub(super) fn run_mythos_draw_chain(
         draw_more = metadata.surge();
     }
 
-    // Chain complete — advance the cursor.
-    advance_mythos_draw_pending(cx);
-    EngineOutcome::Done
+    // Chain complete — advance the encounter-draw loop (drain the drawer,
+    // re-prompt the next, or open the post-1.4 window when drained).
+    advance_encounter_draw(cx)
 }
 
-/// Advance `state.mythos_draw_pending` after a completed chain. If
-/// a next investigator exists in turn order, set to that id.
-/// Otherwise set to None and open the post-1.4 window.
-pub(super) fn advance_mythos_draw_pending(cx: &mut Cx) {
-    let current = cx
+/// Advance the encounter-draw loop after a completed chain (#348, replacing the
+/// former `advance_mythos_draw_pending` cursor advance): drop the just-finished
+/// drawer from the topmost [`Continuation::EncounterDraw`] frame, then skip any
+/// now-eliminated investigators (an encounter card may have eliminated a later
+/// drawer — Rules Reference p.10: eliminated investigators do not draw,
+/// mirroring `next_active_investigator_after`'s skip). When a drawer remains,
+/// re-prompt them ([`EngineOutcome::AwaitingInput`]); when the queue drains, pop
+/// the frame and open the post-1.4 `MythosAfterDraws` window. Called only after
+/// a chain completes, with the `EncounterDraw` frame topmost.
+pub(super) fn advance_encounter_draw(cx: &mut Cx) -> EngineOutcome {
+    let pos = cx
         .state
-        .mythos_draw_pending
-        .expect("advance_mythos_draw_pending called only after a successful chain");
-    // Eliminated-skip semantics live in `next_active_investigator_after`.
-    let next = super::cursor::next_active_investigator_after(cx.state, current);
-    cx.state.mythos_draw_pending = next;
-    if next.is_none() {
+        .continuations
+        .iter()
+        .rposition(|c| matches!(c, Continuation::EncounterDraw { .. }))
+        .expect("advance_encounter_draw: called only after a chain, EncounterDraw frame present");
+    // Pull the queue out to advance it without aliasing `state.investigators`.
+    let Continuation::EncounterDraw { remaining } = &mut cx.state.continuations[pos] else {
+        unreachable!("rposition matched EncounterDraw")
+    };
+    let mut queue = std::mem::take(remaining);
+    queue.remove(0); // drop the finished drawer
+    while let Some(&next) = queue.first() {
+        if cx
+            .state
+            .investigators
+            .get(&next)
+            .is_some_and(|inv| inv.status == Status::Active)
+        {
+            break;
+        }
+        queue.remove(0); // skip a now-eliminated investigator (RR p.10)
+    }
+    if queue.is_empty() {
+        cx.state.continuations.remove(pos); // pop the drained frame
         let outcome = super::reaction_windows::open_fast_window(
             cx,
             WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws),
@@ -786,6 +821,14 @@ pub(super) fn advance_mythos_draw_pending(cx: &mut Cx) {
             EngineOutcome::Done,
             "open_fast_window(MythosAfterDraws) unexpectedly suspended; this window has no suspending continuation",
         );
+        EngineOutcome::Done
+    } else {
+        // Write the advanced queue back and prompt the next drawer.
+        let Continuation::EncounterDraw { remaining } = &mut cx.state.continuations[pos] else {
+            unreachable!("rposition matched EncounterDraw")
+        };
+        *remaining = queue;
+        prompt_encounter_draw(cx)
     }
 }
 
@@ -1635,8 +1678,8 @@ mod spawn_enemy_tests {
             .with_investigator(i1)
             .with_investigator(i2)
             .with_turn_order([InvestigatorId(1), InvestigatorId(2)])
+            .with_mythos_draw_remaining([InvestigatorId(1)])
             .build();
-        state.mythos_draw_pending = Some(InvestigatorId(1));
         let metadata = synth_enemy_metadata(None);
         let mut events = Vec::new();
         let outcome = spawn_enemy(
@@ -1675,8 +1718,8 @@ mod spawn_enemy_tests {
             .with_investigator(i1)
             .with_investigator(i2)
             .with_turn_order([InvestigatorId(1), InvestigatorId(2)])
+            .with_mythos_draw_remaining([InvestigatorId(1)])
             .build();
-        state.mythos_draw_pending = Some(InvestigatorId(1));
         let metadata = synth_enemy_metadata(None);
         let mut events = Vec::new();
         let _ = spawn_enemy(
@@ -1761,7 +1804,7 @@ mod spawn_enemy_tests {
 }
 
 #[cfg(test)]
-mod mythos_draw_for_tests {
+mod resume_encounter_draw_chain_tests {
     use super::*;
     use crate::state::{CardCode, InvestigatorId, Phase};
     use crate::test_support::{test_investigator, GameStateBuilder};
@@ -1784,9 +1827,9 @@ mod mythos_draw_for_tests {
         let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_phase(Phase::Mythos)
+            .with_turn_order([InvestigatorId(1)])
+            .with_mythos_draw_remaining([InvestigatorId(1)])
             .build();
-        state.turn_order = vec![InvestigatorId(1)];
-        state.mythos_draw_pending = Some(InvestigatorId(1));
         // Seed the encounter deck with an unknown code so we prove the
         // reject fires at the registry or unknown-code check, not at the
         // empty-deck check.
@@ -1795,12 +1838,12 @@ mod mythos_draw_for_tests {
             .push_back(CardCode("__no_such_card".into()));
         let pre_deck_len = state.encounter_deck.len();
         let mut events = Vec::new();
-        let outcome = mythos_draw_for(
+        let outcome = resume_encounter_draw(
             &mut Cx {
                 state: &mut state,
                 events: &mut events,
             },
-            InvestigatorId(1),
+            &InputResponse::Confirm,
         );
         match outcome {
             EngineOutcome::Rejected { reason } => {
@@ -1824,73 +1867,50 @@ mod mythos_draw_for_tests {
 }
 
 #[cfg(test)]
-mod draw_encounter_card_tests {
+mod resume_encounter_draw_tests {
     use super::*;
-    use crate::state::{InvestigatorId, Phase};
+    use crate::state::{Continuation, InvestigatorId, Phase};
     use crate::test_support::{test_investigator, GameStateBuilder};
 
-    #[test]
-    fn rejects_outside_mythos_phase() {
-        let mut state = GameStateBuilder::default()
-            .with_investigator(test_investigator(1))
-            .with_phase(Phase::Investigation)
-            .build();
-        state.mythos_draw_pending = Some(InvestigatorId(1));
-        let mut events = Vec::new();
-        let outcome = draw_encounter_card(
-            &mut Cx {
-                state: &mut state,
-                events: &mut events,
-            },
-            InvestigatorId(1),
-        );
-        assert!(matches!(
-            outcome,
-            EngineOutcome::Rejected { reason } if reason.contains("only valid during Mythos")
-        ));
-    }
+    // The former `rejects_outside_mythos_phase` / `rejects_when_no_draw_pending`
+    // / `rejects_when_out_of_order` tests are gone (#348 part 2c-iii-b): the
+    // dedicated `DrawEncounterCard` action is removed. "Outside Mythos" and "no
+    // draw pending" are now structurally impossible — `resume_encounter_draw` is
+    // only reached when an `EncounterDraw` frame is on top, which `mythos_phase`
+    // only pushes during Mythos — and "out of order" is gone because the folded
+    // `Confirm` carries no investigator (the drawer is always `remaining[0]`).
+    // The frame-presence gate is exercised by `apply`'s `EncounterDraw` guard
+    // and `resolve_input`'s no-frame rejection.
 
     #[test]
-    fn rejects_when_no_draw_pending() {
+    fn rejects_non_confirm_response_and_preserves_frame() {
+        // Validate-first: a non-`Confirm` response rejects and leaves the
+        // `EncounterDraw` frame intact for retry.
         let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_phase(Phase::Mythos)
+            .with_turn_order([InvestigatorId(1)])
+            .with_mythos_draw_remaining([InvestigatorId(1)])
             .build();
-        state.mythos_draw_pending = None;
         let mut events = Vec::new();
-        let outcome = draw_encounter_card(
+        let outcome = resume_encounter_draw(
             &mut Cx {
                 state: &mut state,
                 events: &mut events,
             },
-            InvestigatorId(1),
+            &InputResponse::Skip,
         );
         assert!(matches!(
             outcome,
-            EngineOutcome::Rejected { reason } if reason.contains("no draw pending")
+            EngineOutcome::Rejected { reason } if reason.contains("expects InputResponse::Confirm")
         ));
-    }
-
-    #[test]
-    fn rejects_when_out_of_order() {
-        let mut state = GameStateBuilder::default()
-            .with_investigator(test_investigator(1))
-            .with_investigator(test_investigator(2))
-            .with_phase(Phase::Mythos)
-            .build();
-        state.mythos_draw_pending = Some(InvestigatorId(1));
-        let mut events = Vec::new();
-        // Inv2 attempts to draw when inv1 is expected.
-        let outcome = draw_encounter_card(
-            &mut Cx {
-                state: &mut state,
-                events: &mut events,
-            },
-            InvestigatorId(2),
+        assert!(
+            matches!(
+                state.continuations.last(),
+                Some(Continuation::EncounterDraw { remaining }) if remaining == &[InvestigatorId(1)]
+            ),
+            "the EncounterDraw frame must survive a rejected response for retry",
         );
-        assert!(matches!(
-            outcome,
-            EngineOutcome::Rejected { reason } if reason.contains("out of order")
-        ));
+        assert!(events.is_empty(), "a rejected response emits no events");
     }
 }

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -540,16 +540,24 @@ pub(super) fn resume_spawn_engage(
     cx.state.continuations.pop();
     engage_enemy_with(cx, pending.enemy, who);
 
-    // Only re-enter the Mythos surge chain if the suspend happened
-    // mid-chain (the drawing investigator is still the pending cursor).
-    // The `EncounterCardRevealed` single-draw path resolves to `Done`.
+    // Only re-enter the Mythos surge chain if the suspend happened mid-chain.
+    // The `SpawnEngage` frame was pushed *above* the drawing investigator's
+    // `EncounterDraw` frame, so now that we've popped it, that frame is on top
+    // — and its `remaining[0]` is still the drawing investigator (#348). The
+    // `EncounterCardRevealed` single-draw path (no `EncounterDraw` frame on the
+    // stack) resolves to `Done`.
     //
     // Invariant: while a SpawnEngage frame is on the stack, the apply guard
-    // (line 129) rejects every non-`ResolveInput` action, so nothing can
-    // retarget the Mythos cursor between suspend and resume. Hence
-    // `mythos_draw_pending == Some(investigator_to_draw)` reliably means
-    // "we suspended mid-chain for this investigator."
-    if cx.state.mythos_draw_pending == Some(pending.investigator_to_draw) {
+    // rejects every non-`ResolveInput` action, so nothing can retarget the
+    // Mythos loop between suspend and resume. Hence the top frame being the
+    // drawer's `EncounterDraw` reliably means "we suspended mid-chain for this
+    // investigator."
+    let mid_mythos_draw = matches!(
+        cx.state.continuations.last(),
+        Some(crate::state::Continuation::EncounterDraw { remaining })
+            if remaining.first() == Some(&pending.investigator_to_draw)
+    );
+    if mid_mythos_draw {
         super::encounter::run_mythos_draw_chain(
             cx,
             pending.investigator_to_draw,
@@ -1100,7 +1108,10 @@ mod hunter_resume_tests {
             },
             &pick(&outcome, LocationId(3)),
         );
-        assert_eq!(resumed, EngineOutcome::Done);
+        // Resolving the tie continues the Enemy phase; with no registry the
+        // attack windows auto-skip and the cascade runs to Mythos, pausing at
+        // the step-1.4 encounter-draw prompt (AwaitingInput).
+        assert!(matches!(resumed, EngineOutcome::AwaitingInput { .. }));
         assert_eq!(
             state.enemies[&EnemyId(1)].current_location,
             Some(LocationId(3))
@@ -1205,7 +1216,10 @@ mod hunter_resume_tests {
             },
             &pick(&outcome, InvestigatorId(2)),
         );
-        assert_eq!(resumed, EngineOutcome::Done);
+        // Resolving the tie continues the Enemy phase; with no registry the
+        // attack windows auto-skip and the cascade runs to Mythos, pausing at
+        // the step-1.4 encounter-draw prompt (AwaitingInput).
+        assert!(matches!(resumed, EngineOutcome::AwaitingInput { .. }));
         assert_eq!(
             state.enemies[&EnemyId(1)].engaged_with,
             Some(InvestigatorId(2))
@@ -1315,7 +1329,10 @@ mod hunter_resume_tests {
             },
             &pick(&outcome, LocationId(2)),
         );
-        assert_eq!(resumed, EngineOutcome::Done);
+        // Resolving the tie continues the Enemy phase; with no registry the
+        // attack windows auto-skip and the cascade runs to Mythos, pausing at
+        // the step-1.4 encounter-draw prompt (AwaitingInput).
+        assert!(matches!(resumed, EngineOutcome::AwaitingInput { .. }));
         assert_eq!(
             state.enemies[&EnemyId(2)].current_location,
             Some(LocationId(4))

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -224,15 +224,6 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
             instance_id,
             ability_index,
         } => abilities::activate_ability(cx, *investigator, *instance_id, *ability_index),
-        // The Mythos encounter draw now resumes through `ResolveInput` (the top
-        // `EncounterDraw` frame); the dedicated action is removed in the next
-        // commit (#348 part 2c-iii-b, task b2). Until then, reject it loudly.
-        PlayerAction::DrawEncounterCard => EngineOutcome::Rejected {
-            reason:
-                "PlayerAction::DrawEncounterCard is removed; submit a PlayerAction::ResolveInput \
-                     with InputResponse::Confirm instead"
-                    .into(),
-        },
         PlayerAction::ResolveInput { response } => resolve_input(cx, response),
         PlayerAction::AdvanceAct { investigator } => {
             act_agenda::advance_act_action(cx, *investigator)

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -172,6 +172,22 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
         };
     }
 
+    // While the Mythos step-1.4 encounter-draw loop is in progress (an
+    // `EncounterDraw` frame is on top of the stack), only `ResolveInput` can
+    // advance the engine. Mythos-phase only; never coexists with the other
+    // suspension modes, so guard order is immaterial.
+    if matches!(
+        cx.state.continuations.last(),
+        Some(crate::state::Continuation::EncounterDraw { .. })
+    ) && !matches!(action, PlayerAction::ResolveInput { .. })
+    {
+        return EngineOutcome::Rejected {
+            reason: "a Mythos encounter draw is pending; submit a PlayerAction::ResolveInput \
+                     with InputResponse::Confirm in player order before any other action"
+                .into(),
+        };
+    }
+
     let outcome = match action {
         PlayerAction::StartScenario { roster } => phases::start_scenario(cx, roster),
         PlayerAction::EndTurn => phases::end_turn(cx),
@@ -208,13 +224,14 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
             instance_id,
             ability_index,
         } => abilities::activate_ability(cx, *investigator, *instance_id, *ability_index),
-        PlayerAction::DrawEncounterCard => match cx.state.mythos_draw_pending {
-            // DrawEncounterCard carries no investigator payload — the
-            // acting investigator IS the pending cursor.
-            Some(actor) => encounter::draw_encounter_card(cx, actor),
-            None => EngineOutcome::Rejected {
-                reason: "DrawEncounterCard: no draw pending (all investigators have drawn)".into(),
-            },
+        // The Mythos encounter draw now resumes through `ResolveInput` (the top
+        // `EncounterDraw` frame); the dedicated action is removed in the next
+        // commit (#348 part 2c-iii-b, task b2). Until then, reject it loudly.
+        PlayerAction::DrawEncounterCard => EngineOutcome::Rejected {
+            reason:
+                "PlayerAction::DrawEncounterCard is removed; submit a PlayerAction::ResolveInput \
+                     with InputResponse::Confirm instead"
+                    .into(),
         },
         PlayerAction::ResolveInput { response } => resolve_input(cx, response),
         PlayerAction::AdvanceAct { investigator } => {
@@ -414,6 +431,7 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
         Some(Continuation::HandSizeDiscard(_)) => phases::resume_hand_size_discard(cx, response),
         Some(Continuation::ActRoundEnd(_)) => phases::resume_act_round_end_advance(cx, response),
         Some(Continuation::Mulligan { .. }) => cards::resume_mulligan(cx, response),
+        Some(Continuation::EncounterDraw { .. }) => encounter::resume_encounter_draw(cx, response),
         Some(Continuation::SkillTest(_)) => resume_skill_test_commit(cx, response),
         None => EngineOutcome::Rejected {
             reason: "ResolveInput: no AwaitingInput prompt is currently outstanding".into(),

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -351,7 +351,7 @@ fn investigation_phase_end(cx: &mut Cx) -> EngineOutcome {
 /// out the Rules Reference p.24 sub-steps as discrete named call
 /// sites so the rule structure is grep-able and #73 / future-peril-PR
 /// fills in TODO bodies without changing the driver shape.
-fn mythos_phase(cx: &mut Cx) {
+fn mythos_phase(cx: &mut Cx) -> EngineOutcome {
     // 1.1 Round begins. Mythos phase begins.
     //     Rules Reference p.24: "As this is the first framework event
     //     of the round, it [1.1] also formalizes the beginning of a new
@@ -378,14 +378,14 @@ fn mythos_phase(cx: &mut Cx) {
     super::act_agenda::check_doom_threshold(cx);
 
     // 1.4 Each investigator draws 1 encounter card.
-    //     Seed the cursor; the actual draws are player-driven via
-    //     PlayerAction::DrawEncounterCard (lands in T12). The
-    //     dispatch handler advances the cursor after each chain.
-    //     Per Rules Reference p.10 (Elimination), eliminated
-    //     investigators (Killed, Insane, Resigned) do not draw
-    //     encounter cards — skip to the first Active investigator.
-    cx.state.mythos_draw_pending = super::cursor::first_active_investigator(cx.state);
-    if cx.state.mythos_draw_pending.is_none() {
+    //     Push the `EncounterDraw` loop frame; the actual draws are
+    //     player-driven via `ResolveInput(Confirm)` against the top frame
+    //     (#348), and `resume_encounter_draw` advances the queue after each
+    //     chain. Per Rules Reference p.10 (Elimination), eliminated
+    //     investigators (Killed, Insane, Resigned) do not draw — the queue is
+    //     seeded with the Active investigators only.
+    let remaining = super::cursor::active_investigators_in_turn_order(cx.state);
+    if remaining.is_empty() {
         // No Active investigators to draw (turn_order is empty or all
         // investigators are eliminated). Open the post-1.4 window
         // immediately; open_fast_window's auto-skip path triggers
@@ -401,7 +401,12 @@ fn mythos_phase(cx: &mut Cx) {
             EngineOutcome::Done,
             "open_fast_window(MythosAfterDraws) unexpectedly suspended; this window has no suspending continuation",
         );
+        return EngineOutcome::Done;
     }
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::EncounterDraw { remaining });
+    super::encounter::prompt_encounter_draw(cx)
 }
 
 /// Transition to the next phase. Dispatches into phase driver
@@ -442,10 +447,7 @@ fn step_phase(cx: &mut Cx) -> EngineOutcome {
     // Dispatch to phase driver if one exists; otherwise emit
     // PhaseStarted directly (for phases without a driver yet).
     match to {
-        Phase::Mythos if from != Phase::Mythos => {
-            mythos_phase(cx);
-            EngineOutcome::Done
-        }
+        Phase::Mythos if from != Phase::Mythos => mythos_phase(cx),
         Phase::Investigation if from != Phase::Investigation => {
             investigation_phase(cx);
             EngineOutcome::Done
@@ -1234,7 +1236,10 @@ mod investigation_phase_tests {
             events: &mut events,
         });
 
-        assert!(matches!(outcome, EngineOutcome::Done));
+        // Single investigator with no enemies: the round-ending EndTurn
+        // cascades Investigation → Enemy → Upkeep → Mythos and pauses at the
+        // step-1.4 encounter-draw prompt (AwaitingInput).
+        assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
         assert!(
             events.iter().any(|e| matches!(e, Event::TurnEnded { investigator } if *investigator == InvestigatorId(1))),
             "step 2.2.2 emits TurnEnded"
@@ -1391,22 +1396,25 @@ mod mythos_phase_tests {
     use crate::test_support::{test_investigator, GameStateBuilder};
 
     #[test]
-    fn mythos_phase_emits_phase_started_and_seeds_draw_pending() {
+    fn mythos_phase_emits_phase_started_and_prompts_first_drawer() {
         let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .with_phase(Phase::Mythos)
             .build();
         state.turn_order = vec![InvestigatorId(1), InvestigatorId(2)];
-        state.mythos_draw_pending = None;
         let mut events = Vec::new();
 
-        mythos_phase(&mut Cx {
+        let outcome = mythos_phase(&mut Cx {
             state: &mut state,
             events: &mut events,
         });
 
-        assert_eq!(state.mythos_draw_pending, Some(InvestigatorId(1)));
+        assert!(
+            matches!(outcome, EngineOutcome::AwaitingInput { .. }),
+            "mythos_phase opens the first encounter-draw prompt, got {outcome:?}"
+        );
+        assert_eq!(state.current_encounter_drawer(), Some(InvestigatorId(1)));
         assert!(
             events.iter().any(|e| matches!(
                 e,
@@ -1424,10 +1432,9 @@ mod mythos_phase_tests {
             .with_phase(Phase::Mythos)
             .build();
         state.turn_order.clear();
-        state.mythos_draw_pending = None;
         let mut events = Vec::new();
 
-        mythos_phase(&mut Cx {
+        let outcome = mythos_phase(&mut Cx {
             state: &mut state,
             events: &mut events,
         });
@@ -1435,7 +1442,8 @@ mod mythos_phase_tests {
         // No drawers → open_fast_window runs for MythosAfterDraws,
         // which auto-skips (no Fast eligibility), runs continuation
         // (mythos_phase_end), which steps into Investigation.
-        assert_eq!(state.mythos_draw_pending, None);
+        assert_eq!(outcome, EngineOutcome::Done);
+        assert_eq!(state.current_encounter_drawer(), None);
         assert_eq!(state.phase, Phase::Investigation);
         assert!(
             events.iter().any(|e| matches!(
@@ -1511,11 +1519,11 @@ mod mythos_phase_tests {
     }
 
     /// Site 1 fix (Rules Reference p.10): when the lead investigator in
-    /// `turn_order` is eliminated, `mythos_phase` must seed
-    /// `mythos_draw_pending` with the first Active investigator rather
-    /// than blindly taking `turn_order.first()`.
+    /// `turn_order` is eliminated, `mythos_phase` must seed the encounter-draw
+    /// queue from the first Active investigator rather than blindly taking
+    /// `turn_order.first()`.
     #[test]
-    fn mythos_phase_skips_eliminated_lead_when_seeding_cursor() {
+    fn mythos_phase_skips_eliminated_lead_when_seeding_queue() {
         let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
@@ -1527,7 +1535,6 @@ mod mythos_phase_tests {
             .get_mut(&InvestigatorId(1))
             .unwrap()
             .status = Status::Killed;
-        state.mythos_draw_pending = None;
         let mut events = Vec::new();
 
         mythos_phase(&mut Cx {
@@ -1536,9 +1543,9 @@ mod mythos_phase_tests {
         });
 
         assert_eq!(
-            state.mythos_draw_pending,
+            state.current_encounter_drawer(),
             Some(InvestigatorId(2)),
-            "cursor must point to the first Active investigator, not the Killed lead"
+            "the queue must prompt the first Active investigator, not the Killed lead"
         );
     }
 
@@ -1561,7 +1568,6 @@ mod mythos_phase_tests {
             .get_mut(&InvestigatorId(1))
             .unwrap()
             .status = Status::Killed;
-        state.mythos_draw_pending = None;
         let mut events = Vec::new();
 
         mythos_phase(&mut Cx {
@@ -1569,7 +1575,7 @@ mod mythos_phase_tests {
             events: &mut events,
         });
 
-        assert_eq!(state.mythos_draw_pending, None);
+        assert_eq!(state.current_encounter_drawer(), None);
         assert_eq!(
             state.phase,
             Phase::Investigation,
@@ -1577,37 +1583,42 @@ mod mythos_phase_tests {
         );
     }
 
-    /// Site 2 fix (Rules Reference p.10): when advancing the cursor
-    /// after a completed draw, eliminated investigators in the middle of
-    /// `turn_order` must be skipped. Here inv2 is Killed; the cursor must
-    /// advance from inv1 to inv3.
+    /// Site 2 fix (Rules Reference p.10): when advancing the encounter-draw
+    /// queue after a completed draw, eliminated investigators in the middle of
+    /// the queue must be skipped. Here inv2 is Killed; the queue must advance
+    /// from inv1 to inv3.
     #[test]
-    fn advance_mythos_draw_pending_skips_eliminated_middle_investigator() {
+    fn advance_encounter_draw_skips_eliminated_middle_investigator() {
         let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
             .with_investigator(test_investigator(3))
             .with_phase(Phase::Mythos)
+            .with_turn_order([InvestigatorId(1), InvestigatorId(2), InvestigatorId(3)])
+            .with_mythos_draw_remaining([InvestigatorId(1), InvestigatorId(2), InvestigatorId(3)])
             .build();
-        state.turn_order = vec![InvestigatorId(1), InvestigatorId(2), InvestigatorId(3)];
         state
             .investigators
             .get_mut(&InvestigatorId(2))
             .unwrap()
             .status = Status::Killed;
-        // Simulate: inv1 has just completed their draw chain.
-        state.mythos_draw_pending = Some(InvestigatorId(1));
         let mut events = Vec::new();
 
-        super::super::encounter::advance_mythos_draw_pending(&mut super::super::Cx {
+        // inv1 has just completed their draw chain: advance drops inv1 and must
+        // skip the Killed inv2, landing on inv3.
+        let outcome = super::super::encounter::advance_encounter_draw(&mut super::super::Cx {
             state: &mut state,
             events: &mut events,
         });
 
+        assert!(
+            matches!(outcome, EngineOutcome::AwaitingInput { .. }),
+            "a remaining drawer re-prompts, got {outcome:?}"
+        );
         assert_eq!(
-            state.mythos_draw_pending,
+            state.current_encounter_drawer(),
             Some(InvestigatorId(3)),
-            "cursor must skip the Killed inv2 and land on Active inv3"
+            "the queue must skip the Killed inv2 and land on Active inv3"
         );
     }
 
@@ -2153,10 +2164,10 @@ mod upkeep_phase_tests {
     }
 
     #[test]
-    fn end_turn_cascades_through_upkeep_to_mythos_draw_pending() {
+    fn end_turn_cascades_through_upkeep_to_mythos_draw_prompt() {
         // Single investigator, non-empty deck, an exhausted in-play card.
         // After EndTurn: card readied, hand +1, resources +1, landed in
-        // Mythos with draw pending and round bumped.
+        // Mythos paused at the encounter-draw prompt and round bumped.
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
         inv.actions_remaining = 0;
@@ -2176,10 +2187,16 @@ mod upkeep_phase_tests {
 
         let result = apply(state, Action::Player(PlayerAction::EndTurn));
 
-        assert_eq!(result.outcome, EngineOutcome::Done);
+        // The round-ending EndTurn cascades into Mythos and pauses at the
+        // step-1.4 encounter-draw prompt (AwaitingInput).
+        assert!(
+            matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),
+            "round-ending EndTurn pauses at the Mythos draw prompt, got {:?}",
+            result.outcome
+        );
         assert_eq!(result.state.phase, Phase::Mythos);
         assert_eq!(result.state.round, 2, "round bumped on Mythos entry");
-        assert_eq!(result.state.mythos_draw_pending, Some(id));
+        assert_eq!(result.state.current_encounter_drawer(), Some(id));
         assert_eq!(result.state.active_investigator, None);
         assert!(
             !result.state.investigators[&id].cards_in_play[0].exhausted,
@@ -2271,7 +2288,9 @@ mod upkeep_phase_tests {
             state: &mut state,
             events: &mut events,
         });
-        assert_eq!(out, EngineOutcome::Done);
+        // Unaffordable → no round-end window; the cascade steps straight into
+        // Mythos and pauses at the step-1.4 encounter-draw prompt.
+        assert!(matches!(out, EngineOutcome::AwaitingInput { .. }));
         assert!(!matches!(
             state.continuations.last(),
             Some(crate::state::Continuation::ActRoundEnd(_))
@@ -2295,7 +2314,9 @@ mod upkeep_phase_tests {
             },
             &InputResponse::Confirm,
         );
-        assert_eq!(out, EngineOutcome::Done);
+        // Resolving the window continues the upkeep cascade into Mythos, which
+        // pauses at the step-1.4 encounter-draw prompt (AwaitingInput).
+        assert!(matches!(out, EngineOutcome::AwaitingInput { .. }));
         assert_eq!(state.act_index, 1, "advanced act 2 -> act 3");
         assert_eq!(state.investigators[&inv].clues, 0, "spent 3 clues");
         assert!(!matches!(
@@ -2321,7 +2342,9 @@ mod upkeep_phase_tests {
             },
             &InputResponse::Skip,
         );
-        assert_eq!(out, EngineOutcome::Done);
+        // Skipping the window still continues the upkeep cascade into Mythos,
+        // which pauses at the step-1.4 encounter-draw prompt (AwaitingInput).
+        assert!(matches!(out, EngineOutcome::AwaitingInput { .. }));
         assert_eq!(state.act_index, 0, "no advance on Skip");
         assert_eq!(state.investigators[&inv].clues, 3, "no clues spent");
         assert!(!matches!(
@@ -2378,7 +2401,13 @@ mod upkeep_phase_tests {
             state: &mut state,
             events: &mut events,
         });
-        assert_eq!(out, EngineOutcome::Done, "unaffordable by Hallway alone");
+        // Unaffordable by the Hallway alone: no round-end window opens, so the
+        // upkeep cascades straight into Mythos and pauses at the encounter-draw
+        // prompt (AwaitingInput) rather than opening an ActRoundEnd frame.
+        assert!(
+            matches!(out, EngineOutcome::AwaitingInput { .. }),
+            "unaffordable by Hallway alone"
+        );
         assert!(!matches!(
             state.continuations.last(),
             Some(crate::state::Continuation::ActRoundEnd(_))
@@ -2424,12 +2453,12 @@ mod enemy_phase_tests {
             state: &mut state,
             events: &mut events,
         });
-        assert_eq!(outcome, EngineOutcome::Done);
-        // No registry installed → the attack window auto-skips inline and
-        // the cascade runs Enemy→Upkeep→Mythos within this same call (same
-        // as `enemy_phase_emits_phase_started_and_cascades_to_mythos...`).
-        // The hunter still moved + engaged during step 3.2, and the first
-        // attack window still opened — asserted via the event stream below.
+        // No registry installed → the attack window auto-skips inline and the
+        // cascade runs Enemy→Upkeep→Mythos within this same call, pausing at the
+        // step-1.4 encounter-draw prompt (AwaitingInput). The hunter still moved
+        // + engaged during step 3.2, and the first attack window still opened —
+        // asserted via the event stream below.
+        assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
         assert_eq!(state.phase, Phase::Mythos);
         assert_eq!(
             state.enemies[&EnemyId(1)].current_location,
@@ -2490,10 +2519,11 @@ mod enemy_phase_tests {
             },
             &InputResponse::PickSingle(pick),
         );
-        assert_eq!(resumed, EngineOutcome::Done);
-        assert_event!(ev2, Event::WindowOpened { kind } if *kind == WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked));
         // With no registry the attack window auto-skips and the cascade runs
-        // Enemy->Upkeep->Mythos within the same resume call (same as the no-tie test).
+        // Enemy->Upkeep->Mythos within the same resume call, pausing at the
+        // step-1.4 encounter-draw prompt (AwaitingInput).
+        assert!(matches!(resumed, EngineOutcome::AwaitingInput { .. }));
+        assert_event!(ev2, Event::WindowOpened { kind } if *kind == WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked));
         assert_eq!(state.phase, Phase::Mythos);
     }
 
@@ -3105,10 +3135,12 @@ mod enemy_phase_tests {
             }),
         );
 
+        // The Skip resumes the continuation; the cascade runs into Mythos and
+        // pauses at the step-1.4 encounter-draw prompt (AwaitingInput).
         match result.outcome {
-            EngineOutcome::Done => {}
+            EngineOutcome::AwaitingInput { .. } => {}
             ref other => panic!(
-                "expected Done after Skip; got {other:?}; events = {:?}",
+                "expected AwaitingInput (Mythos draw prompt) after Skip; got {other:?}; events = {:?}",
                 result.events
             ),
         }
@@ -3298,7 +3330,9 @@ mod hand_size_tests {
             },
         );
 
-        assert_eq!(outcome, EngineOutcome::Done);
+        // The discard drains the hand-size queue, so 4.6 runs and the cascade
+        // steps into Mythos, pausing at the step-1.4 encounter-draw prompt.
+        assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
         assert!(!matches!(
             state.continuations.last(),
             Some(crate::state::Continuation::HandSizeDiscard(_))

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -770,7 +770,19 @@ fn play_fast_event(
             candidate.code,
         ),
         suspended @ EngineOutcome::AwaitingInput { .. } => suspended,
-        EngineOutcome::Done => advance_resolution(cx, window_idx),
+        EngineOutcome::Done => {
+            // The Fast event's effect completed (RR Appendix I step 4): discard
+            // it NOW, before advancing the window / phase cascade. The apply
+            // loop's `flush_pending_played_event` only fires on a `Done` apply,
+            // so deferring to it would strand the event in `pending_played_event`
+            // whenever this same apply later suspends for an unrelated reason —
+            // e.g. the window close cascades into the Mythos 1.4 draw prompt
+            // (#348) or an upkeep hand-size discard (#111), both `AwaitingInput`.
+            // A no-op if the effect already disposed of the card (e.g. an event
+            // that becomes an asset clears `pending_played_event` itself).
+            super::cards::flush_pending_played_event(cx);
+            advance_resolution(cx, window_idx)
+        }
     }
 }
 

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -1197,19 +1197,23 @@ mod tests {
         assert_no_event!(result.events, Event::ScenarioStarted);
 
         // Second EndTurn (inv2, last in turn_order): auto-advances through
-        // Investigation → Enemy → Upkeep → Mythos and then PAUSES because
-        // mythos_draw_pending is now Some(inv1). The phase chain does NOT
-        // continue to Investigation — that waits for DrawEncounterCard.
+        // Investigation → Enemy → Upkeep → Mythos and then PAUSES at the
+        // step-1.4 encounter-draw prompt for inv1. The phase chain does NOT
+        // continue to Investigation — that waits for the ResolveInput(Confirm)s.
         let result = apply(state, Action::Player(PlayerAction::EndTurn));
+        assert!(
+            matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),
+            "round-ending EndTurn pauses at the Mythos draw prompt, got {:?}",
+            result.outcome
+        );
         let state = result.state;
         assert_eq!(state.round, 2, "round bumps on Mythos entry");
         assert_eq!(state.phase, Phase::Mythos);
         assert_eq!(
-            state.mythos_draw_pending,
+            state.current_encounter_drawer(),
             Some(inv1),
             "lead investigator (inv1) draws first"
         );
-        assert_eq!(result.outcome, EngineOutcome::Done);
 
         // Exactly 3 PhaseEnded events fire (Investigation, Enemy, Upkeep).
         // PhaseEnded(Mythos) does NOT fire here — mythos_phase_end owns it
@@ -1244,9 +1248,9 @@ mod tests {
         // Degenerate edge: with only one investigator in turn_order,
         // their single EndTurn is also the *last* EndTurn of the round.
         // It must auto-advance Investigation → Enemy → Upkeep → Mythos,
-        // bump the round, seed mythos_draw_pending = Some(id), and then
+        // bump the round, prompt the encounter draw for id, and then
         // PAUSE. It does NOT complete the full cycle — that requires the
-        // subsequent DrawEncounterCard action (needs registry, covered by
+        // subsequent ResolveInput(Confirm) (needs registry, covered by
         // crates/scenarios/tests/mythos_phase.rs).
         let id = InvestigatorId(1);
         let state = GameStateBuilder::new()
@@ -1277,11 +1281,15 @@ mod tests {
         .state;
 
         let result = apply(after_mulligan, Action::Player(PlayerAction::EndTurn));
-        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert!(
+            matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),
+            "round-ending EndTurn pauses at the Mythos draw prompt, got {:?}",
+            result.outcome
+        );
         assert_eq!(result.state.round, 2, "round bumps on Mythos entry");
         assert_eq!(result.state.phase, Phase::Mythos);
         assert_eq!(
-            result.state.mythos_draw_pending,
+            result.state.current_encounter_drawer(),
             Some(id),
             "sole investigator is the pending drawer"
         );
@@ -4763,7 +4771,13 @@ mod tests {
             Action::Player(PlayerAction::EndTurn),
             Some(&reg),
         );
-        assert_eq!(second.outcome, EngineOutcome::Done);
+        // The round-ending EndTurn cascades into Mythos and pauses at the
+        // encounter-draw prompt (AwaitingInput); the point of this test is that
+        // the already-latched resolution does NOT re-fire on this later apply.
+        assert!(matches!(
+            second.outcome,
+            EngineOutcome::AwaitingInput { .. }
+        ));
         assert_no_event!(second.events, Event::ScenarioResolved { .. });
     }
 

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -55,6 +55,7 @@ pub struct GameStateBuilder {
     turn_order: Vec<InvestigatorId>,
     rng: RngState,
     mulligan_remaining: Option<Vec<InvestigatorId>>,
+    mythos_draw_remaining: Option<Vec<InvestigatorId>>,
     hand_size_discard_pending: Option<HandSizeDiscard>,
     open_windows: Vec<ResolutionFrame>,
     scenario_id: Option<ScenarioId>,
@@ -78,6 +79,7 @@ impl GameStateBuilder {
             turn_order: Vec::new(),
             rng: RngState::new(0),
             mulligan_remaining: None,
+            mythos_draw_remaining: None,
             hand_size_discard_pending: None,
             open_windows: Vec::new(),
             scenario_id: None,
@@ -218,6 +220,22 @@ impl GameStateBuilder {
         self
     }
 
+    /// Stage a pending Mythos step-1.4 encounter draw over the given
+    /// player-order queue (front = currently prompted). By default none is
+    /// staged; opt in when a test wants to resume the encounter-draw loop
+    /// directly via `ResolveInput(Confirm)` without driving the full Mythos
+    /// cascade. The queue must list the investigators in `turn_order` (set via
+    /// [`with_turn_order`](Self::with_turn_order)) so the loop advances
+    /// correctly. Stages a [`Continuation::EncounterDraw`] frame at
+    /// [`build`](Self::build).
+    pub fn with_mythos_draw_remaining(
+        mut self,
+        remaining: impl IntoIterator<Item = InvestigatorId>,
+    ) -> Self {
+        self.mythos_draw_remaining = Some(remaining.into_iter().collect());
+        self
+    }
+
     /// Seed a pending upkeep hand-size discard for the given player-order
     /// queue (front = currently prompted).
     pub fn with_hand_size_discard_pending(
@@ -273,6 +291,11 @@ impl GameStateBuilder {
         if let Some(remaining) = self.mulligan_remaining {
             continuations.push(Continuation::Mulligan { remaining });
         }
+        // A staged Mythos encounter draw becomes an `EncounterDraw` frame
+        // (#348). Disjoint from setup/upkeep, so push order is immaterial.
+        if let Some(remaining) = self.mythos_draw_remaining {
+            continuations.push(Continuation::EncounterDraw { remaining });
+        }
         GameState {
             investigators: self.investigators,
             locations: self.locations,
@@ -293,7 +316,6 @@ impl GameStateBuilder {
             pending_skill_modifiers: Vec::new(),
             continuations,
             scenario_id: self.scenario_id,
-            mythos_draw_pending: None,
             enemy_attack_pending: None,
             pending_end_turn: None,
             pending_enemy_attack: None,

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -153,16 +153,14 @@ pub struct GameState {
     /// Serializable so action-log replay reproduces the lookup
     /// deterministically across host restarts.
     pub scenario_id: Option<crate::scenario::ScenarioId>,
-    /// The investigator whose Mythos-phase encounter draw is pending,
-    /// during Rules-Reference p.24 step 1.4. `Some(id)` between
-    /// `mythos_phase` entry and the last drawer's completion; `None`
-    /// otherwise. Advanced after each `PlayerAction::DrawEncounterCard`
-    /// completes its chain (including any surge re-draws). `None`
-    /// once all investigators have drawn — at which point the
-    /// `MythosAfterDraws` window opens.
-    pub mythos_draw_pending: Option<InvestigatorId>,
+    // The Mythos step-1.4 encounter-draw loop now lives on its
+    // `Continuation::EncounterDraw` frame (#348); read the prompted drawer via
+    // [`Self::current_encounter_drawer`]. The former `mythos_draw_pending:
+    // Option<InvestigatorId>` cursor is removed — the continuation stack is the
+    // single source of truth (mirroring the `mulligan_pending` fold).
     /// The next investigator due to resolve engaged-enemy attacks
-    /// during Enemy phase step 3.3. Mirror of [`mythos_draw_pending`]:
+    /// during Enemy phase step 3.3. Player-order cursor (the analog of the
+    /// former Mythos `mythos_draw_pending`, now folded onto a frame):
     ///
     /// - Set to the first [`Status::Active`] investigator in
     ///   [`turn_order`] when `enemy_phase` runs step 3.3's loop
@@ -174,10 +172,9 @@ pub struct GameState {
     /// - Stays `None` during all phases other than Enemy.
     ///
     /// Eliminated investigators ([`Status::Killed`] / [`Status::Insane`]
-    /// / [`Status::Resigned`]) are skipped during advance, mirroring
-    /// the `mythos_draw_pending` semantics established in #69.
+    /// / [`Status::Resigned`]) are skipped during advance (the
+    /// player-order-cursor semantics established in #69).
     ///
-    /// [`mythos_draw_pending`]: GameState::mythos_draw_pending
     /// [`turn_order`]: GameState::turn_order
     /// [`Status::Active`]: crate::state::Status::Active
     /// [`Status::Killed`]: crate::state::Status::Killed
@@ -474,6 +471,22 @@ pub enum Continuation {
         /// currently prompted.
         remaining: Vec<InvestigatorId>,
     },
+    /// The Mythos step-1.4 encounter-draw loop (Rules Reference p.24), migrated
+    /// off the former `GameState::mythos_draw_pending` cursor field (#348).
+    /// `remaining[0]` is the investigator currently prompted to draw; the queue
+    /// is the Active investigators in [`turn_order`](GameState::turn_order).
+    /// Pushed by `mythos_phase`, advanced by `resume_encounter_draw` as each
+    /// investigator confirms (running their full surge chain), popped when
+    /// drained — at which point the post-1.4 `MythosAfterDraws` window opens.
+    /// A mid-chain spawn-engagement tie pushes a
+    /// [`SpawnEngage`](Continuation::SpawnEngage) frame *above* this one. While
+    /// present, the engine rejects every non-`ResolveInput` action. Read the
+    /// prompted drawer via [`GameState::current_encounter_drawer`].
+    EncounterDraw {
+        /// Active investigators yet to draw, in player order; front =
+        /// currently prompted.
+        remaining: Vec<InvestigatorId>,
+    },
 }
 
 /// A controller choice paused mid-resolution (umbrella §3, Axis A).
@@ -516,7 +529,8 @@ impl Continuation {
             | Continuation::HandSizeDiscard(_)
             | Continuation::ActRoundEnd(_)
             | Continuation::SubstitutionPrompt { .. }
-            | Continuation::Mulligan { .. } => None,
+            | Continuation::Mulligan { .. }
+            | Continuation::EncounterDraw { .. } => None,
         }
     }
 
@@ -531,7 +545,8 @@ impl Continuation {
             | Continuation::HandSizeDiscard(_)
             | Continuation::ActRoundEnd(_)
             | Continuation::SubstitutionPrompt { .. }
-            | Continuation::Mulligan { .. } => None,
+            | Continuation::Mulligan { .. }
+            | Continuation::EncounterDraw { .. } => None,
         }
     }
 }
@@ -1061,7 +1076,8 @@ pub enum PhaseStep {
     /// the "previous player window" investigators "return to" between
     /// resolutions). The investigator to be attacked next is carried
     /// on [`GameState::enemy_attack_pending`], not in the variant —
-    /// mirror of [`MythosAfterDraws`] + [`GameState::mythos_draw_pending`].
+    /// mirror of [`MythosAfterDraws`] (the encounter-draw loop's analog now
+    /// lives on the [`EncounterDraw`](Continuation::EncounterDraw) frame).
     ///
     /// Continuation (in `run_window_continuation`): read the cursor,
     /// resolve the pending investigator's engaged ready enemies in
@@ -1357,6 +1373,22 @@ impl GameState {
             Some(Continuation::Mulligan { remaining }) => remaining.first().copied(),
             _ => None,
         }
+    }
+
+    /// The investigator currently prompted to draw their Mythos step-1.4
+    /// encounter card, if an encounter-draw loop is in progress; `None`
+    /// otherwise. Reads the topmost [`Continuation::EncounterDraw`] frame's
+    /// `remaining[0]` — the continuation stack is the single source of truth
+    /// for "an encounter draw is pending" (#348, replacing the former
+    /// `mythos_draw_pending` cursor). Topmost (not `.last()`) because a
+    /// mid-chain [`SpawnEngage`](Continuation::SpawnEngage) frame can sit above
+    /// the draw frame while a spawn-engagement tie is resolved.
+    #[must_use]
+    pub fn current_encounter_drawer(&self) -> Option<InvestigatorId> {
+        self.continuations.iter().rev().find_map(|c| match c {
+            Continuation::EncounterDraw { remaining } => remaining.first().copied(),
+            _ => None,
+        })
     }
 
     /// Whether a skill test is currently in flight.
@@ -1702,13 +1734,13 @@ mod id_counter_tests {
 }
 
 #[cfg(test)]
-mod mythos_draw_pending_tests {
+mod encounter_draw_tests {
     use crate::test_support::GameStateBuilder;
 
     #[test]
-    fn game_state_default_has_no_mythos_draw_pending() {
+    fn game_state_default_has_no_encounter_draw_pending() {
         let state = GameStateBuilder::new().build();
-        assert_eq!(state.mythos_draw_pending, None);
+        assert_eq!(state.current_encounter_drawer(), None);
     }
 }
 

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -750,12 +750,16 @@ mod tests {
     #[test]
     fn test_session_fluent_round_trip() {
         let id = InvestigatorId(1);
+        // Two investigators so the first EndTurn is a mid-round rotation
+        // (reaches Done immediately) rather than a round-ending cascade — the
+        // latter would now pause at the Mythos encounter-draw prompt (#348).
         let result = GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_investigator(test_investigator(1))
+            .with_investigator(test_investigator(2))
             .with_location(test_location(10, "Study"))
             .with_active_investigator(id)
-            .with_turn_order([id])
+            .with_turn_order([id, InvestigatorId(2)])
             .session()
             .apply(Action::Player(PlayerAction::EndTurn))
             .resolve_choices(|c| {

--- a/crates/game-core/tests/act_round_end.rs
+++ b/crates/game-core/tests/act_round_end.rs
@@ -84,7 +84,9 @@ fn resolve_confirm_routes_to_resume_and_advances() {
             response: InputResponse::Confirm,
         }),
     );
-    assert_eq!(r.outcome, EngineOutcome::Done);
+    // Confirming the round-end window continues the upkeep cascade into Mythos,
+    // which pauses at the step-1.4 encounter-draw prompt (AwaitingInput).
+    assert!(matches!(r.outcome, EngineOutcome::AwaitingInput { .. }));
     assert_eq!(r.state.act_index, 1, "advanced act 2 -> act 3");
     assert_eq!(
         r.state.investigators[&InvestigatorId(1)].clues,

--- a/crates/game-core/tests/round_ended.rs
+++ b/crates/game-core/tests/round_ended.rs
@@ -169,7 +169,9 @@ fn two_round_end_forced_suspend_then_resume_the_upkeep_tail() {
             response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
         }),
     );
-    assert_eq!(done.outcome, EngineOutcome::Done);
+    // The upkeep tail runs through to Mythos, which pauses at the step-1.4
+    // encounter-draw prompt (AwaitingInput) after placing its +1 doom.
+    assert!(matches!(done.outcome, EngineOutcome::AwaitingInput { .. }));
     assert_eq!(
         done.state.agenda_doom, 6,
         "agenda round-end forced resolved (native set 5), then Mythos entry \

--- a/crates/scenarios/tests/closing_demo.rs
+++ b/crates/scenarios/tests/closing_demo.rs
@@ -115,7 +115,9 @@ fn won_walk_full_cycle_replays_identically() {
         Action::Player(PlayerAction::Investigate { investigator: inv }),
         commit_nothing.clone(), // commit window for investigate 3
         Action::Player(PlayerAction::EndTurn),
-        Action::Player(PlayerAction::DrawEncounterCard),
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
         Action::Player(PlayerAction::Investigate { investigator: inv }),
         commit_nothing.clone(), // commit window for investigate 4
         Action::Player(PlayerAction::AdvanceAct { investigator: inv }),
@@ -190,8 +192,10 @@ fn lost_walk_spawn_attack_doom_replays_identically() {
         if state.resolution.is_some() {
             break;
         }
-        if state.mythos_draw_pending.is_some() {
-            let act = Action::Player(PlayerAction::DrawEncounterCard);
+        if state.current_encounter_drawer().is_some() {
+            let act = Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::Confirm,
+            });
             let (next, ev) = apply_checked(state, &act);
             log.push(act);
             state = next;

--- a/crates/scenarios/tests/hunter_movement.rs
+++ b/crates/scenarios/tests/hunter_movement.rs
@@ -33,16 +33,26 @@ fn multi_investigator_spawn_engagement_resolves_via_lead_pick() {
         .get_mut(&InvestigatorId(1))
         .unwrap()
         .current_location = Some(LocationId(10));
-    // Drive through the real Mythos draw path.
+    // Drive through the real Mythos draw path: stage the EncounterDraw loop
+    // frame for inv1 so the ResolveInput(Confirm) below resumes it (#348).
     state.phase = Phase::Mythos;
-    state.mythos_draw_pending = Some(InvestigatorId(1));
+    state
+        .continuations
+        .push(game_core::state::Continuation::EncounterDraw {
+            remaining: vec![InvestigatorId(1)],
+        });
     state.encounter_deck.clear();
     state
         .encounter_deck
         .push_back(game_core::state::CardCode(SYNTH_ENEMY_CODE.into()));
 
     // 1) Drawing the enemy suspends for the lead's PickSingle.
-    let r1 = apply(state, Action::Player(PlayerAction::DrawEncounterCard));
+    let r1 = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    );
     assert!(
         matches!(r1.outcome, EngineOutcome::AwaitingInput { .. }),
         "multi-investigator spawn suspends, got {:?}",

--- a/crates/scenarios/tests/mythos_phase.rs
+++ b/crates/scenarios/tests/mythos_phase.rs
@@ -95,9 +95,14 @@ fn mythos_phase_resolves_single_treachery() {
 
     let state = setup_at_mythos_draw(base);
     assert_eq!(state.phase, Phase::Mythos, "must be in Mythos before draw");
-    assert_eq!(state.mythos_draw_pending, Some(InvestigatorId(1)));
+    assert_eq!(state.current_encounter_drawer(), Some(InvestigatorId(1)));
 
-    let result = apply(state, Action::Player(PlayerAction::DrawEncounterCard));
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    );
 
     assert_eq!(result.outcome, EngineOutcome::Done);
     // Mythos → Investigation transition completes inline (MythosAfterDraws
@@ -116,7 +121,8 @@ fn mythos_phase_resolves_single_treachery() {
         "treachery must be in discard after Revelation resolves",
     );
     assert_eq!(
-        result.state.mythos_draw_pending, None,
+        result.state.current_encounter_drawer(),
+        None,
         "cursor must be cleared once all investigators have drawn",
     );
     assert_eq!(
@@ -157,7 +163,12 @@ fn mythos_phase_surge_chains_into_next_card() {
         ],
     );
 
-    let result = apply(state, Action::Player(PlayerAction::DrawEncounterCard));
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    );
 
     assert_eq!(result.outcome, EngineOutcome::Done);
     assert!(
@@ -200,7 +211,12 @@ fn mythos_phase_resolves_single_spawn_enemy() {
     let state = setup_at_mythos_draw(base);
     assert_eq!(state.phase, Phase::Mythos);
 
-    let result = apply(state, Action::Player(PlayerAction::DrawEncounterCard));
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    );
 
     assert_eq!(result.outcome, EngineOutcome::Done);
     assert_eq!(
@@ -231,6 +247,7 @@ fn mythos_phase_resolves_single_spawn_enemy() {
 }
 
 #[test]
+#[allow(clippy::too_many_lines)] // end-to-end multi-investigator spawn-suspend walkthrough
 fn mythos_phase_multi_investigator_spawn_suspends_then_resumes_chain() {
     // Two investigators co-located at the synth spawn location: the
     // drawn enemy ties under Prey::Default, so the draw suspends for the
@@ -267,7 +284,7 @@ fn mythos_phase_multi_investigator_spawn_suspends_then_resumes_chain() {
         ],
     );
     assert_eq!(state.phase, Phase::Mythos);
-    assert_eq!(state.mythos_draw_pending, Some(InvestigatorId(1)));
+    assert_eq!(state.current_encounter_drawer(), Some(InvestigatorId(1)));
 
     // Seed the controlled draw order *after* StartScenario's shuffle:
     // inv1 draws the enemy; inv2 draws a plain treachery afterward.
@@ -280,7 +297,12 @@ fn mythos_phase_multi_investigator_spawn_suspends_then_resumes_chain() {
     );
 
     // Draw → spawn tie → suspend.
-    let suspended = apply(state, Action::Player(PlayerAction::DrawEncounterCard));
+    let suspended = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    );
     assert!(
         matches!(suspended.outcome, EngineOutcome::AwaitingInput { .. }),
         "spawn tie must suspend, got {:?}",
@@ -298,7 +320,10 @@ fn mythos_phase_multi_investigator_spawn_suspends_then_resumes_chain() {
         .expect("enemy placed");
     assert_eq!(enemy.engaged_with, None, "engagement deferred");
     // The cursor is unchanged — still mid-chain for inv1.
-    assert_eq!(suspended.state.mythos_draw_pending, Some(InvestigatorId(1)));
+    assert_eq!(
+        suspended.state.current_encounter_drawer(),
+        Some(InvestigatorId(1))
+    );
 
     // Lead picks inv2 (by its offered option id) → engage + resume the chain.
     // The enemy is non-surge, so no further card draws; the chain advances to inv2.
@@ -319,7 +344,12 @@ fn mythos_phase_multi_investigator_spawn_suspends_then_resumes_chain() {
             response: InputResponse::PickSingle(pick),
         }),
     );
-    assert_eq!(resumed.outcome, EngineOutcome::Done);
+    // Picking engages inv2 and re-enters inv1's chain, which completes; the
+    // loop then drains inv1 and re-prompts inv2 (AwaitingInput).
+    assert!(matches!(
+        resumed.outcome,
+        EngineOutcome::AwaitingInput { .. }
+    ));
     assert!(!matches!(
         resumed.state.continuations.last(),
         Some(game_core::state::Continuation::SpawnEngage(_))
@@ -337,7 +367,10 @@ fn mythos_phase_multi_investigator_spawn_suspends_then_resumes_chain() {
     );
     // Chain resumed and advanced to inv2; still in Mythos.
     assert_eq!(resumed.state.phase, Phase::Mythos);
-    assert_eq!(resumed.state.mythos_draw_pending, Some(InvestigatorId(2)));
+    assert_eq!(
+        resumed.state.current_encounter_drawer(),
+        Some(InvestigatorId(2))
+    );
     assert_event!(
         resumed.events,
         Event::EnemyEngaged { investigator, .. }
@@ -391,22 +424,36 @@ fn mythos_phase_multi_investigator_player_order() {
     );
 
     assert_eq!(state.phase, Phase::Mythos);
-    assert_eq!(state.mythos_draw_pending, Some(inv1), "inv1 draws first");
+    assert_eq!(
+        state.current_encounter_drawer(),
+        Some(inv1),
+        "inv1 draws first"
+    );
 
-    // inv1 draws their card.
-    let result1 = apply(state, Action::Player(PlayerAction::DrawEncounterCard));
-    assert_eq!(result1.outcome, EngineOutcome::Done);
+    // inv1 draws their card → the loop re-prompts inv2 (AwaitingInput).
+    let result1 = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    );
+    assert!(matches!(
+        result1.outcome,
+        EngineOutcome::AwaitingInput { .. }
+    ));
     // Still in Mythos; inv2 must draw next.
     assert_eq!(result1.state.phase, Phase::Mythos);
-    assert_eq!(result1.state.mythos_draw_pending, Some(inv2));
+    assert_eq!(result1.state.current_encounter_drawer(), Some(inv2));
 
     // inv2 draws their card → completes the phase.
     let result2 = apply(
         result1.state,
-        Action::Player(PlayerAction::DrawEncounterCard),
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
     );
     assert_eq!(result2.outcome, EngineOutcome::Done);
-    assert_eq!(result2.state.mythos_draw_pending, None);
+    assert_eq!(result2.state.current_encounter_drawer(), None);
     assert_eq!(result2.state.phase, Phase::Investigation);
     assert!(result2.state.encounter_deck.is_empty());
     assert_eq!(result2.state.encounter_discard.len(), 2);
@@ -427,7 +474,12 @@ fn mythos_phase_full_round_chain() {
     assert_eq!(state.round, 2);
     assert_eq!(state.phase, Phase::Mythos);
 
-    let result = apply(state, Action::Player(PlayerAction::DrawEncounterCard));
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    );
 
     assert_eq!(result.outcome, EngineOutcome::Done);
     assert_eq!(
@@ -492,7 +544,11 @@ fn mythos_phase_multi_investigator_surge_does_not_spill() {
     );
 
     assert_eq!(state.phase, Phase::Mythos);
-    assert_eq!(state.mythos_draw_pending, Some(inv1), "inv1 draws first");
+    assert_eq!(
+        state.current_encounter_drawer(),
+        Some(inv1),
+        "inv1 draws first"
+    );
 
     // Seed the controlled draw order *after* StartScenario's shuffle:
     // surge on top, then two plain treacheries.
@@ -505,14 +561,23 @@ fn mythos_phase_multi_investigator_surge_does_not_spill() {
         ],
     );
 
-    // inv1 draws: surge chain pulls TWO cards (surge + plain treachery).
-    let result1 = apply(state, Action::Player(PlayerAction::DrawEncounterCard));
-    assert_eq!(result1.outcome, EngineOutcome::Done);
+    // inv1 draws: surge chain pulls TWO cards (surge + plain treachery), then
+    // the loop re-prompts inv2 (AwaitingInput).
+    let result1 = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    );
+    assert!(matches!(
+        result1.outcome,
+        EngineOutcome::AwaitingInput { .. }
+    ));
     // The surge chain resolves within inv1's single apply; still Mythos
     // because inv2 still needs to draw.
     assert_eq!(result1.state.phase, Phase::Mythos);
     assert_eq!(
-        result1.state.mythos_draw_pending,
+        result1.state.current_encounter_drawer(),
         Some(inv2),
         "cursor advances to inv2 after inv1's chain completes"
     );
@@ -543,11 +608,13 @@ fn mythos_phase_multi_investigator_surge_does_not_spill() {
     // inv2 draws: one plain treachery, no surge.
     let result2 = apply(
         result1.state,
-        Action::Player(PlayerAction::DrawEncounterCard),
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
     );
     assert_eq!(result2.outcome, EngineOutcome::Done);
     assert_eq!(result2.state.phase, Phase::Investigation);
-    assert_eq!(result2.state.mythos_draw_pending, None);
+    assert_eq!(result2.state.current_encounter_drawer(), None);
     assert!(result2.state.encounter_deck.is_empty());
     assert_eq!(
         result2.state.encounter_discard.len(),
@@ -576,9 +643,14 @@ fn mythos_draw_rejects_when_initial_deck_and_discard_both_empty() {
 
     let state = setup_at_mythos_draw(base);
     assert_eq!(state.phase, Phase::Mythos);
-    assert_eq!(state.mythos_draw_pending, Some(InvestigatorId(1)));
+    assert_eq!(state.current_encounter_drawer(), Some(InvestigatorId(1)));
 
-    let result = apply(state, Action::Player(PlayerAction::DrawEncounterCard));
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    );
 
     match result.outcome {
         EngineOutcome::Rejected { reason } => {
@@ -597,7 +669,7 @@ fn mythos_draw_rejects_when_initial_deck_and_discard_both_empty() {
         "phase must not change on Rejected",
     );
     assert_eq!(
-        result.state.mythos_draw_pending,
+        result.state.current_encounter_drawer(),
         Some(InvestigatorId(1)),
         "cursor must be preserved on initial Rejected (validate-first)",
     );
@@ -640,9 +712,14 @@ fn mythos_after_draws_window_stays_open_when_fast_event_in_hand() {
         .push(CardCode(SYNTH_FAST_EVENT_CODE.into()));
 
     assert_eq!(state.phase, Phase::Mythos);
-    assert_eq!(state.mythos_draw_pending, Some(InvestigatorId(1)));
+    assert_eq!(state.current_encounter_drawer(), Some(InvestigatorId(1)));
 
-    let result = apply(state, Action::Player(PlayerAction::DrawEncounterCard));
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    );
 
     // DrawEncounterCard should complete normally (Done) — the window
     // opens but doesn't block the draw action's completion.
@@ -720,7 +797,12 @@ fn mythos_after_draws_window_closed_by_skip_and_transitions_to_investigation() {
         .push(CardCode(SYNTH_FAST_EVENT_CODE.into()));
 
     // Advance through the draw to land in the open-window state.
-    let draw_result = apply(state, Action::Player(PlayerAction::DrawEncounterCard));
+    let draw_result = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    );
     assert_eq!(draw_result.outcome, EngineOutcome::Done);
     assert!(
         !draw_result.state.open_windows().is_empty(),

--- a/crates/scenarios/tests/synthetic_resolution.rs
+++ b/crates/scenarios/tests/synthetic_resolution.rs
@@ -120,8 +120,13 @@ fn synthetic_scenario_resolves_lost_via_doom() {
         if state.resolution.is_some() {
             break;
         }
-        if state.mythos_draw_pending.is_some() {
-            let r2 = apply(state, Action::Player(PlayerAction::DrawEncounterCard));
+        if state.current_encounter_drawer().is_some() {
+            let r2 = apply(
+                state,
+                Action::Player(PlayerAction::ResolveInput {
+                    response: InputResponse::Confirm,
+                }),
+            );
             all_events.extend(r2.events);
             state = r2.state;
             if state.resolution.is_some() {

--- a/crates/scenarios/tests/the_gathering_resolutions.rs
+++ b/crates/scenarios/tests/the_gathering_resolutions.rs
@@ -189,7 +189,9 @@ fn act_progression_and_ghoul_priest_defeat_latches_won() {
     // (1 doom) to advance into Investigation, where Roland can take the Fight.
     let mythos = apply(
         after_confirm.state,
-        Action::Player(PlayerAction::DrawEncounterCard),
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
     );
     assert_eq!(mythos.outcome, EngineOutcome::Done);
     let mut state = mythos.state;

--- a/crates/scenarios/tests/upkeep_hand_size.rs
+++ b/crates/scenarios/tests/upkeep_hand_size.rs
@@ -130,10 +130,10 @@ fn upkeep_prompts_and_discards_down_to_eight() {
         }),
     );
 
-    assert_eq!(
-        r4.outcome,
-        EngineOutcome::Done,
-        "resolving the discard must complete the upkeep cascade"
+    assert!(
+        matches!(r4.outcome, EngineOutcome::AwaitingInput { .. }),
+        "resolving the discard continues the upkeep cascade into Mythos, which \
+         pauses at the encounter-draw prompt"
     );
     assert_eq!(
         r4.state.investigators[&inv1].hand.len(),
@@ -161,7 +161,7 @@ fn upkeep_prompts_and_discards_down_to_eight() {
         "round must proceed into Mythos after the discard resolves"
     );
     assert!(
-        r4.state.mythos_draw_pending.is_some(),
+        r4.state.current_encounter_drawer().is_some(),
         "Mythos draw cursor must be seeded once the round proceeds"
     );
 }

--- a/crates/scenarios/tests/upkeep_phase.rs
+++ b/crates/scenarios/tests/upkeep_phase.rs
@@ -76,10 +76,11 @@ fn upkeep_full_round_draws_and_grants_then_pauses_at_mythos() {
     let hand_before = r2.state.investigators[&inv1].hand.len();
     let round_before = r2.state.round; // should be 1
 
-    // EndTurn: Investigation → Enemy → Upkeep → Mythos.
+    // EndTurn: Investigation → Enemy → Upkeep → Mythos, pausing at the
+    // step-1.4 encounter-draw prompt (AwaitingInput).
     let r3 = apply(r2.state, Action::Player(PlayerAction::EndTurn));
 
-    assert_eq!(r3.outcome, EngineOutcome::Done);
+    assert!(matches!(r3.outcome, EngineOutcome::AwaitingInput { .. }));
     assert_eq!(r3.state.phase, Phase::Mythos, "cascade must land in Mythos");
     assert_eq!(
         r3.state.round,
@@ -87,7 +88,7 @@ fn upkeep_full_round_draws_and_grants_then_pauses_at_mythos() {
         "round bumped on Mythos entry"
     );
     assert!(
-        r3.state.mythos_draw_pending.is_some(),
+        r3.state.current_encounter_drawer().is_some(),
         "draw cursor must be seeded"
     );
     assert_eq!(

--- a/crates/web/src/controls.rs
+++ b/crates/web/src/controls.rs
@@ -274,13 +274,11 @@ pub fn ActionControls() -> impl IntoView {
                         tx.clone(),
                         PlayerAction::EndTurn,
                     )}
-                    {submit_button(
-                        "action draw-encounter",
-                        "Draw encounter",
-                        !has(ActionControl::DrawEncounter),
-                        tx.clone(),
-                        PlayerAction::DrawEncounterCard,
-                    )}
+                    // The dedicated Mythos encounter-draw button is gone (#348
+                    // part 2c-iii-b): the draw is now an `AwaitingInput`
+                    // (Confirm), so — like the act round-end window (#275) — it
+                    // flows through the `ResolveInput` prompt UI. The Confirm /
+                    // Skip prompt rendering is deferred to #205.
                     {move_picker(&game, active, has(ActionControl::Move), tx.as_ref())}
                     {play_picker(&game, active, has(ActionControl::PlayCard), tx.as_ref())}
                     {enemy_picker(&game, active, has(ActionControl::Fight), "fight-target", "Fight", fight_action, tx.as_ref())}

--- a/crates/web/src/legality.rs
+++ b/crates/web/src/legality.rs
@@ -16,7 +16,6 @@ pub enum ActionControl {
     Investigate,
     PlayCard,
     EndTurn,
-    DrawEncounter,
     AdvanceAct,
     Fight,
     Evade,
@@ -37,22 +36,18 @@ pub enum ActionControl {
 /// 2. `round == 0` is the pre-start state straight from a scenario
 ///    `setup()` (the engine bumps to round 1 at `StartScenario` and only
 ///    ever increments), so `StartScenario` is the sole legal action — it
-///    seeds hands and opens the setup mulligan loop. The mulligan itself is
-///    an `AwaitingInput` (case 1 above), so it needs no dedicated control —
-///    it flows through the `ResolveInput` prompt UI like every other
-///    suspension.
-/// 3. The `mythos_draw_pending` setup cursor dominates its window
-///    (⇒ only `DrawEncounter`). A state fact, not phase, so it's checked
-///    before the phase table.
-/// 4. Otherwise, the controls the current `Phase` permits.
+///    seeds hands and opens the setup mulligan loop. The mulligan and the
+///    Mythos step-1.4 encounter draw are both `AwaitingInput`s (case 1
+///    above), so they need no dedicated control — they flow through the
+///    `ResolveInput` prompt UI like every other suspension.
+/// 3. Otherwise, the controls the current `Phase` permits.
 ///
 /// Finer checks (resources, action budget, clue presence) are
 /// deliberately not mirrored — the server's `Rejected` is the truth.
 #[must_use]
 pub fn enabled_controls(game: &GameState, outcome: &EngineOutcome) -> BTreeSet<ActionControl> {
     use ActionControl::{
-        AdvanceAct, Draw, DrawEncounter, EndTurn, Evade, Fight, Investigate, Move, PlayCard,
-        StartScenario,
+        AdvanceAct, Draw, EndTurn, Evade, Fight, Investigate, Move, PlayCard, StartScenario,
     };
 
     if game.resolution.is_some() {
@@ -63,9 +58,6 @@ pub fn enabled_controls(game: &GameState, outcome: &EngineOutcome) -> BTreeSet<A
     }
     if game.round == 0 {
         return BTreeSet::from([StartScenario]);
-    }
-    if game.mythos_draw_pending.is_some() {
-        return BTreeSet::from([DrawEncounter]);
     }
     match game.phase {
         Phase::Investigation => BTreeSet::from([
@@ -127,21 +119,12 @@ mod tests {
         assert_eq!(enabled_controls(&game, &out), BTreeSet::new());
     }
 
-    // The former `mulligan_pending_enables_only_mulligan` test is gone: the
-    // setup mulligan is now an `AwaitingInput`, so it is covered by
-    // `awaiting_input_disables_everything` (the mulligan prompt flows through
-    // the `ResolveInput` UI, not a dedicated control). #348 part 2c-iii-a.
-
-    #[test]
-    fn mythos_draw_pending_enables_only_draw_encounter() {
-        let mut game = investigation_game();
-        game.phase = Phase::Mythos;
-        game.mythos_draw_pending = Some(InvestigatorId(1));
-        assert_eq!(
-            enabled_controls(&game, &EngineOutcome::Done),
-            BTreeSet::from([ActionControl::DrawEncounter])
-        );
-    }
+    // The former `mulligan_pending_enables_only_mulligan` (#348 2c-iii-a) and
+    // `mythos_draw_pending_enables_only_draw_encounter` (#348 2c-iii-b) tests
+    // are gone: the setup mulligan and the Mythos step-1.4 encounter draw are
+    // now `AwaitingInput`s, so both are covered by
+    // `awaiting_input_disables_everything` — they flow through the
+    // `ResolveInput` prompt UI, not a dedicated control.
 
     #[test]
     fn investigation_phase_enables_the_core_loop() {

--- a/crates/web/tests/controls.rs
+++ b/crates/web/tests/controls.rs
@@ -7,7 +7,9 @@
 use futures::channel::mpsc;
 use game_core::state::GameStateBuilder;
 use game_core::state::{CardCode, EnemyId, InvestigatorId, LocationId, Phase};
-use game_core::test_support::fixtures::{test_enemy, test_investigator, test_location};
+use game_core::test_support::fixtures::{
+    awaiting_commit_input, test_enemy, test_investigator, test_location,
+};
 use game_core::{EngineOutcome, PlayerAction};
 use leptos::prelude::*;
 use protocol::{ClientMessage, ServerMessage};
@@ -129,58 +131,33 @@ async fn advance_act_submits_advance_act_for_active() {
     }
 }
 
-#[wasm_bindgen_test]
-async fn draw_encounter_submits_draw_encounter_card() {
-    // Mythos phase with this investigator on the draw cursor: only
-    // DrawEncounter is legal. `mythos_draw_pending` has no builder setter,
-    // so mutate the built state directly (legality.rs tests do the same).
-    let mut game = GameStateBuilder::new()
-        .with_investigator(test_investigator(1))
-        .with_active_investigator(InvestigatorId(1))
-        .with_phase(Phase::Mythos)
-        .with_round(1)
-        .build();
-    game.mythos_draw_pending = Some(InvestigatorId(1));
-
-    let mut rx = mount(game, EngineOutcome::Done).await;
-    click_in(&last_controls(), ".draw-encounter");
-    leptos::task::tick().await;
-    let frame = rx.try_recv().expect("a frame after tick");
-    match submit_action(frame) {
-        PlayerAction::DrawEncounterCard => {}
-        other => panic!("expected DrawEncounterCard, got {other:?}"),
-    }
-}
+// The former `draw_encounter_submits_draw_encounter_card` test is gone (#348
+// part 2c-iii-b): the dedicated Draw-encounter button was removed. The Mythos
+// step-1.4 draw is now an `AwaitingInput(Confirm)` that flows through the
+// `ResolveInput` prompt UI (Confirm/Skip rendering deferred to #205), not a
+// core-loop control.
 
 #[wasm_bindgen_test]
 async fn illegal_controls_are_disabled_and_do_not_submit() {
-    // Mythos + draw cursor: only DrawEncounter is legal, so End turn is
-    // disabled and DrawEncounter is not.
-    let mut game = GameStateBuilder::new()
+    // During an `AwaitingInput` pause, every core-loop control is disabled
+    // (`enabled_controls` returns empty). A disabled button must not submit a
+    // frame when clicked.
+    let game = GameStateBuilder::new()
         .with_investigator(test_investigator(1))
         .with_active_investigator(InvestigatorId(1))
-        .with_phase(Phase::Mythos)
+        .with_phase(Phase::Investigation)
         .with_round(1)
         .build();
-    game.mythos_draw_pending = Some(InvestigatorId(1));
 
-    let mut rx = mount(game, EngineOutcome::Done).await;
+    let mut rx = mount(game, awaiting_commit_input("commit")).await;
     let controls = last_controls();
     let end_turn = controls
         .query_selector(".end-turn")
         .expect("query")
         .expect("end-turn present");
-    let draw = controls
-        .query_selector(".draw-encounter")
-        .expect("query")
-        .expect("draw-encounter present");
     assert!(
         end_turn.has_attribute("disabled"),
-        "End turn should be disabled"
-    );
-    assert!(
-        !draw.has_attribute("disabled"),
-        "Draw encounter should be enabled"
+        "End turn should be disabled during an AwaitingInput pause"
     );
 
     // A disabled button does not fire click → no frame.
@@ -389,7 +366,9 @@ async fn resolved_scenario_disables_all_controls() {
 
     let _rx = mount(game, EngineOutcome::Done).await;
     let controls = last_controls();
-    for selector in [".start-scenario", ".end-turn", ".draw-encounter"] {
+    // `.draw-encounter` is gone (#348 2c-iii-b); `.draw` is a representative
+    // remaining core-loop button.
+    for selector in [".start-scenario", ".end-turn", ".draw"] {
         let btn = controls
             .query_selector(selector)
             .expect("query")

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -93,11 +93,13 @@ integration test. Once the Tier-1 fixes stabilize, this is the first follow-on:
 the web client (shipped Phase 6) must drive the **real** Gathering scenario.
 
 - **#205 — structured `AwaitingInput` discrimination (load-bearing, needs-design).**
-  The Gathering's cards are the first to emit non-`CommitCards` prompts
-  (`PickIndex` / `PickInvestigator` / `Confirm` / `Skip` / `DiscardCards`); the
-  client must render the right control per variant from a machine-readable
-  `InputKind`, not prompt-string heuristics. Keystone of the surface; pairs with
-  #347 (token-routed resume → stale-submit rejection).
+  The Gathering's cards are the first to emit non-commit prompts across the
+  normalized `InputResponse` set (`PickSingle` / `PickMultiple` / `Confirm` /
+  `Skip` — the §1 cleanup folded the former `PickInvestigator`/`PickLocation` and
+  `CommitCards`/`DiscardCards` into `PickSingle`/`PickMultiple`); the client must
+  render the right control per variant from machine-readable offered options, not
+  prompt-string heuristics. Keystone of the surface; pairs with #347 (token-routed
+  resume → stale-submit rejection).
 - **Investigator / scenario picker.** The seating protocol (B2 #221) + registry
   swap (C7a #244) exist engine-side; the browser picker driving `StartScenario`
   with a chosen investigator is the remaining UI.
@@ -117,14 +119,19 @@ rather than deferring wholesale:
 - **§1 continuation-stack cleanup — the full #348 + #345 + #347 + #380, as one
   designed pass. DO-FIRST, before the keystone.** Designed in
   `docs/superpowers/specs/2026-06-19-continuation-stack-cleanup-design.md`.
-  **Progress:** #345 shipped (PR #385); #347 → #348 → #380 follow as separate PRs.
+  **Progress:** #345 shipped (PR #385); #348 is landing incrementally (parts
+  2a–2c via PRs #386–#391) — the `InputResponse` channel is now normalized
+  (`CommitCards`/`DiscardCards` → `PickMultiple`, `PickLocation`/`PickInvestigator`
+  → `PickSingle`, `Mulligan` → `PickMultiple`, `DrawEncounterCard` → `Confirm`),
+  every player-facing suspension resumes through `ResolveInput`, and the bespoke
+  `mulligan_pending`/`mythos_draw_pending` cursors + `in_flight_skill_test` are
+  folded onto continuation frames. #347 and #380 follow as separate PRs.
   #348 migrates the remaining
   `pending_*` suspension modes (incl. `pending_enemy_attack`, `pending_end_turn`)
   onto the one continuation stack and collapses the
   fragile `if pending_X.is_some()` `resolve_input` cascade **and** the parallel
-  `apply_player_action` guard ladder into top-frame dispatch (folding
-  `Mulligan`/`DrawEncounterCard` into `ResolveInput` and `in_flight_skill_test`
-  onto its frame; `clue_interrupt_pending` is already a window); #345 makes
+  `apply_player_action` guard ladder into top-frame dispatch
+  (`clue_interrupt_pending` is already a window); #345 makes
   `EvalContext` serializable with **grouped optional bindings** snapshotted
   per-frame (the Vec / per-frame-enum / global-stack alternatives were evaluated
   and rejected — spec §D; innermost-only is corpus-moot, no TODO) so migrated

--- a/docs/superpowers/specs/2026-06-19-continuation-stack-cleanup-design.md
+++ b/docs/superpowers/specs/2026-06-19-continuation-stack-cleanup-design.md
@@ -40,10 +40,15 @@ depends on it today — this is a correctness-preserving structural pass.
 declares how it resumes. Both ladders die: `apply_player_action`'s reject-guards and
 `resolve_input`'s priority cascade collapse into **one dispatch on the top frame**.
 
-The player-facing resume signal **unifies onto `ResolveInput`**. `PlayerAction::Mulligan` and
-`PlayerAction::DrawEncounterCard` fold into `InputResponse` variants and are **removed** as
-standalone actions. Setup emits `AwaitingInput { mulligan for X }` per investigator; Mythos
-step 1.4 emits `AwaitingInput { encounter draw for X }` per drawer.
+The player-facing resume signal **unifies onto `ResolveInput`**, and the `InputResponse`
+channel is **normalized** as part of the pass: `CommitCards`/`DiscardCards` collapse into
+`PickMultiple` and `PickLocation`/`PickInvestigator` into `PickSingle` (the structured-options
+consolidation — these land here, in #348 part 2c-i/2c-ii; only the *human labels / client
+rendering* defer to #205, not the variant consolidation). On that normalized channel,
+`PlayerAction::Mulligan` and `PlayerAction::DrawEncounterCard` then fold into
+`PickMultiple` / `Confirm` and are **removed** as standalone actions (part 2c-iii). Setup
+emits `AwaitingInput { mulligan for X }` per investigator; Mythos step 1.4 emits
+`AwaitingInput { encounter draw for X }` per drawer.
 
 Two precision points:
 
@@ -278,17 +283,21 @@ applies and is the natural follow-up.
 One spec, landed as reviewable PRs, each green on the full CI gauntlet:
 
 1. **#345** — serializable `EvalContext` + grouped bindings + per-frame snapshot. Foundational;
-   establishes the storage shape the migrated frames use.
-2. **#347** — token plumbing: `next_resume_token` counter, frame stamps, `ResolveInput.token`,
-   stale-reject. Wire change; establishes the router substrate.
-3. **#348** — migrate the suspension modes onto frames (incl. folding `in_flight_skill_test`);
-   collapse both ladders into top-frame dispatch; fold in `Mulligan` / `DrawEncounterCard` →
-   `InputResponse`. The bulk of the pass.
+   establishes the storage shape the migrated frames use. *(Shipped: PR #385.)*
+2. **#348** — migrate the suspension modes onto frames (incl. folding `in_flight_skill_test`);
+   collapse both ladders into top-frame dispatch; **normalize the `InputResponse` channel** —
+   `CommitCards`/`DiscardCards` → `PickMultiple`, `PickLocation`/`PickInvestigator` →
+   `PickSingle`, then fold `Mulligan` → `PickMultiple` and `DrawEncounterCard` → `Confirm`. The
+   bulk of the pass. *(Landed incrementally: parts 2a–2c, PRs #386–#391.)*
+3. **#347** — token plumbing: `next_resume_token` counter, frame stamps, `ResolveInput.token`,
+   stale-reject. Wire change; now trivial on the unified `ResolveInput` channel #348 leaves.
 4. **#380** — encounter-card-as-frame + framework disposal teardown; remove
    `pending_revelation_discard`. Small; rides the clean stack.
 
-Rationale: bindings first (storage), then token (router substrate), then the migration
-(consumes both), then the side-channel cleanup.
+Rationale (corrected from the original `#347`-before-`#348` ordering): bindings first
+(storage), then the migration #348 (consumes the storage and collapses every suspension onto
+one `ResolveInput` channel), then token-routing #347 (trivial once that channel is unified),
+then the side-channel cleanup #380.
 
 ## What "done" looks like
 


### PR DESCRIPTION
## Summary

Migrates the Mythos step-1.4 encounter-draw loop off its bespoke `GameState::mythos_draw_pending` cursor onto a `Continuation::EncounterDraw { remaining }` frame, resumed through `ResolveInput(Confirm)`. After this, **the engine's only player-input channel is `ResolveInput`** — the last non-standard player action (`DrawEncounterCard`) is gone, meeting the §1 router/taxonomy goal of #348.

This is **PR 2c-iii-b**, the second half of 2c-iii (2c-iii-a folded the setup Mulligan, #390).

## What changed

**Engine (commit b1):**
- New `Continuation::EncounterDraw { remaining }` (+ classifier) and `GameState::current_encounter_drawer()` (topmost-search, since a mid-chain `SpawnEngage` frame can sit above it).
- `mythos_phase` pushes the frame and returns `AwaitingInput` (the first draw prompt), or `Done` straight into the `MythosAfterDraws` window when no Active investigator exists. `step_phase`'s Mythos arm propagates that outcome (it previously forced `Done`), so the round-ending cascade now pauses at the draw prompt.
- `draw_encounter_card` → `encounter::resume_encounter_draw` (Confirm-driven) + `prompt_encounter_draw`; `advance_mythos_draw_pending` → `advance_encounter_draw`, which drains the queue (re-prompt next / pop + open `MythosAfterDraws`) and **skips an investigator eliminated mid-loop** (RR p.10).
- **Surge / spawn-engage re-entry rewire:** `resume_spawn_engage` no longer reads `mythos_draw_pending`; it re-enters the chain iff, after popping the `SpawnEngage` frame, the top frame is the drawer's `EncounterDraw` frame (the `SpawnEngage` sits above it mid-chain).
- `apply_player_action` gains an `EncounterDraw`-frame guard; `resolve_input` gains an `EncounterDraw` arm. Builder: `with_mythos_draw_remaining(ids)`.

**Workspace fold (commit b2):**
- Delete `PlayerAction::DrawEncounterCard`; fold every call site onto `ResolveInput(Confirm)`; `mythos_draw_pending` reads → `current_encounter_drawer()`.
- `web`: remove the now-dead `DrawEncounter` control (the encounter draw is an `AwaitingInput`, and `enabled_controls` short-circuits to empty on `AwaitingInput`). Like the act round-end window (#275), it flows through the `ResolveInput` prompt UI; the Confirm/Skip rendering is deferred to #205.

**Latent bug the fold exposed (commit b2):** a Fast event played in a reaction window (e.g. Dodge cancelling an enemy attack) is stashed in `pending_played_event` and was flushed to discard only by the apply loop on a `Done` outcome. Now that the window-close cascade can end the same apply in `AwaitingInput` (the Mythos draw prompt), the completed event was stranded mid-play. `play_fast_event` now flushes the event the instant its effect completes (RR Appendix I step 4), before advancing the window/cascade — leaving the apply-boundary flush as the backstop for a suspending-OnPlay event (Dynamite Blast, untouched, since it goes through `play_card` and returns its suspension before the flush).

## Test notes

- **Mythos entry now returns `AwaitingInput`** — the broad test-shape change. A per-drawer `Confirm` for a non-last drawer returns `AwaitingInput` (re-prompting the next); the last drawer / drained queue returns `Done`. Updated across game-core/scenarios/cards tests, including the round-ending cascade tests (enemy/upkeep/hand-size/act-round-end all now pause at the draw prompt).
- Dropped the out-of-order / phase / no-pending `DrawEncounterCard` rejection tests (the folded `Confirm` carries no investigator and the frame's presence is the gate); added a non-`Confirm` rejection test.
- The dodge fixture gains a spare deck card so the round-ending upkeep 4.4 draw doesn't reshuffle the just-discarded Dodge.
- Full CI gauntlet run locally (all 7 jobs): fmt, test, clippy, doc, wasm-build, wasm-test (headless Firefox), wasm-clippy — all green.

A follow-up doc commit (spec sequencing correction + phase-7 §1 progress line) lands after CI is green, per the repo's phase-doc procedure.

## Linked issues

Part of #348 (remaining series work: #347 token-routing, #380 revelation disposal).