### PR TITLE
engine: open turn becomes an InvestigatorTurn frame (slice 2a-i of #393)

### DIFF
--- a/crates/cards/tests/barricade.rs
+++ b/crates/cards/tests/barricade.rs
@@ -117,6 +117,9 @@ fn map_with_barricade_at_b(enemy_code: &str) -> game_core::GameState {
         .with_phase_anchor(game_core::state::Continuation::InvestigationPhase {
             resume: game_core::state::InvestigationResume::TurnBegins,
         })
+        // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame the
+        // EndTurn cascade pops before rotating / cascading.
+        .with_investigator_turn(INV)
         .build();
     state
         .locations

--- a/crates/cards/tests/dodge.rs
+++ b/crates/cards/tests/dodge.rs
@@ -73,6 +73,9 @@ fn dodge_state() -> (GameState, InvestigatorId, EnemyId) {
         .with_phase_anchor(game_core::state::Continuation::InvestigationPhase {
             resume: game_core::state::InvestigationResume::TurnBegins,
         })
+        // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame the
+        // EndTurn cascade pops before advancing into the Enemy phase.
+        .with_investigator_turn(inv_id)
         .build();
     (state, inv_id, enemy_id)
 }

--- a/crates/cards/tests/guard_dog_soak.rs
+++ b/crates/cards/tests/guard_dog_soak.rs
@@ -101,6 +101,9 @@ fn soak_state(
     builder = builder.with_phase_anchor(game_core::state::Continuation::InvestigationPhase {
         resume: game_core::state::InvestigationResume::TurnBegins,
     });
+    // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame the
+    // EndTurn cascade pops before advancing into the Enemy phase.
+    builder = builder.with_investigator_turn(inv_id);
     (builder.build(), inv_id, loc_id)
 }
 

--- a/crates/cards/tests/persistent_treachery.rs
+++ b/crates/cards/tests/persistent_treachery.rs
@@ -319,7 +319,12 @@ fn frozen_in_fear_end_of_turn_success_discards_and_turn_resumes() {
         Some(InvestigatorId(2)),
         "end_turn resumed after the test and rotated to investigator 2",
     );
-    assert!(r.state.pending_end_turn.is_none());
+    // The turn was not left stranded: no InvestigatorTurn frame is mid-end
+    // (slice 2a-i absorbed the former pending_end_turn into `ending`).
+    assert!(!r.state.continuations.iter().any(|c| matches!(
+        c,
+        game_core::state::Continuation::InvestigatorTurn { ending: true, .. }
+    )));
 }
 
 #[test]
@@ -336,7 +341,12 @@ fn frozen_in_fear_end_of_turn_failure_keeps_card_but_turn_still_resumes() {
     assert!(!r.state.encounter_discard.contains(&CardCode::new("01164")));
     // Turn still progresses regardless of the test outcome.
     assert_eq!(r.state.active_investigator, Some(InvestigatorId(2)));
-    assert!(r.state.pending_end_turn.is_none());
+    // The turn was not left stranded: no InvestigatorTurn frame is mid-end
+    // (slice 2a-i absorbed the former pending_end_turn into `ending`).
+    assert!(!r.state.continuations.iter().any(|c| matches!(
+        c,
+        game_core::state::Continuation::InvestigatorTurn { ending: true, .. }
+    )));
 }
 
 #[test]
@@ -408,7 +418,12 @@ fn two_frozen_in_fear_end_of_turn_tests_both_resolve_then_turn_resumes() {
         Some(InvestigatorId(2)),
         "end_turn resumed after both tests and rotated to investigator 2",
     );
-    assert!(r.state.pending_end_turn.is_none());
+    // The turn was not left stranded: no InvestigatorTurn frame is mid-end
+    // (slice 2a-i absorbed the former pending_end_turn into `ending`).
+    assert!(!r.state.continuations.iter().any(|c| matches!(
+        c,
+        game_core::state::Continuation::InvestigatorTurn { ending: true, .. }
+    )));
 }
 
 #[test]

