### PR TITLE
engine: unified main loop + cascade-fold (slice 1b of #393)

### DIFF
--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -1106,13 +1106,16 @@ mod hunter_resume_tests {
         ));
         // Resume by picking C.
         let mut ev2 = Vec::new();
-        let resumed = super::super::resolve_input(
-            &mut crate::engine::Cx {
+        let resumed = {
+            let mut cx = crate::engine::Cx {
                 state: &mut state,
                 events: &mut ev2,
-            },
-            &pick(&outcome, LocationId(3)),
-        );
+            };
+            // resolve_input resumes the tie; drive then carries the Enemy→Upkeep
+            // →Mythos cascade forward (slice 1b), as the apply boundary does.
+            let o = super::super::resolve_input(&mut cx, &pick(&outcome, LocationId(3)));
+            super::super::drive(&mut cx, o)
+        };
         // Resolving the tie continues the Enemy phase; with no registry the
         // attack windows auto-skip and the cascade runs to Mythos, pausing at
         // the step-1.4 encounter-draw prompt (AwaitingInput).
@@ -1219,13 +1222,14 @@ mod hunter_resume_tests {
         );
         assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
         let mut ev2 = Vec::new();
-        let resumed = super::super::resolve_input(
-            &mut crate::engine::Cx {
+        let resumed = {
+            let mut cx = crate::engine::Cx {
                 state: &mut state,
                 events: &mut ev2,
-            },
-            &pick(&outcome, InvestigatorId(2)),
-        );
+            };
+            let o = super::super::resolve_input(&mut cx, &pick(&outcome, InvestigatorId(2)));
+            super::super::drive(&mut cx, o) // slice 1b: complete the Enemy→… cascade
+        };
         // Resolving the tie continues the Enemy phase; with no registry the
         // attack windows auto-skip and the cascade runs to Mythos, pausing at
         // the step-1.4 encounter-draw prompt (AwaitingInput).
