### PR TITLE
engine: activated abilities provoke attacks of opportunity (K3 of #361)

### DIFF
--- a/crates/cards/tests/activate_ability_aoo.rs
+++ b/crates/cards/tests/activate_ability_aoo.rs
@@ -1,0 +1,489 @@
+//! Attacks of opportunity provoked by **activated abilities** (#361, K3 of the
+//! keystone arc), driven through the public [`apply`] API with the real card
+//! corpus installed.
+//!
+//! Per the Rules Reference (p.5, "Attack of Opportunity"): an investigator
+//! engaged with one or more ready enemies who takes an action **other than to
+//! fight, to evade, or to activate a parley or resign ability** provokes one
+//! `AoO` from each such enemy, after costs are paid and before the action's
+//! effect resolves. So a non-fight/evade action-cost activated ability (First
+//! Aid 01019, Flashlight 01087, Medical Texts 01035, Old Book of Lore 01031)
+//! provokes; a Fight ability (Machete 01020, .45 Automatic) is exempt; and a
+//! fast ability (`action_cost == 0`, e.g. Beat Cop 01018) is not an action and
+//! never provokes.
+//!
+//! `game-core`'s unit tests can't install `cards::REGISTRY` (the engine crate
+//! can't depend on `cards`), so this lives in `crates/cards/tests/`. The `AoO`
+//! window/suspend mechanism itself is covered by `dodge_aoo.rs` /
+//! `guard_dog_soak.rs` (K1); these tests prove the **new firing sites** route
+//! through it.
+//!
+//! ## Verified card text (`ArkhamDB`, 2026-06-21)
+//!
+//! **First Aid (01019):** "[action] Spend 1 supply: Heal 1 damage or 1 horror
+//! from an investigator at your location." A non-fight action ability → provokes.
+//!
+//! **Machete (01020):** "[action]: Fight. You get +1 [combat] for this attack.
+//! …" A Fight ability → `AoO`-exempt (RR p.5).
+#![allow(clippy::too_many_lines)]
+
+use std::sync::Once;
+
+use game_core::engine::{apply, EngineOutcome, OptionId};
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, Enemy, EnemyId, InvestigatorId,
+    LocationId, Phase, UseKind, WindowKind,
+};
+use game_core::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
+use game_core::{Action, InputResponse, PlayerAction};
+
+/// First Aid (01019): Guardian Item, `[action] Spend 1 supply: Heal …`. A
+/// non-fight action ability → provokes an `AoO`.
+const FIRST_AID: &str = "01019";
+/// Machete (01020): Guardian weapon, `[action]: Fight …`. `AoO`-exempt.
+const MACHETE: &str = "01020";
+/// Guard Dog (01021): Guardian Ally, health 3 / sanity 1, damage-retaliate soak.
+const GUARD_DOG: &str = "01021";
+/// Beat Cop (01018): Guardian Ally; ability 1 is `[fast] Discard Beat Cop: Deal
+/// 1 damage to an enemy at your location` — fast, so never provokes.
+const BEAT_COP: &str = "01018";
+/// Dodge (01023): Neutral Tactic, Fast, before-attack cancel reaction.
+const DODGE: &str = "01023";
+
+fn install_real_registry() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// An engaged ready enemy at `loc` dealing `damage` / 0 horror with `max_health`.
+fn engaged_attacker(
+    id: u32,
+    inv: InvestigatorId,
+    loc: LocationId,
+    damage: u8,
+    max_health: u8,
+) -> Enemy {
+    let mut e = test_enemy(id, format!("Attacker {id}"));
+    e.attack_damage = damage;
+    e.attack_horror = 0;
+    e.max_health = max_health;
+    e.current_location = Some(loc);
+    e.engaged_with = Some(inv);
+    e
+}
+
+/// First Aid in play (with `supplies`) + Guard Dog in play (the soaker).
+fn first_aid_and_guard_dog(
+    inv: &mut game_core::state::Investigator,
+    dog: CardInstanceId,
+    kit: CardInstanceId,
+) {
+    let guard_dog = CardInPlay::enter_play(CardCode::new(GUARD_DOG), dog);
+    let mut first_aid = CardInPlay::enter_play(CardCode::new(FIRST_AID), kit);
+    first_aid.uses.insert(UseKind::Supplies, 3);
+    inv.cards_in_play = vec![guard_dog, first_aid];
+}
+
+// -----------------------------------------------------------------------
+// A non-fight action ability provokes an AoO (the new #361 firing site).
+// -----------------------------------------------------------------------
+
+/// Activating First Aid (a non-fight `[action]` ability) while engaged with a
+/// ready enemy provokes an `AoO`. With Guard Dog in play and no Dodge, the `AoO`
+/// damage soaks onto Guard Dog and its reaction window opens — the same
+/// suspend/resume path Move uses (K1), proving `activate_ability` now routes
+/// through `drive_aoo`.
+#[test]
+fn activating_a_non_fight_ability_while_engaged_provokes_an_aoo() {
+    install_real_registry();
+
+    let dog = CardInstanceId(1);
+    let kit = CardInstanceId(2);
+    let inv_id = InvestigatorId(1);
+    let loc = LocationId(101);
+
+    let mut investigator = test_investigator(1);
+    investigator.current_location = Some(loc);
+    first_aid_and_guard_dog(&mut investigator, dog, kit);
+
+    let attacker = engaged_attacker(7, inv_id, loc, 2, 5);
+
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_location(test_location(101, "Study"))
+        .with_investigator(investigator)
+        .with_active_investigator(inv_id)
+        .with_turn_order([inv_id])
+        .with_enemy(attacker)
+        .build();
+
+    // Activate First Aid (ability 0). Action-cost, non-fight → provokes an AoO
+    // after the supply cost is paid and before the heal effect resolves.
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: inv_id,
+            instance_id: kit,
+            ability_index: 0,
+        }),
+    );
+    let state = result.state;
+
+    assert!(
+        matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),
+        "the AoO soak window must suspend the activation: {:?}",
+        result.outcome
+    );
+    assert!(
+        result
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::WindowOpened { kind }
+            if matches!(kind, WindowKind::AfterEnemyAttackDamagedAsset { .. }))),
+        "activating a non-fight action ability provokes an AoO that soaks onto Guard Dog: {:?}",
+        result.events
+    );
+    let dog_in_play = state.investigators[&inv_id]
+        .cards_in_play
+        .iter()
+        .find(|c| c.instance_id == dog)
+        .expect("Guard Dog still in play");
+    assert_eq!(
+        dog_in_play.accumulated_damage, 2,
+        "AoO damage from the activation soaked onto Guard Dog"
+    );
+    assert_eq!(
+        state.investigators[&inv_id].damage, 0,
+        "investigator took no AoO damage (soaked onto Guard Dog)"
+    );
+    // First Aid spent its supply (the cost paid before the AoO).
+    let kit_in_play = state.investigators[&inv_id]
+        .cards_in_play
+        .iter()
+        .find(|c| c.instance_id == kit)
+        .expect("First Aid still in play");
+    assert_eq!(
+        kit_in_play.uses.get(&UseKind::Supplies).copied(),
+        Some(2),
+        "First Aid spent 1 supply as the activation cost, before the AoO"
+    );
+    // The heal effect has NOT run yet — it resolves only after the AoO window closes.
+}
+
+// -----------------------------------------------------------------------
+// A Fight ability is AoO-exempt (RR p.5).
+// -----------------------------------------------------------------------
+
+/// Activating Machete (a `[action]: Fight` ability) while engaged with a ready
+/// enemy provokes **no** `AoO` — Fight is on the exempt list. The activation goes
+/// straight to the Fight skill test (its commit window), and Guard Dog (in play)
+/// soaks nothing.
+#[test]
+fn activating_a_fight_ability_while_engaged_provokes_no_aoo() {
+    install_real_registry();
+
+    let dog = CardInstanceId(1);
+    let blade = CardInstanceId(2);
+    let inv_id = InvestigatorId(1);
+    let loc = LocationId(101);
+
+    let mut investigator = test_investigator(1);
+    investigator.current_location = Some(loc);
+    investigator.cards_in_play = vec![
+        CardInPlay::enter_play(CardCode::new(GUARD_DOG), dog),
+        CardInPlay::enter_play(CardCode::new(MACHETE), blade),
+    ];
+
+    let attacker = engaged_attacker(7, inv_id, loc, 2, 5);
+
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_location(test_location(101, "Study"))
+        .with_investigator(investigator)
+        .with_active_investigator(inv_id)
+        .with_turn_order([inv_id])
+        .with_enemy(attacker)
+        // The Fight starts a Combat skill test, which needs a non-empty bag.
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .build();
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: inv_id,
+            instance_id: blade,
+            ability_index: 0,
+        }),
+    );
+    let state = result.state;
+
+    // No AoO window of any kind opened.
+    assert!(
+        !result
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::WindowOpened { kind }
+            if matches!(kind, WindowKind::AfterEnemyAttackDamagedAsset { .. }
+                          | WindowKind::BeforeEnemyAttack { .. }))),
+        "a Fight ability provokes no AoO — no AoO window should open: {:?}",
+        result.events
+    );
+    // Guard Dog soaked nothing; the investigator took no AoO damage.
+    let dog_in_play = state.investigators[&inv_id]
+        .cards_in_play
+        .iter()
+        .find(|c| c.instance_id == dog)
+        .expect("Guard Dog still in play");
+    assert_eq!(
+        dog_in_play.accumulated_damage, 0,
+        "no AoO soaked onto Guard Dog"
+    );
+    assert_eq!(
+        state.investigators[&inv_id].damage, 0,
+        "no AoO damage to the investigator"
+    );
+    // The activation went straight to the Fight skill test.
+    assert!(
+        result
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::SkillTestStarted { .. })),
+        "the Fight ability began its skill test directly (no AoO first): {:?}",
+        result.events
+    );
+}
+
+// -----------------------------------------------------------------------
+// A fast ability is not an action and never provokes (RR p.11).
+// -----------------------------------------------------------------------
+
+/// Activating Beat Cop's `[fast]` ability (`action_cost == 0`) while engaged
+/// with a ready enemy provokes **no** `AoO` — fast is not an action. The ability
+/// resolves (deals 1 damage to the enemy) without the investigator taking any
+/// `AoO` damage.
+#[test]
+fn activating_a_fast_ability_while_engaged_provokes_no_aoo() {
+    install_real_registry();
+
+    let cop = CardInstanceId(1);
+    let inv_id = InvestigatorId(1);
+    let loc = LocationId(101);
+    let enemy_id = EnemyId(7);
+
+    let mut investigator = test_investigator(1);
+    investigator.current_location = Some(loc);
+    investigator.cards_in_play = vec![CardInPlay::enter_play(CardCode::new(BEAT_COP), cop)];
+
+    let attacker = engaged_attacker(7, inv_id, loc, 2, 5);
+
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_location(test_location(101, "Study"))
+        .with_investigator(investigator)
+        .with_active_investigator(inv_id)
+        .with_turn_order([inv_id])
+        .with_enemy(attacker)
+        .build();
+
+    // Beat Cop ability 1 is the `[fast]` deal-1-damage (ability 0 is its
+    // constant +1 combat).
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: inv_id,
+            instance_id: cop,
+            ability_index: 1,
+        }),
+    );
+    let state = result.state;
+
+    assert!(
+        matches!(result.outcome, EngineOutcome::Done),
+        "the fast ability resolves without suspending on an AoO window: {:?}",
+        result.outcome
+    );
+    assert!(
+        !result
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::WindowOpened { kind }
+            if matches!(kind, WindowKind::AfterEnemyAttackDamagedAsset { .. }
+                          | WindowKind::BeforeEnemyAttack { .. }))),
+        "a fast ability provokes no AoO — no AoO window should open: {:?}",
+        result.events
+    );
+    assert_eq!(
+        state.investigators[&inv_id].damage, 0,
+        "no AoO damage to the investigator"
+    );
+    // The fast ability's own effect resolved: the enemy took 1 damage.
+    assert!(
+        result.events.iter().any(|e| matches!(
+            e,
+            Event::EnemyDamaged { enemy, amount: 1, .. } if *enemy == enemy_id
+        )),
+        "Beat Cop's fast ability dealt its 1 damage to the engaged enemy: {:?}",
+        result.events
+    );
+}
+
+// -----------------------------------------------------------------------
+// The activation's AoO can be cancelled, then the ability's effect resumes.
+// -----------------------------------------------------------------------
+
+/// Dodge cancels the `AoO` provoked by activating First Aid; the activation then
+/// resumes and runs First Aid's heal effect (which itself suspends on its
+/// damage-or-horror choice). Proves `resume_activate_ability` runs the parked
+/// effect after the `AoO` window closes.
+#[test]
+fn dodge_cancels_the_activations_aoo_then_the_ability_effect_resumes() {
+    install_real_registry();
+
+    let kit = CardInstanceId(2);
+    let inv_id = InvestigatorId(1);
+    let loc = LocationId(101);
+
+    let mut investigator = test_investigator(1);
+    investigator.current_location = Some(loc);
+    investigator.damage = 2; // something for First Aid to heal
+    investigator.hand = vec![CardCode::new(DODGE)];
+    let mut first_aid = CardInPlay::enter_play(CardCode::new(FIRST_AID), kit);
+    first_aid.uses.insert(UseKind::Supplies, 3);
+    investigator.cards_in_play = vec![first_aid];
+
+    let attacker = engaged_attacker(7, inv_id, loc, 2, 5);
+
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_location(test_location(101, "Study"))
+        .with_investigator(investigator)
+        .with_active_investigator(inv_id)
+        .with_turn_order([inv_id])
+        .with_enemy(attacker)
+        .build();
+
+    // Activate First Aid → AoO → Dodge is in hand, so the BeforeEnemyAttack
+    // cancel window opens.
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: inv_id,
+            instance_id: kit,
+            ability_index: 0,
+        }),
+    );
+    let state = result.state;
+    assert!(
+        result
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::WindowOpened { kind }
+            if matches!(kind, WindowKind::BeforeEnemyAttack { .. }))),
+        "the activation's AoO opened a cancel window: {:?}",
+        result.events
+    );
+
+    // Play Dodge (the single candidate) → cancel the AoO.
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickSingle(OptionId(0)),
+        }),
+    );
+    let state = result.state;
+
+    // The AoO was cancelled — no damage — and the activation resumed into First
+    // Aid's heal choice (the effect ran after the window closed).
+    assert_eq!(
+        state.investigators[&inv_id].damage, 2,
+        "the cancelled AoO dealt no damage"
+    );
+    assert!(
+        matches!(result.outcome, EngineOutcome::AwaitingInput { .. }),
+        "First Aid's heal choice opened — the parked effect resumed: {:?}",
+        result.outcome
+    );
+
+    // Pick the damage branch → 1 damage healed (2 → 1), proving the resumed
+    // effect actually resolves.
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickSingle(OptionId(0)),
+        }),
+    );
+    let state = result.state;
+    assert_eq!(
+        state.investigators[&inv_id].damage, 1,
+        "First Aid healed 1 damage after the AoO was dodged and the effect resumed"
+    );
+    assert!(
+        state.open_windows().is_empty(),
+        "no windows stranded after the dodge + resume + heal cycle: {:?}",
+        state.open_windows()
+    );
+}
+
+// -----------------------------------------------------------------------
+// An AoO that defeats the actor mid-activation suppresses the ability effect.
+// -----------------------------------------------------------------------
+
+/// If the activation's `AoO` defeats the investigator, the §D re-validation gate
+/// suppresses the parked ability effect: First Aid's heal never runs (no heal
+/// choice opens), though the supply spent as the activation cost stays spent.
+#[test]
+fn aoo_that_defeats_the_actor_suppresses_the_ability_effect() {
+    install_real_registry();
+
+    let kit = CardInstanceId(2);
+    let inv_id = InvestigatorId(1);
+    let loc = LocationId(101);
+
+    let mut investigator = test_investigator(1);
+    investigator.current_location = Some(loc);
+    investigator.damage = 2;
+    let mut first_aid = CardInPlay::enter_play(CardCode::new(FIRST_AID), kit);
+    first_aid.uses.insert(UseKind::Supplies, 3);
+    investigator.cards_in_play = vec![first_aid];
+
+    // A lethal AoO and no soaker / no Dodge → the actor is defeated before the
+    // heal effect can resume.
+    let attacker = engaged_attacker(7, inv_id, loc, 50, 5);
+
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_location(test_location(101, "Study"))
+        .with_investigator(investigator)
+        .with_active_investigator(inv_id)
+        .with_turn_order([inv_id])
+        .with_enemy(attacker)
+        .build();
+
+    let result = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: inv_id,
+            instance_id: kit,
+            ability_index: 0,
+        }),
+    );
+    let state = result.state;
+
+    // The actor was defeated by the AoO.
+    assert_ne!(
+        state.investigators[&inv_id].status,
+        game_core::state::Status::Active,
+        "the lethal AoO defeated the actor"
+    );
+    // The heal effect was suppressed: had it run, First Aid's `choose_one` would
+    // have suspended on its damage-or-horror choice (`AwaitingInput`). Resolving
+    // to `Done` instead proves the §D gate aborted the parked effect.
+    assert!(
+        matches!(result.outcome, EngineOutcome::Done),
+        "the suppressed activation resolves to Done (no heal choice opened): {:?}",
+        result.outcome
+    );
+}

