### PR TITLE
engine: phase anchor frames (slice 1a of #393)

### DIFF
--- a/crates/cards/tests/barricade.rs
+++ b/crates/cards/tests/barricade.rs
@@ -112,6 +112,11 @@ fn map_with_barricade_at_b(enemy_code: &str) -> game_core::GameState {
         .with_enemy(hunter(100, enemy_code, A))
         .with_active_investigator(INV)
         .with_turn_order([INV])
+        // Mid-Investigation invariant (slice 1a): the EndTurn cascade pops the
+        // InvestigationPhase anchor at investigation_phase_end.
+        .with_phase_anchor(game_core::state::Continuation::InvestigationPhase {
+            resume: game_core::state::InvestigationResume::TurnBegins,
+        })
         .build();
     state
         .locations

--- a/crates/cards/tests/dodge.rs
+++ b/crates/cards/tests/dodge.rs
@@ -68,6 +68,11 @@ fn dodge_state() -> (GameState, InvestigatorId, EnemyId) {
         .with_active_investigator(inv_id)
         .with_turn_order([inv_id])
         .with_enemy(engaged_attacker(7, inv_id, loc_id))
+        // Mid-Investigation invariant (slice 1a): the EndTurn cascade pops the
+        // InvestigationPhase anchor at investigation_phase_end.
+        .with_phase_anchor(game_core::state::Continuation::InvestigationPhase {
+            resume: game_core::state::InvestigationResume::TurnBegins,
+        })
         .build();
     (state, inv_id, enemy_id)
 }

--- a/crates/cards/tests/guard_dog_soak.rs
+++ b/crates/cards/tests/guard_dog_soak.rs
@@ -96,6 +96,11 @@ fn soak_state(
     for enemy in enemies {
         builder = builder.with_enemy(enemy);
     }
+    // Mid-Investigation invariant (slice 1a): the EndTurn cascade pops the
+    // InvestigationPhase anchor at investigation_phase_end.
+    builder = builder.with_phase_anchor(game_core::state::Continuation::InvestigationPhase {
+        resume: game_core::state::InvestigationResume::TurnBegins,
+    });
     (builder.build(), inv_id, loc_id)
 }
 

--- a/crates/cards/tests/persistent_treachery.rs
+++ b/crates/cards/tests/persistent_treachery.rs
@@ -281,6 +281,11 @@ fn frozen_in_fear_board(token: ChaosToken) -> game_core::GameState {
         .with_investigator(test_investigator(2))
         .with_active_investigator(InvestigatorId(1))
         .with_turn_order([InvestigatorId(1), InvestigatorId(2)])
+        // Mid-Investigation invariant (slice 1a): EndTurn rotates / cascades
+        // through the InvestigationPhase anchor.
+        .with_phase_anchor(game_core::state::Continuation::InvestigationPhase {
+            resume: game_core::state::InvestigationResume::TurnBegins,
+        })
         .build();
     state.chaos_bag.tokens = vec![token];
     state
@@ -356,6 +361,11 @@ fn two_frozen_in_fear_end_of_turn_tests_both_resolve_then_turn_resumes() {
         .with_investigator(test_investigator(2))
         .with_active_investigator(InvestigatorId(1))
         .with_turn_order([InvestigatorId(1), InvestigatorId(2)])
+        // Mid-Investigation invariant (slice 1a): EndTurn rotates / cascades
+        // through the InvestigationPhase anchor.
+        .with_phase_anchor(game_core::state::Continuation::InvestigationPhase {
+            resume: game_core::state::InvestigationResume::TurnBegins,
+        })
         .build();
     // Two Numeric(0) draws → willpower 3 vs difficulty 3 → both succeed.
     state.chaos_bag.tokens = vec![ChaosToken::Numeric(0), ChaosToken::Numeric(0)];

--- a/crates/cards/tests/theyre_getting_out.rs
+++ b/crates/cards/tests/theyre_getting_out.rs
@@ -90,6 +90,12 @@ fn round_end_act_when_window_opens_before_agenda_at_doom() {
     // BEFORE any doom is placed.
     let mut state = board_with_agenda();
     state.phase = Phase::Upkeep;
+    // UpkeepPhase anchor (slice 1a): the round-end teardown pops it.
+    state
+        .continuations
+        .push(game_core::state::Continuation::UpkeepPhase {
+            resume: game_core::state::UpkeepResume::Begins,
+        });
 
     // Affordable act window: investigator in the Hallway (01112) with >= 3 clues.
     state.act_deck = vec![Act {

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -1152,6 +1152,11 @@ mod combat_tests {
             .with_turn_order([inv_id])
             .with_enemy(e2)
             .with_enemy(e3)
+            // EnemyPhase anchor (slice 1a): the attack-loop resume opens a
+            // window whose close routes to anchor_on_child_pop.
+            .with_phase_anchor(crate::state::Continuation::EnemyPhase {
+                resume: crate::state::EnemyResume::BeforeInvestigatorAttacked,
+            })
             .build();
         // The enemy phase set the cursor to this investigator before opening
         // the BeforeInvestigatorAttacked window; resume must advance it.
@@ -1215,6 +1220,11 @@ mod combat_tests {
             .with_investigator(test_investigator(1))
             .with_turn_order([inv_id])
             .with_enemy(enemy)
+            // EnemyPhase anchor (slice 1a): the attack-loop resume opens a
+            // window whose close routes to anchor_on_child_pop.
+            .with_phase_anchor(crate::state::Continuation::EnemyPhase {
+                resume: crate::state::EnemyResume::BeforeInvestigatorAttacked,
+            })
             .build();
         state.enemy_attack_pending = Some(inv_id);
         state.pending_cancellation = true; // a cancel reaction fired in the window
@@ -1265,6 +1275,11 @@ mod combat_tests {
             .with_investigator(test_investigator(1))
             .with_turn_order([inv_id])
             .with_enemy(enemy)
+            // EnemyPhase anchor (slice 1a): the attack-loop resume opens a
+            // window whose close routes to anchor_on_child_pop.
+            .with_phase_anchor(crate::state::Continuation::EnemyPhase {
+                resume: crate::state::EnemyResume::BeforeInvestigatorAttacked,
+            })
             .build();
         state.enemy_attack_pending = Some(inv_id);
         // pending_cancellation defaults to false (no reaction cancelled).

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -1088,6 +1088,11 @@ mod hunter_resume_tests {
             .with_investigator(inv)
             .with_turn_order([InvestigatorId(1)])
             .with_enemy(hunter)
+            // EnemyPhase anchor (slice 1a): the resume cascade reaches the
+            // attack kickoff / enemy_phase_end, which require it.
+            .with_phase_anchor(crate::state::Continuation::EnemyPhase {
+                resume: crate::state::EnemyResume::BeforeInvestigatorAttacked,
+            })
             .build();
         let mut events = Vec::new();
         let outcome = drive_hunter_moves(&mut Cx {
@@ -1196,6 +1201,11 @@ mod hunter_resume_tests {
             .with_investigator(i2)
             .with_turn_order([InvestigatorId(1), InvestigatorId(2)])
             .with_enemy(h)
+            // EnemyPhase anchor (slice 1a): resume cascades into the attack
+            // kickoff / enemy_phase_end.
+            .with_phase_anchor(crate::state::Continuation::EnemyPhase {
+                resume: crate::state::EnemyResume::BeforeInvestigatorAttacked,
+            })
             .build();
         let mut events = Vec::new();
         let outcome = drive_hunter_moves(&mut Cx {
@@ -1313,6 +1323,11 @@ mod hunter_resume_tests {
             .with_turn_order([InvestigatorId(1)])
             .with_enemy(tie_hunter)
             .with_enemy(clean_hunter)
+            // EnemyPhase anchor (slice 1a): resume cascades into the attack
+            // kickoff / enemy_phase_end.
+            .with_phase_anchor(crate::state::Continuation::EnemyPhase {
+                resume: crate::state::EnemyResume::BeforeInvestigatorAttacked,
+            })
             .build();
         let mut events = Vec::new();
         let outcome = drive_hunter_moves(&mut Cx {
@@ -1371,6 +1386,11 @@ mod hunter_resume_tests {
             .with_investigator(inv)
             .with_turn_order([InvestigatorId(1)])
             .with_enemy(hunter)
+            // EnemyPhase anchor (slice 1a): the resume cascade reaches the
+            // attack kickoff / enemy_phase_end, which require it.
+            .with_phase_anchor(crate::state::Continuation::EnemyPhase {
+                resume: crate::state::EnemyResume::BeforeInvestigatorAttacked,
+            })
             .build();
         let mut events = Vec::new();
         let outcome = drive_hunter_moves(&mut Cx {

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -432,6 +432,17 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
                 .into(),
         },
         Some(Continuation::SkillTest(_)) => resume_skill_test_commit(cx, response),
+        // Phase anchors (slice 1a, #393) never await input — they only sit
+        // beneath framework windows. If one is somehow top, no prompt is
+        // outstanding (defensive, mirrors the EncounterCard arm).
+        Some(
+            Continuation::MythosPhase { .. }
+            | Continuation::InvestigationPhase { .. }
+            | Continuation::EnemyPhase { .. }
+            | Continuation::UpkeepPhase { .. },
+        ) => EngineOutcome::Rejected {
+            reason: "ResolveInput: no input prompt is outstanding (a phase anchor is top)".into(),
+        },
         None => EngineOutcome::Rejected {
             reason: "ResolveInput: no AwaitingInput prompt is currently outstanding".into(),
         },

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -710,9 +710,26 @@ pub(super) fn mythos_phase_end(cx: &mut Cx) {
 /// `AwaitingInput` unchanged. The `resume` is copied out before the body takes
 /// `&mut cx`.
 pub(super) fn anchor_on_child_pop(cx: &mut Cx) -> EngineOutcome {
-    use crate::state::{Continuation, EnemyResume, InvestigationResume, MythosResume};
+    use crate::state::{
+        Continuation, EnemyResume, InvestigationResume, MythosResume, UpkeepResume,
+    };
     let anchor = cx.state.continuations.last().cloned();
     match anchor {
+        Some(Continuation::UpkeepPhase {
+            resume: UpkeepResume::Begins,
+        }) => {
+            // Phase-transitioning continuation (4.2–4.6 then Upkeep→Mythos):
+            // cannot run while a skill test is in flight. Phase 4 has no
+            // Upkeep-phase skill-test source, so structurally unreachable today.
+            if let Some(in_flight) = cx.state.current_skill_test() {
+                unreachable!(
+                    "UpkeepBegins closed while a skill test is in flight \
+                     (continuation={:?}); Phase 4 has no Upkeep-phase skill-test sources",
+                    in_flight.continuation,
+                );
+            }
+            upkeep_resume(cx)
+        }
         Some(Continuation::EnemyPhase {
             resume: EnemyResume::BeforeInvestigatorAttacked,
         }) => {
@@ -819,8 +836,17 @@ fn upkeep_phase(cx: &mut Cx) -> EngineOutcome {
     cx.events.push(Event::PhaseStarted {
         phase: Phase::Upkeep,
     });
+    // Push the Upkeep phase anchor (slice 1a, #393). It persists for the whole
+    // phase — beneath the post-4.1 window, any step-4.5 hand-size discard, and
+    // the round-end act window — and is popped at upkeep_round_end_teardown (the
+    // single Upkeep→Mythos exit, after the round-end sequence finishes).
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::UpkeepPhase {
+            resume: crate::state::UpkeepResume::Begins,
+        });
     // PLAYER WINDOW (post-4.1). Auto-skips inline (running upkeep_resume
-    // via run_window_continuation) when nothing is Fast-eligible.
+    // via the anchor's on_child_pop) when nothing is Fast-eligible.
     super::reaction_windows::open_fast_window(cx, WindowKind::PlayerWindow(PhaseStep::UpkeepBegins))
 }
 
@@ -920,6 +946,18 @@ pub(super) fn upkeep_round_end_at_and_after(cx: &mut Cx) -> EngineOutcome {
 /// the forced run's [`ForcedContinuation::UpkeepAfterRoundEnded`] close (2+).
 pub(super) fn upkeep_round_end_teardown(cx: &mut Cx) -> EngineOutcome {
     cx.state.skill_substitutions.clear();
+    // Pop the Upkeep anchor (slice 1a, #393): this is the single Upkeep→Mythos
+    // exit, reached after the whole round-end sequence (act window, doom) has
+    // resolved, so the anchor is the top frame here.
+    debug_assert!(
+        matches!(
+            cx.state.continuations.last(),
+            Some(crate::state::Continuation::UpkeepPhase { .. })
+        ),
+        "upkeep_round_end_teardown: expected UpkeepPhase anchor on top, got {:?}",
+        cx.state.continuations.last(),
+    );
+    cx.state.continuations.pop();
     // Upkeep → Mythos; calls mythos_phase. Only the Investigation→Enemy
     // transition can suspend (hunter movement), so this never does.
     step_phase(cx)
@@ -2523,6 +2561,10 @@ mod upkeep_phase_tests {
             .with_investigator(test_investigator(1))
             .with_turn_order([inv])
             .with_phase(Phase::Upkeep)
+            // UpkeepPhase anchor (slice 1a): the round-end teardown pops it.
+            .with_phase_anchor(crate::state::Continuation::UpkeepPhase {
+                resume: crate::state::UpkeepResume::Begins,
+            })
             .with_location(Location::new(
                 LocationId(2),
                 CardCode("01112".into()),
@@ -3539,6 +3581,38 @@ mod hand_size_tests {
     }
 
     #[test]
+    fn upkeep_anchor_present_while_suspended_at_hand_size() {
+        // upkeep_phase pushes the UpkeepPhase anchor at entry; it sits beneath
+        // the step-4.5 hand-size discard while the phase is suspended (slice 1a).
+        let id = InvestigatorId(1);
+        let mut inv = test_investigator(1);
+        inv.hand = vec![CardCode("x".into()); 10];
+        inv.deck = vec![CardCode("y".into())]; // step 4.4 draws 1
+        let mut state = GameStateBuilder::new()
+            .with_investigator(inv)
+            .with_turn_order([id])
+            .with_phase(Phase::Upkeep)
+            .build();
+        let mut events = Vec::new();
+        let outcome = upkeep_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
+        assert!(
+            matches!(outcome, EngineOutcome::AwaitingInput { .. }),
+            "suspends at step 4.5 hand-size discard; got {outcome:?}",
+        );
+        assert!(
+            state
+                .continuations
+                .iter()
+                .any(|c| matches!(c, crate::state::Continuation::UpkeepPhase { .. })),
+            "UpkeepPhase anchor present while suspended; stack = {:?}",
+            state.continuations,
+        );
+    }
+
+    #[test]
     fn check_hand_size_suspends_for_over_cap_investigator() {
         use crate::state::CardCode;
         let id = InvestigatorId(1);
@@ -3641,6 +3715,11 @@ mod hand_size_tests {
             .with_investigator(test_investigator(1))
             .with_turn_order([id])
             .with_phase(Phase::Upkeep)
+            // UpkeepPhase anchor (slice 1a) sits beneath the staged hand-size
+            // discard; the round-end teardown pops it.
+            .with_phase_anchor(crate::state::Continuation::UpkeepPhase {
+                resume: crate::state::UpkeepResume::Begins,
+            })
             .with_hand_size_discard_pending([id])
             .build();
         // 10-card hand: discard exactly 2 (indices 0 and 1) → land at 8.
@@ -3896,6 +3975,10 @@ mod start_scenario_tests {
             .with_investigator(test_investigator(1))
             .with_turn_order([id])
             .with_active_investigator(id)
+            // upkeep_round_end_teardown pops the UpkeepPhase anchor (slice 1a).
+            .with_phase_anchor(crate::state::Continuation::UpkeepPhase {
+                resume: crate::state::UpkeepResume::Begins,
+            })
             .build();
         state.round = 1;
         state.skill_substitutions.push(SkillSubstitution {

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -370,6 +370,15 @@ fn mythos_phase(cx: &mut Cx) -> EngineOutcome {
     cx.events.push(Event::PhaseStarted {
         phase: Phase::Mythos,
     });
+    // Push the Mythos phase anchor (slice 1a, #393). It sits beneath the
+    // phase's framework windows; the post-1.4 MythosAfterDraws window's close
+    // routes to its on_child_pop. AfterDraws is the only Mythos boundary, so
+    // the resume is fixed at entry.
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::MythosPhase {
+            resume: crate::state::MythosResume::AfterDraws,
+        });
 
     // 1.2 Place 1 doom on the current agenda.
     super::act_agenda::place_doom_on_agenda(cx);
@@ -582,7 +591,52 @@ pub(super) fn enemy_phase_end(cx: &mut Cx) -> EngineOutcome {
 /// `mythos_phase_end`. Invoked from `close_reaction_window_at`'s
 /// kind-aware tail when a `MythosAfterDraws` window pops, and from
 /// `open_fast_window`'s auto-skip path inline.
+/// Run the top `*Phase` anchor's continuation after one of its framework
+/// windows closed (slice 1a, #393). The window has already been popped by the
+/// close path, so the anchor is now the top frame; its `resume` selects the
+/// relocated body. Suspension-agnostic: a body that itself suspends returns
+/// `AwaitingInput` unchanged. The `resume` is copied out before the body takes
+/// `&mut cx`.
+pub(super) fn anchor_on_child_pop(cx: &mut Cx) -> EngineOutcome {
+    use crate::state::{Continuation, MythosResume};
+    let anchor = cx.state.continuations.last().cloned();
+    match anchor {
+        Some(Continuation::MythosPhase {
+            resume: MythosResume::AfterDraws,
+        }) => {
+            // Phase-transitioning continuation: cannot run while a skill test
+            // is in flight (would strand the test in the wrong phase). Phase 4
+            // has no Mythos-phase skill-test sources, so this is structurally
+            // unreachable today.
+            if let Some(in_flight) = cx.state.current_skill_test() {
+                unreachable!(
+                    "MythosAfterDraws closed while a skill test is in flight \
+                     (continuation={:?}); Phase 4 has no Mythos-phase skill-test sources",
+                    in_flight.continuation,
+                );
+            }
+            mythos_phase_end(cx);
+            EngineOutcome::Done
+        }
+        other => unreachable!(
+            "anchor_on_child_pop: top frame is not a known phase anchor: {other:?}"
+        ),
+    }
+}
+
 pub(super) fn mythos_phase_end(cx: &mut Cx) {
+    // Pop the Mythos anchor (slice 1a, #393): the MythosAfterDraws window has
+    // closed, so the anchor is the top frame. The transition below leaves the
+    // Mythos phase, so the anchor's lifetime ends here.
+    debug_assert!(
+        matches!(
+            cx.state.continuations.last(),
+            Some(crate::state::Continuation::MythosPhase { .. })
+        ),
+        "mythos_phase_end: expected MythosPhase anchor on top, got {:?}",
+        cx.state.continuations.last(),
+    );
+    cx.state.continuations.pop();
     // 1.5 Mythos phase ends.
     //     The PhaseEnded(Mythos) emit lives HERE rather than in
     //     step_phase so step 1.5 has explicit ownership in the
@@ -1436,6 +1490,31 @@ mod mythos_phase_tests {
     }
 
     #[test]
+    fn mythos_anchor_pushed_during_phase() {
+        // The Mythos driver pushes its anchor at entry; it sits beneath the
+        // encounter-draw loop while the phase is suspended (slice 1a).
+        let mut state = GameStateBuilder::default()
+            .with_investigator(test_investigator(1))
+            .with_phase(Phase::Mythos)
+            .build();
+        state.turn_order = vec![InvestigatorId(1)];
+        let mut events = Vec::new();
+        let outcome = mythos_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
+        assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
+        assert!(
+            state
+                .continuations
+                .iter()
+                .any(|c| matches!(c, crate::state::Continuation::MythosPhase { .. })),
+            "MythosPhase anchor on the stack during the phase; stack = {:?}",
+            state.continuations,
+        );
+    }
+
+    #[test]
     fn mythos_phase_with_empty_turn_order_opens_after_draws_window_inline() {
         let mut state = GameStateBuilder::default()
             .with_phase(Phase::Mythos)
@@ -1499,6 +1578,13 @@ mod mythos_phase_tests {
             .with_phase(Phase::Mythos)
             .build();
         state.turn_order = vec![InvestigatorId(1)];
+        // mythos_phase_end now runs only with the MythosPhase anchor on top
+        // (slice 1a) — it pops the anchor as its first act.
+        state
+            .continuations
+            .push(crate::state::Continuation::MythosPhase {
+                resume: crate::state::MythosResume::AfterDraws,
+            });
         let mut events = Vec::new();
 
         mythos_phase_end(&mut Cx {
@@ -1506,6 +1592,10 @@ mod mythos_phase_tests {
             events: &mut events,
         });
 
+        assert!(
+            state.continuations.is_empty(),
+            "mythos_phase_end pops the anchor",
+        );
         assert_eq!(state.phase, Phase::Investigation);
         assert!(
             events.iter().any(|e| matches!(

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -544,6 +544,7 @@ pub(super) fn enemy_attack_kickoff(cx: &mut Cx) -> EngineOutcome {
     cx.state.enemy_attack_pending = super::cursor::first_active_investigator(cx.state);
 
     if cx.state.enemy_attack_pending.is_some() {
+        set_enemy_anchor_resume(cx, crate::state::EnemyResume::BeforeInvestigatorAttacked);
         super::reaction_windows::open_fast_window(
             cx,
             WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked),
@@ -552,10 +553,28 @@ pub(super) fn enemy_attack_kickoff(cx: &mut Cx) -> EngineOutcome {
         // No Active investigators (turn_order empty or all eliminated).
         // Skip straight to the final window — mirror of mythos_phase's
         // no-drawer path.
+        set_enemy_anchor_resume(cx, crate::state::EnemyResume::AfterAllAttacked);
         super::reaction_windows::open_fast_window(
             cx,
             WindowKind::PlayerWindow(PhaseStep::AfterAllInvestigatorsAttacked),
         )
+    }
+}
+
+/// Set the Enemy phase anchor's `resume` (slice 1a, #393) before opening one of
+/// its attack windows, so the window's close routes to the matching
+/// `anchor_on_child_pop` body. The anchor is the bottom-most Enemy frame; a
+/// no-op if it is absent (only in tests that drive the attack loop in
+/// isolation).
+pub(super) fn set_enemy_anchor_resume(cx: &mut Cx, resume: crate::state::EnemyResume) {
+    if let Some(c) = cx
+        .state
+        .continuations
+        .iter_mut()
+        .rev()
+        .find(|c| matches!(c, crate::state::Continuation::EnemyPhase { .. }))
+    {
+        *c = crate::state::Continuation::EnemyPhase { resume };
     }
 }
 
@@ -577,6 +596,16 @@ fn enemy_phase(cx: &mut Cx) -> EngineOutcome {
     cx.events.push(Event::PhaseStarted {
         phase: Phase::Enemy,
     });
+    // Push the Enemy phase anchor (slice 1a, #393) before hunter movement, so a
+    // lead-tie suspension parks above it and the kickoff on resume finds it.
+    // `enemy_attack_kickoff` / `after_enemy_phase_attacks` set its `resume`
+    // before opening each attack window. The placeholder resume is overwritten
+    // before the first window opens.
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::EnemyPhase {
+            resume: crate::state::EnemyResume::BeforeInvestigatorAttacked,
+        });
 
     // 3.2 Hunter enemies move. Park on a lead-investigator tie; the
     //     attack-loop kickoff then happens on resume.
@@ -598,6 +627,17 @@ fn enemy_phase(cx: &mut Cx) -> EngineOutcome {
 /// 3.4's `PhaseEnded(Enemy)` marker, then transitions to Upkeep.
 /// Exact analog of [`mythos_phase_end`] / [`upkeep_phase_end`].
 pub(super) fn enemy_phase_end(cx: &mut Cx) -> EngineOutcome {
+    // Pop the Enemy anchor (slice 1a, #393): the AfterAllInvestigatorsAttacked
+    // window has closed, so the anchor is the top frame, and the phase ends.
+    debug_assert!(
+        matches!(
+            cx.state.continuations.last(),
+            Some(crate::state::Continuation::EnemyPhase { .. })
+        ),
+        "enemy_phase_end: expected EnemyPhase anchor on top, got {:?}",
+        cx.state.continuations.last(),
+    );
+    cx.state.continuations.pop();
     // 3.4 Enemy phase ends.
     cx.events.push(Event::PhaseEnded {
         phase: Phase::Enemy,
@@ -670,9 +710,59 @@ pub(super) fn mythos_phase_end(cx: &mut Cx) {
 /// `AwaitingInput` unchanged. The `resume` is copied out before the body takes
 /// `&mut cx`.
 pub(super) fn anchor_on_child_pop(cx: &mut Cx) -> EngineOutcome {
-    use crate::state::{Continuation, InvestigationResume, MythosResume};
+    use crate::state::{Continuation, EnemyResume, InvestigationResume, MythosResume};
     let anchor = cx.state.continuations.last().cloned();
     match anchor {
+        Some(Continuation::EnemyPhase {
+            resume: EnemyResume::BeforeInvestigatorAttacked,
+        }) => {
+            // Phase-transitioning continuation: cannot run while a skill test is
+            // in flight (would strand it). Phase 4 has no Enemy-phase skill-test
+            // source, so structurally unreachable today.
+            if let Some(in_flight) = cx.state.current_skill_test() {
+                unreachable!(
+                    "BeforeInvestigatorAttacked closed while a skill test is in \
+                     flight (continuation={:?}); Phase 4 has no Enemy-phase \
+                     skill-test sources",
+                    in_flight.continuation,
+                );
+            }
+            // Cursor expect-Some: BeforeInvestigatorAttacked is only ever opened
+            // after enemy_attack_pending is set to Some(_). A None cursor here is
+            // a state-corruption invariant violation.
+            let investigator = cx.state.enemy_attack_pending.unwrap_or_else(|| {
+                unreachable!(
+                    "BeforeInvestigatorAttacked closed with enemy_attack_pending \
+                     == None; state-corruption invariant violation"
+                )
+            });
+            let outcome = super::combat::resolve_attacks_for_investigator(cx, investigator);
+            // The attack loop suspended on a mid-loop soak reaction window (C5b
+            // #237): surface it WITHOUT advancing the cursor. The cursor advances
+            // later, once the loop truly finishes, via resume_enemy_attack →
+            // after_enemy_phase_attacks on window close.
+            if matches!(outcome, EngineOutcome::AwaitingInput { .. }) {
+                return outcome;
+            }
+            debug_assert!(
+                matches!(outcome, EngineOutcome::Done),
+                "resolve_attacks_for_investigator returned unexpected {outcome:?}",
+            );
+            super::reaction_windows::after_enemy_phase_attacks(cx, investigator)
+        }
+        Some(Continuation::EnemyPhase {
+            resume: EnemyResume::AfterAllAttacked,
+        }) => {
+            if let Some(in_flight) = cx.state.current_skill_test() {
+                unreachable!(
+                    "AfterAllInvestigatorsAttacked closed while a skill test is in \
+                     flight (continuation={:?}); Phase 4 has no Enemy-phase \
+                     skill-test sources",
+                    in_flight.continuation,
+                );
+            }
+            enemy_phase_end(cx)
+        }
         Some(Continuation::InvestigationPhase {
             resume: InvestigationResume::Begins,
         }) => {
@@ -2723,6 +2813,16 @@ mod enemy_phase_tests {
         });
         assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
         assert_eq!(state.phase, Phase::Enemy);
+        // The EnemyPhase anchor (slice 1a) is on the stack beneath the
+        // suspended hunter-movement choice.
+        assert!(
+            state
+                .continuations
+                .iter()
+                .any(|c| matches!(c, crate::state::Continuation::EnemyPhase { .. })),
+            "EnemyPhase anchor present while suspended in the Enemy phase; stack = {:?}",
+            state.continuations,
+        );
         let mut ev2 = Vec::new();
         // Pick LocationId(2) by its offered option id (candidates ride the request).
         let crate::engine::EngineOutcome::AwaitingInput { request, .. } = &outcome else {
@@ -3336,6 +3436,12 @@ mod enemy_phase_tests {
             .with_investigator(test_investigator(1))
             .with_enemy(enemy)
             .with_phase(Phase::Enemy)
+            // The EnemyPhase anchor (slice 1a) sits beneath the synthetic
+            // BeforeInvestigatorAttacked window pushed below; its close routes
+            // to anchor_on_child_pop.
+            .with_phase_anchor(crate::state::Continuation::EnemyPhase {
+                resume: crate::state::EnemyResume::BeforeInvestigatorAttacked,
+            })
             .build();
         state.turn_order = vec![inv_id];
         state.active_investigator = None;

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -291,6 +291,15 @@ pub(super) fn investigation_phase(cx: &mut Cx) {
     cx.events.push(Event::PhaseStarted {
         phase: Phase::Investigation,
     });
+    // Push the Investigation phase anchor (slice 1a, #393). It persists for the
+    // whole phase (across every investigator's turn), beneath the framework
+    // windows; popped at investigation_phase_end. Starts at `Begins` (the
+    // post-2.1 InvestigationBegins window opens next).
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::InvestigationPhase {
+            resume: crate::state::InvestigationResume::Begins,
+        });
     // PLAYER WINDOW (post-2.1). Rotation to the first investigator
     // (step 2.2) runs in this window's continuation
     // (`run_window_continuation` → `InvestigationBegins`), so the printed
@@ -320,6 +329,20 @@ pub(super) fn investigation_phase(cx: &mut Cx) {
 /// resolve it via `first_active_investigator` / `next_active_investigator_after`.
 pub(super) fn begin_investigator_turn(cx: &mut Cx, who: InvestigatorId) {
     rotate_to_active(cx, who);
+    // Advance the Investigation anchor to `TurnBegins` so the closing
+    // InvestigatorTurnBegins window routes to the right on_child_pop arm
+    // (slice 1a, #393). The anchor is the bottom-most Investigation frame.
+    if let Some(anchor) = cx
+        .state
+        .continuations
+        .iter_mut()
+        .rev()
+        .find(|c| matches!(c, crate::state::Continuation::InvestigationPhase { .. }))
+    {
+        *anchor = crate::state::Continuation::InvestigationPhase {
+            resume: crate::state::InvestigationResume::TurnBegins,
+        };
+    }
     let outcome = super::reaction_windows::open_fast_window(
         cx,
         WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins),
@@ -337,6 +360,18 @@ pub(super) fn begin_investigator_turn(cx: &mut Cx, who: InvestigatorId) {
 /// Enemy phase. Called only from `end_turn`'s terminal branch (the last
 /// investigator has taken a turn this round).
 fn investigation_phase_end(cx: &mut Cx) -> EngineOutcome {
+    // Pop the Investigation anchor (slice 1a, #393): the phase ends here (last
+    // investigator's turn is over), so the anchor — the bottom-most
+    // Investigation frame, top once the open-action turn finished — is disposed.
+    debug_assert!(
+        matches!(
+            cx.state.continuations.last(),
+            Some(crate::state::Continuation::InvestigationPhase { .. })
+        ),
+        "investigation_phase_end: expected InvestigationPhase anchor on top, got {:?}",
+        cx.state.continuations.last(),
+    );
+    cx.state.continuations.pop();
     // No forced-trigger dispatch here: only Enemy and Upkeep phase-ends have
     // slice consumers (agenda 01107). A `PhaseEnded { Investigation }` forced
     // ability would NOT fire until #212's emit_event restructure centralises
@@ -591,39 +626,6 @@ pub(super) fn enemy_phase_end(cx: &mut Cx) -> EngineOutcome {
 /// `mythos_phase_end`. Invoked from `close_reaction_window_at`'s
 /// kind-aware tail when a `MythosAfterDraws` window pops, and from
 /// `open_fast_window`'s auto-skip path inline.
-/// Run the top `*Phase` anchor's continuation after one of its framework
-/// windows closed (slice 1a, #393). The window has already been popped by the
-/// close path, so the anchor is now the top frame; its `resume` selects the
-/// relocated body. Suspension-agnostic: a body that itself suspends returns
-/// `AwaitingInput` unchanged. The `resume` is copied out before the body takes
-/// `&mut cx`.
-pub(super) fn anchor_on_child_pop(cx: &mut Cx) -> EngineOutcome {
-    use crate::state::{Continuation, MythosResume};
-    let anchor = cx.state.continuations.last().cloned();
-    match anchor {
-        Some(Continuation::MythosPhase {
-            resume: MythosResume::AfterDraws,
-        }) => {
-            // Phase-transitioning continuation: cannot run while a skill test
-            // is in flight (would strand the test in the wrong phase). Phase 4
-            // has no Mythos-phase skill-test sources, so this is structurally
-            // unreachable today.
-            if let Some(in_flight) = cx.state.current_skill_test() {
-                unreachable!(
-                    "MythosAfterDraws closed while a skill test is in flight \
-                     (continuation={:?}); Phase 4 has no Mythos-phase skill-test sources",
-                    in_flight.continuation,
-                );
-            }
-            mythos_phase_end(cx);
-            EngineOutcome::Done
-        }
-        other => unreachable!(
-            "anchor_on_child_pop: top frame is not a known phase anchor: {other:?}"
-        ),
-    }
-}
-
 pub(super) fn mythos_phase_end(cx: &mut Cx) {
     // Pop the Mythos anchor (slice 1a, #393): the MythosAfterDraws window has
     // closed, so the anchor is the top frame. The transition below leaves the
@@ -659,6 +661,60 @@ pub(super) fn mythos_phase_end(cx: &mut Cx) {
         EngineOutcome::Done,
         "unexpected suspension in Mythos→Investigation transition"
     );
+}
+
+/// Run the top `*Phase` anchor's continuation after one of its framework
+/// windows closed (slice 1a, #393). The window has already been popped by the
+/// close path, so the anchor is now the top frame; its `resume` selects the
+/// relocated body. Suspension-agnostic: a body that itself suspends returns
+/// `AwaitingInput` unchanged. The `resume` is copied out before the body takes
+/// `&mut cx`.
+pub(super) fn anchor_on_child_pop(cx: &mut Cx) -> EngineOutcome {
+    use crate::state::{Continuation, InvestigationResume, MythosResume};
+    let anchor = cx.state.continuations.last().cloned();
+    match anchor {
+        Some(Continuation::InvestigationPhase {
+            resume: InvestigationResume::Begins,
+        }) => {
+            // Post-2.1 window closed; start the first investigator's turn
+            // (step 2.2). No skill-test-in-flight guard: runs at phase start
+            // (no test in flight) and does not transition phase.
+            if let Some(id) = super::cursor::first_active_investigator(cx.state) {
+                begin_investigator_turn(cx, id);
+            }
+            // None branch: no active investigator can take a turn — the
+            // cascade-breaker park (the loss already resolved at the defeat
+            // site). See the former run_window_continuation arm.
+            EngineOutcome::Done
+        }
+        Some(Continuation::InvestigationPhase {
+            resume: InvestigationResume::TurnBegins,
+        }) => {
+            // 2.2.1 — the active investigator now acts as player-driven input;
+            // no continuation work (slice 2 makes this an InvestigatorTurn frame).
+            EngineOutcome::Done
+        }
+        Some(Continuation::MythosPhase {
+            resume: MythosResume::AfterDraws,
+        }) => {
+            // Phase-transitioning continuation: cannot run while a skill test
+            // is in flight (would strand the test in the wrong phase). Phase 4
+            // has no Mythos-phase skill-test sources, so this is structurally
+            // unreachable today.
+            if let Some(in_flight) = cx.state.current_skill_test() {
+                unreachable!(
+                    "MythosAfterDraws closed while a skill test is in flight \
+                     (continuation={:?}); Phase 4 has no Mythos-phase skill-test sources",
+                    in_flight.continuation,
+                );
+            }
+            mythos_phase_end(cx);
+            EngineOutcome::Done
+        }
+        other => {
+            unreachable!("anchor_on_child_pop: top frame is not a known phase anchor: {other:?}")
+        }
+    }
 }
 
 /// Entered by [`step_phase`] on the Enemy→Upkeep transition. Owns the
@@ -1161,6 +1217,32 @@ mod investigation_phase_tests {
     }
 
     #[test]
+    fn investigation_anchor_pushed_and_persists_through_turn() {
+        // The Investigation driver pushes its anchor at entry; it persists
+        // beneath the open-action turn (slice 1a) after the framework windows
+        // auto-skip closed.
+        let id = InvestigatorId(1);
+        let mut state = GameStateBuilder::default()
+            .with_investigator(test_investigator(1))
+            .with_phase(Phase::Investigation)
+            .build();
+        state.turn_order = vec![id];
+        let mut events = Vec::new();
+        investigation_phase(&mut Cx {
+            state: &mut state,
+            events: &mut events,
+        });
+        assert!(
+            state
+                .continuations
+                .iter()
+                .any(|c| matches!(c, crate::state::Continuation::InvestigationPhase { .. })),
+            "InvestigationPhase anchor present during the turn; stack = {:?}",
+            state.continuations,
+        );
+    }
+
+    #[test]
     fn investigation_phase_emits_phase_started_and_rotates_to_lead() {
         // Two investigators; investigation_phase should emit
         // PhaseStarted(Investigation), open the post-2.1 InvestigationBegins
@@ -1292,6 +1374,13 @@ mod investigation_phase_tests {
             .with_active_investigator(InvestigatorId(1))
             .build();
         state.turn_order = vec![InvestigatorId(1)];
+        // Mid-Investigation invariant (slice 1a): push the InvestigationPhase
+        // anchor that investigation_phase would have left on the stack.
+        state
+            .continuations
+            .push(crate::state::Continuation::InvestigationPhase {
+                resume: crate::state::InvestigationResume::TurnBegins,
+            });
 
         let mut events = Vec::new();
         let outcome = end_turn(&mut Cx {
@@ -1347,6 +1436,13 @@ mod investigation_phase_tests {
             .with_active_investigator(InvestigatorId(1))
             .build();
         state.turn_order = vec![InvestigatorId(1), InvestigatorId(2)];
+        // Mid-Investigation invariant (slice 1a): push the InvestigationPhase
+        // anchor that investigation_phase would have left on the stack.
+        state
+            .continuations
+            .push(crate::state::Continuation::InvestigationPhase {
+                resume: crate::state::InvestigationResume::TurnBegins,
+            });
 
         let mut events = Vec::new();
         let outcome = end_turn(&mut Cx {
@@ -1593,8 +1689,12 @@ mod mythos_phase_tests {
         });
 
         assert!(
-            state.continuations.is_empty(),
-            "mythos_phase_end pops the anchor",
+            !state
+                .continuations
+                .iter()
+                .any(|c| matches!(c, crate::state::Continuation::MythosPhase { .. })),
+            "mythos_phase_end pops the Mythos anchor (the cascade into \
+             Investigation then pushes its own anchor)",
         );
         assert_eq!(state.phase, Phase::Investigation);
         assert!(
@@ -2283,6 +2383,13 @@ mod upkeep_phase_tests {
         state.turn_order = vec![id];
         state.active_investigator = Some(id);
         state.round = 1;
+        // Mid-Investigation invariant (slice 1a): push the InvestigationPhase
+        // anchor that investigation_phase would have left on the stack.
+        state
+            .continuations
+            .push(crate::state::Continuation::InvestigationPhase {
+                resume: crate::state::InvestigationResume::TurnBegins,
+            });
 
         let result = apply(state, Action::Player(PlayerAction::EndTurn));
 
@@ -2547,6 +2654,14 @@ mod enemy_phase_tests {
             .with_turn_order([InvestigatorId(1)])
             .with_enemy(hunter)
             .build();
+        // Mid-Investigation invariant (slice 1a): the InvestigationPhase anchor
+        // is on the stack all phase. These tests construct the state directly
+        // (bypassing investigation_phase), so push it explicitly.
+        state
+            .continuations
+            .push(crate::state::Continuation::InvestigationPhase {
+                resume: crate::state::InvestigationResume::TurnBegins,
+            });
         let mut events = Vec::new();
         let outcome = end_turn(&mut Cx {
             state: &mut state,
@@ -2593,6 +2708,14 @@ mod enemy_phase_tests {
             .with_turn_order([InvestigatorId(1)])
             .with_enemy(hunter)
             .build();
+        // Mid-Investigation invariant (slice 1a): the InvestigationPhase anchor
+        // is on the stack all phase. These tests construct the state directly
+        // (bypassing investigation_phase), so push it explicitly.
+        state
+            .continuations
+            .push(crate::state::Continuation::InvestigationPhase {
+                resume: crate::state::InvestigationResume::TurnBegins,
+            });
         let mut events = Vec::new();
         let outcome = end_turn(&mut Cx {
             state: &mut state,

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -966,28 +966,11 @@ pub(super) fn close_reaction_window_at(cx: &mut Cx, idx: usize) -> EngineOutcome
 pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) -> EngineOutcome {
     match kind {
         WindowKind::PlayerWindow(step) => match step {
-            PhaseStep::MythosAfterDraws => {
-                // Phase-transitioning continuation: cannot run while a skill
-                // test is in flight (would strand the test in the wrong
-                // phase). Phase 4 has no Mythos-phase skill-test sources, so
-                // this branch is structurally unreachable today. A future PR
-                // adding a Mythos-phase Revelation that initiates a skill
-                // test must redesign the close-window + phase-transition
-                // ordering before this assertion fires.
-                if let Some(in_flight) = cx.state.current_skill_test() {
-                    unreachable!(
-                        "MythosAfterDraws window closed while a skill test is in flight \
-                     (continuation={:?}). Phase transition would strand the skill test \
-                     in the wrong phase. Phase 4 has no Mythos-phase skill test sources; \
-                     if a future PR adds one (e.g. a treachery whose Revelation initiates \
-                     a skill test), the window-close + phase-transition ordering needs \
-                     redesign before this assertion can be relaxed.",
-                        in_flight.continuation,
-                    );
-                }
-                super::phases::mythos_phase_end(cx);
-                EngineOutcome::Done
-            }
+            // Phase-structure continuation now lives on the MythosPhase anchor
+            // (slice 1a, #393): the anchor sits beneath this window, so its
+            // close routes to the anchor's on_child_pop (which keeps the
+            // skill-test-in-flight guard).
+            PhaseStep::MythosAfterDraws => super::phases::anchor_on_child_pop(cx),
             PhaseStep::UpkeepBegins => {
                 // Phase-transitioning continuation (4.2–4.6 then Upkeep→Mythos):
                 // cannot run while a skill test is in flight. Phase 4 has no

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -965,33 +965,13 @@ pub(super) fn close_reaction_window_at(cx: &mut Cx, idx: usize) -> EngineOutcome
 /// [`EngineOutcome::AwaitingInput`] producer (#111).
 pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) -> EngineOutcome {
     match kind {
-        WindowKind::PlayerWindow(step) => match step {
-            // Phase-structure continuations live on the `*Phase` anchor beneath
-            // each window (slice 1a, #393): the anchor's `resume` selects the
-            // relocated body (incl. the skill-test-in-flight guards and the
-            // Enemy soak-window `AwaitingInput` propagation). `UpkeepBegins` is
-            // the last arm still inline (its anchor relocation is the next task).
-            PhaseStep::MythosAfterDraws
-            | PhaseStep::BeforeInvestigatorAttacked
-            | PhaseStep::AfterAllInvestigatorsAttacked
-            | PhaseStep::InvestigationBegins
-            | PhaseStep::InvestigatorTurnBegins => super::phases::anchor_on_child_pop(cx),
-            PhaseStep::UpkeepBegins => {
-                // Phase-transitioning continuation (4.2–4.6 then Upkeep→Mythos):
-                // cannot run while a skill test is in flight. Phase 4 has no
-                // Upkeep-phase skill-test source, so structurally unreachable.
-                if let Some(in_flight) = cx.state.current_skill_test() {
-                    unreachable!(
-                        "UpkeepBegins window closed while a skill test is in flight \
-                     (continuation={:?}). Phase 4 has no Upkeep-phase skill-test \
-                     sources; a future PR adding one needs the window-close + \
-                     phase-transition ordering redesigned before this fires.",
-                        in_flight.continuation,
-                    );
-                }
-                super::phases::upkeep_resume(cx)
-            }
-        },
+        // Every framework `PlayerWindow(PhaseStep)` close routes to the `*Phase`
+        // anchor beneath it (slice 1a, #393): the anchor's `resume` selects the
+        // relocated body — the skill-test-in-flight guards, the Enemy
+        // soak-window `AwaitingInput` propagation, the Upkeep 4.2–4.6 cascade,
+        // the Mythos/Investigation transitions. The `PhaseStep` is no longer the
+        // continuation key; the anchor's `resume` is.
+        WindowKind::PlayerWindow(_) => super::phases::anchor_on_child_pop(cx),
         // AfterEnemyDefeated / AfterSuccessfulInvestigate: no continuation
         // work. The skill-test driver (which queued the window mid-resolution)
         // resumes via `close_reaction_window_at`'s in-flight re-entry.

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -937,32 +937,27 @@ pub(super) fn close_reaction_window_at(cx: &mut Cx, idx: usize) -> EngineOutcome
     EngineOutcome::Done
 }
 
-/// Kind-aware continuation called when a window closes (whether
-/// inline via [`open_fast_window`]'s auto-skip path or via the
-/// [`close_reaction_window_at`] pop path). For
-/// [`PhaseStep::MythosAfterDraws`], runs
-/// [`mythos_phase_end`](super::phases::mythos_phase_end); for
-/// [`PhaseStep::UpkeepBegins`], runs [`upkeep_resume`](super::phases::upkeep_resume). For
-/// [`PhaseStep::BeforeInvestigatorAttacked`], resolves the cursor
-/// investigator's engaged-enemy attacks via
-/// [`resolve_attacks_for_investigator`](super::combat::resolve_attacks_for_investigator), advances
-/// [`GameState::enemy_attack_pending`] to the next Active investigator
-/// via [`cursor::next_active_investigator_after`](super::cursor::next_active_investigator_after),
-/// and opens the next window
-/// ([`PhaseStep::BeforeInvestigatorAttacked`] again if the cursor
-/// advanced to `Some`, otherwise [`PhaseStep::AfterAllInvestigatorsAttacked`]).
-/// For [`PhaseStep::AfterAllInvestigatorsAttacked`], runs
-/// [`enemy_phase_end`](super::phases::enemy_phase_end). For [`PhaseStep::InvestigationBegins`], starts
-/// the first turn via [`begin_investigator_turn`](super::phases::begin_investigator_turn) for the first Active
-/// investigator (or parks if none). [`WindowKind::AfterEnemyDefeated`] and
-/// [`PhaseStep::InvestigatorTurnBegins`] windows have no
-/// continuation — for them this returns [`EngineOutcome::Done`],
-/// preserving the existing [`close_reaction_window_at`] behavior.
+/// Kind-aware continuation called when a window closes (whether inline via
+/// [`open_fast_window`]'s auto-skip path or via the [`close_reaction_window_at`]
+/// pop path).
 ///
-/// Returns the continuation's [`EngineOutcome`]. Today every path
-/// returns [`EngineOutcome::Done`]; the return type is widened ahead of
-/// upkeep step 4.5 (hand-size discard) gaining an
-/// [`EngineOutcome::AwaitingInput`] producer (#111).
+/// Every framework [`WindowKind::PlayerWindow`] close routes to the `*Phase`
+/// anchor beneath it via
+/// [`anchor_on_child_pop`](super::phases::anchor_on_child_pop) (slice 1a, #393):
+/// the anchor's `resume` — not the [`PhaseStep`] — selects the relocated body
+/// (the Mythos/Investigation transitions, the Enemy attack-loop step incl. its
+/// mid-loop soak-window `AwaitingInput` propagation, the Upkeep 4.2–4.6
+/// cascade). The card/ability-reaction kinds run inline here: soak / before-
+/// attack ([`WindowKind::AfterEnemyAttackDamagedAsset`] /
+/// [`WindowKind::BeforeEnemyAttack`]) re-enter the attack loop via
+/// [`resume_enemy_attack`](super::combat::resume_enemy_attack);
+/// [`WindowKind::BeforeDiscoverClues`] performs the deferred discovery;
+/// [`WindowKind::AfterEnemyDefeated`] / [`WindowKind::AfterSuccessfulInvestigate`]
+/// / [`WindowKind::AfterEnteredPlay`] have no continuation work.
+///
+/// Returns the continuation's [`EngineOutcome`] — `Done`, or `AwaitingInput`
+/// when a body suspends (an Enemy soak window, the Upkeep step-4.5 hand-size
+/// discard, …).
 pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) -> EngineOutcome {
     match kind {
         // Every framework `PlayerWindow(PhaseStep)` close routes to the `*Phase`

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -1053,34 +1053,12 @@ pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) -> EngineOu
                 }
                 super::phases::enemy_phase_end(cx)
             }
-            PhaseStep::InvestigationBegins => {
-                // Post-2.1 window closed; start the first turn (step 2.2).
-                // No skill-test-in-flight guard: this runs at phase start
-                // (no test can be in flight) and does not transition phase.
-                if let Some(id) = super::cursor::first_active_investigator(cx.state) {
-                    super::phases::begin_investigator_turn(cx, id);
-                }
-                // None branch: no active investigator can take a turn. Per
-                // Rules Reference p.10 step 6 the scenario ends — that
-                // resolution now fires at the defeat site:
-                // `check_all_defeated` latches `Resolution::Lost` (and emits
-                // `AllInvestigatorsDefeated`), which the `apply` hook turns
-                // into `ScenarioResolved` + `apply_resolution`. So by the
-                // time the cascade would re-enter Investigation with no
-                // active investigator, the loss has already resolved; this
-                // park branch stays as the cascade-breaker (auto-advancing
-                // would loop the round forever — every other phase auto-skips
-                // with no active investigators, so Investigation is the
-                // cascade's only natural pause point).
-                EngineOutcome::Done
+            // Phase-structure continuations now live on the InvestigationPhase
+            // anchor (slice 1a, #393): the anchor's resume (Begins vs.
+            // TurnBegins) selects the body. Both route through on_child_pop.
+            PhaseStep::InvestigationBegins | PhaseStep::InvestigatorTurnBegins => {
+                super::phases::anchor_on_child_pop(cx)
             }
-            // InvestigatorTurnBegins: 2.2.1 — the active investigator now
-            // takes actions (Investigate / Move / Fight / Evade / PlayCard /
-            // Draw / ActivateAbility) as player-driven inputs, then ends the
-            // turn via EndTurn (2.2.2). No continuation work — the engine
-            // waits. The per-action "return to the previous player window"
-            // re-open (Rules Reference p.24 2.2.1) is deferred to #146.
-            PhaseStep::InvestigatorTurnBegins => EngineOutcome::Done,
         },
         // AfterEnemyDefeated / AfterSuccessfulInvestigate: no continuation
         // work. The skill-test driver (which queued the window mid-resolution)
@@ -1937,6 +1915,11 @@ mod open_fast_window_tests {
         // opens and closes without ever landing on state.open_windows.
         let mut state = GameStateBuilder::default()
             .with_investigator(test_investigator(1))
+            // The MythosAfterDraws window now closes onto the MythosPhase anchor
+            // (slice 1a); stage it so the auto-skip continuation has its frame.
+            .with_phase_anchor(crate::state::Continuation::MythosPhase {
+                resume: crate::state::MythosResume::AfterDraws,
+            })
             .build();
         let mut events = Vec::new();
         open_fast_window(

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -966,11 +966,16 @@ pub(super) fn close_reaction_window_at(cx: &mut Cx, idx: usize) -> EngineOutcome
 pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) -> EngineOutcome {
     match kind {
         WindowKind::PlayerWindow(step) => match step {
-            // Phase-structure continuation now lives on the MythosPhase anchor
-            // (slice 1a, #393): the anchor sits beneath this window, so its
-            // close routes to the anchor's on_child_pop (which keeps the
-            // skill-test-in-flight guard).
-            PhaseStep::MythosAfterDraws => super::phases::anchor_on_child_pop(cx),
+            // Phase-structure continuations live on the `*Phase` anchor beneath
+            // each window (slice 1a, #393): the anchor's `resume` selects the
+            // relocated body (incl. the skill-test-in-flight guards and the
+            // Enemy soak-window `AwaitingInput` propagation). `UpkeepBegins` is
+            // the last arm still inline (its anchor relocation is the next task).
+            PhaseStep::MythosAfterDraws
+            | PhaseStep::BeforeInvestigatorAttacked
+            | PhaseStep::AfterAllInvestigatorsAttacked
+            | PhaseStep::InvestigationBegins
+            | PhaseStep::InvestigatorTurnBegins => super::phases::anchor_on_child_pop(cx),
             PhaseStep::UpkeepBegins => {
                 // Phase-transitioning continuation (4.2–4.6 then Upkeep→Mythos):
                 // cannot run while a skill test is in flight. Phase 4 has no
@@ -985,79 +990,6 @@ pub(super) fn run_window_continuation(cx: &mut Cx, kind: WindowKind) -> EngineOu
                     );
                 }
                 super::phases::upkeep_resume(cx)
-            }
-            PhaseStep::BeforeInvestigatorAttacked => {
-                // Phase-transitioning continuation (advances to the next
-                // window and ultimately to Upkeep) — cannot run while a
-                // skill test is in flight (would strand it). Phase 4 has
-                // no Enemy-phase skill-test source, so this branch is
-                // structurally unreachable today. A future PR adding one
-                // (e.g. a treachery-style "make an Agility test or take
-                // damage" attack ability) must redesign the window-close
-                // + phase-transition ordering before this assertion fires.
-                if let Some(in_flight) = cx.state.current_skill_test() {
-                    unreachable!(
-                        "BeforeInvestigatorAttacked window closed while a \
-                     skill test is in flight (continuation={:?}). Phase \
-                     transition would strand the skill test in the \
-                     wrong phase. Phase 4 has no Enemy-phase skill test \
-                     sources; if a future PR adds one, the window-close \
-                     + phase-transition ordering needs redesign before \
-                     this assertion can be relaxed.",
-                        in_flight.continuation,
-                    );
-                }
-
-                // Cursor expect-Some: BeforeInvestigatorAttacked is only
-                // ever opened after enemy_attack_pending is set to Some(_)
-                // in enemy_phase or in the advance below. A None cursor
-                // here is a state-corruption invariant violation, not a
-                // normal rejection path.
-                let investigator = cx.state.enemy_attack_pending.unwrap_or_else(|| {
-                    unreachable!(
-                        "BeforeInvestigatorAttacked closed with \
-                     enemy_attack_pending == None; this is a \
-                     state-corruption invariant violation"
-                    )
-                });
-
-                let outcome = super::combat::resolve_attacks_for_investigator(cx, investigator);
-
-                // The attack loop suspended on a mid-loop soak reaction
-                // window (C5b #237): surface it immediately, WITHOUT
-                // advancing the cursor. The cursor advances later, once
-                // the loop truly finishes, via `resume_enemy_attack` →
-                // `after_enemy_phase_attacks` on window close.
-                if matches!(outcome, EngineOutcome::AwaitingInput { .. }) {
-                    return outcome;
-                }
-                debug_assert!(
-                    matches!(outcome, EngineOutcome::Done),
-                    "resolve_attacks_for_investigator returned unexpected \
-                     {outcome:?} (expected Done or AwaitingInput)",
-                );
-
-                after_enemy_phase_attacks(cx, investigator)
-            }
-            PhaseStep::AfterAllInvestigatorsAttacked => {
-                if let Some(in_flight) = cx.state.current_skill_test() {
-                    unreachable!(
-                        "AfterAllInvestigatorsAttacked window closed while a \
-                     skill test is in flight (continuation={:?}). Phase \
-                     4 has no Enemy-phase skill-test sources; a future \
-                     PR adding one needs the window-close + \
-                     phase-transition ordering redesigned before this \
-                     fires.",
-                        in_flight.continuation,
-                    );
-                }
-                super::phases::enemy_phase_end(cx)
-            }
-            // Phase-structure continuations now live on the InvestigationPhase
-            // anchor (slice 1a, #393): the anchor's resume (Begins vs.
-            // TurnBegins) selects the body. Both route through on_child_pop.
-            PhaseStep::InvestigationBegins | PhaseStep::InvestigatorTurnBegins => {
-                super::phases::anchor_on_child_pop(cx)
             }
         },
         // AfterEnemyDefeated / AfterSuccessfulInvestigate: no continuation
@@ -1168,11 +1100,16 @@ pub(super) fn after_enemy_phase_attacks(
         super::cursor::next_active_investigator_after(cx.state, investigator);
 
     if cx.state.enemy_attack_pending.is_some() {
+        super::phases::set_enemy_anchor_resume(
+            cx,
+            crate::state::EnemyResume::BeforeInvestigatorAttacked,
+        );
         open_fast_window(
             cx,
             WindowKind::PlayerWindow(PhaseStep::BeforeInvestigatorAttacked),
         )
     } else {
+        super::phases::set_enemy_anchor_resume(cx, crate::state::EnemyResume::AfterAllAttacked);
         open_fast_window(
             cx,
             WindowKind::PlayerWindow(PhaseStep::AfterAllInvestigatorsAttacked),

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -391,6 +391,9 @@ mod tests {
             .with_phase(Phase::Investigation)
             .with_investigator(roland)
             .with_active_investigator(id)
+            .with_phase_anchor(crate::state::Continuation::InvestigationPhase {
+                resume: crate::state::InvestigationResume::TurnBegins,
+            })
             .build();
 
         let result = apply(state, Action::Player(PlayerAction::EndTurn));
@@ -4758,7 +4761,15 @@ mod tests {
 
     #[test]
     fn resolution_does_not_refire_on_a_later_apply() {
-        let state = terminal_act_state(Some("stamp"));
+        let mut state = terminal_act_state(Some("stamp"));
+        // Mid-Investigation invariant (slice 1a): the EndTurn below cascades
+        // through investigation_phase_end, which pops the InvestigationPhase
+        // anchor — so it must be present.
+        state
+            .continuations
+            .push(crate::state::Continuation::InvestigationPhase {
+                resume: crate::state::InvestigationResume::TurnBegins,
+            });
         let reg = ScenarioRegistry {
             module_for: stamp_module_for,
         };

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -12,7 +12,7 @@
 //! ```
 //! use game_core::{
 //!     apply, Action, PlayerAction, Phase, InvestigatorId,
-//!     state::GameStateBuilder,
+//!     state::{GameStateBuilder, Continuation, InvestigationResume},
 //!     test_support::{test_investigator, test_location},
 //! };
 //!
@@ -21,6 +21,10 @@
 //!     .with_investigator(test_investigator(1))
 //!     .with_location(test_location(10, "Study"))
 //!     .with_active_investigator(InvestigatorId(1))
+//!     // A state constructed mid-phase needs its phase anchor (slice 1a).
+//!     .with_phase_anchor(Continuation::InvestigationPhase {
+//!         resume: InvestigationResume::TurnBegins,
+//!     })
 //!     .build();
 //!
 //! let result = apply(state, Action::Player(PlayerAction::EndTurn));
@@ -58,6 +62,7 @@ pub struct GameStateBuilder {
     mythos_draw_remaining: Option<Vec<InvestigatorId>>,
     hand_size_discard_pending: Option<HandSizeDiscard>,
     open_windows: Vec<ResolutionFrame>,
+    phase_anchor: Option<Continuation>,
     scenario_id: Option<ScenarioId>,
 }
 
@@ -82,6 +87,7 @@ impl GameStateBuilder {
             mythos_draw_remaining: None,
             hand_size_discard_pending: None,
             open_windows: Vec::new(),
+            phase_anchor: None,
             scenario_id: None,
         }
     }
@@ -260,6 +266,27 @@ impl GameStateBuilder {
         self
     }
 
+    /// Stage a `*Phase` anchor frame (slice 1a, #393) at the **bottom** of the
+    /// continuation stack — the realistic invariant for a state constructed
+    /// mid-phase (the real driver pushes the anchor at phase entry, beneath any
+    /// framework windows). Tests that drive `end_turn` / open phase windows
+    /// without going through the phase driver use this to satisfy the anchor
+    /// invariant. Panics if `c` is not a `*Phase` anchor variant.
+    pub fn with_phase_anchor(mut self, c: Continuation) -> Self {
+        assert!(
+            matches!(
+                c,
+                Continuation::MythosPhase { .. }
+                    | Continuation::InvestigationPhase { .. }
+                    | Continuation::EnemyPhase { .. }
+                    | Continuation::UpkeepPhase { .. }
+            ),
+            "with_phase_anchor expects a *Phase anchor variant, got {c:?}",
+        );
+        self.phase_anchor = Some(c);
+        self
+    }
+
     /// Set the scenario id this state belongs to. `None` (the
     /// default from [`GameStateBuilder::new`]) means the engine's post-apply
     /// resolution hook will short-circuit. Passing a `ScenarioId`
@@ -277,11 +304,10 @@ impl GameStateBuilder {
         // Builder-staged windows become `Resolution` frames on the one
         // continuation stack (Axis-B T3); a staged hand-size discard becomes a
         // `HandSizeDiscard` frame on top of them (#348).
-        let mut continuations: Vec<Continuation> = self
-            .open_windows
-            .into_iter()
-            .map(Continuation::Resolution)
-            .collect();
+        // A staged `*Phase` anchor (slice 1a, #393) sits at the bottom of the
+        // stack — beneath any windows, which open *above* it during the phase.
+        let mut continuations: Vec<Continuation> = self.phase_anchor.into_iter().collect();
+        continuations.extend(self.open_windows.into_iter().map(Continuation::Resolution));
         if let Some(hsd) = self.hand_size_discard_pending {
             continuations.push(Continuation::HandSizeDiscard(hsd));
         }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -496,6 +496,30 @@ pub enum Continuation {
         /// The drawn treachery's card code, disposed of at teardown.
         card: CardCode,
     },
+    /// The Mythos phase anchor (slice 1a, #393). Pushed at Mythos entry; sits
+    /// beneath the phase's framework windows. On a child window's close the
+    /// framework routes to the anchor's `on_child_pop` (keyed by `resume`).
+    /// Never awaits input; popped when the phase transitions away.
+    MythosPhase {
+        /// Which child-pop boundary the anchor resumes at.
+        resume: MythosResume,
+    },
+    /// The Investigation phase anchor (slice 1a, #393). See
+    /// [`Continuation::MythosPhase`].
+    InvestigationPhase {
+        /// Which child-pop boundary the anchor resumes at.
+        resume: InvestigationResume,
+    },
+    /// The Enemy phase anchor (slice 1a, #393). See [`Continuation::MythosPhase`].
+    EnemyPhase {
+        /// Which child-pop boundary the anchor resumes at.
+        resume: EnemyResume,
+    },
+    /// The Upkeep phase anchor (slice 1a, #393). See [`Continuation::MythosPhase`].
+    UpkeepPhase {
+        /// Which child-pop boundary the anchor resumes at.
+        resume: UpkeepResume,
+    },
 }
 
 /// A controller choice paused mid-resolution (umbrella §3, Axis A).
@@ -540,7 +564,11 @@ impl Continuation {
             | Continuation::SubstitutionPrompt { .. }
             | Continuation::Mulligan { .. }
             | Continuation::EncounterDraw { .. }
-            | Continuation::EncounterCard { .. } => None,
+            | Continuation::EncounterCard { .. }
+            | Continuation::MythosPhase { .. }
+            | Continuation::InvestigationPhase { .. }
+            | Continuation::EnemyPhase { .. }
+            | Continuation::UpkeepPhase { .. } => None,
         }
     }
 
@@ -557,9 +585,48 @@ impl Continuation {
             | Continuation::SubstitutionPrompt { .. }
             | Continuation::Mulligan { .. }
             | Continuation::EncounterDraw { .. }
-            | Continuation::EncounterCard { .. } => None,
+            | Continuation::EncounterCard { .. }
+            | Continuation::MythosPhase { .. }
+            | Continuation::InvestigationPhase { .. }
+            | Continuation::EnemyPhase { .. }
+            | Continuation::UpkeepPhase { .. } => None,
         }
     }
+}
+
+/// The Mythos-phase child-pop boundary an anchor resumes at (slice 1a, #393).
+/// Names the framework window whose close re-enters the Mythos driver.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MythosResume {
+    /// Post-step-1.4 (encounter draws done) window closed; run `mythos_phase_end`.
+    AfterDraws,
+}
+
+/// The Investigation-phase child-pop boundary (slice 1a, #393).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum InvestigationResume {
+    /// Post-2.1 window closed; begin the first investigator's turn.
+    Begins,
+    /// Post-2.2 turn-begins window closed; the investigator now acts (no
+    /// continuation work — slice 2 makes this an `InvestigatorTurn` frame).
+    TurnBegins,
+}
+
+/// The Enemy-phase child-pop boundary (slice 1a, #393).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EnemyResume {
+    /// Before-investigator-attacked window closed; resolve this investigator's
+    /// attacks (step 3.3).
+    BeforeInvestigatorAttacked,
+    /// After-all-investigators-attacked window closed; run `enemy_phase_end`.
+    AfterAllAttacked,
+}
+
+/// The Upkeep-phase child-pop boundary (slice 1a, #393).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum UpkeepResume {
+    /// Post-4.1 window closed; run `upkeep_resume` (steps 4.2–4.6).
+    Begins,
 }
 
 /// A skill test paused mid-resolution at the commit window.
@@ -1668,6 +1735,32 @@ mod location_id_counter_tests {
 mod continuation_stack_tests {
     use super::*;
     use crate::test_support::GameStateBuilder;
+
+    #[test]
+    fn phase_anchor_variants_round_trip_and_are_not_resolution_windows() {
+        let anchors = [
+            Continuation::MythosPhase {
+                resume: MythosResume::AfterDraws,
+            },
+            Continuation::InvestigationPhase {
+                resume: InvestigationResume::TurnBegins,
+            },
+            Continuation::EnemyPhase {
+                resume: EnemyResume::BeforeInvestigatorAttacked,
+            },
+            Continuation::UpkeepPhase {
+                resume: UpkeepResume::Begins,
+            },
+        ];
+        for a in anchors {
+            // Anchors are framework frames, never reaction windows.
+            assert!(a.as_resolution().is_none());
+            // Serializable like every other frame.
+            let json = serde_json::to_string(&a).unwrap();
+            let back: Continuation = serde_json::from_str(&json).unwrap();
+            assert_eq!(a, back);
+        }
+    }
 
     #[test]
     fn continuations_default_empty_and_absent_field_loads() {

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -25,10 +25,11 @@ pub(crate) use counter::define_id;
 pub use enemy::{Enemy, EnemyId};
 pub use game_state::{
     Act, ActRoundEndPending, Agenda, AttackLoopPhase, CandidateSource, ChoiceFrame, Continuation,
-    EnemyAttackSource, FastActorScope, FinishContinuation, ForcedContinuation, GameState,
-    HandSizeDiscard, HunterChoice, InFlightSkillTest, PendingEnemyAttack, PendingSkillModifier,
-    PhaseStep, ResolutionCandidate, ResolutionFrame, ResolutionKind, RoundEndAdvance,
-    SkillSubstitution, SkillTestFollowUp, SpawnEngagePending, WindowBinding, WindowKind,
+    EnemyAttackSource, EnemyResume, FastActorScope, FinishContinuation, ForcedContinuation,
+    GameState, HandSizeDiscard, HunterChoice, InFlightSkillTest, InvestigationResume, MythosResume,
+    PendingEnemyAttack, PendingSkillModifier, PhaseStep, ResolutionCandidate, ResolutionFrame,
+    ResolutionKind, RoundEndAdvance, SkillSubstitution, SkillTestFollowUp, SpawnEngagePending,
+    UpkeepResume, WindowBinding, WindowKind,
 };
 pub use investigator::{DefeatCause, Investigator, InvestigatorId, Status};
 pub use location::{Location, LocationId};

--- a/crates/game-core/src/test_support/assertions.rs
+++ b/crates/game-core/src/test_support/assertions.rs
@@ -26,6 +26,7 @@
 //! use game_core::{
 //!     apply, Action, Event, InvestigatorId, PlayerAction, Phase,
 //!     assert_event, assert_no_event,
+//!     state::{Continuation, InvestigationResume},
 //!     test_support::{test_investigator, GameStateBuilder},
 //! };
 //!
@@ -33,6 +34,10 @@
 //!     .with_phase(Phase::Investigation)
 //!     .with_investigator(test_investigator(1))
 //!     .with_active_investigator(InvestigatorId(1))
+//!     // A state constructed mid-phase needs its phase anchor (slice 1a).
+//!     .with_phase_anchor(Continuation::InvestigationPhase {
+//!         resume: InvestigationResume::TurnBegins,
+//!     })
 //!     .build();
 //! let result = apply(state, Action::Player(PlayerAction::EndTurn));
 //!

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -760,6 +760,9 @@ mod tests {
             .with_location(test_location(10, "Study"))
             .with_active_investigator(id)
             .with_turn_order([id, InvestigatorId(2)])
+            .with_phase_anchor(crate::state::Continuation::InvestigationPhase {
+                resume: crate::state::InvestigationResume::TurnBegins,
+            })
             .session()
             .apply(Action::Player(PlayerAction::EndTurn))
             .resolve_choices(|c| {

--- a/crates/game-core/tests/act_round_end.rs
+++ b/crates/game-core/tests/act_round_end.rs
@@ -19,6 +19,10 @@ fn parked_window_state(clues: u8) -> GameState {
         .with_investigator(test_investigator(1))
         .with_turn_order([inv])
         .with_phase(Phase::Upkeep)
+        // UpkeepPhase anchor (slice 1a): the round-end teardown pops it.
+        .with_phase_anchor(game_core::state::Continuation::UpkeepPhase {
+            resume: game_core::state::UpkeepResume::Begins,
+        })
         .with_location(Location::new(
             LocationId(2),
             CardCode("01112".into()),

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -488,6 +488,11 @@ fn end_turn_fires_end_of_turn_forced_for_the_ending_investigator() {
         .with_phase(Phase::Investigation)
         .with_active_investigator(InvestigatorId(1))
         .with_turn_order([InvestigatorId(1)])
+        // Mid-Investigation invariant (slice 1a): the EndTurn cascade pops the
+        // InvestigationPhase anchor at investigation_phase_end.
+        .with_phase_anchor(game_core::state::Continuation::InvestigationPhase {
+            resume: game_core::state::InvestigationResume::TurnBegins,
+        })
         .build();
 
     let result = apply(state, Action::Player(PlayerAction::EndTurn));

--- a/crates/game-core/tests/round_ended.rs
+++ b/crates/game-core/tests/round_ended.rs
@@ -113,6 +113,11 @@ fn two_round_end_forced_suspend_then_resume_the_upkeep_tail() {
         .with_phase(Phase::Investigation)
         .with_active_investigator(InvestigatorId(1))
         .with_turn_order([InvestigatorId(1)])
+        // Mid-Investigation invariant (slice 1a): the EndTurn cascade pops the
+        // InvestigationPhase anchor at investigation_phase_end.
+        .with_phase_anchor(game_core::state::Continuation::InvestigationPhase {
+            resume: game_core::state::InvestigationResume::TurnBegins,
+        })
         .build();
     state.agenda_deck = vec![Agenda {
         code: CardCode::new(AGENDA),

--- a/crates/scenarios/tests/hunter_movement.rs
+++ b/crates/scenarios/tests/hunter_movement.rs
@@ -36,6 +36,13 @@ fn multi_investigator_spawn_engagement_resolves_via_lead_pick() {
     // Drive through the real Mythos draw path: stage the EncounterDraw loop
     // frame for inv1 so the ResolveInput(Confirm) below resumes it (#348).
     state.phase = Phase::Mythos;
+    // Mythos anchor (slice 1a) sits beneath the EncounterDraw loop; the
+    // post-1.4 MythosAfterDraws close routes to it.
+    state
+        .continuations
+        .push(game_core::state::Continuation::MythosPhase {
+            resume: game_core::state::MythosResume::AfterDraws,
+        });
     state
         .continuations
         .push(game_core::state::Continuation::EncounterDraw {
@@ -122,6 +129,11 @@ fn hunter_movement_pick_location_replays_identically() {
             .with_active_investigator(InvestigatorId(1))
             .with_turn_order([InvestigatorId(1)])
             .with_enemy(hunter)
+            // Mid-Investigation invariant (slice 1a): the end_turn cascade pops
+            // the InvestigationPhase anchor at investigation_phase_end.
+            .with_phase_anchor(game_core::state::Continuation::InvestigationPhase {
+                resume: game_core::state::InvestigationResume::TurnBegins,
+            })
             .build()
     }
 

--- a/docs/superpowers/plans/2026-06-20-phase-anchors-1a.md
+++ b/docs/superpowers/plans/2026-06-20-phase-anchors-1a.md
@@ -1,5 +1,7 @@
 # Phase Anchor Frames (slice 1a) Implementation Plan
 
+> **Status: ✅ shipped (PR #397).** All six tasks executed inline; behaviour-preserving (review-confirmed faithful), full gauntlet green. Note: Task 3 (Investigation) expanded well beyond plan — introducing the anchor made "anchor on the stack throughout a phase" a real invariant, so ~20 tests that construct mid-phase states directly needed the new `GameStateBuilder::with_phase_anchor` helper.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Make each game phase a real continuation-stack frame (a `*Phase` *anchor*) that owns "what runs after a framework window closes," relocating `run_window_continuation`'s six `PlayerWindow(PhaseStep)` arms onto the anchors — behaviour-preserving.

--- a/docs/superpowers/plans/2026-06-20-phase-anchors-1a.md
+++ b/docs/superpowers/plans/2026-06-20-phase-anchors-1a.md
@@ -1,0 +1,445 @@
+# Phase Anchor Frames (slice 1a) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make each game phase a real continuation-stack frame (a `*Phase` *anchor*) that owns "what runs after a framework window closes," relocating `run_window_continuation`'s six `PlayerWindow(PhaseStep)` arms onto the anchors — behaviour-preserving.
+
+**Architecture:** Today the phase cascade runs synchronously inside handlers, and `run_window_continuation` (reaction_windows.rs) is a `match WindowKind` whose six `PlayerWindow(PhaseStep)` arms encode the phase-transition continuations. This slice introduces four `Continuation` anchor variants (`MythosPhase`/`InvestigationPhase`/`EnemyPhase`/`UpkeepPhase`), each carrying a per-phase `resume` enum naming its child-pop boundaries. At phase entry the driver pushes the anchor; before opening a framework window it sets the anchor's `resume` to the matching boundary; when that window closes, the close path routes to the anchor's `on_child_pop`, which reads `resume` and runs the relocated logic. The anchor is a real stack frame from day one (not a dispatch table). The synchronous cascade itself is untouched here (that is slice 1b); the guard ladder and action `match` are untouched (slice 1c / slice 2). Card-reaction arms of `run_window_continuation` stay put.
+
+**Tech Stack:** Rust; `game-core` engine (event-sourced `apply`, serializable `Continuation` enum); `TestGame`/`GameStateBuilder` unit harness + `assert_event!` macros; `cargo test`/clippy/fmt/doc gauntlet.
+
+## Global Constraints
+
+- **Behaviour-preserving:** the entire existing engine + integration suite must stay green at every task boundary. This slice changes *structure*, not rules. No event stream changes.
+- **Handler contract:** validate-first / mutate-second; on `Rejected`, state + events unchanged.
+- **Serializable enum, not trait objects:** `Continuation` derives `Debug, Clone, PartialEq, Eq, Serialize, Deserialize`; every new variant + `resume` enum must derive the same. No `Box<dyn …>`.
+- **Closed, kernel-owned frame set:** anchors live in `game-core`; `cards`/`scenarios` never define them.
+- **CI (strict):** `RUSTFLAGS="-D warnings" cargo test --all --all-features`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo fmt --check`; `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`.
+- **Commit style:** `engine: <description>`; body explains *why*; ends with `Refs #393.` (this slice does not close #393).
+- **Branch:** `engine/phase-anchors`.
+
+---
+
+## File Structure
+
+- `crates/game-core/src/state/game_state.rs` — add the four anchor variants + four `*Resume` enums to `Continuation`; extend `as_resolution`/`as_resolution_mut` with the new arms (return `None`). Add an `on_child_pop_resume()` accessor if convenient. (~80 lines added.)
+- `crates/game-core/src/engine/dispatch/phases.rs` — push the anchor at each phase entry; set `resume` before each framework-window open; add the per-phase `on_child_pop` bodies (the relocated arm logic, called from the close router). This is the bulk.
+- `crates/game-core/src/engine/dispatch/reaction_windows.rs` — `run_window_continuation`'s six `PlayerWindow(PhaseStep)` arms route to the top anchor's `on_child_pop` instead of running inline; the card-reaction arms are unchanged.
+- `crates/game-core/src/engine/dispatch/mod.rs` — `resolve_input`'s top-frame `match` gets four new arms (anchors never `await` input → `Rejected` "no prompt outstanding", mirroring the `EncounterCard` arm).
+
+## Mechanism reference (read before Task 1)
+
+The six arms and destinations (current bodies in reaction_windows.rs:966–1101):
+
+| `PhaseStep` (window that closed) | Relocated body | Anchor / `resume` |
+|---|---|---|
+| `MythosAfterDraws` | skill-test-in-flight `unreachable!` guard, then `phases::mythos_phase_end(cx)` | `MythosPhase` / `MythosResume::AfterDraws` |
+| `UpkeepBegins` | guard, then `phases::upkeep_resume(cx)` | `UpkeepPhase` / `UpkeepResume::Begins` |
+| `BeforeInvestigatorAttacked` | guard, read `enemy_attack_pending` (`unreachable!` if `None`), `combat::resolve_attacks_for_investigator`, propagate `AwaitingInput` without advancing, else cursor-advance via `after_enemy_phase_attacks(cx, investigator)` | `EnemyPhase` / `EnemyResume::BeforeInvestigatorAttacked` |
+| `AfterAllInvestigatorsAttacked` | guard, then `phases::enemy_phase_end(cx)` | `EnemyPhase` / `EnemyResume::AfterAllAttacked` |
+| `InvestigationBegins` | `if let Some(id) = cursor::first_active_investigator { begin_investigator_turn(cx, id) }` else `Done` | `InvestigationPhase` / `InvestigationResume::Begins` |
+| `InvestigatorTurnBegins` | `Done` | `InvestigationPhase` / `InvestigationResume::TurnBegins` |
+
+The card-reaction arms (`AfterEnemyDefeated`/`AfterSuccessfulInvestigate`/`AfterEnteredPlay`/`AfterEnemyAttackDamagedAsset`/`BeforeEnemyAttack`/`BeforeDiscoverClues`) are **not** phase-structure — leave them exactly as-is.
+
+The phase-entry / window-open sites that must push the anchor + set `resume` (phases.rs):
+- `mythos_phase` (~354): pushes `MythosPhase` at entry; the `MythosAfterDraws` window is opened after step 1.4 — set `resume = AfterDraws` there.
+- `investigation_phase` (289): push `InvestigationPhase`; `InvestigationBegins` window (300) → `resume = Begins`. `begin_investigator_turn` (321): `InvestigatorTurnBegins` window (323) → `resume = TurnBegins`.
+- `enemy_phase` (531): push `EnemyPhase`; `enemy_attack_kickoff` (499) opens `BeforeInvestigatorAttacked`/`AfterAllInvestigatorsAttacked` → set the matching `resume` at each open site.
+- `upkeep_phase` (617): push `UpkeepPhase`; `UpkeepBegins` window → `resume = Begins`.
+
+**The anchor pops** when its phase transitions away. Today each phase's `*_end` helper (`mythos_phase_end`, `enemy_phase_end`, `upkeep_phase_end`, `investigation_phase_end`) emits `PhaseEnded` and calls `step_phase`/the next driver. Add a single `cx.state.continuations.pop()` of the anchor at the top of each `*_end` helper (the anchor is the top frame once its last child window has closed). Verify the anchor is the top frame with a `debug_assert!`.
+
+---
+
+## Task 1: Add the four anchor variants + `*Resume` enums
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (the `Continuation` enum ~417–499; `as_resolution` ~528–545; `as_resolution_mut` ~548–560)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (`resolve_input` match ~414–438)
+
+**Interfaces:**
+- Produces:
+  - `Continuation::MythosPhase { resume: MythosResume }`
+  - `Continuation::InvestigationPhase { resume: InvestigationResume }`
+  - `Continuation::EnemyPhase { resume: EnemyResume }`
+  - `Continuation::UpkeepPhase { resume: UpkeepResume }`
+  - `enum MythosResume { AfterDraws }`
+  - `enum InvestigationResume { Begins, TurnBegins }`
+  - `enum EnemyResume { BeforeInvestigatorAttacked, AfterAllAttacked }`
+  - `enum UpkeepResume { Begins }`
+
+- [ ] **Step 1: Write the failing test**
+
+In `game_state.rs`'s `#[cfg(test)] mod continuation_stack_tests` (near line 1668), add:
+
+```rust
+#[test]
+fn phase_anchor_variants_round_trip_and_are_not_resolution_windows() {
+    use super::{Continuation, EnemyResume, InvestigationResume, MythosResume, UpkeepResume};
+    let anchors = [
+        Continuation::MythosPhase { resume: MythosResume::AfterDraws },
+        Continuation::InvestigationPhase { resume: InvestigationResume::TurnBegins },
+        Continuation::EnemyPhase { resume: EnemyResume::BeforeInvestigatorAttacked },
+        Continuation::UpkeepPhase { resume: UpkeepResume::Begins },
+    ];
+    for a in anchors {
+        // Anchors are framework frames, never reaction windows.
+        assert!(a.as_resolution().is_none());
+        // Serializable like every other frame.
+        let json = serde_json::to_string(&a).unwrap();
+        let back: Continuation = serde_json::from_str(&json).unwrap();
+        assert_eq!(a, back);
+    }
+}
+```
+
+- [ ] **Step 2: Run it — verify it fails to compile (variants don't exist)**
+
+Run: `cargo test -p game-core --lib phase_anchor_variants_round_trip 2>&1 | head`
+Expected: compile error, `no variant named MythosPhase`.
+
+- [ ] **Step 3: Add the variants and enums**
+
+In `game_state.rs`, add to the `Continuation` enum (after the `EncounterCard` variant, before the closing `}` at ~499):
+
+```rust
+    /// The Mythos phase anchor (slice 1a). Pushed at Mythos entry; sits beneath
+    /// the phase's framework windows. On a child window's close the framework
+    /// routes to its `on_child_pop` (keyed by `resume`). Never awaits input.
+    MythosPhase { resume: MythosResume },
+    /// The Investigation phase anchor (slice 1a). See [`Continuation::MythosPhase`].
+    InvestigationPhase { resume: InvestigationResume },
+    /// The Enemy phase anchor (slice 1a). See [`Continuation::MythosPhase`].
+    EnemyPhase { resume: EnemyResume },
+    /// The Upkeep phase anchor (slice 1a). See [`Continuation::MythosPhase`].
+    UpkeepPhase { resume: UpkeepResume },
+```
+
+Add the four `resume` enums after the `Continuation` enum's `impl` block (near the `ChoiceFrame` definitions, ~500):
+
+```rust
+/// The Mythos-phase child-pop boundary an anchor resumes at (slice 1a). Names
+/// the framework windows whose close re-enters the Mythos driver.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MythosResume {
+    /// Post-step-1.4 (encounter draws done) window closed; run `mythos_phase_end`.
+    AfterDraws,
+}
+
+/// The Investigation-phase child-pop boundary (slice 1a).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum InvestigationResume {
+    /// Post-2.1 window closed; begin the first investigator's turn.
+    Begins,
+    /// Post-2.2 turn-begins window closed; the investigator now acts (no
+    /// continuation work — slice 2 makes this an `InvestigatorTurn` frame).
+    TurnBegins,
+}
+
+/// The Enemy-phase child-pop boundary (slice 1a).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EnemyResume {
+    /// Before-investigator-attacked window closed; resolve this investigator's
+    /// attacks (step 3.3).
+    BeforeInvestigatorAttacked,
+    /// After-all-investigators-attacked window closed; run `enemy_phase_end`.
+    AfterAllAttacked,
+}
+
+/// The Upkeep-phase child-pop boundary (slice 1a).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum UpkeepResume {
+    /// Post-4.1 window closed; run `upkeep_resume` (steps 4.2–4.6).
+    Begins,
+}
+```
+
+Extend `as_resolution` and `as_resolution_mut` (the long match arms that return `None`): add `Continuation::MythosPhase { .. } | Continuation::InvestigationPhase { .. } | Continuation::EnemyPhase { .. } | Continuation::UpkeepPhase { .. }` to the existing `None`-returning arm list in both.
+
+In `dispatch/mod.rs` `resolve_input` (the `match cx.state.continuations.last()`), add an arm before `None`:
+
+```rust
+        // Phase anchors (slice 1a) never await input — they only sit beneath
+        // framework windows. If one is somehow top, no prompt is outstanding.
+        Some(
+            Continuation::MythosPhase { .. }
+            | Continuation::InvestigationPhase { .. }
+            | Continuation::EnemyPhase { .. }
+            | Continuation::UpkeepPhase { .. },
+        ) => EngineOutcome::Rejected {
+            reason: "ResolveInput: no input prompt is outstanding (a phase anchor is top)".into(),
+        },
+```
+
+- [ ] **Step 4: Run — verify the test passes and the workspace compiles**
+
+Run: `cargo test -p game-core --lib phase_anchor_variants_round_trip 2>&1 | tail`
+Expected: PASS. Then `cargo build -p game-core 2>&1 | tail` — expect clean (all exhaustive `Continuation` matches updated; if the compiler flags another non-exhaustive match, add the four anchors to its `None`/unreachable arm).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/game-core/src/state/game_state.rs crates/game-core/src/engine/dispatch/mod.rs
+git commit -m "engine: add *Phase anchor Continuation variants + resume enums (1a)
+
+Inert frames so far — no driver pushes them yet. Refs #393."
+```
+
+---
+
+## Task 2: Relocate the Mythos arm + push/pop the `MythosPhase` anchor
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/phases.rs` (`mythos_phase` ~354; `mythos_phase_end` ~ its definition; the `MythosAfterDraws` window-open site)
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (`MythosAfterDraws` arm ~969)
+- Test: `crates/game-core/src/engine/dispatch/phases.rs` `#[cfg(test)]`
+
+**Interfaces:**
+- Produces: `phases::anchor_on_child_pop(cx: &mut Cx) -> EngineOutcome` — reads the top `*Phase` anchor's `resume` and runs the relocated body. Added incrementally (Mythos arm first; later tasks extend its match).
+- Consumes: `Continuation::MythosPhase`, `MythosResume` (Task 1).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `phases.rs` tests:
+
+```rust
+#[test]
+fn mythos_anchor_on_stack_during_phase_and_popped_at_end() {
+    // A Mythos phase pushes its anchor; after the post-1.4 window closes and
+    // mythos_phase_end runs, the anchor is gone and we've moved to Investigation.
+    let mut state = GameStateBuilder::new()
+        .with_investigator(test_investigator(1))
+        .with_turn_order([InvestigatorId(1)])
+        .with_active_investigator(InvestigatorId(1))
+        .with_phase(Phase::Upkeep) // step_phase Upkeep->Mythos enters mythos_phase
+        .build();
+    state.round = 1;
+    let mut events = Vec::new();
+    // Drive Upkeep->Mythos so mythos_phase runs and pushes the anchor.
+    let _ = step_phase(&mut Cx { state: &mut state, events: &mut events });
+    assert!(
+        state.continuations.iter().any(|c| matches!(c, Continuation::MythosPhase { .. })),
+        "MythosPhase anchor pushed during the Mythos phase",
+    );
+}
+```
+
+(Adjust the build/`step_phase` drive to match the existing `round_increments_on_mythos_entry_via_driver` test's setup if the encounter-draw prompt requires an encounter deck; reuse that test's fixture pattern.)
+
+- [ ] **Step 2: Run — verify it fails**
+
+Run: `cargo test -p game-core --lib mythos_anchor_on_stack 2>&1 | tail`
+Expected: FAIL (no anchor on the stack — nothing pushes it yet).
+
+- [ ] **Step 3: Push the anchor, set `resume`, relocate the arm**
+
+In `phases.rs` `mythos_phase`, immediately after `cx.events.push(Event::PhaseStarted { phase: Phase::Mythos });`, push the anchor:
+
+```rust
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::MythosPhase {
+            resume: crate::state::MythosResume::AfterDraws,
+        });
+```
+
+(`AfterDraws` is the only Mythos boundary, so it can be set at entry.)
+
+In `phases.rs`, add the relocated body as the first arm of a new `anchor_on_child_pop`:
+
+```rust
+/// Run the top `*Phase` anchor's continuation after one of its framework
+/// windows closed (slice 1a). The window has already been popped by the
+/// close path; the anchor is now the top frame. Reads the anchor's `resume`
+/// to pick the relocated body. Suspension-agnostic: a body that itself
+/// suspends returns `AwaitingInput` unchanged.
+pub(super) fn anchor_on_child_pop(cx: &mut Cx) -> EngineOutcome {
+    use crate::state::{Continuation, MythosResume};
+    match cx.state.continuations.last() {
+        Some(Continuation::MythosPhase { resume: MythosResume::AfterDraws }) => {
+            if let Some(in_flight) = cx.state.current_skill_test() {
+                unreachable!(
+                    "MythosAfterDraws closed while a skill test is in flight \
+                     (continuation={:?}); Phase 4 has no Mythos-phase skill-test sources",
+                    in_flight.continuation,
+                );
+            }
+            mythos_phase_end(cx)
+        }
+        other => unreachable!("anchor_on_child_pop: top frame is not a known phase anchor: {other:?}"),
+    }
+}
+```
+
+In `mythos_phase_end`, pop the anchor as the first statement (it is the top frame once `MythosAfterDraws` closed):
+
+```rust
+    debug_assert!(
+        matches!(cx.state.continuations.last(), Some(crate::state::Continuation::MythosPhase { .. })),
+        "mythos_phase_end: expected MythosPhase anchor on top",
+    );
+    cx.state.continuations.pop();
+```
+
+In `reaction_windows.rs`, replace the `MythosAfterDraws` arm body (the guard + `mythos_phase_end(cx)`) with:
+
+```rust
+            PhaseStep::MythosAfterDraws => super::phases::anchor_on_child_pop(cx),
+```
+
+- [ ] **Step 4: Run — verify the new test + the full Mythos suite pass**
+
+Run:
+```bash
+cargo test -p game-core --lib 'dispatch::phases'
+cargo test -p game-core mythos
+cargo test -p scenarios --test mythos_phase
+```
+Expected: all PASS (behaviour-preserving — the anchor pop + relocation produce the identical cascade and event stream).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/phases.rs crates/game-core/src/engine/dispatch/reaction_windows.rs
+git commit -m "engine: Mythos phase anchor + relocate MythosAfterDraws (1a)
+
+Refs #393."
+```
+
+---
+
+## Task 3: Relocate the Investigation arms + anchor (`InvestigationBegins`, `InvestigatorTurnBegins`)
+
+**Files:** `phases.rs` (`investigation_phase` ~289, `begin_investigator_turn` ~321, `investigation_phase_end` ~339), `reaction_windows.rs` (the two arms ~1073, ~1100).
+
+**Interfaces:** Consumes `Continuation::InvestigationPhase`, `InvestigationResume`. Extends `anchor_on_child_pop` with the Investigation arms.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn investigation_anchor_on_stack_through_turn() {
+    let id = InvestigatorId(1);
+    let mut state = GameStateBuilder::new()
+        .with_investigator(test_investigator(1))
+        .with_turn_order([id])
+        .with_active_investigator(id)
+        .with_phase(Phase::Mythos)
+        .build();
+    let mut events = Vec::new();
+    // Mythos->Investigation via step_phase enters investigation_phase.
+    // (Use the existing investigation_phase test fixture if a cleaner entry exists.)
+    investigation_phase(&mut Cx { state: &mut state, events: &mut events });
+    assert!(
+        state.continuations.iter().any(|c| matches!(c, Continuation::InvestigationPhase { .. })),
+        "InvestigationPhase anchor pushed",
+    );
+}
+```
+
+- [ ] **Step 2: Run — verify it fails**
+
+Run: `cargo test -p game-core --lib investigation_anchor_on_stack 2>&1 | tail`
+Expected: FAIL.
+
+- [ ] **Step 3: Push anchor + set resume + relocate both arms**
+
+In `investigation_phase`, after `PhaseStarted(Investigation)` push:
+```rust
+    cx.state.continuations.push(crate::state::Continuation::InvestigationPhase {
+        resume: crate::state::InvestigationResume::Begins,
+    });
+```
+In `begin_investigator_turn`, before opening the `InvestigatorTurnBegins` window, set the anchor's resume:
+```rust
+    if let Some(crate::state::Continuation::InvestigationPhase { resume }) =
+        cx.state.continuations.iter_mut().rev().find(|c| matches!(c, crate::state::Continuation::InvestigationPhase { .. }))
+    {
+        *resume = crate::state::InvestigationResume::TurnBegins;
+    }
+```
+Add the Investigation arms to `anchor_on_child_pop`'s match:
+```rust
+        Some(Continuation::InvestigationPhase { resume: InvestigationResume::Begins }) => {
+            if let Some(id) = super::cursor::first_active_investigator(cx.state) {
+                begin_investigator_turn(cx, id);
+            }
+            EngineOutcome::Done
+        }
+        Some(Continuation::InvestigationPhase { resume: InvestigationResume::TurnBegins }) => {
+            // 2.2.1 — the investigator acts as player-driven input; no
+            // continuation work (slice 2 makes this an InvestigatorTurn frame).
+            EngineOutcome::Done
+        }
+```
+In `investigation_phase_end`, pop the anchor (debug_assert it is top) before `PhaseEnded(Investigation)` + `step_phase`.
+In `reaction_windows.rs`, replace both arms' bodies with `=> super::phases::anchor_on_child_pop(cx),`.
+
+- [ ] **Step 4: Run**
+```bash
+cargo test -p game-core --lib 'dispatch::phases'
+cargo test -p scenarios --test the_gathering
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit** `engine: Investigation phase anchor + relocate its two arms (1a). Refs #393.`
+
+---
+
+## Task 4: Relocate the Enemy arms + anchor (`BeforeInvestigatorAttacked`, `AfterAllInvestigatorsAttacked`)
+
+**Files:** `phases.rs` (`enemy_phase` ~531, `enemy_attack_kickoff` ~499, `enemy_phase_end`), `reaction_windows.rs` (arms ~1006, ~1059).
+
+**Interfaces:** Consumes `Continuation::EnemyPhase`, `EnemyResume`. Extends `anchor_on_child_pop`. **Note** the `BeforeInvestigatorAttacked` arm's mid-loop `AwaitingInput` propagation (soak window) must be preserved exactly — copy the body verbatim from reaction_windows.rs:1006–1057 into the anchor arm, replacing only the surrounding `match`.
+
+- [ ] **Step 1: Write the failing test** — anchor present during the enemy phase (mirror Task 3's shape, entering via `enemy_phase`).
+- [ ] **Step 2: Run — fails.**
+- [ ] **Step 3:** Push `EnemyPhase` anchor in `enemy_phase` after `PhaseStarted(Enemy)`. In `enemy_attack_kickoff`, set `resume = BeforeInvestigatorAttacked` before the `BeforeInvestigatorAttacked` open and `resume = AfterAllAttacked` before the `AfterAllInvestigatorsAttacked` open (and at the advance site in the relocated body). Copy the two arm bodies (verbatim, incl. the skill-test guards, the `enemy_attack_pending` read, and the no-advance `AwaitingInput` propagation) into `anchor_on_child_pop`. Pop the anchor in `enemy_phase_end`. Route both reaction_windows arms to `anchor_on_child_pop`.
+- [ ] **Step 4: Run** `cargo test -p game-core 'dispatch'` + `cargo test -p scenarios --test the_gathering` + the enemy-phase engagement tests. Expected: PASS.
+- [ ] **Step 5: Commit** `engine: Enemy phase anchor + relocate its two arms (1a). Refs #393.`
+
+---
+
+## Task 5: Relocate the Upkeep arm + anchor (`UpkeepBegins`)
+
+**Files:** `phases.rs` (`upkeep_phase` ~617, `upkeep_resume` ~633, `upkeep_phase_end`), `reaction_windows.rs` (arm ~991).
+
+**Interfaces:** Consumes `Continuation::UpkeepPhase`, `UpkeepResume`. Extends `anchor_on_child_pop`.
+
+- [ ] **Step 1: Write the failing test** — `UpkeepPhase` anchor present during Upkeep (mirror Task 2).
+- [ ] **Step 2: Run — fails.**
+- [ ] **Step 3:** Push `UpkeepPhase { resume: Begins }` in `upkeep_phase` after `PhaseStarted(Upkeep)`. Add the `UpkeepResume::Begins => { guard; upkeep_resume(cx) }` arm to `anchor_on_child_pop`. Pop the anchor at the top of `upkeep_phase_end` (it was made `pub(crate)` in slice 0 — the pop is the first statement, `debug_assert!` it is top). Route the reaction_windows `UpkeepBegins` arm to `anchor_on_child_pop`.
+  - **Caution:** verify the anchor is the top frame at `upkeep_phase_end` *and* on the `resume_act_round_end_advance` → `upkeep_round_end_at_and_after` path (slice 0). The anchor is pushed at Upkeep entry and the `ActRoundEnd` window is pushed *above* it later, so by the time `upkeep_phase_end`/teardown runs, the anchor is top once the `ActRoundEnd` frame has popped. If the pop site is ambiguous, pop in `upkeep_round_end_teardown` (the single Upkeep→Mythos exit) instead of `upkeep_phase_end`, and `debug_assert!` there.
+- [ ] **Step 4: Run** `cargo test -p game-core upkeep` + `cargo test -p cards --test theyre_getting_out` + `cargo test -p scenarios --test upkeep_phase --test upkeep_hand_size`. Expected: PASS.
+- [ ] **Step 5: Commit** `engine: Upkeep phase anchor + relocate UpkeepBegins (1a). Refs #393.`
+
+---
+
+## Task 6: Tidy `run_window_continuation` + the slice gauntlet
+
+**Files:** `reaction_windows.rs` (the now-uniform `PlayerWindow(PhaseStep)` arm), spec.
+
+- [ ] **Step 1:** With all six arms routing to `anchor_on_child_pop`, collapse the `WindowKind::PlayerWindow(step) => match step { … }` into `WindowKind::PlayerWindow(_) => super::phases::anchor_on_child_pop(cx)` — the `PhaseStep` is no longer the continuation key (the anchor's `resume` is). Keep the `WindowKind::PlayerWindow` variant itself (it still names the window; slice 1b removes the step). Update the doc-comment to say the phase-structure continuation now lives on the `*Phase` anchors.
+- [ ] **Step 2: Run the full gauntlet**
+```bash
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+```
+Expected: all green.
+- [ ] **Step 3:** Update spec §"Sequencing" 1a line to `✅ shipped (PR #NN)` and the `What "done" looks like` note that `run_window_continuation`'s phase-structure arms are now anchor-owned (the `WindowKind` table for *card reactions* remains until later slices). Commit, push, open the PR (`engine/phase-anchors`), watch CI.
+
+---
+
+## Self-Review
+
+**Spec coverage (1a):** Task 1 adds the four anchor variants + resume enums; Tasks 2–5 relocate all six `PhaseStep` arms onto the anchors and push/pop the anchors at phase entry/exit; Task 6 collapses the dispatcher and runs the gauntlet. Guard ladder, action `match`, and card-reaction arms are explicitly untouched (deferred to 1b/1c/slice 2), matching the spec's 1a scope. ✓
+
+**Placeholder scan:** the relocation bodies are specified by exact source location + the instruction to copy verbatim (Task 4's `BeforeInvestigatorAttacked` body is the one large block — copied, not paraphrased). Tasks 3–5 abbreviate the TDD step prose (mirroring Task 2's fully-shown pattern) but give exact code for every *new* construct; the test-fixture entry is flagged to reuse the existing per-phase test setup rather than invent one. No "TODO"/"handle edge cases". ⚠ If executing strictly TDD, expand Tasks 3–5 Step-1 tests against the actual fixtures as you reach them.
+
+**Type consistency:** `anchor_on_child_pop(cx)` signature is stable across Tasks 2–6; the four `*Resume` enums and their variants are referenced identically everywhere; `Continuation::*Phase { resume }` field name `resume` is consistent. ✓
+
+**Behaviour-preserving check:** every relocated body is the current arm body unchanged (including the `unreachable!` skill-test guards and the soak-window `AwaitingInput` propagation); the only new runtime effect is the anchor push at entry + pop at exit, which is invisible to the event stream and to `resolve_input` (anchors reject as "no prompt"). The existing suite is the regression oracle at every task boundary. ✓

--- a/docs/superpowers/specs/2026-06-20-unified-control-flow-model-design.md
+++ b/docs/superpowers/specs/2026-06-20-unified-control-flow-model-design.md
@@ -417,13 +417,16 @@ Each step is independently green (mirrors §1's parts 2a–2c cadence):
    `AfterAllInvestigatorsAttacked`, `InvestigationBegins`, `InvestigatorTurnBegins` —
    are the phase-structure continuations the anchors own; its other arms are
    card/ability reactions that stay put):
-   - **1a — anchor frames + relocate the 6 `PhaseStep` arms.** Introduce the four
-     `*Phase` anchor `Continuation` variants + per-phase `resume` enums; push an
-     anchor onto the stack at each phase entry (windows/loops push *above* it); on a
-     window close, route to the anchor's `on_child_pop` instead of
-     `run_window_continuation`'s `PhaseStep` match. The anchor is a real stack frame
-     from day one (the "everything is a frame" model, not a delegation table). Guard
-     ladder, action `match`, and the card-reaction arms untouched.
+   - **1a — anchor frames + relocate the 6 `PhaseStep` arms. ✅ shipped (PR #397).**
+     Introduced the four `*Phase` anchor `Continuation` variants + per-phase `resume`
+     enums; each phase pushes its anchor at entry (windows/loops push *above* it) and
+     pops at its exit (Upkeep at `upkeep_round_end_teardown`, after the round-end
+     sequence); the `run_window_continuation` `PlayerWindow` match collapsed to a
+     single `PlayerWindow(_) => anchor_on_child_pop` arm — the `PhaseStep` is no
+     longer the continuation key, the anchor's `resume` is. Behaviour-preserving
+     (review-confirmed faithful). Added `GameStateBuilder::with_phase_anchor` for the
+     ~20 tests that construct mid-phase states directly. Guard ladder, action
+     `match`, card-reaction arms untouched.
    - **1b — fold the synchronous cascade onto anchor `drive`.** `step_phase`'s
      forward-calling cascade becomes each anchor *pushing* its phase's first child;
      the strand-guards become cheap asserts.

--- a/docs/superpowers/specs/2026-06-20-unified-control-flow-model-design.md
+++ b/docs/superpowers/specs/2026-06-20-unified-control-flow-model-design.md
@@ -407,10 +407,29 @@ checkpoint. Re-open #212 (or a successor) scoped to this.
 
 Each step is independently green (mirrors §1's parts 2a–2c cadence):
 
-0. **§G ordering bug** — standalone fix + regression test (pre-req).
-1. **Main-loop scaffold + `*Phase` anchors** — introduce the four anchor variants
-   and relocate `run_window_continuation`'s arms onto them; behaviour-preserving.
-   Strand-guards become asserts.
+0. **§G ordering bug** — standalone fix + regression test (pre-req). ✅ shipped
+   (PR #396, closes #395).
+1. **`*Phase` anchors + uniform main loop** — too large for one PR; decomposes into
+   three behaviour-preserving sub-slices (exploration found `apply()` runs one
+   action per call with a *synchronous* phase cascade, and `run_window_continuation`
+   is a `match WindowKind` whose **6 `PlayerWindow(PhaseStep)` arms** —
+   `MythosAfterDraws`, `UpkeepBegins`, `BeforeInvestigatorAttacked`,
+   `AfterAllInvestigatorsAttacked`, `InvestigationBegins`, `InvestigatorTurnBegins` —
+   are the phase-structure continuations the anchors own; its other arms are
+   card/ability reactions that stay put):
+   - **1a — anchor frames + relocate the 6 `PhaseStep` arms.** Introduce the four
+     `*Phase` anchor `Continuation` variants + per-phase `resume` enums; push an
+     anchor onto the stack at each phase entry (windows/loops push *above* it); on a
+     window close, route to the anchor's `on_child_pop` instead of
+     `run_window_continuation`'s `PhaseStep` match. The anchor is a real stack frame
+     from day one (the "everything is a frame" model, not a delegation table). Guard
+     ladder, action `match`, and the card-reaction arms untouched.
+   - **1b — fold the synchronous cascade onto anchor `drive`.** `step_phase`'s
+     forward-calling cascade becomes each anchor *pushing* its phase's first child;
+     the strand-guards become cheap asserts.
+   - **1c — uniform "handle the top frame" loop in `apply`.** Replace
+     `apply_player_action`'s ad-hoc recursion with the single-rule loop; the guard
+     ladder collapses to the top-frame rule (sets up slice 2's `InvestigatorTurn`).
 2. **`InvestigatorTurn` frame (2a) + legal-action enumerator** — open-turn becomes a
    frame; guard ladder + action `match` deleted; typed `PlayerAction` validated
    against the offered set; `pending_end_turn` absorbed.


### PR DESCRIPTION
## What

**Slice 1a** of the unified control-flow model (#393): make each game phase a real continuation-stack frame (a `*Phase` *anchor*) that owns "what runs after a framework window closes," relocating `run_window_continuation`'s six `PlayerWindow(PhaseStep)` arms onto the anchors. **Behaviour-preserving** — the entire existing suite + full gauntlet stay green; this changes *structure*, not rules.

Design: [`2026-06-20-unified-control-flow-model-design.md`](docs/superpowers/specs/2026-06-20-unified-control-flow-model-design.md) (§"Sequencing" 1a). Plan: [`2026-06-20-phase-anchors-1a.md`](docs/superpowers/plans/2026-06-20-phase-anchors-1a.md).

## How (the mechanism)

- Four `Continuation` anchor variants (`MythosPhase`/`InvestigationPhase`/`EnemyPhase`/`UpkeepPhase`), each carrying a per-phase `resume` enum naming its child-pop boundaries.
- At phase entry the driver **pushes** the anchor (windows/loops push *above* it); before opening a framework window it sets the anchor's `resume`; on the window's close the framework routes to the anchor's `on_child_pop`, which reads `resume` and runs the relocated body. Popped at the phase's exit.
- `run_window_continuation`'s `PlayerWindow(step)` match **collapses to one arm** — `PlayerWindow(_) => anchor_on_child_pop` — the `PhaseStep` is no longer the continuation key; the anchor's `resume` is. The card-reaction arms (`AfterEnemyDefeated`, soak, `BeforeDiscoverClues`, …) are untouched.
- The Enemy `BeforeInvestigatorAttacked` body (incl. the mid-loop soak-window `AwaitingInput` propagation) is relocated **verbatim**. The Upkeep anchor pops at `upkeep_round_end_teardown` (the single Upkeep→Mythos exit, after slice 0's round-end sequence).

## New invariant + test impact

Introducing the anchor makes "the phase anchor is on the stack throughout a phase" a **real invariant**. Many unit/integration tests construct a mid-phase state *directly* (bypassing the phase driver) and drive `EndTurn` / the attack loop / the round-end, so they tripped the anchor assertions. Added `GameStateBuilder::with_phase_anchor(...)` (stages an anchor at the **bottom** of the stack) and updated each such test faithfully — the anchor genuinely belongs in those states.

## Scope (what's deferred)

Guard ladder, action `match`, and the synchronous phase cascade are **untouched** (slices 1b/1c). This slice only relocates the window-close continuations onto anchors. Does not close #393.

## Verification

Full local gauntlet green: `test --all`, `clippy --all-targets`, `fmt --check`, `doc`, `wasm-build`.

Refs #393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)