@@ -1337,13 +1341,14 @@ mod hunter_resume_tests {
         assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
         // Resolve hunter 1's tie -> hunter 2 then moves B->D and engages.
         let mut ev2 = Vec::new();
-        let resumed = super::super::resolve_input(
-            &mut crate::engine::Cx {
+        let resumed = {
+            let mut cx = crate::engine::Cx {
                 state: &mut state,
                 events: &mut ev2,
-            },
-            &pick(&outcome, LocationId(2)),
-        );
+            };
+            let o = super::super::resolve_input(&mut cx, &pick(&outcome, LocationId(2)));
+            super::super::drive(&mut cx, o) // slice 1b: complete the Enemy→… cascade
+        };
         // Resolving the tie continues the Enemy phase; with no registry the
         // attack windows auto-skip and the cascade runs to Mythos, pausing at
         // the step-1.4 encounter-draw prompt (AwaitingInput).

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -59,131 +59,27 @@ pub(crate) mod threat_area;
 /// so callers and tests get a useful signal rather than a silent no-op.
 #[allow(clippy::too_many_lines)] // dispatcher: a guard ladder + one match arm per PlayerAction
 pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome {
-    // While the setup mulligan loop is in progress (a `Mulligan` frame is on
-    // top of the stack), only `ResolveInput` can advance the engine. Per the
-    // Rules Reference, "after all players have completed their mulligans, the
-    // game begins" — the engine enforces that by gating other actions until
-    // every investigator has submitted their mulligan choice. Setup-only;
-    // never coexists with the other suspension modes, so guard order is
-    // immaterial.
-    if matches!(
-        cx.state.continuations.last(),
-        Some(crate::state::Continuation::Mulligan { .. })
-    ) && !matches!(action, PlayerAction::ResolveInput { .. })
-    {
-        return EngineOutcome::Rejected {
-            reason: "a setup mulligan is pending; investigators must submit a \
-                     PlayerAction::ResolveInput with InputResponse::PickMultiple (the hand indices \
-                     to redraw, empty to keep their hand) in player order before any other action"
-                .into(),
-        };
-    }
-
-    // Reaction-window guard runs BEFORE the skill-test guard: when a
-    // window opens mid-skill-test (e.g. Roland's "after you defeat an
-    // enemy" firing during a Fight that defeats), both
-    // `in_flight_skill_test` and the open reaction window on
-    // `cx.state.open_windows` are populated — the test is mid-resolution,
-    // parked at the window boundary inside `drive_skill_test`. The
-    // reaction-window message is the one the client needs.
-    if cx.state.top_reaction_window().is_some()
+    // A pending prompt gates every action but `ResolveInput` (slice 1b, #393).
+    // After the §1 continuation-stack work and the phase-anchor slices, the
+    // frame awaiting input is always the top of the stack, and *every* non-anchor
+    // frame on top is such a prompt — reaction/Fast window, skill-test commit,
+    // choice, substitution prompt, hunter/spawn pick, hand-size discard, act
+    // round-end, mulligan, encounter draw. A `*Phase` anchor on top is the open
+    // turn (or inert), so typed actions are allowed there. This single rule
+    // replaces the former eight per-suspension guard blocks; the specific
+    // expected `InputResponse` rides the `AwaitingInput` request the client
+    // already holds.
+    if cx
+        .state
+        .continuations
+        .last()
+        .is_some_and(crate::state::Continuation::awaits_input)
         && !matches!(action, PlayerAction::ResolveInput { .. })
     {
         return EngineOutcome::Rejected {
-            reason: "a reaction window is open; submit a \
-                     PlayerAction::ResolveInput with an InputResponse::PickSingle(OptionId) \
-                     to resolve an option, or InputResponse::Skip to close \
-                     the window (rejected if forced triggers remain) before any \
-                     other action"
-                .into(),
-        };
-    }
-
-    // While a skill test is paused at its commit window (no reaction
-    // window open yet), only `ResolveInput` can advance the engine.
-    // Mirrors the `Mulligan`-frame guard above.
-    if cx.state.has_skill_test_in_flight() && !matches!(action, PlayerAction::ResolveInput { .. }) {
-        return EngineOutcome::Rejected {
-            reason: "a skill test is paused at its commit window; submit a \
-                     PlayerAction::ResolveInput with an InputResponse::PickMultiple \
-                     (empty selection commits no cards) before any other action"
-                .into(),
-        };
-    }
-
-    // Hunter movement is Enemy-phase only; it can't coexist with an open
-    // reaction window or an in-flight skill test, so order among the guards
-    // is immaterial — but a pending hunter choice still blocks other actions.
-    if matches!(
-        cx.state.continuations.last(),
-        Some(crate::state::Continuation::HunterMove(_))
-    ) && !matches!(action, PlayerAction::ResolveInput { .. })
-    {
-        return EngineOutcome::Rejected {
-            reason: "a hunter-movement choice is pending; submit a PlayerAction::ResolveInput \
-                     with InputResponse::PickSingle (an offered option id) before any other action"
-                .into(),
-        };
-    }
-
-    // A pending engagement-on-spawn choice (#128) likewise blocks every
-    // action but `ResolveInput`. Mirrors the hunter guard above; the two
-    // never coexist (different phases), so guard order is immaterial.
-    if matches!(
-        cx.state.continuations.last(),
-        Some(crate::state::Continuation::SpawnEngage(_))
-    ) && !matches!(action, PlayerAction::ResolveInput { .. })
-    {
-        return EngineOutcome::Rejected {
-            reason: "an engagement-on-spawn choice is pending; submit a \
-                     PlayerAction::ResolveInput with InputResponse::PickSingle \
-                     (an offered option id) before any other action"
-                .into(),
-        };
-    }
-
-    // A pending upkeep hand-size discard (#111) blocks every action but
-    // `ResolveInput`. Upkeep-phase only; never coexists with the other
-    // suspension modes, so guard order is immaterial.
-    if matches!(
-        cx.state.continuations.last(),
-        Some(crate::state::Continuation::HandSizeDiscard(_))
-    ) && !matches!(action, PlayerAction::ResolveInput { .. })
-    {
-        return EngineOutcome::Rejected {
-            reason: "a hand-size discard choice is pending; submit a PlayerAction::ResolveInput \
-                     with InputResponse::PickMultiple before any other action"
-                .into(),
-        };
-    }
-
-    // A pending act round-end advance (#275) blocks every action but
-    // `ResolveInput`. Upkeep-phase only; never coexists with the others.
-    if matches!(
-        cx.state.continuations.last(),
-        Some(crate::state::Continuation::ActRoundEnd(_))
-    ) && !matches!(action, PlayerAction::ResolveInput { .. })
-    {
-        return EngineOutcome::Rejected {
-            reason:
-                "an act round-end advance choice is pending; submit a PlayerAction::ResolveInput \
-                     with InputResponse::Confirm or Skip before any other action"
-                    .into(),
-        };
-    }
-
-    // While the Mythos step-1.4 encounter-draw loop is in progress (an
-    // `EncounterDraw` frame is on top of the stack), only `ResolveInput` can
-    // advance the engine. Mythos-phase only; never coexists with the other
-    // suspension modes, so guard order is immaterial.
-    if matches!(
-        cx.state.continuations.last(),
-        Some(crate::state::Continuation::EncounterDraw { .. })
-    ) && !matches!(action, PlayerAction::ResolveInput { .. })
-    {
-        return EngineOutcome::Rejected {
-            reason: "a Mythos encounter draw is pending; submit a PlayerAction::ResolveInput \
-                     with InputResponse::Confirm in player order before any other action"
+            reason: "a prompt is outstanding; submit a PlayerAction::ResolveInput with the \
+                     InputResponse the AwaitingInput request describes (PickSingle / \
+                     PickMultiple / Confirm / Skip) before any other action"
                 .into(),
         };
     }

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -244,7 +244,50 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
     // driver must add its own boundary check; there's no fallback
     // here.
 
-    outcome
+    // Run the main loop (slice 1b, #393): advance any `*Phase` anchor a handler
+    // left on top (a phase transition), carrying the cascade forward until it
+    // blocks on a suspension, idles at the open turn, or reaches terminal.
+    drive(cx, outcome)
+}
+
+/// The uniform main loop (slice 1b, #393). Given the action's `outcome`,
+/// advance the top continuation frame until the engine blocks or idles:
+///
+/// - non-`Done` `outcome` (a suspension / rejection from the action itself)
+///   passes straight through;
+/// - a `*Phase` anchor on top (other than the open turn) is advanced via
+///   [`phases::anchor_on_child_pop`], which runs its resume-keyed chunk and,
+///   at a phase boundary, transitions by popping itself + pushing the next
+///   phase's anchor (`Entry`) — the loop then advances that;
+/// - the loop stops with `AwaitingInput` when an advance suspends, and with
+///   `Done` at the open turn (`InvestigationPhase{TurnBegins}`), at terminal
+///   (empty stack), or when an advance makes no progress (a parked phase, e.g.
+///   Investigation with no active investigator).
+pub(super) fn drive(cx: &mut Cx, outcome: EngineOutcome) -> EngineOutcome {
+    if !matches!(outcome, EngineOutcome::Done) {
+        return outcome;
+    }
+    loop {
+        let top = cx.state.continuations.last().cloned();
+        match top {
+            Some(ref c) if c.is_phase_anchor() && !c.is_open_turn() => {
+                match phases::anchor_on_child_pop(cx) {
+                    EngineOutcome::Done => {
+                        // No-progress guard: a parked phase (e.g. Investigation
+                        // with no active investigator) leaves the same anchor on
+                        // top — break rather than spin.
+                        if cx.state.continuations.last() == top.as_ref() {
+                            return EngineOutcome::Done;
+                        }
+                    }
+                    other => return other,
+                }
+            }
+            // Open turn idle, terminal (empty), or a suspension on top (which a
+            // handler already surfaced as AwaitingInput before reaching here).
+            _ => return EngineOutcome::Done,
+        }
+    }
 }
 
 /// Apply an [`EngineRecord`] to the state, pushing events.

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -463,58 +463,36 @@ fn mythos_phase(cx: &mut Cx) -> EngineOutcome {
     super::encounter::prompt_encounter_draw(cx)
 }
 
-/// Transition to the next phase. Dispatches into phase driver
-/// functions when they exist (each driver owns its own
-/// `PhaseStarted` emit). For phases without a driver, emits
-/// `PhaseStarted` directly.
-///
-/// **`PhaseEnded` invariant:** `step_phase` emits **no** `PhaseEnded`
-/// for any phase. Each phase's `*_end` helper owns its own boundary
-/// emit: `mythos_phase_end` (step 1.5), `investigation_phase_end`
-/// (step 2.3), `enemy_phase_end` (step 3.4), `upkeep_phase_end`
-/// (step 4.6). `start_scenario`'s first-round-skip path bypasses the
-/// entire Mythos phase — no `PhaseStarted(Mythos)` /
-/// `PhaseEnded(Mythos)` events fire on round 1 — per Rules Reference
-/// p.24 ("skip the mythos phase").
-///
-/// **Round-bump:** the round-counter increment now lives in
-/// `mythos_phase` step 1.1 — the rules' "round begins" point —
-/// rather than here. `step_phase` no longer touches `state.round`.
-///
-/// Returns the transition's [`EngineOutcome`]. Two arms can return
-/// [`EngineOutcome::AwaitingInput`]:
-/// - **Investigation→Enemy**: a hunter-movement tie in [`enemy_phase`],
-///   owned by [`investigation_phase_end`] and propagated through [`end_turn`].
-/// - **Enemy→Upkeep**: the step-4.5 hand-size discard (#111), owned by
-///   [`upkeep_resume`].
-///
-/// Every other arm runs its driver to completion and returns
-/// [`EngineOutcome::Done`].
+/// Test helper (slice 1b, #393): advance to the next phase via the main loop,
+/// the way a real transition does — set `state.phase` to the next phase, push
+/// its anchor at `Entry`, and `drive`. Production no longer has a synchronous
+/// phase-stepping function: the four `*_phase_end`/teardown transitions push the
+/// next `{Entry}` anchor and the apply boundary's `drive` advances it. Tests
+/// that constructed a state in phase *N* and want phase *N+1* run through the
+/// same mechanism here.
+#[cfg(test)]
 fn step_phase(cx: &mut Cx) -> EngineOutcome {
-    let from = cx.state.phase;
-    let to = from.next();
-
+    use crate::state::{
+        Continuation, EnemyResume, InvestigationResume, MythosResume, UpkeepResume,
+    };
+    let to = cx.state.phase.next();
     cx.state.phase = to;
-    // The round-counter bump moves into mythos_phase (step 1.1).
-    // step_phase no longer touches state.round.
-
-    // Dispatch to phase driver if one exists; otherwise emit
-    // PhaseStarted directly (for phases without a driver yet).
-    match to {
-        Phase::Mythos if from != Phase::Mythos => mythos_phase(cx),
-        Phase::Investigation if from != Phase::Investigation => {
-            investigation_phase(cx);
-            EngineOutcome::Done
-        }
-        Phase::Enemy if from != Phase::Enemy => enemy_phase(cx),
-        Phase::Upkeep if from != Phase::Upkeep => upkeep_phase(cx),
-        _ => unreachable!(
-            "step_phase: from == to (from={from:?}, to={to:?}); Phase::next \
-             never returns the same phase, so this branch is structurally \
-             unreachable. If it ever fires, something has corrupted \
-             state.phase between the read and the dispatch."
-        ),
-    }
+    let anchor = match to {
+        Phase::Mythos => Continuation::MythosPhase {
+            resume: MythosResume::Entry,
+        },
+        Phase::Investigation => Continuation::InvestigationPhase {
+            resume: InvestigationResume::Entry,
+        },
+        Phase::Enemy => Continuation::EnemyPhase {
+            resume: EnemyResume::Entry,
+        },
+        Phase::Upkeep => Continuation::UpkeepPhase {
+            resume: UpkeepResume::Entry,
+        },
+    };
+    cx.state.continuations.push(anchor);
+    super::drive(cx, EngineOutcome::Done)
 }
 
 /// Set `active_investigator` to `id`. Does NOT refresh actions —
@@ -664,10 +642,17 @@ pub(super) fn enemy_phase_end(cx: &mut Cx) -> EngineOutcome {
     if !matches!(forced, EngineOutcome::Done) {
         return forced; // 2+-trigger loud reject (unreachable in-slice); propagate
     }
-    // Enemy → Upkeep; calls upkeep_phase. This may now suspend at step
-    // 4.5 (hand-size discard, #111), so the outcome propagates rather
-    // than being asserted Done.
-    step_phase(cx)
+    // Enemy → Upkeep (slice 1b, #393): advance `state.phase` + push the Upkeep
+    // anchor at `Entry`. The main loop's `drive` advances it (runs upkeep_phase,
+    // which may suspend at step 4.5 hand-size discard — surfaced through
+    // `drive`). Replaces the former synchronous `step_phase(cx)`.
+    cx.state.phase = Phase::Upkeep;
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::UpkeepPhase {
+            resume: crate::state::UpkeepResume::Entry,
+        });
+    EngineOutcome::Done
 }
 
 /// Called after the post-1.4 window closes. Emits 1.5's
@@ -1018,9 +1003,18 @@ pub(super) fn upkeep_round_end_teardown(cx: &mut Cx) -> EngineOutcome {
         cx.state.continuations.last(),
     );
     cx.state.continuations.pop();
-    // Upkeep → Mythos; calls mythos_phase. Only the Investigation→Enemy
-    // transition can suspend (hunter movement), so this never does.
-    step_phase(cx)
+    // Upkeep → Mythos (slice 1b, #393): advance `state.phase` + push the Mythos
+    // anchor at `Entry`. The main loop's `drive` advances it (runs mythos_phase —
+    // the round bump + PhaseStarted(Mythos) live there). Replaces the former
+    // synchronous `step_phase(cx)`. With all four transitions now loop-driven,
+    // `step_phase` is gone.
+    cx.state.phase = Phase::Mythos;
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::MythosPhase {
+            resume: crate::state::MythosResume::Entry,
+        });
+    EngineOutcome::Done
 }
 
 /// The round-end advance window to open, if the current act offers one and