--- a/crates/game-core/src/engine/dispatch/abilities.rs
+++ b/crates/game-core/src/engine/dispatch/abilities.rs
@@ -18,6 +18,12 @@ use super::Cx;
 /// (emitting cost events per primitive), emits [`Event::AbilityActivated`],
 /// and dispatches the ability's effect through the DSL evaluator.
 ///
+/// An action-cost, non-fight ability provokes an attack of opportunity (RR
+/// p.5) from each engaged ready enemy, fired after costs and before the effect
+/// — see [`provokes_aoo`]; the effect is parked on an `ActionResolution` frame
+/// and run on resume ([`resume_activate_ability`]). Fight and fast abilities
+/// resolve their effect synchronously.
+///
 /// # Timing gate
 ///
 /// The gate branches on `action_cost` from `Trigger::Activated`:
@@ -94,8 +100,74 @@ pub(super) fn activate_ability(
         ability_index,
     });
 
+    // RR p.5 "Attack of Opportunity": activating an action-cost ability while
+    // engaged with a ready enemy provokes one AoO from each — *unless* it is a
+    // fight/evade/parley/resign ability. The action cost is already spent
+    // (`pay_activation_costs`), so we park the effect on an `ActionResolution`
+    // frame and drive the AoO loop (which may open a Dodge cancel / Guard Dog
+    // soak window), then run the effect on resume. (#361, K3.)
+    if provokes_aoo(action_cost, &effect) {
+        cx.state
+            .continuations
+            .push(crate::state::Continuation::ActionResolution {
+                investigator,
+                resume: crate::state::ActionResume::ActivateAbility {
+                    instance_id,
+                    effect,
+                },
+            });
+        return super::combat::drive_aoo(cx, investigator);
+    }
+
+    // Fast (not an action), or an AoO-exempt Fight ability: resolve synchronously.
     let eval_ctx = EvalContext::for_controller_with_source(investigator, instance_id);
     apply_effect(cx, &effect, eval_ctx)
