### PR TITLE
engine: attacks of opportunity open cancel/soak windows via mid-action park/resume (K1 of #293)

### DIFF
--- a/crates/cards/tests/dodge_aoo.rs
+++ b/crates/cards/tests/dodge_aoo.rs
@@ -1,0 +1,490 @@
+//! End-to-end Dodge 01023 + Guard Dog 01021 against attacks of opportunity
+//! (`AoO`), driven through the public [`apply`] API with the real card corpus
+//! installed (#293 acceptance — K1 keystone integration test).
+//!
+//! These are the registry-backed proofs that the mid-action park / resume
+//! mechanism works end-to-end: when a basic action (Move) fires an `AoO`, the
+//! `AoO` runs through `drive_attack_loop` so it opens the before-attack cancel
+//! window (Dodge) and the per-soaked-asset reaction window (Guard Dog), the
+//! engine suspends with `AwaitingInput`, and the action's primary effect
+//! (the move) resumes correctly after `ResolveInput` closes the window.
+//!
+//! `game-core`'s unit tests can't install `cards::REGISTRY` (the engine crate
+//! can't depend on `cards`), so this lives in `crates/cards/tests/`.
+//!
+//! ## Verified card text (`ArkhamDB`, 2026-06-21)
+//!
+//! **Dodge (01023):** "Fast. Play when an enemy attacks an investigator at
+//! your location. Cancel that attack."
+//! FAQ:
+//!   - Dodge works against any attack type: Enemy phase attacks, attacks of
+//!     opportunity, and Retaliate abilities.
+//!   - When an attack is cancelled in the Enemy phase, the attacking enemy
+//!     still exhausts. (For `AoO`: `AoO` attackers never exhaust per RR p.7,
+//!     so Dodge + `AoO` = no damage, no exhaust — both rules apply.)
+//!   - Against Massive enemies, Dodge cancels only a single attack.
+//!
+//! **Guard Dog (01021):** "[reaction] When an enemy attack deals damage to
+//! Guard Dog: Deal 1 damage to the attacking enemy." Health 3, Sanity 1.
+//! FAQ: "You can use Guard Dog's ability when you assign lethal damage/
+//! horror to it." The trigger is 'when an enemy attack deals damage' with
+//! no `AoO` carve-out — Guard Dog retaliates against `AoO` attacks.
+#![allow(clippy::too_many_lines)]
+
+use std::sync::Once;
+
+use game_core::engine::{apply, EngineOutcome, OptionId};
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, CardInPlay, CardInstanceId, Enemy, EnemyId, InvestigatorId, LocationId, Phase,
+    WindowKind,
+};
+use game_core::test_support::{test_enemy, test_investigator, test_location};
+use game_core::{Action, InputResponse, PlayerAction};
+
+/// Dodge (01023): Neutral Tactic, Fast, before-attack cancel reaction.
+const DODGE: &str = "01023";
+
+/// Guard Dog (01021): Guardian Ally, health 3 / sanity 1, damage-retaliate.
+const GUARD_DOG: &str = "01021";
+
+fn install_real_registry() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// An engaged ready enemy at `loc` dealing `damage` / 0 horror with `max_health`.
+/// `AoO` attackers are ready (not exhausted) and engaged; `max_health` lets
+/// callers ensure the attacker survives a Guard Dog retaliation.
+fn engaged_attacker(
+    id: u32,
+    inv: InvestigatorId,
+    loc: LocationId,
+    damage: u8,
+    max_health: u8,
+) -> Enemy {
+    let mut e = test_enemy(id, format!("Attacker {id}"));
+    e.attack_damage = damage;
+    e.attack_horror = 0;
+    e.max_health = max_health;
+    e.current_location = Some(loc);
+    e.engaged_with = Some(inv);
+    e
+}
+
+// -----------------------------------------------------------------------
+// Test 1 — Dodge cancels an AoO; the move completes; attacker not exhausted
+// -----------------------------------------------------------------------
+
+/// An investigator with Dodge in hand, engaged by a ready enemy, takes a
+/// Move action. The `AoO` opens the `BeforeEnemyAttack` cancel window; the
+/// player plays Dodge to cancel; the attack deals no damage/horror; the
+/// move then completes (`ActionResolution` frame resumes).
+///
+/// Verifies the end-to-end suspend/resume chain:
+///   Move → push `ActionResolution` → `drive_aoo` → `drive_attack_loop` →
+///   `BeforeEnemyAttack` window opens → `AwaitingInput` →
+///   `ResolveInput{PickSingle(0)}` → plays Dodge → cancel →
+///   `resume_enemy_attack` (`BeforeAttack` arm, `cancelled=true`) → no damage →
+///   loop `Done` (`AoO` source) → `drive` → `ActionResolution` on top →
+///   `resume_action_resolution` → `move_primary_effect` → `Done`.
+#[test]
+fn dodge_cancels_attack_of_opportunity_no_damage_move_completes_attacker_not_exhausted() {
+    install_real_registry();
+
+    let inv_id = InvestigatorId(1);
+    let from = LocationId(101);
+    let dest = LocationId(102);
+    let enemy_id = EnemyId(7);
+
+    let mut study = test_location(101, "Study");
+    study.connections = vec![dest];
+    let mut hallway = test_location(102, "Hallway");
+    hallway.connections = vec![from];
+
+    let mut investigator = test_investigator(1);
+    investigator.current_location = Some(from);
+    investigator.hand = vec![CardCode::new(DODGE)];
+
+    let attacker = engaged_attacker(7, inv_id, from, 2, 3);
+
+    let state = game_core::test_support::GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_location(study)
+        .with_location(hallway)
+        .with_investigator(investigator)
+        .with_active_investigator(inv_id)
+        .with_turn_order([inv_id])
+        .with_enemy(attacker)
+        .build();
+
+    // Step 1: take the Move — AoO fires; Dodge is in hand so the
+    // BeforeEnemyAttack cancel window opens and suspends.
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::Move {
+            investigator: inv_id,
+            destination: dest,
+        }),
+    );
+    let mut state = result.state;
+
+    assert!(
+        matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),
+        "BeforeEnemyAttack window must suspend the AoO loop: {:?}",
+        result.outcome
+    );
+    assert!(
+        result
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::WindowOpened { kind }
+                if matches!(kind, WindowKind::BeforeEnemyAttack { .. }))),
+        "BeforeEnemyAttack window opened: {:?}",
+        result.events
+    );
+    // No damage yet; move not yet completed.
+    assert_eq!(state.investigators[&inv_id].damage, 0);
+    assert_eq!(
+        state.investigators[&inv_id].current_location,
+        Some(from),
+        "move not yet resolved while the cancel window is open"
+    );
+    // Dodge still in hand; not yet played.
+    assert!(
+        state.investigators[&inv_id]
+            .hand
+            .contains(&CardCode::new(DODGE)),
+        "Dodge is still in hand before the window is resolved"
+    );
+
+    // Step 2: play Dodge (the single offered candidate) — cancel the AoO.
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickSingle(OptionId(0)),
+        }),
+    );
+    state = result.state;
+
+    // The AoO was cancelled: no damage/horror dealt.
+    assert_eq!(
+        state.investigators[&inv_id].damage, 0,
+        "the cancelled AoO dealt no damage"
+    );
+    assert_eq!(
+        state.investigators[&inv_id].horror, 0,
+        "the cancelled AoO dealt no horror"
+    );
+    assert!(
+        !result
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::DamageTaken { .. })),
+        "a cancelled attack deals no damage: {:?}",
+        result.events
+    );
+
+    // The attacker did NOT exhaust (AoO: RR p.7 — Dodge FAQ says the enemy
+    // still exhausts for an Enemy-phase cancel, but AoO attackers are exempt
+    // from exhaustion by RR p.7 regardless of whether the attack was cancelled).
+    assert!(
+        !state.enemies[&enemy_id].exhausted,
+        "AoO attacker never exhausts, even after a Dodge cancel (RR p.7)"
+    );
+
+    // The move completed after the cancel window closed: the ActionResolution
+    // frame resumed and ran move_primary_effect.
+    assert_eq!(
+        state.investigators[&inv_id].current_location,
+        Some(dest),
+        "move resolved: investigator reached the destination after Dodge cancelled the AoO"
+    );
+    assert_eq!(
+        state.enemies[&enemy_id].current_location,
+        Some(dest),
+        "engaged enemy moved with the investigator to the destination"
+    );
+    assert!(
+        result.events.iter().any(|e| matches!(
+            e,
+            Event::InvestigatorMoved { investigator, to, .. }
+                if *investigator == inv_id && *to == dest
+        )),
+        "InvestigatorMoved emitted after the cancel window closed: {:?}",
+        result.events
+    );
+
+    // Dodge left hand and went to discard (a played Fast event).
+    assert!(
+        !state.investigators[&inv_id]
+            .hand
+            .contains(&CardCode::new(DODGE)),
+        "Dodge left hand after being played"
+    );
+    assert!(
+        state.investigators[&inv_id]
+            .discard
+            .contains(&CardCode::new(DODGE)),
+        "Dodge is in the discard pile after being played"
+    );
+
+    // No windows stranded after the full cycle.
+    assert!(
+        state.open_windows().is_empty(),
+        "no windows stranded after Dodge cancel + move resume: {:?}",
+        state.open_windows()
+    );
+}
+
+// -----------------------------------------------------------------------
+// Test 2 — Skip the cancel window: AoO lands, move still completes
+// -----------------------------------------------------------------------
+
+/// Confirms the resume path works even when the before-attack window is
+/// explicitly skipped (not played): the attack lands normally, and the move
+/// still completes after the `AoO` loop finishes.
+///
+/// This is NOT the primary #293 case (no Guard Dog, no soak window here since
+/// the investigator has no soaking asset), but it verifies that a
+/// `ResolveInput{Skip}` on a `BeforeEnemyAttack` window correctly resumes the
+/// `ActionResolution` frame.
+#[test]
+fn skipping_before_attack_window_lets_aoo_land_and_move_still_completes() {
+    install_real_registry();
+
+    let inv_id = InvestigatorId(1);
+    let from = LocationId(101);
+    let dest = LocationId(102);
+    let enemy_id = EnemyId(7);
+
+    let mut study = test_location(101, "Study");
+    study.connections = vec![dest];
+    let mut hallway = test_location(102, "Hallway");
+    hallway.connections = vec![from];
+
+    let mut investigator = test_investigator(1);
+    investigator.current_location = Some(from);
+    investigator.hand = vec![CardCode::new(DODGE)];
+
+    let attacker = engaged_attacker(7, inv_id, from, 2, 5);
+
+    let state = game_core::test_support::GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_location(study)
+        .with_location(hallway)
+        .with_investigator(investigator)
+        .with_active_investigator(inv_id)
+        .with_turn_order([inv_id])
+        .with_enemy(attacker)
+        .build();
+
+    // Step 1: Move → AoO → BeforeEnemyAttack window.
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::Move {
+            investigator: inv_id,
+            destination: dest,
+        }),
+    );
+    let mut state = result.state;
+    assert!(matches!(
+        result.outcome,
+        EngineOutcome::AwaitingInput { .. }
+    ));
+
+    // Step 2: skip the cancel window → AoO lands → move completes.
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Skip,
+        }),
+    );
+    state = result.state;
+
+    // The AoO landed: investigator took 2 damage.
+    assert!(
+        result.events.iter().any(|e| matches!(
+            e,
+            Event::DamageTaken { investigator, amount: 2 } if *investigator == inv_id
+        )),
+        "the un-cancelled AoO dealt its 2 damage: {:?}",
+        result.events
+    );
+    assert_eq!(state.investigators[&inv_id].damage, 2);
+
+    // Attacker never exhausts (AoO rule, RR p.7).
+    assert!(
+        !state.enemies[&enemy_id].exhausted,
+        "AoO attacker never exhausts (RR p.7)"
+    );
+
+    // Move still completed.
+    assert_eq!(
+        state.investigators[&inv_id].current_location,
+        Some(dest),
+        "move resolved after the skipped AoO cancel window"
+    );
+    assert!(
+        result.events.iter().any(|e| matches!(
+            e,
+            Event::InvestigatorMoved { investigator, to, .. }
+                if *investigator == inv_id && *to == dest
+        )),
+        "InvestigatorMoved emitted: {:?}",
+        result.events
+    );
+}
+
+// -----------------------------------------------------------------------
+// Test 3 — Guard Dog retaliates against an AoO; move completes after resume
+// -----------------------------------------------------------------------
+
+/// An investigator controlling Guard Dog in play, engaged by a ready enemy,
+/// takes a Move action. The `AoO` has no before-attack cancel reaction (no Dodge
+/// in hand), so the `AoO` damage resolves directly, soaking onto Guard Dog.
+/// The soak window opens; the player fires Guard Dog's reaction; the attacker
+/// takes 1 damage; the `ActionResolution` frame then resumes and the move
+/// completes.
+///
+/// This is the canonical K1/#293 acceptance test: a soak window opened by an
+/// `AoO` drives the full suspend/resume cycle, confirming that the
+/// `ActionResolution` frame beneath the `AttackLoop` is correctly resumed by
+/// `drive` once the window closes.
+#[test]
+fn guard_dog_retaliates_against_aoo_and_move_completes() {
+    install_real_registry();
+
+    let dog = CardInstanceId(1);
+    let inv_id = InvestigatorId(1);
+    let from = LocationId(101);
+    let dest = LocationId(102);
+    let enemy_id = EnemyId(7);
+
+    let mut study = test_location(101, "Study");
+    study.connections = vec![dest];
+    let mut hallway = test_location(102, "Hallway");
+    hallway.connections = vec![from];
+
+    let mut investigator = test_investigator(1);
+    investigator.current_location = Some(from);
+    // Guard Dog in play, no Dodge in hand — so no before-attack cancel window.
+    investigator.cards_in_play = vec![CardInPlay::enter_play(CardCode::new(GUARD_DOG), dog)];
+
+    // Attacker deals 2 damage; Guard Dog (health 3) survives (2 < 3) and
+    // retaliates. Max health 5 ensures the attacker survives the 1 retaliate.
+    let attacker = engaged_attacker(7, inv_id, from, 2, 5);
+
+    let state = game_core::test_support::GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_location(study)
+        .with_location(hallway)
+        .with_investigator(investigator)
+        .with_active_investigator(inv_id)
+        .with_turn_order([inv_id])
+        .with_enemy(attacker)
+        .build();
+
+    // Step 1: Move → AoO → damage soaks onto Guard Dog → soak window opens.
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::Move {
+            investigator: inv_id,
+            destination: dest,
+        }),
+    );
+    let mut state = result.state;
+
+    assert!(
+        matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),
+        "Guard Dog soak window must suspend the AoO loop: {:?}",
+        result.outcome
+    );
+    assert!(
+        result
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::WindowOpened { kind }
+                if matches!(kind, WindowKind::AfterEnemyAttackDamagedAsset { .. }))),
+        "AfterEnemyAttackDamagedAsset window opened: {:?}",
+        result.events
+    );
+    // Guard Dog soaked the damage; investigator took none.
+    let dog_in_play = state.investigators[&inv_id]
+        .cards_in_play
+        .iter()
+        .find(|c| c.instance_id == dog)
+        .expect("Guard Dog still in play");
+    assert_eq!(
+        dog_in_play.accumulated_damage, 2,
+        "AoO damage soaked onto Guard Dog"
+    );
+    assert_eq!(state.investigators[&inv_id].damage, 0);
+    // Move not yet resolved (parked on ActionResolution).
+    assert_eq!(
+        state.investigators[&inv_id].current_location,
+        Some(from),
+        "move not yet resolved while soak window is open"
+    );
+    // No retaliate damage yet.
+    assert_eq!(state.enemies[&enemy_id].damage, 0);
+
+    // Step 2: fire Guard Dog's reaction (the single pending trigger).
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickSingle(OptionId(0)),
+        }),
+    );
+    state = result.state;
+
+    // Guard Dog dealt 1 retaliate damage to the AoO attacker.
+    assert_eq!(
+        state.enemies[&enemy_id].damage, 1,
+        "Guard Dog's reaction dealt 1 damage to the AoO attacker"
+    );
+    assert!(
+        result.events.iter().any(|e| matches!(
+            e,
+            Event::EnemyDamaged { enemy, amount: 1, .. } if *enemy == enemy_id
+        )),
+        "EnemyDamaged {{ amount: 1 }} emitted: {:?}",
+        result.events
+    );
+
+    // AoO attacker never exhausts (RR p.7).
+    assert!(
+        !state.enemies[&enemy_id].exhausted,
+        "AoO attacker does not exhaust even after Guard Dog retaliates (RR p.7)"
+    );
+
+    // Move completed: ActionResolution frame resumed after the window closed.
+    assert_eq!(
+        state.investigators[&inv_id].current_location,
+        Some(dest),
+        "move resolved: investigator reached the destination after Guard Dog retaliated"
+    );
+    assert_eq!(
+        state.enemies[&enemy_id].current_location,
+        Some(dest),
+        "engaged enemy moved with the investigator"
+    );
+    assert!(
+        result.events.iter().any(|e| matches!(
+            e,
+            Event::InvestigatorMoved { investigator, to, .. }
+                if *investigator == inv_id && *to == dest
+        )),
+        "InvestigatorMoved emitted after the soak window closed: {:?}",
+        result.events
+    );
+
+    // No windows remain after the full cycle.
+    assert!(
+        state.open_windows().is_empty(),
+        "no windows stranded after Guard Dog reaction + move resume: {:?}",
+        state.open_windows()
+    );
+}

--- a/crates/cards/tests/guard_dog_soak.rs
+++ b/crates/cards/tests/guard_dog_soak.rs
@@ -523,21 +523,35 @@ fn two_attackers_suspend_on_first_soak_then_resume_second_attacker() {
 }
 
 // ---------------------------------------------------------------------
-// Case 5 — attack of opportunity soaks onto Guard Dog but strands no
-// reaction window (regression guard for the AoO seam; C5b #237)
+// Case 5 — attack of opportunity soaks onto Guard Dog; the soak window
+// opens, Guard Dog retaliates, and the move completes after resume
+// (#293 acceptance).
+//
+// Verified card text (ArkhamDB https://arkhamdb.com/card/01021, 2026-06-21):
+//   Guard Dog (01021): "[reaction] When an enemy attack deals damage to
+//   Guard Dog: Deal 1 damage to the attacking enemy." Health 3, Sanity 1.
+//   FAQ: "You can use Guard Dog's ability when you assign lethal damage/
+//   horror to it." Also confirmed via FAQ: Guard Dog's reaction fires
+//   against attacks of opportunity (the trigger is 'when an enemy attack
+//   deals damage', with no carve-out for AoO).
+//
+// The before-#293 behaviour was: `drive_aoo` dropped the survivor list so
+// Guard Dog's soak window was never queued. After #293 the AoO runs through
+// `drive_attack_loop` (which opens both the BeforeEnemyAttack cancel window
+// and the AfterEnemyAttackDamagedAsset soak window), so the full suspend/
+// resume cycle now applies to AoO attacks.
 // ---------------------------------------------------------------------
 
 #[test]
-fn move_attack_of_opportunity_soaks_onto_guard_dog_without_stranding_a_window() {
+#[allow(clippy::too_many_lines)]
+fn move_attack_of_opportunity_guard_dog_retaliates_and_move_completes() {
     // An investigator controlling Guard Dog, engaged by a ready enemy,
-    // takes a Move action. The Move fires an attack of opportunity BEFORE
-    // resolving, and the AoO's damage soaks onto Guard Dog. The bug this
-    // guards: `enemy_attack` used to queue an `AfterEnemyAttackDamagedAsset`
-    // reaction window unconditionally, so the AoO would leave an undriven
-    // window on `open_windows` after `fire_attacks_of_opportunity` returns.
-    // AoO now drops the soak-survivor list (Guard Dog does not retaliate
-    // against AoO yet — deferred fast-follow), so the move resolves cleanly
-    // with no stranded window.
+    // takes a Move action. The Move fires an attack of opportunity (through
+    // the ActionResolution frame + drive_aoo path, #293). Guard Dog has no
+    // cancel reaction so the before-attack window auto-skips; the AoO
+    // damage soaks onto Guard Dog; the soak window opens and suspends;
+    // the player fires Guard Dog's reaction; the attacker takes 1 damage;
+    // the move then completes as the ActionResolution frame resumes.
     let dog = CardInstanceId(1);
     let enemy_id = EnemyId(7);
     let inv_id = InvestigatorId(1);
@@ -556,7 +570,7 @@ fn move_attack_of_opportunity_soaks_onto_guard_dog_without_stranding_a_window() 
     investigator.cards_in_play = vec![CardInPlay::enter_play(CardCode::new(GUARD_DOG), dog)];
 
     // Engaged ready attacker dealing 2 damage; Guard Dog (health 3) soaks
-    // all of it.
+    // all of it and survives (2 < 3).
     let attacker = engaged_attacker(7, inv_id, from, 2, 3);
 
     let state = game_core::test_support::GameStateBuilder::new()
@@ -569,6 +583,9 @@ fn move_attack_of_opportunity_soaks_onto_guard_dog_without_stranding_a_window() 
         .with_enemy(attacker)
         .build();
 
+    // Step 1: take the Move — AoO runs; Guard Dog has no cancel reaction
+    // so the before-attack window is skipped; damage soaks onto Guard Dog;
+    // the soak window opens and suspends.
     let result = apply(
         state,
         Action::Player(PlayerAction::Move {
@@ -576,9 +593,16 @@ fn move_attack_of_opportunity_soaks_onto_guard_dog_without_stranding_a_window() 
             destination: dest,
         }),
     );
-    let state = result.state;
+    let mut state = result.state;
 
-    // The AoO soaked its damage onto Guard Dog.
+    // The AoO's soak window suspended the loop (the ActionResolution
+    // frame is parked beneath the AttackLoop beneath the Resolution window).
+    assert!(
+        matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),
+        "AoO soak window must suspend the loop: {:?}",
+        result.outcome
+    );
+    // AoO damage fully soaked onto Guard Dog; investigator took none.
     assert_eq!(
         guard_dog_card(&state, inv_id, dog).accumulated_damage,
         2,
@@ -588,48 +612,80 @@ fn move_attack_of_opportunity_soaks_onto_guard_dog_without_stranding_a_window() 
         state.investigators[&inv_id].damage, 0,
         "investigator took no AoO damage (fully soaked)"
     );
-
-    // The bug guard: no stranded soak window, and the outcome is NOT a
-    // dangling AwaitingInput on a soak window — AoO does not open one.
+    // The soak window opened.
     assert!(
-        state.open_windows().is_empty(),
-        "no reaction window stranded by the AoO: {:?}",
-        state.open_windows()
-    );
-    assert!(
-        !matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),
-        "AoO must not suspend on a soak window: {:?}",
-        result.outcome
-    );
-    assert!(
-        !result
+        result
             .events
             .iter()
             .any(|e| matches!(e, Event::WindowOpened { kind }
-            if matches!(kind, game_core::state::WindowKind::AfterEnemyAttackDamagedAsset { .. }))),
-        "no soak window opened for the AoO: {:?}",
+                if matches!(kind, game_core::state::WindowKind::AfterEnemyAttackDamagedAsset { .. }))),
+        "AfterEnemyAttackDamagedAsset window opened: {:?}",
+        result.events
+    );
+    // Investigator has NOT moved yet (the ActionResolution frame is parked).
+    assert_eq!(
+        state.investigators[&inv_id].current_location,
+        Some(from),
+        "move not yet resolved while window is open"
+    );
+    // No retaliation damage on the attacker yet.
+    assert_eq!(state.enemies[&enemy_id].damage, 0);
+
+    // Step 2: fire Guard Dog's soak reaction (the single pending trigger).
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickSingle(game_core::engine::OptionId(0)),
+        }),
+    );
+    state = result.state;
+
+    // Guard Dog dealt 1 retaliate damage to the attacker.
+    assert_eq!(
+        state.enemies[&enemy_id].damage, 1,
+        "Guard Dog's reaction dealt 1 damage to the AoO attacker"
+    );
+    assert!(
+        result.events.iter().any(|e| matches!(
+            e,
+            Event::EnemyDamaged { enemy, amount: 1, .. } if *enemy == enemy_id
+        )),
+        "EnemyDamaged {{ amount: 1 }} emitted: {:?}",
         result.events
     );
 
