### PR TITLE
engine: dispose of encounter treacheries via an EncounterCard frame (#380)

### DIFF
--- a/crates/cards/tests/revelation_treacheries.rs
+++ b/crates/cards/tests/revelation_treacheries.rs
@@ -73,7 +73,6 @@ fn grasping_hands_deals_one_damage_per_point_failed_then_discards() {
         "the treachery discards after its suspended Revelation resolves",
     );
     assert!(!result.state.has_skill_test_in_flight());
-    assert!(result.state.pending_revelation_discard.is_none());
 }
 
 #[test]

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -178,11 +178,13 @@ pub fn resolve_encounter_card(
             {
                 match apply_effect(cx, &ability.effect, eval_ctx) {
                     EngineOutcome::Done => {}
-                    // Suspended: the `EncounterCard` frame sits beneath the
+                    // Suspended → the `EncounterCard` frame sits beneath the
                     // suspension; the `resolve_input` chokepoint disposes of the
-                    // card once the sub-resolution completes.
-                    outcome @ EngineOutcome::AwaitingInput { .. } => return outcome,
-                    outcome @ EngineOutcome::Rejected { .. } => return outcome,
+                    // card once the sub-resolution completes. Rejected → the
+                    // apply loop's transactional snapshot rolls back the pushed
+                    // frame. Either way, propagate without disposing here.
+                    outcome @ (EngineOutcome::AwaitingInput { .. }
+                    | EngineOutcome::Rejected { .. }) => return outcome,
                 }
             }
             // Synchronous completion: the frame is still top — dispose now.

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -164,32 +164,31 @@ pub fn resolve_encounter_card(
             };
             let abilities = (registry.abilities_for)(&code).unwrap_or_default();
             let eval_ctx = EvalContext::for_controller(investigator);
+            // Push the disposal frame BEFORE the Revelation so the framework
+            // disposes of the card after the Revelation's whole sub-resolution
+            // completes — even if it suspends into a skill test or a choice
+            // (#380). A mid-Revelation `Rejected` is rolled back by the apply
+            // loop's transactional snapshot, this frame included.
+            cx.state
+                .continuations
+                .push(Continuation::EncounterCard { card: code.clone() });
             for ability in abilities
                 .iter()
                 .filter(|a| a.trigger == Trigger::Revelation)
             {
                 match apply_effect(cx, &ability.effect, eval_ctx) {
                     EngineOutcome::Done => {}
-                    outcome @ EngineOutcome::AwaitingInput { .. } => {
-                        // Revelation suspended (e.g. `Effect::SkillTest`
-                        // opened a commit window). The card discards only
-                        // once the suspended resolution completes — record
-                        // it so the resume path (skill-test teardown)
-                        // flushes it to `encounter_discard`.
-                        cx.state.pending_revelation_discard = Some(code.clone());
-                        return outcome;
-                    }
+                    // Suspended: the `EncounterCard` frame sits beneath the
+                    // suspension; the `resolve_input` chokepoint disposes of the
+                    // card once the sub-resolution completes.
+                    outcome @ EngineOutcome::AwaitingInput { .. } => return outcome,
                     outcome @ EngineOutcome::Rejected { .. } => return outcome,
                 }
             }
-            // A persistent treachery (one with an ongoing ability) placed
-            // itself during its Revelation and owns its own disposition
-            // (including Obscuring Fog's limit-1 discard); only a one-shot
-            // is auto-discarded here.
-            if !treachery_is_persistent(&abilities) {
-                cx.state.encounter_discard.push(code);
-            }
-            EngineOutcome::Done
+            // Synchronous completion: the frame is still top — dispose now.
+            // (One-shot → `encounter_discard`; persistent → it placed itself
+            // during its Revelation and is skipped.)
+            teardown_encounter_card_if_top(cx)
         }
         CardType::Enemy => {
             // Revelation effects on enemies (rare, but printed on
@@ -830,6 +829,37 @@ pub(super) fn advance_encounter_draw(cx: &mut Cx) -> EngineOutcome {
         *remaining = queue;
         prompt_encounter_draw(cx)
     }
+}
+
+/// If the top continuation frame is a [`Continuation::EncounterCard`], dispose
+/// of its card per the framework default and pop the frame; otherwise a no-op.
+/// Always returns [`EngineOutcome::Done`].
+///
+/// Disposal (Rules Reference p.18 default): a one-shot treachery is discarded
+/// to `encounter_discard`; a **persistent** treachery (one carrying a
+/// non-`Revelation` ability) placed itself during its Revelation and owns its
+/// own disposition, so it is skipped. Persistence is re-derived from the
+/// registry by card code — the frame stays payload-minimal (#380). The discard
+/// is eventless, matching the synchronous path in [`resolve_encounter_card`].
+/// The `while` loop covers a hypothetical nested encounter resolution at no
+/// cost.
+///
+/// Called from two sites: inline at the end of [`resolve_encounter_card`]'s
+/// treachery branch (synchronous Revelation), and at the `resolve_input`
+/// chokepoint after a resume returns `Done` (a Revelation that suspended into a
+/// skill test / choice and has now completed).
+pub(super) fn teardown_encounter_card_if_top(cx: &mut Cx) -> EngineOutcome {
+    while let Some(Continuation::EncounterCard { card }) = cx.state.continuations.last() {
+        let card = card.clone();
+        cx.state.continuations.pop();
+        let persistent = card_registry::current()
+            .and_then(|reg| (reg.abilities_for)(&card))
+            .is_some_and(|abilities| treachery_is_persistent(&abilities));
+        if !persistent {
+            cx.state.encounter_discard.push(card);
+        }
+    }
+    EngineOutcome::Done
 }
 
 #[cfg(test)]

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -411,7 +411,7 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
     // variant"; the former hand-ordered `if pending_X.is_some()` priority
     // cascade is gone.
     use crate::state::Continuation;