+}
+
+/// Whether activating an ability with this `action_cost` and `effect` provokes
+/// an attack of opportunity (RR p.5).
+///
+/// True iff it is an **action** (`action_cost > 0`) that is **not** a
+/// fight/evade/parley/resign ability. In this engine weapons are activated
+/// `Effect::Fight` abilities (Machete 01020, .45 Automatic, Roland's .38
+/// Special, Knife), so those are exempt by an effect-root match. There is no
+/// `Effect::Evade` and no activated parley/resign card in scope, so Fight is
+/// the only exemptible activated kind — extend this (and add the variant) if a
+/// `Seq`-wrapped weapon ability or an activated evade lands. Fast abilities
+/// (`action_cost == 0`) are not actions and never provoke (RR p.11).
+fn provokes_aoo(action_cost: u8, effect: &crate::dsl::Effect) -> bool {
+    action_cost > 0 && !matches!(effect, crate::dsl::Effect::Fight { .. })
+}
+
+/// Run a parked activated ability's `effect` after its `AoO` loop completes
+/// (#361). The actor-`Active` re-validation gate has already run in
+/// [`resume_action_resolution`](super::resume_action_resolution); the source
+/// may have self-discarded as a cost (so we run the snapshotted `effect`, not a
+/// re-resolution by instance), with `instance_id` only seeding the eval
+/// context's source.
+///
+/// TODO (richer mid-action invalidation): unlike the basic-action resumes
+/// (`investigate_primary_effect` etc., which return `Done` to *suppress*
+/// gracefully when their target precondition has lapsed), this delegates
+/// straight to `apply_effect`. Some effects (`Effect::Investigate` on
+/// Flashlight 01087, `Effect::Heal` on First Aid 01019) return
+/// [`EngineOutcome::Rejected`] on a lapsed precondition, which `apply()`
+/// snapshot-restores — rolling back the *whole* activation (the `AoO` damage +
+/// the spent cost) rather than suppressing the primary only (the §D contract).
+/// Unreachable in scope: for the actor to survive the `Active` gate yet have a
+/// lapsed precondition, an `AoO` reaction would have to relocate it / unreveal
+/// the location without defeating it, and no in-scope reaction (Dodge cancel,
+/// Guard Dog soak) does that. Give this the basic actions' suppress-on-lapse
+/// shape when a board-changing `AoO` reaction lands (pairs with the §D
+/// "richer mid-action invalidation" hook in the keystone spec).
+pub(super) fn resume_activate_ability(
+    cx: &mut Cx,
+    investigator: InvestigatorId,
+    instance_id: CardInstanceId,
+    effect: &crate::dsl::Effect,
+) -> EngineOutcome {
+    let eval_ctx = EvalContext::for_controller_with_source(investigator, instance_id);
+    apply_effect(cx, effect, eval_ctx)
 }
 
 /// Pay the action cost and every payment cost of an activated
