### PR TITLE
engine: reference #417 from the mid-action Rejected-rollback TODOs

### DIFF
--- a/crates/game-core/src/engine/dispatch/abilities.rs
+++ b/crates/game-core/src/engine/dispatch/abilities.rs
@@ -146,7 +146,7 @@ fn provokes_aoo(action_cost: u8, effect: &crate::dsl::Effect) -> bool {
 /// re-resolution by instance), with `instance_id` only seeding the eval
 /// context's source.
 ///
-/// TODO (richer mid-action invalidation): unlike the basic-action resumes
+/// TODO(#417) (richer mid-action invalidation): unlike the basic-action resumes
 /// (`investigate_primary_effect` etc., which return `Done` to *suppress*
 /// gracefully when their target precondition has lapsed), this delegates
 /// straight to `apply_effect`. Some effects (`Effect::Investigate` on

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -605,8 +605,9 @@ pub(super) fn play_card(
 /// effect that suspends (Dynamite Blast's location choice) returns its outcome;
 /// its frame resumes through its own path.
 ///
-/// TODO (richer mid-action invalidation, shared with `resume_activate_ability`,
-/// #361): a resumed `OnPlay` effect that returns [`EngineOutcome::Rejected`] on
+/// TODO(#417) (richer mid-action invalidation, shared with
+/// `resume_activate_ability`, #361): a resumed `OnPlay` effect that returns
+/// [`EngineOutcome::Rejected`] on
 /// a lapsed precondition rolls back the *whole* play (the `AoO` damage + spent
 /// action) via `apply()`'s snapshot, rather than suppressing the primary only
 /// (the §D contract). Unreachable in scope — the only non-fast `OnPlay` cards


### PR DESCRIPTION
Tiny follow-up to #415 / #416. The resumed-effect `Rejected`-rolls-back-instead-of-suppressing asymmetry surfaced in both K3 reviews is now tracked as #417; this wires the issue number into the two in-code `TODO`s (`resume_activate_ability`, `complete_play`) so the latent trap is greppable from its tracker.

Comment-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)