### PR TITLE
design: unified continuation-stack control-flow model (#393) + slice-0 plan

### DIFF
--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -74,12 +74,13 @@ clue" is stubbed; needs the dynamic skill-test-modifier DSL surface
 ### Ordering, dependencies, simplifications
 
 1. ~~**Basic actions first** (#141, #77)~~ — ✅ shipped (PR #383); Engage also unblocks #300's condition. (Resign/Parley aren't basic actions — see Tier-1 A.)
-2. **§1 continuation-stack cleanup before the keystone** — the full #348 + #345 + #347 + #380 as one designed pass (see Refactor triage). The keystone *adds* suspension modes, so migrate the existing `pending_*` onto the one stack (with serializable context + token-routed resume) first rather than building the Nth ad-hoc route on top.
-3. **The keystone: mid-action suspend/resume.** Tier-1 B **and** C all hinge on `drive_attack_loop` being able to park the triggering action, open a window, and resume. Build it once and #293/#379/#361/#378/#143/#44 collapse into a single attack-loop arc — the highest-leverage item in the phase. Fold #119 in for #44's soak (symmetric token storage).
-4. **Skill-test windows** (#374 + #64) — one reaction-window work-stream.
-5. **Roland elder-sign** (#118).
-6. **Edge correctness** (#300 after Engage, then #368, #353).
-7. **Browser playable surface** (capstone) — once the above stabilizes; see below.
+2. **§1 continuation-stack cleanup — ✅ done.** #345 (PR #385) + #348 via parts 2a–2c + #380 (PRs #386–#392). The last piece, **#347** (token-routed resume / stale-submit rejection), **folds into #393** rather than landing standalone: the literal "token on `ResolveInput`, validated in the engine" is a ~145-site churn that #393 would rework, and stale-submit rejection is properly a *session* concern — the engine emits deterministic token *values*, the **server** rejects stale client echoes at the network boundary (the engine's `apply`/action-log stays token-free for replay). So token-routing is designed on #393's unified resume channel, at the right layer. (#348/#347 closed → #393.)
+3. **Unified control-flow model (#393) — the foundation arc, before the rest of Tier-1. ✅ designed** ([`2026-06-20-unified-control-flow-model-design.md`](../superpowers/specs/2026-06-20-unified-control-flow-model-design.md)). Reify *every* step of control flow as a continuation frame (phases, turns, the open-action choice), so the main loop collapses to a single rule: **handle the top frame.** The `InvestigatorTurn` frame re-emits the player's legal actions as `OptionId`s while actions remain — so the stack is never empty during play (empty only at bootstrap and the terminal resolution). The spec scopes a **C checkpoint** (a step is a frame *iff* it suspends or loops; net-new surface = four per-phase anchors + `InvestigatorTurn` + `AttackLoop`) and three sequenced post-C **end-states**: **B** (every step a frame, reached content-driven), **2b** (eliminate typed `PlayerAction` → gameplay is `ResolveInput(OptionId)` only; committed for UX/#205), and the **EmitEvent-frame** (the `when/at/after × forced/reaction` ordering axis as nested frames; #212 successor). It **subsumes** the keystone's substrate, the three framework cursors (`enemy_attack_pending` / `pending_end_turn` / `pending_enemy_attack`), #384's engine half (#384 closed → #393), and **token-routing / stale-submit rejection (#347, folded in → server-side)**. The engine emits `OptionId`s + keeps the id→action map internal; option metadata / browser rendering is #205 at the capstone. Build the model **before** the rest of Tier-1 so each item lands on the final engine shape.
+4. **The keystone: mid-action suspend/resume** — designed as §D of the #393 spec (its riskiest slice). Tier-1 B **and** C all hinge on the attack loop parking the *triggering action*, opening a window, and resuming — built as an `AttackLoop` frame above the action's sub-resolution (the model's first and hardest consumer), **not** a new cursor; an `on_child_pop` re-validation gate handles actor-eliminated-mid-action. #293/#379/#361/#378/#143/#44 collapse into a single attack-loop arc — the highest-leverage item in the phase. Fold #119 in for #44's soak (symmetric token storage).
+5. **Skill-test windows** (#374 + #64) — one reaction-window work-stream, offered as frame options on the #393 model.
+6. **Roland elder-sign** (#118).
+7. **Edge correctness** (#300 after Engage, then #368, #353).
+8. **Browser playable surface** (capstone) — once the above stabilizes; renders the enumerated actions / #205. See below.
 
 **Simplifications:**
 - **#300 does not need #363 (general fan-out).** Once Engage (#77) exists, Machete's "only enemy engaged with you" is a count==1 read — gate `extra_damage` on it; don't wait for multi-target Fight.
@@ -92,14 +93,16 @@ The gate's "done" is a solo human playing in the *browser*, not just a green
 integration test. Once the Tier-1 fixes stabilize, this is the first follow-on:
 the web client (shipped Phase 6) must drive the **real** Gathering scenario.
 
-- **#205 — structured `AwaitingInput` discrimination (load-bearing, needs-design).**
-  The Gathering's cards are the first to emit non-commit prompts across the
-  normalized `InputResponse` set (`PickSingle` / `PickMultiple` / `Confirm` /
-  `Skip` — the §1 cleanup folded the former `PickInvestigator`/`PickLocation` and
-  `CommitCards`/`DiscardCards` into `PickSingle`/`PickMultiple`); the client must
-  render the right control per variant from machine-readable offered options, not
-  prompt-string heuristics. Keystone of the surface; pairs with #347 (token-routed
-  resume → stale-submit rejection).
+- **#205 — structured `AwaitingInput` discrimination + action rendering
+  (load-bearing, needs-design).** The engine side is provided by #393: every
+  player decision — including the open-turn's *enumerated legal actions* —
+  surfaces as a frame offering `OptionId`s on the normalized `InputResponse` set
+  (`PickSingle` / `PickMultiple` / `Confirm` / `Skip`). #205 is the **client
+  half**: decide what option *metadata* the engine surfaces (labels, per-variant
+  controls, action parameters — #393 keeps the id→action map internal for now)
+  and render the right control per option, not prompt-string heuristics. (Absorbs
+  the former #384 client half.) Keystone of the surface; pairs with #393's
+  token-routing (#347, folded in → server-side stale-submit rejection).
 - **Investigator / scenario picker.** The seating protocol (B2 #221) + registry
   swap (C7a #244) exist engine-side; the browser picker driving `StartScenario`
   with a chosen investigator is the remaining UI.
@@ -116,38 +119,54 @@ target.
 Not rules bugs, but several simplify or de-risk the Tier-1 work — pull these in
 rather than deferring wholesale:
 
-- **§1 continuation-stack cleanup — the full #348 + #345 + #347 + #380, as one
-  designed pass. DO-FIRST, before the keystone.** Designed in
+- **§1 continuation-stack cleanup — ✅ done (#345 + #348 + #380); #347 folds
+  into #393.** Designed in
   `docs/superpowers/specs/2026-06-19-continuation-stack-cleanup-design.md`.
-  **Progress:** #345 shipped (PR #385); #348 is landing incrementally (parts
+  **Progress:** #345 shipped (PR #385); #348 landed incrementally (parts
   2a–2c via PRs #386–#391) — the `InputResponse` channel is now normalized
   (`CommitCards`/`DiscardCards` → `PickMultiple`, `PickLocation`/`PickInvestigator`
   → `PickSingle`, `Mulligan` → `PickMultiple`, `DrawEncounterCard` → `Confirm`),
   every player-facing suspension resumes through `ResolveInput`, and the bespoke
   `mulligan_pending`/`mythos_draw_pending` cursors + `in_flight_skill_test` are
   folded onto continuation frames. #380 (the `pending_revelation_discard`
-  side-channel → an `EncounterCard` frame, PR #392) has also landed; only
-  #347 (token-routed resume) remains.
-  #348 migrates the remaining
-  `pending_*` suspension modes (incl. `pending_enemy_attack`, `pending_end_turn`)
-  onto the one continuation stack and collapses the
+  side-channel → an `EncounterCard` frame, PR #392) has also landed. The last
+  piece, **#347** (token-routed resume), **folds into #393** rather than landing
+  standalone (engine-level `ResolveInput.token` is ~145-site churn #393 would
+  rework; stale-submit rejection is a session concern — engine emits token
+  *values*, the server rejects stale echoes, the action log stays replay-clean).
+  Likewise the **remaining framework cursors — `enemy_attack_pending` /
+  `pending_end_turn` / `pending_enemy_attack` — move to #393** (the unified
+  control-flow model, the foundation arc that follows §1 — see Ordering step 3):
+  internal sequencing, never player-facing, they fall out when #393 reifies the
+  phase/turn/attack-loop drivers as frames.
+  #348 collapsed the
   fragile `if pending_X.is_some()` `resolve_input` cascade **and** the parallel
   `apply_player_action` guard ladder into top-frame dispatch
   (`clue_interrupt_pending` is already a window); #345 makes
   `EvalContext` serializable with **grouped optional bindings** snapshotted
   per-frame (the Vec / per-frame-enum / global-stack alternatives were evaluated
   and rejected — spec §D; innermost-only is corpus-moot, no TODO) so migrated
-  frames snapshot context instead of re-storing ingredient tuples; #347 makes resume
-  **token-routed** (deterministic counter, stamped on the awaiting frame) so
-  routing becomes token → frame → dispatch-on-variant, with stale/double-submit
-  rejection; #380 removes the `pending_revelation_discard` side-channel by making
-  encounter-card resolution a frame whose framework teardown disposes of the card.
-  Designed together (they share the seam). The keystone
-  adds attack-loop suspension, so this lands first and the keystone rides one
-  clean stack. **Token-routing (#347b) also de-risks the browser surface** —
-  #205's client can submit against a superseded prompt and be rejected cleanly,
-  so doing the full cleanup in-phase (rather than a focused subset) pays off at
-  the Slice-D capstone too.
+  frames snapshot context instead of re-storing ingredient tuples; #380 removed
+  the `pending_revelation_discard` side-channel by making encounter-card
+  resolution a frame whose framework teardown disposes of the card. **Token-
+  routing (#347 → #393)** stays valuable for the browser surface — #205's client
+  can submit against a superseded prompt and be rejected cleanly — but lands as
+  part of #393's unified resume channel, at the session layer, rather than as a
+  standalone engine pass.
+- **EmitEvent-frame — the `when/at/after` ordering axis (a #393 end-state, #212
+  successor).** `emit_event` (T5a chokepoint, PR #342) models only the RR p.2
+  `forced → reaction` axis; the orthogonal `when → at → after` axis (RR "At"
+  entry) is still hand-threaded per site. The #393 spec (§"named end-states")
+  reifies it as two nested coordinator frames (`EmitEvent` over buckets,
+  `TimingPoint` over forced/reaction) — built post-C on the proven model, since
+  `emit_event` is the highest-blast-radius engine function. Re-open #212 (or a
+  successor) scoped to this.
+- **Upkeep round-end `when→at` ordering bug — surfaced by the #393 design; fix
+  before the Upkeep-anchor slice.** `upkeep_phase_end` fires agenda 01107's `at`-
+  the-end-of-round doom **before** act 01109's `when`-the-round-ends clue-spend
+  window — inverted vs. the RR "At" rule (`when → at → after`). Consequential when
+  the doom advances the agenda (loss on agenda 3). Cheap reorder + regression test
+  (agenda-3 + act-2 at round end); file its own bug issue. (Spec §G.)
 - **#119 — unify damage/horror/clues onto `CardInPlay`. DO-WITH #44.** #44 (soak
   distribution, Tier-1 C) needs symmetric investigator/asset token storage; #119
   makes the soak machinery symmetric instead of special-casing the investigator

--- a/docs/superpowers/plans/2026-06-20-upkeep-round-end-ordering-fix.md
+++ b/docs/superpowers/plans/2026-06-20-upkeep-round-end-ordering-fix.md
@@ -1,0 +1,355 @@
+# Upkeep round-end `when→at` ordering fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Upkeep step-4.6 round-end fire act 01109's "**when** the round ends" clue-spend window *before* agenda 01107's "**at** the end of the round" doom, per the Rules Reference "At" entry (`when → at → after`).
+
+**Architecture:** Today `upkeep_phase_end` fires the `RoundEnded` Forced abilities (the agenda's `at` doom) and *then* opens the act's `when` window — inverted. The fix rethreads the two independently-suspendable round-end steps: open the `when` window first; run the `at` `RoundEnded` Forced abilities + teardown (lasting-effect expiry + Upkeep→Mythos) on the window's *resume* (or inline when no window opens). This is the standalone pre-req (spec §G / spec step 0) for the #393 unified-control-flow arc; it must land before the Upkeep-anchor slice so that slice stays behaviour-preserving.
+
+**Tech Stack:** Rust; `game-core` engine (event-sourced `apply`); `cards` integration tests with the real card registry; `cargo test` / clippy / fmt / doc gauntlet.
+
+## Global Constraints
+
+- **Handler contract:** validate-first / mutate-second — on any `Rejected`, state and events unchanged (dispatch/mod.rs apply loop clears events on `Rejected`).
+- **Card/rules text:** never paraphrase from memory; the load-bearing rule here is the RR **"At"** entry — *"abilities [using] 'at' … such as 'at the end of the round' … trigger in between any 'when…' abilities and any 'after…' abilities with the same triggering condition."* Quote verbatim in doc-comments where it shapes behaviour.
+- **CI (all must pass with strict flags):** `RUSTFLAGS="-D warnings" cargo test --all --all-features`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo fmt --check`; `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`.
+- **Commit subject style:** `engine: <description>`; body explains *why* and ends with `Closes #NN.`
+- **Branch:** `engine/upkeep-round-end-ordering` (one branch for this issue).
+- **Generated files:** never hand-edit `crates/cards/src/generated/cards.rs`.
+
+---
+
+## Prep (not code)
+
+- [ ] **File the bug issue.** Title: `[engine] Upkeep round-end ordering: act 01109 "when" window must precede agenda 01107 "at" doom`. Labels: `engine`, `p1-next`. Body: summarize the RR `when→at` rule, the two cards (01109 act / 01107 agenda), the inverted ordering in `upkeep_phase_end`, and that it's the spec §G pre-req for #393. Note its number as `#NN` for the commit's `Closes #NN.`
+
+---
+
+## Task 1: Rethread Upkeep round-end so the act `when` window precedes the agenda `at` doom
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/phases.rs` (`upkeep_phase_end` ~646–681; replace `upkeep_after_round_ended` ~690–719; `resume_act_round_end_advance` tails ~750–770)
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs:1175` (`UpkeepAfterRoundEnded` continuation target)
+- Modify: `crates/game-core/src/engine/mod.rs` (re-export the two fns the test shims call)
+- Modify: `crates/game-core/src/test_support/mod.rs` (add two driver shims)
+- Test: `crates/cards/tests/agenda_01107.rs` (add the ordering regression test)
+
+**Interfaces:**
+- Produces (engine internals, `pub(crate)` re-exported from `crate::engine`):
+  - `upkeep_phase_end(cx: &mut Cx) -> EngineOutcome`
+  - `resume_act_round_end_advance(cx: &mut Cx, response: &InputResponse) -> EngineOutcome`
+  - `upkeep_round_end_at_and_after(cx: &mut Cx) -> EngineOutcome` (`pub(super)`)
+  - `upkeep_round_end_teardown(cx: &mut Cx) -> EngineOutcome` (`pub(super)`)
+- Produces (`test_support`, `pub`):
+  - `run_upkeep_round_end(state: &mut GameState, events: &mut Vec<Event>) -> EngineOutcome`
+  - `resume_round_end_window(state: &mut GameState, events: &mut Vec<Event>, response: &InputResponse) -> EngineOutcome`
+- Consumes (existing): `round_end_advance_window`, `super::act_agenda::{investigators_at, clues_held, spend_clues_from, advance_act}`, `super::emit::{emit_event, TimingEvent}`, `crate::state::Continuation::ActRoundEnd`.
+
+- [ ] **Step 1: Bump visibility of the two driver fns and re-export them**
+
+In `crates/game-core/src/engine/dispatch/phases.rs`, change the signature line of `upkeep_phase_end` from:
+
+```rust
+fn upkeep_phase_end(cx: &mut Cx) -> EngineOutcome {
+```
+to:
+```rust
+pub(crate) fn upkeep_phase_end(cx: &mut Cx) -> EngineOutcome {
+```
+
+Change `resume_act_round_end_advance` from `pub(super) fn` to `pub(crate) fn`:
+
+```rust
+pub(crate) fn resume_act_round_end_advance(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
+```
+
+In `crates/game-core/src/engine/mod.rs`, after the existing `pub(crate) use dispatch::...` lines (near line 44), add:
+
+```rust
+pub(crate) use dispatch::phases::{resume_act_round_end_advance, upkeep_phase_end};
+```
+
+- [ ] **Step 2: Add the two `test_support` driver shims**
+
+In `crates/game-core/src/test_support/mod.rs`, after `fire_forced_on_round_end` (ends ~line 70), add:
+
+```rust
+/// Test helper: run the Upkeep step-4.6 round-end sequence
+/// (`upkeep_phase_end`), returning the `EngineOutcome`. Suspends on act
+/// 01109's "when the round ends" clue-spend window when affordable; resume it
+/// with [`resume_round_end_window`].
+pub fn run_upkeep_round_end(
+    state: &mut crate::state::GameState,
+    events: &mut Vec<crate::event::Event>,
+) -> crate::engine::EngineOutcome {
+    let mut cx = crate::engine::Cx { state, events };
+    crate::engine::upkeep_phase_end(&mut cx)
+}
+
+/// Test helper: resume a parked act round-end clue-spend window
+/// (`resume_act_round_end_advance`) with `response`.
+pub fn resume_round_end_window(
+    state: &mut crate::state::GameState,
+    events: &mut Vec<crate::event::Event>,
+    response: &crate::action::InputResponse,
+) -> crate::engine::EngineOutcome {
+    let mut cx = crate::engine::Cx { state, events };
+    crate::engine::resume_act_round_end_advance(&mut cx, response)
+}
+```
+
+- [ ] **Step 3: Write the failing regression test**
+
+In `crates/cards/tests/agenda_01107.rs`, extend the imports. Change the `game_core::state` import line to include `Act` and `RoundEndAdvance`, and the `game_core::test_support` import to include the two new shims, and add `InputResponse` + `Continuation`:
+
+```rust
+use game_core::state::{
+    Act, Agenda, CardCode, Continuation, Enemy, EnemyId, GameState, InvestigatorId, Location,
+    LocationId, Phase, RoundEndAdvance,
+};
+use game_core::action::InputResponse;
+use game_core::test_support::{
+    fire_forced_on_phase_end, fire_forced_on_round_end, resume_round_end_window,
+    run_upkeep_round_end, test_enemy, test_investigator, GameStateBuilder,
+};
+```
+
+Then append this test:
+
+```rust
+#[test]
+fn round_end_act_when_window_opens_before_agenda_at_doom() {
+    install();
+    // Act 01109 ("The Barrier") carries the "when the round ends" clue-spend
+    // window; agenda 01107 carries the "at the end of the round" doom. Per the
+    // RR "At" entry, `when` resolves before `at`, so the act window must open
+    // BEFORE any doom is placed.
+    let mut state = board_with_agenda();
+    state.phase = Phase::Upkeep;
+
+    // Affordable act window: investigator in the Hallway (01112) with >= 3 clues.
+    state.act_deck = vec![Act {
+        code: CardCode::new("01109"),
+        clue_threshold: 3,
+        resolution: None,
+        round_end_advance: Some(RoundEndAdvance {
+            contributor_location: CardCode::new("01112"),
+        }),
+    }];
+    state.act_index = 0;
+    {
+        let inv = state.investigators.get_mut(&InvestigatorId(1)).unwrap();
+        inv.current_location = Some(LocationId(2)); // Hallway
+        inv.clues = 3;
+    }
+    // Two Ghouls in Hallway/Parlor -> agenda 01107 would place 2 doom.
+    state.enemies.insert(EnemyId(1), ghoul(1, LocationId(2)));
+    state.enemies.insert(EnemyId(2), ghoul(2, LocationId(5)));
+
+    let mut events = Vec::new();
+    let out = run_upkeep_round_end(&mut state, &mut events);
+
+    // The act's `when the round ends` window opens first...
+    assert!(matches!(out, EngineOutcome::AwaitingInput { .. }));
+    assert!(matches!(
+        state.continuations.last(),
+        Some(Continuation::ActRoundEnd(_))
+    ));
+    // ...and the agenda's `at the end of the round` doom is NOT placed yet.
+    assert_eq!(
+        state.agenda_doom, 0,
+        "`when` resolves before `at`: doom must wait for the act window"
+    );
+
+    // Declining the `when` window then runs the `at` doom.
+    let _ = resume_round_end_window(&mut state, &mut events, &InputResponse::Skip);
+    assert!(
+        state.agenda_doom >= 2,
+        "the `at` doom lands after the act window resolves"
+    );
+}
+```
+
+- [ ] **Step 4: Run the regression test against current code — verify it FAILS**
+
+Run:
+```bash
+cargo test -p cards --test agenda_01107 round_end_act_when_window_opens_before_agenda_at_doom
+```
+Expected: **FAIL** at the `agenda_doom == 0` assertion (`left: 2, right: 0`) — today's code fires `RoundEnded` (placing 2 doom) before opening the act window.
+
+- [ ] **Step 5: Implement the rethread in `phases.rs`**
+
+Replace the body of `upkeep_phase_end` (the `match super::emit::emit_event(... RoundEnded)` block) so it opens the `when` window first. The full function becomes:
+
+```rust
+pub(crate) fn upkeep_phase_end(cx: &mut Cx) -> EngineOutcome {
+    // 4.6 Upkeep phase ends. Round ends.
+    cx.events.push(Event::PhaseEnded {
+        phase: Phase::Upkeep,
+    });
+    // "End of the upkeep phase" Forced (none in the Core+Dunwich corpus).
+    let forced = super::emit::emit_event(
+        cx,
+        &super::emit::TimingEvent::PhaseEnded {
+            phase: Phase::Upkeep,
+        },
+    );
+    debug_assert!(
+        matches!(forced, EngineOutcome::Done),
+        "upkeep_phase_end PhaseEnded(Upkeep) forced did not resolve to Done: {forced:?}"
+    );
+    // RR "At" entry: `at the end of the round` abilities "trigger in between any
+    // 'when...' abilities and any 'after...' abilities with the same triggering
+    // condition." So act 01109's "when the round ends" clue-spend window opens
+    // BEFORE agenda 01107's "at the end of the round" doom. Open the `when`
+    // window first; the `at` RoundEnded Forced abilities + teardown run on its
+    // resume (resume_act_round_end_advance) or inline below when no window opens.
+    if let Some(pending) = round_end_advance_window(cx.state) {
+        let prompt = format!(
+            "End of round: investigators at the contributor location may, as a group, \
+             spend {} clues to advance the current act. Submit ResolveInput with \
+             InputResponse::Confirm to spend and advance, or Skip to decline.",
+            pending.threshold,
+        );
+        cx.state
+            .continuations
+            .push(crate::state::Continuation::ActRoundEnd(pending));
+        return EngineOutcome::AwaitingInput {
+            request: InputRequest::prompt(prompt),
+            resume_token: ResumeToken(0),
+        };
+    }
+    upkeep_round_end_at_and_after(cx)
+}
+```
+
+Replace the entire `upkeep_after_round_ended` function (the one beginning `pub(super) fn upkeep_after_round_ended`, ~690–719) with these two functions:
+
+```rust
+/// The round-end `at the end of the round` bucket + teardown, run after the
+/// `when the round ends` act window (if any) has resolved. Fires the
+/// `RoundEnded` Forced abilities — agenda 01107's doom, Dissonant Voices
+/// 01165's discard (the RR `at` bucket) — then tears down. If 2+ Forced fire
+/// and the run suspends for the lead's ordering (#213), the
+/// `UpkeepAfterRoundEnded` continuation resumes the teardown via
+/// [`upkeep_round_end_teardown`].
+pub(super) fn upkeep_round_end_at_and_after(cx: &mut Cx) -> EngineOutcome {
+    match super::emit::emit_event(cx, &super::emit::TimingEvent::RoundEnded) {
+        EngineOutcome::Done => upkeep_round_end_teardown(cx),
+        suspended @ EngineOutcome::AwaitingInput { .. } => suspended,
+        rejected @ EngineOutcome::Rejected { .. } => rejected,
+    }
+}
+
+/// Teardown after the round-end `at` Forced abilities resolve: expire active
+/// "until the end of the round" lasting effects (Mind over Matter 01036's
+/// substitution — RR p.24, "after the round-end forced abilities have
+/// resolved"), then transition Upkeep -> Mythos.
+pub(super) fn upkeep_round_end_teardown(cx: &mut Cx) -> EngineOutcome {
+    cx.state.skill_substitutions.clear();
+    // Upkeep -> Mythos; calls mythos_phase. Only Investigation->Enemy suspends
+    // (hunter movement), so this never suspends on its own.
+    step_phase(cx)
+}
+```
+
+In `resume_act_round_end_advance`, change **both** tail calls from `step_phase(cx)` to `upkeep_round_end_at_and_after(cx)` so the `at` doom runs *after* this `when` window. The `Confirm` arm's last line:
+
+```rust
+        super::act_agenda::spend_clues_from(cx.state, &contributors, pending.threshold);
+        cx.state.continuations.pop();
+        // The round-end-advance act (01109) is non-terminal (resolution
+        // None) — advance the cursor to the next act.
+        super::act_agenda::advance_act(cx);
+        // Now run the `at the end of the round` doom + teardown, AFTER this
+        // `when the round ends` window (RR `when` -> `at`).
+        upkeep_round_end_at_and_after(cx)
+```
+
+The `Skip` arm:
+
+```rust
+    InputResponse::Skip => {
+        cx.state.continuations.pop();
+        upkeep_round_end_at_and_after(cx)
+    }
+```
+
+In `crates/game-core/src/engine/dispatch/reaction_windows.rs:1175`, repoint the continuation (the `at`-doom run now happens *after* the window, so its suspend-resume tail is teardown-only — it must not re-open the window):
+
+```rust
+        ForcedContinuation::UpkeepAfterRoundEnded => super::phases::upkeep_round_end_teardown(cx),
+```
+
+- [ ] **Step 6: Run the regression test — verify it PASSES**
+
+Run:
+```bash
+cargo test -p cards --test agenda_01107 round_end_act_when_window_opens_before_agenda_at_doom
+```
+Expected: **PASS** — `agenda_doom == 0` at the suspend; `>= 2` after the `Skip` resume.
+
+- [ ] **Step 7: Run the existing round-end / upkeep suites — verify still green**
+
+Run:
+```bash
+cargo test -p game-core upkeep
+cargo test -p game-core round_end
+cargo test -p cards --test agenda_01107
+```
+Expected: **all PASS**, including `upkeep_phase_end_opens_window_when_affordable`, `upkeep_phase_end_skips_window_when_unaffordable`, `resume_confirm_spends_and_advances`, `resume_skip_advances_nothing_and_continues`, and `round_end_clears_round_scoped_skill_substitutions` (teardown still clears `skill_substitutions`, now after the `at` doom). If `round_end_clears_round_scoped_skill_substitutions` fails, confirm its setup reaches `upkeep_round_end_teardown` (no affordable act window) and adjust only the test's drive if needed — do **not** weaken the clear.
+
+- [ ] **Step 8: Run the full CI gauntlet locally**
+
+Run:
+```bash
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+```
+Expected: all green. (No wasm-only code touched, so the wasm jobs are unaffected, but CI will run them.)
+
+- [ ] **Step 9: Correct spec §G and commit**
+
+In `docs/superpowers/specs/2026-06-20-unified-control-flow-model-design.md` §G, replace "the cheap reorder" / "It's a pre-req bug" framing with the accurate shape: *a small rethread of two independently-suspendable round-end steps (act `when` window → `at` doom → teardown), since both the window and the multi-Forced doom run (#213) can suspend.* Keep the rest of §G.
+
+Commit:
+```bash
+git add crates/game-core/src/engine/dispatch/phases.rs \
+        crates/game-core/src/engine/dispatch/reaction_windows.rs \
+        crates/game-core/src/engine/mod.rs \
+        crates/game-core/src/test_support/mod.rs \
+        crates/cards/tests/agenda_01107.rs \
+        docs/superpowers/specs/2026-06-20-unified-control-flow-model-design.md
+git commit -m "$(cat <<'EOF'
+engine: round-end fires act `when` window before agenda `at` doom
+
+Per the RR "At" entry (`when -> at -> after`), act 01109's "when the round
+ends" clue-spend window must resolve before agenda 01107's "at the end of
+the round" doom. upkeep_phase_end had it inverted (fired RoundEnded Forced,
+then opened the act window). Rethread: open the `when` window first; run the
+`at` RoundEnded Forced + teardown (until-end-of-round expiry, Upkeep->Mythos)
+on the window's resume, or inline when no window opens. Both the window and
+the multi-Forced run can suspend, so the teardown has a dedicated
+continuation (UpkeepAfterRoundEnded -> upkeep_round_end_teardown).
+
+Pre-req for the #393 unified-control-flow arc (spec step 0 / §G).
+
+Closes #NN.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (§G):** the plan implements the §G fix (act `when` before agenda `at`), adds a regression test on the agenda-3 + act-2 + ghouls state, files the bug issue, and corrects §G's "cheap reorder" wording (Step 9). ✓
+
+**Placeholder scan:** no TBD/TODO/"handle edge cases" — every step has exact code, paths, and commands. The only `#NN` is the to-be-filed issue number, resolved in Prep and used in the commit. ✓
+
+**Type consistency:** `run_upkeep_round_end` / `resume_round_end_window` signatures match between the `test_support` definitions (Step 2), the `Interfaces` block, and the test call sites (Step 3). `upkeep_round_end_at_and_after` / `upkeep_round_end_teardown` are defined once (Step 5) and referenced consistently in `upkeep_phase_end`, `resume_act_round_end_advance`, and the `reaction_windows.rs` continuation. The re-export (Step 1) names match the shim calls (`crate::engine::upkeep_phase_end`, `crate::engine::resume_act_round_end_advance`). ✓

--- a/docs/superpowers/specs/2026-06-20-unified-control-flow-model-design.md
+++ b/docs/superpowers/specs/2026-06-20-unified-control-flow-model-design.md
@@ -1,0 +1,434 @@
+# Unified continuation-stack control-flow model (#393) — design
+
+Tracking issue: **#393** (`engine`, `needs-design`, `p1-next`). Successor to the
+**§1 continuation-stack cleanup** (`2026-06-19-continuation-stack-cleanup-design.md`,
+#345 + #348 + #380, shipped via PRs #385–#392). Folds in #347 (token-routing,
+relayered) and #384's engine half; subsumes the keystone substrate.
+
+## Why this pass exists
+
+Today the continuation stack holds **suspensions** (`SkillTest`, `Choice`,
+reaction `Resolution` windows, `EncounterDraw`, …) while **phase/turn structure**
+lives on the native Rust call stack (`step_phase → enemy_phase → …`) plus a
+handful of bespoke cursors, and the **open-turn action choice** isn't modelled at
+all — the engine opens a Fast window and passively waits for the player to send a
+typed `PlayerAction` variant, dispatched through a `match`.
+
+This produces three hand-wired control-flow idioms that the §1 cleanup left
+standing:
+
+1. **The guard ladder** — `apply_player_action` (dispatch/mod.rs:61–189) opens
+   with ~130 lines of `if matches!(top frame, Pending::X) && !ResolveInput { reject }`
+   blocks, one per suspension mode.
+2. **The action-variant `match`** (mod.rs:191–231) — passive dispatch on whichever
+   typed `PlayerAction` arrives, with no notion of *which* actions are currently
+   legal.
+3. **`run_window_continuation`** (reaction_windows.rs:966) — a `match kind { PhaseStep::X => run the next chunk of the phase cascade }`. This is the engine's de-facto
+   continuation table: "what runs after this window closes" is encoded as
+   `WindowKind`-keyed arms threading the synchronous `step_phase` cascade, with
+   three loop bookmarks — `enemy_attack_pending`, `pending_end_turn`,
+   `pending_enemy_attack` — standing in for resume state.
+
+The §1 spec's own argument — *"the keystone adds suspension modes, so migrate onto
+the one stack first rather than building the Nth ad-hoc route on top"* — applies
+one level up. The engine's suspension surface is now mature enough to finish the
+trajectory: **reify every step of control flow as a frame**, so the main loop
+becomes a single rule — *handle the top frame*.
+
+## The model
+
+`Continuation` stays a serializable **enum** (not trait objects). Each frame
+answers three questions, expressed as `match`-on-variant dispatch, not trait
+methods:
+
+- **`drive`** — run my next chunk: emit straight-line effects, then push a child
+  frame / await input / pop. (New: the play-loop half.)
+- **`on_child_pop`** — a child just completed; continue from where I parked. (This
+  *is* `run_window_continuation`'s per-`WindowKind` logic, relocated onto the
+  parent frame.)
+- **`awaiting`** — what input am I blocked on → `(Vec<OptionId>, InputResponse variant)`,
+  or `None`. (Already exists: `resolve_input`'s top-frame `match`.)
+
+The uniform main loop:
+
+```text
+loop {
+    match top frame {
+        None                                  => bootstrap / terminal only
+        Some(f) if f.awaiting().is_some()      => break;  // emit AwaitingInput + token
+        Some(f)                                => f.drive(cx);  // may push / pop / await
+    }
+}
+```
+
+During play the stack is **never empty** — the `InvestigatorTurn` frame
+re-emits an action choice while the active investigator has actions. The stack is
+empty only at bootstrap (the action that pushes the first phase frame) and at the
+terminal resolution.
+
+### Why the enum, not a `trait Frame` with `Box<dyn Frame>` stacks
+
+The three operations are trait-shaped, and a `trait Frame` for *behaviour* is
+fine — but the **stored stack must be the enum**, because `GameState` derives
+`Debug, Clone, PartialEq, Eq, Serialize, Deserialize` and a `Vec<Box<dyn Frame>>`
+field satisfies **none** of `Deserialize`, `PartialEq`, `Eq` automatically:
+
+- `Deserialize` is **not object-safe** (`fn deserialize() -> Self`, no `&self`
+  receiver), so `dyn Deserialize` cannot exist; deserializing a polymorphic stack
+  needs hand-rolled tagged dispatch (`typetag`/`inventory`) — which is, with a
+  dependency, exactly the tagged union an enum already is.
+- `dyn Frame` is not `Eq`/`PartialEq` (GameState derives `Eq`) and not `Clone`
+  without `dyn-clone`.
+
+A trait also models **open extension** (foreign crates defining frames) — the
+precise opposite of the kernel/content layering: the frame set is **closed and
+kernel-owned**; `cards`/`scenarios` never define control-flow frames. So
+`impl Continuation { fn drive(&self) { match self { … } } }` is both the more
+correct model and the one that keeps the derives.
+
+### Why frames must serialize at all
+
+Not (today) because we persist the live stack: the server stores **seed state +
+action log** and `load()` **replays from seed** (server/src/session.rs), so the
+stack is rebuilt by `apply()` during replay, never deserialized from a persisted
+live state. The real reasons:
+
+1. **Whole-struct derives.** The stack is a field of `GameState`, which is
+   `Serialize + Deserialize + Eq` as a whole; a type's derives are only as
+   available as its least-capable field. Hard, today, compile-time constraint.
+2. **Transport.** `GameState` is serialized to the web client (server/src/ws.rs,
+   web/src/transport.rs).
+3. **Snapshot persistence (future, YAGNI).** `load()` is O(n) in game length
+   (full action-log replay); the obvious optimization is periodic live-state
+   snapshots, which need the (turn-non-empty) stack to round-trip. Keeping frames
+   serializable keeps that door open for free.
+
+(The existing `Continuation` doc-comment overstates "for persistence" — corrected
+to the above.)
+
+## Granularity: C checkpoint, B end-state, the promotion rule
+
+"Everything is a frame" is the destination; *how finely* is the lever.
+
+- **C (the checkpoint we build):** a step is a frame **iff it can suspend (await
+  input) or loop over actors**. Straight-line, non-suspending steps stay
+  synchronous *inside* the frame that owns them.
+- **B (the named end-state):** *every* step is a frame, including straight-line
+  ones; phase drivers become pure sequencers with zero embedded step logic.
+
+C's frame set is a **strict subset** of B's, so C → B is monotonic: never a
+restructure, only *extract a straight-line chunk into its own frame* and change
+the parent from "run inline" to "push it." B's marginal frames (steps that never
+suspend) earn nothing operationally — they never survive an `apply()` boundary, so
+C is already fully serializable *at rest* at every boundary; B's payoff is purely
+**code uniformity**.
+
+**The promotion rule (why C is not a coin-flip, and how B is reached):**
+
+> A step is a frame iff it can suspend or loop. A straight-line step stays
+> synchronous **until content introduces a decision or trigger window there** — at
+> which point promoting it is a local extract-into-frame.
+
+So B is reached **content-driven**, one step at a time, each promotion paid for by
+a real card. Worked example: Upkeep step 4.4 (`upkeep_draw_and_resource`) is
+straight-line today; a card that lets a player *decline* the resource gain (a
+per-turn decision) is exactly the trigger that promotes 4.4 to an `AwaitingInput`
+frame. (Pattern only — no such card is in the Core+Dunwich corpus; not cited.)
+
+## A. Frame variant set (C-checkpoint additions)
+
+`Continuation` has 11 variants today, all already frames: `Resolution`,
+`SkillTest`, `Choice`, `HunterMove`, `SpawnEngage`, `HandSizeDiscard`,
+`ActRoundEnd`, `SubstitutionPrompt`, `Mulligan`, `EncounterDraw`, `EncounterCard`.
+The C checkpoint adds **the per-phase anchors (four variants) plus two net-new
+frames** (`InvestigatorTurn`, `AttackLoop`):
+
+1. **Per-phase anchor variants** — `MythosPhase { resume: MythosResume }`,
+   `InvestigationPhase { resume: InvestigationResume }`,
+   `EnemyPhase { resume: EnemyResume }`, `UpkeepPhase { resume: UpkeepResume }`
+   (four `Continuation` arms, **not** one generic `Phase { phase, resume }`). The
+   anchor's `on_child_pop` **is** the relocated `run_window_continuation` logic for
+   that phase. Per-phase variants make illegal phase/boundary pairings (e.g.
+   `Mythos` + `AfterAttackLoop`) **unrepresentable**; the generic variant's "less
+   boilerplate" only holds in its *unsafe* flat-`resume` form (a safe generic
+   variant needs nested per-phase enums — strictly more machinery than four thin
+   variants). Handlers co-locate with each phase's existing module.
+
+2. **`InvestigatorTurn { who, … }`** (net-new behaviour) — step 2.2.1. `awaiting`
+   → the legal-action enumeration as `Vec<OptionId>` + `PickSingle`; re-emits
+   while `who` has actions; each chosen action runs as a transient sub-resolution
+   (§D), and on its pop the turn frame re-emits the next choice; pops at 0 actions
+   / `EndTurn` → the `InvestigationPhase` anchor rotates to the next investigator
+   or ends the phase. **Absorbs `pending_end_turn`** (end-turn teardown becomes
+   this frame's pop sequence; a skill test opening mid-teardown pushes a `SkillTest`
+   above it, and `on_child_pop` finishes teardown).
+
+3. **`AttackLoop { investigator, remaining_attackers, source, phase }`** (net-new,
+   the keystone — §D) — step 3.3. A literal lift of `PendingEnemyAttack`. **Absorbs
+   both `enemy_attack_pending`** (→ the `EnemyPhase` anchor's per-investigator
+   iteration cursor) **and `pending_enemy_attack`** (→ this frame's fields).
+
+All three deleted cursors land as frame state. Nothing else is net-new — every
+other framework suspension already is a frame.
+
+## B. Uniform main loop & the deletions
+
+The guard ladder (8 blocks) and the action `match` both die:
+
+- **Guard ladder → one rule.** "Is this action allowed?" is answered by the top
+  frame: an `InvestigatorTurn` (or fast window) offering it → allowed; otherwise
+  only `ResolveInput` is valid. No `if pending_X { reject }` cascade.
+- **`run_window_continuation`'s `match` → per-anchor `on_child_pop`.** Its
+  `WindowKind`-keyed arms move onto the relevant `*Phase` anchor.
+- **The strand-guards dissolve where they were fragile.** The
+  `unreachable!("…would strand the test in the wrong phase")` guards on every
+  phase-transitioning window arm (reaction_windows.rs) exist because a synchronous
+  phase cascade can't coexist with an in-flight skill test. A `*Phase` anchor sitting
+  *beneath* a `SkillTest` frame can't be stranded — it simply resumes when the test
+  pops. The guards become cheap asserts (or vanish) exactly at the looping/suspending
+  steps; they stay as asserts where already fine.
+
+## C. Per-phase CPS decomposition (under the rule)
+
+| Phase | Step | C verdict |
+|---|---|---|
+| **Mythos** | 1.1 round+`PhaseStarted`, 1.2 place doom, 1.3 doom threshold | **sync** (anchor; agenda-advance may push a `Choice` child) |
+| | 1.4 each investigator draws encounter | **frame** — `EncounterDraw` *(exists)* |
+| | post-1.4 `MythosAfterDraws` window | **frame** — `Resolution` *(exists)* |
+| | end + → Upkeep | **sync** (anchor `on_child_pop`) |
+| **Investigation** | 2.1 `PhaseStarted` + `InvestigationBegins` window | window **frame** *(exists)*; emit **sync** |
+| | 2.2 rotate to active investigator | **sync** |
+| | `InvestigatorTurnBegins` window | **frame** *(exists)* |
+| | **2.2.1 the active investigator's actions** | **frame** — `InvestigatorTurn` **(net-new)** |
+| | 2.3 end + → Enemy | **sync** (anchor) |
+| **Enemy** | 3.1 `PhaseStarted` | **sync** |
+| | 3.2 hunter movement | **frame** — `HunterMove` *(exists)* |
+| | **3.3 per-investigator attack loop** | **frame** — `AttackLoop` **(net-new, keystone)** |
+| | 3.4 `PhaseEnded` + → Upkeep | **sync** (anchor) |
+| **Upkeep** | 4.1 `PhaseStarted` + window | window **frame** *(exists)*; emit **sync** |
+| | 4.2 reset actions, 4.3 ready cards | **sync** |
+| | 4.4 draw + gain resource | **sync today → frame when content makes it a choice** *(B-promotion example)* |
+| | 4.5 hand-size discard | **frame** — `HandSizeDiscard` *(exists)* |
+| | act round-end clue spend | **frame** — `ActRoundEnd` *(exists; see §G ordering fix)* |
+| | 4.6 `PhaseEnded`/round-end + → Mythos | **sync** (anchor) |
+
+**Net-new surface = `InvestigatorTurn` + `AttackLoop` + the four `*Phase` anchors.**
+Everything else that's a frame already exists; the work is relocating
+`run_window_continuation` onto the anchors, building the legal-action enumerator,
+converting the three cursors, and extending the attack loop to park player actions.
+
+## D. The keystone — `AttackLoop` + mid-action park/resume
+
+**The problem.** AoO fires from 5 sites — cards.rs:258 (play card),
+actions.rs:73/121/205/334 (move/investigate/…) — each a *synchronous*
+`fire_attacks_of_opportunity(cx, investigator)` returning `()` mid-handler. A
+synchronous mid-handler call **can't suspend**, so AoO drops any cancel/soak/
+reaction window (combat.rs:559–566 documents this as `TODO(#293)`). Fixing it
+requires the action to run as a frame so the AoO has a resume point — *which is why
+the keystone is inseparable from `InvestigatorTurn`.*
+
+**Part 1 — `AttackLoop` frame.** `PendingEnemyAttack` becomes the frame's fields
+verbatim. `source: EnemyAttackSource` **preserves the RR p.7 non-exhaust rule**
+(AoO doesn't exhaust; enemy-phase always does); `phase: AttackLoopPhase`
+(`BeforeAttack`/`AfterSoak`) is the sub-cursor; cancel/soak windows are children
+pushed above it. `enemy_attack_pending` → the `EnemyPhase` anchor's per-investigator
+cursor (the anchor pushes one `AttackLoop` per active investigator).
+
+**Part 2 — mid-action park.** An action runs as a **transient sub-resolution frame**
+above `InvestigatorTurn`. At the AoO boundary the action frame **pushes
+`AttackLoop { source: AttackOfOpportunity }`** and records its resume point; the
+`AttackLoop` runs (suspending on windows, no longer dropping them); on pop, the
+action frame's `on_child_pop` runs the **post-AoO chunk** (the primary effect). The
+chunk boundary sits exactly where the synchronous call sits today, so AoO-vs-effect
+ordering is preserved by construction. Collapses #293 / #379 / #361 / #378 / #143 /
+#44 into one attack-loop arc.
+
+**The hardest design constraint — mid-action viability.** Mid-action suspension
+means the world can change underneath an action: an AoO can defeat the actor,
+discard a needed card, exhaust the source. So the action frame's `on_child_pop`
+**re-checks viability before completing** and aborts cleanly if the actor is no
+longer `Active` or a primary-effect precondition no longer holds. This is the same
+hazard CLAUDE.md notes for `play_card` ("on-play effect that rejects mid-resolution
+leaves partial state"), made load-bearing.
+
+The atomicity requirement is **softer than it was**, because `GameState` is
+`Clone`/serializable: the apply loop already clears events on `Rejected` and returns
+state unchanged, a snapshot-and-rollback safety net that makes per-handler
+validate-first a belt-and-suspenders nicety rather than the sole guard against
+corruption (this snapshot-ability is also the substrate a future **undo** would ride
+— explicitly downstream/out-of-scope). The one subtlety: mid-action abort is **not**
+a clean whole-action rollback — the AoO damage and the player's window choices are
+real and must persist even if the action's primary effect aborts. So the in-scope
+mechanism stays the **re-validation gate** in `on_child_pop`, not a blanket rollback.
+
+Expected the **riskiest slice**; gets its own PR + a test matrix (AoO that defeats
+the actor mid-Move; AoO cancelled by Dodge; AoO soaked onto Guard Dog → retaliate).
+
+**Multi-step action parameterization (issue open-Q2, resolved).** Top-level
+enumeration = **action + primary target** (move-to-X, fight-enemy-Y, play-card-Z);
+everything downstream (the AoO sub-loop, a Fight/Investigate skill test, a
+play-card commit/choice window) is a **child frame the action frame pushes**. The
+AoO `AttackLoop` is just one such child — structurally identical to how a Fight
+already pushes a `SkillTest`. Keeps the open-turn enumeration flat (≈30 options).
+
+## E. Enumerated-action input & the `PlayerAction` surface
+
+The `InvestigatorTurn` frame emits the **legal-action enumeration** as `OptionId`s
+and keeps an internal id→action map. Eager enumeration is cheap (board tops out
+~30 legal actions; the client needs the list regardless). The enumerator's source
+of truth is the existing per-action precondition checks (`check_play_card`,
+`check_activate_ability`, move adjacency, fight/evade co-location), which must be
+callable in *"is this legal?"* mode, not only *"validate this submitted action."*
+
+Two sequenced sub-checkpoints for the action API:
+
+- **2a (this checkpoint):** typed `PlayerAction::{Move, Investigate, Fight, …}`
+  **survive**, accepted iff they match an offered option. The guard ladder still
+  dies; the enumeration still ships; existing tests keep working; lands
+  incrementally.
+- **2b (committed, scheduled — *not* content-triggered):** eliminate the typed
+  gameplay variants; all gameplay becomes `ResolveInput(PickSingle(OptionId))`
+  against the open-turn frame; id→action map fully internal. Motivated by *player*
+  UX (the heart of #205): the client becomes a thin renderer of exactly the
+  engine-offered options, one input mechanism instead of "render options *and*
+  know how to construct typed actions." Distinct from B's content-driven
+  promotions — this one is on the roadmap regardless of any card.
+
+## F. #347 — server-only stale-submit rejection
+
+The engine emits a **deterministic token value** on each `AwaitingInput` (a counter
+derived from state — e.g. suspend count / action-log length). The **server** holds
+the token from its last broadcast and rejects a client echo that's stale, **at the
+network boundary, before `apply()`**. No `token` field on `ResolveInput` or on
+frames; `apply()` and the action log stay **token-free** so replay stays bit-for-bit
+deterministic (stale-submit rejection is a session/protocol concern, not a replay
+concern). The engine's token *emission* is in scope here; the server's *rejection*
+is the consuming half (network boundary, outside `game-core`).
+
+## G. Pre-req bug — Upkeep `when → at` round-end ordering
+
+The RR **"At"** entry: *"abilities [using] 'at' … such as 'at the end of the round'
+… trigger **in between** any 'when…' abilities and any 'after…' abilities with the
+same triggering condition."* So at one timing point: **`when` → `at` → `after`**;
+within each, RR **"Forced"** sorts forced-before-reaction *"in the same manner"*
+(i.e. within a bucket). For The Gathering:
+
+- Act 01109 "The Barrier" — *"**When** the round ends … may … spend … to advance"* → `when`.
+- Agenda 01107 "They're Getting Out!" — *"Forced – **At the end of** the round: Place 1 doom …"* → `at`.
+
+So the act's clue-spend window must open **before** the agenda's doom. Current code
+is **inverted**: `upkeep_phase_end` (phases.rs:646) fires `emit_event(RoundEnded)`
+(the agenda's `at` forced) and only then, in `upkeep_after_round_ended`, opens the
+act's `when` window. Consequential — if the doom advances the agenda (a loss
+condition on agenda 3), players per the rules should have gotten their act-advance
+window first.
+
+**Action:** fix the ordering directly (the cheap reorder — `when` window before
+`at` forced — plus a regression test on agenda-3 + act-2 at round end), landed as
+its **own small bug issue before** the Upkeep-anchor relocation slice, so the
+refactor stays behaviour-preserving. (Confirm during implementation there's no
+Gathering-specific FFG ruling exception — the act page has "No faqs yet" and the RR
+"At" rule governs.)
+
+## Named end-states (sequenced destinations beyond C)
+
+| Destination | What | Trigger to pursue |
+|---|---|---|
+| **B** — full frame granularity | every straight-line step a frame | **content-driven** (a card makes a step a decision) |
+| **2b** — `PlayerAction` elimination | gameplay → `ResolveInput(OptionId)` only | **committed/scheduled** (UX; §E) |
+| **EmitEvent-frame** — when/at/after × forced/reaction | event emission as frames | **committed/scheduled** (3rd checkpoint) |
+
+**EmitEvent-frame detail (3rd checkpoint).** `emit_event` (T5a chokepoint, PR #342,
+closing #212) models only the RR p.2 **forced → reaction** axis. The orthogonal
+**`when`/`at`/`after`** axis (§G) is still hand-threaded per site — the source of
+the Upkeep bug, and the "hand-wiring smell" #212 was filed against. The two RR
+rules compose into a **3×2 nested grid**:
+
+```text
+when-forced → when-reaction → at-forced → at-reaction → after-forced → after-reaction
+```
+
+On the model this is two thin coordinator frames:
+
+- **`EmitEvent { event, bucket }`** — iterates `when → at → after` (the unfinished
+  tail of #212).
+- **`TimingPoint { event, bucket, sub }`** — for one bucket, runs `forced → reaction`
+  (exactly what T5a's `emit_event` does today, made frame-resumable). Its children
+  already are/want frames (the `forced` sub-step is #213's iterative lead-ordering
+  loop; the `reaction` sub-step is the existing `Resolution` window).
+
+**Correctness caution:** the six cells must be evaluated **in order with eligibility
+re-checked at each cell** — a `when` reaction can change whether an `at` forced even
+fires — so the grid is *not* pre-computed. The nested frames make "enter each cell
+fresh, re-scan" structural. Build on the *proven* model (post-C); `emit_event` is
+the highest-blast-radius function in the engine, so it does not ride the C
+checkpoint. Re-open #212 (or a successor) scoped to this.
+
+## Bugs surfaced
+
+- **Upkeep `when→at` round-end ordering** (§G) — file + fix before the Upkeep-anchor
+  relocation slice.
+
+## Out of scope (explicitly)
+
+- **B promotions, 2b, EmitEvent-frame** — named end-states above; their own slices/
+  issues.
+- **Undo** — the snapshot-ability discussed in §D is its substrate, but undo itself
+  is way downstream.
+- **Browser rendering / option metadata (#205, #384 client half)** — the engine
+  emits `OptionId`s; tests drive via `OptionId(n)`; what labels/controls/parameters
+  the client surfaces is #205 at the capstone.
+- **Server-side stale-submit rejection** (§F) — engine emits the token value here;
+  the server consumes it at the network boundary.
+
+## Testing strategy
+
+1. **Behaviour-preserving for C.** The whole existing engine + integration suite
+   must stay green through 2a — the C checkpoint changes *structure*, not rules
+   (except the §G fix, which gets its own regression test). Per-cursor / per-anchor
+   conversions are individually green at each PR boundary.
+2. **New unit coverage** (`game-core` engine tests, `TestGame` builder +
+   event-assertion macros): the uniform main loop (top-frame dispatch; empty-stack
+   only at bootstrap/terminal); each `*Phase` anchor's `on_child_pop` chunk
+   sequencing; `InvestigatorTurn` re-emission while actions remain and pop at 0 /
+   `EndTurn`; the legal-action enumerator (each precondition check in "is-legal"
+   mode) against known board states.
+3. **Keystone matrix** (§D) — AoO that defeats the actor mid-Move; AoO cancelled by
+   Dodge; AoO soaked onto Guard Dog → retaliate; multi-attacker AoO; the
+   re-validation-gate abort path.
+4. **Integration** (`crates/cards/tests/`) — a real Gathering turn driven entirely
+   through the new loop (and, at 2b, entirely through `OptionId`s).
+
+## Sequencing (PR decomposition)
+
+Each step is independently green (mirrors §1's parts 2a–2c cadence):
+
+0. **§G ordering bug** — standalone fix + regression test (pre-req).
+1. **Main-loop scaffold + `*Phase` anchors** — introduce the four anchor variants
+   and relocate `run_window_continuation`'s arms onto them; behaviour-preserving.
+   Strand-guards become asserts.
+2. **`InvestigatorTurn` frame (2a) + legal-action enumerator** — open-turn becomes a
+   frame; guard ladder + action `match` deleted; typed `PlayerAction` validated
+   against the offered set; `pending_end_turn` absorbed.
+3. **`AttackLoop` frame (cursor lift)** — `PendingEnemyAttack` +
+   `enemy_attack_pending` → frame/anchor; enemy-phase attacks unchanged in behaviour.
+4. **Keystone mid-action park** — actions run as sub-resolution frames; AoO pushes
+   `AttackLoop`; re-validation gate; the §D matrix. **Riskiest.**
+5. **#347 token emission** (engine half, §F).
+
+Post-checkpoint, separately tracked: **2b**, **EmitEvent-frame** (#212 successor),
+**B** promotions (content-driven), **#205/#384 client** (capstone).
+
+## What "done" looks like (C checkpoint)
+
+- The guard ladder, the action-variant `match`, `run_window_continuation`'s
+  `WindowKind` table, and all three cursors (`enemy_attack_pending`,
+  `pending_end_turn`, `pending_enemy_attack`) are **gone**.
+- `apply_player_action` is the uniform main loop; the only "is this allowed?" rule
+  is the top frame's offered set.
+- AoO opens cancel/soak/reaction windows (Dodge, Guard Dog retaliate work against
+  AoO); the keystone matrix passes.
+- The engine emits a legal-action enumeration as `OptionId`s; typed `PlayerAction`
+  still accepted (2a).
+- The §G ordering bug is fixed with a regression test.
+- Full CI gauntlet green; the Gathering plays end-to-end through the new loop.


### PR DESCRIPTION
## What

Design + planning artifacts for **#393** — the Tier-1 foundation arc that reifies every step of control flow as a continuation frame so the engine main loop collapses to *"handle the top frame."* **Docs-only** (no engine code changes): a spec, the phase-7 reframe, and the first slice's implementation plan.

- `docs/superpowers/specs/2026-06-20-unified-control-flow-model-design.md` — the design.
- `docs/phases/phase-7-the-gathering.md` — reframed around #393 (C checkpoint + sequenced end-states) and updated with this session's findings.
- `docs/superpowers/plans/2026-06-20-upkeep-round-end-ordering-fix.md` — bite-sized TDD plan for spec step 0.

## Design decisions

- **Granularity: ship "C", document "B".** A step becomes a frame *iff* it suspends or loops; straight-line steps stay synchronous until content introduces a decision there (a content-driven promotion rule). C's frame set ⊂ B's, so C→B is monotonic.
- **Serializable enum, not `Box<dyn Frame>`.** `GameState` derives `Eq`/`Serialize`/`Deserialize` as a whole; trait objects break all three (and `Deserialize` isn't object-safe). The frame set is closed + kernel-owned, so an enum is the *more correct* model anyway.
- **Keystone in scope.** Mid-action AoO park/resume (an `AttackLoop` frame above the action's sub-resolution, with a re-validation gate) is the model's hardest consumer, designed here.
- **#347 = server-only.** Engine emits a deterministic token *value*; the server rejects stale echoes at the network boundary; `apply()`/action log stay token-free for replay.
- **Three sequenced post-C end-states:** B (granularity, content-driven), 2b (eliminate typed `PlayerAction`, committed for UX/#205), EmitEvent-frame (the `when/at/after × forced/reaction` ordering axis; #212 successor).

## Bug surfaced

Designing the round-end ordering exposed a live latent bug: `upkeep_phase_end` fires agenda 01107's "at the end of the round" doom **before** act 01109's "when the round ends" clue-spend window — inverted vs. the RR "At" entry (`when → at → after`). Spec §G + the slice-0 plan fix it (its own follow-up issue).

## Not in this PR

All engine implementation — slices 0–5 land as their own PRs, each with a just-in-time plan. This PR is design + plan only.

Refs #393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)