--- a/crates/cards/tests/persistent_treachery.rs
+++ b/crates/cards/tests/persistent_treachery.rs
@@ -286,6 +286,9 @@ fn frozen_in_fear_board(token: ChaosToken) -> game_core::GameState {
         .with_phase_anchor(game_core::state::Continuation::InvestigationPhase {
             resume: game_core::state::InvestigationResume::TurnBegins,
         })
+        // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame the
+        // EndTurn pops (or strands a skill test below, then pops on resume).
+        .with_investigator_turn(InvestigatorId(1))
         .build();
     state.chaos_bag.tokens = vec![token];
     state
@@ -366,6 +369,9 @@ fn two_frozen_in_fear_end_of_turn_tests_both_resolve_then_turn_resumes() {
         .with_phase_anchor(game_core::state::Continuation::InvestigationPhase {
             resume: game_core::state::InvestigationResume::TurnBegins,
         })
+        // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame the
+        // EndTurn pops (or strands a skill test below, then pops on resume).
+        .with_investigator_turn(InvestigatorId(1))
         .build();
     // Two Numeric(0) draws → willpower 3 vs difficulty 3 → both succeed.
     state.chaos_bag.tokens = vec![ChaosToken::Numeric(0), ChaosToken::Numeric(0)];

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -371,6 +371,15 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
                 .into(),
         },
         Some(Continuation::SkillTest(_)) => resume_skill_test_commit(cx, response),
+        // The open turn does not emit an AwaitingInput prompt in 2a (typed
+        // actions drive it; the enumeration is 2a-ii / surfacing is 2b). A
+        // ResolveInput arriving here is spurious — reject defensively, mirroring
+        // the phase-anchor arm (slice 2a-i, #393).
+        Some(Continuation::InvestigatorTurn { .. }) => EngineOutcome::Rejected {
+            reason: "ResolveInput: no input prompt is outstanding (the open turn \
+                     takes typed actions, not ResolveInput)"
+                .into(),
+        },
         // Phase anchors (slice 1a, #393) never await input — they only sit
         // beneath framework windows. If one is somehow top, no prompt is
         // outstanding (defensive, mirrors the EncounterCard arm).

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -151,13 +151,14 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
 ///
 /// - non-`Done` `outcome` (a suspension / rejection from the action itself)
 ///   passes straight through;
-/// - a `*Phase` anchor on top (other than the open turn) is advanced via
+/// - a `*Phase` anchor on top is advanced via
 ///   [`phases::anchor_on_child_pop`], which runs its resume-keyed chunk and,
 ///   at a phase boundary, transitions by popping itself + pushing the next
 ///   phase's anchor (`Entry`) — the loop then advances that;
 /// - the loop stops with `AwaitingInput` when an advance suspends, and with
-///   `Done` at the open turn (`InvestigationPhase{TurnBegins}`), at terminal
-///   (empty stack), or when an advance makes no progress (a parked phase, e.g.
+///   `Done` when an [`InvestigatorTurn`](crate::state::Continuation::InvestigatorTurn)
+///   frame is on top (the open turn — slice 2a-i, #393), at terminal (empty
+///   stack), or when an advance makes no progress (a parked phase, e.g.
 ///   Investigation with no active investigator).
 pub(super) fn drive(cx: &mut Cx, outcome: EngineOutcome) -> EngineOutcome {
     if !matches!(outcome, EngineOutcome::Done) {
@@ -166,7 +167,7 @@ pub(super) fn drive(cx: &mut Cx, outcome: EngineOutcome) -> EngineOutcome {
     loop {
         let top = cx.state.continuations.last().cloned();
         match top {
-            Some(ref c) if c.is_phase_anchor() && !c.is_open_turn() => {
+            Some(ref c) if c.is_phase_anchor() => {
                 match phases::anchor_on_child_pop(cx) {
                     EngineOutcome::Done => {
                         // No-progress guard: a parked phase (e.g. Investigation
@@ -179,8 +180,9 @@ pub(super) fn drive(cx: &mut Cx, outcome: EngineOutcome) -> EngineOutcome {
                     other => return other,
                 }
             }
-            // Open turn idle, terminal (empty), or a suspension on top (which a
-            // handler already surfaced as AwaitingInput before reaching here).
+            // Open turn idle (an `InvestigatorTurn` frame on top), terminal
+            // (empty), or a suspension on top (which a handler already surfaced
+            // as AwaitingInput before reaching here).
             _ => return EngineOutcome::Done,
         }
     }

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -287,9 +287,9 @@ fn resume_skill_test_commit(cx: &mut Cx, response: &InputResponse) -> EngineOutc
                 // simultaneous `EndOfTurn` forced — two Frozen in Fear copies,
                 // #213). The run's frame is now back on top; re-enter it to
                 // fire the remaining siblings, or close it (running its
-                // continuation, e.g. end-of-turn rotation). Checked before
-                // `pending_end_turn`: a forced run owns its own post-run
-                // continuation and never sets `pending_end_turn`.
+                // continuation, e.g. end-of-turn rotation). Checked before the
+                // `ending` frame: a forced run owns its own post-run
+                // continuation and never flags the `InvestigatorTurn` frame.
                 if matches!(
                     cx.state.continuations.last(),
                     Some(crate::state::Continuation::Resolution(f)) if f.is_forced()
@@ -298,11 +298,17 @@ fn resume_skill_test_commit(cx: &mut Cx, response: &InputResponse) -> EngineOutc
                     return reaction_windows::advance_resolution(cx, idx);
                 }
                 // Otherwise: a single suspending `EndOfTurn` forced effect
-                // (one Frozen in Fear) stranded `end_turn` before rotation;
-                // resume it now that the test is fully done (C4c, #235). An
-                // `AwaitingInput` mid-teardown leaves `pending_end_turn` set
-                // for the next resume.
-                if let Some(active_id) = cx.state.pending_end_turn.take() {
+                // (one Frozen in Fear) stranded `end_turn` before rotation. The
+                // SkillTest has popped, so the `InvestigatorTurn` frame is back
+                // on top; if its `ending` flag is set, resume rotation now that
+                // the test is fully done (C4c, #235; slice 2a-i absorbs
+                // `pending_end_turn`). `resume_end_turn` pops the frame.
+                if let Some(crate::state::Continuation::InvestigatorTurn {
+                    investigator,
+                    ending: true,
+                }) = cx.state.continuations.last()
+                {
+                    let active_id = *investigator;
                     return phases::resume_end_turn(cx, active_id);
                 }
             }

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -1610,22 +1610,14 @@ mod investigation_phase_tests {
             .with_investigator(test_investigator(1))
             .with_phase(Phase::Investigation)
             .with_active_investigator(InvestigatorId(1))
-            .build();
-        state.turn_order = vec![InvestigatorId(1)];
-        // Mid-Investigation invariant (slice 1a): push the InvestigationPhase
-        // anchor that investigation_phase would have left on the stack.
-        state
-            .continuations
-            .push(crate::state::Continuation::InvestigationPhase {
+            .with_turn_order([InvestigatorId(1)])
+            // Mid-Investigation invariant: the InvestigationPhase anchor (slice
+            // 1a) + the open-turn frame (slice 2a-i) the driver leaves mid-turn.
+            .with_phase_anchor(crate::state::Continuation::InvestigationPhase {
                 resume: crate::state::InvestigationResume::TurnBegins,
-            });
-        // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame the
-        // driver leaves on top once the InvestigatorTurnBegins window closes.
-        state
-            .continuations
-            .push(crate::state::Continuation::InvestigatorTurn {
-                investigator: InvestigatorId(1),
-            });
+            })
+            .with_investigator_turn(InvestigatorId(1))
+            .build();
 
         let mut events = Vec::new();
         let outcome = {
@@ -1685,22 +1677,14 @@ mod investigation_phase_tests {
             .with_investigator(test_investigator(2))
             .with_phase(Phase::Investigation)
             .with_active_investigator(InvestigatorId(1))
-            .build();
-        state.turn_order = vec![InvestigatorId(1), InvestigatorId(2)];
-        // Mid-Investigation invariant (slice 1a): push the InvestigationPhase
-        // anchor that investigation_phase would have left on the stack.
-        state
-            .continuations
-            .push(crate::state::Continuation::InvestigationPhase {
+            .with_turn_order([InvestigatorId(1), InvestigatorId(2)])
+            // Mid-Investigation invariant: the InvestigationPhase anchor (slice
+            // 1a) + the open-turn frame (slice 2a-i) the driver leaves mid-turn.
+            .with_phase_anchor(crate::state::Continuation::InvestigationPhase {
                 resume: crate::state::InvestigationResume::TurnBegins,
-            });
-        // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame the
-        // driver leaves on top once the InvestigatorTurnBegins window closes.
-        state
-            .continuations
-            .push(crate::state::Continuation::InvestigatorTurn {
-                investigator: InvestigatorId(1),
-            });
+            })
+            .with_investigator_turn(InvestigatorId(1))
+            .build();
 
         let mut events = Vec::new();
         let outcome = {
@@ -2685,27 +2669,19 @@ mod upkeep_phase_tests {
         inv.cards_in_play = vec![card];
         let res_before = inv.resources;
         let hand_before = inv.hand.len();
-        let mut state = GameStateBuilder::default()
+        let state = GameStateBuilder::default()
             .with_investigator(inv)
             .with_phase(Phase::Investigation)
-            .build();
-        state.turn_order = vec![id];
-        state.active_investigator = Some(id);
-        state.round = 1;
-        // Mid-Investigation invariant (slice 1a): push the InvestigationPhase
-        // anchor that investigation_phase would have left on the stack.
-        state
-            .continuations
-            .push(crate::state::Continuation::InvestigationPhase {
+            .with_turn_order([id])
+            .with_active_investigator(id)
+            .with_round(1)
+            // Mid-Investigation invariant: the InvestigationPhase anchor (slice
+            // 1a) + the open-turn frame (slice 2a-i) the driver leaves mid-turn.
+            .with_phase_anchor(crate::state::Continuation::InvestigationPhase {
                 resume: crate::state::InvestigationResume::TurnBegins,
-            });
-        // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame the
-        // driver leaves on top once the InvestigatorTurnBegins window closes.
-        state
-            .continuations
-            .push(crate::state::Continuation::InvestigatorTurn {
-                investigator: InvestigatorId(1),
-            });
+            })
+            .with_investigator_turn(id)
+            .build();
 
         let result = apply(state, Action::Player(PlayerAction::EndTurn));
 
@@ -2984,22 +2960,15 @@ mod enemy_phase_tests {
             .with_active_investigator(InvestigatorId(1))
             .with_turn_order([InvestigatorId(1)])
             .with_enemy(hunter)
-            .build();
-        // Mid-Investigation invariant (slice 1a): the InvestigationPhase anchor
-        // is on the stack all phase. These tests construct the state directly
-        // (bypassing investigation_phase), so push it explicitly.
-        state
-            .continuations
-            .push(crate::state::Continuation::InvestigationPhase {
+            // Mid-Investigation invariant: the InvestigationPhase anchor (slice
+            // 1a) + the open-turn frame (slice 2a-i) the driver leaves mid-turn.
+            // These tests construct the state directly (bypassing
+            // investigation_phase), so stage both explicitly.
+            .with_phase_anchor(crate::state::Continuation::InvestigationPhase {
                 resume: crate::state::InvestigationResume::TurnBegins,
-            });
-        // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame the
-        // driver leaves on top once the InvestigatorTurnBegins window closes.
-        state
-            .continuations
-            .push(crate::state::Continuation::InvestigatorTurn {
-                investigator: InvestigatorId(1),
-            });
+            })
+            .with_investigator_turn(InvestigatorId(1))
+            .build();
         let mut events = Vec::new();
         let outcome = {
             // end_turn may push the next phase's Entry anchor (slice 1b); drive
@@ -3051,22 +3020,15 @@ mod enemy_phase_tests {
             .with_active_investigator(InvestigatorId(1))
             .with_turn_order([InvestigatorId(1)])
             .with_enemy(hunter)
-            .build();
-        // Mid-Investigation invariant (slice 1a): the InvestigationPhase anchor
-        // is on the stack all phase. These tests construct the state directly
-        // (bypassing investigation_phase), so push it explicitly.
-        state
-            .continuations
-            .push(crate::state::Continuation::InvestigationPhase {
+            // Mid-Investigation invariant: the InvestigationPhase anchor (slice
+            // 1a) + the open-turn frame (slice 2a-i) the driver leaves mid-turn.
+            // These tests construct the state directly (bypassing
+            // investigation_phase), so stage both explicitly.
+            .with_phase_anchor(crate::state::Continuation::InvestigationPhase {
                 resume: crate::state::InvestigationResume::TurnBegins,
-            });
-        // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame the
-        // driver leaves on top once the InvestigatorTurnBegins window closes.
-        state
-            .continuations
-            .push(crate::state::Continuation::InvestigatorTurn {
-                investigator: InvestigatorId(1),
-            });
+            })
+            .with_investigator_turn(InvestigatorId(1))
+            .build();
         let mut events = Vec::new();
         let outcome = {
             // end_turn may push the next phase's Entry anchor (slice 1b); drive

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -257,6 +257,21 @@ pub(super) fn end_turn(cx: &mut Cx) -> EngineOutcome {
 /// suspending `EndOfTurn` forced effect (Frozen in Fear 01164) stranded
 /// `end_turn` before rotation.
 pub(super) fn resume_end_turn(cx: &mut Cx, active_id: InvestigatorId) -> EngineOutcome {
+    // The turn is over: pop the InvestigatorTurn frame this turn ran on (slice
+    // 2a-i, #393). It is always on top here — end_turn reaches this after the
+    // EndOfTurn forced run resolves, the stranded-skill-test resume after the
+    // SkillTest pops, and the forced-run continuation after its Resolution pops.
+    debug_assert!(
+        matches!(
+            cx.state.continuations.last(),
+            Some(crate::state::Continuation::InvestigatorTurn { investigator })
+                if *investigator == active_id
+        ),
+        "resume_end_turn: expected InvestigatorTurn({active_id:?}) on top, got {:?}",
+        cx.state.continuations.last(),
+    );
+    cx.state.continuations.pop();
+
     // 2.2.2 decision: "return to 2.2" for the next investigator, or
     // proceed to 2.3. next_active_investigator_after skips eliminated
     // investigators (Rules Reference p.10) — the same shared helper the
@@ -834,8 +849,20 @@ pub(super) fn anchor_on_child_pop(cx: &mut Cx) -> EngineOutcome {
         Some(Continuation::InvestigationPhase {
             resume: InvestigationResume::TurnBegins,
         }) => {
-            // 2.2.1 — the active investigator now acts as player-driven input;
-            // no continuation work (slice 2 makes this an InvestigatorTurn frame).
+            // 2.2.1 — push the InvestigatorTurn frame above the anchor (slice
+            // 2a-i, #393). The anchor stays at TurnBegins beneath it; the frame
+            // is the open-turn idle point (drive breaks here, returning Done).
+            // `active_investigator` was set by rotate_to_active in
+            // begin_investigator_turn; it is the frame's investigator.
+            let investigator = cx.state.active_investigator.unwrap_or_else(|| {
+                unreachable!(
+                    "TurnBegins reached with no active_investigator; \
+                     begin_investigator_turn always sets it"
+                )
+            });
+            cx.state
+                .continuations
+                .push(Continuation::InvestigatorTurn { investigator });
             EngineOutcome::Done
         }
         Some(Continuation::MythosPhase {
@@ -1320,6 +1347,47 @@ mod investigation_phase_tests {
     use crate::test_support::{test_investigator, GameStateBuilder};
 
     #[test]
+    fn open_turn_leaves_investigator_turn_frame_on_top() {
+        use crate::state::{Continuation, InvestigationResume};
+        // Reach the open turn the way production does: enter the Investigation
+        // phase for a single investigator (no Fast cards → windows auto-skip).
+        let mut state = GameStateBuilder::default()
+            .with_investigator(test_investigator(1))
+            .with_phase(Phase::Investigation)
+            .build();
+        state.turn_order = vec![InvestigatorId(1)];
+
+        let mut events = Vec::new();
+        let outcome = {
+            let mut cx = crate::engine::Cx {
+                state: &mut state,
+                events: &mut events,
+            };
+            // investigation_phase pushes the anchor + opens (auto-skips) both
+            // windows, landing the first investigator's open turn.
+            investigation_phase(&mut cx);
+            super::super::drive(&mut cx, EngineOutcome::Done)
+        };
+
+        // The open turn idles as Done (NOT AwaitingInput) — behaviour-preserving.
+        assert_eq!(outcome, EngineOutcome::Done);
+        // Top frame is the InvestigatorTurn for investigator 1...
+        assert_eq!(
+            state.continuations.last(),
+            Some(&Continuation::InvestigatorTurn {
+                investigator: InvestigatorId(1),
+            }),
+        );
+        // ...sitting above the still-present InvestigationPhase anchor.
+        assert!(state.continuations.iter().any(|c| matches!(
+            c,
+            Continuation::InvestigationPhase {
+                resume: InvestigationResume::TurnBegins
+            }
+        )));
+    }
+
+    #[test]
     fn mulligan_completion_kicks_off_investigation_phase() {
         // After the last investigator mulligans, setup ends and the
         // Investigation phase begins (Rules Reference p.27: no action
@@ -1551,6 +1619,13 @@ mod investigation_phase_tests {
             .push(crate::state::Continuation::InvestigationPhase {
                 resume: crate::state::InvestigationResume::TurnBegins,
             });
+        // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame the
+        // driver leaves on top once the InvestigatorTurnBegins window closes.
+        state
+            .continuations
+            .push(crate::state::Continuation::InvestigatorTurn {
+                investigator: InvestigatorId(1),
+            });
 
         let mut events = Vec::new();
         let outcome = {
@@ -1618,6 +1693,13 @@ mod investigation_phase_tests {
             .continuations
             .push(crate::state::Continuation::InvestigationPhase {
                 resume: crate::state::InvestigationResume::TurnBegins,
+            });
+        // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame the
+        // driver leaves on top once the InvestigatorTurnBegins window closes.
+        state
+            .continuations
+            .push(crate::state::Continuation::InvestigatorTurn {
+                investigator: InvestigatorId(1),
             });
 
         let mut events = Vec::new();
@@ -2617,6 +2699,13 @@ mod upkeep_phase_tests {
             .push(crate::state::Continuation::InvestigationPhase {
                 resume: crate::state::InvestigationResume::TurnBegins,
             });
+        // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame the
+        // driver leaves on top once the InvestigatorTurnBegins window closes.
+        state
+            .continuations
+            .push(crate::state::Continuation::InvestigatorTurn {
+                investigator: InvestigatorId(1),
+            });
 
         let result = apply(state, Action::Player(PlayerAction::EndTurn));
 
@@ -2904,6 +2993,13 @@ mod enemy_phase_tests {
             .push(crate::state::Continuation::InvestigationPhase {
                 resume: crate::state::InvestigationResume::TurnBegins,
             });
+        // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame the
+        // driver leaves on top once the InvestigatorTurnBegins window closes.
+        state
+            .continuations
+            .push(crate::state::Continuation::InvestigatorTurn {
+                investigator: InvestigatorId(1),
+            });
         let mut events = Vec::new();
         let outcome = {
             // end_turn may push the next phase's Entry anchor (slice 1b); drive
@@ -2963,6 +3059,13 @@ mod enemy_phase_tests {
             .continuations
             .push(crate::state::Continuation::InvestigationPhase {
                 resume: crate::state::InvestigationResume::TurnBegins,
+            });
+        // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame the
+        // driver leaves on top once the InvestigatorTurnBegins window closes.
+        state
+            .continuations
+            .push(crate::state::Continuation::InvestigatorTurn {
+                investigator: InvestigatorId(1),
             });
         let mut events = Vec::new();
         let outcome = {

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -220,11 +220,12 @@ pub(super) fn end_turn(cx: &mut Cx) -> EngineOutcome {
     // - **2+ simultaneous** `EndOfTurn` forced (two Frozen in Fear copies)
     //   open a forced run (#213) that carries its own
     //   `ForcedContinuation::EndOfTurnAfterForced` — it resumes rotation on
-    //   close, so `end_turn` must *not* also set `pending_end_turn`.
-    // - **a single** suspending hit has no run frame; record the active
-    //   investigator in `pending_end_turn` so the skill-test commit-resume
-    //   path re-enters [`resume_end_turn`] once the test resolves (C4c, #235
-    //   — mirrors the SpawnEngage frame).
+    //   close, so `end_turn` must *not* also flag the frame.
+    // - **a single** suspending hit has no run frame; flag the
+    //   `InvestigatorTurn` frame (below the skill test) as `ending` so the
+    //   skill-test commit-resume path re-enters [`resume_end_turn`] once the
+    //   test resolves (C4c, #235; slice 2a-i absorbs the former
+    //   `pending_end_turn` — mirrors the SpawnEngage frame).
     //
     // A `Rejected` propagates as-is.
     let end_of_turn = super::emit::emit_event(
@@ -241,7 +242,26 @@ pub(super) fn end_turn(cx: &mut Cx) -> EngineOutcome {
                 Some(crate::state::Continuation::Resolution(f)) if f.is_forced()
             );
             if !forced_run_open {
-                cx.state.pending_end_turn = Some(active_id);
+                // The skill test sits above the InvestigatorTurn frame; find it
+                // and set `ending` so the commit-resume triggers rotation.
+                let ending = cx
+                    .state
+                    .continuations
+                    .iter_mut()
+                    .rev()
+                    .find_map(|c| match c {
+                        crate::state::Continuation::InvestigatorTurn {
+                            investigator,
+                            ending,
+                        } if *investigator == active_id => Some(ending),
+                        _ => None,
+                    })
+                    .unwrap_or_else(|| {
+                        unreachable!(
+                            "end_turn stranded with no InvestigatorTurn({active_id:?}) on the stack"
+                        )
+                    });
+                *ending = true;
             }
             end_of_turn
         }
@@ -253,9 +273,9 @@ pub(super) fn end_turn(cx: &mut Cx) -> EngineOutcome {
 /// Reference p.24 step 2.2.2): rotate to the next active investigator, or
 /// end the Investigation phase. Called inline by `end_turn` when the
 /// `EndOfTurn` forced effects resolved synchronously, and by the
-/// skill-test commit-resume path (via `pending_end_turn`) when a
-/// suspending `EndOfTurn` forced effect (Frozen in Fear 01164) stranded
-/// `end_turn` before rotation.
+/// skill-test commit-resume path (keyed off the `InvestigatorTurn` frame's
+/// `ending` flag) when a suspending `EndOfTurn` forced effect (Frozen in
+/// Fear 01164) stranded `end_turn` before rotation.
 pub(super) fn resume_end_turn(cx: &mut Cx, active_id: InvestigatorId) -> EngineOutcome {
     // The turn is over: pop the InvestigatorTurn frame this turn ran on (slice
     // 2a-i, #393). It is always on top here — end_turn reaches this after the
@@ -264,7 +284,7 @@ pub(super) fn resume_end_turn(cx: &mut Cx, active_id: InvestigatorId) -> EngineO
     debug_assert!(
         matches!(
             cx.state.continuations.last(),
-            Some(crate::state::Continuation::InvestigatorTurn { investigator })
+            Some(crate::state::Continuation::InvestigatorTurn { investigator, .. })
                 if *investigator == active_id
         ),
         "resume_end_turn: expected InvestigatorTurn({active_id:?}) on top, got {:?}",
@@ -860,9 +880,10 @@ pub(super) fn anchor_on_child_pop(cx: &mut Cx) -> EngineOutcome {
                      begin_investigator_turn always sets it"
                 )
             });
-            cx.state
-                .continuations
-                .push(Continuation::InvestigatorTurn { investigator });
+            cx.state.continuations.push(Continuation::InvestigatorTurn {
+                investigator,
+                ending: false,
+            });
             EngineOutcome::Done
         }
         Some(Continuation::MythosPhase {
@@ -1347,6 +1368,29 @@ mod investigation_phase_tests {
     use crate::test_support::{test_investigator, GameStateBuilder};
 
     #[test]
+    fn investigator_turn_defaults_to_not_ending() {
+        use crate::state::Continuation;
+        // The builder-staged open-turn frame is not mid-end-turn.
+        let state = GameStateBuilder::default()
+            .with_investigator(test_investigator(1))
+            .with_phase(Phase::Investigation)
+            .with_active_investigator(InvestigatorId(1))
+            .with_turn_order([InvestigatorId(1)])
+            .with_phase_anchor(Continuation::InvestigationPhase {
+                resume: crate::state::InvestigationResume::TurnBegins,
+            })
+            .with_investigator_turn(InvestigatorId(1))
+            .build();
+        assert_eq!(
+            state.continuations.last(),
+            Some(&Continuation::InvestigatorTurn {
+                investigator: InvestigatorId(1),
+                ending: false,
+            }),
+        );
+    }
+
+    #[test]
     fn open_turn_leaves_investigator_turn_frame_on_top() {
         use crate::state::{Continuation, InvestigationResume};
         // Reach the open turn the way production does: enter the Investigation
@@ -1376,6 +1420,7 @@ mod investigation_phase_tests {
             state.continuations.last(),
             Some(&Continuation::InvestigatorTurn {
                 investigator: InvestigatorId(1),
+                ending: false,
             }),
         );
         // ...sitting above the still-present InvestigationPhase anchor.

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -394,6 +394,7 @@ mod tests {
             .with_phase_anchor(crate::state::Continuation::InvestigationPhase {
                 resume: crate::state::InvestigationResume::TurnBegins,
             })
+            .with_investigator_turn(id)
             .build();
 
         let result = apply(state, Action::Player(PlayerAction::EndTurn));
@@ -4771,6 +4772,13 @@ mod tests {
             .continuations
             .push(crate::state::Continuation::InvestigationPhase {
                 resume: crate::state::InvestigationResume::TurnBegins,
+            });
+        // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame on
+        // top of the anchor, popped by the EndTurn below.
+        state
+            .continuations
+            .push(crate::state::Continuation::InvestigatorTurn {
+                investigator: InvestigatorId(1),
             });
         let reg = ScenarioRegistry {
             module_for: stamp_module_for,

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -4779,6 +4779,7 @@ mod tests {
             .continuations
             .push(crate::state::Continuation::InvestigatorTurn {
                 investigator: InvestigatorId(1),
+                ending: false,
             });
         let reg = ScenarioRegistry {
             module_for: stamp_module_for,

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -25,6 +25,8 @@
 //!     .with_phase_anchor(Continuation::InvestigationPhase {
 //!         resume: InvestigationResume::TurnBegins,
 //!     })
+//!     // ...and the open-turn frame above it (slice 2a-i), popped by EndTurn.
+//!     .with_investigator_turn(InvestigatorId(1))
 //!     .build();
 //!
 //! let result = apply(state, Action::Player(PlayerAction::EndTurn));

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -324,7 +324,10 @@ impl GameStateBuilder {
         // A staged open turn (slice 2a-i, #393) sits directly above the anchor;
         // any window opened during the turn is a sub-resolution above it.
         if let Some(investigator) = self.investigator_turn {
-            continuations.push(Continuation::InvestigatorTurn { investigator });
+            continuations.push(Continuation::InvestigatorTurn {
+                investigator,
+                ending: false,
+            });
         }
         continuations.extend(self.open_windows.into_iter().map(Continuation::Resolution));
         if let Some(hsd) = self.hand_size_discard_pending {
@@ -362,7 +365,6 @@ impl GameStateBuilder {
             continuations,
             scenario_id: self.scenario_id,
             enemy_attack_pending: None,
-            pending_end_turn: None,
             pending_enemy_attack: None,
             pending_cancellation: false,
             pending_played_event: None,

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -63,6 +63,7 @@ pub struct GameStateBuilder {
     hand_size_discard_pending: Option<HandSizeDiscard>,
     open_windows: Vec<ResolutionFrame>,
     phase_anchor: Option<Continuation>,
+    investigator_turn: Option<InvestigatorId>,
     scenario_id: Option<ScenarioId>,
 }
 
@@ -88,6 +89,7 @@ impl GameStateBuilder {
             hand_size_discard_pending: None,
             open_windows: Vec::new(),
             phase_anchor: None,
+            investigator_turn: None,
             scenario_id: None,
         }
     }
@@ -287,6 +289,16 @@ impl GameStateBuilder {
         self
     }
 
+    /// Stage an [`InvestigatorTurn`](Continuation::InvestigatorTurn) frame
+    /// (slice 2a-i, #393) on top of the staged `*Phase` anchor — the realistic
+    /// invariant for a state constructed mid-turn (the real driver pushes it once
+    /// the `InvestigatorTurnBegins` window closes). Pair with
+    /// `with_phase_anchor(InvestigationPhase { resume: TurnBegins })`.
+    pub fn with_investigator_turn(mut self, investigator: InvestigatorId) -> Self {
+        self.investigator_turn = Some(investigator);
+        self
+    }
+
     /// Set the scenario id this state belongs to. `None` (the
     /// default from [`GameStateBuilder::new`]) means the engine's post-apply
     /// resolution hook will short-circuit. Passing a `ScenarioId`
@@ -307,6 +319,11 @@ impl GameStateBuilder {
         // A staged `*Phase` anchor (slice 1a, #393) sits at the bottom of the
         // stack — beneath any windows, which open *above* it during the phase.
         let mut continuations: Vec<Continuation> = self.phase_anchor.into_iter().collect();
+        // A staged open turn (slice 2a-i, #393) sits directly above the anchor;
+        // any window opened during the turn is a sub-resolution above it.
+        if let Some(investigator) = self.investigator_turn {
+            continuations.push(Continuation::InvestigatorTurn { investigator });
+        }
         continuations.extend(self.open_windows.into_iter().map(Continuation::Resolution));
         if let Some(hsd) = self.hand_size_discard_pending {
             continuations.push(Continuation::HandSizeDiscard(hsd));

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -579,21 +579,6 @@ impl Continuation {
         )
     }
 
-    /// True if this is the open-turn idle point — `InvestigationPhase` at
-    /// `TurnBegins` (slice 1b, #393). The engine waits for the active
-    /// investigator's *typed* action here, so `drive` must break (not advance)
-    /// rather than spin. Slice 2 replaces this with a real `InvestigatorTurn`
-    /// frame that awaits input.
-    #[must_use]
-    pub fn is_open_turn(&self) -> bool {
-        matches!(
-            self,
-            Continuation::InvestigationPhase {
-                resume: InvestigationResume::TurnBegins,
-            }
-        )
-    }
-
     /// True if this top frame is a mandatory prompt that only `ResolveInput` may
     /// advance (slice 1b, #393): a reaction/forced window, skill-test commit,
     /// choice, hunter/spawn pick, hand-size discard, act round-end, substitution

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -181,15 +181,10 @@ pub struct GameState {
     /// [`Status::Insane`]: crate::state::Status::Insane
     /// [`Status::Resigned`]: crate::state::Status::Resigned
     pub enemy_attack_pending: Option<InvestigatorId>,
-    /// Suspended end-of-turn continuation (C4c, #235): `Some(active)` while
-    /// `end_turn` is paused on a suspending `EndOfTurn` forced effect
-    /// (Frozen in Fear 01164's willpower test). The skill-test commit-resume
-    /// path re-enters `resume_end_turn` to run the stranded rotation /
-    /// phase-end once the test resolves. Defaults to `None`.
-    #[serde(default)]
-    pub pending_end_turn: Option<InvestigatorId>,
     /// `Some` while an enemy-attack loop is suspended on a soak reaction
-    /// window (C5b #237). Mirror of [`pending_end_turn`](Self::pending_end_turn).
+    /// window (C5b #237). Mirror of the former `pending_end_turn` (now the
+    /// [`InvestigatorTurn`](Continuation::InvestigatorTurn) frame's `ending`
+    /// flag, slice 2a-i #393): a framework cursor for a suspended continuation.
     #[serde(default)]
     pub pending_enemy_attack: Option<PendingEnemyAttack>,
     /// Set by [`Effect::Cancel`](crate::dsl::Effect::Cancel) while a
@@ -388,7 +383,8 @@ pub struct SkillSubstitution {
 /// damage; C5b #237) or the before-attack cancel window (`BeforeEnemyAttack`,
 /// before damage; Axis D #336), distinguished by [`Self::phase`]. Resumed by
 /// `resume_enemy_attack` once the window closes — the same suspend/resume
-/// shape as [`GameState::pending_end_turn`].
+/// shape as the [`InvestigatorTurn`](Continuation::InvestigatorTurn) frame's
+/// `ending` flag (slice 2a-i #393, which absorbed the former `pending_end_turn`).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PendingEnemyAttack {
     /// The investigator whose engaged enemies are attacking.
@@ -534,6 +530,13 @@ pub enum Continuation {
         /// Whose turn this is. Mirrors [`GameState::active_investigator`] while on
         /// top; the durable source for the end-of-turn rotation.
         investigator: InvestigatorId,
+        /// `true` once `end_turn`'s `EndOfTurn` forced effect suspended into a
+        /// skill test before rotation (a single Frozen in Fear 01164), stranding
+        /// the turn (slice 2a-i, #393 — absorbs the former
+        /// `GameState::pending_end_turn`). The skill-test commit resume reads this
+        /// to decide the resolved test triggers rotation; an ordinary mid-turn
+        /// test leaves it `false`.
+        ending: bool,
     },
 }
 
@@ -1840,6 +1843,7 @@ mod continuation_stack_tests {
     fn investigator_turn_frame_classification() {
         let frame = Continuation::InvestigatorTurn {
             investigator: InvestigatorId(1),
+            ending: false,
         };
         // The open turn is not a framework anchor...
         assert!(!frame.is_phase_anchor());

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -520,6 +520,21 @@ pub enum Continuation {
         /// Which child-pop boundary the anchor resumes at.
         resume: UpkeepResume,
     },
+    /// The active investigator's open turn — Rules Reference step 2.2.1
+    /// (slice 2a-i, #393). Pushed *above* the [`Continuation::InvestigationPhase`]
+    /// anchor once the `InvestigatorTurnBegins` window closes; the anchor spans the
+    /// whole phase beneath it. The player takes basic actions (each a typed
+    /// `PlayerAction` today; a sub-resolution frame above this one tomorrow) while
+    /// it is on top; `EndTurn` pops it via
+    /// [`resume_end_turn`](crate::engine). Does **not** await `ResolveInput` — like
+    /// the `TurnBegins` anchor it replaced, typed actions run against it (the idle
+    /// outcome stays `Done`; surfacing the legal-action enumeration as
+    /// `AwaitingInput` is slice 2b/#205).
+    InvestigatorTurn {
+        /// Whose turn this is. Mirrors [`GameState::active_investigator`] while on
+        /// top; the durable source for the end-of-turn rotation.
+        investigator: InvestigatorId,
+    },
 }
 
 /// A controller choice paused mid-resolution (umbrella §3, Axis A).
@@ -599,6 +614,9 @@ impl Continuation {
     pub fn awaits_input(&self) -> bool {
         match self {
             Continuation::Resolution(f) => !f.pending_triggers.is_empty(),
+            // The open turn: typed actions (Move/Investigate/Fight/…) run, so it
+            // is NOT a mandatory ResolveInput prompt (slice 2a-i, #393).
+            Continuation::InvestigatorTurn { .. } => false,
             other => !other.is_phase_anchor(),
         }
     }
@@ -618,6 +636,7 @@ impl Continuation {
             | Continuation::Mulligan { .. }
             | Continuation::EncounterDraw { .. }
             | Continuation::EncounterCard { .. }
+            | Continuation::InvestigatorTurn { .. }
             | Continuation::MythosPhase { .. }
             | Continuation::InvestigationPhase { .. }
             | Continuation::EnemyPhase { .. }
@@ -639,6 +658,7 @@ impl Continuation {
             | Continuation::Mulligan { .. }
             | Continuation::EncounterDraw { .. }
             | Continuation::EncounterCard { .. }
+            | Continuation::InvestigatorTurn { .. }
             | Continuation::MythosPhase { .. }
             | Continuation::InvestigationPhase { .. }
             | Continuation::EnemyPhase { .. }
@@ -1829,6 +1849,20 @@ mod continuation_stack_tests {
         .awaits_input());
         assert!(Continuation::Mulligan { remaining: vec![] }.awaits_input());
         assert!(Continuation::EncounterDraw { remaining: vec![] }.awaits_input());
+    }
+
+    #[test]
+    fn investigator_turn_frame_classification() {
+        let frame = Continuation::InvestigatorTurn {
+            investigator: InvestigatorId(1),
+        };
+        // The open turn is not a framework anchor...
+        assert!(!frame.is_phase_anchor());
+        // ...and it does NOT await ResolveInput — typed actions (Move, Fight, …)
+        // run against it, exactly as they ran against the TurnBegins anchor.
+        assert!(!frame.awaits_input());
+        // It carries no resolution payload.
+        assert!(frame.as_resolution().is_none());
     }
 
     #[test]

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -1855,6 +1855,21 @@ mod continuation_stack_tests {
     }
 
     #[test]
+    fn investigator_turn_frame_round_trips_both_ending_states() {
+        // The frame is replay state (the `ending` flag absorbed the former
+        // `pending_end_turn`), so both flag values must serialize round-trip.
+        for ending in [false, true] {
+            let frame = Continuation::InvestigatorTurn {
+                investigator: InvestigatorId(1),
+                ending,
+            };
+            let json = serde_json::to_string(&frame).unwrap();
+            let back: Continuation = serde_json::from_str(&json).unwrap();
+            assert_eq!(frame, back);
+        }
+    }
+
+    #[test]
     fn phase_anchor_variants_round_trip_and_are_not_resolution_windows() {
         let anchors = [
             Continuation::MythosPhase {

--- a/crates/game-core/src/test_support/assertions.rs
+++ b/crates/game-core/src/test_support/assertions.rs
@@ -38,6 +38,8 @@
 //!     .with_phase_anchor(Continuation::InvestigationPhase {
 //!         resume: InvestigationResume::TurnBegins,
 //!     })
+//!     // ...and the open-turn frame above it (slice 2a-i), popped by EndTurn.
+//!     .with_investigator_turn(InvestigatorId(1))
 //!     .build();
 //! let result = apply(state, Action::Player(PlayerAction::EndTurn));
 //!

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -763,6 +763,7 @@ mod tests {
             .with_phase_anchor(crate::state::Continuation::InvestigationPhase {
                 resume: crate::state::InvestigationResume::TurnBegins,
             })
+            .with_investigator_turn(id)
             .session()
             .apply(Action::Player(PlayerAction::EndTurn))
             .resolve_choices(|c| {

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -493,6 +493,9 @@ fn end_turn_fires_end_of_turn_forced_for_the_ending_investigator() {
         .with_phase_anchor(game_core::state::Continuation::InvestigationPhase {
             resume: game_core::state::InvestigationResume::TurnBegins,
         })
+        // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame the
+        // EndTurn pops (or strands a skill test below, then pops on resume).
+        .with_investigator_turn(InvestigatorId(1))
         .build();
 
     let result = apply(state, Action::Player(PlayerAction::EndTurn));

--- a/crates/game-core/tests/round_ended.rs
+++ b/crates/game-core/tests/round_ended.rs
@@ -118,6 +118,9 @@ fn two_round_end_forced_suspend_then_resume_the_upkeep_tail() {
         .with_phase_anchor(game_core::state::Continuation::InvestigationPhase {
             resume: game_core::state::InvestigationResume::TurnBegins,
         })
+        // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame the
+        // EndTurn cascade pops before advancing past Investigation.
+        .with_investigator_turn(InvestigatorId(1))
         .build();
     state.agenda_deck = vec![Agenda {
         code: CardCode::new(AGENDA),

--- a/crates/scenarios/tests/hunter_movement.rs
+++ b/crates/scenarios/tests/hunter_movement.rs
@@ -134,6 +134,9 @@ fn hunter_movement_pick_location_replays_identically() {
             .with_phase_anchor(game_core::state::Continuation::InvestigationPhase {
                 resume: game_core::state::InvestigationResume::TurnBegins,
             })
+            // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame
+            // the end_turn cascade pops before advancing into the Enemy phase.
+            .with_investigator_turn(InvestigatorId(1))
             .build()
     }
 

--- a/docs/superpowers/plans/2026-06-20-investigator-turn-frame-2a-i.md
+++ b/docs/superpowers/plans/2026-06-20-investigator-turn-frame-2a-i.md
@@ -1,0 +1,668 @@
+# InvestigatorTurn Frame (slice 2a-i) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reify the active investigator's open turn (Rules Reference step 2.2.1) as a `Continuation::InvestigatorTurn` frame sitting above the `InvestigationPhase` anchor, absorbing the `pending_end_turn` cursor — a behaviour-preserving structural relocation.
+
+**Architecture:** Today the open turn is *not* a frame: the `InvestigationPhase` anchor idles at `InvestigationResume::TurnBegins` (`is_open_turn()` → `drive` breaks with `Done`) and `state.pending_end_turn` flags an `end_turn` that stranded before rotation. This slice pushes an `InvestigatorTurn { investigator }` frame above the anchor when the `InvestigatorTurnBegins` window closes; `resume_end_turn` pops it; the idle is now "an `InvestigatorTurn` frame is on top" instead of "the anchor is at `TurnBegins`". `pending_end_turn` becomes an `ending: bool` field on the frame. No new anchor-resume variant is needed: `resume_end_turn` is always called *directly* (from `end_turn`, the stranded-skill-test resume, and the forced-run continuation), never re-entered through the anchor's `on_child_pop`, so the anchor stays at `TurnBegins` beneath the frame and is popped/rotated as before.
+
+**Tech Stack:** Rust, `game-core` kernel crate. No new deps.
+
+## Global Constraints
+
+- **Behaviour-preserving:** every existing test must stay green by the end of each task (the C-checkpoint changes *structure*, not rules — spec §"Testing strategy"). The open-turn idle outcome stays `EngineOutcome::Done`; do **not** flip it to `AwaitingInput` (that is 2b/#205). (Decision, this slice.)
+- **Validate-first / mutate-second** handler contract (CLAUDE.md): preconditions first, mutate + push events only after.
+- **CI gauntlet, warnings-as-errors.** Before declaring done, run all host jobs: `RUSTFLAGS="-D warnings" cargo test --all --all-features`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`. (The wasm jobs don't touch this engine-only change but stay green by construction.)
+- **Design of record:** `docs/superpowers/specs/2026-06-20-unified-control-flow-model-design.md` §C (the per-phase CPS table — row "2.2.1 the active investigator's actions → frame `InvestigatorTurn` net-new") and §E (the `InvestigatorTurn` frame, 2a sub-checkpoint: "typed `PlayerAction` survive, accepted iff they match an offered option … existing tests keep working"). The **legal-action enumerator** named in §E is **slice 2a-ii**, NOT this slice — this slice ships only the frame + cursor absorption.
+- **Commit-message footer** (every commit), copied verbatim:
+  ```
+  Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_011oqjdoNhbcH4kay8J3FEoJ
+  ```
+- **Branch:** `engine/investigator-turn-frame`. One branch for the slice; one commit per task.
+
+---
+
+### Task 1: Introduce the `InvestigatorTurn` continuation variant + builder helper
+
+Pure type plumbing: add the variant, satisfy every exhaustive `match` on `Continuation`, classify it (not a phase anchor; does **not** await input so typed actions run at the open turn), and add a test-only builder helper. **The frame is never pushed yet**, so behaviour is unchanged and all tests stay green.
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` — add the `Continuation::InvestigatorTurn` variant (~after the `*Phase` anchor variants, near line 522); extend `awaits_input` (~line 599), `as_resolution`/`as_resolution_mut` (~lines 608/629).
+- Modify: `crates/game-core/src/state/builder.rs` — add `with_investigator_turn` (~near `with_phase_anchor`, line 275) and stage it in `build()` (~line 303).
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` — add the defensive `InvestigatorTurn` arm to `resolve_input`'s top-frame match (~line 353).
+- Test: inline `#[cfg(test)]` in `crates/game-core/src/state/game_state.rs`.
+
+**Interfaces:**
+- Produces: `Continuation::InvestigatorTurn { investigator: InvestigatorId }` (a struct-like variant). `GameStateBuilder::with_investigator_turn(self, investigator: InvestigatorId) -> Self` — stages an `InvestigatorTurn` frame on top of whatever `with_phase_anchor` staged.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)]` module in `crates/game-core/src/state/game_state.rs`:
+
+```rust
+#[test]
+fn investigator_turn_frame_classification() {
+    let frame = Continuation::InvestigatorTurn {
+        investigator: InvestigatorId(1),
+    };
+    // The open turn is not a framework anchor...
+    assert!(!frame.is_phase_anchor());
+    // ...and it does NOT await ResolveInput — typed actions (Move, Fight, …)
+    // run against it, exactly as they ran against the TurnBegins anchor.
+    assert!(!frame.awaits_input());
+    // It carries no resolution payload.
+    assert!(frame.as_resolution().is_none());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p game-core investigator_turn_frame_classification`
+Expected: FAIL to compile — `no variant named InvestigatorTurn`.
+
+- [ ] **Step 3: Add the variant and exhaustive-match arms**
+
+In `crates/game-core/src/state/game_state.rs`, add the variant to `enum Continuation` (place it after the four `*Phase` anchor variants, before the closing `}` near line 522):
+
+```rust
+    /// The active investigator's open turn — Rules Reference step 2.2.1
+    /// (slice 2a-i, #393). Pushed *above* the [`Continuation::InvestigationPhase`]
+    /// anchor once the `InvestigatorTurnBegins` window closes; the anchor spans the
+    /// whole phase beneath it. The player takes basic actions (each a typed
+    /// `PlayerAction` today; a sub-resolution frame above this one tomorrow) while
+    /// it is on top; `EndTurn` pops it via
+    /// [`resume_end_turn`](crate::engine). Does **not** await `ResolveInput` — like
+    /// the `TurnBegins` anchor it replaced, typed actions run against it (the idle
+    /// outcome stays `Done`; surfacing the legal-action enumeration as
+    /// `AwaitingInput` is slice 2b/#205).
+    InvestigatorTurn {
+        /// Whose turn this is. Mirrors [`GameState::active_investigator`] while on
+        /// top; the durable source for the end-of-turn rotation.
+        investigator: InvestigatorId,
+    },
+```
+
+Extend `awaits_input` (the `match self` near line 599) — add an explicit arm so the open turn accepts typed actions (the default `!is_phase_anchor()` would wrongly return `true`):
+
+```rust
+    pub fn awaits_input(&self) -> bool {
+        match self {
+            Continuation::Resolution(f) => !f.pending_triggers.is_empty(),
+            // The open turn: typed actions (Move/Investigate/Fight/…) run, so it
+            // is NOT a mandatory ResolveInput prompt (slice 2a-i, #393).
+            Continuation::InvestigatorTurn { .. } => false,
+            other => !other.is_phase_anchor(),
+        }
+    }
+```
+
+Add `Continuation::InvestigatorTurn { .. }` to the `None`-returning lists in both `as_resolution` and `as_resolution_mut` (the long `| ...` chains near lines 611–624 and 632–645), e.g.:
+
+```rust
+            Continuation::SkillTest(_)
+            | Continuation::Choice(_)
+            | Continuation::HunterMove(_)
+            | Continuation::SpawnEngage(_)
+            | Continuation::HandSizeDiscard(_)
+            | Continuation::ActRoundEnd(_)
+            | Continuation::SubstitutionPrompt { .. }
+            | Continuation::Mulligan { .. }
+            | Continuation::EncounterDraw { .. }
+            | Continuation::EncounterCard { .. }
+            | Continuation::InvestigatorTurn { .. }
+            | Continuation::MythosPhase { .. }
+            | Continuation::InvestigationPhase { .. }
+            | Continuation::EnemyPhase { .. }
+            | Continuation::UpkeepPhase { .. } => None,
+```
+
+- [ ] **Step 4: Add the defensive `resolve_input` arm**
+
+In `crates/game-core/src/engine/dispatch/mod.rs`, in the `resolve_input` top-frame `match` (near line 353), add an arm before the `None =>` arm:
+
+```rust
+        // The open turn does not emit an AwaitingInput prompt in 2a (typed
+        // actions drive it; the enumeration is 2a-ii / surfacing is 2b). A
+        // ResolveInput arriving here is spurious — reject defensively, mirroring
+        // the phase-anchor arm (slice 2a-i, #393).
+        Some(Continuation::InvestigatorTurn { .. }) => EngineOutcome::Rejected {
+            reason: "ResolveInput: no input prompt is outstanding (the open turn \
+                     takes typed actions, not ResolveInput)"
+                .into(),
+        },
+```
+
+- [ ] **Step 5: Add the builder helper**
+
+In `crates/game-core/src/state/builder.rs`, add after `with_phase_anchor` (near line 288):
+
+```rust
+    /// Stage an [`InvestigatorTurn`](Continuation::InvestigatorTurn) frame
+    /// (slice 2a-i, #393) on top of the staged `*Phase` anchor — the realistic
+    /// invariant for a state constructed mid-turn (the real driver pushes it once
+    /// the `InvestigatorTurnBegins` window closes). Pair with
+    /// `with_phase_anchor(InvestigationPhase { resume: TurnBegins })`.
+    pub fn with_investigator_turn(mut self, investigator: InvestigatorId) -> Self {
+        self.investigator_turn = Some(investigator);
+        self
+    }
+```
+
+Add the field to the builder struct (find the struct definition — it holds `phase_anchor: Option<Continuation>`; add alongside it):
+
+```rust
+    investigator_turn: Option<InvestigatorId>,
+```
+
+Initialize it in the builder's `Default`/`new` (wherever `phase_anchor` is initialized to `None`):
+
+```rust
+            investigator_turn: None,
+```
+
+In `build()` (near line 303, right after the `phase_anchor` is pushed onto `continuations`), push the frame above it:
+
+```rust
+        if let Some(investigator) = self.investigator_turn {
+            continuations.push(Continuation::InvestigatorTurn { investigator });
+        }
+```
+
+Ensure `InvestigatorId` is in scope in `builder.rs` (it already imports state types; add to the `use` if the compiler flags it).
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cargo test -p game-core investigator_turn_frame_classification`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full host gauntlet**
+
+Run:
+```
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+```
+Expected: all PASS. (Behaviour is unchanged — the frame is never pushed by production code yet.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A
+git commit -m "engine: introduce InvestigatorTurn continuation variant (slice 2a-i of #393)
+
+Type plumbing only: the open turn becomes a Continuation::InvestigatorTurn
+variant classified as a non-anchor frame that accepts typed actions (does not
+await ResolveInput). Adds the with_investigator_turn test builder. Production
+never pushes the frame yet, so behaviour is unchanged.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_011oqjdoNhbcH4kay8J3FEoJ"
+```
+
+---
+
+### Task 2: Push the frame at the open turn; route `end_turn` through it
+
+The behaviour-preserving switchover. The `InvestigatorTurnBegins`-window-close (`anchor_on_child_pop`'s `TurnBegins` arm) now **pushes** the `InvestigatorTurn` frame instead of idling; `drive` idles on the frame (so `is_open_turn` is removed); `resume_end_turn` **pops** the frame before rotating. `pending_end_turn` is left exactly as-is this task (Task 3 absorbs it).
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/phases.rs` — the `TurnBegins` arm of `anchor_on_child_pop` (~line 834); `resume_end_turn` (~line 259).
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` — `drive` (~line 169).
+- Modify: `crates/game-core/src/state/game_state.rs` — remove `is_open_turn` (~line 573) and its inline test if any.
+- Modify (tests): every `#[cfg(test)]` site that constructs `InvestigationPhase { resume: TurnBegins }` and then drives `end_turn`/`EndTurn` — in `crates/game-core/src/engine/dispatch/phases.rs` (the push sites near lines 1551, 1619, 2617, 2904, 2964) — must also stage the `InvestigatorTurn` frame.
+
+**Interfaces:**
+- Consumes: `Continuation::InvestigatorTurn { investigator }`, `GameStateBuilder::with_investigator_turn` (Task 1).
+- Produces: production code that leaves an `InvestigatorTurn` frame on top during the open turn; `resume_end_turn(cx, active_id)` now pops that frame as its first act.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)]` module in `crates/game-core/src/engine/dispatch/phases.rs`:
+
+```rust
+#[test]
+fn open_turn_leaves_investigator_turn_frame_on_top() {
+    use crate::state::{Continuation, InvestigationResume};
+    // Reach the open turn the way production does: enter the Investigation
+    // phase for a single investigator (no Fast cards → windows auto-skip).
+    let mut state = GameStateBuilder::default()
+        .with_investigator(test_investigator(1))
+        .with_phase(Phase::Investigation)
+        .build();
+    state.turn_order = vec![InvestigatorId(1)];
+
+    let mut events = Vec::new();
+    let outcome = {
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+        // investigation_phase pushes the anchor + opens (auto-skips) both
+        // windows, landing the first investigator's open turn.
+        investigation_phase(&mut cx);
+        super::super::drive(&mut cx, EngineOutcome::Done)
+    };
+
+    // The open turn idles as Done (NOT AwaitingInput) — behaviour-preserving.
+    assert_eq!(outcome, EngineOutcome::Done);
+    // Top frame is the InvestigatorTurn for investigator 1...
+    assert_eq!(
+        state.continuations.last(),
+        Some(&Continuation::InvestigatorTurn {
+            investigator: InvestigatorId(1),
+        }),
+    );
+    // ...sitting above the still-present InvestigationPhase anchor.
+    assert!(state.continuations.iter().any(|c| matches!(
+        c,
+        Continuation::InvestigationPhase {
+            resume: InvestigationResume::TurnBegins
+        }
+    )));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p game-core open_turn_leaves_investigator_turn_frame_on_top`
+Expected: FAIL — `continuations.last()` is the `InvestigationPhase` anchor (no frame pushed), assertion on `InvestigatorTurn` fails.
+
+- [ ] **Step 3: Push the frame in the `TurnBegins` arm**
+
+In `crates/game-core/src/engine/dispatch/phases.rs`, replace the `TurnBegins` arm of `anchor_on_child_pop` (currently near line 834):
+
+```rust
+        Some(Continuation::InvestigationPhase {
+            resume: InvestigationResume::TurnBegins,
+        }) => {
+            // 2.2.1 — the active investigator now acts as player-driven input;
+            // no continuation work (slice 2 makes this an InvestigatorTurn frame).
+            EngineOutcome::Done
+        }
+```
+
+with:
+
+```rust
+        Some(Continuation::InvestigationPhase {
+            resume: InvestigationResume::TurnBegins,
+        }) => {
+            // 2.2.1 — push the InvestigatorTurn frame above the anchor (slice
+            // 2a-i, #393). The anchor stays at TurnBegins beneath it; the frame
+            // is the open-turn idle point (drive breaks here, returning Done).
+            // `active_investigator` was set by rotate_to_active in
+            // begin_investigator_turn; it is the frame's investigator.
+            let investigator = cx.state.active_investigator.unwrap_or_else(|| {
+                unreachable!(
+                    "TurnBegins reached with no active_investigator; \
+                     begin_investigator_turn always sets it"
+                )
+            });
+            cx.state
+                .continuations
+                .push(Continuation::InvestigatorTurn { investigator });
+            EngineOutcome::Done
+        }
+```
+
+- [ ] **Step 4: Idle `drive` on the frame; drop `is_open_turn`**
+
+In `crates/game-core/src/engine/dispatch/mod.rs`, change the `drive` loop's anchor-advance guard (near line 169) from:
+
+```rust
+            Some(ref c) if c.is_phase_anchor() && !c.is_open_turn() => {
+```
+
+to:
+
+```rust
+            Some(ref c) if c.is_phase_anchor() => {
+```
+
+The `_ => return EngineOutcome::Done` arm below now also catches the `InvestigatorTurn` frame on top (the open-turn idle) — exactly the old `is_open_turn` break, now keyed off the frame's presence rather than the anchor's resume. Update the doc-comment on `drive` (the bullet "and with `Done` at the open turn (`InvestigationPhase{TurnBegins}`)") to say "and with `Done` when an `InvestigatorTurn` frame is on top (the open turn)".
+
+Then delete the now-unused `is_open_turn` method from `crates/game-core/src/state/game_state.rs` (near line 573) and any inline test that referenced it.
+
+- [ ] **Step 5: Pop the frame in `resume_end_turn`**
+
+In `crates/game-core/src/engine/dispatch/phases.rs`, at the top of `resume_end_turn` (near line 259), pop the `InvestigatorTurn` frame before the existing rotate-or-end logic:
+
+```rust
+pub(super) fn resume_end_turn(cx: &mut Cx, active_id: InvestigatorId) -> EngineOutcome {
+    // The turn is over: pop the InvestigatorTurn frame this turn ran on (slice
+    // 2a-i, #393). It is always on top here — end_turn reaches this after the
+    // EndOfTurn forced run resolves, the stranded-skill-test resume after the
+    // SkillTest pops, and the forced-run continuation after its Resolution pops.
+    debug_assert!(
+        matches!(
+            cx.state.continuations.last(),
+            Some(crate::state::Continuation::InvestigatorTurn { investigator })
+                if *investigator == active_id
+        ),
+        "resume_end_turn: expected InvestigatorTurn({active_id:?}) on top, got {:?}",
+        cx.state.continuations.last(),
+    );
+    cx.state.continuations.pop();
+
+    // 2.2.2 decision: "return to 2.2" for the next investigator, or
+    // proceed to 2.3. next_active_investigator_after skips eliminated
+    // investigators (Rules Reference p.10) — the same shared helper the
+    // Enemy phase uses.
+    if let Some(next_id) = super::cursor::next_active_investigator_after(cx.state, active_id) {
+        begin_investigator_turn(cx, next_id);
+        EngineOutcome::Done
+    } else {
+        cx.state.active_investigator = None;
+        // 2.3 → Enemy. The cascade may suspend on a hunter-movement tie
+        // (Enemy 3.2); propagate its outcome rather than swallowing it.
+        investigation_phase_end(cx)
+    }
+}
+```
+
+- [ ] **Step 6: Update the test push-sites**
+
+For each `#[cfg(test)]` setup in `crates/game-core/src/engine/dispatch/phases.rs` that pushes `InvestigationPhase { resume: TurnBegins }` and then exercises `end_turn`/`EndTurn` (near lines 1551, 1619, 2617, 2904, 2964), push the `InvestigatorTurn` frame on top of the anchor so the constructed state matches the real open-turn invariant. Replace each block of the form:
+
+```rust
+        state
+            .continuations
+            .push(crate::state::Continuation::InvestigationPhase {
+                resume: crate::state::InvestigationResume::TurnBegins,
+            });
+```
+
+with:
+
+```rust
+        state
+            .continuations
+            .push(crate::state::Continuation::InvestigationPhase {
+                resume: crate::state::InvestigationResume::TurnBegins,
+            });
+        // Open-turn invariant (slice 2a-i, #393): the InvestigatorTurn frame the
+        // driver leaves on top once the InvestigatorTurnBegins window closes.
+        state
+            .continuations
+            .push(crate::state::Continuation::InvestigatorTurn {
+                investigator: <ACTIVE_ID>,
+            });
+```
+
+where `<ACTIVE_ID>` is the `with_active_investigator(...)` id used in that test (e.g. `InvestigatorId(1)` at lines 1551/2617; check each site). For the two-investigator rotation test (near line 1619, active `InvestigatorId(1)`), use `InvestigatorId(1)` — the test then asserts rotation to `InvestigatorId(2)` after `end_turn` pops `1`'s frame and pushes `2`'s.
+
+> NOTE for the implementer: run the failing tests after this edit and read each panic — the `resume_end_turn` `debug_assert` will point to any site whose active id you mismatched. Fix the id to match that test's `with_active_investigator`.
+
+- [ ] **Step 7: Run the targeted + full test suite**
+
+Run: `cargo test -p game-core open_turn_leaves_investigator_turn_frame_on_top`
+Expected: PASS.
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: all PASS (this is the behaviour-preservation gate — every existing `end_turn`/rotation/phase-cascade test must still pass).
+
+- [ ] **Step 8: Run the rest of the gauntlet**
+
+```
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+```
+Expected: all PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add -A
+git commit -m "engine: open turn becomes an InvestigatorTurn frame (slice 2a-i of #393)
+
+The InvestigatorTurnBegins-window close now pushes a Continuation::InvestigatorTurn
+frame above the InvestigationPhase anchor instead of idling at the TurnBegins
+resume; drive idles on the frame (is_open_turn removed); resume_end_turn pops it
+before rotating. Behaviour-preserving — the idle outcome stays Done and every
+end_turn/rotation/phase-cascade test is unchanged. pending_end_turn is untouched
+this commit (absorbed next).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_011oqjdoNhbcH4kay8J3FEoJ"
+```
+
+---
+
+### Task 3: Absorb `pending_end_turn` into the frame's `ending` flag
+
+`pending_end_turn` is the flag meaning "an `end_turn` stranded before rotation, so the resolving skill test must trigger rotation" — the discriminator `resume_skill_test_commit` uses to tell a stranded `EndOfTurn`-forced test from an ordinary mid-turn test. Move it onto the `InvestigatorTurn` frame as `ending: bool` and delete the `GameState` field.
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` — add `ending: bool` to the `InvestigatorTurn` variant; remove the `pub pending_end_turn: Option<InvestigatorId>` field (~line 190).
+- Modify: `crates/game-core/src/state/builder.rs` — drop the `pending_end_turn: None` initializer (~line 346); the `with_investigator_turn` push now sets `ending: false`.
+- Modify: `crates/game-core/src/engine/dispatch/phases.rs` — `end_turn`'s stranded branch (~line 243) sets the frame's `ending` instead of `pending_end_turn`.
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` — `resume_skill_test_commit`'s stranded branch (~line 303) reads the frame's `ending`.
+- Modify (tests): `crates/cards/tests/persistent_treachery.rs` — the three `pending_end_turn.is_none()` asserts (lines 319, 336, 405).
+- Modify: any site that constructs `Continuation::InvestigatorTurn { investigator }` now needs `ending: false` (Task 1/2 builder + test push-sites + the Task 2 `TurnBegins` arm). The compiler lists them all.
+
+**Interfaces:**
+- Consumes: the `InvestigatorTurn` frame (Tasks 1–2), `resume_end_turn` (Task 2, pops the frame).
+- Produces: `Continuation::InvestigatorTurn { investigator, ending }`; no `GameState::pending_end_turn`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)]` module in `crates/game-core/src/engine/dispatch/phases.rs` (it exercises the field absorption directly — the full stranded-`EndOfTurn`-forced-into-skill-test flow is already covered by the existing Frozen-in-Fear integration test, which stays green as the behaviour gate):
+
+```rust
+#[test]
+fn investigator_turn_defaults_to_not_ending() {
+    use crate::state::Continuation;
+    // The builder-staged open-turn frame is not mid-end-turn.
+    let state = GameStateBuilder::default()
+        .with_investigator(test_investigator(1))
+        .with_phase(Phase::Investigation)
+        .with_phase_anchor(Continuation::InvestigationPhase {
+            resume: crate::state::InvestigationResume::TurnBegins,
+        })
+        .with_active_investigator(InvestigatorId(1))
+        .with_investigator_turn(InvestigatorId(1))
+        .build();
+    assert_eq!(
+        state.continuations.last(),
+        Some(&Continuation::InvestigatorTurn {
+            investigator: InvestigatorId(1),
+            ending: false,
+        }),
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p game-core investigator_turn_defaults_to_not_ending`
+Expected: FAIL to compile — `InvestigatorTurn` has no field `ending`.
+
+- [ ] **Step 3: Add the `ending` field**
+
+In `crates/game-core/src/state/game_state.rs`, extend the `InvestigatorTurn` variant:
+
+```rust
+    InvestigatorTurn {
+        /// Whose turn this is. Mirrors [`GameState::active_investigator`] while on
+        /// top; the durable source for the end-of-turn rotation.
+        investigator: InvestigatorId,
+        /// `true` once `end_turn`'s `EndOfTurn` forced effect suspended into a
+        /// skill test before rotation (a single Frozen in Fear 01164), stranding
+        /// the turn (slice 2a-i, #393 — absorbs the former
+        /// `GameState::pending_end_turn`). The skill-test commit resume reads this
+        /// to decide the resolved test triggers rotation; an ordinary mid-turn
+        /// test leaves it `false`.
+        ending: bool,
+    },
+```
+
+Update the Task 1/2 construction sites to `ending: false`: the `with_investigator_turn` push in `builder.rs`, the `TurnBegins` arm push in `phases.rs`, the test builder/push-sites, and the Task 1/2 unit tests' literal matches. The compiler enumerates every one — fix each to `{ investigator, ending: false }` (and the assertion-literals in `open_turn_leaves_investigator_turn_frame_on_top` and `investigator_turn_frame_classification`).
+
+- [ ] **Step 4: Remove the `pending_end_turn` field**
+
+In `crates/game-core/src/state/game_state.rs`, delete the field (near line 190):
+
+```rust
+    pub pending_end_turn: Option<InvestigatorId>,
+```
+
+(Keep `pending_enemy_attack` — it is a different cursor, lifted in slice 3 not here. Leave its doc-comment's "Mirror of `pending_end_turn`" reference; reword it to "Mirror of the former `pending_end_turn` (now the InvestigatorTurn frame's `ending`)" so the doc link doesn't dangle.)
+
+In `crates/game-core/src/state/builder.rs`, delete the `pending_end_turn: None,` initializer (near line 346).
+
+- [ ] **Step 5: Set `ending` in `end_turn`'s stranded branch**
+
+In `crates/game-core/src/engine/dispatch/phases.rs`, in `end_turn`'s `AwaitingInput` arm (near line 238), replace the `pending_end_turn` write:
+
+```rust
+        EngineOutcome::AwaitingInput { .. } => {
+            let forced_run_open = matches!(
+                cx.state.continuations.last(),
+                Some(crate::state::Continuation::Resolution(f)) if f.is_forced()
+            );
+            if !forced_run_open {
+                cx.state.pending_end_turn = Some(active_id);
+            }
+            end_of_turn
+        }
+```
+
+with:
+
+```rust
+        EngineOutcome::AwaitingInput { .. } => {
+            let forced_run_open = matches!(
+                cx.state.continuations.last(),
+                Some(crate::state::Continuation::Resolution(f)) if f.is_forced()
+            );
+            if !forced_run_open {
+                // Single suspending EndOfTurn forced (one Frozen in Fear): flag
+                // the InvestigatorTurn frame (below the skill test) as ending, so
+                // the commit-resume triggers rotation (slice 2a-i, #393 — was
+                // pending_end_turn). A forced run owns its own EndOfTurnAfterForced
+                // continuation, so it must NOT be flagged.
+                let frame = cx
+                    .state
+                    .continuations
+                    .iter_mut()
+                    .rev()
+                    .find_map(|c| match c {
+                        crate::state::Continuation::InvestigatorTurn {
+                            investigator,
+                            ending,
+                        } if *investigator == active_id => Some(ending),
+                        _ => None,
+                    })
+                    .unwrap_or_else(|| {
+                        unreachable!(
+                            "end_turn stranded with no InvestigatorTurn({active_id:?}) on the stack"
+                        )
+                    });
+                *frame = true;
+            }
+            end_of_turn
+        }
+```
+
+Update the doc-comment block above (lines ~218–228) that describes the two cases to reference the frame's `ending` flag instead of `pending_end_turn`.
+
+- [ ] **Step 6: Read `ending` in `resume_skill_test_commit`**
+
+In `crates/game-core/src/engine/dispatch/mod.rs` (near line 298–306), replace the stranded-resume branch:
+
+```rust
+                // Otherwise: a single suspending `EndOfTurn` forced effect
+                // (one Frozen in Fear) stranded `end_turn` before rotation;
+                // resume it now that the test is fully done (C4c, #235). An
+                // `AwaitingInput` mid-teardown leaves `pending_end_turn` set
+                // for the next resume.
+                if let Some(active_id) = cx.state.pending_end_turn.take() {
+                    return phases::resume_end_turn(cx, active_id);
+                }
+```
+
+with:
+
+```rust
+                // Otherwise: a single suspending `EndOfTurn` forced effect
+                // (one Frozen in Fear) stranded `end_turn` before rotation. The
+                // SkillTest has popped, so the InvestigatorTurn frame is back on
+                // top; if its `ending` flag is set, resume rotation now that the
+                // test is fully done (C4c, #235; slice 2a-i absorbs
+                // pending_end_turn). resume_end_turn pops the frame.
+                if let Some(crate::state::Continuation::InvestigatorTurn {
+                    investigator,
+                    ending: true,
+                }) = cx.state.continuations.last()
+                {
+                    let active_id = *investigator;
+                    return phases::resume_end_turn(cx, active_id);
+                }
+```
+
+- [ ] **Step 7: Update the integration-test asserts**
+
+In `crates/cards/tests/persistent_treachery.rs`, the three `assert!(r.state.pending_end_turn.is_none());` lines (319, 336, 405) reference a field that no longer exists. These assert the turn is not mid-strand. Replace each with an assertion on the frame, e.g.:
+
+```rust
+    // No InvestigatorTurn frame is flagged as ending (turn not stranded mid-end).
+    assert!(!r.state.continuations.iter().any(|c| matches!(
+        c,
+        game_core::state::Continuation::InvestigatorTurn { ending: true, .. }
+    )));
+```
+
+(Match the crate's actual import path for `Continuation` — check the file's existing `use` lines; it may already alias `game_core::state::...`.)
+
+- [ ] **Step 8: Run the targeted test + the Frozen-in-Fear gate**
+
+Run: `cargo test -p game-core investigator_turn_defaults_to_not_ending`
+Expected: PASS.
+
+Find and run the existing stranded-`EndOfTurn` test (the single-Frozen-in-Fear / `EndOfTurn`-forced-into-skill-test case; grep `pending_end_turn` history or `EndOfTurn` in `crates/game-core/src/engine` and `crates/cards/tests` to locate it):
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: all PASS — particularly the Frozen-in-Fear stranded-rotation test and `persistent_treachery`.
+
+- [ ] **Step 9: Run the rest of the gauntlet**
+
+```
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+```
+Expected: all PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add -A
+git commit -m "engine: absorb pending_end_turn into the InvestigatorTurn frame (slice 2a-i of #393)
+
+The stranded-end-turn flag moves from GameState::pending_end_turn onto the
+InvestigatorTurn frame as `ending: bool`; the field is removed. end_turn flags the
+frame when a single EndOfTurn forced suspends before rotation; the skill-test
+commit resume reads the flag to trigger rotation. Behaviour-preserving — the
+Frozen in Fear stranded-rotation path is unchanged.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_011oqjdoNhbcH4kay8J3FEoJ"
+```
+
+---
+
+## After the tasks
+
+- **PR:** open against `main` with the repo template; design-decisions paragraph: the frame relocation + `pending_end_turn` absorption, the "no `AfterTurn` resume needed because `resume_end_turn` is always called directly" simplification, and that the legal-action enumerator is the *next* slice (2a-ii), not this one. `Closes` — there's no issue filed for the sub-slice; reference #393 and the spec. (Confirm with the user whether to file a tracking issue first, per the issue-first-PR norm.)
+- **Phase/spec doc update (final commit, only once CI is green):** add a "2a-i shipped" note to the spec's Sequencing §2 line and/or `docs/phases/phase-7-the-gathering.md` ordering step 3, mirroring how 1a/1b were annotated. Record the one load-bearing decision (open turn is a frame above the anchor; `pending_end_turn` → `InvestigatorTurn.ending`; no `AfterTurn` resume).
+- **Next slice (2a-ii):** the legal-action enumerator + validate-typed-against-offered (spec §E). Sets up `AttackLoop` (slice 3) and the keystone (slice 4).
+
+## Self-review notes
+
+- **Spec coverage:** §C row "2.2.1 → `InvestigatorTurn` net-new" ✅ (Tasks 1–2). §E "frame + pending_end_turn absorbed, typed actions survive, tests green" ✅ (Tasks 1–3; idle stays `Done`). §E enumerator ✅ explicitly deferred to 2a-ii (out of scope, stated). No other slice-2 spec clause is in this sub-slice.
+- **Type consistency:** `InvestigatorTurn { investigator, ending }` — `investigator: InvestigatorId`, `ending: bool`. `resume_end_turn(cx, active_id: InvestigatorId)` signature unchanged (pops the frame). `with_investigator_turn(investigator: InvestigatorId)`. All construction sites carry both fields after Task 3.
+- **Behaviour-preservation gate:** `RUSTFLAGS="-D warnings" cargo test --all --all-features` green at the end of every task; the open-turn idle stays `EngineOutcome::Done`; the Frozen-in-Fear stranded-rotation and `persistent_treachery` integration tests are the load-bearing guards.

--- a/docs/superpowers/specs/2026-06-20-unified-control-flow-model-design.md
+++ b/docs/superpowers/specs/2026-06-20-unified-control-flow-model-design.md
@@ -451,8 +451,21 @@ Each step is independently green (mirrors §1's parts 2a–2c cadence):
      call `investigation_phase` directly rather than pushing
      `InvestigationPhase{Entry}`; behaviour-identical, but two conventions).
 2. **`InvestigatorTurn` frame (2a) + legal-action enumerator** — open-turn becomes a
-   frame; guard ladder + action `match` deleted; typed `PlayerAction` validated
-   against the offered set; `pending_end_turn` absorbed.
+   frame; typed `PlayerAction` validated against the offered set; `pending_end_turn`
+   absorbed. Splits into two behaviour-preserving sub-slices:
+   - **2a-i — the frame + cursor absorption. ✅ shipped (PR #400).** The open turn is a
+     `Continuation::InvestigatorTurn { investigator, ending }` pushed above the
+     `InvestigationPhase` anchor when the `InvestigatorTurnBegins` window closes; `drive`
+     idles on it (`is_open_turn` removed); `resume_end_turn` pops it. `pending_end_turn`
+     folded onto the frame's `ending` flag (field removed). Idle outcome stays `Done`
+     (typed actions survive; `AwaitingInput` surfacing is 2b). **No `AfterTurn` anchor-
+     resume variant needed** — `resume_end_turn` is always called directly (the three
+     end-of-turn sites), never re-entered via the anchor's `on_child_pop`, so the anchor
+     parks at `TurnBegins` beneath the frame. (Legacy build-then-push test setups for
+     other phases tracked in #399.)
+   - **2a-ii — the legal-action enumerator** + validate-typed-against-offered (§E). The
+     `InvestigatorTurn` frame emits the enumeration as `OptionId`s with an internal
+     id→action map. (Not yet shipped.)
 3. **`AttackLoop` frame (cursor lift)** — `PendingEnemyAttack` +
    `enemy_attack_pending` → frame/anchor; enemy-phase attacks unchanged in behaviour.
 4. **Keystone mid-action park** — actions run as sub-resolution frames; AoO pushes


### PR DESCRIPTION
## Summary

Reifies the active investigator's open turn (Rules Reference step 2.2.1) as a `Continuation::InvestigatorTurn { investigator, ending }` frame above the `InvestigationPhase` anchor — slice **2a-i** of the unified control-flow arc (#393). A behaviour-preserving structural relocation: it replaces the `InvestigationPhase{TurnBegins}`-idle + two side-channel cursors (`is_open_turn`, `GameState::pending_end_turn`) with one frame. The idle outcome stays `Done`; surfacing the enumeration via `AwaitingInput` is a later slice.

## What changed

- **New `Continuation::InvestigatorTurn { investigator, ending }`** — pushed above the anchor when the `InvestigatorTurnBegins` window closes; `awaits_input()` returns `false` so typed actions still run against it. The anchor spans the whole phase beneath it.
- **`drive` idles on the frame** (the open turn) instead of on the anchor; `is_open_turn()` removed.
- **`resume_end_turn` pops the frame** before rotating / ending the phase — at all three call sites (synchronous `end_turn`, the single-stranded skill-test resume, the 2+ `EndOfTurn` forced-run continuation).
- **`pending_end_turn` absorbed into `InvestigatorTurn.ending`** and the `GameState` field removed. `end_turn` flags the frame (found below the suspending skill test) when a single `EndOfTurn` forced strands before rotation; `resume_skill_test_commit` reads `ending: true` to trigger rotation.
- **Test cleanup:** the 5 Investigation/open-turn unit tests that built-then-`continuations.push(...)` now use the builder chain (`with_phase_anchor` + the new `with_investigator_turn`). The broader legacy-push sweep for other phases is tracked in #399.

## Design decisions

- **No `AfterTurn` anchor-resume variant** (the spec sketch implied one). `resume_end_turn` is always called *directly*, never re-entered via the anchor's `on_child_pop`, so the anchor just stays parked at `TurnBegins` beneath the frame. One fewer moving part. (Verified at all three call sites.)
- **Idle stays `Done`, typed actions survive** — per spec §E's 2a sub-checkpoint ("existing tests keep working"). The legal-action enumerator + validate-typed-against-offered is the next slice, **2a-ii**.
- **`ending: bool` has no `#[serde(default)]`** (unlike the removed field) — intentional and safe: it's a net-new struct variant, so no pre-existing serialized state can carry it with a missing key. Replay stays bit-for-bit; the variant + both `ending` states are pinned by a serde round-trip test.

## Test notes

- Full host gauntlet green (`RUSTFLAGS=-D warnings cargo test --all --all-features`, clippy, fmt, doc) + `wasm-build`.
- Behaviour-preservation gate: the Frozen in Fear stranded-rotation paths (single / double `EndOfTurn` forced × success / failure) and `persistent_treachery` integration tests pass unchanged.
- New tests: `investigator_turn_frame_classification`, `investigator_turn_frame_round_trips_both_ending_states`, `open_turn_leaves_investigator_turn_frame_on_top`, `investigator_turn_defaults_to_not_ending`.
- Pre-push review (clean — zero Critical/Important) added the round-trip test (Minor #1).

## Linked issues

Refs #393 (slice 2a-i; the issue is closed — this is one of its sequenced slices, as with #397/#398). Follow-up: #399.

🤖 Generated with [Claude Code](https://claude.com/claude-code)