-    // The move resolved: the engaged enemy is NOT exhausted (AoO does not
-    // exhaust the attacker), the investigator and the engaged enemy both
-    // moved to the destination, and no retaliation hit the attacker.
+    // The attacker did NOT exhaust (RR p.7: AoO attackers never exhaust).
     assert!(
         !state.enemies[&enemy_id].exhausted,
-        "an attack of opportunity does not exhaust the attacker"
+        "an attack of opportunity does not exhaust the attacker (RR p.7)"
     );
+
+    // The move completed: investigator and engaged enemy are at the
+    // destination, confirming the ActionResolution frame resumed correctly.
     assert_eq!(
         state.investigators[&inv_id].current_location,
         Some(dest),
-        "investigator moved to the destination"
+        "move resolved: investigator reached the destination"
     );
     assert_eq!(
         state.enemies[&enemy_id].current_location,
         Some(dest),
-        "engaged enemy moved with the investigator"
+        "engaged enemy moved with the investigator to the destination"
     );
-    assert_eq!(
-        state.enemies[&enemy_id].damage, 0,
-        "Guard Dog does not retaliate against an attack of opportunity (yet)"
+    assert!(
+        result.events.iter().any(|e| matches!(
+            e,
+            Event::InvestigatorMoved { investigator, from: f, to } if
+                *investigator == inv_id && *f == from && *to == dest
+        )),
+        "InvestigatorMoved event emitted after window closed: {:?}",
+        result.events
+    );
+
+    // No reaction windows remain after the full cycle.
+    assert!(
+        state.open_windows().is_empty(),
+        "no windows stranded after Guard Dog reaction + move resume: {:?}",
+        state.open_windows()
     );
 }

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -138,38 +138,54 @@ pub(super) fn investigate_primary_effect(
 ///
 /// Validate-first: Investigation phase, `investigator` is active and
 /// `Status::Active`, `actions_remaining >= 1`. Mutate-second: spend 1
-/// action, fire attacks of opportunity (Resource is NOT `AoO`-exempt),
-/// then — if the investigator survived the `AoO` — gain 1 resource.
+/// action, push an [`ActionResolution`] frame, and drive the
+/// attack-of-opportunity loop (#293). If the investigator survives the
+/// `AoO` loop, [`resource_primary_effect`] fires and gains 1 resource.
+///
+/// [`ActionResolution`]: crate::state::Continuation::ActionResolution
 pub(super) fn resource_action(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
     if let Err(rejection) = validate_basic_action(cx.state, "Resource", investigator) {
         return rejection;
     }
 
-    // Mutate-second: spend the action, fire AoO, then gain the resource.
+    // Mutate-second: spend the action, then park the resource gain over its
+    // attack-of-opportunity loop (#293). Push the resume frame, then drive
+    // the AoO. Resource is NOT on the AoO-exempt list (only Fight, Evade,
+    // Parley, Resign are), so each ready engaged enemy attacks before the
+    // gain resolves.
     spend_one_action(cx, investigator);
-    super::combat::fire_attacks_of_opportunity(cx, investigator);
-
-    // If AoO eliminated the investigator, the gain is suppressed; the
-    // spent action + AoO events stay (mirrors `investigate`).
-    let inv_after = cx
-        .state
-        .investigators
-        .get(&investigator)
-        .unwrap_or_else(|| {
-            unreachable!(
-                "Resource: investigator {investigator:?} disappeared between AoO and gain; \
-             this is a state-corruption invariant violation"
-            )
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::ActionResolution {
+            investigator,
+            resume: crate::state::ActionResume::Resource,
         });
-    if inv_after.status != Status::Active {
-        return EngineOutcome::Done;
-    }
+    super::combat::drive_aoo(cx, investigator)
+}
 
+/// The gain half of a Resource action, run after its `AoO` loop (#293).
+///
+/// Resource has no target precondition (unlike Move or Investigate), so
+/// there is no secondary precondition re-check here. The `resume_action_resolution`
+/// `Status::Active` gate upstream already guarantees the investigator is
+/// present and Active; a missing map entry here is therefore a
+/// state-corruption invariant violation — it must `unreachable!`-panic.
+/// There is no legitimate `Done`-return inside `resource_primary_effect`:
+/// it always gains 1 resource and returns `Done`.
+pub(super) fn resource_primary_effect(
+    cx: &mut Cx,
+    investigator: InvestigatorId,
+) -> EngineOutcome {
     let inv_mut = cx
         .state
         .investigators
         .get_mut(&investigator)
-        .expect("investigator existence checked above");
+        .unwrap_or_else(|| {
+            unreachable!(
+                "resource_primary_effect: investigator {investigator:?} not in map after the \
+                 Status::Active re-validation gate; this is a state-corruption invariant violation"
+            )
+        });
     inv_mut.resources = inv_mut.resources.saturating_add(1);
     cx.events.push(Event::ResourcesGained {
         investigator,
@@ -1044,6 +1060,138 @@ mod actions_tests {
             result.state.investigators[&inv_id].status,
             Status::Active,
             "investigator must not be Active after lethal AoO"
+        );
+    }
+
+    /// Build a Resource scenario: investigator at a location, 3 actions,
+    /// Investigation phase, active. Adds a ready engaged enemy with the
+    /// given `attack_damage` and `inv_health`.
+    fn resource_scenario_with_enemy(
+        attack_damage: u8,
+        inv_health: u8,
+    ) -> (InvestigatorId, EnemyId, crate::state::GameState) {
+        let inv_id = InvestigatorId(1);
+        let loc_id = LocationId(10);
+        let enemy_id = EnemyId(300);
+
+        let mut inv = test_investigator(1);
+        inv.current_location = Some(loc_id);
+        inv.actions_remaining = 3;
+        inv.max_health = inv_health;
+        inv.damage = 0;
+        inv.resources = 0;
+
+        let loc = test_location(10, "Study");
+
+        let mut enemy = test_enemy(300, "Ghoul");
+        enemy.current_location = Some(loc_id);
+        enemy.engaged_with = Some(inv_id);
+        enemy.attack_damage = attack_damage;
+        enemy.attack_horror = 0;
+        enemy.exhausted = false;
+
+        let state = GameStateBuilder::new()
+            .with_investigator(inv)
+            .with_location(loc)
+            .with_enemy(enemy)
+            .with_phase(Phase::Investigation)
+            .with_active_investigator(inv_id)
+            .build();
+
+        (inv_id, enemy_id, state)
+    }
+
+    #[test]
+    fn resource_with_lethal_aoo_suppresses_the_gain() {
+        // AoO defeats the investigator: no ResourcesGained, action spent.
+        // Investigator has 1 health, enemy deals 1 damage → lethal AoO.
+        let (inv_id, _enemy_id, state) = resource_scenario_with_enemy(1, 1);
+
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Resource {
+                investigator: inv_id,
+            }),
+        );
+
+        assert_eq!(
+            result.outcome,
+            EngineOutcome::Done,
+            "expected Done when AoO is lethal, got {:?}",
+            result.outcome
+        );
+        // Action was still spent.
+        assert_event!(
+            result.events,
+            Event::ActionsRemainingChanged { investigator, new_count: 2 }
+                if *investigator == inv_id
+        );
+        // No resources were gained.
+        assert_no_event!(result.events, Event::ResourcesGained { .. });
+        // Investigator's resource count is unchanged (still 0).
+        assert_eq!(
+            result.state.investigators[&inv_id].resources,
+            0,
+            "resources must not change when AoO is lethal"
+        );
+        // Investigator is no longer Active (defeated by AoO).
+        assert_ne!(
+            result.state.investigators[&inv_id].status,
+            Status::Active,
+            "investigator must not be Active after lethal AoO"
+        );
+    }
+
+    #[test]
+    fn resource_with_no_engaged_enemy_gains_normally() {
+        // No engaged enemy: behaviour-preserving — resources +1, Done.
+        let inv_id = InvestigatorId(1);
+        let loc_id = LocationId(10);
+
+        let mut inv = test_investigator(1);
+        inv.current_location = Some(loc_id);
+        inv.actions_remaining = 3;
+        inv.resources = 2;
+
+        let loc = test_location(10, "Study");
+
+        let state = GameStateBuilder::new()
+            .with_investigator(inv)
+            .with_location(loc)
+            .with_phase(Phase::Investigation)
+            .with_active_investigator(inv_id)
+            .build();
+
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Resource {
+                investigator: inv_id,
+            }),
+        );
+
+        assert_eq!(
+            result.outcome,
+            EngineOutcome::Done,
+            "expected Done on no-AoO resource gain, got {:?}",
+            result.outcome
+        );
+        // Action was spent.
+        assert_event!(
+            result.events,
+            Event::ActionsRemainingChanged { investigator, new_count: 2 }
+                if *investigator == inv_id
+        );
+        // ResourcesGained emitted.
+        assert_event!(
+            result.events,
+            Event::ResourcesGained { investigator, amount: 1 }
+                if *investigator == inv_id
+        );
+        // Resource count incremented.
+        assert_eq!(
+            result.state.investigators[&inv_id].resources,
+            3,
+            "resources must increase by 1"
         );
     }
 }

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -280,22 +280,24 @@ pub(super) fn engage_primary_effect(
     investigator: InvestigatorId,
     enemy_id: EnemyId,
 ) -> EngineOutcome {
-    let inv_location = cx
+    let inv = cx
         .state
         .investigators
         .get(&investigator)
         .unwrap_or_else(|| {
             unreachable!(
-                "engage_primary_effect: investigator {investigator:?} absent after the \
+                "engage_primary_effect: investigator {investigator:?} not in map after the \
                  Status::Active re-validation gate; this is a state-corruption invariant violation"
             )
-        })
-        .current_location;
-    let Some(enemy) = cx.state.enemies.get(&enemy_id) else {
-        return EngineOutcome::Done; // target gone
+        });
+    let Some(inv_location) = inv.current_location else {
+        return EngineOutcome::Done; // lapsed: investigator lost its location during the AoO
     };