-    match cx.state.continuations.last() {
+    let outcome = match cx.state.continuations.last() {
         Some(Continuation::SubstitutionPrompt { .. }) => {
             skill_test::resume_substitution_choice(cx, response)
         }
@@ -423,9 +423,25 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
         Some(Continuation::ActRoundEnd(_)) => phases::resume_act_round_end_advance(cx, response),
         Some(Continuation::Mulligan { .. }) => cards::resume_mulligan(cx, response),
         Some(Continuation::EncounterDraw { .. }) => encounter::resume_encounter_draw(cx, response),
+        // An `EncounterCard` frame never awaits input — it only ever sits
+        // beneath a real suspension. If it is somehow top, no prompt is
+        // outstanding (defensive; #380).
+        Some(Continuation::EncounterCard { .. }) => EngineOutcome::Rejected {
+            reason: "ResolveInput: no input prompt is outstanding (encounter-card disposal is \
+                     framework-internal)"
+                .into(),
+        },
         Some(Continuation::SkillTest(_)) => resume_skill_test_commit(cx, response),
         None => EngineOutcome::Rejected {
             reason: "ResolveInput: no AwaitingInput prompt is currently outstanding".into(),
         },
+    };
+    // A treachery Revelation that suspended parks its `EncounterCard` frame
+    // beneath the suspension (#380); once that sub-resolution completes (`Done`)
+    // the frame is top again, so dispose of the card here — one generic site,
+    // no resume handler aware of treacheries.
+    if matches!(outcome, EngineOutcome::Done) {
+        return encounter::teardown_encounter_card_if_top(cx);
     }
+    outcome
 }

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -1197,10 +1197,10 @@ mod tests {
     // `crates/cards/tests/revelation_treacheries.rs::grasping_hands_*`
     // (01162), and the margin-damage math by the same test.
 
-    /// A plain (non-revelation) skill test never touches the
-    /// `pending_revelation_discard` slot — the flush is a no-op for it.
+    /// A plain (non-revelation) skill test disposes of no encounter card — the
+    /// skill-test driver no longer touches encounter disposal at all (#380).
     #[test]
-    fn plain_skill_test_leaves_pending_revelation_discard_untouched() {
+    fn plain_skill_test_disposes_of_no_encounter_card() {
         use crate::state::ChaosToken;
 
         let inv = InvestigatorId(1);
@@ -1218,10 +1218,6 @@ mod tests {
         assert!(matches!(out, EngineOutcome::AwaitingInput { .. }));
         let out = finish_skill_test(&mut cx, &[]);
         assert_eq!(out, EngineOutcome::Done);
-        assert!(
-            state.pending_revelation_discard.is_none(),
-            "plain test must not set or flush the revelation-discard slot"
-        );
         assert!(state.encounter_discard.is_empty());
     }
 

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -460,14 +460,11 @@ pub(super) fn drive_skill_test(cx: &mut Cx) -> EngineOutcome {
                 cx.state
                     .pending_skill_modifiers
                     .retain(|m| m.investigator != investigator);
-                // A treachery whose Revelation suspended into this test
-                // discards once the test fully resolves (the discard
-                // step `resolve_encounter_card` skipped on suspend).
-                // Eventless push, matching the normal treachery-discard
-                // path in `resolve_encounter_card`.
-                if let Some(code) = cx.state.pending_revelation_discard.take() {
-                    cx.state.encounter_discard.push(code);
-                }
+                // Encounter-treachery disposal is no longer the skill-test
+                // driver's concern (#380): a treachery whose Revelation
+                // suspended into this test parks an `EncounterCard` frame
+                // beneath it, which the framework disposes of at the
+                // `resolve_input` chokepoint once this test completes.
                 // Tear down the test's SkillTest frame (Axis-B T4), which also
                 // carries the test data (#348). `take_skill_test` removes the
                 // (unique — no nesting today) frame by position, so a player-
@@ -1192,63 +1189,13 @@ mod tests {
         assert_event!(ev, Event::HorrorTaken { investigator, amount: 1 } if *investigator == inv);
     }
 
-    /// A treachery-Revelation `Effect::SkillTest` (simulated via
-    /// `start_skill_test` with an `on_fail` + the `pending_revelation_discard`
-    /// slot `resolve_encounter_card` would set) suspends at the commit
-    /// window, then on a failing draw deals the margin in damage and
-    /// flushes the source treachery to `encounter_discard`.
-    #[test]
-    fn revelation_skill_test_failure_deals_margin_damage_and_discards() {
-        use crate::dsl::{deal_damage, for_each_point_failed, InvestigatorTarget};
-        use crate::state::{CardCode, ChaosToken};
-
-        let inv = InvestigatorId(1);
-        let mut state = GameStateBuilder::new()
-            .with_investigator(test_investigator(1))
-            .with_active_investigator(inv)
-            .build();
-        // AutoFail forces the total to 0 → fail by `difficulty` (= 2).
-        state.chaos_bag.tokens = vec![ChaosToken::AutoFail];
-        let mut events = Vec::new();
-        let mut cx = Cx {
-            state: &mut state,
-            events: &mut events,
-        };
-
-        // What the evaluator's Effect::SkillTest arm does:
-        let out = start_skill_test(
-            &mut cx,
-            inv,
-            SkillKind::Willpower,
-            SkillTestKind::Plain,
-            2,
-            SkillTestFollowUp::None,
-            None,
-            Some(for_each_point_failed(deal_damage(
-                InvestigatorTarget::You,
-                1,
-            ))),
-            None,
-            0,
-        );
-        assert!(matches!(out, EngineOutcome::AwaitingInput { .. }));
-        // What resolve_encounter_card does on a suspended revelation:
-        cx.state.pending_revelation_discard = Some(CardCode("01162".into()));
-
-        // Resume: commit no cards → AutoFail → fail by 2 → 2 damage.
-        let out = finish_skill_test(&mut cx, &[]);
-        assert_eq!(out, EngineOutcome::Done);
-        assert_eq!(
-            state.investigators[&inv].damage, 2,
-            "1 damage per point failed"
-        );
-        assert!(
-            state.encounter_discard.contains(&CardCode("01162".into())),
-            "suspended treachery flushed to encounter_discard at teardown"
-        );
-        assert!(!state.has_skill_test_in_flight());
-        assert!(state.pending_revelation_discard.is_none());
-    }
+    // The former `revelation_skill_test_failure_deals_margin_damage_and_discards`
+    // unit test is gone (#380): it simulated the removed
+    // `pending_revelation_discard` slot and drove `finish_skill_test` directly,
+    // bypassing the new `resolve_input`-chokepoint disposal. The real
+    // suspended-Revelation-into-skill-test discard is integration-tested by
+    // `crates/cards/tests/revelation_treacheries.rs::grasping_hands_*`
+    // (01162), and the margin-damage math by the same test.
 
     /// A plain (non-revelation) skill test never touches the
     /// `pending_revelation_discard` slot — the flush is a no-op for it.

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -320,7 +320,6 @@ impl GameStateBuilder {
             pending_end_turn: None,
             pending_enemy_attack: None,
             pending_cancellation: false,
-            pending_revelation_discard: None,
             pending_played_event: None,
             skill_substitutions: Vec::new(),
             encounter_deck: VecDeque::new(),

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -487,6 +487,20 @@ pub enum Continuation {
         /// currently prompted.
         remaining: Vec<InvestigatorId>,
     },
+    /// A drawn encounter **treachery** whose Revelation is mid-resolution
+    /// (#380). Pushed by `resolve_encounter_card` *before* it runs the
+    /// Revelation; sits beneath any suspension the Revelation opens (a skill
+    /// test, a choice, a nested effect). When that sub-resolution completes and
+    /// this frame is top again, the **framework** disposes of the card
+    /// (one-shot → `encounter_discard`; persistent → it placed itself during
+    /// its Revelation, so skip) and pops. Suspension-reason-agnostic — replaces
+    /// the former `pending_revelation_discard` slot, which only the skill-test
+    /// driver flushed (so a choice-only Revelation was never disposed of).
+    /// Never emits `AwaitingInput`.
+    EncounterCard {
+        /// The drawn treachery's card code, disposed of at teardown.
+        card: CardCode,
+    },
 }
 
 /// A controller choice paused mid-resolution (umbrella §3, Axis A).
@@ -530,7 +544,8 @@ impl Continuation {
             | Continuation::ActRoundEnd(_)
             | Continuation::SubstitutionPrompt { .. }
             | Continuation::Mulligan { .. }
-            | Continuation::EncounterDraw { .. } => None,
+            | Continuation::EncounterDraw { .. }
+            | Continuation::EncounterCard { .. } => None,
         }
     }
 
@@ -546,7 +561,8 @@ impl Continuation {
             | Continuation::ActRoundEnd(_)
             | Continuation::SubstitutionPrompt { .. }
             | Continuation::Mulligan { .. }
-            | Continuation::EncounterDraw { .. } => None,
+            | Continuation::EncounterDraw { .. }
+            | Continuation::EncounterCard { .. } => None,
         }
     }
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -200,25 +200,20 @@ pub struct GameState {
     /// ever in flight. TODO(#367): typed marker once Before-windows can nest.
     #[serde(default)]
     pub pending_cancellation: bool,
-    /// A treachery whose Revelation suspended (e.g. initiated a skill
-    /// test) and must be pushed to [`encounter_discard`](Self::encounter_discard)
-    /// once the suspending sub-resolution completes. Set by
-    /// `resolve_encounter_card` (in `engine::dispatch`) when its
-    /// Revelation loop yields `AwaitingInput`; flushed by the skill-test
-    /// driver's terminal teardown step. `None` for the common
-    /// Investigate/Fight/Evade test (no pending revelation).
-    /// TODO(#380): generalize beyond skill-test-suspended revelations —
-    /// `ChooseOne` can now suspend mid-resolution (#350), so this side
-    /// channel can fold onto the continuation stack (coordinates with #348).
-    pub pending_revelation_discard: Option<CardCode>,
+    // The former `pending_revelation_discard: Option<CardCode>` side-channel is
+    // removed (#380): a drawn treachery's disposal now rides a
+    // `Continuation::EncounterCard` frame whose framework teardown discards it
+    // once the Revelation's whole sub-resolution completes — covering a
+    // Revelation that suspends into a choice, not just a skill test.
     /// An event card mid-play: it has left hand ("commences being played",
     /// RR Appendix I step 3) but is not yet in discard. The apply loop
     /// flushes it to the owner's discard pile on `Done` (step 4: the event is
     /// placed in discard "simultaneously with the completion" of its effect),
     /// so an `OnPlay` effect that suspends — Dynamite Blast 01024's location
     /// choice — discards the event when it resumes rather than stranding it in
-    /// hand. The player-event analogue of
-    /// [`pending_revelation_discard`](Self::pending_revelation_discard). `None`
+    /// hand. The player-event analogue of the treachery disposal that #380
+    /// moved onto the [`EncounterCard`](Continuation::EncounterCard) frame
+    /// (a sibling side-channel, folded similarly in a future cycle). `None`
     /// outside an in-flight event play.
     #[serde(default)]
     pub pending_played_event: Option<(InvestigatorId, CardCode)>,

--- a/crates/scenarios/src/test_fixtures/synth_cards.rs
+++ b/crates/scenarios/src/test_fixtures/synth_cards.rs
@@ -20,8 +20,8 @@ use game_core::card_data::{
 };
 use game_core::card_registry::{CardRegistry, NativeEffectFn};
 use game_core::dsl::{
-    forced_on_event, gain_resources, native, on_play, reaction_on_event, revelation, Ability,
-    Effect, EventPattern, EventTiming, InvestigatorTarget,
+    choose_one, forced_on_event, gain_resources, native, on_play, reaction_on_event, revelation,
+    Ability, Effect, EventPattern, EventTiming, InvestigatorTarget,
 };
 use game_core::engine::{Cx, EngineOutcome, EvalContext};
 use game_core::event::{Event, TraumaKind};
@@ -54,6 +54,14 @@ pub const SYNTH_TREACHERY_CODE: &str = "_synth_treachery";
 /// which drives the surge re-draw path in the per-card sub-sequence
 /// (Rules Reference p.19, p.24 1.4 step 5).
 pub const SYNTH_SURGE_TREACHERY_CODE: &str = "_synth_surge_treachery";
+
+/// Code for a synthetic treachery whose Revelation is a top-level
+/// [`Effect::ChooseOne`] (gain 2 vs gain 5 resources) — i.e. it suspends
+/// **directly** into a choice, *not* nested inside a skill test (the Crypt
+/// Chill 01167 shape). The #380 motivating case: before the `EncounterCard`
+/// frame, its disposal was stranded because the `pending_revelation_discard`
+/// slot was only flushed by the skill-test driver.
+pub const SYNTH_CHOICE_TREACHERY_CODE: &str = "_synth_choice_treachery";
 
 /// Code for the synthetic Fast event. Used to test the `MythosAfterDraws`
 /// window's push-then-scan ordering fix: a Fast event in hand during
@@ -101,6 +109,27 @@ fn synth_treachery_metadata() -> CardMetadata {
 fn synth_treachery_metadata_static() -> &'static CardMetadata {
     static M: OnceLock<CardMetadata> = OnceLock::new();
     M.get_or_init(synth_treachery_metadata)
+}
+
+/// Metadata for the choice-Revelation treachery (#380). A one-shot treachery
+/// shell; the load-bearing part is its `Effect::ChooseOne` Revelation in
+/// [`abilities_for`].
+fn synth_choice_treachery_metadata() -> CardMetadata {
+    CardMetadata {
+        code: SYNTH_CHOICE_TREACHERY_CODE.to_owned(),
+        name: "Synthetic Choice Treachery".to_owned(),
+        text: Some(
+            "Revelation - Choose one: gain 2 resources; or gain 5 resources. \
+             (Synthetic; not a printed card.)"
+                .to_owned(),
+        ),
+        ..synth_treachery_metadata()
+    }
+}
+
+fn synth_choice_treachery_metadata_static() -> &'static CardMetadata {
+    static M: OnceLock<CardMetadata> = OnceLock::new();
+    M.get_or_init(synth_choice_treachery_metadata)
 }
 
 fn synth_enemy_metadata() -> CardMetadata {
@@ -275,6 +304,7 @@ fn metadata_for(code: &CardCode) -> Option<&'static CardMetadata> {
         SYNTH_TREACHERY_CODE => Some(synth_treachery_metadata_static()),
         SYNTH_ENEMY_CODE => Some(synth_enemy_metadata_static()),
         SYNTH_SURGE_TREACHERY_CODE => Some(synth_surge_treachery_metadata_static()),
+        SYNTH_CHOICE_TREACHERY_CODE => Some(synth_choice_treachery_metadata_static()),
         SYNTH_FAST_EVENT_CODE => Some(synth_fast_event_metadata_static()),
         SYNTH_COVER_UP_CODE => Some(synth_cover_up_metadata_static()),
         _ => None,
@@ -287,6 +317,13 @@ fn abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
         SYNTH_TREACHERY_CODE | SYNTH_SURGE_TREACHERY_CODE => {
             Some(vec![revelation(gain_resources(InvestigatorTarget::You, 1))])
         }
+        // #380: a Revelation that suspends *directly* into a choice (two
+        // resource-gain branches), unlike Crypt Chill's choice nested inside a
+        // skill test.
+        SYNTH_CHOICE_TREACHERY_CODE => Some(vec![revelation(choose_one([
+            gain_resources(InvestigatorTarget::You, 2),
+            gain_resources(InvestigatorTarget::You, 5),
+        ]))]),
         SYNTH_FAST_EVENT_CODE => Some(vec![on_play(gain_resources(InvestigatorTarget::You, 1))]),
         SYNTH_COVER_UP_CODE => Some(vec![
             reaction_on_event(

--- a/crates/scenarios/tests/revelation_choice.rs
+++ b/crates/scenarios/tests/revelation_choice.rs
@@ -20,9 +20,9 @@ fn install() {
     });
 }
 
-/// Synthetic setup → mulligan → the sole investigator's round-ending EndTurn
+/// Synthetic setup → mulligan → the sole investigator's round-ending `EndTurn`
 /// cascades to the Mythos step-1.4 encounter-draw prompt. Seed the encounter
-/// deck (after StartScenario's shuffle) with only the choice-treachery on top.
+/// deck (after `StartScenario`'s shuffle) with only the choice-treachery on top.
 fn at_mythos_draw_with_choice_treachery() -> GameState {
     install();
     let mut state = synthetic::setup();

--- a/crates/scenarios/tests/revelation_choice.rs
+++ b/crates/scenarios/tests/revelation_choice.rs
@@ -1,0 +1,81 @@
+//! #380: a treachery whose Revelation suspends **directly** into a choice
+//! (not nested in a skill test) must still be discarded once the choice
+//! resolves. Before the `EncounterCard`-frame fix the disposal was stranded —
+//! `resolve_encounter_card` set the `pending_revelation_discard` slot on
+//! suspend, but only the skill-test driver's teardown ever flushed it, so a
+//! choice-only Revelation never reached `encounter_discard`.
+
+use std::sync::Once;
+
+use game_core::engine::{apply, EngineOutcome, OptionId};
+use game_core::state::{CardCode, GameState, InvestigatorId};
+use game_core::{Action, InputResponse, PlayerAction};
+use scenarios::test_fixtures::synth_cards::{SYNTH_CHOICE_TREACHERY_CODE, TEST_REGISTRY};
+use scenarios::test_fixtures::synthetic;
+
+static INSTALL: Once = Once::new();
+fn install() {
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(TEST_REGISTRY);
+    });
+}
+
+/// Synthetic setup → mulligan → the sole investigator's round-ending EndTurn
+/// cascades to the Mythos step-1.4 encounter-draw prompt. Seed the encounter
+/// deck (after StartScenario's shuffle) with only the choice-treachery on top.
+fn at_mythos_draw_with_choice_treachery() -> GameState {
+    install();
+    let mut state = synthetic::setup();
+    for action in [
+        Action::Player(PlayerAction::StartScenario { roster: vec![] }),
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickMultiple { selected: vec![] },
+        }),
+        Action::Player(PlayerAction::EndTurn),
+    ] {
+        state = apply(state, action).state;
+    }
+    synthetic::with_encounter_deck(&mut state, vec![CardCode::new(SYNTH_CHOICE_TREACHERY_CODE)]);
+    state
+}
+
+#[test]
+fn revelation_suspending_into_a_choice_discards_after_the_pick() {
+    let inv = InvestigatorId(1);
+    let state = at_mythos_draw_with_choice_treachery();
+
+    // Confirm the draw → the Revelation's ChooseOne suspends for the pick.
+    let drawn = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    );
+    assert!(
+        matches!(drawn.outcome, EngineOutcome::AwaitingInput { .. }),
+        "the Revelation choice suspends, got {:?}",
+        drawn.outcome
+    );
+    let res_before = drawn.state.investigators[&inv].resources;
+
+    // Pick branch 0 (gain 2 resources). The choice resolves, and the framework
+    // disposes of the treachery to encounter_discard.
+    let resolved = apply(
+        drawn.state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickSingle(OptionId(0)),
+        }),
+    );
+    assert_eq!(
+        resolved.state.investigators[&inv].resources,
+        res_before + 2,
+        "branch 0 granted 2 resources",
+    );
+    assert!(
+        resolved
+            .state
+            .encounter_discard
+            .contains(&CardCode::new(SYNTH_CHOICE_TREACHERY_CODE)),
+        "the treachery discards once its directly-suspended choice resolves",
+    );
+}

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -125,7 +125,9 @@ rather than deferring wholesale:
   → `PickSingle`, `Mulligan` → `PickMultiple`, `DrawEncounterCard` → `Confirm`),
   every player-facing suspension resumes through `ResolveInput`, and the bespoke
   `mulligan_pending`/`mythos_draw_pending` cursors + `in_flight_skill_test` are
