### PR TITLE
engine: Retaliate opens cancel/soak windows via the attack loop (K2 of #379)

### DIFF
--- a/crates/cards/tests/retaliate_windows.rs
+++ b/crates/cards/tests/retaliate_windows.rs
@@ -373,8 +373,8 @@ fn dodge_cancels_retaliate_and_skill_test_ends() {
         result.events
     );
 
-    // The retaliating enemy did NOT exhaust (RR p.18 + Dodge FAQ: enemy-phase
-    // cancels exhaust; retaliate never exhausts regardless — no exhaust here).
+    // The retaliating enemy did NOT exhaust: a retaliate attacker never
+    // exhausts, regardless of a cancel (RR p.18).
     assert!(
         !state.enemies[&enemy_id].exhausted,
         "a retaliate attacker does not exhaust, even after a Dodge cancel (RR p.18)"

--- a/crates/cards/tests/retaliate_windows.rs
+++ b/crates/cards/tests/retaliate_windows.rs
@@ -1,0 +1,426 @@
+//! Integration tests proving that a failed Fight against a ready retaliate
+//! enemy (a) lets Dodge cancel the resulting retaliate attack, and (b) lets
+//! Guard Dog retaliate against the retaliating enemy — the acceptance test
+//! for #379 (K2b).
+//!
+//! These are registry-backed proofs of the full
+//! `drive_retaliate` → suspend (`BeforeEnemyAttack` or
+//! `AfterEnemyAttackDamagedAsset` window) → `ResolveInput` → resume →
+//! `drive_skill_test` (teardown: `SkillTestEnded`, pop `SkillTest` frame)
+//! cycle.  That resume seam is not exercised by the unit tests in
+//! `game-core` (those don't install the real card registry and so the
+//! windows never open).
+//!
+//! ## Verified card text (`ArkhamDB`, 2026-06-21)
+//!
+//! **Dodge (01023)** — Event. Tactic. Cost 1. Fast.
+//! "Fast. Play when an enemy attacks an investigator at your location.
+//! Cancel that attack."
+//! FAQ:
+//!   - "Dodge can cancel any type of enemy attack: a normal attack during
+//!     the Enemy phase, an attack of opportunity, or a Retaliate attack."
+//!   - "If the attacking enemy has a Forced ability that says 'When attacks'
+//!     or 'After attacks', that ability does not trigger if an attack is
+//!     Dodged."
+//!   - "When a Massive enemy attacks each investigator in its location,
+//!     Dodge will cancel only one of these attacks, not all of them."
+//!   - "If an attack was cancelled during the Enemy phase, the attacking
+//!     enemy still exhausts."
+//!
+//! **Guard Dog (01021)** — Asset. Ally. Creature. Cost 3. Health 3, Sanity 1.
+//! "[reaction] When an enemy attack deals damage to Guard Dog: Deal 1 damage
+//! to the attacking enemy."
+//! FAQ:
+//!   - "You can use Guard Dog's ability when you assign lethal damage/horror
+//!     to it."
+//!   - Guard Dog's ability triggers only on damage, not horror.
+#![allow(clippy::too_many_lines)]
+
+use std::sync::Once;
+
+use game_core::engine::{apply, EngineOutcome, OptionId};
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, Continuation, Enemy, EnemyId,
+    InvestigatorId, LocationId, Phase, TokenModifiers, WindowKind,
+};
+use game_core::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
+use game_core::{Action, InputResponse, PlayerAction};
+
+/// Dodge (01023): Neutral Tactic, Fast, before-attack cancel reaction.
+const DODGE: &str = "01023";
+
+/// Guard Dog (01021): Guardian Ally, health 3 / sanity 1, damage-retaliate.
+const GUARD_DOG: &str = "01021";
+
+fn install_real_registry() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// Build a ready retaliate enemy at `loc`, engaged with `inv`.
+/// `fight` is set high enough that the investigator (combat 1) will fail
+/// the test with a `Numeric(0)` token (1 + 0 = 1 < fight).
+/// `attack_damage` is the retaliate attack's damage payload;
+/// `max_health` ensures the enemy can survive Guard Dog's 1-point retaliation.
+fn retaliate_enemy(
+    id: u32,
+    inv: InvestigatorId,
+    loc: LocationId,
+    fight: i8,
+    attack_damage: u8,
+    max_health: u8,
+) -> Enemy {
+    let mut e = test_enemy(id, format!("Retaliate Enemy {id}"));
+    e.fight = fight;
+    e.max_health = max_health;
+    e.attack_damage = attack_damage;
+    e.attack_horror = 0;
+    e.retaliate = true;
+    e.current_location = Some(loc);
+    e.engaged_with = Some(inv);
+    e
+}
+
+/// Build a minimal Investigation-phase state with one active investigator
+/// at a location, `enemy` engaged, and a deterministically-failing chaos bag
+/// (`Numeric(0)`; investigator combat = 1; enemy fight = 5 → 1 < 5 → fail).
+fn fight_state(
+    enemy: Enemy,
+    hand: Vec<CardCode>,
+    cards_in_play: Vec<CardInPlay>,
+) -> (game_core::GameState, InvestigatorId, LocationId) {
+    install_real_registry();
+
+    let inv_id = InvestigatorId(1);
+    let loc_id = LocationId(101);
+
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(loc_id);
+    // Low combat so the test always fails: 1 + Numeric(0) = 1 < 5 (enemy fight).
+    inv.skills.combat = 1;
+    inv.hand = hand;
+    inv.cards_in_play = cards_in_play;
+
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_location(test_location(101, "Study"))
+        .with_investigator(inv)
+        .with_active_investigator(inv_id)
+        .with_turn_order([inv_id])
+        .with_enemy(enemy)
+        // Single `Numeric(0)` token → total = combat(1) + 0 = 1 < fight(5) → fail.
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default())
+        .build();
+
+    (state, inv_id, loc_id)
+}
+
+/// Drive the Fight through its commit window with no commits, so that the
+/// chaos token is drawn and the skill test is resolved (failed → retaliate).
+/// Returns the `ApplyResult` from submitting the empty commit.
+fn submit_empty_commit(
+    state: game_core::GameState,
+    investigator: InvestigatorId,
+    enemy: EnemyId,
+) -> game_core::engine::ApplyResult {
+    // Step 1: initiate the Fight — suspends at the commit window.
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::Fight {
+            investigator,
+            enemy,
+        }),
+    );
+    assert!(
+        matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),
+        "Fight must suspend at the commit window: {:?}",
+        result.outcome
+    );
+
+    // Step 2: submit an empty commit — the chaos token is drawn, the test
+    // resolves (failed), and fire_retaliate_if_any is called.
+    apply(
+        result.state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickMultiple { selected: vec![] },
+        }),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — Guard Dog retaliates against the retaliate attack
+// ---------------------------------------------------------------------------
+
+/// Investigator controls Guard Dog, fails a Fight against a ready retaliate
+/// enemy → the retaliate runs through the attack loop (K2a, #379) → Guard
+/// Dog soaks the retaliate's 1 damage → the
+/// `AfterEnemyAttackDamagedAsset` window opens → fire Guard Dog's reaction
+/// → the retaliating enemy takes 1 → the Fight's skill test tears down
+/// cleanly (`SkillTestEnded` emitted, no `SkillTest` frame on the stack).
+#[test]
+fn guard_dog_retaliates_against_retaliate_and_skill_test_ends() {
+    install_real_registry();
+
+    let dog = CardInstanceId(1);
+    let inv_id = InvestigatorId(1);
+    let loc_id = LocationId(101);
+    let enemy_id = EnemyId(7);
+
+    // Enemy fight 5, damage 1 (soaks onto Guard Dog health 3), max_health 5
+    // (survives Guard Dog's 1-point retaliation after absorbing 0 prior damage).
+    let enemy = retaliate_enemy(7, inv_id, loc_id, 5, 1, 5);
+    let guard_dog_in_play = CardInPlay::enter_play(CardCode::new(GUARD_DOG), dog);
+
+    let (state, _, _) = fight_state(enemy, vec![], vec![guard_dog_in_play]);
+
+    // Initiate Fight → empty commit → fails → fire_retaliate_if_any → drive_retaliate
+    // → Guard Dog has no cancel reaction so BeforeEnemyAttack auto-skips → damage
+    // lands on Guard Dog → AfterEnemyAttackDamagedAsset window opens → suspend.
+    let result = submit_empty_commit(state, inv_id, enemy_id);
+    let mut state = result.state;
+
+    assert!(
+        matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),
+        "Guard Dog soak window must suspend after the failed Fight: {:?}",
+        result.outcome
+    );
+    assert!(
+        result
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::WindowOpened { kind }
+                if matches!(kind, WindowKind::AfterEnemyAttackDamagedAsset { .. }))),
+        "AfterEnemyAttackDamagedAsset window opened for the retaliate: {:?}",
+        result.events
+    );
+
+    // Guard Dog soaked the retaliate's 1 damage; investigator took none.
+    let dog_in_play = state.investigators[&inv_id]
+        .cards_in_play
+        .iter()
+        .find(|c| c.instance_id == dog)
+        .expect("Guard Dog still in play before reaction fires");
+    assert_eq!(
+        dog_in_play.accumulated_damage, 1,
+        "retaliate's 1 damage soaked onto Guard Dog"
+    );
+    assert_eq!(
+        state.investigators[&inv_id].damage, 0,
+        "investigator took no damage from the retaliate (Guard Dog soaked it)"
+    );
+    // Enemy has not retaliated back yet.
+    assert_eq!(state.enemies[&enemy_id].damage, 0);
+
+    // The SkillTest frame must still be present while the soak window is open
+    // (teardown only happens after the window closes via the resume seam).
+    assert!(
+        state
+            .continuations
+            .iter()
+            .any(|c| matches!(c, Continuation::SkillTest(_))),
+        "SkillTest frame must still be on the stack while the Guard Dog window is open"
+    );
+
+    // Fire Guard Dog's reaction (PickSingle(0) = the single offered trigger).
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickSingle(OptionId(0)),
+        }),
+    );
+    state = result.state;
+
+    // Guard Dog dealt 1 damage to the retaliating enemy.
+    assert_eq!(
+        state.enemies[&enemy_id].damage, 1,
+        "Guard Dog's reaction dealt 1 damage to the retaliating enemy"
+    );
+    assert!(
+        result.events.iter().any(|e| matches!(
+            e,
+            Event::EnemyDamaged { enemy, amount: 1, .. } if *enemy == enemy_id
+        )),
+        "EnemyDamaged {{ amount: 1 }} emitted: {:?}",
+        result.events
+    );
+
+    // The retaliating enemy did NOT exhaust (RR p.18: retaliate attacks do
+    // not exhaust the attacker; Dodge FAQ confirms this is not Enemy-phase).
+    assert!(
+        !state.enemies[&enemy_id].exhausted,
+        "a retaliate attack does not exhaust the attacker (RR p.18)"
+    );
+
+    // The Fight's skill test tore down cleanly after the window closed:
+    // SkillTestEnded was emitted and the SkillTest frame was popped.
+    assert!(
+        result.events.iter().any(|e| matches!(
+            e,
+            Event::SkillTestEnded { investigator } if *investigator == inv_id
+        )),
+        "SkillTestEnded emitted after Guard Dog window closed (K2 resume seam): {:?}",
+        result.events
+    );
+    assert!(
+        !state
+            .continuations
+            .iter()
+            .any(|c| matches!(c, Continuation::SkillTest(_))),
+        "no SkillTest frame on the stack after the skill test tore down: {:?}",
+        state.continuations
+    );
+
+    // No windows remain stranded.
+    assert!(
+        state.open_windows().is_empty(),
+        "no windows stranded after Guard Dog reaction + skill-test teardown: {:?}",
+        state.open_windows()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — Dodge cancels the retaliate attack; skill test tears down cleanly
+// ---------------------------------------------------------------------------
+
+/// Investigator has Dodge in hand, fails a Fight against a ready retaliate
+/// enemy → the retaliate runs through the attack loop → the
+/// `BeforeEnemyAttack` cancel window opens → play Dodge to cancel →
+/// no damage/horror from the retaliate → the Fight's skill test tears down
+/// cleanly (`SkillTestEnded` emitted, no `SkillTest` frame left).
+#[test]
+fn dodge_cancels_retaliate_and_skill_test_ends() {
+    install_real_registry();
+
+    let inv_id = InvestigatorId(1);
+    let loc_id = LocationId(101);
+    let enemy_id = EnemyId(7);
+
+    // Enemy fight 5, damage 2, max_health 5.  No Guard Dog — Dodge is the
+    // only reaction card.
+    let enemy = retaliate_enemy(7, inv_id, loc_id, 5, 2, 5);
+
+    let (state, _, _) = fight_state(enemy, vec![CardCode::new(DODGE)], vec![]);
+
+    // Initiate Fight → empty commit → fails → fire_retaliate_if_any → drive_retaliate
+    // → BeforeEnemyAttack window opens (Dodge in hand) → suspend.
+    let result = submit_empty_commit(state, inv_id, enemy_id);
+    let mut state = result.state;
+
+    assert!(
+        matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),
+        "BeforeEnemyAttack window must suspend after the failed Fight: {:?}",
+        result.outcome
+    );
+    assert!(
+        result
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::WindowOpened { kind }
+                if matches!(kind, WindowKind::BeforeEnemyAttack { .. }))),
+        "BeforeEnemyAttack window opened for the retaliate: {:?}",
+        result.events
+    );
+
+    // No damage yet; Dodge still in hand.
+    assert_eq!(
+        state.investigators[&inv_id].damage, 0,
+        "no damage before Dodge resolves"
+    );
+    assert_eq!(
+        state.investigators[&inv_id].horror, 0,
+        "no horror before Dodge resolves"
+    );
+    assert!(
+        state.investigators[&inv_id]
+            .hand
+            .contains(&CardCode::new(DODGE)),
+        "Dodge is still in hand while the cancel window is open"
+    );
+
+    // The SkillTest frame must still be present while the window is open.
+    assert!(
+        state
+            .continuations
+            .iter()
+            .any(|c| matches!(c, Continuation::SkillTest(_))),
+        "SkillTest frame present while BeforeEnemyAttack window is open"
+    );
+
+    // Play Dodge (PickSingle(0) = the single cancel candidate).
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickSingle(OptionId(0)),
+        }),
+    );
+    state = result.state;
+
+    // The retaliate was cancelled: no damage or horror dealt to the investigator.
+    assert_eq!(
+        state.investigators[&inv_id].damage, 0,
+        "Dodge cancelled the retaliate: no damage to the investigator"
+    );
+    assert_eq!(
+        state.investigators[&inv_id].horror, 0,
+        "Dodge cancelled the retaliate: no horror to the investigator"
+    );
+    assert!(
+        !result
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::DamageTaken { .. })),
+        "a Dodge-cancelled retaliate deals no damage: {:?}",
+        result.events
+    );
+
+    // The retaliating enemy did NOT exhaust (RR p.18 + Dodge FAQ: enemy-phase
+    // cancels exhaust; retaliate never exhausts regardless — no exhaust here).
+    assert!(
+        !state.enemies[&enemy_id].exhausted,
+        "a retaliate attacker does not exhaust, even after a Dodge cancel (RR p.18)"
+    );
+
+    // Dodge left the investigator's hand and went to discard.
+    assert!(
+        !state.investigators[&inv_id]
+            .hand
+            .contains(&CardCode::new(DODGE)),
+        "Dodge left hand after being played"
+    );
+    assert!(
+        state.investigators[&inv_id]
+            .discard
+            .contains(&CardCode::new(DODGE)),
+        "Dodge is in the discard pile after being played"
+    );
+
+    // The Fight's skill test tore down cleanly after the cancel window closed:
+    // SkillTestEnded was emitted and the SkillTest frame was popped.
+    assert!(
+        result.events.iter().any(|e| matches!(
+            e,
+            Event::SkillTestEnded { investigator } if *investigator == inv_id
+        )),
+        "SkillTestEnded emitted after Dodge cancel (K2 resume seam): {:?}",
+        result.events
+    );
+    assert!(
+        !state
+            .continuations
+            .iter()
+            .any(|c| matches!(c, Continuation::SkillTest(_))),
+        "no SkillTest frame on the stack after the skill test tore down: {:?}",
+        state.continuations
+    );
+
+    // No windows remain stranded.
+    assert!(
+        state.open_windows().is_empty(),
+        "no windows stranded after Dodge cancel + skill-test teardown: {:?}",
+        state.open_windows()
+    );
+}