@@ -2739,10 +2733,15 @@ mod upkeep_phase_tests {
     fn upkeep_phase_end_skips_window_when_unaffordable() {
         let (mut state, _) = round_end_window_state(2); // < threshold 3
         let mut events = Vec::new();
-        let out = upkeep_phase_end(&mut Cx {
-            state: &mut state,
-            events: &mut events,
-        });
+        let out = {
+            let mut cx = Cx {
+                state: &mut state,
+                events: &mut events,
+            };
+            // slice 1b: the Upkeep→Mythos transition is loop-driven.
+            let o = upkeep_phase_end(&mut cx);
+            super::super::drive(&mut cx, o)
+        };
         // Unaffordable → no round-end window; the cascade steps straight into
         // Mythos and pauses at the step-1.4 encounter-draw prompt.
         assert!(matches!(out, EngineOutcome::AwaitingInput { .. }));
@@ -2762,13 +2761,14 @@ mod upkeep_phase_tests {
             state: &mut state,
             events: &mut events,
         });
-        let out = resume_act_round_end_advance(
-            &mut Cx {
+        let out = {
+            let mut cx = Cx {
                 state: &mut state,
                 events: &mut events,
-            },
-            &InputResponse::Confirm,
-        );
+            };
+            let o = resume_act_round_end_advance(&mut cx, &InputResponse::Confirm);
+            super::super::drive(&mut cx, o) // slice 1b: loop-driven Upkeep→Mythos
+        };
         // Resolving the window continues the upkeep cascade into Mythos, which
         // pauses at the step-1.4 encounter-draw prompt (AwaitingInput).
         assert!(matches!(out, EngineOutcome::AwaitingInput { .. }));
@@ -2790,13 +2790,14 @@ mod upkeep_phase_tests {
             state: &mut state,
             events: &mut events,
         });
-        let out = resume_act_round_end_advance(
-            &mut Cx {
+        let out = {
+            let mut cx = Cx {
                 state: &mut state,
                 events: &mut events,
-            },
-            &InputResponse::Skip,
-        );
+            };
+            let o = resume_act_round_end_advance(&mut cx, &InputResponse::Skip);
+            super::super::drive(&mut cx, o) // slice 1b: loop-driven Upkeep→Mythos
+        };
         // Skipping the window still continues the upkeep cascade into Mythos,
         // which pauses at the step-1.4 encounter-draw prompt (AwaitingInput).
         assert!(matches!(out, EngineOutcome::AwaitingInput { .. }));
@@ -2852,10 +2853,14 @@ mod upkeep_phase_tests {
             Location::new(LocationId(9), CardCode("99999".into()), "Far", 1, 0),
         );
         let mut events = Vec::new();
-        let out = upkeep_phase_end(&mut Cx {
-            state: &mut state,
-            events: &mut events,
-        });
+        let out = {
+            let mut cx = Cx {
+                state: &mut state,
+                events: &mut events,
+            };
+            let o = upkeep_phase_end(&mut cx);
+            super::super::drive(&mut cx, o) // slice 1b: loop-driven Upkeep→Mythos
+        };
         // Unaffordable by the Hallway alone: no round-end window opens, so the
         // upkeep cascades straight into Mythos and pauses at the encounter-draw
         // prompt (AwaitingInput) rather than opening an ActRoundEnd frame.
