### PR TITLE
engine: Fight targets any co-located enemy, not only engaged ones (#401)

### DIFF
--- a/crates/cards/tests/evidence.rs
+++ b/crates/cards/tests/evidence.rs
@@ -54,6 +54,7 @@ fn investigator_with_evidence_and_enemy(
     enemy.max_health = 1;
     enemy.damage = 0;
     enemy.engaged_with = Some(inv_id);
+    enemy.current_location = Some(loc_id); // co-located: Fight is location-gated (#401)
 
     let mut loc = test_location(10, "Study");
     loc.clues = location_clues;
@@ -203,6 +204,7 @@ fn window_offers_both_in_play_reaction_and_hand_evidence() {
     enemy.max_health = 1;
     enemy.damage = 0;
     enemy.engaged_with = Some(inv_id);
+    enemy.current_location = Some(loc_id); // co-located: Fight is location-gated (#401)
 
     let mut loc = test_location(10, "Study");
     loc.clues = 2;

--- a/crates/cards/tests/mind_over_matter.rs
+++ b/crates/cards/tests/mind_over_matter.rs
@@ -47,6 +47,7 @@ fn board(combat: i8, intellect: i8, hand: Vec<CardCode>) -> game_core::GameState
     enemy.fight = 3;
     enemy.max_health = 5; // survives so we can read `damage`
     enemy.engaged_with = Some(INV);
+    enemy.current_location = Some(LOC); // co-located: Fight is location-gated (#401)
 
     GameStateBuilder::new()
         .with_phase(Phase::Investigation)
@@ -220,6 +221,7 @@ fn weapon_fight_substituting_uses_intellect_and_keeps_weapon_damage() {
     enemy.fight = 3;
     enemy.max_health = 5;
     enemy.engaged_with = Some(INV);
+    enemy.current_location = Some(LOC); // co-located: Fight is location-gated (#401)
 
     let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)

--- a/crates/cards/tests/roland_banks.rs
+++ b/crates/cards/tests/roland_banks.rs
@@ -71,6 +71,7 @@ fn roland_at_location_with_enemy(
     enemy.max_health = 1;
     enemy.damage = 0;
     enemy.engaged_with = Some(inv_id);
+    enemy.current_location = Some(loc_id); // co-located: Fight is location-gated (#401)
 
     let mut loc = test_location(10, "Study");
     loc.clues = location_clues;

--- a/crates/cards/tests/vicious_blow.rs
+++ b/crates/cards/tests/vicious_blow.rs
@@ -9,10 +9,10 @@ use std::sync::Once;
 
 use game_core::event::Event;
 use game_core::state::{
-    CardCode, ChaosBag, ChaosToken, EnemyId, InvestigatorId, Phase, TokenModifiers,
+    CardCode, ChaosBag, ChaosToken, EnemyId, InvestigatorId, LocationId, Phase, TokenModifiers,
 };
 use game_core::test_support::{
-    drive, test_enemy, test_investigator, GameStateBuilder, ScriptedResolver,
+    drive, test_enemy, test_investigator, test_location, GameStateBuilder, ScriptedResolver,
 };
 use game_core::{assert_event, Action, EngineOutcome, PlayerAction};
 
@@ -31,20 +31,24 @@ fn install() {
 /// health 10 so the dealt damage is observable, not clamped), Vicious
 /// Blow in hand, a `Numeric(0)` chaos bag for a deterministic success.
 fn board() -> GameState {
+    let loc_id = LocationId(10);
     let mut inv = test_investigator(1);
     inv.skills.combat = 3;
     inv.hand = vec![CardCode::new(VICIOUS_BLOW)];
+    inv.current_location = Some(loc_id);
 
     let mut enemy = test_enemy(100, "Ghoul");
     enemy.fight = 2;
     enemy.max_health = 10;
     enemy.engaged_with = Some(INV);
+    enemy.current_location = Some(loc_id); // co-located: Fight is location-gated (#401)
 
     GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_active_investigator(INV)
         .with_turn_order([INV])
         .with_investigator(inv)
+        .with_location(test_location(10, "Study"))
         .with_enemy(enemy)
         .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
         .with_token_modifiers(TokenModifiers::default())

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -418,8 +418,9 @@ pub(super) fn move_action(
 ///
 /// Move / Fight / Evade defer the action-point check to `charge_action`
 /// (which folds in the Frozen-in-Fear surcharge), so `move_action` keeps
-/// its own prefix; Fight and Evade reach this via
-/// [`validate_engaged_action`], which then adds the enemy checks.
+/// its own prefix; `fight` calls this directly then does its own co-location
+/// check (#401), while `evade` reaches it via [`validate_engaged_action`],
+/// which adds the engagement check.
 pub(crate) fn validate_basic_action<'a>(
     state: &'a GameState,
     action_name: &'static str,
@@ -466,21 +467,20 @@ pub(crate) fn validate_basic_action<'a>(
     Ok(inv)
 }
 
-/// Validate the prefix shared by Fight and Evade: the basic-action
-/// preconditions (via [`validate_basic_action`]) plus enemy exists and
-/// engaged with the named enemy. Returns the borrowed enemy so the
-/// caller can pick which difficulty (fight / evade) and read any other
-/// fields it needs.
+/// Validate the Evade prefix: the basic-action preconditions (via
+/// [`validate_basic_action`]) plus enemy exists and is engaged with the
+/// named enemy. Returns the borrowed enemy so the caller can read the evade
+/// difficulty and any other fields it needs. (Only `evade` uses this — Evade
+/// is engagement-only per RR p.11; `fight` is co-location-gated since #401 and
+/// does its own check.)
 ///
 /// On `Err`, returns the rejection; the caller should propagate it
 /// without further state mutation. State-corruption invariants
 /// (active investigator missing from map) panic via `unreachable!`.
 ///
-/// Does NOT validate the chosen difficulty is non-negative — the
-/// caller must do that after picking, because Fight and Evade each
-/// only care about one of the two values, and validating both
-/// upfront would reject legitimate states (an enemy with `fight: -1`
-/// the investigator only ever Evades).
+/// Does NOT validate the evade difficulty is non-negative — the caller does
+/// that after the engagement check, so a malformed `evade: -1` rejects with a
+/// clear reason rather than being silently clamped.
 fn validate_engaged_action<'a>(
     state: &'a GameState,
     action_name: &'static str,

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -603,26 +603,53 @@ fn charge_action(
 /// fight value, and on success deals 1 damage. If damage reaches
 /// `max_health`, the enemy is defeated and removed from play.
 ///
+/// Per Rules Reference p.12 ("To fight an enemy **at his or her location**…"),
+/// Fight targets any enemy at the investigator's location — engaged with them or
+/// not (unlike Evade, which is engagement-only; RR p.11). The eligibility check
+/// is co-location, mirroring [`engage`] (#401).
+///
 /// Damage > 1 (weapons, card buffs), after-success / after-failure
 /// triggers (#64), and `AoO` from *other* engaged enemies (#78) are all
 /// downstream. `AoO` does NOT fire on Fight itself per the Rules
 /// Reference's `AoO`-exempt list.
 pub(super) fn fight(cx: &mut Cx, investigator: InvestigatorId, enemy_id: EnemyId) -> EngineOutcome {
-    let fight_difficulty = match validate_engaged_action(cx.state, "Fight", investigator, enemy_id)
-    {
-        Ok(enemy) => {
-            if enemy.fight < 0 {
-                return EngineOutcome::Rejected {
-                    reason: format!(
-                        "Fight: enemy {enemy_id:?} has negative fight value {} (malformed state)",
-                        enemy.fight,
-                    )
-                    .into(),
-                };
-            }
-            enemy.fight
+    let inv = match validate_basic_action(cx.state, "Fight", investigator) {
+        Ok(inv) => inv,
+        Err(rejection) => return rejection,
+    };
+    // A `None` location can't host a fight (mirrors `engage`); without it the
+    // `enemy.current_location != inv_location` check would let a locationless
+    // investigator fight a locationless enemy (`None != None == false`).
+    let Some(inv_location) = inv.current_location else {
+        return EngineOutcome::Rejected {
+            reason: format!("Fight: {investigator:?} has no current_location to fight from").into(),
+        };
+    };
+    let fight_difficulty = {
+        let Some(enemy) = cx.state.enemies.get(&enemy_id) else {
+            return EngineOutcome::Rejected {
+                reason: format!("Fight: enemy {enemy_id:?} is not in state").into(),
+            };
+        };
+        if enemy.current_location != Some(inv_location) {
+            return EngineOutcome::Rejected {
+                reason: format!(
+                    "Fight: enemy {enemy_id:?} (at {:?}) is not at {investigator:?}'s location ({inv_location:?})",
+                    enemy.current_location,
+                )
+                .into(),
+            };
         }
-        Err(rejected) => return rejected,
+        if enemy.fight < 0 {
+            return EngineOutcome::Rejected {
+                reason: format!(
+                    "Fight: enemy {enemy_id:?} has negative fight value {} (malformed state)",
+                    enemy.fight,
+                )
+                .into(),
+            };
+        }
+        enemy.fight
     };
     if let Err(rejected) = charge_action(cx, investigator, crate::dsl::ActionClass::Fight, "Fight")
     {

--- a/crates/game-core/src/engine/enumerate.rs
+++ b/crates/game-core/src/engine/enumerate.rs
@@ -107,10 +107,13 @@ fn push_card_actions(state: &GameState, investigator: InvestigatorId, out: &mut 
 }
 
 /// Append the combat / engage actions legal for `investigator`, mirroring the
-/// `fight`/`evade`/`engage` handlers (slice 2a-ii-2, #393). Fight/Evade target
-/// enemies *engaged with* the investigator — matching the current handler
-/// (`validate_engaged_action`); the rules allow Fight against any co-located
-/// enemy (RR p.12), tracked in #401, which will widen this domain in lockstep.
+/// `fight`/`evade`/`engage` handlers (slice 2a-ii-2, #393). The three target
+/// distinct, overlapping enemy sets:
+/// - **Fight**: any enemy at the investigator's location, engaged or not (RR
+///   p.12, #401 — co-location, like Engage).
+/// - **Evade**: only an enemy engaged with the investigator (RR p.11).
+/// - **Engage**: a co-located enemy not already engaged with the investigator
+///   (including one engaged with another investigator; RR p.11).
 fn push_combat_engage_actions(
     state: &GameState,
     investigator: InvestigatorId,
@@ -130,34 +133,31 @@ fn push_combat_engage_actions(
         action_cost(state, investigator, crate::dsl::ActionClass::Evade) <= actions_remaining;
     let inv_location = inv.current_location;
 
-    // One pass over the enemies. An enemy is either engaged with the
-    // investigator — a Fight/Evade target — or it is not, in which case it is an
-    // Engage target if it shares the investigator's location. The two cases are
-    // mutually exclusive (Fight/Evade need `engaged_with == me`; Engage needs
-    // `!= me`), so a single `if`/`else` covers both.
+    // One pass over the enemies; the three actions' conditions are independent
+    // and can overlap (a co-located engaged enemy is both a Fight and an Evade
+    // target; a co-located unengaged enemy is both a Fight and an Engage target).
+    // The `inv_location.is_some()` guard avoids a `None == None` co-location match
+    // when both are locationless (mirrors the fight/engage handlers' guard).
     for (&enemy_id, enemy) in &state.enemies {
-        if enemy.engaged_with == Some(investigator) {
-            // Fight / Evade: gated on a non-negative difficulty (the handler
-            // rejects a negative one) and affordability.
-            if fight_affordable && enemy.fight >= 0 {
-                out.push(PlayerAction::Fight {
-                    investigator,
-                    enemy: enemy_id,
-                });
-            }
-            if evade_affordable && enemy.evade >= 0 {
-                out.push(PlayerAction::Evade {
-                    investigator,
-                    enemy: enemy_id,
-                });
-            }
-        } else if inv_location.is_some() && enemy.current_location == inv_location {
-            // Engage: at the investigator's location, not already engaged with
-            // them — including an enemy engaged with *another* investigator
-            // (engaging pulls it across; RR p.11). Engage costs 1 action, already
-            // gated by the `validate_basic_action` prologue above. The
-            // `inv_location.is_some()` guard avoids a `None == None` match when
-            // both are locationless (mirrors the handler's guard).
+        let co_located = inv_location.is_some() && enemy.current_location == inv_location;
+        let engaged_with_me = enemy.engaged_with == Some(investigator);
+
+        // Fight: any co-located enemy, non-negative difficulty, affordable.
+        if co_located && fight_affordable && enemy.fight >= 0 {
+            out.push(PlayerAction::Fight {
+                investigator,
+                enemy: enemy_id,
+            });
+        }
+        // Evade: only an enemy engaged with the investigator.
+        if engaged_with_me && evade_affordable && enemy.evade >= 0 {
+            out.push(PlayerAction::Evade {
+                investigator,
+                enemy: enemy_id,
+            });
+        }
+        // Engage: a co-located enemy not already engaged with the investigator.
+        if co_located && !engaged_with_me {
             out.push(PlayerAction::Engage {
                 investigator,
                 enemy: enemy_id,
@@ -340,15 +340,61 @@ mod tests {
     }
 
     #[test]
-    fn no_fight_or_evade_for_an_unengaged_enemy() {
+    fn fight_but_not_evade_for_an_unengaged_co_located_enemy() {
+        // #401: Fight targets any co-located enemy (RR p.12); Evade is
+        // engagement-only (RR p.11). An unengaged enemy at the investigator's
+        // location is a Fight target but not an Evade target.
         let mut state = open_turn_state();
+        let loc = crate::test_support::test_location(10, "Study");
+        let loc_id = loc.id;
+        state.locations.insert(loc_id, loc);
+        state
+            .investigators
+            .get_mut(&InvestigatorId(1))
+            .unwrap()
+            .current_location = Some(loc_id);
         state
             .investigators
             .get_mut(&InvestigatorId(1))
             .unwrap()
             .actions_remaining = 3;
-        // Enemy present but engaged with nobody → not a Fight/Evade target.
-        let e = crate::test_support::test_enemy(7, "Ghoul");
+        let mut e = crate::test_support::test_enemy(7, "Ghoul");
+        e.current_location = Some(loc_id); // co-located, but engaged with nobody
+        state.enemies.insert(e.id, e);
+
+        let actions = legal_actions(&state);
+        assert!(actions.contains(&PlayerAction::Fight {
+            investigator: InvestigatorId(1),
+            enemy: crate::state::EnemyId(7),
+        }));
+        assert!(!actions.contains(&PlayerAction::Evade {
+            investigator: InvestigatorId(1),
+            enemy: crate::state::EnemyId(7),
+        }));
+    }
+
+    #[test]
+    fn no_combat_for_an_enemy_at_a_different_location() {
+        // An enemy elsewhere (and unengaged) is neither a Fight nor an Evade
+        // target (#401: Fight needs co-location).
+        let mut state = open_turn_state();
+        let here = crate::test_support::test_location(10, "Study");
+        let there = crate::test_support::test_location(11, "Attic");
+        let (here_id, there_id) = (here.id, there.id);
+        state.locations.insert(here_id, here);
+        state.locations.insert(there_id, there);
+        state
+            .investigators
+            .get_mut(&InvestigatorId(1))
+            .unwrap()
+            .current_location = Some(here_id);
+        state
+            .investigators
+            .get_mut(&InvestigatorId(1))
+            .unwrap()
+            .actions_remaining = 3;
+        let mut e = crate::test_support::test_enemy(7, "Ghoul");
+        e.current_location = Some(there_id);
         state.enemies.insert(e.id, e);
         assert!(!legal_actions(&state)
             .iter()

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -268,8 +268,8 @@ mod tests {
     use crate::event::{Event, FailureReason};
     use crate::state::EnemyId;
     use crate::state::{
-        CardCode, ChaosToken, DefeatCause, GameState, InvestigatorId, Phase, SkillKind, Status,
-        TokenModifiers, TokenResolution, Zone,
+        CardCode, ChaosToken, DefeatCause, GameState, InvestigatorId, LocationId, Phase, SkillKind,
+        Status, TokenModifiers, TokenResolution, Zone,
     };
     use crate::test_support::{
         apply_no_commits, test_enemy, test_investigator, test_location, GameStateBuilder,
@@ -1869,16 +1869,22 @@ mod tests {
     fn fight_evade_scenario() -> (InvestigatorId, EnemyId, GameState) {
         let inv_id = InvestigatorId(1);
         let enemy_id = EnemyId(100);
+        let loc_id = LocationId(40);
         let mut inv = test_investigator(1);
         inv.actions_remaining = 3;
+        // Investigator and enemy share a location: Fight is co-location-gated
+        // (RR p.12, #401), Evade engagement-gated (RR p.11) — this satisfies both.
+        inv.current_location = Some(loc_id);
         let mut enemy = test_enemy(100, "Test Ghoul");
         enemy.fight = 3;
         enemy.evade = 3;
         enemy.max_health = 2;
         enemy.engaged_with = Some(inv_id);
+        enemy.current_location = Some(loc_id);
         let state = GameStateBuilder::new()
             .with_investigator(inv)
             .with_enemy(enemy)
+            .with_location(test_location(40, "Test Hall"))
             .with_chaos_bag(bag_only_zero())
             .with_phase(Phase::Investigation)
             .with_active_investigator(inv_id)
@@ -2150,9 +2156,58 @@ mod tests {
     }
 
     #[test]
-    fn fight_when_not_engaged_with_target_is_rejected() {
+    fn fight_against_co_located_unengaged_enemy_is_accepted() {
+        // Rules Reference p.12: "To fight an enemy at his or her location…" —
+        // Fight targets any enemy at the investigator's location, engaged or not
+        // (#401). An unengaged but co-located enemy is a legal Fight target.
         let (inv_id, enemy_id, mut state) = fight_evade_scenario();
-        state.enemies.get_mut(&enemy_id).unwrap().engaged_with = None;
+        let loc = test_location(50, "Hall");
+        let loc_id = loc.id;
+        state.locations.insert(loc_id, loc);
+        state
+            .investigators
+            .get_mut(&inv_id)
+            .unwrap()
+            .current_location = Some(loc_id);
+        let enemy = state.enemies.get_mut(&enemy_id).unwrap();
+        enemy.current_location = Some(loc_id);
+        enemy.engaged_with = None;
+
+        let result = apply_no_commits(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+        // Accepted: the Fight resolves its combat test rather than rejecting.
+        assert!(
+            !matches!(result.outcome, EngineOutcome::Rejected { .. }),
+            "co-located fight should be accepted, got {:?}",
+            result.outcome,
+        );
+    }
+
+    #[test]
+    fn fight_against_enemy_at_a_different_location_is_rejected() {
+        // The flip side of #401: an enemy NOT at the investigator's location is
+        // not a Fight target, even though enemies engaged with the investigator
+        // are (they share the location). Here the enemy is unengaged and elsewhere.
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        let here = test_location(50, "Hall");
+        let there = test_location(51, "Attic");
+        let (here_id, there_id) = (here.id, there.id);
+        state.locations.insert(here_id, here);
+        state.locations.insert(there_id, there);
+        state
+            .investigators
+            .get_mut(&inv_id)
+            .unwrap()
+            .current_location = Some(here_id);
+        let enemy = state.enemies.get_mut(&enemy_id).unwrap();
+        enemy.current_location = Some(there_id);
+        enemy.engaged_with = None;
+
         let result = apply_no_commits(
             state,
             Action::Player(PlayerAction::Fight {

--- a/crates/game-core/tests/commit_attack_buff.rs
+++ b/crates/game-core/tests/commit_attack_buff.rs
@@ -17,9 +17,9 @@ use game_core::dsl::{boost_attack_damage, on_commit, Ability};
 use game_core::engine::{EngineOutcome, OptionId};
 use game_core::event::Event;
 use game_core::state::{
-    CardCode, ChaosBag, ChaosToken, EnemyId, InvestigatorId, Phase, TokenModifiers,
+    CardCode, ChaosBag, ChaosToken, EnemyId, InvestigatorId, LocationId, Phase, TokenModifiers,
 };
-use game_core::test_support::{test_enemy, test_investigator, GameStateBuilder};
+use game_core::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
 use game_core::{assert_event, Action, InputResponse, PlayerAction};
 
 /// Mock skill: combat icon + `[OnCommit] that attack deals +1 damage`.
@@ -83,20 +83,24 @@ fn board() -> (game_core::GameState, InvestigatorId, EnemyId) {
     let id = InvestigatorId(1);
     let enemy_id = EnemyId(100);
 
+    let loc_id = LocationId(10);
     let mut inv = test_investigator(1);
     inv.skills.combat = 3;
     inv.hand = vec![CardCode::new(SKILL)];
+    inv.current_location = Some(loc_id);
 
     let mut enemy = test_enemy(100, "Ghoul");
     enemy.fight = 2;
     enemy.max_health = 10;
     enemy.engaged_with = Some(id);
+    enemy.current_location = Some(loc_id); // co-located: Fight is location-gated (#401)
 
     let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_active_investigator(id)
         .with_turn_order([id])
         .with_investigator(inv)
+        .with_location(test_location(10, "Study"))
         .with_enemy(enemy)
         .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
         .with_token_modifiers(TokenModifiers::default())

--- a/crates/game-core/tests/reaction_windows.rs
+++ b/crates/game-core/tests/reaction_windows.rs
@@ -136,6 +136,7 @@ fn fight_to_defeat_scenario(
     enemy.max_health = 2;
     enemy.damage = 1;
     enemy.engaged_with = Some(inv_id);
+    enemy.current_location = Some(loc_id); // co-located: Fight is location-gated (#401)
     let mut loc = test_location(10, "Mock Location");
     loc.clues = 3;
     let state = GameStateBuilder::new()
@@ -354,6 +355,7 @@ fn by_controller_filter_excludes_unrelated_investigators() {
     enemy.max_health = 2;
     enemy.damage = 1;
     enemy.engaged_with = Some(attacker);
+    enemy.current_location = Some(loc_id); // co-located: Fight is location-gated (#401)
     let mut loc = test_location(10, "Mock Location");
     loc.clues = 3;
     let state = GameStateBuilder::new()
@@ -402,6 +404,7 @@ fn unqualified_pattern_matches_any_defeat() {
     enemy.max_health = 2;
     enemy.damage = 1;
     enemy.engaged_with = Some(attacker);
+    enemy.current_location = Some(loc_id); // co-located: Fight is location-gated (#401)
     let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_active_investigator(attacker)
@@ -690,6 +693,7 @@ fn reaction_window_closes_before_on_skill_test_resolution_fires() {
     enemy.max_health = 2;
     enemy.damage = 1;
     enemy.engaged_with = Some(inv_id);
+    enemy.current_location = Some(loc_id); // co-located: Fight is location-gated (#401)
     let mut loc = test_location(10, "Mock Location");
     loc.clues = 3;
     let state = GameStateBuilder::new()
@@ -803,6 +807,7 @@ fn pending_triggers_order_active_investigator_first_then_turn_order() {
     enemy.max_health = 2;
     enemy.damage = 1;
     enemy.engaged_with = Some(active);
+    enemy.current_location = Some(loc_id); // co-located: Fight is location-gated (#401)
     let state = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_active_investigator(active)
@@ -927,6 +932,7 @@ fn reaction_trigger_in_threat_area_opens_window() {
     enemy.max_health = 2;
     enemy.damage = 1;
     enemy.engaged_with = Some(inv_id);
+    enemy.current_location = Some(loc_id); // co-located: Fight is location-gated (#401)
     let mut loc = test_location(10, "Mock Location");
     loc.clues = 3;
     let state = GameStateBuilder::new()
@@ -1056,6 +1062,7 @@ fn pick_index_fires_threat_area_reaction_and_closes_window() {
     enemy.max_health = 2;
     enemy.damage = 1;
     enemy.engaged_with = Some(inv_id);
+    enemy.current_location = Some(loc_id); // co-located: Fight is location-gated (#401)
     let mut loc = test_location(10, "Mock Location");
     loc.clues = 3;
     let state = GameStateBuilder::new()


### PR DESCRIPTION
## Summary

Fixes #401: the Fight action handler wrongly required engagement. Per Rules Reference p.12 ("To fight an enemy **at his or her location**…"), Fight targets any enemy at the investigator's location — engaged or not. Only **Evade** is engagement-only (RR p.11); **Engage** is already co-location-based.

## What changed

- **Handler** (`actions.rs` `fight`): replaced `validate_engaged_action` with a co-location check mirroring `engage` — `validate_basic_action` + investigator has a location + enemy in state + `enemy.current_location == Some(inv_location)`, keeping the `fight >= 0` guard. `evade` still uses `validate_engaged_action` (correct, engagement-only).
- **Enumerator lockstep** (`enumerate.rs`): Fight's domain widens from engaged to co-located. Fight (co-located), Evade (engaged), and Engage (co-located & not-engaged-with-me) are now distinct *overlapping* sets, so the combat loop uses three independent conditions instead of the old engaged/not-engaged `if`/`else`. The cross-check now applies a co-located unengaged Fight, enforcing the lockstep.
- **Test fixtures**: several tests fought an enemy that was engaged but had no `current_location`. Since an engaged enemy is always co-located per the rules, those fixtures now set `enemy.current_location` to match the investigator's — inert for their non-Fight assertions (e.g. Evade tests).

## Tests

- New handler tests: `fight_against_co_located_unengaged_enemy_is_accepted`, `fight_against_enemy_at_a_different_location_is_rejected`.
- New enumerator tests: `fight_but_not_evade_for_an_unengaged_co_located_enemy`, `no_combat_for_an_enemy_at_a_different_location` (replacing the old engagement-only test).
- Full host gauntlet green (`RUSTFLAGS=-D warnings cargo test --all --all-features`, clippy, fmt, doc) + wasm jobs unaffected.

## Notes / follow-ups

- The web fight-target picker still filters by engagement — pre-2b prototype rendering, untouched here; #205/2b reconciles it when the client renders from `legal_actions`.
- A now-**reachable** RR clause (failed Fight against an enemy engaged with *another* investigator redirects the attack damage to that investigator) is filed as **#409** — out of scope for the 1-player gate, lands with solo-2/multiplayer.
- Pre-push review: **Ready to merge, zero Critical/Important** (verified verbatim against the vendored Rules Reference); applied the two doc-comment fixes it flagged.

## Linked issues

Closes #401. Follow-up: #409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)