--- a/crates/cards/tests/retaliate_windows.rs
+++ b/crates/cards/tests/retaliate_windows.rs
@@ -163,8 +163,6 @@ fn submit_empty_commit(
 /// cleanly (`SkillTestEnded` emitted, no `SkillTest` frame on the stack).
 #[test]
 fn guard_dog_retaliates_against_retaliate_and_skill_test_ends() {
-    install_real_registry();
-
     let dog = CardInstanceId(1);
     let inv_id = InvestigatorId(1);
     let loc_id = LocationId(101);
@@ -212,7 +210,7 @@ fn guard_dog_retaliates_against_retaliate_and_skill_test_ends() {
         state.investigators[&inv_id].damage, 0,
         "investigator took no damage from the retaliate (Guard Dog soaked it)"
     );
-    // Enemy has not retaliated back yet.
+    // Guard Dog has not yet dealt its retaliate damage to the enemy.
     assert_eq!(state.enemies[&enemy_id].damage, 0);
 
     // The SkillTest frame must still be present while the soak window is open
@@ -293,8 +291,6 @@ fn guard_dog_retaliates_against_retaliate_and_skill_test_ends() {
 /// cleanly (`SkillTestEnded` emitted, no `SkillTest` frame left).
 #[test]
 fn dodge_cancels_retaliate_and_skill_test_ends() {
-    install_real_registry();
-
     let inv_id = InvestigatorId(1);
     let loc_id = LocationId(101);
     let enemy_id = EnemyId(7);

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -537,6 +537,26 @@ fn build_soakers(state: &crate::state::GameState, investigator: InvestigatorId) 
 /// reaction window (Guard Dog 01021). Returns [`EngineOutcome::AwaitingInput`]
 /// if a window suspends the loop, [`EngineOutcome::Done`] otherwise. Attackers
 /// resolve in deterministic [`EnemyId`] order (player-pick is #143/K4). `AoO`
+/// Fire a single Retaliate attack from `enemy` against `investigator`, driving it
+/// through the shared attack loop (#379) so it opens the before-attack cancel
+/// window (Dodge 01023) and the per-soaked-asset reaction window (Guard Dog 01021).
+/// A retaliate is one enemy attacking once, so the attacker list is a singleton;
+/// the two sequential suspension points are tracked by [`AttackLoopStage`]. Returns
+/// [`AwaitingInput`] if a window suspends, [`Done`] otherwise. Non-exhausting
+/// (RR p.18) — honored by [`EnemyAttackSource::Retaliate`] (exhaust is
+/// `EnemyPhase`-gated). Caller (`fire_retaliate_if_any`) has already confirmed the
+/// enemy is ready + has the retaliate keyword.
+///
+/// [`AwaitingInput`]: crate::engine::EngineOutcome::AwaitingInput
+/// [`Done`]: crate::engine::EngineOutcome::Done
+pub(super) fn drive_retaliate(
+    cx: &mut Cx,
+    enemy: EnemyId,
+    investigator: InvestigatorId,
+) -> EngineOutcome {
+    drive_attack_loop(cx, investigator, vec![enemy], EnemyAttackSource::Retaliate)
+}
+
 /// attackers never exhaust (RR p.7) — honored by
 /// [`EnemyAttackSource::AttackOfOpportunity`].
 pub(super) fn drive_aoo(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
@@ -909,6 +929,10 @@ pub(super) fn resume_enemy_attack(cx: &mut Cx) -> EngineOutcome {
             super::reaction_windows::after_enemy_phase_attacks(cx, investigator)
         }
         EnemyAttackSource::AttackOfOpportunity => EngineOutcome::Done,
+        // The retaliate's window closed; the loop drained. Hand control back to the
+        // Fight's skill-test follow-up (its `SkillTest` frame is now top, cursor at
+        // `PostOnResolution`) so teardown finishes (#379).
+        EnemyAttackSource::Retaliate => super::skill_test::drive_skill_test(cx),
     }
 }
 
@@ -1318,6 +1342,39 @@ mod combat_tests {
             "an un-cancelled attack deals its damage"
         );
         assert!(state.enemies[&attacker].exhausted, "attacker exhausted");
+    }
+
+    #[test]
+    fn drive_retaliate_deals_damage_but_does_not_exhaust_the_attacker() {
+        // RR p.18: a retaliate attack does not exhaust the attacker.
+        let inv_id = InvestigatorId(1);
+        let mut enemy = test_enemy(100, "Retaliator");
+        enemy.retaliate = true;
+        enemy.attack_damage = 1;
+        enemy.attack_horror = 0;
+        // Not engaged: a retaliate fires regardless of engagement, driven by enemy id.
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_enemy(enemy)
+            .build();
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+
+        let outcome = super::drive_retaliate(&mut cx, EnemyId(100), inv_id);
+
+        assert!(matches!(outcome, crate::engine::EngineOutcome::Done));
+        assert!(
+            !cx.state.enemies[&EnemyId(100)].exhausted,
+            "retaliate must not exhaust (RR p.18)"
+        );
+        assert_eq!(
+            cx.state.investigators[&inv_id].damage, 1,
+            "retaliate dealt 1 damage"
+        );
+        assert_no_event!(events, Event::EnemyExhausted { .. });
     }
 
     #[test]

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -537,6 +537,24 @@ fn build_soakers(state: &crate::state::GameState, investigator: InvestigatorId) 
 /// reaction window (Guard Dog 01021). Returns [`EngineOutcome::AwaitingInput`]
 /// if a window suspends the loop, [`EngineOutcome::Done`] otherwise. Attackers
 /// resolve in deterministic [`EnemyId`] order (player-pick is #143/K4). `AoO`
+/// attackers never exhaust (RR p.7) — honored by
+/// [`EnemyAttackSource::AttackOfOpportunity`].
+pub(super) fn drive_aoo(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
+    let attackers: Vec<EnemyId> = cx
+        .state
+        .enemies
+        .iter()
+        .filter(|(_, e)| e.engaged_with == Some(investigator) && !e.exhausted)
+        .map(|(id, _)| *id)
+        .collect();
+    drive_attack_loop(
+        cx,
+        investigator,
+        attackers,
+        EnemyAttackSource::AttackOfOpportunity,
+    )
+}
+
 /// Fire a single Retaliate attack from `enemy` against `investigator`, driving it
 /// through the shared attack loop (#379) so it opens the before-attack cancel
 /// window (Dodge 01023) and the per-soaked-asset reaction window (Guard Dog 01021).
@@ -555,24 +573,6 @@ pub(super) fn drive_retaliate(
     investigator: InvestigatorId,
 ) -> EngineOutcome {
     drive_attack_loop(cx, investigator, vec![enemy], EnemyAttackSource::Retaliate)
-}
-
-/// attackers never exhaust (RR p.7) — honored by
-/// [`EnemyAttackSource::AttackOfOpportunity`].
-pub(super) fn drive_aoo(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutcome {
-    let attackers: Vec<EnemyId> = cx
-        .state
-        .enemies
-        .iter()
-        .filter(|(_, e)| e.engaged_with == Some(investigator) && !e.exhausted)
-        .map(|(id, _)| *id)
-        .collect();
-    drive_attack_loop(
-        cx,
-        investigator,
-        attackers,
-        EnemyAttackSource::AttackOfOpportunity,
-    )
 }
 
 /// Resolve all of one investigator's engaged ready enemies' attacks
@@ -1374,6 +1374,7 @@ mod combat_tests {
             cx.state.investigators[&inv_id].damage, 1,
             "retaliate dealt 1 damage"
         );
+        assert_event!(events, Event::DamageTaken { .. });
         assert_no_event!(events, Event::EnemyExhausted { .. });
     }
 

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -440,11 +440,17 @@ pub(super) fn drive_skill_test(cx: &mut Cx) -> EngineOutcome {
                     .continuation = FinishContinuation::PostRetaliate { succeeded };
             }
             FinishContinuation::PostRetaliate { succeeded } => {
-                fire_retaliate_if_any(cx, investigator, succeeded);
+                // Advance the cursor first: a retaliate that suspends on its
+                // cancel/soak window resumes here at PostOnResolution (the retaliate
+                // already happened; only its window is being resolved).
                 cx.state
                     .current_skill_test_mut()
                     .expect("the SkillTest frame must persist across driver steps")
                     .continuation = FinishContinuation::PostOnResolution { succeeded };
+                let outcome = fire_retaliate_if_any(cx, investigator, succeeded);
+                if matches!(outcome, EngineOutcome::AwaitingInput { .. }) {
+                    return outcome; // parked on the retaliate's window; resume via drive_skill_test
+                }
             }
             FinishContinuation::PostOnResolution { succeeded: _ } => {
                 // "After you successfully investigate" (Obscuring Fog forced +
@@ -840,24 +846,33 @@ fn apply_skill_test_follow_up(
 ///
 /// Runs at the `PostRetaliate` step — after `fire_on_skill_test_resolution`
 /// (the rest of ST.7) and before the `PostOnResolution` teardown (ST.8) —
-/// matching "after applying all results." The attack routes through
-/// [`super::combat::enemy_attack`], which does not exhaust the attacker,
-/// satisfying the no-exhaust clause for free.
+/// matching "after applying all results." Routes through
+/// [`super::combat::drive_retaliate`] so the attack opens its before-attack
+/// cancel window (Dodge 01023) and per-soaked-asset soak window (Guard Dog
+/// 01021) (#379). Returns [`AwaitingInput`] if a window suspends, [`Done`]
+/// otherwise. Non-exhausting (RR p.18) — honored by
+/// [`EnemyAttackSource::Retaliate`] inside `drive_retaliate`.
 ///
 /// No-op unless every condition holds: the test failed; its follow-up was
 /// `Fight`; the enemy is still in play, ready (`!exhausted`), and has
 /// `retaliate`. A missing enemy is skipped quietly — a failed fight deals
 /// no damage, so the target can't have been defeated mid-test; this only
-/// guards against future enemy-removing commit effects. This step is also
-/// the future home of the "after an enemy attacks" reaction window (Guard
-/// Dog C5b, Roland's reaction).
-fn fire_retaliate_if_any(cx: &mut Cx, investigator: InvestigatorId, succeeded: bool) {
+/// guards against future enemy-removing commit effects.
+///
+/// [`AwaitingInput`]: crate::engine::EngineOutcome::AwaitingInput
+/// [`Done`]: crate::engine::EngineOutcome::Done
+/// [`EnemyAttackSource::Retaliate`]: crate::state::EnemyAttackSource::Retaliate
+fn fire_retaliate_if_any(
+    cx: &mut Cx,
+    investigator: InvestigatorId,
+    succeeded: bool,
+) -> EngineOutcome {
     if succeeded {
-        return;
+        return EngineOutcome::Done;
     }
     let follow_up = cx.state.current_skill_test().map(|t| t.follow_up);
     let Some(SkillTestFollowUp::Fight { enemy, .. }) = follow_up else {
-        return;
+        return EngineOutcome::Done;
     };
     let retaliates = cx
         .state
@@ -865,7 +880,11 @@ fn fire_retaliate_if_any(cx: &mut Cx, investigator: InvestigatorId, succeeded: b
         .get(&enemy)
         .is_some_and(|e| e.retaliate && !e.exhausted);
     if retaliates {
-        super::combat::enemy_attack(cx, enemy, investigator);
+        // Route through the attack loop (#379) so the retaliate opens its cancel
+        // (Dodge) and soak (Guard Dog) windows; non-exhausting (RR p.18).
+        super::combat::drive_retaliate(cx, enemy, investigator)
+    } else {
+        EngineOutcome::Done
     }
 }
 

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -2073,6 +2073,36 @@ mod tests {
     }
 
     #[test]
+    fn retaliate_via_loop_does_not_exhaust_the_enemy() {
+        // After K2 routes retaliate through drive_attack_loop, a failed Fight against a
+        // ready retaliate enemy still deals the retaliate damage AND leaves the enemy
+        // ready (RR p.18) — the loop path must not exhaust it.
+        let (inv_id, enemy_id, mut state) = fight_evade_scenario();
+        state.investigators.get_mut(&inv_id).unwrap().skills.combat = 1; // vs fight 3 → fail
+        let e = state.enemies.get_mut(&enemy_id).unwrap();
+        e.retaliate = true;
+        e.attack_damage = 1;
+        e.attack_horror = 0;
+        let result = apply_no_commits(
+            state,
+            Action::Player(PlayerAction::Fight {
+                investigator: inv_id,
+                enemy: enemy_id,
+            }),
+        );
+
+        assert_eq!(result.outcome, EngineOutcome::Done);
+        assert_event!(result.events, Event::SkillTestFailed { .. });
+        // Retaliate damage landed.
+        assert_eq!(result.state.investigators[&inv_id].damage, 1);
+        // Enemy must remain ready (not exhausted) after the retaliate (RR p.18).
+        assert!(!result.state.enemies[&enemy_id].exhausted);
+        assert_no_event!(result.events, Event::EnemyExhausted { .. });
+        // Skill test still tears down cleanly.
+        assert_event!(result.events, Event::SkillTestEnded { .. });
+    }
+
+    #[test]
     fn fight_defeats_enemy_when_damage_reaches_max_health() {
         // Enemy at 1/2 already; Fight success → damage 2, defeated,
         // removed from state, engagement cleared.

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -319,6 +319,8 @@ pub enum EnemyAttackSource {
     EnemyPhase,
     /// Attack of opportunity (`drive_aoo`).
     AttackOfOpportunity,
+    /// Retaliate attack from a failed Fight (`drive_retaliate`, RR p.18).
+    Retaliate,
 }
 
 /// Which point in the per-attacker sequence a parked enemy-attack loop

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -49,7 +49,7 @@ Lita's Parley), **not** the gate. #77 stays open for its Parley half.
 one shared mechanism (mid-action park/resume), now a sub-sliced arc **K1→K5**
 (see Ordering step 4 + its design spec). **The foundation shipped:**
 - ✅ [#293](https://github.com/talelburg/eldritch/issues/293) — AoO open cancel/soak windows (Guard Dog, Dodge). **Shipped — K1, PR #413** (`ActionResolution` frame + `drive_aoo`).
-- [#379](https://github.com/talelburg/eldritch/issues/379) — Retaliate opens no soak/cancel window (Guard Dog, Dodge). **K2.**
+- ✅ [#379](https://github.com/talelburg/eldritch/issues/379) — Retaliate opens cancel/soak windows (Guard Dog, Dodge). **Shipped — K2, PR #414** (`drive_retaliate`; resume re-enters `drive_skill_test`).
 - [#361](https://github.com/talelburg/eldritch/issues/361) — activated abilities don't provoke AoO (First Aid, Medical Texts, Flashlight). **K3.**
 - [#378](https://github.com/talelburg/eldritch/issues/378) — action-event play doesn't provoke AoO (Dynamite Blast, Emergency Cache). **K3.**
 
@@ -80,7 +80,8 @@ clue" is stubbed; needs the dynamic skill-test-modifier DSL surface
    - **Slice 3 — `AttackLoop` frame (cursor lift). ✅ shipped (PR #412, closes #411).** Lifted the last two framework cursors onto the stack: the parked enemy-attack loop is now a `Continuation::AttackLoop` frame (inserted *beneath* the reaction window it suspends on), and the per-investigator cursor is the `EnemyPhase` anchor's `attacking: Option<InvestigatorId>` field. Behaviour-preserving. **Deliberately Shape A:** the `AttackLoop` frame spans only the *parked suspension*, not the whole per-investigator step 3.3 — see the keystone caveat below.
 4. **The keystone: mid-action suspend/resume — 🔨 in progress (K1 shipped).** Designed in its own spec ([`2026-06-20-phase-7-keystone-mid-action-park-design.md`](../superpowers/specs/2026-06-20-phase-7-keystone-mid-action-park-design.md)) — §D of #393 expanded into a sub-sliced arc **K1→K5** collapsing #293/#379/#361/#378/#143/#44 (+#119), the highest-leverage item in the phase. The action parks its *triggering action* on a `Continuation::ActionResolution` frame (above `InvestigatorTurn`) with the AoO `AttackLoop` (slice 3 / #411) as its child; on the loop's pop an `on_child_pop` re-validation gate (actor-Active + the primary's target precondition) resumes the action's primary effect, aborting cleanly on a mid-action lapse.
    - **K1 — AoO open cancel/soak windows (#293). ✅ shipped (PR #413).** `ActionResolution` frame + `drive_aoo`; the five basic actions fire AoO through `drive_attack_loop`, so Dodge cancels and Guard Dog retaliates against an AoO; `fire_attacks_of_opportunity` deleted. RR p.7 AoO-non-exhaust source-gated.
-   - **K2 #379** retaliate windows · **K3 #361/#378** AoO from activated abilities + action-event play · **K4 #143** player attack-order — *also extends the enemy-phase `AttackLoop` to span the whole step 3.3 (resolving slice 3's Shape-A caveat) and settles attacker-snapshot timing* · **K5 #44 (+#119)** player damage/soak distribution. Each rides the K1 substrate.
+   - **K2 — Retaliate opens cancel/soak windows (#379). ✅ shipped (PR #414).** `drive_retaliate` routes the failed-Fight retaliate through `drive_attack_loop` under `EnemyAttackSource::Retaliate`; the resume re-enters `drive_skill_test` (the retaliate's park point is the existing `SkillTest` frame, not an `ActionResolution` frame).
+   - **K3 #361/#378** AoO from activated abilities + action-event play · **K4 #143** player attack-order — *also extends the enemy-phase `AttackLoop` to span the whole step 3.3 (resolving slice 3's Shape-A caveat) and settles attacker-snapshot timing* · **K5 #44 (+#119)** player damage/soak distribution. Each rides the K1 substrate.
 5. **Skill-test windows** (#374 + #64) — one reaction-window work-stream, offered as frame options on the #393 model.
 6. **Roland elder-sign** (#118).
 7. **Edge correctness** (#300 after Engage, then #368, #353).
@@ -213,8 +214,11 @@ a `Continuation::ActionResolution` frame and fire AoO via **`drive_aoo`** →
 `drive_attack_loop` (so `EnemyAttackSource::AttackOfOpportunity` is now live), opening
 the cancel (Dodge) and soak (Guard Dog) windows; on the loop's pop the `drive` loop
 resumes the action frame under an actor-Active + target re-validation gate.
-**`fire_retaliate_if_any` still calls `enemy_attack` directly, bypassing the loop —
-K2 (#379) routes it through the same mechanism.** Exhaust rules differ by source:
+**K2 (PR #414) routed `fire_retaliate_if_any` through `drive_retaliate` →
+`drive_attack_loop` (`EnemyAttackSource::Retaliate`), so a failed-Fight retaliate now
+opens the cancel/soak windows too; its resume re-enters `drive_skill_test` (the
+retaliate's park point is the `SkillTest` frame). No direct-`enemy_attack` window
+bypass remains.** Exhaust rules differ by source:
 enemy-phase always exhausts (cancelled too — RR p.6/p.25); AoO never (RR p.7 —
 source-gated in `process_attacker_dealing`); Retaliate never (RR p.18). Activating an
 ability or playing an event fire no AoO yet — **K3 (#361/#378)**.

--- a/docs/superpowers/plans/2026-06-21-k2-retaliate-windows.md
+++ b/docs/superpowers/plans/2026-06-21-k2-retaliate-windows.md
@@ -1,0 +1,294 @@
+# K2 — Retaliate cancel/soak windows — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a failed-Fight Retaliate attack open its cancel (Dodge 01023) and soak (Guard Dog 01021) reaction windows by routing it through the shared attack loop, resuming the Fight's skill-test teardown after the window closes (#379).
+
+**Architecture:** `fire_retaliate_if_any` stops calling `combat::enemy_attack` directly and instead drives the single retaliate attacker through the existing `drive_attack_loop` under a new `EnemyAttackSource::Retaliate` (reusing K1's `BeforeEnemyAttack`/`AfterEnemyAttackDamagedAsset` windows + `AttackLoopStage` two-stage cursor, and K1's `EnemyPhase`-gated non-exhaust). The retaliate fires from the `PostRetaliate` stage of the skill-test follow-up, which runs on the existing `SkillTest` continuation frame; on the window's close, `resume_enemy_attack`'s new `Retaliate` arm re-enters `drive_skill_test` so the follow-up finishes teardown.
+
+**Tech Stack:** Rust, `game-core` kernel crate (compiles to wasm via the `web` crate), `cards` content crate for registry-backed integration tests. Event-sourced `apply`; serializable `Continuation` stack.
+
+## Global Constraints
+
+- **Match CI's strict flags before pushing:** `RUSTFLAGS="-D warnings" cargo test --all --all-features`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo fmt --check`; `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`. (Per-task: run at least `fmt --check`, `clippy -p game-core`, and the doc build for the crate you touched — accumulated fmt/doc drift bit the K1 slice when only `test`+`clippy` were run per task.)
+- **Handler contract — validate-first / mutate-second** stays intact; K2 changes a *route*, not when retaliate fires or its damage.
+- **`game-core` never depends on `cards`:** card-data via `card_registry::current()`; registry-free unit tests get the no-registry fallback (no reaction windows open). Tests needing real card abilities live in `crates/cards/tests/`.
+- **RR p.18 (verified, quoted in the existing `fire_retaliate_if_any` doc):** *"Each time an investigator fails a skill test while attacking a ready enemy with the retaliate keyword, after applying all results for that skill test, that enemy performs an attack against the attacking investigator. An enemy does not exhaust after performing a retaliate attack."* — trigger is **failed Fight only**; **no exhaust** (already satisfied: exhaust is gated to `EnemyAttackSource::EnemyPhase` in `process_attacker_dealing`).
+- **Card text verified, never paraphrased:** confirm Dodge 01023 / Guard Dog 01021 text + FAQ at `https://arkhamdb.com/card/01023` / `/01021` before asserting in K2b.
+- **Event-assertion macros** (`assert_event!` / `assert_no_event!` / `assert_event_sequence!`) over raw slice indexing.
+
+---
+
+### Task 1 (K2a): Route retaliate through the attack loop
+
+The whole engine change as one reviewable unit: the new source variant, the `drive_retaliate` helper, the suspendable `fire_retaliate_if_any`, the `PostRetaliate` suspension handling, and the resume arm. The no-window path is behaviour-preserving (the existing `failed_fight_*` tests stay green); the window-suspend/resume path is first exercised by Task 2's registry-backed tests (mirroring K1, where the suspend path lived in the integration task).
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (the `EnemyAttackSource` enum, ~line 317)
+- Modify: `crates/game-core/src/engine/dispatch/combat.rs` (add `drive_retaliate`; `resume_enemy_attack`'s `match source` tail, ~line 922)
+- Modify: `crates/game-core/src/engine/dispatch/skill_test.rs` (`fire_retaliate_if_any` ~line 854; the `PostRetaliate` arm of `drive_skill_test` ~line 442)
+- Test: `crates/game-core/src/engine/dispatch/combat.rs` (`#[cfg(test)] mod combat_tests`) + the existing `engine/mod.rs` retaliate tests stay green.
+
+**Interfaces:**
+- Consumes: `drive_attack_loop(cx, investigator, attackers: Vec<EnemyId>, source) -> EngineOutcome`; `skill_test::drive_skill_test(cx) -> EngineOutcome` (pub(super)); `Continuation::SkillTest` carrying the `FinishContinuation` cursor.
+- Produces: `EnemyAttackSource::Retaliate`; `pub(super) fn drive_retaliate(cx: &mut Cx, enemy: EnemyId, investigator: InvestigatorId) -> EngineOutcome`; `fire_retaliate_if_any(cx, investigator, succeeded) -> EngineOutcome` (was `()`).
+
+- [ ] **Step 1: Write the failing test — `drive_retaliate` deals damage and does not exhaust**
+
+Add to `combat_tests` (mirror the existing `drive_aoo_deals_damage_but_does_not_exhaust_the_attacker` test for the harness idiom — same `Cx { state, events }` construction and real `Event` names):
+
+```rust
+#[test]
+fn drive_retaliate_deals_damage_but_does_not_exhaust_the_attacker() {
+    // RR p.18: a retaliate attack does not exhaust the attacker.
+    let inv_id = InvestigatorId(1);
+    let mut enemy = test_enemy(100, "Retaliator");
+    enemy.retaliate = true;
+    enemy.attack_damage = 1;
+    enemy.attack_horror = 0;
+    // Not engaged: a retaliate fires regardless of engagement, driven by enemy id.
+    let mut state = GameStateBuilder::new()
+        .with_investigator(test_investigator(1))
+        .with_enemy(enemy)
+        .build();
+    let mut events = Vec::new();
+    let mut cx = Cx { state: &mut state, events: &mut events };
+
+    let outcome = super::drive_retaliate(&mut cx, EnemyId(100), inv_id);
+
+    assert!(matches!(outcome, crate::engine::EngineOutcome::Done));
+    assert!(!cx.state.enemies[&EnemyId(100)].exhausted, "retaliate must not exhaust (RR p.18)");
+    assert_eq!(cx.state.investigators[&inv_id].damage, 1, "retaliate dealt 1 damage");
+    assert_no_event!(events, Event::EnemyExhausted { .. });
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p game-core --lib drive_retaliate_deals_damage`
+Expected: FAIL — `drive_retaliate` not found.
+
+- [ ] **Step 3: Add the `Retaliate` source variant**
+
+In `game_state.rs`, extend `EnemyAttackSource`:
+
+```rust
+pub enum EnemyAttackSource {
+    /// Enemy-phase step 3.3 (`resolve_attacks_for_investigator`).
+    EnemyPhase,
+    /// Attack of opportunity (`drive_aoo`).
+    AttackOfOpportunity,
+    /// Retaliate attack from a failed Fight (`drive_retaliate`, RR p.18).
+    Retaliate,
+}
+```
+
+- [ ] **Step 4: Add `drive_retaliate`**
+
+In `combat.rs`, next to `drive_aoo`:
+
+```rust
+/// Fire a single Retaliate attack from `enemy` against `investigator`, driving it
+/// through the shared attack loop (#379) so it opens the before-attack cancel
+/// window (Dodge 01023) and the per-soaked-asset reaction window (Guard Dog 01021).
+/// A retaliate is one enemy attacking once, so the attacker list is a singleton;
+/// the two sequential suspension points are tracked by [`AttackLoopStage`]. Returns
+/// [`AwaitingInput`] if a window suspends, [`Done`] otherwise. Non-exhausting
+/// (RR p.18) — honored by [`EnemyAttackSource::Retaliate`] (exhaust is
+/// `EnemyPhase`-gated). Caller (`fire_retaliate_if_any`) has already confirmed the
+/// enemy is ready + has the retaliate keyword.
+///
+/// [`AwaitingInput`]: crate::engine::EngineOutcome::AwaitingInput
+/// [`Done`]: crate::engine::EngineOutcome::Done
+pub(super) fn drive_retaliate(
+    cx: &mut Cx,
+    enemy: EnemyId,
+    investigator: InvestigatorId,
+) -> EngineOutcome {
+    drive_attack_loop(cx, investigator, vec![enemy], EnemyAttackSource::Retaliate)
+}
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `cargo test -p game-core --lib drive_retaliate_deals_damage`
+Expected: PASS.
+Run: `cargo build -p game-core 2>&1 | grep -i "non-exhaustive\|match"` — expect the `resume_enemy_attack` `match source` to now be non-exhaustive (compile error). That is the next step's failing signal:
+
+Run: `RUSTFLAGS="-D warnings" cargo build -p game-core`
+Expected: FAIL — `match source` in `resume_enemy_attack` doesn't cover `Retaliate`.
+
+- [ ] **Step 6: Wire the resume arm**
+
+In `combat.rs`, `resume_enemy_attack`'s `match source` tail, add the `Retaliate` arm:
+
+```rust
+    match source {
+        EnemyAttackSource::EnemyPhase => {
+            super::reaction_windows::after_enemy_phase_attacks(cx, investigator)
+        }
+        EnemyAttackSource::AttackOfOpportunity => EngineOutcome::Done,
+        // The retaliate's window closed; the loop drained. Hand control back to the
+        // Fight's skill-test follow-up (its `SkillTest` frame is now top, cursor at
+        // `PostOnResolution`) so teardown finishes (#379).
+        EnemyAttackSource::Retaliate => super::skill_test::drive_skill_test(cx),
+    }
+```
+
+Run: `RUSTFLAGS="-D warnings" cargo build -p game-core`
+Expected: PASS (match is total again).
+
+- [ ] **Step 7: Write the failing test — retaliate still fires + the new route keeps the existing behaviour**
+
+The existing retaliate tests (`engine/mod.rs`: `failed_fight_against_ready_retaliate_enemy_triggers_attack`, `successful_fight_against_retaliate_enemy_does_not_trigger_attack`, `failed_fight_against_exhausted_retaliate_enemy_does_not_trigger_attack`) are the behaviour-preservation pins; they must stay green after Step 8. They already assert the investigator takes retaliate damage on a failed Fight and not otherwise. Run them now to confirm the baseline:
+
+Run: `cargo test -p game-core --lib retaliate`
+Expected: PASS (pre-change baseline).
+
+Add one new pin for the non-exhaust route in `engine/mod.rs` next to those tests (use that module's existing builder idiom for a failed Fight; copy the setup from `failed_fight_against_ready_retaliate_enemy_triggers_attack`):
+
+```rust
+#[test]
+fn retaliate_via_loop_does_not_exhaust_the_enemy() {
+    // After K2 routes retaliate through drive_attack_loop, a failed Fight against a
+    // ready retaliate enemy still deals the retaliate damage AND leaves the enemy
+    // ready (RR p.18) — the loop path must not exhaust it.
+    // ... build a failed-Fight scenario vs a ready retaliate enemy (copy the
+    //     setup from failed_fight_against_ready_retaliate_enemy_triggers_attack),
+    //     drive it to completion, then assert:
+    //   - the investigator took the enemy's attack_damage (retaliate landed), and
+    //   - state.enemies[&enemy].exhausted == false.
+}
+```
+
+- [ ] **Step 8: Make `fire_retaliate_if_any` suspendable + route through `drive_retaliate`; handle the `PostRetaliate` suspension**
+
+In `skill_test.rs`, change `fire_retaliate_if_any` to return `EngineOutcome` and route through `drive_retaliate`:
+
+```rust
+fn fire_retaliate_if_any(
+    cx: &mut Cx,
+    investigator: InvestigatorId,
+    succeeded: bool,
+) -> EngineOutcome {
+    if succeeded {
+        return EngineOutcome::Done;
+    }
+    let follow_up = cx.state.current_skill_test().map(|t| t.follow_up);
+    let Some(SkillTestFollowUp::Fight { enemy, .. }) = follow_up else {
+        return EngineOutcome::Done;
+    };
+    let retaliates = cx
+        .state
+        .enemies
+        .get(&enemy)
+        .is_some_and(|e| e.retaliate && !e.exhausted);
+    if retaliates {
+        // Route through the attack loop (#379) so the retaliate opens its cancel
+        // (Dodge) and soak (Guard Dog) windows; non-exhausting (RR p.18).
+        super::combat::drive_retaliate(cx, enemy, investigator)
+    } else {
+        EngineOutcome::Done
+    }
+}
+```
+
+Update the `PostRetaliate` arm of `drive_skill_test` (advance the cursor **before** firing, so a suspended retaliate resumes at `PostOnResolution`; propagate a suspension):
+
+```rust
+            FinishContinuation::PostRetaliate { succeeded } => {
+                // Advance the cursor first: a retaliate that suspends on its
+                // cancel/soak window resumes here at PostOnResolution (the retaliate
+                // already happened; only its window is being resolved).
+                cx.state
+                    .current_skill_test_mut()
+                    .expect("the SkillTest frame must persist across driver steps")
+                    .continuation = FinishContinuation::PostOnResolution { succeeded };
+                let outcome = fire_retaliate_if_any(cx, investigator, succeeded);
+                if matches!(outcome, EngineOutcome::AwaitingInput { .. }) {
+                    return outcome; // parked on the retaliate's window; resume via drive_skill_test
+                }
+            }
+```
+
+Also update `fire_retaliate_if_any`'s doc-comment: it now routes through `drive_retaliate` (not `enemy_attack`) and opens the cancel/soak windows; drop the "future home of the reaction window" line (now realized for the attack windows; the separate after-resolution window is still #64).
+
+- [ ] **Step 9: Run the retaliate suite + the new pin**
+
+Run: `cargo test -p game-core --lib retaliate`
+Expected: PASS (existing pins green + `retaliate_via_loop_does_not_exhaust_the_enemy`).
+Run: `RUSTFLAGS="-D warnings" cargo test -p game-core`
+Expected: PASS (full crate — the no-window route is behaviour-preserving everywhere).
+
+- [ ] **Step 10: Per-task gauntlet + commit**
+
+Run: `cargo clippy -p game-core --all-targets --all-features -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc -p game-core --no-deps --all-features`, `cargo fmt` then `cargo fmt --check`.
+Expected: all clean.
+
+```bash
+git add crates/game-core/src/state/game_state.rs crates/game-core/src/engine/dispatch/combat.rs crates/game-core/src/engine/dispatch/skill_test.rs crates/game-core/src/engine/mod.rs
+git commit -m "engine: route Retaliate through the attack loop so it opens cancel/soak windows (K2a of #379)"
+```
+
+---
+
+### Task 2 (K2b): Integration — Dodge cancels + Guard Dog retaliates against a retaliate
+
+The registry-backed proof of the suspend→`ResolveInput`→resume cycle and the #379 acceptance. This is where the `Retaliate` resume arm (Task 1, Step 6) is first exercised end-to-end.
+
+**Files:**
+- Create: `crates/cards/tests/retaliate_windows.rs`
+
+**Interfaces:**
+- Consumes: `cards::REGISTRY` (installed per test process); the Fight action + `InputResponse` for window resolution; a `retaliate`-keyword enemy. Follow the harness pattern in `crates/cards/tests/dodge_aoo.rs` and `guard_dog_soak.rs` (K1).
+
+- [ ] **Step 1: Verify card text before asserting**
+
+WebFetch `https://arkhamdb.com/card/01023` (Dodge) and `https://arkhamdb.com/card/01021` (Guard Dog), **including FAQ**. Confirm Dodge cancels an enemy attack (a retaliate is an enemy attack) and Guard Dog's reaction deals 1 to the attacking enemy when it soaks damage. Record the verified text in the test file's header comment. If WebFetch is unavailable, fall back to `data/arkhamdb-snapshot/pack/` and say so in the report.
+
+- [ ] **Step 2: Write the failing test — Guard Dog retaliates against a retaliate**
+
+In `retaliate_windows.rs` (install `cards::REGISTRY` per the existing tests' pattern): set up an investigator controlling Guard Dog in play, at a ready `retaliate`-keyword enemy (a `test_enemy` with `retaliate = true` is fine — the registry is for Dodge/Guard Dog, not the enemy). Force a **failed Fight** (low combat vs high enemy fight + a deterministic chaos token so the total misses). The failed Fight fires the retaliate; its damage soaks onto Guard Dog, opening the `AfterEnemyAttackDamagedAsset` window; resolve it (`ResolveInput`) so Guard Dog deals 1 to the retaliating enemy. Assert: the enemy took 1 (Guard Dog's reaction), the enemy did **not** exhaust (RR p.18), and the Fight's skill test completed afterward (`Event::SkillTestEnded` fired; no `SkillTest` frame remains on `state.continuations`).
+
+- [ ] **Step 3: Write the failing test — Dodge cancels a retaliate**
+
+Same setup but Dodge in hand instead (or alongside): the failed Fight fires the retaliate; the `BeforeEnemyAttack` window opens; play Dodge (`ResolveInput`) to cancel. Assert: no damage/horror dealt by the retaliate (investigator damage unchanged from pre-retaliate), the enemy did not exhaust, and the skill test completed (`SkillTestEnded`, no `SkillTest` frame left).
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test -p cards --test retaliate_windows`
+Expected: PASS — Tasks 1+2 together wire the full cycle. If a test FAILs (e.g. the skill test never tears down after the window, or the retaliate window never opens), debug the resume chain (`drive_retaliate` → window → `resume_enemy_attack` Retaliate arm → `drive_skill_test` → teardown). Do **not** weaken assertions to pass.
+
+- [ ] **Step 5: Full CI gauntlet**
+
+```bash
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cards/tests/retaliate_windows.rs
+git commit -m "test: Dodge cancels + Guard Dog retaliates against a retaliate attack (closes #379)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** ✅ new `EnemyAttackSource::Retaliate` + `drive_retaliate` (Task 1 Steps 3–4); `fire_retaliate_if_any` returns `EngineOutcome` + routes through the loop (Step 8); `PostRetaliate` advances the cursor before firing + propagates the suspension (Step 8); `resume_enemy_attack` Retaliate arm re-enters `drive_skill_test` (Step 6); non-exhaust inherited (covered by the Step-1 and Step-7 tests); failed-Fight-only scope unchanged (the gate in `fire_retaliate_if_any` is untouched); Dodge-cancel + Guard-Dog-retaliate windows (Task 2). The "after an enemy attacks" window (#64) is explicitly out of scope and no task adds it.
+- **Placeholder scan:** the two `// ...` markers (Task 1 Step 7 test body, Task 2 test bodies) are explicit "copy the setup from named existing test" instructions with concrete assertions enumerated, not vague logic — the registry-backed Fight-setup idiom is non-trivial and lives in the named sibling tests, so pointing at them is correct over transcribing a guessed setup.
+- **Type consistency:** `drive_retaliate(cx, enemy, investigator) -> EngineOutcome`, `fire_retaliate_if_any(...) -> EngineOutcome`, and `EnemyAttackSource::Retaliate` are named identically across the tasks that define and call them; the `resume_enemy_attack` arm and the `PostRetaliate` handler both rely on `drive_skill_test(cx) -> EngineOutcome` (the real pub(super) signature).
+
+## Risks & notes for the implementer
+
+- **The resume chain is the seam:** a retaliate window closing must unwind `resume_enemy_attack` (pops the `AttackLoop`, drains) → its `Retaliate` arm → `drive_skill_test` → reads cursor `PostOnResolution` → teardown (`SkillTestEnded`, pop `SkillTest`). If Task 2's tests hang at the window or never emit `SkillTestEnded`, trace that chain — the cursor must be `PostOnResolution` at park time (Task 1 Step 8 advances it before firing).
+- **`run_window_continuation` needs no change:** it routes the soak/cancel window-close to `resume_enemy_attack` by *window kind*, and `resume_enemy_attack` reads the source from the `AttackLoop` frame — so a `Retaliate`-source loop resumes through the same path as AoO/enemy-phase.
+- **Event/field names** (`EnemyExhausted`, `DamageTaken`/the real attack-damage event, `SkillTestEnded`) — confirm against `crates/game-core/src/event.rs`; `Event::EnemyAttacked` does **not** exist (the attack emits `DamageTaken`).
+- **Keep assertions honest** (verification-before-completion): if Task 2 fails, fix the engine, never the assertion.

--- a/docs/superpowers/specs/2026-06-21-phase-7-k2-retaliate-windows-design.md
+++ b/docs/superpowers/specs/2026-06-21-phase-7-k2-retaliate-windows-design.md
@@ -1,0 +1,177 @@
+# Phase 7 keystone — K2: Retaliate opens cancel/soak windows (#379) — design
+
+Tracking: **#379**, the **K2** sub-slice of the keystone attack-loop arc
+(`2026-06-20-phase-7-keystone-mid-action-park-design.md`). K1 (#293, PR #413,
+merged) shipped the mid-action park/resume mechanism: attacks of opportunity now
+drive through `drive_attack_loop` (via `drive_aoo`) and open the `BeforeEnemyAttack`
+cancel window (Dodge 01023) and `AfterEnemyAttackDamagedAsset` soak window (Guard
+Dog 01021). K2 applies the **same mechanism to the one remaining direct-`enemy_attack`
+caller**: the Retaliate attack fired from a failed Fight.
+
+## Why this pass exists
+
+`fire_retaliate_if_any` (`crates/game-core/src/engine/dispatch/skill_test.rs:854`)
+fires a Retaliate attack after a *failed Fight* against a ready enemy with the
+retaliate keyword. It calls `combat::enemy_attack` **directly**, so — exactly like
+pre-K1 AoO — it opens no cancel/soak windows: Dodge cannot cancel a retaliate
+strike and Guard Dog does not retaliate against one. Its own doc-comment names this
+step "the future home of the 'after an enemy attacks' reaction window."
+
+K1 left this site untouched on purpose (the master arc spec, §K2): retaliate fires
+from a **different park point** than the basic actions. A basic action's AoO parks
+on an `ActionResolution` frame above `InvestigatorTurn`; a retaliate fires from
+*inside the Fight's skill-test follow-up*, after the test resolves — so its park
+point is the already-existing `SkillTest` frame, and its resume must return to the
+follow-up, not to the main `drive` loop. That asymmetry is the whole of K2's design.
+
+### Rules (verified)
+
+RR p.18 (quoted in the existing doc-comment): *"Each time an investigator fails a
+skill test while attacking a ready enemy with the retaliate keyword, after applying
+all results for that skill test, that enemy performs an attack against the attacking
+investigator. An enemy does not exhaust after performing a retaliate attack."*
+
+- **Trigger: failed Fight only.** "While attacking" = Fight; Evade is not an attack.
+  K2 does **not** expand the trigger — `fire_retaliate_if_any` already gates on
+  `SkillTestFollowUp::Fight` + `!succeeded` + `retaliate && !exhausted`.
+- **A retaliate attack is an enemy attack**, so Dodge 01023 ("Cancel that attack")
+  cancels it and Guard Dog 01021 (soak + deal 1 to the attacker) reacts to it —
+  the same two windows K1 wired for AoO.
+- **No exhaust** — already satisfied: K1 gated the exhaust step in
+  `process_attacker_dealing` to `EnemyAttackSource::EnemyPhase` only, so any
+  non-enemy-phase source is non-exhausting for free.
+
+## The model
+
+### The follow-up cursor is the park substrate (already exists)
+
+The Fight follow-up runs as a `FinishContinuation` cursor carried **on the
+`SkillTest` frame**, driven by the `drive_skill_test` loop
+(`skill_test.rs`): `AwaitingCommit → PostFollowUp → PostRetaliate →
+PostOnResolution → teardown`. Retaliate fires at the **`PostRetaliate`** stage.
+Mid-test reaction windows already suspend and resume against this frame: a window
+pushed *above* the `SkillTest` frame returns `AwaitingInput`, and on close the
+window-continuation path re-enters `drive_skill_test`, which re-reads the cursor.
+K2 reuses this substrate unchanged — it adds no new continuation frame.
+
+### Stack shape
+
+At `PostRetaliate`, with the `SkillTest` frame on the stack, routing the retaliate
+through `drive_attack_loop` pushes the loop frame + window above it:
+
+```
+[ …, SkillTest{cursor: PostOnResolution}, AttackLoop{source: Retaliate}, Resolution(window) ]
+```
+
+The window is the player-facing prompt (Dodge? / resolve Guard Dog). `AwaitingInput`
+returns. On close, `resume_enemy_attack` drains the loop, pops the `AttackLoop`, and
+— for the `Retaliate` source — **re-enters `drive_skill_test`**, which reads the
+cursor (`PostOnResolution`) and runs teardown. No retaliate-specific frame; the
+`SkillTest` frame is the resume point.
+
+### The pieces
+
+1. **`EnemyAttackSource::Retaliate`** — a new variant. Reuses `drive_attack_loop`
+   with a **single-element attacker list** (a retaliate is one enemy attacking once);
+   the two sequential suspension points (BeforeAttack cancel, AfterSoak) are tracked
+   by the existing `AttackLoopStage` cursor on the `AttackLoop` frame. Non-exhaust is
+   inherited (exhaust is `EnemyPhase`-gated). A thin `drive_retaliate(cx, enemy,
+   investigator)` helper mirrors `drive_aoo`: build the 1-element list, call
+   `drive_attack_loop(…, Retaliate)`.
+
+2. **`fire_retaliate_if_any` returns `EngineOutcome`** — instead of the `()` direct
+   `enemy_attack`, it calls `drive_retaliate` and returns its outcome (`Done` when no
+   window opens, `AwaitingInput` when one does). The no-retaliate early-returns
+   become `EngineOutcome::Done`.
+
+3. **`PostRetaliate` stage handles the suspension** — in `drive_skill_test`, the
+   `PostRetaliate` arm advances the cursor to `PostOnResolution` **before** firing
+   retaliate, then calls `fire_retaliate_if_any`; if it returns `AwaitingInput`,
+   return that (the `SkillTest` frame is parked at `PostOnResolution` beneath the
+   `AttackLoop` + window); otherwise fall through to the loop's next iteration as
+   today. Setting the cursor first means resume continues cleanly at
+   `PostOnResolution` regardless of whether a window opened.
+
+4. **`resume_enemy_attack`'s `Retaliate` arm** — after draining the loop, re-enter
+   `drive_skill_test(cx)` so the follow-up continues to teardown. (Contrast:
+   `EnemyPhase → after_enemy_phase_attacks`; `AttackOfOpportunity → Done`.)
+
+### Why this routing, not the alternatives
+
+- **Reuse `drive_attack_loop` (chosen)** vs. opening the windows ad-hoc from
+  `fire_retaliate_if_any`: the ad-hoc path would re-implement the two-stage
+  BeforeAttack→AfterSoak cancel/soak tracking that `AttackLoopStage` already
+  encodes. A 1-element loop is DRY and exercises the identical, already-tested code.
+- **New `Retaliate` source** vs. reusing `AttackOfOpportunity`: the resume
+  *destination* differs — AoO returns `Done` to the main `drive` loop (which then
+  resumes an `ActionResolution` frame), whereas retaliate must re-enter
+  `drive_skill_test`. The source enum is exactly the dispatch key
+  `resume_enemy_attack` already switches on, so a third variant is the natural seam.
+
+### Re-validation / mid-attack viability
+
+Lighter than K1's gate. The retaliate fires *after* the Fight test fully resolves,
+so there is no pending primary effect to re-validate — once the retaliate's
+cancel/soak windows close, the only remaining work is the skill-test teardown
+(`PostOnResolution`: discard committed cards, emit `SkillTestEnded`, drain
+this-test modifiers, pop the `SkillTest` frame). That teardown reads only the
+investigator's own committed-cards record, which a retaliate cannot disturb. The
+existing `current_skill_test()` lookups in `drive_skill_test` keep their
+`unreachable!`/`expect` guards (state-corruption invariants). No new re-validation
+surface.
+
+## Sub-PR decomposition
+
+K2 is small; two behaviour-green steps (mirroring K1's cadence at smaller scale):
+
+- **K2a — engine: route retaliate through the loop.** Add
+  `EnemyAttackSource::Retaliate` + `drive_retaliate`; make `fire_retaliate_if_any`
+  return `EngineOutcome`; handle the suspension in the `PostRetaliate` stage; add the
+  `Retaliate` arm to `resume_enemy_attack` (re-enter `drive_skill_test`). Engine unit
+  tests: retaliate still fires on a failed Fight, still doesn't exhaust, no-window
+  path behaviour-preserving (the existing `failed_fight_*` tests stay green); a
+  synthetic before/soak suspension is registry-gated, so the window-suspend proof
+  lives in K2b.
+- **K2b — integration: Dodge cancels + Guard Dog retaliates against a retaliate.**
+  Registry-backed tests in `crates/cards/tests/`: a failed Fight against a ready
+  retaliate enemy (a `retaliate` test enemy, or Ghoul Priest 01116 — The Gathering's
+  boss carries `retaliate: true`) → the retaliate opens its windows → Dodge cancels
+  it (no damage, the Fight teardown still completes); Guard Dog soaks it and deals 1
+  back to the retaliating enemy, the attacker does not exhaust (RR p.18), and the
+  skill test ends cleanly.
+
+## Testing strategy
+
+- **Behaviour-preserving:** the existing `failed_fight_against_ready_retaliate_enemy_
+  triggers_attack`, `successful_fight_…does_not_trigger`, and
+  `failed_fight_against_exhausted_retaliate_enemy_…` unit tests
+  (`engine/mod.rs:1955+`) must stay green — K2a changes the *route*, not when
+  retaliate fires or its damage.
+- **Non-exhaust:** assert the retaliate attacker stays ready after the attack
+  (RR p.18), through the new loop path.
+- **Suspend/resume (K2b, registry-backed):** the real proof — the retaliate's
+  window opens (`AwaitingInput`), a `ResolveInput` resolves it, and the Fight's
+  skill-test teardown completes afterward (`SkillTestEnded` fires, the `SkillTest`
+  frame is popped). Card text for Dodge 01023 / Guard Dog 01021 verified against
+  ArkhamDB (incl. FAQ) before asserting.
+- **Full native gauntlet** green (`fmt`, `test --all`, `clippy --all-targets
+  --all-features`, `doc --workspace`); wasm-build + wasm-clippy (no web code
+  changes).
+
+## Open questions / deferrals
+
+- **The "after an enemy attacks" reaction window (#64)** — the broader
+  after-resolution skill-test reaction window (Roland's reaction; Ordering step 5 of
+  #393) is **out of K2 scope**. K2 opens only the cancel/soak windows *on the
+  retaliate attack itself*, matching K1.
+- **Multi-attacker retaliate** — not a thing: a retaliate is one enemy attacking
+  once. The 1-element loop is exact, not a simplification.
+
+## What "done" looks like
+
+A failed Fight against a ready retaliate enemy fires a retaliate attack that opens
+its cancel (Dodge) and soak (Guard Dog) windows — Dodge cancels it, Guard Dog
+retaliates against it — and the Fight's skill-test teardown completes after the
+window closes, with the attacker non-exhausted (RR p.18). This closes #379 and
+leaves K3 (#361/#378 — AoO from activated abilities + action-event play) as the next
+sub-slice of the arc.


### PR DESCRIPTION
## Summary

A failed-Fight **Retaliate** attack now opens its cancel (Dodge 01023) and soak (Guard Dog 01021) reaction windows — Dodge cancels a retaliate strike and Guard Dog retaliates against one — and the Fight's skill test tears down cleanly after the window closes. This is **K2** of the keystone attack-loop arc (#393); K1 (PR #413) did the same for attacks of opportunity. With K2, the last direct-`enemy_attack` caller that bypassed the window machinery is gone.

## What changed

- **New `EnemyAttackSource::Retaliate`** + a `drive_retaliate` helper (mirrors K1's `drive_aoo`): the single retaliate attacker routes through the shared `drive_attack_loop`, reusing the `BeforeEnemyAttack` (Dodge) / `AfterEnemyAttackDamagedAsset` (Guard Dog) windows and the `AttackLoopStage` two-stage cursor. Non-exhaust (RR p.18) is inherited — exhaust is `EnemyPhase`-gated.
- **`fire_retaliate_if_any` is now suspendable** (`-> EngineOutcome`): it routes through `drive_retaliate` instead of calling `enemy_attack` directly. The failed-Fight trigger gate is unchanged.
- **Resume routes back to the skill-test follow-up.** A retaliate fires from the `PostRetaliate` stage of the `FinishContinuation` cursor (on the existing `SkillTest` frame). The stage advances the cursor to `PostOnResolution` **before** firing (so a suspended retaliate doesn't re-fire on resume) and propagates the suspension; `resume_enemy_attack`'s `Retaliate` arm re-enters `drive_skill_test` so teardown completes.

## Design decisions

- **New source variant, not reuse of `AttackOfOpportunity`:** the resume *destination* differs — AoO returns `Done` to the main `drive` loop (which resumes an `ActionResolution` frame), whereas a retaliate must re-enter `drive_skill_test`. The source enum is exactly the dispatch key `resume_enemy_attack` switches on.
- **Reuse `drive_attack_loop` with a 1-element list, not an ad-hoc window path:** a retaliate is one enemy attacking once, but it still has two sequential suspension points (before-cancel, then soak) that `AttackLoopStage` already encodes — so a singleton loop is DRY and exercises the identical, already-tested code.
- **Scope kept narrow:** failed-Fight only (RR's "while attacking"; Evade isn't an attack — the existing `failed_evade_…_does_not_trigger` test still holds). The separate "after an enemy attacks" reaction window (#64) is **not** K2.
- Design: `docs/superpowers/specs/2026-06-21-phase-7-k2-retaliate-windows-design.md`; plan: `docs/superpowers/plans/2026-06-21-k2-retaliate-windows.md`.

## Test notes

- **Integration (registry-backed, the #379 acceptance):** `crates/cards/tests/retaliate_windows.rs` — a failed Fight against a ready retaliate enemy fires the retaliate; Guard Dog soaks it and deals 1 back (attacker stays ready), or Dodge cancels it (no damage). Both tests assert the **resume seam**: the `SkillTest` frame is present while the window is open, `Event::SkillTestEnded` fires after it closes, and no `SkillTest` frame remains. Card text for Dodge/Guard Dog verified against ArkhamDB (incl. FAQ).
- **Unit:** `drive_retaliate` deals damage + non-exhaust; the no-window route is behaviour-preserving (the existing `failed_fight_*` retaliate pins stay green).
- Full native gauntlet green locally (`fmt`, `test --all`, `clippy --all-targets --all-features`, `doc --workspace`).

## Linked issues

Closes #379