@@ -3005,13 +3010,14 @@ mod enemy_phase_tests {
             .find(|o| o.label == format!("{:?}", LocationId(2)))
             .expect("LocationId(2) among offered options")
             .id;
-        let resumed = resolve_input(
-            &mut crate::engine::Cx {
+        let resumed = {
+            let mut cx = crate::engine::Cx {
                 state: &mut state,
                 events: &mut ev2,
-            },
-            &InputResponse::PickSingle(pick),
-        );
+            };
+            let o = resolve_input(&mut cx, &InputResponse::PickSingle(pick));
+            super::super::drive(&mut cx, o) // slice 1b: complete the cascade
+        };
         // With no registry the attack window auto-skips and the cascade runs
         // Enemy->Upkeep->Mythos within the same resume call, pausing at the
         // step-1.4 encounter-draw prompt (AwaitingInput).
@@ -3856,15 +3862,19 @@ mod hand_size_tests {
             (0..10).map(|i| CardCode(format!("c{i}"))).collect();
 
         let mut events = Vec::new();
-        let outcome = resume_hand_size_discard(
-            &mut Cx {
+        let outcome = {
+            let mut cx = Cx {
                 state: &mut state,
                 events: &mut events,
-            },
-            &InputResponse::PickMultiple {
-                selected: vec![OptionId(0), OptionId(1)],
-            },
-        );
+            };
+            let o = resume_hand_size_discard(
+                &mut cx,
+                &InputResponse::PickMultiple {
+                    selected: vec![OptionId(0), OptionId(1)],
+                },
+            );
+            super::super::drive(&mut cx, o) // slice 1b: loop-driven Upkeep→Mythos
+        };
 
         // The discard drains the hand-size queue, so 4.6 runs and the cascade
         // steps into Mythos, pausing at the step-1.4 encounter-draw prompt.

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -763,32 +763,26 @@ pub(super) fn anchor_on_child_pop(cx: &mut Cx) -> EngineOutcome {
         Some(Continuation::UpkeepPhase {
             resume: UpkeepResume::Begins,
         }) => {
-            // Phase-transitioning continuation (4.2–4.6 then Upkeep→Mythos):
-            // cannot run while a skill test is in flight. Phase 4 has no
-            // Upkeep-phase skill-test source, so structurally unreachable today.
-            if let Some(in_flight) = cx.state.current_skill_test() {
-                unreachable!(
-                    "UpkeepBegins closed while a skill test is in flight \
-                     (continuation={:?}); Phase 4 has no Upkeep-phase skill-test sources",
-                    in_flight.continuation,
-                );
-            }
+            // Structurally impossible under the main loop (slice 1b, #393): a
+            // skill test in flight sits *above* its phase anchor, so `drive`
+            // never advances the anchor with one pending. (Was an `unreachable!`
+            // gated on "no Upkeep-phase skill-test source"; now a cheap assert.)
+            debug_assert!(
+                cx.state.current_skill_test().is_none(),
+                "UpkeepBegins advanced with a skill test in flight",
+            );
             upkeep_resume(cx)
         }
         Some(Continuation::EnemyPhase {
             resume: EnemyResume::BeforeInvestigatorAttacked,
         }) => {
-            // Phase-transitioning continuation: cannot run while a skill test is
-            // in flight (would strand it). Phase 4 has no Enemy-phase skill-test
-            // source, so structurally unreachable today.
-            if let Some(in_flight) = cx.state.current_skill_test() {
-                unreachable!(
-                    "BeforeInvestigatorAttacked closed while a skill test is in \
-                     flight (continuation={:?}); Phase 4 has no Enemy-phase \
-                     skill-test sources",
-                    in_flight.continuation,
-                );
-            }
+            // Structurally impossible under the main loop (slice 1b): a skill
+            // test in flight sits above its phase anchor, so `drive` never
+            // advances the anchor with one pending.
+            debug_assert!(
+                cx.state.current_skill_test().is_none(),
+                "BeforeInvestigatorAttacked advanced with a skill test in flight",
+            );
             // Cursor expect-Some: BeforeInvestigatorAttacked is only ever opened
             // after enemy_attack_pending is set to Some(_). A None cursor here is
             // a state-corruption invariant violation.
@@ -815,14 +809,12 @@ pub(super) fn anchor_on_child_pop(cx: &mut Cx) -> EngineOutcome {
         Some(Continuation::EnemyPhase {
             resume: EnemyResume::AfterAllAttacked,
         }) => {
-            if let Some(in_flight) = cx.state.current_skill_test() {
-                unreachable!(
-                    "AfterAllInvestigatorsAttacked closed while a skill test is in \
-                     flight (continuation={:?}); Phase 4 has no Enemy-phase \
-                     skill-test sources",
-                    in_flight.continuation,
-                );
-            }
+            // Structurally impossible under the main loop (slice 1b): see the
+            // BeforeInvestigatorAttacked arm above.
+            debug_assert!(
+                cx.state.current_skill_test().is_none(),
+                "AfterAllInvestigatorsAttacked advanced with a skill test in flight",
+            );
             enemy_phase_end(cx)
         }
         Some(Continuation::InvestigationPhase {
@@ -849,17 +841,13 @@ pub(super) fn anchor_on_child_pop(cx: &mut Cx) -> EngineOutcome {
         Some(Continuation::MythosPhase {
             resume: MythosResume::AfterDraws,
         }) => {
-            // Phase-transitioning continuation: cannot run while a skill test
-            // is in flight (would strand the test in the wrong phase). Phase 4
-            // has no Mythos-phase skill-test sources, so this is structurally
-            // unreachable today.
-            if let Some(in_flight) = cx.state.current_skill_test() {
-                unreachable!(
-                    "MythosAfterDraws closed while a skill test is in flight \
-                     (continuation={:?}); Phase 4 has no Mythos-phase skill-test sources",
-                    in_flight.continuation,
-                );
-            }
+            // Structurally impossible under the main loop (slice 1b): a skill
+            // test in flight sits above its phase anchor, so `drive` never
+            // advances the anchor with one pending.
+            debug_assert!(
+                cx.state.current_skill_test().is_none(),
+                "MythosAfterDraws advanced with a skill test in flight",
+            );
             mythos_phase_end(cx);
             EngineOutcome::Done
         }

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -379,7 +379,17 @@ fn investigation_phase_end(cx: &mut Cx) -> EngineOutcome {
     cx.events.push(Event::PhaseEnded {
         phase: Phase::Investigation,
     });
-    step_phase(cx) // Investigation → Enemy; calls enemy_phase
+    // Investigation → Enemy (slice 1b, #393): advance `state.phase` + push the
+    // Enemy anchor at `Entry`. The main loop's `drive` advances it (runs
+    // enemy_phase); a hunter-movement-tie suspension surfaces through `drive`.
+    // Replaces the former synchronous `step_phase(cx)`.
+    cx.state.phase = Phase::Enemy;
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::EnemyPhase {
+            resume: crate::state::EnemyResume::Entry,
+        });
+    EngineOutcome::Done
 }
 
 /// Entered by [`step_phase`] on the Upkeep→Mythos transition. Lays
@@ -1561,10 +1571,16 @@ mod investigation_phase_tests {
             });
 
         let mut events = Vec::new();
-        let outcome = end_turn(&mut Cx {
-            state: &mut state,
-            events: &mut events,
-        });
+        let outcome = {
+            // end_turn may push the next phase's Entry anchor (slice 1b); drive
+            // completes the transition, as the apply boundary does in production.
+            let mut cx = Cx {
+                state: &mut state,
+                events: &mut events,
+            };
+            let o = end_turn(&mut cx);
+            super::super::drive(&mut cx, o)
+        };
 
         // Single investigator with no enemies: the round-ending EndTurn
         // cascades Investigation → Enemy → Upkeep → Mythos and pauses at the
@@ -1623,10 +1639,16 @@ mod investigation_phase_tests {
             });
 
         let mut events = Vec::new();
-        let outcome = end_turn(&mut Cx {
-            state: &mut state,
-            events: &mut events,
-        });
+        let outcome = {
+            // end_turn may push the next phase's Entry anchor (slice 1b); drive
+            // completes the transition, as the apply boundary does in production.
+            let mut cx = Cx {
+                state: &mut state,
+                events: &mut events,
+            };
+            let o = end_turn(&mut cx);
+            super::super::drive(&mut cx, o)
+        };
 
         assert!(matches!(outcome, EngineOutcome::Done));
         assert_eq!(
@@ -2890,10 +2912,16 @@ mod enemy_phase_tests {
                 resume: crate::state::InvestigationResume::TurnBegins,
             });
         let mut events = Vec::new();
-        let outcome = end_turn(&mut Cx {
-            state: &mut state,
-            events: &mut events,
-        });
+        let outcome = {
+            // end_turn may push the next phase's Entry anchor (slice 1b); drive
+            // completes the transition, as the apply boundary does in production.
+            let mut cx = Cx {
+                state: &mut state,
+                events: &mut events,
+            };
+            let o = end_turn(&mut cx);
+            super::super::drive(&mut cx, o)
+        };
         // No registry installed → the attack window auto-skips inline and the
         // cascade runs Enemy→Upkeep→Mythos within this same call, pausing at the
         // step-1.4 encounter-draw prompt (AwaitingInput). The hunter still moved
@@ -2944,10 +2972,16 @@ mod enemy_phase_tests {
                 resume: crate::state::InvestigationResume::TurnBegins,
             });
         let mut events = Vec::new();
-        let outcome = end_turn(&mut Cx {
-            state: &mut state,
-            events: &mut events,
-        });
+        let outcome = {
+            // end_turn may push the next phase's Entry anchor (slice 1b); drive
+            // completes the transition, as the apply boundary does in production.
+            let mut cx = Cx {
+                state: &mut state,
+                events: &mut events,
+            };
+            let o = end_turn(&mut cx);
+            super::super::drive(&mut cx, o)
+        };
         assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
         assert_eq!(state.phase, Phase::Enemy);
         // The EnemyPhase anchor (slice 1a) is on the stack beneath the

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -692,21 +692,66 @@ pub(super) fn mythos_phase_end(cx: &mut Cx) {
     cx.events.push(Event::PhaseEnded {
         phase: Phase::Mythos,
     });
-    // Mythos → Investigation; calls investigation_phase. Only the
-    // Investigation→Enemy transition can suspend (hunter movement), so
-    // this cascade always completes.
-    let outcome = step_phase(cx);
-    debug_assert_eq!(
-        outcome,
-        EngineOutcome::Done,
-        "unexpected suspension in Mythos→Investigation transition"
-    );
+    // Mythos → Investigation (slice 1b, #393): advance `state.phase` and push the
+    // next phase's anchor at `Entry`. The main loop's `drive` advances it (runs
+    // investigation_phase's opening). Replaces the former synchronous
+    // `step_phase(cx)` call — the transition is now loop-driven.
+    cx.state.phase = Phase::Investigation;
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::InvestigationPhase {
+            resume: crate::state::InvestigationResume::Entry,
+        });
+}
+
+/// Advance a freshly-entered phase anchor (slice 1b, #393): if the top frame is
+/// a `*Phase` anchor at `Entry`, pop the placeholder and run that phase's
+/// opening via its existing driver (which pushes the running anchor at its first
+/// boundary resume + the phase's first child). Returns `None` when the top is
+/// not an `Entry` anchor, so [`anchor_on_child_pop`] falls through to its
+/// boundary dispatch.
+fn advance_phase_entry(
+    cx: &mut Cx,
+    anchor: Option<&crate::state::Continuation>,
+) -> Option<EngineOutcome> {
+    use crate::state::{
+        Continuation, EnemyResume, InvestigationResume, MythosResume, UpkeepResume,
+    };
+    match anchor {
+        Some(Continuation::MythosPhase {
+            resume: MythosResume::Entry,
+        }) => {
+            cx.state.continuations.pop();
+            Some(mythos_phase(cx))
+        }
+        Some(Continuation::InvestigationPhase {
+            resume: InvestigationResume::Entry,
+        }) => {
+            cx.state.continuations.pop();
+            investigation_phase(cx);
+            Some(EngineOutcome::Done)
+        }
+        Some(Continuation::EnemyPhase {
+            resume: EnemyResume::Entry,
+        }) => {
+            cx.state.continuations.pop();
+            Some(enemy_phase(cx))
+        }
+        Some(Continuation::UpkeepPhase {
+            resume: UpkeepResume::Entry,
+        }) => {
+            cx.state.continuations.pop();
+            Some(upkeep_phase(cx))
+        }
+        _ => None,
+    }
 }
 
 /// Run the top `*Phase` anchor's continuation after one of its framework
-/// windows closed (slice 1a, #393). The window has already been popped by the
-/// close path, so the anchor is now the top frame; its `resume` selects the
-/// relocated body. Suspension-agnostic: a body that itself suspends returns
+/// windows closed (slice 1a, #393), or advance it from `Entry` (slice 1b, via
+/// [`advance_phase_entry`]). The window has already been popped by the close
+/// path, so the anchor is now the top frame; its `resume` selects the relocated
+/// body. Suspension-agnostic: a body that itself suspends returns
 /// `AwaitingInput` unchanged. The `resume` is copied out before the body takes
 /// `&mut cx`.
 pub(super) fn anchor_on_child_pop(cx: &mut Cx) -> EngineOutcome {
@@ -714,6 +759,11 @@ pub(super) fn anchor_on_child_pop(cx: &mut Cx) -> EngineOutcome {
         Continuation, EnemyResume, InvestigationResume, MythosResume, UpkeepResume,
     };
     let anchor = cx.state.continuations.last().cloned();
+    // `Entry` advances (slice 1b, #393) run the phase opening; delegated so this
+    // function stays the boundary-dispatch it was in slice 1a.
+    if let Some(out) = advance_phase_entry(cx, anchor.as_ref()) {
+        return out;
+    }
     match anchor {
         Some(Continuation::UpkeepPhase {
             resume: UpkeepResume::Begins,
@@ -1714,6 +1764,44 @@ mod mythos_phase_tests {
     }
 
     #[test]
+    fn mythos_drives_from_entry_via_the_loop() {
+        // slice 1b: a MythosPhase{Entry} anchor advanced by `drive` runs the
+        // phase opening (PhaseStarted + round bump + push the EncounterDraw
+        // loop) and suspends at the first drawer prompt — same as the old
+        // synchronous mythos_phase entry.
+        let mut state = GameStateBuilder::default()
+            .with_investigator(test_investigator(1))
+            .with_phase(Phase::Mythos)
+            .with_phase_anchor(crate::state::Continuation::MythosPhase {
+                resume: crate::state::MythosResume::Entry,
+            })
+            .build();
+        state.turn_order = vec![InvestigatorId(1)];
+        let mut events = Vec::new();
+        let outcome = super::super::drive(
+            &mut Cx {
+                state: &mut state,
+                events: &mut events,
+            },
+            EngineOutcome::Done,
+        );
+        assert!(
+            matches!(outcome, EngineOutcome::AwaitingInput { .. }),
+            "drive advances the Entry anchor and suspends at the draw prompt; got {outcome:?}",
+        );
+        assert!(events.iter().any(|e| matches!(
+            e,
+            Event::PhaseStarted {
+                phase: Phase::Mythos
+            }
+        )));
+        assert!(state
+            .continuations
+            .iter()
+            .any(|c| matches!(c, crate::state::Continuation::EncounterDraw { .. })));
+    }
+
+    #[test]
     fn mythos_anchor_pushed_during_phase() {
         // The Mythos driver pushes its anchor at entry; it sits beneath the
         // encounter-draw loop while the phase is suspended (slice 1a).
@@ -1746,14 +1834,16 @@ mod mythos_phase_tests {
         state.turn_order.clear();
         let mut events = Vec::new();
 
-        let outcome = mythos_phase(&mut Cx {
+        // No drawers → MythosAfterDraws auto-skips, mythos_phase_end pushes the
+        // Investigation anchor; `drive` then advances it (slice 1b) — completing
+        // the Mythos→Investigation transition that was synchronous in slice 1a.
+        let mut cx = Cx {
             state: &mut state,
             events: &mut events,
-        });
+        };
+        let outcome = mythos_phase(&mut cx);
+        let outcome = super::super::drive(&mut cx, outcome);
 
-        // No drawers → open_fast_window runs for MythosAfterDraws,
-        // which auto-skips (no Fast eligibility), runs continuation
-        // (mythos_phase_end), which steps into Investigation.
         assert_eq!(outcome, EngineOutcome::Done);
         assert_eq!(state.current_encounter_drawer(), None);
         assert_eq!(state.phase, Phase::Investigation);
@@ -1811,10 +1901,15 @@ mod mythos_phase_tests {
             });
         let mut events = Vec::new();
 
-        mythos_phase_end(&mut Cx {
+        // mythos_phase_end pops the Mythos anchor + pushes the Investigation
+        // anchor (Entry); `drive` advances it to run investigation_phase (slice
+        // 1b) — completing the transition.
+        let mut cx = Cx {
             state: &mut state,
             events: &mut events,
-        });
+        };
+        mythos_phase_end(&mut cx);
+        let _ = super::super::drive(&mut cx, EngineOutcome::Done);
 
         assert!(
             !state

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -4563,8 +4563,10 @@ mod tests {
         let rejected = apply(paused.state, Action::Player(PlayerAction::EndTurn));
         match rejected.outcome {
             EngineOutcome::Rejected { reason } => {
+                // slice 1b collapsed the per-suspension guards into one rule with
+                // a unified reason; the specific InputResponse rides the request.
                 assert!(
-                    reason.contains("commit window"),
+                    reason.contains("a prompt is outstanding") && reason.contains("ResolveInput"),
                     "unexpected reason: {reason}",
                 );
             }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -550,6 +550,35 @@ pub struct ChoiceFrame {
 }
 
 impl Continuation {
+    /// True if this is a `*Phase` anchor (slice 1b, #393): an inert framework
+    /// frame the main loop's `drive` advances, never one that awaits player
+    /// input itself. Everything else on top of the stack *is* awaiting input.
+    #[must_use]
+    pub fn is_phase_anchor(&self) -> bool {
+        matches!(
+            self,
+            Continuation::MythosPhase { .. }
+                | Continuation::InvestigationPhase { .. }
+                | Continuation::EnemyPhase { .. }
+                | Continuation::UpkeepPhase { .. }
+        )
+    }
+
+    /// True if this is the open-turn idle point — `InvestigationPhase` at
+    /// `TurnBegins` (slice 1b, #393). The engine waits for the active
+    /// investigator's *typed* action here, so `drive` must break (not advance)
+    /// rather than spin. Slice 2 replaces this with a real `InvestigatorTurn`
+    /// frame that awaits input.
+    #[must_use]
+    pub fn is_open_turn(&self) -> bool {
+        matches!(
+            self,
+            Continuation::InvestigationPhase {
+                resume: InvestigationResume::TurnBegins,
+            }
+        )
+    }
+
     /// The window payload if this frame is a [`Continuation::Resolution`].
     #[must_use]
     pub fn as_resolution(&self) -> Option<&ResolutionFrame> {
@@ -598,6 +627,10 @@ impl Continuation {
 /// Names the framework window whose close re-enters the Mythos driver.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MythosResume {
+    /// Just entered (slice 1b, #393): the loop's `advance` runs the phase opening
+    /// (round bump, `PhaseStarted`, steps 1.1–1.4) and replaces this with the
+    /// running anchor.
+    Entry,
     /// Post-step-1.4 (encounter draws done) window closed; run `mythos_phase_end`.
     AfterDraws,
 }
@@ -605,6 +638,8 @@ pub enum MythosResume {
 /// The Investigation-phase child-pop boundary (slice 1a, #393).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum InvestigationResume {
+    /// Just entered (slice 1b, #393): the loop's `advance` runs the phase opening.
+    Entry,
     /// Post-2.1 window closed; begin the first investigator's turn.
     Begins,
     /// Post-2.2 turn-begins window closed; the investigator now acts (no
@@ -615,6 +650,8 @@ pub enum InvestigationResume {
 /// The Enemy-phase child-pop boundary (slice 1a, #393).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EnemyResume {
+    /// Just entered (slice 1b, #393): the loop's `advance` runs the phase opening.
+    Entry,
     /// Before-investigator-attacked window closed; resolve this investigator's
     /// attacks (step 3.3).
     BeforeInvestigatorAttacked,
@@ -625,6 +662,8 @@ pub enum EnemyResume {
 /// The Upkeep-phase child-pop boundary (slice 1a, #393).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum UpkeepResume {
+    /// Just entered (slice 1b, #393): the loop's `advance` runs the phase opening.
+    Entry,
     /// Post-4.1 window closed; run `upkeep_resume` (steps 4.2–4.6).
     Begins,
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -1800,6 +1800,38 @@ mod continuation_stack_tests {
     use crate::test_support::GameStateBuilder;
 
     #[test]
+    fn awaits_input_gates_suspensions_but_not_anchors_or_fast_windows() {
+        // slice 1b: the one guard rule keys off this. Phase anchors are inert
+        // (open turn / loop-driven), so typed actions run there.
+        assert!(!Continuation::InvestigationPhase {
+            resume: InvestigationResume::TurnBegins,
+        }
+        .awaits_input());
+        assert!(!Continuation::MythosPhase {
+            resume: MythosResume::Entry,
+        }
+        .awaits_input());
+        // A Fast-play window (Resolution with no pending triggers) is a play
+        // opportunity, not a mandatory prompt — Fast plays stay allowed.
+        assert!(!Continuation::Resolution(ResolutionFrame::new_empty(
+            WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins),
+            FastActorScope::Any,
+        ))
+        .awaits_input());
+        // Every other suspension hits the `_ => true` arm and awaits
+        // ResolveInput. This includes a `Choice` (e.g. a `ChooseOne` OnPlay
+        // event mid-resolution) and a `SubstitutionPrompt`, which the former
+        // eight-block guard ladder did NOT explicitly gate — the unified rule
+        // now correctly rejects typed actions while one is on top.
+        assert!(Continuation::SubstitutionPrompt {
+            investigator: InvestigatorId(1),
+        }
+        .awaits_input());
+        assert!(Continuation::Mulligan { remaining: vec![] }.awaits_input());
+        assert!(Continuation::EncounterDraw { remaining: vec![] }.awaits_input());
+    }
+
+    #[test]
     fn phase_anchor_variants_round_trip_and_are_not_resolution_windows() {
         let anchors = [
             Continuation::MythosPhase {

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -579,6 +579,30 @@ impl Continuation {
         )
     }
 
+    /// True if this top frame is a mandatory prompt that only `ResolveInput` may
+    /// advance (slice 1b, #393): a reaction/forced window, skill-test commit,
+    /// choice, hunter/spawn pick, hand-size discard, act round-end, substitution
+    /// prompt, mulligan, or encounter draw.
+    ///
+    /// Two exceptions return `false` — the engine accepts other actions:
+    /// - **`*Phase` anchors** are inert / the open turn, so typed actions run.
+    /// - a **Fast-play window** — a [`Continuation::Resolution`] with *no*
+    ///   pending triggers — is a play *opportunity*, not a mandatory prompt:
+    ///   Fast `PlayCard`/`ActivateAbility` are allowed (the handlers gate
+    ///   eligibility) and `ResolveInput::Skip` closes it. A window *with* pending
+    ///   triggers (reaction or forced) does await `ResolveInput`. This mirrors
+    ///   [`GameState::top_reaction_window`], which skips empty-trigger windows.
+    ///
+    /// (`EncounterCard` is framework-internal and never sits on top at an action
+    /// boundary, so its `true` here is moot.)
+    #[must_use]
+    pub fn awaits_input(&self) -> bool {
+        match self {
+            Continuation::Resolution(f) => !f.pending_triggers.is_empty(),
+            other => !other.is_phase_anchor(),
+        }
+    }
+
     /// The window payload if this frame is a [`Continuation::Resolution`].
     #[must_use]
     pub fn as_resolution(&self) -> Option<&ResolutionFrame> {

--- a/crates/game-core/tests/reaction_windows.rs
+++ b/crates/game-core/tests/reaction_windows.rs
@@ -486,8 +486,9 @@ fn non_resolve_input_action_rejects_while_window_open() {
     let rejected = game_core::engine::apply(paused.state, Action::Player(PlayerAction::EndTurn));
     match rejected.outcome {
         EngineOutcome::Rejected { reason } => {
+            // slice 1b: one unified guard reason (the request carries specifics).
             assert!(
-                reason.contains("reaction window"),
+                reason.contains("a prompt is outstanding") && reason.contains("ResolveInput"),
                 "unexpected reason: {reason}",
             );
         }

--- a/docs/superpowers/plans/2026-06-20-unified-main-loop-1b.md
+++ b/docs/superpowers/plans/2026-06-20-unified-main-loop-1b.md
@@ -1,0 +1,195 @@
+# Unified Main Loop + Cascade-Fold (slice 1b) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the forward-calling synchronous phase cascade (`step_phase` → driver → `*_phase_end` → `step_phase`) with a uniform `drive(cx)` loop that advances the top continuation frame, so phase transitions are loop-driven (pop anchor + push next anchor) rather than native-stack recursion — and the guard ladder + strand-guards collapse out of it. Behaviour-preserving.
+
+**Architecture:** After slice 1a each phase is a `*Phase` anchor frame whose `resume`-keyed body runs on window close (`anchor_on_child_pop`). This slice makes those anchors **self-driving**: each `*Resume` gains an `Entry` variant; a new `advance(cx)` (the generalized `anchor_on_child_pop`) handles `Entry` (the phase opening — today's `mythos_phase`/… body), the boundary chunks (today's bodies), and **transitions** (pop self + advance `state.phase` + push next anchor `{Entry}` — replacing `*_phase_end`'s synchronous `step_phase`). A `drive(cx)` loop in the `apply` entry advances the top frame until it (a) hits a suspension awaiting input → `AwaitingInput`, (b) reaches the open turn (`InvestigationPhase{TurnBegins}`) → idle `Done`, or (c) reaches terminal → `Done`. `step_phase` and the four `*_phase_end` functions dissolve. The guard ladder collapses to "top frame is a non-anchor suspension ⇒ only `ResolveInput`"; the strand-guards become `debug_assert!` (a skill test sits *above* its phase anchor, so the loop never advances the anchor while one is in flight).
+
+**Tech Stack:** Rust; `game-core` engine (event-sourced `apply` with transactional snapshot); serializable `Continuation` enum; `GameStateBuilder` + `with_phase_anchor` test harness; `cargo test`/clippy/fmt/doc/wasm gauntlet.
+
+## Global Constraints
+
+- **Behaviour-preserving:** the entire workspace suite + gauntlet must stay green at every task boundary. No event-stream changes.
+- **Handler contract:** validate-first / mutate-second; `Rejected` ⇒ state + events unchanged (the `apply` transactional snapshot must keep covering the whole loop).
+- **Serializable enum:** new `Entry` resume variants derive `Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize`.
+- **Determinism:** the loop runs entirely within one `apply`; it must produce the identical event sequence the synchronous cascade did.
+- **CI (strict):** `RUSTFLAGS="-D warnings" cargo test --all --all-features`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo fmt --check`; `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`; `cargo build -p web --target wasm32-unknown-unknown`.
+- **Commit style:** `engine: <description>`; body explains *why*; ends with `Refs #393.` (does not close #393).
+- **Branch:** `engine/unified-main-loop`.
+
+## File Structure
+
+- `crates/game-core/src/state/game_state.rs` — add `Entry` to the four `*Resume` enums.
+- `crates/game-core/src/engine/dispatch/phases.rs` — the bulk: generalize `anchor_on_child_pop` → `advance` with `Entry` + transition arms; fold the four phase drivers + four `*_phase_end` bodies into it; delete `step_phase`.
+- `crates/game-core/src/engine/dispatch/mod.rs` — add the `drive(cx)` loop; run it from `apply_player_action`; collapse the guard ladder.
+- `crates/game-core/src/engine/dispatch/reaction_windows.rs` — `run_window_continuation`'s `PlayerWindow(_)` arm calls `advance` (rename follow-through).
+- Tests across `game-core`/`cards`/`scenarios` — fixtures that call `step_phase`/`*_phase_end` directly migrate to `advance`/`drive`; the `with_phase_anchor` helper absorbs mid-phase-state needs.
+
+## Mechanism reference (read before Task 1)
+
+**The loop.** `drive(cx)` after the action dispatch:
+```text
+loop {
+    match cx.state.continuations.last() {
+        None => return Done,                              // terminal / bootstrap
+        Some(f) if f.awaits_input() => return AwaitingInput{…},  // suspension on top
+        Some(f) if f.is_open_turn() => return Done,       // InvestigationPhase{TurnBegins} idle
+        Some(_phase_anchor) => match advance(cx) {        // advance the phase anchor
+            AwaitingInput{…} => return it,                // a child suspended mid-advance
+            Done => continue,                             // progressed; loop
+            Rejected{…} => return it,
+        }
+    }
+}
+```
+- `awaits_input()` = "top frame is a suspension" = **not** a `*Phase` anchor. (Anchors are the only inert frames; everything else on top awaits input.)
+- `is_open_turn()` = `InvestigationPhase{TurnBegins}` (the pre-slice-2 idle). Distinct from other anchor states because the engine waits for a *typed* player action here, not a `ResolveInput`.
+
+**`advance(cx)`** = today's `anchor_on_child_pop` generalized. Match on the top anchor's `(phase, resume)`:
+- `Entry` → run the phase opening (the current `mythos_phase`/`investigation_phase`/`enemy_phase`/`upkeep_phase` body: `PhaseStarted` + straight-line steps + push first child), setting `resume` to the first boundary.
+- boundary (`AfterDraws`, `BeforeInvestigatorAttacked`, `AfterAllAttacked`, `Begins`, `TurnBegins`) → today's relocated body.
+- transition (a phase's terminal chunk — today's `*_phase_end` tail) → emit `PhaseEnded`, pop self, set `state.phase = phase.next()`, push the next phase's anchor `{Entry}`, return `Done` (the loop advances it). The `PhaseEnded`-keyed forced emit + the Enemy/Upkeep round-end machinery stay exactly as today, just relocated.
+
+**Entry points that push the *first* phase anchor** (today they call `step_phase`/a driver): `start_scenario`'s kickoff, and the bootstrap. After this slice, "enter phase X" = push `XPhase{Entry}` and let `drive` advance it.
+
+**The open-turn idle.** `InvestigationPhase{TurnBegins}` advance is a no-op today (the player acts via typed actions). The loop must *not* call `advance` on it (would loop forever) — hence the explicit `is_open_turn()` break. Slice 2 replaces this with the real `InvestigatorTurn` frame that `awaits_input()`.
+
+---
+
+## Task 1: Add `Entry` resume variants + the `drive` loop scaffold (Mythos self-driving first)
+
+**Files:** `game_state.rs` (`*Resume` enums), `phases.rs` (`advance`, Mythos fold, `mythos_phase_end` → transition), `mod.rs` (`drive` loop + call site).
+
+**Interfaces:**
+- Produces: `MythosResume::Entry` (+ `Entry` on the other three enums, unused until their tasks); `phases::advance(cx: &mut Cx) -> EngineOutcome` (renamed/generalized `anchor_on_child_pop`); `dispatch::drive(cx: &mut Cx, outcome: EngineOutcome) -> EngineOutcome`.
+- Consumes: the slice-1a anchors + `anchor_on_child_pop` body.
+
+- [ ] **Step 1: Write the failing test** — a Mythos phase entered via `MythosPhase{Entry}` + `drive` produces the same event stream as the old `mythos_phase`:
+
+```rust
+#[test]
+fn mythos_drives_from_entry_via_the_loop() {
+    let mut state = GameStateBuilder::default()
+        .with_investigator(test_investigator(1))
+        .with_phase(Phase::Mythos)
+        .with_phase_anchor(crate::state::Continuation::MythosPhase {
+            resume: crate::state::MythosResume::Entry,
+        })
+        .build();
+    state.turn_order = vec![InvestigatorId(1)];
+    let mut events = Vec::new();
+    // drive advances the Entry anchor: emits PhaseStarted(Mythos), pushes the
+    // EncounterDraw loop, and suspends at the first drawer prompt.
+    let outcome = drive(
+        &mut Cx { state: &mut state, events: &mut events },
+        EngineOutcome::Done,
+    );
+    assert!(matches!(outcome, EngineOutcome::AwaitingInput { .. }));
+    assert!(events.iter().any(|e| matches!(e, Event::PhaseStarted { phase: Phase::Mythos })));
+    assert!(state.continuations.iter().any(|c| matches!(c, crate::state::Continuation::EncounterDraw { .. })));
+}
+```
+
+- [ ] **Step 2: Run it — verify it fails** (`MythosResume::Entry` and `drive` don't exist). `cargo test -p game-core --lib mythos_drives_from_entry 2>&1 | head`.
+
+- [ ] **Step 3: Implement.**
+  - Add `Entry` to all four `*Resume` enums (game_state.rs), deriving as the existing variants.
+  - In phases.rs, rename `anchor_on_child_pop` → `advance` (update its `run_window_continuation` caller). Add the `MythosPhase { resume: Entry }` arm = the current `mythos_phase` body (emit `PhaseStarted(Mythos)`, round bump moved here, steps 1.1–1.3, push `EncounterDraw` or open the no-drawer `MythosAfterDraws` window), setting `resume = AfterDraws` where it pushes the loop. Change the `MythosPhase { resume: AfterDraws }` arm (today's `mythos_phase_end` body) to **transition via pop+push**: emit `PhaseEnded(Mythos)`, pop the anchor, `state.phase = Phase::Investigation`, push `InvestigationPhase { resume: Entry }`, return `Done`.
+  - Add `advance(InvestigationPhase{Entry})` = the current `investigation_phase` body (so the loop can advance the pushed Investigation anchor). Leave Investigation's *other* arms + its `*_phase_end` synchronous for now (coexistence — Investigation→Enemy still uses `step_phase`).
+  - Add `dispatch::drive(cx, outcome)`: if `outcome` is `AwaitingInput`/`Rejected`, return it; else run the loop above. Implement `Continuation::awaits_input()` (= not a `*Phase` anchor) and `is_open_turn()` (= `InvestigationPhase{TurnBegins}`) as methods on `Continuation`.
+  - In `apply_player_action`, wrap the action `match`'s `outcome` in `drive(cx, outcome)` before returning (so any phase anchor left on top by a handler is advanced).
+  - Keep `mythos_phase`/`step_phase` callable for the not-yet-migrated phases (Investigation/Enemy/Upkeep still cascade synchronously; only Mythos→Investigation is loop-driven this task).
+
+- [ ] **Step 4: Run** `cargo test -p game-core --lib mythos` + `cargo test -p scenarios --test mythos_phase` + the_gathering. Expected PASS (behaviour-preserving). Fix the mid-phase fixtures the new `drive` path touches.
+
+- [ ] **Step 5: Commit** `engine: drive loop + Mythos self-driving from Entry (1b). Refs #393.`
+
+---
+
+## Task 2: Investigation transition loop-driven
+
+**Files:** `phases.rs`.
+
+- [ ] **Step 1: Failing test** — `InvestigationPhase{Entry}` driven by `drive` rotates to the first turn and reaches the open-turn idle (`Done`, anchor `TurnBegins` on top), mirroring the old `investigation_phase` + cascade.
+- [ ] **Step 2: Run — fails.**
+- [ ] **Step 3:** Change `investigation_phase_end` (its body now an `advance` transition arm reached from the last turn's `EndTurn`) to pop the `InvestigationPhase` anchor, emit `PhaseEnded(Investigation)`, `state.phase = Enemy`, push `EnemyPhase{Entry}`, return `Done`. Add `advance(EnemyPhase{Entry})` = current `enemy_phase` body. Update `end_turn`'s terminal branch to route through `advance`/the transition rather than `investigation_phase_end → step_phase`. Verify the open-turn idle: when `begin_investigator_turn` leaves `InvestigationPhase{TurnBegins}` on top, `drive` breaks with `Done` (the `is_open_turn` arm) — the engine waits for the player's typed action.
+- [ ] **Step 4: Run** `cargo test -p game-core --lib 'dispatch::phases'` + the_gathering + `end_turn` tests. PASS.
+- [ ] **Step 5: Commit** `engine: Investigation transition loop-driven (1b). Refs #393.`
+
+---
+
+## Task 3: Enemy transition loop-driven
+
+**Files:** `phases.rs`.
+
+- [ ] **Step 1: Failing test** — `EnemyPhase{Entry}` via `drive` runs hunters + attack loop and transitions to Upkeep, mirroring the old cascade (use the hunter-tie fixture; assert the `UpkeepPhase{Entry}` push at the end).
+- [ ] **Step 2: Run — fails.**
+- [ ] **Step 3:** Change `enemy_phase_end`'s body (now an `advance` transition arm) to pop the `EnemyPhase` anchor, emit `PhaseEnded(Enemy)` + its forced emit (unchanged), `state.phase = Upkeep`, push `UpkeepPhase{Entry}`, return `Done`. Add `advance(UpkeepPhase{Entry})` = current `upkeep_phase` body. Confirm the soak/cancel-window resume path (`resume_enemy_attack` → `after_enemy_phase_attacks`) still drives the per-investigator loop correctly beneath the anchor.
+- [ ] **Step 4: Run** the enemy-phase + combat + hunter suites + the_gathering. PASS.
+- [ ] **Step 5: Commit** `engine: Enemy transition loop-driven (1b). Refs #393.`
+
+---
+
+## Task 4: Upkeep transition loop-driven + delete `step_phase`
+
+**Files:** `phases.rs`.
+
+- [ ] **Step 1: Failing test** — `UpkeepPhase{Entry}` via `drive` runs 4.2–4.6 + the round-end sequence and transitions to Mythos (`MythosPhase{Entry}` pushed; round bump fires on the Mythos `Entry` advance). Cover the act round-end window path (slice 0).
+- [ ] **Step 2: Run — fails.**
+- [ ] **Step 3:** Change `upkeep_round_end_teardown` (the single Upkeep→Mythos exit) to pop the `UpkeepPhase` anchor, `state.phase = Mythos`, push `MythosPhase{Entry}`, return `Done` (the loop advances it — running the round bump + `PhaseStarted(Mythos)`). With all four transitions loop-driven, **delete `step_phase`** (now unreferenced) and its `from == to` unreachable. Verify `start_scenario` pushes the first phase anchor `{Entry}` instead of calling a driver/`step_phase`.
+- [ ] **Step 4: Run** the full workspace suite. PASS. (Expect the largest fixture tail here — tests that called `step_phase` directly must switch to pushing an `{Entry}` anchor + `drive`.)
+- [ ] **Step 5: Commit** `engine: Upkeep transition loop-driven; delete step_phase (1b). Refs #393.`
+
+---
+
+## Task 5: Collapse the guard ladder
+
+**Files:** `mod.rs`.
+
+- [ ] **Step 1: Failing test** — assert a representative pending state (e.g. a `Choice` frame on top) rejects a non-`ResolveInput` action with the unified reason, and that an open-turn state (`InvestigationPhase{TurnBegins}` on top) *accepts* a typed `Move`/`EndTurn`.
+- [ ] **Step 2: Run — fails** (the new unified reason string isn't produced yet, or behaviour differs).
+- [ ] **Step 3:** Replace the 8 `if matches!(top, Pending::X) && !ResolveInput { reject }` blocks (mod.rs:61–189) with one:
+  ```rust
+  if let Some(top) = cx.state.continuations.last() {
+      if top.awaits_input() && !matches!(action, PlayerAction::ResolveInput { .. }) {
+          return EngineOutcome::Rejected {
+              reason: "a prompt is outstanding; submit a PlayerAction::ResolveInput \
+                       (see the AwaitingInput request for the expected InputResponse)".into(),
+          };
+      }
+  }
+  ```
+  (`awaits_input()` is false for `*Phase` anchors, so the open turn still allows typed actions.) Keep `StartScenario`'s own gate if it has one.
+- [ ] **Step 4: Run** the full workspace suite. PASS. (Reason-string assertions in existing rejection tests may need updating to the unified message — setup/expectation only, not behaviour.)
+- [ ] **Step 5: Commit** `engine: collapse the guard ladder onto the top-frame rule (1b). Refs #393.`
+
+---
+
+## Task 6: Dissolve the strand-guards + gauntlet + PR
+
+**Files:** `phases.rs`, spec/plan docs.
+
+- [ ] **Step 1:** Downgrade the `unreachable!("…would strand the test in the wrong phase…")` skill-test-in-flight guards in `advance` to `debug_assert!(cx.state.current_skill_test().is_none(), …)` — they are now genuinely impossible (a skill test sits above its phase anchor, so `drive` never advances the anchor while one is in flight), so the comment changes from "corpus-absent" to "structurally impossible under the loop."
+- [ ] **Step 2: Full gauntlet:**
+  ```bash
+  RUSTFLAGS="-D warnings" cargo test --all --all-features
+  cargo clippy --all-targets --all-features -- -D warnings
+  cargo fmt --check
+  RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+  cargo build -p web --target wasm32-unknown-unknown
+  ```
+  Expected: all green.
+- [ ] **Step 3:** Update spec §"Sequencing" 1b → `✅ shipped (PR #NN)` and the `What "done" looks like` note (`step_phase`/guard-ladder gone; transitions loop-driven). Add a plan status note. Commit, push, open the PR, watch CI. Request a review (this is a high-blast-radius change executed inline).
+
+---
+
+## Self-Review
+
+**Spec coverage (1b merged):** Tasks 1–4 build the loop + fold all four transitions onto it (deleting `step_phase` + the `*_phase_end` functions); Task 5 collapses the guard ladder; Task 6 dissolves the strand-guards + ships. Matches the merged spec sequencing entry. ✓
+
+**Placeholder scan:** the per-phase folds reference the *current* driver / `*_phase_end` bodies by name (copied, not paraphrased — the implementer reads each as they reach it). The `drive` loop, `awaits_input()`/`is_open_turn()`, and the guard-ladder replacement are shown in full. ⚠ Tasks 2–4's per-phase Step-1 tests are specified by pattern; expand them against the actual fixtures (mirroring Task 1's fully-shown test) at execution time.
+
+**Type consistency:** `advance(cx) -> EngineOutcome` and `drive(cx, outcome) -> EngineOutcome` signatures are stable across tasks; `Entry` is added to all four enums in Task 1 (used in later tasks); `awaits_input()`/`is_open_turn()` are `Continuation` methods referenced identically in `drive` and the guard collapse. ✓
+
+**Risk note:** highest-blast-radius slice in the arc. The coexistence states (Tasks 1–3, where some transitions are loop-driven and others synchronous) are the trickiest — verify the suite is green at *each* per-phase task, not just at the end. The transactional `apply` snapshot must still wrap the whole `drive` loop (a `Rejected` mid-loop restores cleanly) — confirm in Task 1.

--- a/docs/superpowers/plans/2026-06-20-unified-main-loop-1b.md
+++ b/docs/superpowers/plans/2026-06-20-unified-main-loop-1b.md
@@ -1,5 +1,7 @@
 # Unified Main Loop + Cascade-Fold (slice 1b) Implementation Plan
 
+> **Status: ✅ shipped (PR #398).** Executed inline as 6 commits; behaviour-preserving, full gauntlet green, review APPROVE (`drive` proven non-spinning). Deviation from plan: the per-phase migration used driver *reuse* (`advance(Entry)` = pop placeholder + call the existing driver) rather than moving driver bodies, and Tasks 3+4 merged (the `step_phase` retirement touches all its call sites at once). Review surfaced a beneficial behaviour change — the unified guard now gates `Choice`/`SubstitutionPrompt` (a latent hole the old ladder missed) — and a `*Phase`-entry unification follow-up (`start_scenario`/`resume_mulligan`).
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Replace the forward-calling synchronous phase cascade (`step_phase` → driver → `*_phase_end` → `step_phase`) with a uniform `drive(cx)` loop that advances the top continuation frame, so phase transitions are loop-driven (pop anchor + push next anchor) rather than native-stack recursion — and the guard ladder + strand-guards collapse out of it. Behaviour-preserving.

--- a/docs/superpowers/specs/2026-06-20-unified-control-flow-model-design.md
+++ b/docs/superpowers/specs/2026-06-20-unified-control-flow-model-design.md
@@ -427,12 +427,22 @@ Each step is independently green (mirrors §1's parts 2a–2c cadence):
      (review-confirmed faithful). Added `GameStateBuilder::with_phase_anchor` for the
      ~20 tests that construct mid-phase states directly. Guard ladder, action
      `match`, card-reaction arms untouched.
-   - **1b — fold the synchronous cascade onto anchor `drive`.** `step_phase`'s
-     forward-calling cascade becomes each anchor *pushing* its phase's first child;
-     the strand-guards become cheap asserts.
-   - **1c — uniform "handle the top frame" loop in `apply`.** Replace
-     `apply_player_action`'s ad-hoc recursion with the single-rule loop; the guard
-     ladder collapses to the top-frame rule (sets up slice 2's `InvestigatorTurn`).
+   - **1b — uniform main loop + cascade-fold (merges the former 1b/1c).** On
+     exploration the cascade-fold and the loop proved inseparable — "anchor drive"
+     only means something once a loop *invokes* the advance when a child pops, and
+     the strand-guard payoff only materializes with loop-driven transitions. So one
+     slice: add a `drive(cx)` loop the `apply` entry runs, which **advances the top
+     frame** until it (a) hits a suspension awaiting input → `AwaitingInput`, (b)
+     reaches the open turn (`InvestigationPhase{TurnBegins}`) → idle `Done`, or (c)
+     reaches terminal → `Done`. Each `*Resume` gains an **`Entry`** variant; the
+     anchor's resume-keyed `advance` subsumes the phase drivers (`Entry` = today's
+     `mythos_phase`/… opening), the boundary chunks (today's `anchor_on_child_pop`),
+     and the transitions (pop self + advance `state.phase` + push next anchor
+     `{Entry}` — replacing `*_phase_end`'s synchronous `step_phase`). `step_phase`
+     and the four `*_phase_end` functions dissolve. The **guard ladder** collapses to
+     one rule (top frame is a non-anchor suspension ⇒ only `ResolveInput`); the
+     **strand-guards** become genuinely impossible (a skill test sits *above* its
+     phase anchor) → `debug_assert!`. Sets up slice 2's `InvestigatorTurn`.
 2. **`InvestigatorTurn` frame (2a) + legal-action enumerator** — open-turn becomes a
    frame; guard ladder + action `match` deleted; typed `PlayerAction` validated
    against the offered set; `pending_end_turn` absorbed.

--- a/docs/superpowers/specs/2026-06-20-unified-control-flow-model-design.md
+++ b/docs/superpowers/specs/2026-06-20-unified-control-flow-model-design.md
@@ -427,8 +427,8 @@ Each step is independently green (mirrors §1's parts 2a–2c cadence):
      (review-confirmed faithful). Added `GameStateBuilder::with_phase_anchor` for the
      ~20 tests that construct mid-phase states directly. Guard ladder, action
      `match`, card-reaction arms untouched.
-   - **1b — uniform main loop + cascade-fold (merges the former 1b/1c).** On
-     exploration the cascade-fold and the loop proved inseparable — "anchor drive"
+   - **1b — uniform main loop + cascade-fold (merges the former 1b/1c). ✅ shipped
+     (PR #398).** On exploration the cascade-fold and the loop proved inseparable — "anchor drive"
      only means something once a loop *invokes* the advance when a child pops, and
      the strand-guard payoff only materializes with loop-driven transitions. So one
      slice: add a `drive(cx)` loop the `apply` entry runs, which **advances the top
@@ -443,6 +443,13 @@ Each step is independently green (mirrors §1's parts 2a–2c cadence):
      one rule (top frame is a non-anchor suspension ⇒ only `ResolveInput`); the
      **strand-guards** become genuinely impossible (a skill test sits *above* its
      phase anchor) → `debug_assert!`. Sets up slice 2's `InvestigatorTurn`.
+     *Surfaced in review:* the unified guard rule also gates `Choice` /
+     `SubstitutionPrompt` frames that the eight-block ladder never covered —
+     closing a latent hole where a typed action arriving mid-`Choice` (a
+     `ChooseOne` OnPlay) fell through and mutated half-resolved state. A
+     `*Phase`-entry follow-up remains (`start_scenario`/`resume_mulligan` still
+     call `investigation_phase` directly rather than pushing
+     `InvestigationPhase{Entry}`; behaviour-identical, but two conventions).
 2. **`InvestigatorTurn` frame (2a) + legal-action enumerator** — open-turn becomes a
    frame; guard ladder + action `match` deleted; typed `PlayerAction` validated
    against the offered set; `pending_end_turn` absorbed.


### PR DESCRIPTION
## What

**Slice 1b** of #393 (merges the spec's former 1b/1c — they proved inseparable). Replace the forward-calling synchronous phase cascade (`step_phase` → driver → `*_phase_end` → `step_phase`) with a uniform **`drive(cx)` loop** that advances the top continuation frame; collapse the guard ladder and dissolve the strand-guards that fall out of it. **Behaviour-preserving** — full workspace + gauntlet green.

Design/plan: spec §"Sequencing" 1b + [`2026-06-20-unified-main-loop-1b.md`](docs/superpowers/plans/2026-06-20-unified-main-loop-1b.md).

## How (the mechanism)

- **`drive(cx, outcome)`** advances the top frame until it (a) blocks on a suspension awaiting input → `AwaitingInput`, (b) reaches the open turn (`InvestigationPhase{TurnBegins}`) → idle `Done`, (c) reaches terminal → `Done`, or (d) parks with no progress → `Done`. Run at the `apply` boundary.
- Each `*Resume` gains an **`Entry`** variant; `advance_phase_entry` pops the placeholder and runs the phase opening via the **existing driver** (reuse, not rewrite). `Continuation::is_phase_anchor`/`is_open_turn` classify frames.
- The four transitions (`*_phase_end` / `upkeep_round_end_teardown`) now **pop self + set `state.phase` + push the next anchor `{Entry}`** instead of calling `step_phase`; `drive` carries the cascade. **`step_phase` retired** (now a `#[cfg(test)]` helper routing through the loop).
- **Guard ladder → one rule**: top frame `awaits_input()` && action ≠ `ResolveInput` ⇒ reject (~120 lines deleted). Subtlety preserved: `awaits_input()` is `false` for a **Fast-play window** (a `Resolution` with no pending triggers), mirroring `top_reaction_window`, so Fast plays stay allowed there.
- **Strand-guards** → `debug_assert!` (a skill test sits *above* its phase anchor, so `drive` never advances the anchor with one in flight — structurally impossible, not just corpus-absent).

## Test impact

Unit tests that drive a phase-completing flow *directly* (bypassing `apply`'s `drive`) now wrap the completing call with `drive`, mirroring production; two reason-string assertions updated to the unified guard message. All setup/expectation-only — no behaviour assertions weakened.

## Scope

Out of scope (slice 2): the `InvestigatorTurn` frame + legal-action enumeration replace the `InvestigationPhase{TurnBegins}` open-turn idle. This slice keeps the typed-`PlayerAction` open turn.

## Verification

Full local gauntlet green: `test --all`, `clippy --all-targets`, `fmt --check`, `doc`, `wasm-build`.

Refs #393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)