@@ -331,6 +403,24 @@ pub(super) fn check_cost_payable(
 mod tests {
     use super::*;
     use crate::test_support::fixtures::test_investigator;
+
+    #[test]
+    fn provokes_aoo_classifies_action_cost_and_fight_exemption() {
+        use crate::dsl::{Effect, IntExpr};
+        let fight = Effect::Fight {
+            combat_modifier: IntExpr::Lit(0),
+            extra_damage: 0,
+        };
+        let non_fight = Effect::Native { tag: "heal".into() };
+
+        // Action-cost non-fight ability → provokes.
+        assert!(provokes_aoo(1, &non_fight));
+        // Action-cost Fight ability → exempt (RR p.5).
+        assert!(!provokes_aoo(1, &fight));
+        // Fast ability (action_cost 0) → not an action, never provokes.
+        assert!(!provokes_aoo(0, &non_fight));
+        assert!(!provokes_aoo(0, &fight));
+    }
 
     #[test]
     fn spend_uses_payable_only_with_enough_of_the_named_kind() {

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -233,6 +233,10 @@ fn resume_action_resolution(cx: &mut Cx) -> EngineOutcome {
         ActionResume::Resource => actions::resource_primary_effect(cx, investigator),
         ActionResume::Engage { enemy } => actions::engage_primary_effect(cx, investigator, enemy),
         ActionResume::Draw => cards::draw_primary_effect(cx, investigator),
+        ActionResume::ActivateAbility {
+            instance_id,
+            effect,
+        } => abilities::resume_activate_ability(cx, investigator, instance_id, &effect),
     }
 }
 

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -562,10 +562,12 @@ pub struct ChoiceFrame {
 }
 
 /// Which action's primary effect a parked [`Continuation::ActionResolution`]
-/// frame runs once its attack-of-opportunity loop completes (#293). Carries
-/// only the action's *parameters*; board-dependent values (Investigate
-/// difficulty, enemy presence) are re-derived live on resume so a mid-action
-/// board change is reflected.
+/// frame runs once its attack-of-opportunity loop completes (#293). The
+/// basic-action variants carry only the action's *parameters*; board-dependent
+/// values (Investigate difficulty, enemy presence) are re-derived live on
+/// resume so a mid-action board change is reflected. The exception is
+/// [`ActivateAbility`](ActionResume::ActivateAbility), which snapshots its
+/// resolved effect (fixed at activation, not board-dependent) — see its docs.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ActionResume {
     /// Relocate the investigator (and engaged enemies) to `destination`.
@@ -578,6 +580,19 @@ pub enum ActionResume {
     Engage { enemy: EnemyId },
     /// Draw 1 card (with the empty-deck penalty path).
     Draw,
+    /// Run the activated ability's `effect` for `instance_id`'s source (#361).
+    /// Unlike the basic actions, this snapshots the resolved `effect` rather
+    /// than re-deriving it: an ability's effect is fixed at activation (not
+    /// board-dependent), and the source may have self-discarded as a cost
+    /// (First Aid 01019 depleting its last supply), so a live re-resolution by
+    /// instance would be fragile. `instance_id` is kept only as the eval
+    /// context's source.
+    ActivateAbility {
+        /// The source card instance — the eval context's `source` on resume.
+        instance_id: CardInstanceId,
+        /// The ability's effect, resolved at activation, run after the `AoO` loop.
+        effect: card_dsl::dsl::Effect,
+    },
 }
 
 impl Continuation {

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -82,7 +82,7 @@ clue" is stubbed; needs the dynamic skill-test-modifier DSL surface
    - **K1 — AoO open cancel/soak windows (#293). ✅ shipped (PR #413).** `ActionResolution` frame + `drive_aoo`; the five basic actions fire AoO through `drive_attack_loop`, so Dodge cancels and Guard Dog retaliates against an AoO; `fire_attacks_of_opportunity` deleted. RR p.7 AoO-non-exhaust source-gated.
    - **K2 — Retaliate opens cancel/soak windows (#379). ✅ shipped (PR #414).** `drive_retaliate` routes the failed-Fight retaliate through `drive_attack_loop` under `EnemyAttackSource::Retaliate`; the resume re-enters `drive_skill_test` (the retaliate's park point is the existing `SkillTest` frame, not an `ActionResolution` frame).
    - **K3 #361/#378** AoO from activated abilities + action-event play · **K4 #143** player attack-order — *also extends the enemy-phase `AttackLoop` to span the whole step 3.3 (resolving slice 3's Shape-A caveat) and settles attacker-snapshot timing* · **K5 #44 (+#119)** player damage/soak distribution. Each rides the K1 substrate.
-5. **Skill-test windows** (#374 + #64) — one reaction-window work-stream, offered as frame options on the #393 model.
+5. **Skill-test windows** (#374 + #64) — one reaction-window work-stream, offered as frame options on the #393 model. **Also the moment to move the skill-test path from Shape A toward end-state B:** today the intra-test sequence is an inline `FinishContinuation` cursor re-entered imperatively from `close_reaction_window_at` (see Architecture → "Skill-test control-flow shape (Shape A)"). #374/#64 insert player windows *between* those steps, so reify the steps as frames under uniform top-frame dispatch here, rather than deepening the enum with two more variants.
 6. **Roland elder-sign** (#118).
 7. **Edge correctness** (#300 after Engage, then #368, #353).
 8. **Browser playable surface** (capstone) — once the above stabilizes; renders the enumerated actions / #205. See below.
@@ -250,6 +250,34 @@ when picked; it is window-only at the play gate (`TriggerKind::Reaction`
 exists; the ST.1/ST.2 framework player windows and the after-resolution window
 (#64) are absent — `OnCommit` / `OnSkillTestResolution` card triggers fire, but
 a player cannot play a Fast card mid-test.
+
+**Skill-test control-flow shape (Shape A — not yet end-state B).** The skill
+test conforms to the #393 model on *storage* — `InFlightSkillTest` is folded
+onto the `Continuation::SkillTest` frame (#348), no `*_pending` side-channels —
+but its *control flow* is only partly on the stack:
+- **Intra-test sequencing is an inline cursor, not a frame per step.** The
+  `FinishContinuation` enum (`AwaitingCommit → PostFollowUp → PostRetaliate →
+  PostOnResolution`) is a field on the one `SkillTest` frame, advanced by a
+  `loop` in `drive_skill_test` — Shape A, the same compression as `AttackLoop`.
+  `PostRetaliate` *can* suspend (its cancel/soak window), so it's a borderline
+  step folded into the enum rather than reified.
+- **The driver is re-entered imperatively, not by uniform top-frame dispatch.**
+  `close_reaction_window_at` reaches *down* the stack — "if a skill test is
+  mid-resolution, call `drive_skill_test`" — instead of popping the window back
+  to the main loop and letting it dispatch on `SkillTest`-on-top. (`AttackLoop`
+  does the same via `resume_enemy_attack`; codebase-wide pattern, still a
+  divergence.)
+- **The driver scans the stack to locate itself.** `drive_skill_test` does
+  `rposition(SkillTest)` + `win_idx > st` to tell a window *above* it (mid-test
+  → suspend) from a forced `Resolution` *below* it (#213 reentrancy → ignore); a
+  clean top frame never reasons about relative positions. `current_skill_test` /
+  `take_skill_test` are located-singleton reads, not `last()`.
+- **Two entry points:** commit → `finish_skill_test`; the rest →
+  `drive_skill_test` (`AwaitingCommit` is `unreachable!` there).
+
+This is the intended C-checkpoint shape, **not drift.** Moving it toward
+end-state B (each step a frame, driven by top-frame dispatch) belongs with
+#374/#64 — see Ordering step 5.
 
 **Content patterns (mostly later slices).** Card stats come from the corpus
 (`CardKind`; read via `cards::by_code` / `metadata_for`, never hand-typed) — a

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -50,8 +50,8 @@ one shared mechanism (mid-action park/resume), now a sub-sliced arc **K1→K5**
 (see Ordering step 4 + its design spec). **The foundation shipped:**
 - ✅ [#293](https://github.com/talelburg/eldritch/issues/293) — AoO open cancel/soak windows (Guard Dog, Dodge). **Shipped — K1, PR #413** (`ActionResolution` frame + `drive_aoo`).
 - ✅ [#379](https://github.com/talelburg/eldritch/issues/379) — Retaliate opens cancel/soak windows (Guard Dog, Dodge). **Shipped — K2, PR #414** (`drive_retaliate`; resume re-enters `drive_skill_test`).
-- [#361](https://github.com/talelburg/eldritch/issues/361) — activated abilities don't provoke AoO (First Aid, Medical Texts, Flashlight). **K3.**
-- [#378](https://github.com/talelburg/eldritch/issues/378) — action-event play doesn't provoke AoO (Dynamite Blast, Emergency Cache). **K3.**
+- ✅ [#361](https://github.com/talelburg/eldritch/issues/361) — activated abilities provoke AoO (First Aid, Flashlight, Medical Texts, Old Book of Lore; Fight weapons exempt). **Shipped — K3, PR #415** (`provokes_aoo` gate + `ActionResume::ActivateAbility`).
+- [#378](https://github.com/talelburg/eldritch/issues/378) — action-event play doesn't provoke AoO (Dynamite Blast, Emergency Cache); also adds the missing non-fast play-action charge. **K3 (remaining half).**
 
 **C. Enemy-attack-loop player agency:**
 - [#143](https://github.com/talelburg/eldritch/issues/143) — player picks attack order with 2+ engaged enemies.
@@ -81,7 +81,7 @@ clue" is stubbed; needs the dynamic skill-test-modifier DSL surface
 4. **The keystone: mid-action suspend/resume — 🔨 in progress (K1 shipped).** Designed in its own spec ([`2026-06-20-phase-7-keystone-mid-action-park-design.md`](../superpowers/specs/2026-06-20-phase-7-keystone-mid-action-park-design.md)) — §D of #393 expanded into a sub-sliced arc **K1→K5** collapsing #293/#379/#361/#378/#143/#44 (+#119), the highest-leverage item in the phase. The action parks its *triggering action* on a `Continuation::ActionResolution` frame (above `InvestigatorTurn`) with the AoO `AttackLoop` (slice 3 / #411) as its child; on the loop's pop an `on_child_pop` re-validation gate (actor-Active + the primary's target precondition) resumes the action's primary effect, aborting cleanly on a mid-action lapse.
    - **K1 — AoO open cancel/soak windows (#293). ✅ shipped (PR #413).** `ActionResolution` frame + `drive_aoo`; the five basic actions fire AoO through `drive_attack_loop`, so Dodge cancels and Guard Dog retaliates against an AoO; `fire_attacks_of_opportunity` deleted. RR p.7 AoO-non-exhaust source-gated.
    - **K2 — Retaliate opens cancel/soak windows (#379). ✅ shipped (PR #414).** `drive_retaliate` routes the failed-Fight retaliate through `drive_attack_loop` under `EnemyAttackSource::Retaliate`; the resume re-enters `drive_skill_test` (the retaliate's park point is the existing `SkillTest` frame, not an `ActionResolution` frame).
-   - **K3 #361/#378** AoO from activated abilities + action-event play · **K4 #143** player attack-order — *also extends the enemy-phase `AttackLoop` to span the whole step 3.3 (resolving slice 3's Shape-A caveat) and settles attacker-snapshot timing* · **K5 #44 (+#119)** player damage/soak distribution. Each rides the K1 substrate.
+   - **K3 ✅ #361 (PR #415)** AoO from activated abilities (Fight-exempt by effect root; effect snapshotted on the resume frame) · **#378** action-event play (remaining; folds in the missing non-fast play-action charge) · **K4 #143** player attack-order — *also extends the enemy-phase `AttackLoop` to span the whole step 3.3 (resolving slice 3's Shape-A caveat) and settles attacker-snapshot timing* · **K5 #44 (+#119)** player damage/soak distribution. Each rides the K1 substrate.
 5. **Skill-test windows** (#374 + #64) — one reaction-window work-stream, offered as frame options on the #393 model. **Also the moment to move the skill-test path from Shape A toward end-state B:** today the intra-test sequence is an inline `FinishContinuation` cursor re-entered imperatively from `close_reaction_window_at` (see Architecture → "Skill-test control-flow shape (Shape A)"). #374/#64 insert player windows *between* those steps, so reify the steps as frames under uniform top-frame dispatch here, rather than deepening the enum with two more variants.
 6. **Roland elder-sign** (#118).
 7. **Edge correctness** (#300 after Engage, then #368, #353).
@@ -220,8 +220,12 @@ opens the cancel/soak windows too; its resume re-enters `drive_skill_test` (the
 retaliate's park point is the `SkillTest` frame). No direct-`enemy_attack` window
 bypass remains.** Exhaust rules differ by source:
 enemy-phase always exhausts (cancelled too — RR p.6/p.25); AoO never (RR p.7 —
-source-gated in `process_attacker_dealing`); Retaliate never (RR p.18). Activating an
-ability or playing an event fire no AoO yet — **K3 (#361/#378)**.
+source-gated in `process_attacker_dealing`); Retaliate never (RR p.18).
+**K3 (PR #415) added the activated-ability AoO site:** a non-fight action-cost
+activation parks its effect on an `ActionResolution` frame and fires AoO via
+`drive_aoo` (the `provokes_aoo` gate exempts `Effect::Fight` weapons; fast
+abilities never provoke). Playing an event fires no AoO yet — **#378** (the
+remaining K3 half, which also adds the missing non-fast play-action charge).
 
 **Trigger spine.** `emit_event` is the one dispatch chokepoint (two-phase
 forced-then-reaction, RR p.2). Simultaneous triggers resolve through the

--- a/docs/superpowers/specs/2026-06-20-phase-7-keystone-mid-action-park-design.md
+++ b/docs/superpowers/specs/2026-06-20-phase-7-keystone-mid-action-park-design.md
@@ -252,6 +252,38 @@ play-card action cost is charged** — `play_card` does not call `spend_one_acti
 in its body today (the cost handling is not visible there); the AoO must fire
 after the action cost is paid, so this is a prerequisite to verify, not assume.
 
+#### K3 refinements (from the 2026-06-21 implementation survey)
+
+Verified against the corpus + dispatch before implementing; settles the two K3
+open items above and splits the slice into two PRs.
+
+**Activated-ability exemption (#361) — classify by effect root.** Fight/Evade
+*basic actions* are separate handlers (`actions::fight` / `actions::evade`) that
+never touch the AoO path. **Weapons are activated `Effect::Fight` abilities**
+(Machete 01020, .45 Automatic, Roland's .38 Special 01006, Knife 01086 — all
+`activated(1, …, fight(…))`, bare `Effect::Fight` at the root), so they *do* go
+through `activate_ability` and must be exempted there. The gate is therefore:
+fire AoO iff `action_cost > 0 && !matches!(effect, Effect::Fight {..} |
+Effect::Evade {..})`. In-scope provokers: First Aid 01019 (`choose_one` heal),
+Flashlight 01087 (`investigate`), Medical Texts 01035 (`skill_test`), Old Book of
+Lore 01031 (`search_deck`). No activated Evade/Parley/Resign in scope — the
+`Evade` arm is a correct-by-construction hook. `activate_ability` already charges
+the action in `pay_activation_costs`, so AoO fires there (after costs, before
+`apply_effect`) with no new charging — #361 is the clean half.
+
+**Play-action charge (#378) — entirely missing, folded in.** Stronger than the
+spec assumed: `play_card` / `check_play_card` / `begin_event_play` never call
+`spend_one_action` nor validate `actions_remaining` (only the Draw handler does).
+Non-fast plays — **assets and events** — cost **zero actions** today. So #378
+*adds* the non-fast play-action charge (validate ≥1 action + spend 1, gated
+`!is_fast`), then fires AoO after it and before the OnPlay effect — matching the
+Dynamite Blast 01024 FAQ. Both the charge and the AoO key on `!is_fast`, so they
+cover non-fast **assets** too, not only events.
+
+**Two PRs.** **PR-A** = #361 (clean) + this spec note + the phase-7 skill-test
+Shape-A doc note. **PR-B** = #378 (+ the play-action charge). Splits the clean
+change from the higher-blast-radius one.
+
 ### K4 — player attack-order (#143) + enemy-phase frame extension
 
 When an investigator is engaged with **2+ ready enemies**, offer an order choice


### PR DESCRIPTION
## Summary

`activate_ability` fired no attack of opportunity, so activating a non-fight `[action]` ability (First Aid, Flashlight, Medical Texts, Old Book of Lore) while engaged with a ready enemy skipped the AoO the rules require. Per **RR p.5** ("Attack of Opportunity"): an investigator engaged with one or more ready enemies who takes an action **other than to fight, to evade, or to activate a parley or resign ability** provokes one AoO from each such enemy, after costs are paid and before the action's effect resolves.

This is **K3** of the keystone arc ([keystone spec](docs/superpowers/specs/2026-06-20-phase-7-keystone-mid-action-park-design.md)) — the activated-ability half. It reuses the K1 `ActionResolution` frame + `drive_aoo` substrate (the basic actions already route through it).

## What changed

- `activate_ability`: after `pay_activation_costs` spends the action and `AbilityActivated` is emitted, an action-cost non-fight ability **parks its effect** on a new `ActionResume::ActivateAbility` frame and **drives the AoO loop** (which opens the Dodge cancel / Guard Dog soak windows), running the effect on resume. Fight and fast abilities resolve synchronously as before.
- `provokes_aoo(action_cost, effect)`: the gate — `action_cost > 0 && !matches!(effect, Effect::Fight { .. })`. Weapons (Machete, .45 Automatic, Roland's .38, Knife) are activated `Effect::Fight` abilities, so the naive action-cost gate would wrongly provoke them; the effect-root match exempts them. There is no `Effect::Evade` and no activated parley/resign card in scope.
- `ActionResume::ActivateAbility { instance_id, effect }` + the `resume_activate_ability` handler + the `drive` resume arm.

## Design decisions

- **Snapshot the effect, don't re-derive it.** Unlike the basic-action resumes (which re-derive board-dependent values live), the variant carries the resolved `Effect`: an ability's effect is fixed at activation (not board-dependent), and the source may self-discard as a cost (First Aid depleting its last supply) before the effect resumes — a live re-resolution by instance would be fragile. `Effect` is `Serialize`/`Deserialize`, so the frame stays replay-safe.
- **Fight exemption by effect root.** Verified against every activated-ability impl in the corpus; no `Seq`-wrapped Fight exists, so a root match suffices (documented; extend if one lands).
- **Re-validation gate.** The §D actor-`Active` gate (already in `resume_action_resolution`) suppresses the effect if the AoO defeats the actor.

## Known limitation (documented)

A resumed effect that returns `Rejected` on a *lapsed* precondition (vs. the basic actions' `Done`-to-suppress) would roll back the whole activation via `apply()`'s snapshot. **Unreachable in scope** — no in-scope AoO reaction relocates the actor without defeating it — so it's a documented `TODO` on `resume_activate_ability`, to be given the suppress-on-lapse shape when a board-changing AoO reaction lands. (Surfaced in pre-push review.)

## Tests

`crates/cards/tests/activate_ability_aoo.rs` (registry-backed, 5 tests) + a `provokes_aoo` unit test:
- non-fight ability provokes (soak window onto Guard Dog; supply spent before the AoO);
- Fight ability (Machete) exempt — routes straight to its skill test;
- fast ability (Beat Cop) exempt;
- Dodge cancels the activation's AoO, then the heal effect resumes and applies;
- an AoO that defeats the actor suppresses the effect.

Full local gauntlet green (fmt, clippy host + wasm, `RUSTFLAGS=-D warnings` test --all, doc, wasm-build).

Closes #361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)