-    if enemy.engaged_with == Some(investigator) || enemy.current_location != inv_location {
-        return EngineOutcome::Done; // precondition lapsed
+    let Some(enemy) = cx.state.enemies.get(&enemy_id) else {
+        return EngineOutcome::Done; // lapsed: target gone
+    };
+    if enemy.engaged_with == Some(investigator) || enemy.current_location != Some(inv_location) {
+        return EngineOutcome::Done; // lapsed: already engaged, or no longer co-located
     }
     let enemy_mut = cx
         .state
@@ -1279,7 +1281,7 @@ mod actions_tests {
     #[test]
     fn engage_with_nonlethal_aoo_engages_after_the_attack() {
         // A second engaged enemy AoOs (1 damage); the target (co-located, not yet
-        // engaged) is then engaged. Assert EnemyAttacked precedes EnemyEngaged, the
+        // engaged) is then engaged. Assert DamageTaken (the AoO) precedes EnemyEngaged, the
         // target's engaged_with == Some(investigator), investigator survived.
         let (inv_id, target_id, aoo_enemy_id, state) = engage_scenario_with_aoo_enemy(8, 1);
 

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -79,20 +79,29 @@ pub(super) fn investigate(cx: &mut Cx, investigator: InvestigatorId) -> EngineOu
 /// The skill-test half of an Investigate, run after its `AoO` loop (#293).
 /// Re-reads the location + effective shroud live and re-checks the location
 /// is still revealed (the §D precondition re-check); suppresses (returns
-/// `Done`) if not.
+/// `Done`) if the precondition has lapsed.
+///
+/// A missing investigator map entry panics — `resume_action_resolution`'s
+/// `Status::Active` gate upstream already guarantees the investigator is
+/// present, so absence here is a state-corruption invariant violation. A
+/// legitimately lapsed precondition (no `current_location`, or location
+/// absent / not `revealed`) returns `Done` instead.
 pub(super) fn investigate_primary_effect(
     cx: &mut Cx,
     investigator: InvestigatorId,
 ) -> EngineOutcome {
-    let Some(location_id) = cx
+    let inv = cx
         .state
         .investigators
         .get(&investigator)
-        .and_then(|inv| inv.current_location)
-    else {
-        // Active but locationless after AoO — not expected, but suppress
-        // (return Done) defensively rather than panic.
-        return EngineOutcome::Done;
+        .unwrap_or_else(|| {
+            unreachable!(
+                "investigate_primary_effect: investigator {investigator:?} not in map after the \
+                 Status::Active re-validation gate; this is a state-corruption invariant violation"
+            )
+        });
+    let Some(location_id) = inv.current_location else {
+        return EngineOutcome::Done; // lapsed: locationless after AoO
     };
     let Some(location) = cx.state.locations.get(&location_id) else {
         return EngineOutcome::Done;
@@ -772,7 +781,7 @@ mod actions_tests {
     use crate::test_support::{
         apply_no_commits, test_enemy, test_investigator, test_location, GameStateBuilder,
     };
-    use crate::{assert_event, assert_no_event};
+    use crate::{assert_event, assert_event_sequence, assert_no_event};
 
     /// Build a Move scenario: investigator at L1, L1 connected to L2,
     /// 3 actions, Investigation phase, active investigator, with one
@@ -980,14 +989,12 @@ mod actions_tests {
             "expected AwaitingInput (commit window) after nonlethal AoO, got {:?}",
             outcome.outcome
         );
-        // AoO damage landed before the test started.
-        assert_event!(
+        // AoO damage landed before the test started — prove ordering.
+        assert_event_sequence!(
             outcome.events,
-            Event::DamageTaken { investigator, amount: 1 }
-                if *investigator == inv_id
+            Event::DamageTaken { .. },
+            Event::SkillTestStarted { .. }
         );
-        // The skill test started.
-        assert_event!(outcome.events, Event::SkillTestStarted { .. });
         // Investigator is still Active.
         assert_eq!(
             outcome.state.investigators[&inv_id].status,

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -201,11 +201,15 @@ pub(super) fn resource_primary_effect(
 /// Validate-first: Investigation phase, active + `Status::Active`,
 /// `actions_remaining >= 1`, enemy in state, enemy at the investigator's
 /// `current_location`, not already engaged with the investigator.
-/// Mutate-second: spend 1 action, fire attacks of opportunity (Engage is
-/// NOT `AoO`-exempt — the target is not engaged yet so it cannot `AoO`;
-/// only OTHER engaged ready enemies do), then — if the investigator
-/// survived —
-/// engage the enemy.
+/// Mutate-second: spend 1 action, then park the engagement over its
+/// attack-of-opportunity loop (#293). The target enemy is not yet engaged
+/// so it cannot `AoO`; only OTHER ready engaged enemies do. If the
+/// investigator survives, [`engage_primary_effect`] runs the engagement.
+///
+/// The `AoO` loop now runs as an [`ActionResolution`] frame (#293): the
+/// frame is pushed, then [`combat::drive_aoo`] drives the loop.
+///
+/// [`ActionResolution`]: crate::state::Continuation::ActionResolution
 pub(super) fn engage(
     cx: &mut Cx,
     investigator: InvestigatorId,
@@ -245,30 +249,59 @@ pub(super) fn engage(
         };
     }
 
-    // Mutate-second.
+    // Mutate-second: spend the action, then park the engagement over its
+    // attack-of-opportunity loop (#293). Push the resume frame, then drive
+    // the AoO. Engage is NOT on the AoO-exempt list (only Fight, Evade,
+    // Parley, Resign are). The target is not yet engaged so it cannot AoO;
+    // only OTHER ready engaged enemies do.
     spend_one_action(cx, investigator);
-    super::combat::fire_attacks_of_opportunity(cx, investigator);
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::ActionResolution {
+            investigator,
+            resume: crate::state::ActionResume::Engage { enemy: enemy_id },
+        });
+    super::combat::drive_aoo(cx, investigator)
+}
 
-    let inv_after = cx
+/// The engagement half of an Engage action, run after its `AoO` loop (#293).
+///
+/// Re-reads the enemy from live state and re-checks the target precondition
+/// (the §D primary-precondition re-check): enemy still exists, is co-located
+/// with the investigator, and is not already engaged with this investigator.
+/// Returns `Done` on any lapsed precondition (the engagement simply does not
+/// happen — legitimately suppressed, not a state corruption).
+///
+/// A missing investigator map entry after the `Status::Active` gate in
+/// `resume_action_resolution` is a state-corruption invariant violation and
+/// must `unreachable!`-panic — absence here is impossible if the gate held.
+pub(super) fn engage_primary_effect(
+    cx: &mut Cx,
+    investigator: InvestigatorId,
+    enemy_id: EnemyId,
+) -> EngineOutcome {
+    let inv_location = cx
         .state
         .investigators
         .get(&investigator)
         .unwrap_or_else(|| {
             unreachable!(
-                "Engage: investigator {investigator:?} disappeared between AoO and engagement; \
-             this is a state-corruption invariant violation"
+                "engage_primary_effect: investigator {investigator:?} absent after the \
+                 Status::Active re-validation gate; this is a state-corruption invariant violation"
             )
-        });
-    if inv_after.status != Status::Active {
-        return EngineOutcome::Done;
+        })
+        .current_location;
+    let Some(enemy) = cx.state.enemies.get(&enemy_id) else {
+        return EngineOutcome::Done; // target gone
+    };
+    if enemy.engaged_with == Some(investigator) || enemy.current_location != inv_location {
+        return EngineOutcome::Done; // precondition lapsed
     }
-
-    let enemy_mut = cx.state.enemies.get_mut(&enemy_id).unwrap_or_else(|| {
-        unreachable!(
-            "Engage: enemy {enemy_id:?} disappeared between validation and engagement; \
-             this is a state-corruption invariant violation"
-        )
-    });
+    let enemy_mut = cx
+        .state
+        .enemies
+        .get_mut(&enemy_id)
+        .expect("checked above");
     enemy_mut.engaged_with = Some(investigator);
     cx.events.push(Event::EnemyEngaged {
         enemy: enemy_id,
@@ -1192,6 +1225,155 @@ mod actions_tests {
             result.state.investigators[&inv_id].resources,
             3,
             "resources must increase by 1"
+        );
+    }
+
+    /// Build an Engage scenario: investigator at L1, a target enemy at L1
+    /// (not yet engaged), and an `AoO` enemy at L1 already engaged with the
+    /// investigator. Returns `(inv_id, target_id, aoo_enemy_id, state)`.
+    fn engage_scenario_with_aoo_enemy(
+        inv_health: u8,
+        aoo_damage: u8,
+    ) -> (InvestigatorId, EnemyId, EnemyId, crate::state::GameState) {
+        let inv_id = InvestigatorId(1);
+        let loc_id = LocationId(10);
+        let target_id = EnemyId(400);
+        let aoo_enemy_id = EnemyId(401);
+
+        let mut inv = test_investigator(1);
+        inv.current_location = Some(loc_id);
+        inv.actions_remaining = 3;
+        inv.max_health = inv_health;
+        inv.damage = 0;
+
+        let loc = test_location(10, "Study");
+
+        // The target: co-located, not yet engaged — cannot AoO.
+        let mut target = test_enemy(400, "Cultist");
+        target.current_location = Some(loc_id);
+        target.engaged_with = None;
+        target.attack_damage = 0;
+        target.attack_horror = 0;
+        target.exhausted = false;
+
+        // The AoO attacker: already engaged, ready — it WILL AoO.
+        let mut aoo_enemy = test_enemy(401, "Ghoul");
+        aoo_enemy.current_location = Some(loc_id);
+        aoo_enemy.engaged_with = Some(inv_id);
+        aoo_enemy.attack_damage = aoo_damage;
+        aoo_enemy.attack_horror = 0;
+        aoo_enemy.exhausted = false;
+
+        let state = GameStateBuilder::new()
+            .with_investigator(inv)
+            .with_location(loc)
+            .with_enemy(target)
+            .with_enemy(aoo_enemy)
+            .with_phase(Phase::Investigation)
+            .with_active_investigator(inv_id)
+            .build();
+
+        (inv_id, target_id, aoo_enemy_id, state)
+    }
+
+    #[test]
+    fn engage_with_nonlethal_aoo_engages_after_the_attack() {
+        // A second engaged enemy AoOs (1 damage); the target (co-located, not yet
+        // engaged) is then engaged. Assert EnemyAttacked precedes EnemyEngaged, the
+        // target's engaged_with == Some(investigator), investigator survived.
+        let (inv_id, target_id, aoo_enemy_id, state) = engage_scenario_with_aoo_enemy(8, 1);
+
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Engage {
+                investigator: inv_id,
+                enemy: target_id,
+            }),
+        );
+
+        assert_eq!(
+            result.outcome,
+            EngineOutcome::Done,
+            "expected Done after nonlethal AoO + engage, got {:?}",
+            result.outcome
+        );
+        // AoO damage landed.
+        assert_event!(
+            result.events,
+            Event::DamageTaken { investigator, amount: 1 }
+                if *investigator == inv_id
+        );
+        // EnemyEngaged fired (target is now engaged).
+        assert_event!(
+            result.events,
+            Event::EnemyEngaged { enemy, investigator }
+                if *enemy == target_id && *investigator == inv_id
+        );
+        // AoO damage (DamageTaken) precedes the engagement.
+        assert_event_sequence!(
+            result.events,
+            Event::DamageTaken { .. },
+            Event::EnemyEngaged { .. }
+        );
+        // Target is now engaged with the investigator.
+        assert_eq!(
+            result.state.enemies[&target_id].engaged_with,
+            Some(inv_id),
+            "target must be engaged with the investigator after engage action"
+        );
+        // Investigator is still Active.
+        assert_eq!(
+            result.state.investigators[&inv_id].status,
+            crate::state::Status::Active,
+            "investigator must still be Active after nonlethal AoO"
+        );
+        // Investigator took 1 damage.
+        assert_eq!(
+            result.state.investigators[&inv_id].damage,
+            1,
+            "investigator damage == 1 after nonlethal AoO"
+        );
+        // AoO attacker is not exhausted (RR p.7).
+        assert!(!result.state.enemies[&aoo_enemy_id].exhausted);
+    }
+
+    #[test]
+    fn engage_with_lethal_aoo_suppresses_the_engagement() {
+        // The other engaged enemy's AoO defeats the investigator: no EnemyEngaged.
+        let (inv_id, target_id, _aoo_enemy_id, state) = engage_scenario_with_aoo_enemy(1, 1);
+
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Engage {
+                investigator: inv_id,
+                enemy: target_id,
+            }),
+        );
+
+        assert_eq!(
+            result.outcome,
+            EngineOutcome::Done,
+            "expected Done when AoO is lethal, got {:?}",
+            result.outcome
+        );
+        // Action was still spent.
+        assert_event!(
+            result.events,
+            Event::ActionsRemainingChanged { investigator, new_count: 2 }
+                if *investigator == inv_id
+        );
+        // No engagement — target must not be engaged.
+        assert_no_event!(result.events, Event::EnemyEngaged { .. });
+        assert_eq!(
+            result.state.enemies[&target_id].engaged_with,
+            None,
+            "target must not be engaged when AoO is lethal"
+        );
+        // Investigator is not Active (defeated by AoO).
+        assert_ne!(
+            result.state.investigators[&inv_id].status,
+            crate::state::Status::Active,
+            "investigator must not be Active after lethal AoO"
         );
     }
 }

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -172,10 +172,7 @@ pub(super) fn resource_action(cx: &mut Cx, investigator: InvestigatorId) -> Engi
 /// state-corruption invariant violation — it must `unreachable!`-panic.
 /// There is no legitimate `Done`-return inside `resource_primary_effect`:
 /// it always gains 1 resource and returns `Done`.
-pub(super) fn resource_primary_effect(
-    cx: &mut Cx,
-    investigator: InvestigatorId,
-) -> EngineOutcome {
+pub(super) fn resource_primary_effect(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
     let inv_mut = cx
         .state
         .investigators
@@ -299,11 +296,7 @@ pub(super) fn engage_primary_effect(
     if enemy.engaged_with == Some(investigator) || enemy.current_location != Some(inv_location) {
         return EngineOutcome::Done; // lapsed: already engaged, or no longer co-located
     }
-    let enemy_mut = cx
-        .state
-        .enemies
-        .get_mut(&enemy_id)
-        .expect("checked above");
+    let enemy_mut = cx.state.enemies.get_mut(&enemy_id).expect("checked above");
     enemy_mut.engaged_with = Some(investigator);
     cx.events.push(Event::EnemyEngaged {
         enemy: enemy_id,
@@ -915,8 +908,7 @@ mod actions_tests {
             "move suppressed: investigator must not appear at destination"
         );
         assert_eq!(
-            result.state.investigators[&inv_id].actions_remaining,
-            2,
+            result.state.investigators[&inv_id].actions_remaining, 2,
             "action still spent"
         );
         // Investigator is no longer Active (defeated by AoO).
@@ -964,8 +956,7 @@ mod actions_tests {
         );
         // AoO damage is visible.
         assert_eq!(
-            result.state.investigators[&inv_id].damage,
-            1,
+            result.state.investigators[&inv_id].damage, 1,
             "investigator damage == 1 after nonlethal AoO"
         );
         // Engaged enemy moved with investigator to L2.
@@ -1011,7 +1002,9 @@ mod actions_tests {
             .with_investigator(inv)
             .with_location(loc)
             .with_enemy(enemy)
-            .with_chaos_bag(crate::state::ChaosBag::new([crate::state::ChaosToken::Numeric(0)]))
+            .with_chaos_bag(crate::state::ChaosBag::new([
+                crate::state::ChaosToken::Numeric(0),
+            ]))
             .with_phase(Phase::Investigation)
             .with_active_investigator(inv_id)
             .build();
@@ -1054,8 +1047,7 @@ mod actions_tests {
         );
         // Investigator took 1 damage.
         assert_eq!(
-            outcome.state.investigators[&inv_id].damage,
-            1,
+            outcome.state.investigators[&inv_id].damage, 1,
             "investigator must have taken 1 damage from AoO"
         );
         // AoO does not exhaust the attacker (RR p.7).
@@ -1165,8 +1157,7 @@ mod actions_tests {
         assert_no_event!(result.events, Event::ResourcesGained { .. });
         // Investigator's resource count is unchanged (still 0).
         assert_eq!(
-            result.state.investigators[&inv_id].resources,
-            0,
+            result.state.investigators[&inv_id].resources, 0,
             "resources must not change when AoO is lethal"
         );
         // Investigator is no longer Active (defeated by AoO).
@@ -1224,8 +1215,7 @@ mod actions_tests {
         );
         // Resource count incremented.
         assert_eq!(
-            result.state.investigators[&inv_id].resources,
-            3,
+            result.state.investigators[&inv_id].resources, 3,
             "resources must increase by 1"
         );
     }
@@ -1331,8 +1321,7 @@ mod actions_tests {
         );
         // Investigator took 1 damage.
         assert_eq!(
-            result.state.investigators[&inv_id].damage,
-            1,
+            result.state.investigators[&inv_id].damage, 1,
             "investigator damage == 1 after nonlethal AoO"
         );
         // AoO attacker is not exhausted (RR p.7).
@@ -1367,8 +1356,7 @@ mod actions_tests {
         // No engagement — target must not be engaged.
         assert_no_event!(result.events, Event::EnemyEngaged { .. });
         assert_eq!(
-            result.state.enemies[&target_id].engaged_with,
-            None,
+            result.state.enemies[&target_id].engaged_with, None,
             "target must not be engaged when AoO is lethal"
         );
         // Investigator is not Active (defeated by AoO).

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -1169,6 +1169,56 @@ mod actions_tests {
     }
 
     #[test]
+    fn resource_with_nonlethal_aoo_still_gains() {
+        // Engaged enemy deals 1 damage, investigator has 8 health (survives).
+        // After the AoO the Resource gain resolves: ResourcesGained IS emitted,
+        // resources incremented by 1, investigator still Active, enemy not
+        // exhausted (RR p.7), investigator took 1 damage.
+        let (inv_id, enemy_id, state) = resource_scenario_with_enemy(1, 8);
+
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Resource {
+                investigator: inv_id,
+            }),
+        );
+
+        assert_eq!(
+            result.outcome,
+            EngineOutcome::Done,
+            "expected Done after nonlethal AoO + resource gain, got {:?}",
+            result.outcome
+        );
+        // ResourcesGained IS emitted (primary effect ran after the AoO).
+        assert_event!(
+            result.events,
+            Event::ResourcesGained { investigator, amount: 1 }
+                if *investigator == inv_id
+        );
+        // Resource count incremented by 1.
+        assert_eq!(
+            result.state.investigators[&inv_id].resources, 1,
+            "resources must increase by 1 after a nonlethal AoO"
+        );
+        // Investigator is still Active.
+        assert_eq!(
+            result.state.investigators[&inv_id].status,
+            Status::Active,
+            "investigator must still be Active after nonlethal AoO"
+        );
+        // AoO does not exhaust the attacker (RR p.7).
+        assert!(
+            !result.state.enemies[&enemy_id].exhausted,
+            "AoO must not exhaust the attacker (RR p.7)"
+        );
+        // Investigator took the AoO damage.
+        assert_eq!(
+            result.state.investigators[&inv_id].damage, 1,
+            "investigator damage == 1 after nonlethal AoO"
+        );
+    }
+
+    #[test]
     fn resource_with_no_engaged_enemy_gains_normally() {
         // No engaged enemy: behaviour-preserving — resources +1, Done.
         let inv_id = InvestigatorId(1);

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -240,9 +240,13 @@ pub(super) fn engage(
 /// opportunity before the move resolves, and engaged enemies move
 /// with the investigator. Both behaviors land alongside enemy state
 /// in #67; this handler covers only the bare movement.
-// Pre-existing bulk (99/100 lines before the Cx migration); the longer
-// `cx.state.` qualifier nudged it past the limit without adding logic.
-#[allow(clippy::too_many_lines)]
+///
+/// The `AoO` loop now runs as an [`ActionResolution`] frame (#293): the
+/// frame is pushed, then [`combat::drive_aoo`] drives the loop. If a
+/// cancel/soak window opens the loop suspends; `drive` resumes the
+/// frame once the window closes, calling [`move_primary_effect`].
+///
+/// [`ActionResolution`]: crate::state::Continuation::ActionResolution
 pub(super) fn move_action(
     cx: &mut Cx,
     investigator: InvestigatorId,
@@ -328,26 +332,45 @@ pub(super) fn move_action(
         return rejected;
     }
 
-    // Move triggers attacks of opportunity from each ready engaged
-    // enemy. Per the Rules Reference, this happens BEFORE the move
-    // resolves.
-    super::combat::fire_attacks_of_opportunity(cx, investigator);
+    // Park the move over its attack-of-opportunity loop (#293): push the
+    // resume frame, then drive the AoO. If a cancel/soak window opens the loop
+    // suspends here; otherwise `drive` resumes the frame and relocates.
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::ActionResolution {
+            investigator,
+            resume: crate::state::ActionResume::Move { destination },
+        });
+    super::combat::drive_aoo(cx, investigator)
+}
 
-    // If AoO defeated the investigator, the move is cancelled. The
-    // action point and AoO events stay; the investigator (and any
-    // engaged enemies) don't change location.
-    let inv_after_aoo = cx
+/// The relocation half of a Move, run after its attack-of-opportunity loop
+/// completes (#293). Re-derives `from` from the live `current_location` (the `AoO`
+/// never moves the actor) and re-checks the destination is still connected —
+/// the §D primary-precondition re-check — suppressing the move (returns `Done`)
+/// if it no longer holds. Engaged enemies move with the investigator; the
+/// entered location's Forced on-enter abilities become the move's outcome.
+pub(super) fn move_primary_effect(
+    cx: &mut Cx,
+    investigator: InvestigatorId,
+    destination: LocationId,
+) -> EngineOutcome {
+    let Some(from) = cx
         .state
         .investigators
         .get(&investigator)
-        .unwrap_or_else(|| {
-            unreachable!(
-                "Move: investigator {investigator:?} disappeared between AoO and move resolution; \
-             this is a state-corruption invariant violation"
-            )
-        });
-    if inv_after_aoo.status != Status::Active {
-        return EngineOutcome::Done;
+        .and_then(|inv| inv.current_location)
+    else {
+        return EngineOutcome::Done; // actor gone/locationless: suppress
+    };
+    let still_connected = cx
+        .state
+        .locations
+        .get(&from)
+        .is_some_and(|l| l.connections.contains(&destination))
+        && cx.state.locations.contains_key(&destination);
+    if !still_connected {
+        return EngineOutcome::Done; // precondition lapsed: suppress
     }
 
     // Engaged enemies move with the investigator. Capture the
@@ -364,7 +387,7 @@ pub(super) fn move_action(
     cx.state
         .investigators
         .get_mut(&investigator)
-        .expect("investigator existence checked above")
+        .expect("investigator existence checked above via current_location")
         .current_location = Some(destination);
     for enemy_id in engaged {
         if let Some(enemy) = cx.state.enemies.get_mut(&enemy_id) {
@@ -709,4 +732,158 @@ pub(super) fn evade(cx: &mut Cx, investigator: InvestigatorId, enemy_id: EnemyId
         None,
         0, // no weapon/effect modifier on a base Evade
     )
+}
+
+#[cfg(test)]
+mod actions_tests {
+    use crate::action::{Action, PlayerAction};
+    use crate::engine::apply;
+    use crate::event::Event;
+    use crate::state::{EnemyId, InvestigatorId, LocationId, Phase};
+    use crate::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
+    use crate::{assert_event, assert_no_event};
+
+    /// Build a Move scenario: investigator at L1, L1 connected to L2,
+    /// 3 actions, Investigation phase, active investigator, with one
+    /// engaged ready enemy at the same location.
+    fn move_scenario_with_enemy(
+        attack_damage: u8,
+        inv_health: u8,
+    ) -> (
+        InvestigatorId,
+        LocationId,
+        LocationId,
+        EnemyId,
+        crate::state::GameState,
+    ) {
+        let inv_id = InvestigatorId(1);
+        let l1 = LocationId(10);
+        let l2 = LocationId(11);
+        let enemy_id = EnemyId(100);
+
+        let mut inv = test_investigator(1);
+        inv.current_location = Some(l1);
+        inv.actions_remaining = 3;
+        inv.max_health = inv_health;
+        inv.damage = 0;
+
+        let mut loc1 = test_location(10, "L1");
+        loc1.connections = vec![l2];
+        let loc2 = test_location(11, "L2");
+
+        let mut enemy = test_enemy(100, "Ghoul");
+        enemy.current_location = Some(l1);
+        enemy.engaged_with = Some(inv_id);
+        enemy.attack_damage = attack_damage;
+        enemy.attack_horror = 0;
+        enemy.exhausted = false;
+
+        let state = GameStateBuilder::new()
+            .with_investigator(inv)
+            .with_location(loc1)
+            .with_location(loc2)
+            .with_enemy(enemy)
+            .with_phase(Phase::Investigation)
+            .with_active_investigator(inv_id)
+            .build();
+
+        (inv_id, l1, l2, enemy_id, state)
+    }
+
+    #[test]
+    fn move_with_lethal_aoo_suppresses_relocation_but_keeps_spent_action() {
+        // An engaged enemy whose AoO defeats the investigator: the move is
+        // suppressed, the action point + AoO damage persist.
+        // Investigator has 1 health, enemy deals 1 damage → lethal AoO.
+        //
+        // Note: `apply_investigator_defeat` clears `current_location` to `None`
+        // on defeat — the investigator is removed from their location as part of
+        // defeat resolution. The key invariant is that no `InvestigatorMoved`
+        // event fires and the investigator does NOT appear at the destination.
+        let (inv_id, _l1, l2, _enemy_id, state) = move_scenario_with_enemy(1, 1);
+
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: inv_id,
+                destination: l2,
+            }),
+        );
+
+        assert_eq!(result.outcome, crate::engine::EngineOutcome::Done);
+        // Action was still spent.
+        assert_event!(
+            result.events,
+            Event::ActionsRemainingChanged { investigator, new_count: 2 }
+                if *investigator == inv_id
+        );
+        // Move is suppressed — investigator did NOT reach L2.
+        assert_ne!(
+            result.state.investigators[&inv_id].current_location,
+            Some(l2),
+            "move suppressed: investigator must not appear at destination"
+        );
+        assert_eq!(
+            result.state.investigators[&inv_id].actions_remaining,
+            2,
+            "action still spent"
+        );
+        // Investigator is no longer Active (defeated by AoO).
+        assert_ne!(
+            result.state.investigators[&inv_id].status,
+            crate::state::Status::Active,
+            "investigator not Active after lethal AoO"
+        );
+        // No InvestigatorMoved emitted.
+        assert_no_event!(result.events, Event::InvestigatorMoved { .. });
+    }
+
+    #[test]
+    fn move_with_nonlethal_aoo_relocates_after_the_attack() {
+        // Engaged enemy, 1 damage, investigator survives (8 health):
+        // AoO deals damage, then the move resolves.
+        // No registry installed → no cancel/soak windows → no suspension.
+        let (inv_id, _l1, l2, enemy_id, state) = move_scenario_with_enemy(1, 8);
+
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Move {
+                investigator: inv_id,
+                destination: l2,
+            }),
+        );
+
+        assert_eq!(result.outcome, crate::engine::EngineOutcome::Done);
+        // AoO damage landed.
+        assert_event!(
+            result.events,
+            Event::DamageTaken { investigator, amount: 1 }
+                if *investigator == inv_id
+        );
+        // Move proceeded: investigator is at L2.
+        assert_eq!(
+            result.state.investigators[&inv_id].current_location,
+            Some(l2),
+            "investigator must have relocated to L2"
+        );
+        assert_event!(
+            result.events,
+            Event::InvestigatorMoved { investigator, from: _, to }
+                if *investigator == inv_id && *to == l2
+        );
+        // AoO damage is visible.
+        assert_eq!(
+            result.state.investigators[&inv_id].damage,
+            1,
+            "investigator damage == 1 after nonlethal AoO"
+        );
+        // Engaged enemy moved with investigator to L2.
+        assert_eq!(
+            result.state.enemies[&enemy_id].current_location,
+            Some(l2),
+            "engaged enemy must follow to L2"
+        );
+        // AoO does not exhaust the attacker (RR p.7).
+        assert!(!result.state.enemies[&enemy_id].exhausted);
+    }
 }

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -25,7 +25,13 @@ use super::Cx;
 /// Hunch's discover-without-test) implement their own paths; this
 /// handler is the bare turn-action.
 ///
+/// The `AoO` loop now runs as an [`ActionResolution`] frame (#293): the
+/// frame is pushed, then [`combat::drive_aoo`] drives the loop. If a
+/// cancel/soak window opens the loop suspends; `drive` resumes the
+/// frame once the window closes, calling [`investigate_primary_effect`].
+///
 /// [`Effect::DiscoverClue`]: crate::dsl::Effect::DiscoverClue
+/// [`ActionResolution`]: crate::state::Continuation::ActionResolution
 pub(super) fn investigate(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
     // Validate-first (the shared basic-action prefix, then the
     // location-specific checks).
@@ -54,6 +60,46 @@ pub(super) fn investigate(cx: &mut Cx, investigator: InvestigatorId) -> EngineOu
             reason: format!("Investigate: location {location_id:?} is not revealed").into(),
         };
     }
+
+    // Mutate-second: spend the action, then park the investigate over
+    // its attack-of-opportunity loop (#293). Push the resume frame,
+    // then drive the AoO. Investigate is NOT on the AoO-exempt list
+    // (only Fight, Evade, Parley, Resign are), so each ready engaged
+    // enemy attacks before the skill test resolves.
+    spend_one_action(cx, investigator);
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::ActionResolution {
+            investigator,
+            resume: crate::state::ActionResume::Investigate,
+        });
+    super::combat::drive_aoo(cx, investigator)
+}
+
+/// The skill-test half of an Investigate, run after its `AoO` loop (#293).
+/// Re-reads the location + effective shroud live and re-checks the location
+/// is still revealed (the §D precondition re-check); suppresses (returns
+/// `Done`) if not.
+pub(super) fn investigate_primary_effect(
+    cx: &mut Cx,
+    investigator: InvestigatorId,
+) -> EngineOutcome {
+    let Some(location_id) = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .and_then(|inv| inv.current_location)
+    else {
+        // Active but locationless after AoO — not expected, but suppress
+        // (return Done) defensively rather than panic.
+        return EngineOutcome::Done;
+    };
+    let Some(location) = cx.state.locations.get(&location_id) else {
+        return EngineOutcome::Done;
+    };
+    if !location.revealed {
+        return EngineOutcome::Done; // precondition lapsed
+    }
     // Shroud is u8 in state but skill-test difficulty is i8. Saturate
     // at i8::MAX for the absurd case; realistic shrouds are 0–6. The
     // *effective* shroud folds in location-attachment modifiers (Obscuring
@@ -64,32 +110,6 @@ pub(super) fn investigate(cx: &mut Cx, investigator: InvestigatorId) -> EngineOu
         None => location.shroud,
     };
     let difficulty = i8::try_from(shroud).unwrap_or(i8::MAX);
-
-    // Mutate-second: spend the action, fire AoO, then resolve the
-    // test. Investigate is NOT on the AoO-exempt list (only Fight,
-    // Evade, Parley, Resign are), so each ready engaged enemy attacks
-    // before the test resolves.
-    spend_one_action(cx, investigator);
-    super::combat::fire_attacks_of_opportunity(cx, investigator);
-
-    // If AoO defeated the investigator, the action's primary effect
-    // (the skill test) is suppressed. The action point and AoO events
-    // already fired — they stay. The action declaration was legal;
-    // the investigator just can't complete it.
-    let inv_after_aoo = cx
-        .state
-        .investigators
-        .get(&investigator)
-        .unwrap_or_else(|| {
-            unreachable!(
-            "Investigate: investigator {investigator:?} disappeared between AoO and skill test; \
-             this is a state-corruption invariant violation"
-        )
-        });
-    if inv_after_aoo.status != Status::Active {
-        return EngineOutcome::Done;
-    }
-
     super::skill_test::start_skill_test(
         cx,
         investigator,
@@ -746,9 +766,12 @@ pub(super) fn evade(cx: &mut Cx, investigator: InvestigatorId, enemy_id: EnemyId
 mod actions_tests {
     use crate::action::{Action, PlayerAction};
     use crate::engine::apply;
+    use crate::engine::EngineOutcome;
     use crate::event::Event;
-    use crate::state::{EnemyId, InvestigatorId, LocationId, Phase};
-    use crate::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
+    use crate::state::{EnemyId, InvestigatorId, LocationId, Phase, Status};
+    use crate::test_support::{
+        apply_no_commits, test_enemy, test_investigator, test_location, GameStateBuilder,
+    };
     use crate::{assert_event, assert_no_event};
 
     /// Build a Move scenario: investigator at L1, L1 connected to L2,
@@ -893,5 +916,127 @@ mod actions_tests {
         );
         // AoO does not exhaust the attacker (RR p.7).
         assert!(!result.state.enemies[&enemy_id].exhausted);
+    }
+
+    /// Build an Investigate scenario: investigator at a revealed location with
+    /// 2 clues and shroud 2, 3 actions, Investigation phase, active. Adds a
+    /// ready engaged enemy with the given `attack_damage` and a chaos bag
+    /// with a single `Numeric(0)` token (intellect 3 vs. shroud 2 → success).
+    fn investigate_scenario_with_enemy(
+        inv_health: u8,
+        attack_damage: u8,
+    ) -> (InvestigatorId, LocationId, EnemyId, crate::state::GameState) {
+        let inv_id = InvestigatorId(1);
+        let loc_id = LocationId(10);
+        let enemy_id = EnemyId(200);
+
+        let mut inv = test_investigator(1);
+        inv.current_location = Some(loc_id);
+        inv.actions_remaining = 3;
+        inv.max_health = inv_health;
+        inv.damage = 0;
+
+        let mut loc = test_location(10, "Study");
+        loc.clues = 2;
+        loc.shroud = 2;
+
+        let mut enemy = test_enemy(200, "Ghoul");
+        enemy.current_location = Some(loc_id);
+        enemy.engaged_with = Some(inv_id);
+        enemy.attack_damage = attack_damage;
+        enemy.attack_horror = 0;
+        enemy.exhausted = false;
+
+        let state = GameStateBuilder::new()
+            .with_investigator(inv)
+            .with_location(loc)
+            .with_enemy(enemy)
+            .with_chaos_bag(crate::state::ChaosBag::new([crate::state::ChaosToken::Numeric(0)]))
+            .with_phase(Phase::Investigation)
+            .with_active_investigator(inv_id)
+            .build();
+
+        (inv_id, loc_id, enemy_id, state)
+    }
+
+    #[test]
+    fn investigate_with_nonlethal_aoo_starts_the_test_after_the_attack() {
+        // Engaged enemy deals 1 damage, investigator has 8 health (survives).
+        // After the AoO, the Investigate skill test starts (AwaitingInput at
+        // the commit window). Assert DamageTaken precedes the test start,
+        // the investigator is still Active, and took 1 damage.
+        let (inv_id, _loc_id, enemy_id, state) = investigate_scenario_with_enemy(8, 1);
+
+        let outcome = apply(
+            state,
+            crate::action::Action::Player(PlayerAction::Investigate {
+                investigator: inv_id,
+            }),
+        );
+
+        // Outcome should be AwaitingInput (skill-test commit window).
+        assert!(
+            matches!(outcome.outcome, EngineOutcome::AwaitingInput { .. }),
+            "expected AwaitingInput (commit window) after nonlethal AoO, got {:?}",
+            outcome.outcome
+        );
+        // AoO damage landed before the test started.
+        assert_event!(
+            outcome.events,
+            Event::DamageTaken { investigator, amount: 1 }
+                if *investigator == inv_id
+        );
+        // The skill test started.
+        assert_event!(outcome.events, Event::SkillTestStarted { .. });
+        // Investigator is still Active.
+        assert_eq!(
+            outcome.state.investigators[&inv_id].status,
+            Status::Active,
+            "investigator must still be Active after nonlethal AoO"
+        );
+        // Investigator took 1 damage.
+        assert_eq!(
+            outcome.state.investigators[&inv_id].damage,
+            1,
+            "investigator must have taken 1 damage from AoO"
+        );
+        // AoO does not exhaust the attacker (RR p.7).
+        assert!(!outcome.state.enemies[&enemy_id].exhausted);
+    }
+
+    #[test]
+    fn investigate_with_lethal_aoo_suppresses_the_test() {
+        // AoO deals 1 damage, investigator has 1 health → lethal → no skill
+        // test starts, outcome is Done, action was spent, investigator not Active.
+        let (inv_id, _loc_id, _enemy_id, state) = investigate_scenario_with_enemy(1, 1);
+
+        let result = apply_no_commits(
+            state,
+            crate::action::Action::Player(PlayerAction::Investigate {
+                investigator: inv_id,
+            }),
+        );
+
+        // Outcome is Done (skill test suppressed).
+        assert_eq!(
+            result.outcome,
+            EngineOutcome::Done,
+            "expected Done when AoO is lethal, got {:?}",
+            result.outcome
+        );
+        // Action was spent.
+        assert_event!(
+            result.events,
+            Event::ActionsRemainingChanged { investigator, new_count: 2 }
+                if *investigator == inv_id
+        );
+        // No skill test started.
+        assert_no_event!(result.events, Event::SkillTestStarted { .. });
+        // Investigator is not Active (defeated by AoO).
+        assert_ne!(
+            result.state.investigators[&inv_id].status,
+            Status::Active,
+            "investigator must not be Active after lethal AoO"
+        );
     }
 }

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -355,13 +355,21 @@ pub(super) fn move_primary_effect(
     investigator: InvestigatorId,
     destination: LocationId,
 ) -> EngineOutcome {
-    let Some(from) = cx
+    let inv = cx
         .state
         .investigators
         .get(&investigator)
-        .and_then(|inv| inv.current_location)
-    else {
-        return EngineOutcome::Done; // actor gone/locationless: suppress
+        .unwrap_or_else(|| {
+            unreachable!(
+                "move_primary_effect: investigator {investigator:?} absent after the \
+                 Status::Active re-validation gate; this is a state-corruption invariant \
+                 violation"
+            )
+        });
+    let Some(from) = inv.current_location else {
+        // Active but locationless — not expected post-AoO, but suppress
+        // (return Done) defensively rather than panic.
+        return EngineOutcome::Done;
     };
     let still_connected = cx
         .state

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -6,7 +6,7 @@ use crate::card_data::CardType;
 use crate::card_registry;
 use crate::dsl::Trigger;
 use crate::event::Event;
-use crate::state::{CardCode, InvestigatorId, Status, Zone};
+use crate::state::{CardCode, InvestigatorId, Zone};
 
 use super::super::evaluator::{apply_effect, EvalContext};
 use super::super::outcome::{EngineOutcome, InputRequest, ResumeToken};
@@ -243,31 +243,38 @@ pub(super) fn draw_one_with_deckout(cx: &mut Cx, investigator: InvestigatorId) {
 ///   is rare enough in practice (only high-cycle decks burn through
 ///   both zones) that the difference is mostly theoretical.
 ///
-/// The draw logic itself is delegated to [`draw_one_with_deckout`].
+/// The draw logic itself is delegated to [`draw_primary_effect`] after
+/// the attack-of-opportunity loop runs as an
+/// [`ActionResolution`](crate::state::Continuation::ActionResolution) frame (#293).
 pub(super) fn draw(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
     if let Err(rejection) = super::actions::validate_basic_action(cx.state, "Draw", investigator) {
         return rejection;
     }
 
-    // Mutate.
+    // Mutate-second: spend the action, then park the draw over its
+    // attack-of-opportunity loop (#293). Push the resume frame, then
+    // drive the AoO. Draw is NOT on the AoO-exempt list (only Fight,
+    // Evade, Parley, Resign are), so each ready engaged enemy attacks
+    // before the card is drawn (RR p.5).
     super::actions::spend_one_action(cx, investigator);
+    cx.state
+        .continuations
+        .push(crate::state::Continuation::ActionResolution {
+            investigator,
+            resume: crate::state::ActionResume::Draw,
+        });
+    super::combat::drive_aoo(cx, investigator)
+}
 
-    // Draw is NOT on the AoO-exempt list (only Fight, Evade, Parley,
-    // Resign are), so each ready engaged enemy attacks before the card
-    // is drawn (RR p.5).
-    super::combat::fire_attacks_of_opportunity(cx, investigator);
-
-    // If the AoO eliminated the investigator, suppress the draw (the
-    // spent action + AoO events stay), mirroring `investigate`.
-    let still_active = cx
-        .state
-        .investigators
-        .get(&investigator)
-        .is_some_and(|inv| inv.status == Status::Active);
-    if !still_active {
-        return EngineOutcome::Done;
-    }
-
+/// The draw half of a Draw action, run after its `AoO` loop (#293).
+///
+/// Draw has no target precondition (unlike Move or Investigate), so
+/// there is no secondary precondition re-check here. The `resume_action_resolution`
+/// `Status::Active` gate upstream already guarantees the investigator is
+/// present and Active; a missing map entry here is therefore a
+/// state-corruption invariant violation — it must `unreachable!`-panic,
+/// never return a silent `Done`.
+pub(super) fn draw_primary_effect(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
     draw_one_with_deckout(cx, investigator);
     EngineOutcome::Done
 }

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -272,8 +272,8 @@ pub(super) fn draw(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
 /// there is no secondary precondition re-check here. The `resume_action_resolution`
 /// `Status::Active` gate upstream already guarantees the investigator is
 /// present and Active; a missing map entry here is therefore a
-/// state-corruption invariant violation — it must `unreachable!`-panic,
-/// never return a silent `Done`.
+/// state-corruption invariant violation — it must panic (via
+/// `draw_one_with_deckout`'s `expect`), never silently return `Done`.
 pub(super) fn draw_primary_effect(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
     draw_one_with_deckout(cx, investigator);
     EngineOutcome::Done

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -534,43 +534,6 @@ fn build_soakers(state: &crate::state::GameState, investigator: InvestigatorId) 
 }
 
 /// Fire attacks of opportunity from every ready enemy engaged with
-/// `investigator`. Each attacker resolves via [`enemy_attack`]; order
-/// is deterministic by `EnemyId` (`BTreeMap` iteration).
-///
-/// Per the Rules Reference, the active player chooses the order of
-/// `AoOs` from multiple engaged ready enemies; v1 uses deterministic
-/// `EnemyId` order. `TODO(#143)`: player-pick attack order
-/// (unmilestoned) covers this site alongside
-/// [`resolve_attacks_for_investigator`] — both sites share the same
-/// deterministic-order TODO.
-pub(super) fn fire_attacks_of_opportunity(cx: &mut Cx, investigator: InvestigatorId) {
-    let attackers: Vec<EnemyId> = cx
-        .state
-        .enemies
-        .iter()
-        .filter(|(_, e)| e.engaged_with == Some(investigator) && !e.exhausted)
-        .map(|(id, _)| *id)
-        .collect();
-    for enemy_id in attackers {
-        // AoO soaks damage onto assets (the `enemy_attack` placement runs
-        // fully) but does NOT open soak reaction windows: the returned
-        // damaged-survivor list is deliberately dropped. Guard Dog 01021
-        // therefore does not retaliate against attacks of opportunity yet —
-        // a documented faithfulness gap. Likewise, AoO does not open the
-        // before-attack cancel window (Dodge 01023, Axis D #336): it calls
-        // `enemy_attack` directly, not `drive_attack_loop`. Both gaps share
-        // one cause — driving a window here would require suspending the
-        // *triggering* action (Move / Investigate) and resuming its primary
-        // effect after the window closes, a mid-action suspension mechanism
-        // deferred to `TODO(#293)` (which also keeps the AoO non-exhaust rule,
-        // RR p.7, distinct from the enemy-phase loop's always-exhaust). Dropping
-        // the survivors is exactly what prevents an undriven window stranded
-        // on `open_windows` (the bug this seam fixes; C5b #237).
-        let _ = enemy_attack(cx, enemy_id, investigator);
-    }
-}
-
-/// Fire attacks of opportunity from every ready enemy engaged with
 /// `investigator`, driving them through the shared attack loop (#293) so each
 /// `AoO` opens its before-attack cancel window (Dodge 01023) and per-soaked-asset
 /// reaction window (Guard Dog 01021). Returns [`EngineOutcome::AwaitingInput`]

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -578,7 +578,6 @@ pub(super) fn fire_attacks_of_opportunity(cx: &mut Cx, investigator: Investigato
 /// resolve in deterministic [`EnemyId`] order (player-pick is #143/K4). `AoO`
 /// attackers never exhaust (RR p.7) — honored by
 /// [`EnemyAttackSource::AttackOfOpportunity`].
-#[allow(dead_code)] // TODO(#293): wired into handlers in Tasks 3–7
 pub(super) fn drive_aoo(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
     let attackers: Vec<EnemyId> = cx
         .state

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -1345,6 +1345,10 @@ mod combat_tests {
             !cx.state.enemies[&EnemyId(100)].exhausted,
             "AoO must not exhaust the attacker (RR p.7)"
         );
+        assert_eq!(
+            cx.state.investigators[&inv_id].damage, 1,
+            "AoO damage landed on the investigator"
+        );
         // Enemy attack fires DamageTaken (no EnemyAttacked event exists); verify
         // damage landed on the investigator and no exhaust event was emitted.
         assert_event!(events, Event::DamageTaken { .. });

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -459,14 +459,12 @@ pub(super) fn apply_horror_numeric(cx: &mut Cx, investigator: InvestigatorId, am
 /// Returns the **damaged surviving soaker assets** (the
 /// [`place_assignment`] survivor list) so the caller can queue one
 /// [`WindowKind::AfterEnemyAttackDamagedAsset`] reaction window per
-/// survivor. This function does **not** queue the windows itself: the
-/// enemy phase ([`drive_attack_loop`]) drives them (suspending the loop),
-/// while attacks of opportunity ([`fire_attacks_of_opportunity`])
-/// deliberately drop the list — they soak but don't yet open soak
-/// windows, because that needs mid-action suspension of the triggering
-/// action (deferred fast-follow, `TODO(#293)`). Keeping the queueing at the call site
-/// is what lets the two callers diverge without `enemy_attack` stranding
-/// an undriven window (C5b #237).
+/// survivor. This function does **not** queue the windows itself: both
+/// callers — the enemy phase ([`drive_attack_loop`]) and attacks of
+/// opportunity ([`drive_aoo`]) — queue soak windows via the same loop
+/// mechanic (#293), so neither drops the survivor list. Keeping the
+/// queueing at the call site is what lets `enemy_attack` stay stateless
+/// and avoids stranding an undriven window (C5b #237).
 ///
 /// [`AwaitingInput`]: crate::engine::EngineOutcome::AwaitingInput
 pub(super) fn enemy_attack(
@@ -563,8 +561,7 @@ pub(super) fn drive_aoo(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutc
 /// p.25 prescribes "the order of the attacked investigator's
 /// choosing" when an investigator is engaged with multiple enemies;
 /// `TODO(#143)`: player-pick attack order, unmilestoned, covers both
-/// this site and [`fire_attacks_of_opportunity`] (which has the same
-/// TODO).
+/// this site and [`drive_aoo`] (which has the same TODO).
 pub(super) fn resolve_attacks_for_investigator(
     cx: &mut Cx,
     investigator: InvestigatorId,
@@ -851,11 +848,10 @@ fn drive_attack_loop(
 /// - [`EnemyAttackSource::EnemyPhase`]: advance the enemy-phase cursor and open
 ///   the next window via [`after_enemy_phase_attacks`].
 /// - [`EnemyAttackSource::AttackOfOpportunity`]: return [`EngineOutcome::Done`].
-///   **Currently unreachable** — attacks of opportunity
-///   ([`fire_attacks_of_opportunity`]) open neither soak nor cancel windows, so
-///   they never park. Reserved for the deferred fast-follow (`TODO(#293)`) that
-///   suspends the triggering action; kept so the source-keyed dispatch stays
-///   total (C5b #237).
+///   The `AoO` loop ([`drive_aoo`]) does open soak and cancel windows, so this
+///   arm is reachable — it fires when the mid-action park unwinds and the
+///   `AoO` loop completes (#293). Kept as a distinct arm so the source-keyed
+///   dispatch stays total (C5b #237).
 ///
 /// Called from
 /// [`run_window_continuation`](super::reaction_windows::run_window_continuation)'s

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -570,6 +570,26 @@ pub(super) fn fire_attacks_of_opportunity(cx: &mut Cx, investigator: Investigato
     }
 }
 
+/// Fire attacks of opportunity from every ready enemy engaged with
+/// `investigator`, driving them through the shared attack loop (#293) so each
+/// `AoO` opens its before-attack cancel window (Dodge 01023) and per-soaked-asset
+/// reaction window (Guard Dog 01021). Returns [`EngineOutcome::AwaitingInput`]
+/// if a window suspends the loop, [`EngineOutcome::Done`] otherwise. Attackers
+/// resolve in deterministic [`EnemyId`] order (player-pick is #143/K4). `AoO`
+/// attackers never exhaust (RR p.7) — honored by
+/// [`EnemyAttackSource::AttackOfOpportunity`].
+#[allow(dead_code)] // TODO(#293): wired into handlers in Tasks 3–7
+pub(super) fn drive_aoo(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
+    let attackers: Vec<EnemyId> = cx
+        .state
+        .enemies
+        .iter()
+        .filter(|(_, e)| e.engaged_with == Some(investigator) && !e.exhausted)
+        .map(|(id, _)| *id)
+        .collect();
+    drive_attack_loop(cx, investigator, attackers, EnemyAttackSource::AttackOfOpportunity)
+}
+
 /// Resolve all of one investigator's engaged ready enemies' attacks
 /// (Rules Reference p.25 step 3.3 inner body). Snapshot the attacker
 /// list in [`EnemyId`] order (`BTreeMap` iteration is sorted), then
@@ -646,14 +666,15 @@ pub(super) fn resolve_attacks_for_investigator(
 /// Returns [`EngineOutcome::Done`] when the list is exhausted with no
 /// suspension.
 /// Deal one attacker's damage (unless `cancelled`), queue its soak window(s),
-/// and exhaust it. The open-window suspend check is left to the caller (so the
-/// before-cancel and soak resume paths can both reuse this body). Enemy-phase
-/// only — attacks of opportunity neither route through here nor exhaust (RR
-/// p.7); see [`fire_attacks_of_opportunity`].
+/// and exhaust it (enemy phase only). The open-window suspend check is left to
+/// the caller (so the before-cancel and soak resume paths can both reuse this
+/// body). `AoO` attacks route through here via [`drive_aoo`] but never exhaust
+/// (RR p.7) — the `source` parameter guards that branch.
 fn process_attacker_dealing(
     cx: &mut Cx,
     investigator: InvestigatorId,
     enemy_id: EnemyId,
+    source: EnemyAttackSource,
     cancelled: bool,
 ) {
     // Unless cancelled (Dodge 01023, RR p.6): damage + horror placement
@@ -681,19 +702,20 @@ fn process_attacker_dealing(
         }
     }
 
-    // Exhaust the attacker — even on cancel. RR p.6: a cancelled attack is
-    // "still regarded as initiated"; RR p.25: the enemy exhausts "upon
-    // completion of dealing the attack". The attack was made; only its effect
-    // was prevented. (AoO never exhausts, RR p.7 — but AoO doesn't reach here.)
-    let enemy = cx.state.enemies.get_mut(&enemy_id).unwrap_or_else(|| {
-        unreachable!(
-            "process_attacker_dealing: snapshotted enemy {enemy_id:?} is \
-             gone from state.enemies; this is a state-corruption \
-             invariant violation"
-        )
-    });
-    enemy.exhausted = true;
-    cx.events.push(Event::EnemyExhausted { enemy: enemy_id });
+    // Exhaust only on the enemy phase. AoO never exhausts (RR p.7).
+    // RR p.6: a cancelled attack is "still regarded as initiated"; RR p.25:
+    // the enemy exhausts "upon completion of dealing the attack". The attack
+    // was made; only its effect was prevented.
+    if source == EnemyAttackSource::EnemyPhase {
+        let enemy = cx.state.enemies.get_mut(&enemy_id).unwrap_or_else(|| {
+            unreachable!(
+                "process_attacker_dealing: snapshotted enemy {enemy_id:?} is gone from \
+                 state.enemies; this is a state-corruption invariant violation"
+            )
+        });
+        enemy.exhausted = true;
+        cx.events.push(Event::EnemyExhausted { enemy: enemy_id });
+    }
 }
 
 /// Park the loop on the soak reaction window the just-dealt attack opened and
@@ -782,7 +804,7 @@ fn deal_head_and_maybe_park(
     cancelled: bool,
 ) -> Option<EngineOutcome> {
     let enemy_id = attackers.remove(0);
-    process_attacker_dealing(cx, investigator, enemy_id, cancelled);
+    process_attacker_dealing(cx, investigator, enemy_id, source, cancelled);
     if cx.state.open_windows().is_empty() {
         None
     } else {
@@ -1333,6 +1355,37 @@ mod combat_tests {
             "an un-cancelled attack deals its damage"
         );
         assert!(state.enemies[&attacker].exhausted, "attacker exhausted");
+    }
+
+    #[test]
+    fn drive_aoo_deals_damage_but_does_not_exhaust_the_attacker() {
+        // RR p.7: an enemy does not exhaust while making an attack of opportunity.
+        let inv_id = InvestigatorId(1);
+        let mut enemy = test_enemy(100, "Ghoul");
+        enemy.engaged_with = Some(inv_id);
+        enemy.attack_damage = 1;
+        enemy.attack_horror = 0;
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_enemy(enemy)
+            .build();
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+
+        let outcome = super::drive_aoo(&mut cx, inv_id);
+
+        assert!(matches!(outcome, crate::engine::EngineOutcome::Done));
+        assert!(
+            !cx.state.enemies[&EnemyId(100)].exhausted,
+            "AoO must not exhaust the attacker (RR p.7)"
+        );
+        // Enemy attack fires DamageTaken (no EnemyAttacked event exists); verify
+        // damage landed on the investigator and no exhaust event was emitted.
+        assert_event!(events, Event::DamageTaken { .. });
+        assert_no_event!(events, Event::EnemyExhausted { .. });
     }
 
     #[test]

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -547,7 +547,12 @@ pub(super) fn drive_aoo(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutc
         .filter(|(_, e)| e.engaged_with == Some(investigator) && !e.exhausted)
         .map(|(id, _)| *id)
         .collect();
-    drive_attack_loop(cx, investigator, attackers, EnemyAttackSource::AttackOfOpportunity)
+    drive_attack_loop(
+        cx,
+        investigator,
+        attackers,
+        EnemyAttackSource::AttackOfOpportunity,
+    )
 }
 
 /// Resolve all of one investigator's engaged ready enemies' attacks

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -228,8 +228,9 @@ fn resume_action_resolution(cx: &mut Cx) -> EngineOutcome {
             actions::move_primary_effect(cx, investigator, destination)
         }
         ActionResume::Investigate => actions::investigate_primary_effect(cx, investigator),
-        // Resource/Engage/Draw arms land in Tasks 5–7.
-        other => unreachable!("resume_action_resolution: {other:?} not yet wired (K1 tasks 5-7)"),
+        ActionResume::Resource => actions::resource_primary_effect(cx, investigator),
+        // Engage/Draw arms land in Tasks 6–7.
+        other => unreachable!("resume_action_resolution: {other:?} not yet wired (K1 tasks 6-7)"),
     }
 }
 

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -229,8 +229,11 @@ fn resume_action_resolution(cx: &mut Cx) -> EngineOutcome {
         }
         ActionResume::Investigate => actions::investigate_primary_effect(cx, investigator),
         ActionResume::Resource => actions::resource_primary_effect(cx, investigator),
-        // Engage/Draw arms land in Tasks 6–7.
-        other => unreachable!("resume_action_resolution: {other:?} not yet wired (K1 tasks 6-7)"),
+        ActionResume::Engage { enemy } => actions::engage_primary_effect(cx, investigator, enemy),
+        // Draw arm lands in Task 7.
+        other @ ActionResume::Draw => {
+            unreachable!("resume_action_resolution: {other:?} not yet wired (K1 task 7)")
+        }
     }
 }
 

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -155,12 +155,16 @@ pub fn apply_player_action(cx: &mut Cx, action: &PlayerAction) -> EngineOutcome 
 ///   [`phases::anchor_on_child_pop`], which runs its resume-keyed chunk and,
 ///   at a phase boundary, transitions by popping itself + pushing the next
 ///   phase's anchor (`Entry`) — the loop then advances that;
+/// - an [`ActionResolution`](crate::state::Continuation::ActionResolution) frame
+///   on top is resumed via [`resume_action_resolution`], which runs the
+///   action's primary effect (or suppresses it if the actor was defeated);
 /// - the loop stops with `AwaitingInput` when an advance suspends, and with
 ///   `Done` when an [`InvestigatorTurn`](crate::state::Continuation::InvestigatorTurn)
 ///   frame is on top (the open turn — slice 2a-i, #393), at terminal (empty
 ///   stack), or when an advance makes no progress (a parked phase, e.g.
 ///   Investigation with no active investigator).
 pub(super) fn drive(cx: &mut Cx, outcome: EngineOutcome) -> EngineOutcome {
+    use crate::state::Continuation;
     if !matches!(outcome, EngineOutcome::Done) {
         return outcome;
     }
@@ -180,11 +184,51 @@ pub(super) fn drive(cx: &mut Cx, outcome: EngineOutcome) -> EngineOutcome {
                     other => return other,
                 }
             }
+            Some(Continuation::ActionResolution { .. }) => {
+                match resume_action_resolution(cx) {
+                    EngineOutcome::Done => {
+                        // Primary ran (or was suppressed) + frame popped; loop
+                        // on — the InvestigatorTurn frame beneath is now top.
+                    }
+                    other => return other, // primary effect suspended (e.g. skill test)
+                }
+            }
             // Open turn idle (an `InvestigatorTurn` frame on top), terminal
             // (empty), or a suspension on top (which a handler already surfaced
             // as AwaitingInput before reaching here).
             _ => return EngineOutcome::Done,
         }
+    }
+}
+
+/// Resume a parked [`ActionResolution`](crate::state::Continuation::ActionResolution)
+/// frame (#293): pop it, run the §D re-validation gate, then dispatch to the
+/// action's primary effect. The gate suppresses the primary (returns `Done`,
+/// leaving the spent action + AoO/window effects in place) if the actor was
+/// defeated mid-action; each primary effect additionally re-checks its own
+/// target precondition. Called only by [`drive`] with such a frame on top.
+fn resume_action_resolution(cx: &mut Cx) -> EngineOutcome {
+    use crate::state::{ActionResume, Continuation};
+    let Some(Continuation::ActionResolution { investigator, resume }) =
+        cx.state.continuations.pop()
+    else {
+        unreachable!("resume_action_resolution: top frame is not an ActionResolution");
+    };
+    // §D re-validation: actor still Active? If not, suppress the primary.
+    let active = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .is_some_and(|inv| inv.status == crate::state::Status::Active);
+    if !active {
+        return EngineOutcome::Done;
+    }
+    match resume {
+        ActionResume::Move { destination } => {
+            actions::move_primary_effect(cx, investigator, destination)
+        }
+        // Investigate/Resource/Engage/Draw arms land in Tasks 4–7.
+        other => unreachable!("resume_action_resolution: {other:?} not yet wired (K1 tasks 4-7)"),
     }
 }
 

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -230,10 +230,7 @@ fn resume_action_resolution(cx: &mut Cx) -> EngineOutcome {
         ActionResume::Investigate => actions::investigate_primary_effect(cx, investigator),
         ActionResume::Resource => actions::resource_primary_effect(cx, investigator),
         ActionResume::Engage { enemy } => actions::engage_primary_effect(cx, investigator, enemy),
-        // Draw arm lands in Task 7.
-        other @ ActionResume::Draw => {
-            unreachable!("resume_action_resolution: {other:?} not yet wired (K1 task 7)")
-        }
+        ActionResume::Draw => cards::draw_primary_effect(cx, investigator),
     }
 }
 

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -227,8 +227,9 @@ fn resume_action_resolution(cx: &mut Cx) -> EngineOutcome {
         ActionResume::Move { destination } => {
             actions::move_primary_effect(cx, investigator, destination)
         }
-        // Investigate/Resource/Engage/Draw arms land in Tasks 4–7.
-        other => unreachable!("resume_action_resolution: {other:?} not yet wired (K1 tasks 4-7)"),
+        ActionResume::Investigate => actions::investigate_primary_effect(cx, investigator),
+        // Resource/Engage/Draw arms land in Tasks 5–7.
+        other => unreachable!("resume_action_resolution: {other:?} not yet wired (K1 tasks 5-7)"),
     }
 }
 

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -209,8 +209,10 @@ pub(super) fn drive(cx: &mut Cx, outcome: EngineOutcome) -> EngineOutcome {
 /// target precondition. Called only by [`drive`] with such a frame on top.
 fn resume_action_resolution(cx: &mut Cx) -> EngineOutcome {
     use crate::state::{ActionResume, Continuation};
-    let Some(Continuation::ActionResolution { investigator, resume }) =
-        cx.state.continuations.pop()
+    let Some(Continuation::ActionResolution {
+        investigator,
+        resume,
+    }) = cx.state.continuations.pop()
     else {
         unreachable!("resume_action_resolution: top frame is not an ActionResolution");
     };

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -387,6 +387,13 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
             reason: "ResolveInput: no input prompt is outstanding (a parked attack loop is top)"
                 .into(),
         },
+        // A mid-action ActionResolution frame never awaits input — it is only
+        // momentarily top inside `drive`. A ResolveInput here is spurious.
+        Some(Continuation::ActionResolution { .. }) => EngineOutcome::Rejected {
+            reason: "ResolveInput: no input prompt is outstanding (a mid-action resolution \
+                     frame is top)"
+                .into(),
+        },
         // The open turn does not emit an AwaitingInput prompt in 2a (typed
         // actions drive it; the enumeration is 2a-ii / surfacing is 2b). A
         // ResolveInput arriving here is spurious — reject defensively, mirroring

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -2949,6 +2949,87 @@ mod tests {
     }
 
     #[test]
+    fn draw_with_lethal_aoo_suppresses_the_draw() {
+        // A lethal AoO (attack_damage == max_health) defeats the investigator
+        // before the card is drawn; the draw is suppressed (no CardsDrawn event)
+        // while the AoO damage still lands. Action is still spent.
+        let inv_id = InvestigatorId(1);
+        let loc = crate::state::LocationId(10);
+        let mut enemy = test_enemy(200, "Lethal Ghoul");
+        enemy.current_location = Some(loc);
+        enemy.engaged_with = Some(inv_id);
+        enemy.attack_damage = 8; // == test_investigator max_health
+        let state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .with_location(test_location(10, "Study"))
+            .with_investigator({
+                let mut i = test_investigator(1);
+                i.current_location = Some(loc);
+                i.deck = vec![CardCode::new("_test_card_1")];
+                i
+            })
+            .with_active_investigator(inv_id)
+            .with_enemy(enemy)
+            .build();
+
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Draw {
+                investigator: inv_id,
+            }),
+        );
+
+        // Lethal AoO landed.
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(
+            result.events,
+            Event::DamageTaken { investigator, amount: 8 } if *investigator == inv_id
+        );
+        // ...but the draw was suppressed.
+        assert_no_event!(result.events, Event::CardsDrawn { .. });
+    }
+
+    #[test]
+    fn draw_with_no_engaged_enemy_draws_normally() {
+        // Behaviour-preserving: no AoO enemy, so the draw resolves without
+        // interruption. One card drawn, Done.
+        let inv_id = InvestigatorId(1);
+        let loc = crate::state::LocationId(10);
+        let state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .with_location(test_location(10, "Study"))
+            .with_investigator({
+                let mut i = test_investigator(1);
+                i.current_location = Some(loc);
+                i.deck = vec![CardCode::new("_test_card_1")];
+                i
+            })
+            .with_active_investigator(inv_id)
+            .build();
+
+        let hand_before = state.investigators[&inv_id].hand.len();
+
+        let result = apply(
+            state,
+            Action::Player(PlayerAction::Draw {
+                investigator: inv_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_eq!(
+            result.state.investigators[&inv_id].hand.len(),
+            hand_before + 1,
+            "one card drawn"
+        );
+        assert_event!(
+            result.events,
+            Event::CardsDrawn { investigator, count: 1 } if *investigator == inv_id
+        );
+        assert_no_event!(result.events, Event::DamageTaken { .. });
+    }
+
+    #[test]
     fn move_with_unengaged_enemy_at_origin_leaves_enemy_behind() {
         let (inv_id, a, b, _, mut state) = move_scenario_with_engaged_enemy();
         // Convert the engagement into a non-engagement: enemy is at A

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -2985,6 +2985,12 @@ mod tests {
             result.events,
             Event::DamageTaken { investigator, amount: 8 } if *investigator == inv_id
         );
+        // Action was spent before the lethal AoO (3 → 2).
+        assert_event!(
+            result.events,
+            Event::ActionsRemainingChanged { investigator, new_count: 2 }
+                if *investigator == inv_id
+        );
         // ...but the draw was suppressed.
         assert_no_event!(result.events, Event::CardsDrawn { .. });
     }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -517,6 +517,19 @@ pub enum Continuation {
         /// Where in the per-attacker sequence the loop suspended (Axis D #336).
         stage: AttackLoopStage,
     },
+    /// An action paused over its attack-of-opportunity loop (#293, keystone of
+    /// #393). Pushed above [`InvestigatorTurn`] when an AoO-provoking action is
+    /// taken; the `AoO` [`AttackLoop`] is its child. On the loop's pop the
+    /// `drive` loop resumes this frame: it re-validates (actor still active +
+    /// the primary's precondition) and runs the primary effect, then pops.
+    /// Transient — it persists across an `apply()` boundary only while a window
+    /// suspends the loop. Never awaits input itself.
+    ActionResolution {
+        /// The acting investigator.
+        investigator: InvestigatorId,
+        /// Which primary effect to run when the `AoO` loop completes.
+        resume: ActionResume,
+    },
 }
 
 /// A controller choice paused mid-resolution (umbrella §3, Axis A).
@@ -544,6 +557,25 @@ pub struct ChoiceFrame {
     /// re-storing ingredient tuples) means bindings survive the suspend; resume
     /// re-runs the effect with this exact context. (#345.)
     pub context: crate::engine::EvalContext,
+}
+
+/// Which action's primary effect a parked [`Continuation::ActionResolution`]
+/// frame runs once its attack-of-opportunity loop completes (#293). Carries
+/// only the action's *parameters*; board-dependent values (Investigate
+/// difficulty, enemy presence) are re-derived live on resume so a mid-action
+/// board change is reflected.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ActionResume {
+    /// Relocate the investigator (and engaged enemies) to `destination`.
+    Move { destination: LocationId },
+    /// Begin the Investigate skill test on the investigator's location.
+    Investigate,
+    /// Gain 1 resource.
+    Resource,
+    /// Engage `enemy`.
+    Engage { enemy: EnemyId },
+    /// Draw 1 card (with the empty-deck penalty path).
+    Draw,
 }
 
 impl Continuation {
@@ -587,7 +619,9 @@ impl Continuation {
             // reaction window pushed above it is the player-facing prompt, not
             // this frame — it is only ever momentarily on top inside
             // `resume_enemy_attack`, never at a suspension boundary (#411).
-            Continuation::InvestigatorTurn { .. } | Continuation::AttackLoop { .. } => false,
+            Continuation::InvestigatorTurn { .. }
+            | Continuation::AttackLoop { .. }
+            | Continuation::ActionResolution { .. } => false,
             other => !other.is_phase_anchor(),
         }
     }
@@ -609,6 +643,7 @@ impl Continuation {
             | Continuation::EncounterCard { .. }
             | Continuation::InvestigatorTurn { .. }
             | Continuation::AttackLoop { .. }
+            | Continuation::ActionResolution { .. }
             | Continuation::MythosPhase { .. }
             | Continuation::InvestigationPhase { .. }
             | Continuation::EnemyPhase { .. }
@@ -632,6 +667,7 @@ impl Continuation {
             | Continuation::EncounterCard { .. }
             | Continuation::InvestigatorTurn { .. }
             | Continuation::AttackLoop { .. }
+            | Continuation::ActionResolution { .. }
             | Continuation::MythosPhase { .. }
             | Continuation::InvestigationPhase { .. }
             | Continuation::EnemyPhase { .. }
@@ -2319,5 +2355,20 @@ mod starting_location_tests {
         let json = serde_json::to_string(&state).expect("serialize");
         let back: GameState = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back.starting_location, Some(crate::state::LocationId(7)));
+    }
+}
+
+#[cfg(test)]
+mod action_resolution_frame_tests {
+    use super::*;
+
+    #[test]
+    fn action_resolution_frame_never_awaits_input_and_is_not_a_phase_anchor() {
+        let f = Continuation::ActionResolution {
+            investigator: InvestigatorId(1),
+            resume: ActionResume::Resource,
+        };
+        assert!(!f.awaits_input(), "a mid-action frame is internal, never a prompt");
+        assert!(!f.is_phase_anchor(), "a mid-action frame is not a phase anchor");
     }
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -2368,7 +2368,13 @@ mod action_resolution_frame_tests {
             investigator: InvestigatorId(1),
             resume: ActionResume::Resource,
         };
-        assert!(!f.awaits_input(), "a mid-action frame is internal, never a prompt");
-        assert!(!f.is_phase_anchor(), "a mid-action frame is not a phase anchor");
+        assert!(
+            !f.awaits_input(),
+            "a mid-action frame is internal, never a prompt"
+        );
+        assert!(
+            !f.is_phase_anchor(),
+            "a mid-action frame is not a phase anchor"
+        );
     }
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -317,7 +317,7 @@ pub struct ActRoundEndPending {
 pub enum EnemyAttackSource {
     /// Enemy-phase step 3.3 (`resolve_attacks_for_investigator`).
     EnemyPhase,
-    /// Attack of opportunity (`fire_attacks_of_opportunity`).
+    /// Attack of opportunity (`drive_aoo`).
     AttackOfOpportunity,
 }
 
@@ -518,8 +518,8 @@ pub enum Continuation {
         stage: AttackLoopStage,
     },
     /// An action paused over its attack-of-opportunity loop (#293, keystone of
-    /// #393). Pushed above [`InvestigatorTurn`] when an AoO-provoking action is
-    /// taken; the `AoO` [`AttackLoop`] is its child. On the loop's pop the
+    /// #393). Pushed above [`Self::InvestigatorTurn`] when an AoO-provoking action is
+    /// taken; the `AoO` [`Self::AttackLoop`] is its child. On the loop's pop the
     /// `drive` loop resumes this frame: it re-validates (actor still active +
     /// the primary's precondition) and runs the primary effect, then pops.
     /// Transient — it persists across an `apply()` boundary only while a window

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -24,12 +24,12 @@ pub use counter::Counter;
 pub(crate) use counter::define_id;
 pub use enemy::{Enemy, EnemyId};
 pub use game_state::{
-    Act, ActRoundEndPending, Agenda, AttackLoopStage, CandidateSource, ChoiceFrame, Continuation,
-    EnemyAttackSource, EnemyResume, FastActorScope, FinishContinuation, ForcedContinuation,
-    GameState, HandSizeDiscard, HunterChoice, InFlightSkillTest, InvestigationResume, MythosResume,
-    PendingSkillModifier, PhaseStep, ResolutionCandidate, ResolutionFrame, ResolutionKind,
-    RoundEndAdvance, SkillSubstitution, SkillTestFollowUp, SpawnEngagePending, UpkeepResume,
-    WindowBinding, WindowKind,
+    Act, ActRoundEndPending, ActionResume, Agenda, AttackLoopStage, CandidateSource, ChoiceFrame,
+    Continuation, EnemyAttackSource, EnemyResume, FastActorScope, FinishContinuation,
+    ForcedContinuation, GameState, HandSizeDiscard, HunterChoice, InFlightSkillTest,
+    InvestigationResume, MythosResume, PendingSkillModifier, PhaseStep, ResolutionCandidate,
+    ResolutionFrame, ResolutionKind, RoundEndAdvance, SkillSubstitution, SkillTestFollowUp,
+    SpawnEngagePending, UpkeepResume, WindowBinding, WindowKind,
 };
 pub use investigator::{DefeatCause, Investigator, InvestigatorId, Status};
 pub use location::{Location, LocationId};

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -46,11 +46,12 @@ by card/location abilities, so they live with the optional content in
 Lita's Parley), **not** the gate. #77 stays open for its Parley half.
 
 **B. Attacks of opportunity + non-enemy-phase attack windows** — one cluster,
-one shared mechanism (mid-action park/resume; see the keystone note):
-- [#361](https://github.com/talelburg/eldritch/issues/361) — activated abilities don't provoke AoO (First Aid, Medical Texts, Flashlight).
-- [#378](https://github.com/talelburg/eldritch/issues/378) — action-event play doesn't provoke AoO (Dynamite Blast, Emergency Cache).
-- [#293](https://github.com/talelburg/eldritch/issues/293) — AoO opens no soak/cancel window (Guard Dog, Dodge).
-- [#379](https://github.com/talelburg/eldritch/issues/379) — Retaliate opens no soak/cancel window (Guard Dog, Dodge).
+one shared mechanism (mid-action park/resume), now a sub-sliced arc **K1→K5**
+(see Ordering step 4 + its design spec). **The foundation shipped:**
+- ✅ [#293](https://github.com/talelburg/eldritch/issues/293) — AoO open cancel/soak windows (Guard Dog, Dodge). **Shipped — K1, PR #413** (`ActionResolution` frame + `drive_aoo`).
+- [#379](https://github.com/talelburg/eldritch/issues/379) — Retaliate opens no soak/cancel window (Guard Dog, Dodge). **K2.**
+- [#361](https://github.com/talelburg/eldritch/issues/361) — activated abilities don't provoke AoO (First Aid, Medical Texts, Flashlight). **K3.**
+- [#378](https://github.com/talelburg/eldritch/issues/378) — action-event play doesn't provoke AoO (Dynamite Blast, Emergency Cache). **K3.**
 
 **C. Enemy-attack-loop player agency:**
 - [#143](https://github.com/talelburg/eldritch/issues/143) — player picks attack order with 2+ engaged enemies.
@@ -77,7 +78,9 @@ clue" is stubbed; needs the dynamic skill-test-modifier DSL surface
 2. **§1 continuation-stack cleanup — ✅ done.** #345 (PR #385) + #348 via parts 2a–2c + #380 (PRs #386–#392). The last piece, **#347** (token-routed resume / stale-submit rejection), **folds into #393** rather than landing standalone: the literal "token on `ResolveInput`, validated in the engine" is a ~145-site churn that #393 would rework, and stale-submit rejection is properly a *session* concern — the engine emits deterministic token *values*, the **server** rejects stale client echoes at the network boundary (the engine's `apply`/action-log stays token-free for replay). So token-routing is designed on #393's unified resume channel, at the right layer. (#348/#347 closed → #393.)
 3. **Unified control-flow model (#393) — the foundation arc, before the rest of Tier-1. ✅ designed** ([`2026-06-20-unified-control-flow-model-design.md`](../superpowers/specs/2026-06-20-unified-control-flow-model-design.md)). Reify *every* step of control flow as a continuation frame (phases, turns, the open-action choice), so the main loop collapses to a single rule: **handle the top frame.** The `InvestigatorTurn` frame re-emits the player's legal actions as `OptionId`s while actions remain — so the stack is never empty during play (empty only at bootstrap and the terminal resolution). The spec scopes a **C checkpoint** (a step is a frame *iff* it suspends or loops; net-new surface = four per-phase anchors + `InvestigatorTurn` + `AttackLoop`) and three sequenced post-C **end-states**: **B** (every step a frame, reached content-driven), **2b** (eliminate typed `PlayerAction` → gameplay is `ResolveInput(OptionId)` only; committed for UX/#205), and the **EmitEvent-frame** (the `when/at/after × forced/reaction` ordering axis as nested frames; #212 successor). It **subsumes** the keystone's substrate, the three framework cursors (`enemy_attack_pending` / `pending_end_turn` / `pending_enemy_attack`), #384's engine half (#384 closed → #393), and **token-routing / stale-submit rejection (#347, folded in → server-side)**. The engine emits `OptionId`s + keeps the id→action map internal; option metadata / browser rendering is #205 at the capstone. Build the model **before** the rest of Tier-1 so each item lands on the final engine shape.
    - **Slice 3 — `AttackLoop` frame (cursor lift). ✅ shipped (PR #412, closes #411).** Lifted the last two framework cursors onto the stack: the parked enemy-attack loop is now a `Continuation::AttackLoop` frame (inserted *beneath* the reaction window it suspends on), and the per-investigator cursor is the `EnemyPhase` anchor's `attacking: Option<InvestigatorId>` field. Behaviour-preserving. **Deliberately Shape A:** the `AttackLoop` frame spans only the *parked suspension*, not the whole per-investigator step 3.3 — see the keystone caveat below.
-4. **The keystone: mid-action suspend/resume** — designed as §D of the #393 spec (its riskiest slice). Tier-1 B **and** C all hinge on the attack loop parking the *triggering action*, opening a window, and resuming — built on the `AttackLoop` frame (slice 3 / #411) above the action's sub-resolution (the model's first and hardest consumer), **not** a new cursor; an `on_child_pop` re-validation gate handles actor-eliminated-mid-action. **Caveat from slice 3:** today the `AttackLoop` frame is pushed only when a loop parks on a window and popped on resume — it does *not* yet span the whole per-investigator step 3.3, and the attacker list is still snapshotted when the `BeforeInvestigatorAttacked` window closes (after Fast plays). Extending the frame to span the action (and deciding the attacker-snapshot timing) is the keystone's job; do it here, not earlier, since changing it is a behaviour change. #293/#379/#361/#378/#143/#44 collapse into a single attack-loop arc — the highest-leverage item in the phase. Fold #119 in for #44's soak (symmetric token storage).
+4. **The keystone: mid-action suspend/resume — 🔨 in progress (K1 shipped).** Designed in its own spec ([`2026-06-20-phase-7-keystone-mid-action-park-design.md`](../superpowers/specs/2026-06-20-phase-7-keystone-mid-action-park-design.md)) — §D of #393 expanded into a sub-sliced arc **K1→K5** collapsing #293/#379/#361/#378/#143/#44 (+#119), the highest-leverage item in the phase. The action parks its *triggering action* on a `Continuation::ActionResolution` frame (above `InvestigatorTurn`) with the AoO `AttackLoop` (slice 3 / #411) as its child; on the loop's pop an `on_child_pop` re-validation gate (actor-Active + the primary's target precondition) resumes the action's primary effect, aborting cleanly on a mid-action lapse.
+   - **K1 — AoO open cancel/soak windows (#293). ✅ shipped (PR #413).** `ActionResolution` frame + `drive_aoo`; the five basic actions fire AoO through `drive_attack_loop`, so Dodge cancels and Guard Dog retaliates against an AoO; `fire_attacks_of_opportunity` deleted. RR p.7 AoO-non-exhaust source-gated.
+   - **K2 #379** retaliate windows · **K3 #361/#378** AoO from activated abilities + action-event play · **K4 #143** player attack-order — *also extends the enemy-phase `AttackLoop` to span the whole step 3.3 (resolving slice 3's Shape-A caveat) and settles attacker-snapshot timing* · **K5 #44 (+#119)** player damage/soak distribution. Each rides the K1 substrate.
 5. **Skill-test windows** (#374 + #64) — one reaction-window work-stream, offered as frame options on the #393 model.
 6. **Roland elder-sign** (#118).
 7. **Edge correctness** (#300 after Engage, then #368, #353).
@@ -202,18 +205,19 @@ window-queuing lives in the caller `drive_attack_loop`, which parks remaining
 attackers as a `Continuation::AttackLoop` frame *beneath* the window (#411) and
 returns `AwaitingInput`, resuming via `resume_enemy_attack` (which pops the frame;
 the per-investigator cursor is the `EnemyPhase` anchor's `attacking` field,
-advanced once via `after_enemy_phase_attacks`). The frame currently exists only
-while parked (Shape A) — the keystone extends it to span the action (see Ordering
-step 4). **Both `fire_attacks_of_opportunity` (called
-from the Move/Investigate handlers) and `fire_retaliate_if_any` call
-`enemy_attack` directly, bypassing the loop — so they open no windows;
-`EnemyAttackSource::AttackOfOpportunity` is the reserved-unconstructed variant
-the fix wires up.** Exhaust rules differ by source: enemy-phase always
-exhausts (cancelled too — RR p.6/p.25); AoO never (RR p.7); Retaliate never
-(RR p.18). **Every non-exempt basic action — Draw, Resource, Move, Investigate,
-Engage (PR #383) — already calls `fire_attacks_of_opportunity` (window-less),
-so the keystone's window-upgrade must cover all of them uniformly**; activating
-an ability or playing an event fire no AoO yet (#361/#378).
+advanced once via `after_enemy_phase_attacks`). The enemy-phase frame still exists
+only while parked (Shape A) — K4 (#143) extends it to span the action (see Ordering
+step 4). **K1 (PR #413) shipped the AoO half:** `fire_attacks_of_opportunity` is
+gone; the five basic actions (Draw, Resource, Move, Investigate, Engage) now run as
+a `Continuation::ActionResolution` frame and fire AoO via **`drive_aoo`** →
+`drive_attack_loop` (so `EnemyAttackSource::AttackOfOpportunity` is now live), opening
+the cancel (Dodge) and soak (Guard Dog) windows; on the loop's pop the `drive` loop
+resumes the action frame under an actor-Active + target re-validation gate.
+**`fire_retaliate_if_any` still calls `enemy_attack` directly, bypassing the loop —
+K2 (#379) routes it through the same mechanism.** Exhaust rules differ by source:
+enemy-phase always exhausts (cancelled too — RR p.6/p.25); AoO never (RR p.7 —
+source-gated in `process_attacker_dealing`); Retaliate never (RR p.18). Activating an
+ability or playing an event fire no AoO yet — **K3 (#361/#378)**.
 
 **Trigger spine.** `emit_event` is the one dispatch chokepoint (two-phase
 forced-then-reaction, RR p.2). Simultaneous triggers resolve through the

--- a/docs/superpowers/plans/2026-06-20-keystone-k1-aoo-mid-action-park.md
+++ b/docs/superpowers/plans/2026-06-20-keystone-k1-aoo-mid-action-park.md
@@ -1,0 +1,827 @@
+# Keystone K1 — AoO mid-action park/resume — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make attacks of opportunity open their cancel (Dodge 01023) and soak (Guard Dog 01021) reaction windows by running each AoO-provoking action as a suspendable `ActionResolution` frame, so the action's primary effect resumes after the window closes (#293).
+
+**Architecture:** A new transient `Continuation::ActionResolution { investigator, resume: ActionResume }` frame sits above `InvestigatorTurn`. The five AoO-firing basic-action handlers restructure to `validate → spend action → push ActionResolution → drive_aoo`. `drive_aoo` routes attacks of opportunity through the existing `drive_attack_loop` (so they queue cancel/soak windows and suspend) instead of the window-dropping `fire_attacks_of_opportunity`. When the AoO loop pops, the uniform `drive` loop resumes the `ActionResolution` frame, which re-validates (actor still `Active` + the primary's own precondition) and runs the action's primary effect — aborting cleanly (keep spent action + AoO/window effects, suppress primary) on failure.
+
+**Tech Stack:** Rust, `game-core` kernel crate (no_std-friendly, wasm target), `cards` content crate for registry-backed integration tests. Event-sourced `apply(state, action) -> ApplyResult`; serializable `Continuation` enum stack.
+
+## Global Constraints
+
+- **Match CI's strict flags before pushing:** `RUSTFLAGS="-D warnings" cargo test --all --all-features`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo fmt --check`; `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`.
+- **Handler contract — validate-first / mutate-second:** check every precondition and return `EngineOutcome::Rejected { reason }` with state + events unchanged before any mutation.
+- **`game-core` never depends on `cards`:** card-data lookups go through `card_registry::current()`; registry-free unit tests get the no-registry fallback. Tests needing real card abilities live in `crates/cards/tests/` (each file is its own process and may `install(cards::REGISTRY)`).
+- **AoO never exhausts the attacker (RR p.7):** *"An enemy does not exhaust while making an attack of opportunity."* The enemy-phase loop always exhausts; the AoO path must not.
+- **Card-text / rules citations are verified, never paraphrased from memory.** Dodge 01023 and Guard Dog 01021 text: confirm against `https://arkhamdb.com/card/01023` / `/01021` (incl. FAQ) before asserting behaviour in tests or comments.
+- **Event-assertion macros:** use `assert_event!` / `assert_no_event!` / `assert_event_count!` / `assert_event_sequence!` (order-insensitive by default) over raw slice indexing.
+- **`Continuation` derives** `Debug, Clone, PartialEq, Eq, Serialize, Deserialize` — every field of a new variant must too (the K1 fields — `InvestigatorId`, `LocationId`, `EnemyId`, an enum of those — already do).
+
+---
+
+### Task 1: Add the `ActionResolution` frame + `ActionResume` enum (type plumbing)
+
+Introduce the frame type and update every exhaustive `Continuation` match so the crate compiles with the variant present but unused. No behaviour change yet.
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (the `Continuation` enum near line 508; `awaits_input` line 581; `as_resolution` line 597; `as_resolution_mut` line 620)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (`resolve_input` match, line 361)
+- Test: `crates/game-core/src/state/game_state.rs` (`#[cfg(test)]` module)
+
+**Interfaces:**
+- Produces: `Continuation::ActionResolution { investigator: InvestigatorId, resume: ActionResume }`; `enum ActionResume { Move { destination: LocationId }, Investigate, Resource, Engage { enemy: EnemyId }, Draw }`. `ActionResolution::awaits_input()` is `false`; `is_phase_anchor()` is `false`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)]` module in `game_state.rs`:
+
+```rust
+#[test]
+fn action_resolution_frame_never_awaits_input_and_is_not_a_phase_anchor() {
+    let f = Continuation::ActionResolution {
+        investigator: InvestigatorId(1),
+        resume: ActionResume::Resource,
+    };
+    assert!(!f.awaits_input(), "a mid-action frame is internal, never a prompt");
+    assert!(!f.is_phase_anchor(), "a mid-action frame is not a phase anchor");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p game-core action_resolution_frame_never_awaits_input -v`
+Expected: FAIL to compile — `no variant named ActionResolution` / `ActionResume`.
+
+- [ ] **Step 3: Add the enum + variant**
+
+In `game_state.rs`, add above `impl Continuation` (near the other frame payload types):
+
+```rust
+/// Which action's primary effect a parked [`Continuation::ActionResolution`]
+/// frame runs once its attack-of-opportunity loop completes (#293). Carries
+/// only the action's *parameters*; board-dependent values (Investigate
+/// difficulty, enemy presence) are re-derived live on resume so a mid-action
+/// board change is reflected.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ActionResume {
+    /// Relocate the investigator (and engaged enemies) to `destination`.
+    Move { destination: LocationId },
+    /// Begin the Investigate skill test on the investigator's location.
+    Investigate,
+    /// Gain 1 resource.
+    Resource,
+    /// Engage `enemy`.
+    Engage { enemy: EnemyId },
+    /// Draw 1 card (with the empty-deck penalty path).
+    Draw,
+}
+```
+
+Add the variant to the `Continuation` enum (after `AttackLoop`):
+
+```rust
+    /// An action paused over its attack-of-opportunity loop (#293, keystone of
+    /// #393). Pushed above [`InvestigatorTurn`] when an AoO-provoking action is
+    /// taken; the AoO [`AttackLoop`] is its child. On the loop's pop the
+    /// `drive` loop resumes this frame: it re-validates (actor still active +
+    /// the primary's precondition) and runs the primary effect, then pops.
+    /// Transient — it persists across an `apply()` boundary only while a window
+    /// suspends the loop. Never awaits input itself.
+    ActionResolution {
+        /// The acting investigator.
+        investigator: InvestigatorId,
+        /// Which primary effect to run when the AoO loop completes.
+        resume: ActionResume,
+    },
+```
+
+- [ ] **Step 4: Update the exhaustive matches**
+
+In `awaits_input` (line ~590), add `ActionResolution` to the explicit-`false` arm (otherwise the `other => !other.is_phase_anchor()` fallback wrongly returns `true`):
+
+```rust
+            Continuation::InvestigatorTurn { .. }
+            | Continuation::AttackLoop { .. }
+            | Continuation::ActionResolution { .. } => false,
+```
+
+In `as_resolution` and `as_resolution_mut`, add `| Continuation::ActionResolution { .. }` to the `None`-returning list in each.
+
+In `resolve_input` (`dispatch/mod.rs`, alongside the `AttackLoop`/`InvestigatorTurn` defensive arms), add:
+
+```rust
+        // A mid-action ActionResolution frame never awaits input — it is only
+        // momentarily top inside `drive`. A ResolveInput here is spurious.
+        Some(Continuation::ActionResolution { .. }) => EngineOutcome::Rejected {
+            reason: "ResolveInput: no input prompt is outstanding (a mid-action resolution \
+                     frame is top)"
+                .into(),
+        },
+```
+
+(`is_phase_anchor` uses `matches!`, so an unlisted variant is already `false` — no change. `builder.rs::with_phase_anchor` is also `matches!` — no change.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test -p game-core action_resolution_frame_never_awaits_input -v`
+Expected: PASS.
+
+- [ ] **Step 6: Verify the whole crate still compiles clean**
+
+Run: `RUSTFLAGS="-D warnings" cargo test -p game-core` then `cargo clippy -p game-core --all-targets --all-features -- -D warnings`
+Expected: PASS (no non-exhaustive-match errors).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/game-core/src/state/game_state.rs crates/game-core/src/engine/dispatch/mod.rs
+git commit -m "engine: add ActionResolution frame + ActionResume enum (K1 of #293)"
+```
+
+---
+
+### Task 2: Route AoO through the attack loop with non-exhaust (`drive_aoo`)
+
+Add the source-aware non-exhaust branch to the shared attack loop and a `drive_aoo` entry that fires attacks of opportunity through `drive_attack_loop` (so they queue cancel/soak windows). Not yet called by any handler — proven by a direct unit test.
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/combat.rs` (`process_attacker_dealing` ~line 653; `deal_head_and_maybe_park` ~line 777; new `drive_aoo`)
+- Test: `crates/game-core/src/engine/dispatch/combat.rs` (`#[cfg(test)] mod combat_tests`)
+
+**Interfaces:**
+- Consumes: `drive_attack_loop(cx, investigator, attackers, source) -> EngineOutcome`; `EnemyAttackSource::{EnemyPhase, AttackOfOpportunity}`.
+- Produces: `pub(super) fn drive_aoo(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome`. `process_attacker_dealing` gains a `source: EnemyAttackSource` parameter and only exhausts when `source == EnemyPhase`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `combat_tests`:
+
+```rust
+#[test]
+fn drive_aoo_deals_damage_but_does_not_exhaust_the_attacker() {
+    // RR p.7: an enemy does not exhaust while making an attack of opportunity.
+    let inv_id = InvestigatorId(1);
+    let mut enemy = test_enemy(100, "Ghoul");
+    enemy.engaged_with = Some(inv_id);
+    enemy.attack_damage = 1;
+    enemy.attack_horror = 0;
+    let mut state = GameStateBuilder::new()
+        .with_investigator(test_investigator(1))
+        .with_enemy(enemy)
+        .build();
+    let mut events = Vec::new();
+    let mut cx = Cx { state: &mut state, events: &mut events };
+
+    let outcome = super::drive_aoo(&mut cx, inv_id);
+
+    assert!(matches!(outcome, crate::engine::EngineOutcome::Done));
+    assert!(
+        !cx.state.enemies[&EnemyId(100)].exhausted,
+        "AoO must not exhaust the attacker (RR p.7)"
+    );
+    assert_event!(events, Event::EnemyAttacked { .. });
+    assert_no_event!(events, Event::EnemyExhausted { .. });
+}
+```
+
+(Match the exact `Cx` construction and `EnemyAttacked` event name used by the sibling tests in `combat_tests`; adjust field names to the real `Event` variants if they differ.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p game-core drive_aoo_deals_damage_but_does_not_exhaust -v`
+Expected: FAIL — `drive_aoo` not found.
+
+- [ ] **Step 3: Thread `source` into the exhaust decision**
+
+Change `process_attacker_dealing`'s signature to take `source: EnemyAttackSource` and guard the exhaust block (currently unconditional, ~line 688):
+
+```rust
+fn process_attacker_dealing(
+    cx: &mut Cx,
+    investigator: InvestigatorId,
+    enemy_id: EnemyId,
+    source: EnemyAttackSource,
+    cancelled: bool,
+) {
+    if !cancelled {
+        // ... unchanged damaged_survivors + soak-window queueing ...
+    }
+
+    // Exhaust only on the enemy phase. AoO never exhausts (RR p.7).
+    if source == EnemyAttackSource::EnemyPhase {
+        let enemy = cx.state.enemies.get_mut(&enemy_id).unwrap_or_else(|| {
+            unreachable!(
+                "process_attacker_dealing: snapshotted enemy {enemy_id:?} is gone from \
+                 state.enemies; this is a state-corruption invariant violation"
+            )
+        });
+        enemy.exhausted = true;
+        cx.events.push(Event::EnemyExhausted { enemy: enemy_id });
+    }
+}
+```
+
+In `deal_head_and_maybe_park` (which already has `source`), pass it through:
+
+```rust
+    process_attacker_dealing(cx, investigator, enemy_id, source, cancelled);
+```
+
+- [ ] **Step 4: Add `drive_aoo`**
+
+Add near `resolve_attacks_for_investigator` in `combat.rs`:
+
+```rust
+/// Fire attacks of opportunity from every ready enemy engaged with
+/// `investigator`, driving them through the shared attack loop (#293) so each
+/// AoO opens its before-attack cancel window (Dodge 01023) and per-soaked-asset
+/// reaction window (Guard Dog 01021). Returns [`EngineOutcome::AwaitingInput`]
+/// if a window suspends the loop, [`EngineOutcome::Done`] otherwise. Attackers
+/// resolve in deterministic [`EnemyId`] order (player-pick is #143/K4). AoO
+/// attackers never exhaust (RR p.7) — honored by
+/// [`EnemyAttackSource::AttackOfOpportunity`].
+pub(super) fn drive_aoo(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
+    let attackers: Vec<EnemyId> = cx
+        .state
+        .enemies
+        .iter()
+        .filter(|(_, e)| e.engaged_with == Some(investigator) && !e.exhausted)
+        .map(|(id, _)| *id)
+        .collect();
+    drive_attack_loop(cx, investigator, attackers, EnemyAttackSource::AttackOfOpportunity)
+}
+```
+
+- [ ] **Step 5: Run the test (and the enemy-phase regression) to verify pass**
+
+Run: `cargo test -p game-core drive_aoo_deals_damage_but_does_not_exhaust -v`
+Expected: PASS.
+Run: `cargo test -p game-core resume_enemy_attack_drains_remaining_attackers_and_advances_cursor -v`
+Expected: PASS (enemy-phase loop still exhausts — regression intact).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/combat.rs
+git commit -m "engine: drive_aoo routes attacks of opportunity through the attack loop, non-exhausting (K1 of #293)"
+```
+
+---
+
+### Task 3: The `drive` extension + `resume_action_resolution` + convert Move
+
+The mechanism, proven end-to-end on Move (the most complex primary effect). After this, an AoO with no available reaction is behaviour-preserving, an AoO that defeats the actor suppresses the move, and (covered by Task 9's registry tests) a Dodge/Guard Dog window suspends and resumes the move.
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/actions.rs` (`move_action` ~line 246; extract `move_primary_effect`)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (`drive` ~line 163; add `resume_action_resolution`)
+- Test: `crates/game-core/src/engine/dispatch/actions.rs` (`#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: `combat::drive_aoo`; `Continuation::ActionResolution`; `ActionResume::Move`.
+- Produces: `pub(super) fn move_primary_effect(cx, investigator, destination) -> EngineOutcome` (the relocation + reveal + Left/Entered emits). `resume_action_resolution(cx) -> EngineOutcome` (central re-validation + per-`resume` dispatch). `drive` resumes `ActionResolution` frames.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `actions.rs` tests (use the existing test helpers; an AoO with no registry opens no window, so these cover the no-window + defeat paths):
+
+```rust
+#[test]
+fn move_with_lethal_aoo_suppresses_relocation_but_keeps_spent_action() {
+    // An engaged enemy whose AoO defeats the investigator: the move is
+    // suppressed (still at origin), the action point + AoO damage persist.
+    // ... build investigator at L1 (connected to L2), 3 actions, 1 health;
+    //     engaged enemy with attack_damage >= investigator health ...
+    // ... apply PlayerAction::Move { investigator, destination: L2 } ...
+    assert_eq!(/* investigator.current_location */, Some(L1), "move suppressed");
+    assert_eq!(/* investigator.actions_remaining */, 2, "action still spent");
+    assert!(/* investigator not Active */);
+}
+
+#[test]
+fn move_with_nonlethal_aoo_relocates_after_the_attack() {
+    // Engaged enemy, 1 damage, investigator survives: AoO deals damage, then
+    // the move resolves (no reaction available, so no window opens).
+    // ... assert current_location == Some(L2), engaged enemy moved with it,
+    //     investigator damage == 1 ...
+}
+```
+
+Fill the `...` using the patterns in the existing `move_action` tests in this file (same builder + fixtures).
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p game-core move_with_lethal_aoo move_with_nonlethal_aoo -v`
+Expected: FAIL (assertions / behaviour mismatch — today the synchronous path already suppresses on defeat, so `move_with_lethal_aoo` may pass; `move_with_nonlethal_aoo` must pass too. The point of these is to *pin* behaviour across the refactor — if both pass pre-refactor, that is the behaviour-preservation baseline; keep them and proceed.)
+
+- [ ] **Step 3: Extract `move_primary_effect`**
+
+Move the post-AoO body of `move_action` (current lines ~353–409: capture engaged set, relocate investigator + engaged enemies, emit `InvestigatorMoved`, `reveal_location`, the `LeftLocation` then `EnteredLocation` emits) into:
+
+```rust
+/// The relocation half of a Move, run after its attack-of-opportunity loop
+/// completes (#293). Re-derives `from` from the live `current_location` (the AoO
+/// never moves the actor) and re-checks the destination is still connected —
+/// the §D primary-precondition re-check — suppressing the move (returns `Done`)
+/// if it no longer holds. Engaged enemies move with the investigator; the
+/// entered location's Forced on-enter abilities become the move's outcome.
+pub(super) fn move_primary_effect(
+    cx: &mut Cx,
+    investigator: InvestigatorId,
+    destination: LocationId,
+) -> EngineOutcome {
+    let Some(from) = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .and_then(|inv| inv.current_location)
+    else {
+        return EngineOutcome::Done; // actor gone/locationless: suppress
+    };
+    let still_connected = cx
+        .state
+        .locations
+        .get(&from)
+        .is_some_and(|l| l.connections.contains(&destination))
+        && cx.state.locations.contains_key(&destination);
+    if !still_connected {
+        return EngineOutcome::Done; // precondition lapsed: suppress
+    }
+    // ... the verbatim relocation + reveal + LeftLocation/EnteredLocation body
+    //     from the original move_action (lines ~357–409), using `from` above ...
+}
+```
+
+- [ ] **Step 4: Restructure `move_action`**
+
+Replace `move_action`'s tail (from the `fire_attacks_of_opportunity` call through the original relocation body) with: push the frame, drive the AoO loop, and let `drive` resume the frame.
+
+```rust
+    // Mutate-second. Charge the action (base 1 + surcharge) last.
+    if let Err(rejected) = charge_action(cx, investigator, crate::dsl::ActionClass::Move, "Move") {
+        return rejected;
+    }
+
+    // Park the move over its attack-of-opportunity loop (#293): push the
+    // resume frame, then drive the AoO. If a cancel/soak window opens the loop
+    // suspends here; otherwise `drive` resumes the frame and relocates.
+    cx.state.continuations.push(crate::state::Continuation::ActionResolution {
+        investigator,
+        resume: crate::state::ActionResume::Move { destination },
+    });
+    super::combat::drive_aoo(cx, investigator)
+```
+
+Delete the now-extracted relocation body and the old `inv_after_aoo` defeat check (the re-validation gate in `resume_action_resolution` replaces it).
+
+- [ ] **Step 5: Add `resume_action_resolution` + extend `drive`**
+
+In `dispatch/mod.rs`, add:
+
+```rust
+/// Resume a parked [`ActionResolution`](crate::state::Continuation::ActionResolution)
+/// frame (#293): pop it, run the §D re-validation gate, then dispatch to the
+/// action's primary effect. The gate suppresses the primary (returns `Done`,
+/// leaving the spent action + AoO/window effects in place) if the actor was
+/// defeated mid-action; each primary effect additionally re-checks its own
+/// target precondition. Called only by [`drive`] with such a frame on top.
+fn resume_action_resolution(cx: &mut Cx) -> EngineOutcome {
+    use crate::state::{ActionResume, Continuation};
+    let Some(Continuation::ActionResolution { investigator, resume }) =
+        cx.state.continuations.pop()
+    else {
+        unreachable!("resume_action_resolution: top frame is not an ActionResolution");
+    };
+    // §D re-validation: actor still Active? If not, suppress the primary.
+    let active = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .is_some_and(|inv| inv.status == crate::state::Status::Active);
+    if !active {
+        return EngineOutcome::Done;
+    }
+    match resume {
+        ActionResume::Move { destination } => {
+            actions::move_primary_effect(cx, investigator, destination)
+        }
+        // Investigate/Resource/Engage/Draw arms land in Tasks 4–7.
+        other => unreachable!("resume_action_resolution: {other:?} not yet wired (K1 tasks 4-7)"),
+    }
+}
+```
+
+Extend `drive`'s loop `match` with an `ActionResolution` arm (before the `_ => return Done` catch-all):
+
+```rust
+            Some(Continuation::ActionResolution { .. }) => {
+                match resume_action_resolution(cx) {
+                    EngineOutcome::Done => {
+                        // Primary ran (or was suppressed) + frame popped; loop
+                        // on — the InvestigatorTurn frame beneath is now top.
+                    }
+                    other => return other, // primary effect suspended (e.g. skill test)
+                }
+            }
+```
+
+(Add `use crate::state::Continuation;` to `drive` if not already in scope.)
+
+- [ ] **Step 6: Run tests to verify pass**
+
+Run: `cargo test -p game-core move_with_lethal_aoo move_with_nonlethal_aoo -v`
+Expected: PASS.
+Run: `RUSTFLAGS="-D warnings" cargo test -p game-core` (full crate — pins the no-AoO move path + every other suite still green).
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/actions.rs crates/game-core/src/engine/dispatch/mod.rs
+git commit -m "engine: Move runs as an ActionResolution frame over its AoO loop (K1 of #293)"
+```
+
+---
+
+### Task 4: Convert Investigate
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/actions.rs` (`investigate` ~line 30; extract `investigate_primary_effect`)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (`resume_action_resolution` Investigate arm)
+- Test: `crates/game-core/src/engine/dispatch/actions.rs`
+
+**Interfaces:**
+- Produces: `pub(super) fn investigate_primary_effect(cx, investigator) -> EngineOutcome` — re-derives the location + effective shroud and starts the Investigate skill test; re-checks the location is still revealed (suppress on failure).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn investigate_with_nonlethal_aoo_starts_the_test_after_the_attack() {
+    // Engaged enemy (1 damage), revealed location: AoO deals damage, then the
+    // Investigate skill test begins (outcome is AwaitingInput at the commit
+    // window). Assert the EnemyAttacked event precedes the test, and the
+    // investigator took 1 damage and is still Active.
+}
+
+#[test]
+fn investigate_with_lethal_aoo_suppresses_the_test() {
+    // AoO defeats the investigator: no skill test starts (outcome Done), action
+    // spent, investigator not Active.
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p game-core investigate_with_nonlethal_aoo investigate_with_lethal_aoo -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Extract `investigate_primary_effect`**
+
+Move `investigate`'s post-AoO body (re-read location, compute effective shroud + difficulty, `start_skill_test(...)`) into:
+
+```rust
+/// The skill-test half of an Investigate, run after its AoO loop (#293).
+/// Re-reads the location + effective shroud live and re-checks it is still
+/// revealed (the §D precondition re-check); suppresses (returns `Done`) if not.
+pub(super) fn investigate_primary_effect(
+    cx: &mut Cx,
+    investigator: InvestigatorId,
+) -> EngineOutcome {
+    let Some(location_id) = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .and_then(|inv| inv.current_location)
+    else {
+        return EngineOutcome::Done;
+    };
+    let Some(location) = cx.state.locations.get(&location_id) else {
+        return EngineOutcome::Done;
+    };
+    if !location.revealed {
+        return EngineOutcome::Done; // precondition lapsed
+    }
+    // ... verbatim effective-shroud + difficulty + start_skill_test body from
+    //     the original investigate (lines ~62–104) ...
+}
+```
+
+Restructure `investigate`'s tail (after `spend_one_action`) to push the frame + `drive_aoo`, mirroring Task 3:
+
+```rust
+    spend_one_action(cx, investigator);
+    cx.state.continuations.push(crate::state::Continuation::ActionResolution {
+        investigator,
+        resume: crate::state::ActionResume::Investigate,
+    });
+    super::combat::drive_aoo(cx, investigator)
+```
+
+Delete the old `inv_after_aoo` defeat check.
+
+- [ ] **Step 4: Wire the resume arm**
+
+In `resume_action_resolution`, replace the Investigate part of the catch-all with:
+
+```rust
+        ActionResume::Investigate => actions::investigate_primary_effect(cx, investigator),
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `cargo test -p game-core investigate_with_nonlethal_aoo investigate_with_lethal_aoo -v` then `RUSTFLAGS="-D warnings" cargo test -p game-core`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/actions.rs crates/game-core/src/engine/dispatch/mod.rs
+git commit -m "engine: Investigate runs as an ActionResolution frame (K1 of #293)"
+```
+
+---
+
+### Task 5: Convert Resource
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/actions.rs` (`resource_action` ~line 114; extract `resource_primary_effect`)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (Resource arm)
+- Test: `crates/game-core/src/engine/dispatch/actions.rs`
+
+**Interfaces:**
+- Produces: `pub(super) fn resource_primary_effect(cx, investigator) -> EngineOutcome` — gains 1 resource (no target precondition beyond actor-Active, handled centrally).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn resource_with_lethal_aoo_suppresses_the_gain() {
+    // AoO defeats the investigator: no ResourcesGained, action spent.
+}
+
+#[test]
+fn resource_with_no_engaged_enemy_gains_normally() {
+    // No engaged enemy: behaviour-preserving — resources +1, Done.
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p game-core resource_with_lethal_aoo resource_with_no_engaged_enemy -v`
+Expected: FAIL (compile — no `resource_primary_effect`).
+
+- [ ] **Step 3: Extract + restructure**
+
+Extract the gain body (the `inv_mut.resources = ... saturating_add(1)` + `ResourcesGained` event) into `resource_primary_effect(cx, investigator) -> EngineOutcome` returning `Done`. Restructure `resource_action`'s tail to push `ActionResume::Resource` + `drive_aoo`; delete the old defeat check.
+
+- [ ] **Step 4: Wire the resume arm**
+
+```rust
+        ActionResume::Resource => actions::resource_primary_effect(cx, investigator),
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `cargo test -p game-core resource_with_lethal_aoo resource_with_no_engaged_enemy -v` then `RUSTFLAGS="-D warnings" cargo test -p game-core`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/actions.rs crates/game-core/src/engine/dispatch/mod.rs
+git commit -m "engine: Resource runs as an ActionResolution frame (K1 of #293)"
+```
+
+---
+
+### Task 6: Convert Engage
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/actions.rs` (`engage` ~line 164; extract `engage_primary_effect`)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (Engage arm)
+- Test: `crates/game-core/src/engine/dispatch/actions.rs`
+
+**Interfaces:**
+- Produces: `pub(super) fn engage_primary_effect(cx, investigator, enemy) -> EngineOutcome` — re-checks the enemy still exists, is co-located, and is not already engaged with the investigator (suppress on failure), then sets `engaged_with` + emits `EnemyEngaged`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn engage_with_nonlethal_aoo_engages_after_the_attack() {
+    // A second engaged enemy AoOs (1 damage); the target (co-located, not yet
+    // engaged) is then engaged. Assert EnemyAttacked precedes EnemyEngaged, the
+    // target's engaged_with == Some(investigator), investigator survived.
+}
+
+#[test]
+fn engage_with_lethal_aoo_suppresses_the_engagement() {
+    // The other engaged enemy's AoO defeats the investigator: no EnemyEngaged.
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p game-core engage_with_nonlethal_aoo engage_with_lethal_aoo -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Extract + restructure**
+
+Extract the engagement body into `engage_primary_effect`, re-checking the target enemy (its existence + co-location + not-already-engaged) live and returning `Done` if the precondition lapsed:
+
+```rust
+pub(super) fn engage_primary_effect(
+    cx: &mut Cx,
+    investigator: InvestigatorId,
+    enemy_id: EnemyId,
+) -> EngineOutcome {
+    let inv_location = cx
+        .state
+        .investigators
+        .get(&investigator)
+        .and_then(|inv| inv.current_location);
+    let Some(enemy) = cx.state.enemies.get(&enemy_id) else {
+        return EngineOutcome::Done; // target gone
+    };
+    if enemy.engaged_with == Some(investigator) || enemy.current_location != inv_location {
+        return EngineOutcome::Done; // precondition lapsed
+    }
+    let enemy_mut = cx.state.enemies.get_mut(&enemy_id).expect("checked");
+    enemy_mut.engaged_with = Some(investigator);
+    cx.events.push(Event::EnemyEngaged { enemy: enemy_id, investigator });
+    EngineOutcome::Done
+}
+```
+
+Restructure `engage`'s tail to push `ActionResume::Engage { enemy: enemy_id }` + `drive_aoo`; delete the old defeat check.
+
+- [ ] **Step 4: Wire the resume arm**
+
+```rust
+        ActionResume::Engage { enemy } => actions::engage_primary_effect(cx, investigator, enemy),
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `cargo test -p game-core engage_with_nonlethal_aoo engage_with_lethal_aoo -v` then `RUSTFLAGS="-D warnings" cargo test -p game-core`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/actions.rs crates/game-core/src/engine/dispatch/mod.rs
+git commit -m "engine: Engage runs as an ActionResolution frame (K1 of #293)"
+```
+
+---
+
+### Task 7: Convert Draw
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/cards.rs` (`draw` ~line 247; extract `draw_primary_effect`)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (Draw arm; remove the `unreachable!` catch-all — now total)
+- Test: `crates/game-core/src/engine/dispatch/cards.rs`
+
+**Interfaces:**
+- Produces: `pub(super) fn draw_primary_effect(cx, investigator) -> EngineOutcome` — wraps `draw_one_with_deckout` (no target precondition beyond actor-Active). After this task `resume_action_resolution`'s match is exhaustive over `ActionResume`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn draw_with_lethal_aoo_suppresses_the_draw() {
+    // AoO defeats the investigator: hand unchanged, action spent.
+}
+
+#[test]
+fn draw_with_no_engaged_enemy_draws_normally() {
+    // Behaviour-preserving — one card drawn, Done.
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p game-core draw_with_lethal_aoo draw_with_no_engaged_enemy -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Extract + restructure**
+
+Extract the draw body into `draw_primary_effect(cx, investigator) -> EngineOutcome` (calls `draw_one_with_deckout(cx, investigator)`; returns `Done`). Restructure `draw`'s tail to push `ActionResume::Draw` + `super::combat::drive_aoo(cx, investigator)`; delete the old `still_active` defeat check.
+
+- [ ] **Step 4: Wire the resume arm + make the match total**
+
+```rust
+        ActionResume::Draw => cards::draw_primary_effect(cx, investigator),
+```
+
+Remove the `other => unreachable!(...)` arm — all five `ActionResume` variants are now handled.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `cargo test -p game-core draw_with_lethal_aoo draw_with_no_engaged_enemy -v` then `RUSTFLAGS="-D warnings" cargo test -p game-core`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/cards.rs crates/game-core/src/engine/dispatch/mod.rs
+git commit -m "engine: Draw runs as an ActionResolution frame; resume match now total (K1 of #293)"
+```
+
+---
+
+### Task 8: Delete `fire_attacks_of_opportunity` + refresh combat docs
+
+No handler calls the window-dropping AoO path anymore. Remove it and the now-stale `TODO(#293)` doc comments.
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/combat.rs` (delete `fire_attacks_of_opportunity` ~line 546; update `enemy_attack` doc ~line 459 and `resume_enemy_attack` doc ~line 869)
+
+- [ ] **Step 1: Confirm there are no remaining callers**
+
+Run: `grep -rn "fire_attacks_of_opportunity" crates/`
+Expected: only the definition + doc-comment references remain.
+
+- [ ] **Step 2: Delete the function and update docs**
+
+Delete `fire_attacks_of_opportunity`. In `enemy_attack`'s doc, replace the paragraph describing the AoO caller "deliberately dropping the list" with: the AoO caller now drives the loop (`drive_aoo`), so both callers queue soak windows; the survivor list is never dropped (#293). In `resume_enemy_attack`'s doc, mark the `AttackOfOpportunity` arm **reachable** (the mid-action park, #293) rather than "currently unreachable."
+
+- [ ] **Step 3: Verify the build + docs**
+
+Run: `RUSTFLAGS="-D warnings" cargo test -p game-core` and `RUSTDOCFLAGS="-D warnings" cargo doc -p game-core --no-deps --all-features`
+Expected: PASS (no dead-code warning, no broken intra-doc links to the deleted fn).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/combat.rs
+git commit -m "engine: remove the window-dropping fire_attacks_of_opportunity; AoO now drives the loop (K1 of #293)"
+```
+
+---
+
+### Task 9: Integration — Dodge cancels an AoO; Guard Dog retaliates against an AoO
+
+The window-suspend/resume path needs real card abilities, so it lives in `crates/cards/tests/`. This is the #293 acceptance + the registry-backed slice of the §D keystone matrix.
+
+**Files:**
+- Modify/Create: `crates/cards/tests/guard_dog_soak.rs` (extend the existing AoO case — currently asserts only "no window stranded")
+- Create (or extend): `crates/cards/tests/dodge_aoo.rs`
+
+**Interfaces:**
+- Consumes: `cards::REGISTRY` (installed per test process); `PlayerAction::Move`/`Investigate`; `InputResponse` for window resolution. Follow the existing `crates/cards/tests/play_card.rs` / `guard_dog_soak.rs` harness pattern.
+
+- [ ] **Step 1: Verify the card text before asserting**
+
+WebFetch `https://arkhamdb.com/card/01023` (Dodge) and `https://arkhamdb.com/card/01021` (Guard Dog), **including FAQ**. Confirm: Dodge — *"Cancel all damage and horror dealt by [an] attacking enemy"* as a reaction to an enemy attacking an investigator at your location; Guard Dog — the retaliate reaction when it takes damage. Record the verified text in each test's header comment.
+
+- [ ] **Step 2: Write the failing test — Guard Dog retaliates against an AoO**
+
+In `guard_dog_soak.rs`, add a test: investigator controls Guard Dog (in play), engaged with a ready enemy, takes a basic action (Move) that provokes the AoO; the AoO damage soaks onto Guard Dog, opening the `AfterEnemyAttackDamagedAsset` window; resolve the window so Guard Dog's retaliate deals damage back to the attacker. Assert: the attacker took retaliate damage, the move completed after the window closed, the attacker did **not** exhaust (RR p.7).
+
+- [ ] **Step 3: Write the failing test — Dodge cancels an AoO**
+
+In `dodge_aoo.rs`: investigator with Dodge in hand, engaged with a ready enemy, takes Move; the AoO opens the `BeforeEnemyAttack` window; play Dodge to cancel; assert no damage/horror dealt by the AoO, the move resolved, the attacker did not exhaust.
+
+- [ ] **Step 4: Run to verify they fail (pre-implementation baseline)**
+
+Run: `cargo test -p cards --test guard_dog_soak` and `cargo test -p cards --test dodge_aoo`
+Expected: these are the acceptance tests; they should PASS now that Tasks 1–8 wired the mechanism. If either FAILs, debug the suspend/resume chain (window opens → `AwaitingInput`; `ResolveInput` → `resume_enemy_attack` pops `AttackLoop` → `drive` resumes `ActionResolution` → primary effect). Do not weaken the assertions to pass.
+
+- [ ] **Step 5: Full CI gauntlet**
+
+Run all strict-flag jobs from Global Constraints:
+```bash
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cards/tests/guard_dog_soak.rs crates/cards/tests/dodge_aoo.rs
+git commit -m "test: Dodge cancels + Guard Dog retaliates against attacks of opportunity (closes #293)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage (K1 section of the design):** ✅ `ActionResolution` frame + `ActionResume` enum (Task 1); restructure the five basic-action handlers (Tasks 3–7); AoO drives the loop / stops dropping survivors (Task 2 + 8); RR p.7 non-exhaust preserved (Task 2); `resume_enemy_attack` AoO arm + `drive` extension + re-validation gate (Task 3); defensive `resolve_input` arm (Task 1); Dodge-cancel + Guard-Dog-retaliate windows on AoO (Task 9). The §D matrix's defeat-mid-action + no-window paths are unit-tested (Tasks 3–7); the window paths are integration-tested (Task 9).
+- **Deferred-by-design (not K1):** retaliate windows (#379/K2), play-card/activate AoO (#361/#378/K3), player attack-order + enemy-phase frame extension (#143/K4), damage distribution (#44/K5). Not gaps — sequenced sub-slices.
+- **Placeholder scan:** the `...` markers in Tasks 3–4 are explicit "reproduce the verbatim existing body" instructions with line references, not under-specified logic; every new function has a complete signature + body or a faithful-move instruction.
+- **Type consistency:** `drive_aoo`, `move_primary_effect`/`investigate_primary_effect`/`resource_primary_effect`/`engage_primary_effect`/`draw_primary_effect`, and `resume_action_resolution` names + signatures are used identically across the tasks that define and call them; `ActionResume` variant names (`Move{destination}`, `Investigate`, `Resource`, `Engage{enemy}`, `Draw`) match between Task 1 and Tasks 3–7.
+
+## Risks & notes for the implementer
+
+- **The riskiest seam** is the resume chain: an AoO window closing must unwind `resume_enemy_attack (pops AttackLoop, returns Done) → resolve_input → apply_player_action → drive → resume_action_resolution`. If a converted action's primary effect never runs after a window, trace that chain — `drive` must see `ActionResolution` on top after the `AttackLoop` pops.
+- **Event names in tests** (`EnemyAttacked`, `EnemyExhausted`, `ResourcesGained`, `EnemyEngaged`, `InvestigatorMoved`) — confirm the exact variant + field names against `crates/game-core/src/event.rs`; the plan uses the names visible in the current handlers.
+- **`move_primary_effect`'s `EnteredLocation` emit can itself suspend** (2+ simultaneous forced, #213) — it returns that outcome, which `drive` surfaces. This is preserved from the original `move_action` tail; don't swallow it.
+- **Keep assertions honest** (verification-before-completion): if Task 9's acceptance tests fail, fix the engine, never the assertion.

--- a/docs/superpowers/specs/2026-06-20-phase-7-keystone-mid-action-park-design.md
+++ b/docs/superpowers/specs/2026-06-20-phase-7-keystone-mid-action-park-design.md
@@ -1,0 +1,325 @@
+# Phase 7 keystone — mid-action park/resume + the attack-loop arc — design
+
+Tracking: the **keystone** of the unified control-flow model
+(`2026-06-20-unified-control-flow-model-design.md`, **#393**), §D. This is
+**Ordering step 4** of that spec and **the riskiest slice in Phase 7** — it
+collapses six issues into one attack-loop arc:
+
+- **#293** — attacks of opportunity open no soak/cancel window (Guard Dog, Dodge).
+- **#379** — Retaliate opens no soak/cancel window (Guard Dog, Dodge).
+- **#361** — activated abilities don't provoke AoO (First Aid, Medical Texts, Flashlight).
+- **#378** — action-event play doesn't provoke AoO (Dynamite Blast, Emergency Cache).
+- **#143** — player picks attack order with 2+ engaged enemies.
+- **#44** — player chooses damage/horror distribution across soakers + self.
+
+Plus the refactor pull-in **#119** (unify damage/horror/clue tokens onto
+`CardInPlay`), which #44's soak distribution needs for symmetric
+investigator/asset token storage.
+
+This spec designs the whole arc as **one coherent mechanism** with an explicit
+**sub-PR decomposition (K1→K5)**, each behaviour-preserving-or-additive and
+independently green (mirroring the slice-1/2 cadence).
+
+## Why this pass exists
+
+Today every action that provokes an attack of opportunity does so
+**synchronously and window-droppingly**. Each basic-action handler runs:
+
+```
+validate → spend_one_action → fire_attacks_of_opportunity → if-survived → primary effect
+```
+
+and `fire_attacks_of_opportunity` (combat.rs) — together with
+`fire_retaliate_if_any` (skill_test.rs) — calls `enemy_attack` **directly**,
+bypassing `drive_attack_loop`. It deliberately **drops the damaged-soaker
+survivor list** `enemy_attack` returns, so no `AfterEnemyAttackDamagedAsset`
+soak window and no `BeforeEnemyAttack` cancel window ever opens. The result:
+Guard Dog 01021 does not retaliate against an AoO, and Dodge 01023 cannot cancel
+one. combat.rs documents this as the `TODO(#293)` gap.
+
+The fix is structural: **a synchronous mid-handler call can't suspend**, so AoO
+can never open a window mid-action. The action must run as a *frame* with a
+resume point, so the AoO loop can suspend on a window and the action's primary
+effect resumes after the window closes. This is why the keystone is inseparable
+from the `InvestigatorTurn` frame (slice 2a-i) and the unified `drive` loop
+(slice 1b): the substrate already exists; this slice is its **first and hardest
+consumer**.
+
+### The actual AoO-firing sites today (corrected)
+
+The #393 spec §D listed "5 sites — cards.rs:258 (play card), actions.rs:73/121/205/334".
+On inspection **cards.rs:258 is the `draw` handler, not `play_card`** — `play_card`
+fires **no** AoO today (nor does `activate_ability`). The real AoO-firing sites
+are the **five basic actions**:
+
+| Action | Site | AoO call |
+|---|---|---|
+| Investigate | actions.rs:73 | `fire_attacks_of_opportunity` |
+| Resource | actions.rs:121 | `fire_attacks_of_opportunity` |
+| Engage | actions.rs:205 | `fire_attacks_of_opportunity` |
+| Move | actions.rs:334 | `fire_attacks_of_opportunity` |
+| Draw | cards.rs:258 | `fire_attacks_of_opportunity` |
+
+This cleanly separates **K1** (the five basic actions get the frame + windows)
+from **K3** (*add* AoO firing to non-fast play-card #378 + action-cost activated
+abilities #361 — sites that fire none today). Fight and Evade are AoO-exempt
+(RR p.5) and never enter the AoO path at all; **Retaliate** (K2 / #379) fires
+from the Fight follow-up (skill_test.rs:443), a different park point — see K2.
+
+## The model
+
+### Stack shape
+
+During an open turn the continuation stack idles as:
+
+```
+[ …, InvestigationPhase{TurnBegins}, InvestigatorTurn{who} ]
+```
+
+`InvestigatorTurn` is on top (idle in 2a — it accepts typed `PlayerAction`s; it
+emits `OptionId`s in 2b). A typed action arrives; its handler validates, spends
+the action, and pushes an **`ActionResolution`** frame **above**
+`InvestigatorTurn`, then drives the AoO loop. If an engaged ready enemy attacks
+and a cancel/soak reaction is available, the loop pushes `AttackLoop` then the
+reaction window above it:
+
+```
+[ …, InvestigationPhase{TurnBegins}, InvestigatorTurn{who}, ActionResolution{Move}, AttackLoop, Resolution(window) ]
+                                                            └─ the action ──────────┘└─ its AoO child ──────────────┘
+```
+
+The window is the player-facing top prompt ("play Dodge?"); `AwaitingInput`
+returns. When it closes, `resume_enemy_attack` drains the loop and pops
+`AttackLoop`; `ActionResolution` is now top; the uniform `drive` loop resumes it;
+it re-validates, pops itself, and runs the Move primary effect; `Done` →
+`drive` sees `InvestigatorTurn` again → idle. Turn continues.
+
+**Key invariants:**
+
+- `ActionResolution` sits **above** `InvestigatorTurn` (the action belongs to that
+  turn); `AttackLoop` is **its child**; windows are the loop's children.
+- The frame is **transient**: pushed when an action arrives, popped the moment its
+  primary effect runs. Between actions only `InvestigatorTurn` is on top.
+- It persists **across an `apply()` boundary only when a window suspends**. In the
+  no-window case it is pushed and popped within one `apply()` call, so every
+  observable boundary (between player actions) is unchanged — **behaviour-preserving**.
+
+### The frame variant
+
+`ActionResolution` is a **generic frame carrying a resume enum**, not one variant
+per action:
+
+```rust
+Continuation::ActionResolution {
+    investigator: InvestigatorId,
+    resume: ActionResume,
+}
+
+enum ActionResume {
+    Move { destination: LocationId },
+    Investigate,
+    Resource,
+    Engage { enemy: EnemyId },
+    Draw,
+    // K3 adds:
+    // PlayCard { hand_index: u8 },
+    // ActivateAbility { instance_id: CardInstanceId, ability_index: u8 },
+}
+```
+
+**Why generic, not per-action variants** (contrast the per-phase anchors, which
+*are* one variant each): the per-phase split exists to make illegal
+phase/boundary pairings (e.g. `Mythos` + `AfterAttackLoop`) *unrepresentable*.
+There is no analogous illegal action/stage cross-product here — the resume runs
+to completion or aborts; it carries no orthogonal stage axis. So the generic
+form wins on less enum surface with no unrepresentable-illegal-state payoff
+forgone.
+
+**Why the resume re-derives board state rather than snapshotting it.** Each
+resume carries only the *parameters of the action* (the destination, the target
+enemy), not derived values like the Investigate difficulty. On resume it re-reads
+board-dependent values live (location shroud, enemy presence), so a mid-action
+board change is reflected — this is the same liveness the re-validation gate
+needs, and it keeps the frame minimal and serializable.
+
+### Pop-self-then-run-primary (no stage cursor)
+
+When the AoO loop pops, `ActionResolution`'s resume **pops itself first, then runs
+the primary effect**. The primary effect's *own* suspensions (Investigate's skill
+test pushes `SkillTest`; a played card's on-play `ChooseOne` pushes `Choice`) are
+independent frames that resume through their existing paths. So the action frame
+needs **no internal stage cursor** — it bridges exactly the AoO gap and is gone
+before the primary effect's sub-resolution begins. The chunk boundary sits
+exactly where the synchronous `fire_attacks_of_opportunity` call sits today, so
+AoO-vs-primary-effect ordering is preserved by construction.
+
+### The `drive` extension
+
+`drive` (dispatch/mod.rs) today advances only `*Phase` anchors via
+`anchor_on_child_pop`. K1 extends its "handle the top frame" rule to
+`ActionResolution`: when an `ActionResolution` is on top (whether because the
+handler just pushed it with no window, or because the AoO `AttackLoop` just
+popped), `drive` runs its resume. `resume_enemy_attack`'s reserved
+`EnemyAttackSource::AttackOfOpportunity` arm (currently the unreachable `Done`
+stub) becomes reachable: it pops the `AttackLoop` and returns `Done`, unwinding to
+`drive`, which then sees `ActionResolution` and resumes it. One code path for
+window and no-window cases.
+
+## The re-validation gate (§D "mid-action viability")
+
+Mid-action suspension means the world can change underneath an action: an AoO can
+defeat the actor, a retaliate can defeat an enemy, a soak can exhaust a source.
+So `ActionResolution`'s resume **re-validates before completing**:
+
+1. **Actor still `Status::Active`** — today's `if inv_after_aoo.status != Active
+   { return Done }` check, relocated onto the frame.
+2. **The primary effect's own target precondition** — re-run the relevant
+   `check_*` predicate (Investigate: location still revealed; Engage: enemy still
+   present + not-already-engaged; Move: destination still connected). These are
+   the **same shared predicates the 2a-ii `legal_actions` enumerator extracted** —
+   the enumerator predicates *are* the re-validation predicates, so no new surface.
+
+On failure the resume **aborts cleanly**: pop self, suppress the primary effect,
+return `Done`. The spent action and the AoO/window effects (damage dealt, Dodge
+played, retaliate dealt) **persist** — they really happened. This is **not** a
+clean whole-action rollback: mid-action abort suppresses only the *primary
+effect*, not the AoO side effects. (The apply loop's snapshot-and-rollback on
+`Rejected` is a separate, whole-action safety net; the gate is the in-scope
+mechanism for *partial* abort.)
+
+**In-scope reachability.** In 1-player Gathering scope the only mid-AoO change
+that actually fires is **actor defeat** (no in-scope AoO/retaliate can change a
+Move/Investigate/Engage *target* other than by defeating the actor). The full
+target re-check is therefore a **structural hook** that is correct-by-construction
+today and ready when a card forces a richer invalidation — chosen (over
+actor-Active-only) so the gate is uniform and the predicate reuse is total.
+
+## Sub-PR decomposition (K1→K5)
+
+Each step is independently green; behaviour-preserving except where it adds the
+documented new player agency.
+
+### K1 — foundation: mid-action park/resume + AoO windows (#293)
+
+The load-bearing, riskiest PR. Scope:
+
+- Add `Continuation::ActionResolution { investigator, resume: ActionResume }` and
+  `ActionResume` (the five K1 variants).
+- Restructure the five basic-action handlers (Move/Investigate/Resource/Engage/
+  Draw) to `validate → spend action → push ActionResolution → drive_attack_loop(
+  …, AttackOfOpportunity)`. The post-AoO chunk (the primary effect) moves into the
+  frame's resume.
+- Make AoO **drive the loop** instead of `fire_attacks_of_opportunity`'s direct
+  `enemy_attack`: AoO now queues the cancel/soak windows (stops dropping the
+  survivor list). Preserve the **RR p.7 non-exhaust rule** for AoO (the
+  `EnemyAttackSource` already distinguishes it; enemy-phase exhausts, AoO does not).
+- Wire `resume_enemy_attack`'s `AttackOfOpportunity` arm + extend `drive` to
+  resume `ActionResolution` (re-validation gate).
+- Update the `resolve_input` defensive arm: an `ActionResolution` frame, like
+  `AttackLoop`/`EncounterCard`, never awaits input (it is only ever momentarily
+  top inside `drive`), so a `ResolveInput` arriving against it rejects defensively.
+
+**Delivers:** Dodge cancels an AoO; Guard Dog retaliates against an AoO.
+**Carries the §D test matrix** (below).
+
+`fire_attacks_of_opportunity` becomes a thin "collect engaged ready attackers →
+`drive_attack_loop(AttackOfOpportunity)`" — converging with
+`resolve_attacks_for_investigator`'s shape (both snapshot attackers in `EnemyId`
+order, then delegate to `drive_attack_loop`), differing only by `source`.
+
+### K2 — Retaliate windows (#379)
+
+Retaliate fires from the **Fight follow-up** (skill_test.rs:443
+`fire_retaliate_if_any`), *after* the Fight skill test resolves — **not** at
+action declaration. So its park point differs from K1's action frame: the
+`AttackLoop{source: Retaliate-or-AoO}` is pushed from inside the skill-test
+follow-up resolution, suspending it on the retaliate's soak/cancel window and
+resuming the follow-up's tail when the window closes. This needs either a new
+`EnemyAttackSource::Retaliate` (to route `resume_enemy_attack` back to the
+follow-up) or reuse of the existing AoO source with a distinct resume site — to
+be settled in K2's own thin design. Behaviour added: Guard Dog retaliates / Dodge
+cancels against a retaliate strike.
+
+### K3 — new AoO sites: action-event play (#378) + activated abilities (#361)
+
+Wire AoO firing into `play_card` (non-fast) and `activate_ability`
+(`action_cost > 0`), gated so **fast plays remain exempt** (RR p.11 — fast
+events/abilities are not actions). Both reuse K1's `ActionResolution` frame with
+the two new `ActionResume` variants. The chunk boundary mirrors the basic
+actions: spend cost → fire AoO (suspendable) → on resume, run the card's on-play
+effects / the ability's effect. **K3 must first confirm where the non-fast
+play-card action cost is charged** — `play_card` does not call `spend_one_action`
+in its body today (the cost handling is not visible there); the AoO must fire
+after the action cost is paid, so this is a prerequisite to verify, not assume.
+
+### K4 — player attack-order (#143) + enemy-phase frame extension
+
+When an investigator is engaged with **2+ ready enemies**, offer an order choice
+(a `Choice`/`OptionId` prompt) instead of the deterministic `EnemyId` order — for
+**both** the AoO loop and the enemy-phase loop (`resolve_attacks_for_investigator`).
+
+This is where the **slice-3 carry-over** lands: today the enemy-phase `AttackLoop`
+frame exists only *while parked on a window* (Shape A). Holding a player-chosen
+order requires the frame to **span the whole per-investigator step 3.3** (pushed
+at the start of that investigator's attacks, carrying the chosen order), and
+forces a decision on **attacker-snapshot timing** (the list is currently
+snapshotted when `BeforeInvestigatorAttacked` closes, after Fast plays). Both are
+deferred to here deliberately — the order-choice is the first consumer that needs
+the frame to span the action, so the extension is paid for by a real need (the
+#393 promotion rule), and changing the snapshot timing is a behaviour change best
+made where it is exercised.
+
+### K5 — player damage/soak distribution (#44) + token unification (#119)
+
+Replace the fill-to-capacity `assign_attack` default (which today auto-soaks onto
+the lowest-`CardInstanceId` asset first) with a **player-choice `AwaitingInput`**
+distributing each point of damage/horror across eligible soakers + self. **Do
+with #119** (unify damage/horror/clue tokens onto `CardInPlay`) so the investigator
+and asset token storage is symmetric, rather than special-casing the investigator
+side. This also makes the multi-soak-window case (today guarded as
+unconstructible in `park_on_soak_window`) reachable, so K5 must also lift that
+single-window-per-attack guard into a real multi-window drain (coordinating with
+simultaneous-trigger ordering, #213).
+
+## Testing strategy
+
+- **K1 — the §D keystone matrix** (`game-core` engine tests + `crates/cards/tests`
+  for registry-backed cards):
+  - AoO that **defeats the actor mid-Move** → primary effect suppressed, spent
+    action + AoO events persist (re-validation abort path).
+  - AoO **cancelled by Dodge** → no damage, action completes.
+  - AoO **soaked onto Guard Dog → retaliate** fires against the AoO.
+  - **multi-attacker** AoO (two engaged ready enemies).
+  - the **re-validation-gate abort** path explicitly.
+- **Behaviour-preserving** for the no-AoO path (no engaged enemy) and the
+  no-window path (AoO with no available cancel/soak reaction): the existing engine
+  + integration suite stays green through K1.
+- **Per-slice green**: K2–K5 each add their own coverage (retaliate matrix;
+  fast-exempt AoO gating; 2+-enemy order choice; multi-soak distribution +
+  multi-window drain) and keep the prior slices green.
+
+## Open questions / deferrals
+
+- **No-op fast path.** When the actor has no engaged ready enemies, the AoO loop
+  is a no-op and no window can open — the `ActionResolution` frame is pushed and
+  immediately popped within one `apply()` call. Skipping the frame entirely in
+  that case is an available optimization, **deferred (YAGNI)** in favour of one
+  uniform code path; revisit only if profiling demands.
+- **K2 retaliate source routing** — new `EnemyAttackSource::Retaliate` vs. reuse;
+  settled in K2's thin design.
+- **K3 play-card action-cost site** — verify where the non-fast play cost is
+  charged before wiring AoO (prerequisite, above).
+- **K4 attacker-snapshot timing** — when the per-investigator attacker list is
+  fixed relative to Fast plays in the `BeforeInvestigatorAttacked` window;
+  settled in K4 alongside the frame extension.
+
+## What "done" looks like (the arc)
+
+Attacks of opportunity and retaliate resolve with **full player agency**: cancel
+(Dodge) and soak (Guard Dog retaliate) windows open against them; activated
+abilities and action-event plays provoke them; the player picks attack order with
+2+ engaged enemies and distributes damage/horror across soakers. The
+`ActionResolution` frame + re-validation gate are the engine substrate; the §D
+keystone matrix passes; the Gathering plays end-to-end through the new path. This
+closes Ordering step 4 of #393, leaving step 5 (#347 token emission) to finish the
+C checkpoint.


### PR DESCRIPTION
## Summary

Attacks of opportunity now open their cancel (Dodge 01023) and soak (Guard Dog 01021) reaction windows. Each AoO-provoking basic action runs as a suspendable `ActionResolution` continuation frame, so the AoO can drive through the shared attack loop, suspend on a window, and resume the action's primary effect after the window closes. This is **K1 — the foundation** of the keystone attack-loop arc (#393 Ordering step 4); K2–K5 (retaliate windows, AoO from activated abilities/action-events, player attack-order, damage distribution) follow on the same substrate.

## What changed

- **New `Continuation::ActionResolution { investigator, resume: ActionResume }` frame** pushed above `InvestigatorTurn`. The AoO `AttackLoop` is its child; cancel/soak windows are the loop's children. Transient — it persists across an `apply()` boundary only while a window suspends.
- **`drive_aoo`** routes attacks of opportunity through the existing `drive_attack_loop` (replacing the window-dropping `fire_attacks_of_opportunity`, now deleted), so AoO queue their `BeforeEnemyAttack` (Dodge) and `AfterEnemyAttackDamagedAsset` (Guard Dog) windows. AoO attackers do **not** exhaust (RR p.7) — source-gated in `process_attacker_dealing`; the enemy phase still exhausts.
- **The five AoO-firing basic actions** (Move/Investigate/Resource/Engage/Draw) restructure to `validate → spend action → push ActionResolution → drive_aoo`; each action's primary effect moves into a `*_primary_effect` fn run on resume.
- **`drive` extension + `resume_action_resolution`**: when the AoO loop pops, the uniform `drive` loop resumes the frame, which runs a **§D re-validation gate** (actor still `Status::Active` + the primary's own target precondition) then the primary effect — suppressing cleanly on a lapse (spent action + AoO/window effects persist). The `ActionResume` match is compiler-total.

## Design decisions

- **Generic frame + `resume` enum**, not one `Continuation` variant per action: unlike the per-phase anchors (which exist to make illegal phase/boundary pairings unrepresentable), there's no illegal action/stage cross-product here, so the generic form wins on less enum surface.
- **Pop-self-then-run-primary, no stage cursor**: the frame bridges exactly the AoO gap; the primary effect's own suspensions (Investigate's skill test) are independent frames resuming through their existing paths.
- **Re-validation is actor-Active + target precondition**: in 1-player Gathering scope the only mid-AoO change that fires is actor defeat, so the per-primary target re-checks (Engage co-location, Move connectivity, Investigate revealed) are a correct-by-construction structural hook, not yet independently exercised by a test — an intentional, documented deferral (design §D).
- Full arc design: `docs/superpowers/specs/2026-06-20-phase-7-keystone-mid-action-park-design.md`; K1 plan: `docs/superpowers/plans/2026-06-20-keystone-k1-aoo-mid-action-park.md`.

## Test notes

- **Integration (registry-backed, the #293 acceptance):** `crates/cards/tests/dodge_aoo.rs` (Dodge cancels an AoO; skip lets it land; Guard Dog retaliates vs AoO) and `crates/cards/tests/guard_dog_soak.rs` (Case 5 rewritten: the soak window now opens, Guard Dog deals 1 retaliate, attacker doesn't exhaust, the move completes after the frame resumes). Card text verified against ArkhamDB (01023/01021, incl. FAQ).
- **Unit:** per-action no-AoO (behaviour-preserving), nonlethal-AoO-survives, and lethal-AoO-suppresses-primary (spent action persists) cases; `drive_aoo` non-exhaust.
- Full native gauntlet green locally (`fmt`, `test --all`, `clippy --all-targets --all-features`, `doc --workspace`), plus `wasm-build` and `wasm-clippy`. wasm-test (headless browser) unaffected (no web code changed) — left to CI.

## Linked issues

Closes #293