-  folded onto continuation frames. #347 and #380 follow as separate PRs.
+  folded onto continuation frames. #380 (the `pending_revelation_discard`
+  side-channel → an `EncounterCard` frame, PR #392) has also landed; only
+  #347 (token-routed resume) remains.
   #348 migrates the remaining
   `pending_*` suspension modes (incl. `pending_enemy_attack`, `pending_end_turn`)
   onto the one continuation stack and collapses the

--- a/docs/superpowers/plans/2026-06-19-380-revelation-disposal-frame.md
+++ b/docs/superpowers/plans/2026-06-19-380-revelation-disposal-frame.md
@@ -1,0 +1,449 @@
+# #380 — Revelation disposal as an `EncounterCard` frame — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (or subagent-driven-development) to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the global `pending_revelation_discard` side-channel (flushed only by the skill-test driver) with a `Continuation::EncounterCard { card }` frame whose framework teardown disposes of the card after its Revelation's *whole* sub-resolution completes — covering suspension into a skill test **or a choice** (the latter is currently broken).
+
+**Architecture:** Spec §E. `resolve_encounter_card`'s treachery branch pushes an `EncounterCard` frame, runs the Revelation, then calls a shared `teardown_encounter_card_if_top(cx)`: if the top frame is `EncounterCard`, dispose (one-shot → `encounter_discard`; persistent → skip) and pop, else no-op. It is called from two sites — inline in `resolve_encounter_card` (synchronous Revelation) and at the `resolve_input` chokepoint after a resume returns `Done` (suspended-then-resumed). No resume handler knows treacheries exist.
+
+**Tech Stack:** Rust — `game-core` (engine), `scenarios` test fixtures.
+
+## Global Constraints
+
+- **CI gauntlet, warnings-as-errors** (all seven jobs) before every push.
+- **No behavior change** for any in-scope card/scenario that already worked: `crates/cards/tests/revelation_treacheries.rs` (Grasping Hands 01162 suspended-into-skill-test discard, Crypt Chill 01167 fail-branch-choice-within-skill-test, Ancient Evils 01166) and the synthetic-treachery Mythos tests must pass unchanged. The **only** intended behavior change is fixing the *new* case: a Revelation that suspends **directly** into a choice now discards (today it never does).
+- The treachery discard is **eventless** (a bare `encounter_discard.push(code)`), matching today's `resolve_encounter_card` path — no `CardDiscarded` event.
+
+---
+
+## File structure
+
+- `crates/game-core/src/state/game_state.rs` — add `Continuation::EncounterCard { card }` + classifier arms; add `current_encounter_card()` is **not** needed (framework-internal); remove the `pending_revelation_discard` field (Task 3).
+- `crates/game-core/src/engine/dispatch/encounter.rs` — push the frame in `resolve_encounter_card`; add `teardown_encounter_card_if_top`; drop the `pending_revelation_discard` set-site.
+- `crates/game-core/src/engine/dispatch/mod.rs` — `resolve_input` chokepoint teardown + the exhaustive-match `EncounterCard` arm.
+- `crates/game-core/src/engine/dispatch/skill_test.rs` — remove the driver flush; delete/reframe the two slot unit tests.
+- `crates/game-core/src/state/builder.rs` — remove the `pending_revelation_discard: None` init (Task 3).
+- `crates/scenarios/src/test_fixtures/synth_cards.rs` — add a choice-Revelation synthetic treachery.
+- `crates/scenarios/tests/revelation_choice.rs` — **new** integration test (the #380 motivating case).
+
+---
+
+## Task 1: Synthetic choice-Revelation treachery + RED test
+
+A treachery whose Revelation is a top-level `ChooseOne` (two `gain_resources` branches) — distinct from Crypt Chill, whose choice is *nested inside a skill test*. Today drawing it leaves it un-discarded (the slot is set but never flushed); the new test asserts the discard and so **fails RED** until Task 2.
+
+**Files:**
+- Modify: `crates/scenarios/src/test_fixtures/synth_cards.rs`
+- Create: `crates/scenarios/tests/revelation_choice.rs`
+
+**Interfaces produced:**
+- `synth_cards::SYNTH_CHOICE_TREACHERY_CODE: &str` (`"_synth_choice_treachery"`).
+- `synth_cards::TEST_REGISTRY` resolves the new code's metadata + abilities.
+
+- [ ] **Step 1: Add the fixture's code constant + metadata.** In `synth_cards.rs`, near `SYNTH_SURGE_TREACHERY_CODE`:
+
+```rust
+/// Code for a synthetic treachery whose Revelation is a top-level
+/// `Effect::ChooseOne` (gain 2 vs gain 5 resources) — i.e. it suspends
+/// **directly** into a choice, *not* nested inside a skill test (the Crypt
+/// Chill 01167 shape). The #380 motivating case: today its disposal is
+/// stranded because the slot is only flushed by the skill-test driver.
+pub const SYNTH_CHOICE_TREACHERY_CODE: &str = "_synth_choice_treachery";
+```
+
+And a metadata builder modeled on `synth_treachery_metadata` (treachery type, one-shot):
+
+```rust
+fn synth_choice_treachery_metadata() -> CardMetadata {
+    CardMetadata {
+        code: SYNTH_CHOICE_TREACHERY_CODE.to_owned(),
+        name: "Synthetic Choice Treachery".to_owned(),
+        text: Some(
+            "Revelation - Choose one: gain 2 resources; or gain 5 resources. \
+             (Synthetic; not a printed card.)"
+                .to_owned(),
+        ),
+        ..synth_treachery_metadata() // same CardType::Treachery shell
+    }
+}
+
+fn synth_choice_treachery_metadata_static() -> &'static CardMetadata {
+    static M: OnceLock<CardMetadata> = OnceLock::new();
+    M.get_or_init(synth_choice_treachery_metadata)
+}
+```
+
+> NOTE: if `synth_treachery_metadata` is not `..`-spreadable (non-`Default`/private fields), copy its literal body and change `code`/`name`/`text`. Verify the exact `CardMetadata` shape in `synth_treachery_metadata` first and mirror it.
+
+- [ ] **Step 2: Add the abilities builder + register both lookups.** In `synth_cards.rs`, add to the abilities the `revelation(choose_one([...]))` (import `choose_one`, `gain_resources`, `revelation`, `InvestigatorTarget` as the file already imports the DSL prelude — confirm and extend the `use` line):
+
+```rust
+fn synth_choice_treachery_abilities() -> Vec<Ability> {
+    vec![revelation(choose_one([
+        gain_resources(InvestigatorTarget::You, 2),
+        gain_resources(InvestigatorTarget::You, 5),
+    ]))]
+}
+```
+
+Wire the registry fns (`metadata_for` and `abilities_for` match arms — mirror the `SYNTH_TREACHERY_CODE` arms):
+
+```rust
+// metadata_for:
+SYNTH_CHOICE_TREACHERY_CODE => Some(synth_choice_treachery_metadata_static()),
+// abilities_for:
+SYNTH_CHOICE_TREACHERY_CODE => Some(synth_choice_treachery_abilities()),
+```
+
+- [ ] **Step 3: Write the RED integration test.** Create `crates/scenarios/tests/revelation_choice.rs`:
+
+```rust
+//! #380: a treachery whose Revelation suspends **directly** into a choice
+//! (not nested in a skill test) must still be discarded once the choice
+//! resolves. Before the `EncounterCard`-frame fix the disposal was stranded
+//! (the `pending_revelation_discard` slot was set but only the skill-test
+//! driver flushed it).
+
+use std::sync::Once;
+
+use game_core::engine::{apply, EngineOutcome, OptionId};
+use game_core::state::CardCode;
+use game_core::{Action, InputResponse, PlayerAction};
+use scenarios::test_fixtures::synth_cards::{SYNTH_CHOICE_TREACHERY_CODE, TEST_REGISTRY};
+use scenarios::test_fixtures::synthetic;
+
+static INSTALL: Once = Once::new();
+fn install() {
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(TEST_REGISTRY);
+    });
+}
+
+/// Drive synthetic setup → mulligan → the last EndTurn into Mythos, leaving the
+/// state at the encounter-draw prompt with only the choice-treachery on top of
+/// the encounter deck.
+fn at_mythos_draw_with_choice_treachery() -> game_core::state::GameState {
+    install();
+    let mut state = synthetic::setup();
+    let (state2, _) = drive(
+        state.clone(),
+        vec![
+            Action::Player(PlayerAction::StartScenario { roster: vec![] }),
+            Action::Player(PlayerAction::ResolveInput {
+                response: InputResponse::PickMultiple { selected: vec![] },
+            }),
+            Action::Player(PlayerAction::EndTurn),
+        ],
+    );
+    state = state2;
+    // Seed the controlled draw order AFTER StartScenario's shuffle.
+    synthetic::with_encounter_deck(
+        &mut state,
+        vec![CardCode::new(SYNTH_CHOICE_TREACHERY_CODE)],
+    );
+    state
+}
+
+fn drive(
+    initial: game_core::state::GameState,
+    actions: Vec<Action>,
+) -> (game_core::state::GameState, ()) {
+    let mut state = initial;
+    for action in actions {
+        state = apply(state, action).state;
+    }
+    (state, ())
+}
+
+#[test]
+fn revelation_suspending_into_a_choice_discards_after_the_pick() {
+    let state = at_mythos_draw_with_choice_treachery();
+
+    // Confirm the draw → the Revelation's ChooseOne suspends for the pick.
+    let drawn = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    );
+    assert!(
+        matches!(drawn.outcome, EngineOutcome::AwaitingInput { .. }),
+        "the Revelation choice suspends, got {:?}",
+        drawn.outcome
+    );
+    let res_before = drawn.state.investigators[&game_core::state::InvestigatorId(1)].resources;
+
+    // Pick branch 0 (gain 2 resources). The choice resolves, and the framework
+    // disposes of the treachery to encounter_discard.
+    let resolved = apply(
+        drawn.state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickSingle(OptionId(0)),
+        }),
+    );
+    assert_eq!(
+        resolved.state.investigators[&game_core::state::InvestigatorId(1)].resources,
+        res_before + 2,
+        "branch 0 granted 2 resources",
+    );
+    assert!(
+        resolved
+            .state
+            .encounter_discard
+            .contains(&CardCode::new(SYNTH_CHOICE_TREACHERY_CODE)),
+        "the treachery discards once its directly-suspended choice resolves",
+    );
+}
+```
+
+> NOTE: confirm `synthetic::with_encounter_deck` exists with that signature (it is used in `mythos_phase.rs`); if its name differs, match the real helper. If `drive` already exists as a shared scenarios test helper, reuse it instead of redefining.
+
+- [ ] **Step 4: Run the test — expect RED.**
+
+```sh
+cargo test -p scenarios --test revelation_choice revelation_suspending_into_a_choice_discards_after_the_pick
+```
+
+Expected: **FAIL** at the `encounter_discard.contains(...)` assertion (today the treachery is never discarded — the slot is set on suspend but no skill-test driver flushes it).
+
+- [ ] **Step 5: Commit (RED test + fixture).**
+
+```sh
+git add crates/scenarios/src/test_fixtures/synth_cards.rs crates/scenarios/tests/revelation_choice.rs
+git commit -m "test: failing #380 case — Revelation suspending directly into a choice never discards"
+```
+
+---
+
+## Task 2: `EncounterCard` frame + teardown + chokepoint (GREEN)
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (variant + classifier)
+- Modify: `crates/game-core/src/engine/dispatch/encounter.rs` (push frame, teardown helper, drop slot-set)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (chokepoint + match arm)
+- Modify: `crates/game-core/src/engine/dispatch/skill_test.rs` (drop driver flush; delete obsolete unit test)
+
+**Interfaces produced:**
+- `Continuation::EncounterCard { card: CardCode }`.
+- `encounter::teardown_encounter_card_if_top(cx: &mut Cx) -> EngineOutcome` (`pub(super)`).
+
+- [ ] **Step 1: Add the `EncounterCard` variant + classifier arms.** In `game_state.rs`, after the `EncounterDraw` variant:
+
+```rust
+    /// A drawn encounter **treachery** whose Revelation is mid-resolution
+    /// (#380). Pushed by `resolve_encounter_card` *before* it runs the
+    /// Revelation; sits beneath any suspension the Revelation opens (skill
+    /// test, choice, nested effect). When that sub-resolution completes and
+    /// this frame is top again, the **framework** disposes of the card
+    /// (one-shot → `encounter_discard`; persistent → it placed itself, skip)
+    /// and pops. Suspension-reason-agnostic — replaces the former
+    /// `pending_revelation_discard` slot, which only the skill-test driver
+    /// flushed. Never emits `AwaitingInput`.
+    EncounterCard {
+        /// The drawn treachery's card code, disposed of at teardown.
+        card: CardCode,
+    },
+```
+
+Add `| Continuation::EncounterCard { .. } => None` to both `as_resolution` and `as_resolution_mut`.
+
+- [ ] **Step 2: Add `teardown_encounter_card_if_top` to `encounter.rs`.** Near `advance_encounter_draw`:
+
+```rust
+/// If the top continuation frame is a [`Continuation::EncounterCard`], dispose
+/// of its card per the framework default and pop the frame; otherwise a no-op.
+/// Always returns [`EngineOutcome::Done`].
+///
+/// Disposal (RR p.18 default): a one-shot treachery is discarded to
+/// `encounter_discard`; a **persistent** treachery (one carrying a
+/// non-`Revelation` ability) placed itself during its Revelation and owns its
+/// own disposition, so it is skipped. Persistence is re-derived from the
+/// registry by card code — the frame stays payload-minimal (#380). The discard
+/// is eventless, matching the synchronous path. The `while` loop covers
+/// hypothetical nested encounter resolutions at no cost.
+pub(super) fn teardown_encounter_card_if_top(cx: &mut Cx) -> EngineOutcome {
+    while let Some(Continuation::EncounterCard { card }) = cx.state.continuations.last() {
+        let card = card.clone();
+        cx.state.continuations.pop();
+        let persistent = card_registry::current()
+            .and_then(|reg| (reg.abilities_for)(&card))
+            .is_some_and(|abilities| treachery_is_persistent(&abilities));
+        if !persistent {
+            cx.state.encounter_discard.push(card);
+        }
+    }
+    EngineOutcome::Done
+}
+```
+
+- [ ] **Step 3: Wire `resolve_encounter_card`'s treachery branch.** Replace the treachery branch's revelation loop + tail. Push the frame before the loop; on suspend just return (the frame stays beneath); on synchronous completion call the teardown:
+
+```rust
+        CardType::Treachery => {
+            let Some(registry) = card_registry::current() else {
+                return EngineOutcome::Rejected {
+                    reason: "encounter card resolution: no card registry installed".into(),
+                };
+            };
+            let abilities = (registry.abilities_for)(&code).unwrap_or_default();
+            let eval_ctx = EvalContext::for_controller(investigator);
+            // Push the disposal frame BEFORE the Revelation so the framework
+            // disposes of the card after the Revelation's whole sub-resolution
+            // completes — even if it suspends into a skill test or a choice
+            // (#380). A mid-Revelation Rejected is rolled back by the apply
+            // loop's transactional snapshot, frame included.
+            cx.state
+                .continuations
+                .push(Continuation::EncounterCard { card: code.clone() });
+            for ability in abilities.iter().filter(|a| a.trigger == Trigger::Revelation) {
+                match apply_effect(cx, &ability.effect, eval_ctx) {
+                    EngineOutcome::Done => {}
+                    // Suspended: the EncounterCard frame sits beneath the
+                    // suspension; the resolve_input chokepoint disposes of it
+                    // when the sub-resolution completes.
+                    outcome @ EngineOutcome::AwaitingInput { .. } => return outcome,
+                    outcome @ EngineOutcome::Rejected { .. } => return outcome,
+                }
+            }
+            // Synchronous completion → dispose now (frame is still top).
+            teardown_encounter_card_if_top(cx)
+        }
+```
+
+Delete the old `pending_revelation_discard = Some(code.clone())` line and the trailing `if !treachery_is_persistent(&abilities) { cx.state.encounter_discard.push(code); } EngineOutcome::Done` (their logic moves into `teardown_encounter_card_if_top`). Ensure `Continuation` is imported in `encounter.rs` (it is, from Task b1 of 2c-iii-b).
+
+- [ ] **Step 4: Add the `resolve_input` chokepoint + match arm in `mod.rs`.** In `resolve_input`, add an `EncounterCard` arm to the top-frame match (it never awaits input, so reject — defensive), and wrap the dispatch result so a completed resume disposes of an underlying `EncounterCard`:
+
+```rust
+    use crate::state::Continuation;
+    let outcome = match cx.state.continuations.last() {
+        // ... existing arms ...
+        Some(Continuation::EncounterCard { .. }) => EngineOutcome::Rejected {
+            reason: "ResolveInput: no input prompt is outstanding (encounter-card disposal is \
+                     framework-internal)"
+                .into(),
+        },
+        Some(Continuation::SkillTest(_)) => resume_skill_test_commit(cx, response),
+        None => EngineOutcome::Rejected {
+            reason: "ResolveInput: no AwaitingInput prompt is currently outstanding".into(),
+        },
+    };
+    // A treachery Revelation that suspended (#380) parks its EncounterCard frame
+    // beneath the suspension; once that sub-resolution completes (Done) the
+    // frame is top again, so dispose of the card here — one generic site, no
+    // resume handler aware of treacheries.
+    if matches!(outcome, EngineOutcome::Done) {
+        return encounter::teardown_encounter_card_if_top(cx);
+    }
+    outcome
+```
+
+(Keep the existing doc-comment on `resolve_input`; the `match` is no longer the final expression — bind it to `outcome`.)
+
+- [ ] **Step 5: Remove the skill-test driver flush.** In `skill_test.rs` `finish_skill_test`'s `PostOnResolution` arm, delete the block:
+
+```rust
+                if let Some(code) = cx.state.pending_revelation_discard.take() {
+                    cx.state.encounter_discard.push(code);
+                }
+```
+
+and its preceding comment (the driver no longer knows treacheries exist).
+
+- [ ] **Step 6: Delete the obsolete slot unit test.** In `skill_test.rs`, delete `revelation_skill_test_failure_deals_margin_damage_and_discards` (it simulated the removed slot + a direct `finish_skill_test` call that bypasses the new chokepoint; the real suspended-Revelation discard is integration-tested by `revelation_treacheries.rs::grasping_hands_*`). Leave `plain_skill_test_leaves_pending_revelation_discard_untouched` for Task 3.
+
+- [ ] **Step 7: Run the new test + the regression guard.**
+
+```sh
+cargo test -p scenarios --test revelation_choice
+cargo test -p cards --test revelation_treacheries
+cargo test -p game-core
+```
+
+Expected: all **PASS** (the new choice case now discards; Grasping Hands / Crypt Chill / Ancient Evils unchanged).
+
+- [ ] **Step 8: Commit.**
+
+```sh
+git add crates/game-core/src/state/game_state.rs crates/game-core/src/engine/dispatch/encounter.rs crates/game-core/src/engine/dispatch/mod.rs crates/game-core/src/engine/dispatch/skill_test.rs
+git commit -m "engine: dispose of encounter treacheries via an EncounterCard frame, not pending_revelation_discard (#380)"
+```
+
+---
+
+## Task 3: Remove the vestigial `pending_revelation_discard` field
+
+The field is now always `None` (no set-site, no flush). Remove it and reframe the last unit test that reads it.
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (field + doc)
+- Modify: `crates/game-core/src/state/builder.rs` (init)
+- Modify: `crates/game-core/src/engine/dispatch/skill_test.rs` (reframe the plain-test unit test)
+
+- [ ] **Step 1: Reframe the plain-test unit test.** In `skill_test.rs`, change `plain_skill_test_leaves_pending_revelation_discard_untouched` to drop the two `pending_revelation_discard` lines, keeping the `encounter_discard.is_empty()` assertion (the surviving intent: the skill-test driver never disposes of encounter cards). Rename it `plain_skill_test_disposes_of_no_encounter_card`:
+
+```rust
+    /// A plain (non-revelation) skill test disposes of no encounter card — the
+    /// skill-test driver no longer touches encounter disposal at all (#380).
+    #[test]
+    fn plain_skill_test_disposes_of_no_encounter_card() {
+        use crate::state::ChaosToken;
+        let inv = InvestigatorId(1);
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_active_investigator(inv)
+            .build();
+        state.chaos_bag.tokens = vec![ChaosToken::Numeric(0)];
+        let mut events = Vec::new();
+        let mut cx = Cx { state: &mut state, events: &mut events };
+        let out = perform_skill_test(&mut cx, inv, SkillKind::Intellect, 1);
+        assert!(matches!(out, EngineOutcome::AwaitingInput { .. }));
+        let out = finish_skill_test(&mut cx, &[]);
+        assert_eq!(out, EngineOutcome::Done);
+        assert!(state.encounter_discard.is_empty());
+    }
+```
+
+- [ ] **Step 2: Remove the field + builder init.** In `game_state.rs` delete the `pub pending_revelation_discard: Option<CardCode>,` field and its doc-comment (replace with a one-line `// removed in #380 …` breadcrumb if a neighbor's doc references it — grep first). In `builder.rs` delete `pending_revelation_discard: None,` from `build()`.
+
+- [ ] **Step 3: Build to confirm no stragglers.**
+
+```sh
+cargo build -p game-core 2>&1 | rg "pending_revelation_discard" ; echo "(no output above = clean)"
+grep -rn "pending_revelation_discard" crates/   # expect: nothing
+```
+
+- [ ] **Step 4: Full CI gauntlet.**
+
+```sh
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+wasm-pack test --headless --firefox crates/web
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit.**
+
+```sh
+git add -A
+git commit -m "engine: remove the now-vestigial pending_revelation_discard field (#380)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (§E):** `EncounterCard { card }` frame ✓ (Task 2.1); pushed in the treachery branch only ✓ (Task 2.3, enemies unaffected); teardown helper called inline + at the resolve_input chokepoint ✓ (Task 2.3/2.4); `pending_revelation_discard` slot + set-site + skill-test flush removed ✓ (Task 2.3/2.5, Task 3); one-shot→discard / persistent→skip ✓ (Task 2.2); revelation-suspends-into-a-choice test added ✓ (Task 1); `revelation_treacheries.rs` + Crypt Chill hold unchanged ✓ (Task 2.7 regression guard). `pending_played_event` explicitly out of scope (untouched).
+
+**Placeholder scan:** the two `NOTE:` callouts in Task 1 flag fixture-shape facts to confirm against the real `synth_treachery_metadata` / `with_encounter_deck` at execution (not placeholders for behavior — the behavior code is concrete).
+
+**Type consistency:** `teardown_encounter_card_if_top(&mut Cx) -> EngineOutcome` used identically in encounter.rs (definition + inline call) and mod.rs (chokepoint). `Continuation::EncounterCard { card: CardCode }` matched the same way in the helper, the classifier, and the resolve_input arm.
+
+**Risk flags:** (1) The chokepoint fires `teardown_encounter_card_if_top` after *every* `Done` resume — verified no-op unless an `EncounterCard` is top, but run the full `game-core` + `scenarios` + `cards` suites to confirm no resume path leaves a stray `EncounterCard` top (Task 2.7 + Task 3.4). (2) `resolve_encounter_card` is reached from the EngineRecord path (`encounter_card_revealed`) and the Mythos chain; both are within an `apply` transactional snapshot, so a mid-Revelation `Rejected` rolls back the pushed frame (no manual pop needed) — confirmed against `apply_with_scenario_registry`'s pristine-restore. (3) Persistence re-derivation at teardown uses the registry by code; a persistent treachery (none in current corpus carry a *choice* Revelation, but Obscuring Fog is persistent) must still be skipped — covered by `treachery_is_persistent` parity with the old inline check.
+
+**Out of scope:** `pending_played_event` (sibling, separate follow-up), `enemy_attack_pending` and the other framework cursors, the keystone.

--- a/docs/superpowers/specs/2026-06-19-continuation-stack-cleanup-design.md
+++ b/docs/superpowers/specs/2026-06-19-continuation-stack-cleanup-design.md
@@ -242,19 +242,35 @@ Continuation::EncounterCard { card: CardCode }
 `FinishContinuation` — a single post-Revelation disposal step suffices for the four in-scope
 one-shot treacheries, so the frame starts payload-minimal.)
 
-- `resolve_encounter_card` pushes this frame, then runs the Revelation.
+- `resolve_encounter_card`'s **treachery** branch pushes this frame (enemies spawn into play,
+  not discard — no frame), then runs the Revelation. (Only treacheries carry the framework
+  discard step.)
 - If the Revelation suspends — into a skill test, a choice, a nested effect, *anything* — the
   `EncounterCard` frame sits on the stack **beneath** that suspension.
 - When the Revelation's whole sub-resolution completes and control pops back to the
   `EncounterCard` frame, the **framework** runs the standard teardown: one-shot → discard to
-  `encounter_discard`; persistent → attach (#235). Then it pops.
+  `encounter_discard`; persistent → attach (#235, i.e. skip — it placed itself). Then it pops.
+
+**Resume seam (the teardown hook).** A single shared helper —
+`teardown_encounter_card_if_top(cx)`: *if the top frame is `EncounterCard`, run the disposal
+and pop; else no-op* — is called from exactly two places:
+
+1. **Inline**, at the end of `resolve_encounter_card`'s treachery branch, after the Revelation
+   returns. On a synchronous `Done` the frame is top → teardown fires immediately (net-identical
+   to today's inline discard). On a suspend the suspension's frame is on top → no-op → the
+   `AwaitingInput` propagates with `EncounterCard` parked beneath it.
+2. At the **`resolve_input` chokepoint**, after the top-frame resume handler returns `Done`.
+   Whichever suspension completed (skill test, choice, …) has popped its own frame, so
+   `EncounterCard` is now top and the teardown fires. This one generic site covers *every*
+   suspension reason without the skill-test driver — or any resume handler — knowing treacheries
+   exist. (A `while top is EncounterCard` loop costs nothing and covers hypothetical nesting.)
 
 Properties: card authors write nothing (just the Revelation effect); suspension-reason-
 agnostic (rides the continuation mechanism, not a skill-test-specific flush); removes the
-global `pending_revelation_discard` slot **and** the skill-test driver's special teardown for
-it (the driver no longer knows treacheries exist). `pending_played_event` (the event-play
-analogue) is a sibling side-channel — *not* in scope here, but the same frame-teardown shape
-applies and is the natural follow-up.
+global `pending_revelation_discard` slot, its set-site in `resolve_encounter_card`, **and** the
+skill-test driver's special teardown for it (the driver no longer knows treacheries exist).
+`pending_played_event` (the event-play analogue) is a sibling side-channel — *not* in scope
+here, but the same frame-teardown shape applies and is the natural follow-up.
 
 ## Out of scope (explicitly)
 


### PR DESCRIPTION
## Summary

Replaces the global `pending_revelation_discard` side-channel — flushed only by the skill-test driver — with a `Continuation::EncounterCard { card }` frame whose framework teardown disposes of the drawn treachery after its Revelation's *whole* sub-resolution completes. This fixes a real latent bug: a Revelation that suspends **directly into a choice** (not nested in a skill test) was never disposed of, because no skill-test driver ran to flush the slot.

This is **#380** (spec §E), the small side-channel cleanup that rides the clean continuation stack the rest of the §1 pass (#348) built.

## What changed

**Task 1 (RED test):** a synthetic treachery (`SYNTH_CHOICE_TREACHERY_CODE`) whose Revelation is a top-level `Effect::ChooseOne` — distinct from Crypt Chill, whose choice is *nested inside a skill test*. The new `revelation_choice.rs` integration test draws it, resolves the choice, and asserts the treachery reaches `encounter_discard` — which **fails** on the parent commit (the slot is set but never flushed).

**Task 2 (GREEN):**
- New `Continuation::EncounterCard { card }`, pushed by `resolve_encounter_card`'s treachery branch *before* it runs the Revelation, so it sits beneath any suspension the Revelation opens.
- `teardown_encounter_card_if_top(cx)`: if the top frame is `EncounterCard`, run the framework disposal (one-shot → `encounter_discard`; persistent → it placed itself, skip) and pop. Called from **two sites** — inline at the end of `resolve_encounter_card` (synchronous Revelation) and at the **`resolve_input` chokepoint** after any resume returns `Done` (suspended-then-resumed). One generic site; no resume handler — including the skill-test driver — knows treacheries exist.
- The skill-test driver's terminal `pending_revelation_discard` flush is removed.

**Task 3 (cleanup):** removed the now-vestigial `pending_revelation_discard` field, its builder init, and the two test reads of it.

## Test notes

- New `crates/scenarios/tests/revelation_choice.rs` proves the fixed case (direct-choice Revelation now discards).
- **No behavior change** for cards that already worked: `crates/cards/tests/revelation_treacheries.rs` (Grasping Hands 01162 suspend-into-skill-test, Crypt Chill 01167 fail-branch-choice-within-skill-test, Ancient Evils 01166) pass unchanged.
- The skill-test unit test that simulated the removed slot is deleted (its real behavior is integration-tested by `grasping_hands_*`); a sibling unit test is reframed to "a plain skill test disposes of no encounter card."
- Full CI gauntlet run locally (all 7 jobs): fmt, test, clippy, doc, wasm-build, wasm-test (headless Firefox), wasm-clippy — all green.

A follow-up doc commit (phase-7 §1 progress line) lands after CI is green.

## Linked issues

Closes #380. (Part of #348's §1 arc; remaining: #347 token-routed resume.)