### PR TITLE
engine: migrate event windows + forced run to TimingPointWindow (Slice A-i task 2)

### DIFF
--- a/crates/cards/tests/guard_dog_soak.rs
+++ b/crates/cards/tests/guard_dog_soak.rs
@@ -427,7 +427,7 @@ fn only_guard_dogs_reaction_is_offered_not_another_controlled_soaker() {
     let soak_windows: Vec<_> = state
         .open_windows()
         .iter()
-        .filter_map(|w| match w.kind() {
+        .filter_map(|w| match w.window_kind() {
             Some(game_core::state::WindowKind::AfterEnemyAttackDamagedAsset { asset, .. }) => {
                 Some(asset)
             }

--- a/crates/game-core/src/engine/dispatch/emit.rs
+++ b/crates/game-core/src/engine/dispatch/emit.rs
@@ -172,7 +172,7 @@ impl TimingEvent {
 
     /// The reaction window this timing event opens, if any. `Some` only for
     /// the reaction-capable points.
-    fn reaction_window(&self) -> Option<WindowKind> {
+    pub(crate) fn reaction_window(&self) -> Option<WindowKind> {
         match self {
             TimingEvent::EnemyDefeated { enemy, by, .. } => Some(WindowKind::AfterEnemyDefeated {
                 enemy: *enemy,
@@ -302,8 +302,8 @@ impl TimingEvent {
 /// suspends or rejects). T5b replaces the forced phase's internals with the
 /// iterative ordering loop.
 pub(crate) fn emit_event(cx: &mut Cx, event: &TimingEvent) -> EngineOutcome {
-    if let Some(kind) = event.reaction_window() {
-        super::reaction_windows::queue_reaction_window(cx, kind);
+    if event.reaction_window().is_some() {
+        super::reaction_windows::queue_reaction_window(cx, event);
     }
     let Some(point) = event.forced_point() else {
         return EngineOutcome::Done;
@@ -324,7 +324,7 @@ pub(crate) fn emit_event(cx: &mut Cx, event: &TimingEvent) -> EngineOutcome {
                  variant + a TimingEvent::forced_continuation arm",
             )
         });
-        super::reaction_windows::open_forced_resolution(cx, candidates, continuation)
+        super::reaction_windows::open_forced_resolution(cx, event, candidates, continuation)
     } else {
         fire_forced_triggers(cx, &point)
     }

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -401,14 +401,13 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
         Some(Continuation::SubstitutionPrompt { .. }) => {
             skill_test::resume_substitution_choice(cx, response)
         }
-        Some(Continuation::Resolution(_)) => resume_window(cx, response),
-        // Slice A-i: nothing constructs `TimingPointWindow` until task 2/3, so a
-        // ResolveInput here is unreachable today. Reject loudly rather than
-        // silently no-op (the event-window/forced routing lands in task 2/3).
-        Some(Continuation::TimingPointWindow { .. }) => EngineOutcome::Rejected {
-            reason: "ResolveInput: TimingPointWindow routing not yet wired (Slice A-i task 2/3)"
-                .into(),
-        },
+        // Both an event reaction window and the forced run (now
+        // `TimingPointWindow`, #433) resolve through the same window driver as
+        // the legacy framework `Resolution` windows — the driver reads
+        // candidates/mode through the frame-agnostic accessors.
+        Some(Continuation::Resolution(_) | Continuation::TimingPointWindow { .. }) => {
+            resume_window(cx, response)
+        }
         // An effect node suspended in place for a controller pick (#422): the
         // top `Continuation::Effect(Leaf)` frame *is* the prompt. Route its
         // `PickSingle` to the effect-choice resume. A non-suspending effect

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -53,29 +53,32 @@ use super::Cx;
 /// doesn't arise; the overwrite is a loud-on-debug placeholder
 /// rather than silent stacking — multi-window queueing lands when a
 /// multi-defeat effect arrives.
-pub(super) fn queue_reaction_window(cx: &mut Cx, kind: WindowKind) {
-    let mut pending_triggers = scan_pending_triggers(cx.state, kind);
+pub(super) fn queue_reaction_window(cx: &mut Cx, event: &crate::engine::TimingEvent) {
+    let kind = event
+        .reaction_window()
+        .expect("queue_reaction_window: caller checks the event opens a reaction window");
+    let mut candidates = scan_pending_triggers(cx.state, kind);
     // Axis C (#335): the window also opens for a matching Fast event in hand,
     // so a defeat with Evidence! in hand (and no in-play reaction) still opens
     // the after-defeat window. Hand plays are offered after the in-play
     // triggers.
-    pending_triggers.extend(scan_hand_fast_events(cx.state, kind));
-    if pending_triggers.is_empty() {
+    candidates.extend(scan_hand_fast_events(cx.state, kind));
+    if candidates.is_empty() {
         return;
     }
+    // `WindowOpened` carries the derived `WindowKind` so the observable event
+    // is byte-identical to the pre-#433 payload.
     cx.events.push(Event::WindowOpened { kind });
-    // Reaction windows admit any investigator's Fast actions
-    // (Rules Reference: Fast may be played at any player window).
-    // Multi-window nesting is now structural — push twice is valid.
+    // Reaction windows admit any investigator's Fast actions (RR: Fast may be
+    // played at any player window) — encoded by `mode: Reaction` (the former
+    // `FastActorScope::Any` binding). Multi-window nesting is structural.
     cx.state
         .continuations
-        .push(Continuation::Resolution(ResolutionFrame {
-            pending_triggers,
-            kind: ResolutionKind::Window(WindowBinding {
-                kind,
-                fast_actors: FastActorScope::Any,
-            }),
-        }));
+        .push(Continuation::TimingPointWindow {
+            event: event.clone(),
+            mode: crate::state::TimingMode::Reaction,
+            candidates,
+        });
 }
 
 /// Open the forced-resolution run (Axis-B T5b / #213): push a
@@ -87,15 +90,17 @@ pub(super) fn queue_reaction_window(cx: &mut Cx, kind: WindowKind) {
 /// ([`super::emit::emit_event`]) returns the resulting `AwaitingInput`.
 pub(super) fn open_forced_resolution(
     cx: &mut Cx,
+    event: &crate::engine::TimingEvent,
     candidates: Vec<ResolutionCandidate>,
     continuation: ForcedContinuation,
 ) -> EngineOutcome {
     cx.state
         .continuations
-        .push(Continuation::Resolution(ResolutionFrame {
-            pending_triggers: candidates,
-            kind: ResolutionKind::Forced(continuation),
-        }));
+        .push(Continuation::TimingPointWindow {
+            event: event.clone(),
+            mode: crate::state::TimingMode::Forced(continuation),
+            candidates,
+        });
     open_queued_reaction_window(cx)
 }
 
@@ -448,9 +453,8 @@ fn trigger_matches(
 /// `OptionId(i)` is the index into the returned list — the Axis-A convention
 /// shared with [`super::choice`]. The label distinguishes a hand Fast-event
 /// play ([`CandidateSource::Hand`]) from an in-play reaction.
-fn build_resolution_options(frame: &ResolutionFrame) -> Vec<ChoiceOption> {
-    frame
-        .pending_triggers
+fn build_resolution_options(candidates: &[ResolutionCandidate]) -> Vec<ChoiceOption> {
+    candidates
         .iter()
         .enumerate()
         .map(|(i, cand)| {
@@ -486,7 +490,11 @@ pub(crate) fn open_queued_reaction_window(cx: &mut Cx) -> EngineOutcome {
     } else {
         ", or InputResponse::Skip to close"
     };
-    let options = build_resolution_options(window);
+    let options = build_resolution_options(
+        window
+            .pending_candidates()
+            .expect("open_queued_reaction_window: top window has candidates"),
+    );
     EngineOutcome::AwaitingInput {
         request: InputRequest::choice(
             format!(
@@ -532,12 +540,9 @@ pub(super) fn resume_reaction_window(cx: &mut Cx, response: &InputResponse) -> E
                 .state
                 .top_reaction_window_index()
                 .expect("resume_reaction_window: caller checked is_some");
-            // Forced abilities are mandatory — the forced run (`window: None`)
-            // cannot be skipped (RR p.2 / #213). The lead must pick one.
-            if cx.state.continuations[idx]
-                .as_resolution()
-                .is_some_and(ResolutionFrame::is_forced)
-            {
+            // Forced abilities are mandatory — the forced run cannot be
+            // skipped (RR p.2 / #213). The lead must pick one.
+            if cx.state.continuations[idx].is_forced() {
                 return EngineOutcome::Rejected {
                     reason: "ResolveInput::Skip: forced abilities are mandatory; submit \
                              InputResponse::PickSingle(OptionId) to resolve one (the lead \
@@ -574,23 +579,23 @@ fn fire_pending_trigger(cx: &mut Cx, i: u32) -> EngineOutcome {
         .expect("fire_pending_trigger: caller checked is_some");
     // Snapshot to avoid borrowing state across the apply_effect call.
     let (trigger, pending_idx) = {
-        let window = cx.state.continuations[window_idx]
-            .as_resolution()
-            .expect("fire_pending_trigger: top_reaction_window_index points at a Resolution frame");
+        let candidates = cx.state.continuations[window_idx]
+            .pending_candidates()
+            .expect("fire_pending_trigger: top_reaction_window_index points at an open window/run");
         let idx = match usize::try_from(i) {
-            Ok(idx) if idx < window.pending_triggers.len() => idx,
+            Ok(idx) if idx < candidates.len() => idx,
             _ => {
                 return EngineOutcome::Rejected {
                     reason: format!(
                         "ResolveInput: reaction-window PickSingle(OptionId({i})) out of bounds \
                          (pending size {})",
-                        window.pending_triggers.len(),
+                        candidates.len(),
                     )
                     .into(),
                 };
             }
         };
-        (window.pending_triggers[idx].clone(), idx)
+        (candidates[idx].clone(), idx)
     };
 
     // Axis C (#335): a hand candidate is *played*, not fired in place. Remove
@@ -598,12 +603,10 @@ fn fire_pending_trigger(cx: &mut Cx, i: u32) -> EngineOutcome {
     // siblings, not this one again — mirrors the in-play path below), then
     // play it.
     if trigger.source == CandidateSource::Hand {
-        {
-            let window = cx.state.continuations[window_idx]
-                .as_resolution_mut()
-                .expect("fire_pending_trigger: window_idx is a Resolution frame");
-            window.pending_triggers.remove(pending_idx);
-        }
+        cx.state.continuations[window_idx]
+            .pending_candidates_mut()
+            .expect("fire_pending_trigger: window_idx is an open window/run")
+            .remove(pending_idx);
         return play_fast_event(cx, window_idx, &trigger);
     }
 
@@ -651,19 +654,16 @@ fn fire_pending_trigger(cx: &mut Cx, i: u32) -> EngineOutcome {
     // `eval_ctx.attacking_enemy`. Mirrors `failed_by` /
     // `clue_discovery_count`. `None` for all other window kinds. (C5b
     // #237.)
-    match cx.state.continuations[window_idx]
-        .as_resolution()
-        .and_then(ResolutionFrame::kind)
-    {
-        Some(WindowKind::AfterEnemyAttackDamagedAsset { enemy, .. }) => {
-            eval_ctx.set_attacking_enemy(enemy);
+    match cx.state.continuations[window_idx].window_timing_event() {
+        Some(crate::engine::TimingEvent::EnemyAttackDamagedSelf { enemy, .. }) => {
+            eval_ctx.set_attacking_enemy(*enemy);
         }
-        // For `BeforeDiscoverClues`, bind the would-be discovery count so the
+        // For `WouldDiscoverClues`, bind the would-be discovery count so the
         // replacement effect (Cover Up's "discard that many") discards the
         // right number. Mirrors `attacking_enemy`. TODO(#368): `count` is the
         // requested, not the capped, count.
-        Some(WindowKind::BeforeDiscoverClues { count, .. }) => {
-            eval_ctx.set_clue_discovery_count(count);
+        Some(crate::engine::TimingEvent::WouldDiscoverClues { count, .. }) => {
+            eval_ctx.set_clue_discovery_count(*count);
         }
         _ => {}
     }
@@ -674,12 +674,10 @@ fn fire_pending_trigger(cx: &mut Cx, i: u32) -> EngineOutcome {
     // Fear 01164), the entry must already be consumed so the resume drives
     // the *remaining* siblings, not this one again. `apply_effect` does not
     // push/pop continuations, so `window_idx` stays valid across it.
-    {
-        let window = cx.state.continuations[window_idx]
-            .as_resolution_mut()
-            .expect("fire_pending_trigger: window_idx is a Resolution frame");
-        window.pending_triggers.remove(pending_idx);
-    }
+    cx.state.continuations[window_idx]
+        .pending_candidates_mut()
+        .expect("fire_pending_trigger: window_idx is an open window/run")
+        .remove(pending_idx);
 
     let result = apply_effect(cx, &ability.effect, eval_ctx);
     match result {
@@ -794,13 +792,14 @@ fn play_fast_event(
 /// commit-resume path ([`super::resume_skill_test_commit`]) — the latter
 /// re-enters a forced run parked beneath a sibling's now-resolved skill test.
 pub(super) fn advance_resolution(cx: &mut Cx, window_idx: usize) -> EngineOutcome {
-    let window = cx.state.continuations[window_idx]
-        .as_resolution()
-        .expect("advance_resolution: window_idx is a Resolution frame");
+    let window = &cx.state.continuations[window_idx];
+    let candidates = window
+        .pending_candidates()
+        .expect("advance_resolution: window_idx is an open window/run");
     // Close when no candidate remains. Hand Fast-event plays (Axis C) ride
-    // `pending_triggers` alongside in-play triggers, so this single check
+    // the candidate list alongside in-play triggers, so this single check
     // keeps a window with only a remaining hand play open.
-    if window.pending_triggers.is_empty() {
+    if candidates.is_empty() {
         return close_reaction_window_at(cx, window_idx);
     }
     let skip_hint = if window.is_forced() {
@@ -808,7 +807,7 @@ pub(super) fn advance_resolution(cx: &mut Cx, window_idx: usize) -> EngineOutcom
     } else {
         ", or InputResponse::Skip to close"
     };
-    let options = build_resolution_options(window);
+    let options = build_resolution_options(candidates);
     EngineOutcome::AwaitingInput {
         request: InputRequest::choice(
             format!(
@@ -893,23 +892,24 @@ pub(super) fn close_reaction_window_at(cx: &mut Cx, idx: usize) -> EngineOutcome
     // "forced abilities are mandatory" rule lives in the forced resolution
     // run (its frame is `window: None` — Axis-B T5b), not here.
     let removed = cx.state.continuations.remove(idx);
-    let frame = removed
-        .as_resolution()
-        .expect("close_reaction_window_at: removed frame must be a Resolution frame");
 
     // A window emits `WindowClosed` and runs its kind-specific continuation
-    // (e.g. MythosAfterDraws → mythos_phase_end). The forced run (#213) is
-    // not a window: no event; instead it resumes the framework flow it
-    // suspended via its `ForcedContinuation`. Either may suspend (e.g. the
-    // upkeep act round-end advance window), so propagate the outcome.
-    let continuation = if let Some(kind) = frame.kind() {
+    // (e.g. MythosAfterDraws → mythos_phase_end). Its `WindowKind` comes from
+    // the legacy `Resolution` frame (framework windows) or is derived from the
+    // `TimingEvent` of a `TimingPointWindow` reaction window (#433) — so the
+    // `WindowClosed` payload + continuation are byte-identical across the
+    // migration. The forced run (#213) is not a window: no event; instead it
+    // resumes the framework flow it suspended via its `ForcedContinuation`.
+    // Either may suspend (e.g. the upkeep act round-end advance window), so
+    // propagate the outcome.
+    let continuation = if let Some(kind) = removed.window_kind() {
         cx.events.push(Event::WindowClosed { kind });
         run_window_continuation(cx, kind)
     } else {
-        let cont = frame.forced_continuation().unwrap_or_else(|| {
+        let cont = removed.forced_continuation().unwrap_or_else(|| {
             unreachable!(
-                "close_reaction_window_at: a non-window Resolution frame is the forced \
-                 run and must carry a ForcedContinuation"
+                "close_reaction_window_at: a non-window frame is the forced run \
+                 and must carry a ForcedContinuation"
             )
         });
         resume_forced_continuation(cx, cont)
@@ -1132,7 +1132,8 @@ pub(super) fn open_fast_window(cx: &mut Cx, kind: WindowKind) -> EngineOutcome {
         .state
         .top_window()
         .expect("just pushed; cannot be empty")
-        .pending_triggers
+        .pending_candidates()
+        .expect("top_window is an open window/run")
         .is_empty();
     let has_fast_eligible = any_fast_play_eligible(cx.state);
 
@@ -1241,7 +1242,7 @@ pub(crate) fn check_play_card(
     let owner_is_active = state.active_investigator == Some(investigator);
     let permissive_window = state
         .top_window()
-        .is_some_and(|w| w.fast_actors().is_some_and(|fa| fa.permits(investigator)));
+        .is_some_and(|w| w.permits_fast(investigator));
     // "Play only during your turn" (Mind over Matter 01036, Working a Hunch
     // 01037, …): a Fast card with this clause is restricted to the active
     // investigator's Investigation turn — never an out-of-turn permissive Fast
@@ -1481,7 +1482,7 @@ pub(crate) fn check_activate_ability(
         state.phase == Phase::Investigation && state.active_investigator == Some(investigator);
     let in_permissive_window = state
         .top_window()
-        .is_some_and(|w| w.fast_actors().is_some_and(|fa| fa.permits(investigator)));
+        .is_some_and(|w| w.permits_fast(investigator));
     if action_cost > 0 {
         // Action-cost ability: requires Investigation phase + active investigator.
         if !active_during_investigation {

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -551,10 +551,12 @@ pub(super) fn advance(cx: &mut Cx) -> EngineOutcome {
                 // before rotation; resume it now (C4c, #235). A forced run owns
                 // its own post-run continuation and never flags the turn frame,
                 // so it is checked first.
-                if matches!(
-                    cx.state.continuations.last(),
-                    Some(crate::state::Continuation::Resolution(f)) if f.is_forced()
-                ) {
+                if cx
+                    .state
+                    .continuations
+                    .last()
+                    .is_some_and(crate::state::Continuation::is_forced)
+                {
                     let idx = cx.state.continuations.len() - 1;
                     return super::reaction_windows::advance_resolution(cx, idx);
                 }

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -1320,8 +1320,8 @@ fn discover_clue(
     if matches!(
         cx.state
             .top_reaction_window()
-            .and_then(crate::state::ResolutionFrame::kind),
-        Some(crate::state::WindowKind::BeforeDiscoverClues { .. })
+            .and_then(crate::state::Continuation::window_timing_event),
+        Some(crate::engine::TimingEvent::WouldDiscoverClues { .. })
     ) {
         return crate::engine::dispatch::reaction_windows::open_queued_reaction_window(cx);
     }
@@ -1343,7 +1343,7 @@ fn cancel_current_impact(cx: &mut Cx) -> EngineOutcome {
         cx.state
             .continuations
             .iter()
-            .any(|c| matches!(c, crate::state::Continuation::Resolution(_))),
+            .any(|c| c.pending_candidates().is_some()),
         "Effect::Cancel evaluated with no open resolution window — a card \
          cancelled outside a Before-timing window (TODO(#367) covers nesting; \
          a malformed card otherwise)"

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -414,10 +414,15 @@ mod with_open_window_tests {
             .build();
         assert_eq!(state.open_windows().len(), 1);
         assert_eq!(
-            state.open_windows()[0].fast_actors(),
+            state.open_windows()[0]
+                .as_resolution()
+                .and_then(ResolutionFrame::fast_actors),
             Some(&FastActorScope::Any)
         );
-        assert!(state.open_windows()[0].pending_triggers.is_empty());
+        assert!(state.open_windows()[0]
+            .pending_candidates()
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
@@ -435,7 +440,7 @@ mod with_open_window_tests {
             .build();
         assert_eq!(state.open_windows().len(), 2);
         assert!(matches!(
-            state.open_windows()[1].kind(),
+            state.open_windows()[1].window_kind(),
             Some(WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins))
         ));
     }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -862,6 +862,61 @@ impl Continuation {
             _ => None,
         }
     }
+
+    /// The [`TimingEvent`](crate::engine::TimingEvent) that opened this frame,
+    /// if it is a [`TimingPointWindow`](Self::TimingPointWindow) (event window
+    /// or forced run). `None` for legacy [`Resolution`](Self::Resolution)
+    /// framework windows (no timing event) and non-window frames. Lets the
+    /// driver bind event-specific `EvalContext` (the attacking enemy, the
+    /// would-be discovery count) without a `WindowKind` round-trip (#433).
+    #[must_use]
+    pub fn window_timing_event(&self) -> Option<&crate::engine::TimingEvent> {
+        match self {
+            Continuation::TimingPointWindow { event, .. } => Some(event),
+            _ => None,
+        }
+    }
+
+    /// The [`WindowKind`] of this open frame, for either representation: a
+    /// legacy [`Resolution`](Self::Resolution) framework window returns its
+    /// stored kind; a [`TimingPointWindow`](Self::TimingPointWindow) reaction
+    /// window derives it from the [`TimingEvent`](crate::engine::TimingEvent)
+    /// (so `WindowOpened`/`WindowClosed` payloads are byte-identical across the
+    /// #433 migration). `None` for the forced run (no window) and non-window
+    /// frames.
+    #[must_use]
+    pub fn window_kind(&self) -> Option<WindowKind> {
+        match self {
+            Continuation::Resolution(w) => w.kind(),
+            Continuation::TimingPointWindow {
+                event,
+                mode: TimingMode::Reaction,
+                ..
+            } => event.reaction_window(),
+            _ => None,
+        }
+    }
+
+    /// Whether `investigator` may submit a Fast action into this open
+    /// window, in either representation. A legacy [`Resolution`](Self::Resolution)
+    /// window delegates to its [`FastActorScope`]; a
+    /// [`TimingPointWindow`](Self::TimingPointWindow) reaction window admits
+    /// any investigator (the constant `FastActorScope::Any` the legacy
+    /// reaction-window binding carried). Forced runs and non-window frames
+    /// admit none.
+    #[must_use]
+    pub fn permits_fast(&self, investigator: InvestigatorId) -> bool {
+        match self {
+            Continuation::Resolution(w) => {
+                w.fast_actors().is_some_and(|fa| fa.permits(investigator))
+            }
+            Continuation::TimingPointWindow {
+                mode: TimingMode::Reaction,
+                ..
+            } => true,
+            _ => false,
+        }
+    }
 }
 
 /// The Mythos-phase child-pop boundary an anchor resumes at (slice 1a, #393).
@@ -1720,21 +1775,21 @@ impl GameState {
     /// `pending_triggers`. Pure Fast-gating framework windows (empty
     /// `pending_triggers`) are skipped — they don't block dispatch.
     #[must_use]
-    pub fn top_reaction_window(&self) -> Option<&ResolutionFrame> {
-        self.windows()
+    pub fn top_reaction_window(&self) -> Option<&Continuation> {
+        self.continuations
+            .iter()
             .rev()
-            .find(|w| !w.pending_triggers.is_empty())
+            .find(|c| c.pending_candidates().is_some_and(|p| !p.is_empty()))
     }
 
     /// Mutable counterpart to `top_reaction_window`. Same skip rule
-    /// applies: windows with empty `pending_triggers` are skipped —
+    /// applies: windows with empty candidate lists are skipped —
     /// phase-gate-only windows are not exposed as reaction-work.
-    pub fn top_reaction_window_mut(&mut self) -> Option<&mut ResolutionFrame> {
+    pub fn top_reaction_window_mut(&mut self) -> Option<&mut Continuation> {
         self.continuations
             .iter_mut()
             .rev()
-            .filter_map(Continuation::as_resolution_mut)
-            .find(|w| !w.pending_triggers.is_empty())
+            .find(|c| c.pending_candidates().is_some_and(|p| !p.is_empty()))
     }
 
     /// The skill test currently in flight, if any; `None` outside a test. Reads
@@ -1812,17 +1867,22 @@ impl GameState {
     /// Iterator over the open windows on the continuation stack, in stack
     /// order (bottom to top). The windows are `Continuation::Resolution`
     /// frames; non-window frames (Task 4+) are skipped.
-    fn windows(&self) -> impl DoubleEndedIterator<Item = &ResolutionFrame> {
+    /// Every open window/run frame on the stack, in stack order — legacy
+    /// [`Resolution`](Continuation::Resolution) framework windows **and**
+    /// [`TimingPointWindow`](Continuation::TimingPointWindow) event windows /
+    /// forced runs (#433). A frame is a window/run iff it carries a candidate
+    /// list ([`Continuation::pending_candidates`]).
+    fn windows(&self) -> impl DoubleEndedIterator<Item = &Continuation> {
         self.continuations
             .iter()
-            .filter_map(Continuation::as_resolution)
+            .filter(|c| c.pending_candidates().is_some())
     }
 
     /// The open windows as a `Vec` of references, in stack order. Read
     /// accessor for callers (and tests) that inspect the window stack the
     /// way they used to read the former `open_windows` field.
     #[must_use]
-    pub fn open_windows(&self) -> Vec<&ResolutionFrame> {
+    pub fn open_windows(&self) -> Vec<&Continuation> {
         self.windows().collect()
     }
 
@@ -1831,7 +1891,7 @@ impl GameState {
     /// timing gate. Distinct from [`Self::top_reaction_window`], which
     /// skips empty-`pending_triggers` (pure-Fast) windows.
     #[must_use]
-    pub fn top_window(&self) -> Option<&ResolutionFrame> {
+    pub fn top_window(&self) -> Option<&Continuation> {
         self.windows().next_back()
     }
 
@@ -1854,10 +1914,9 @@ impl GameState {
     /// window, by construction, has no forced triggers to guard against.
     #[must_use]
     pub fn top_reaction_window_index(&self) -> Option<usize> {
-        self.continuations.iter().rposition(|c| {
-            c.as_resolution()
-                .is_some_and(|w| !w.pending_triggers.is_empty())
-        })
+        self.continuations
+            .iter()
+            .rposition(|c| c.pending_candidates().is_some_and(|p| !p.is_empty()))
     }
 
     /// Build a [`Location`] from its card `metadata`, minting a fresh id.
@@ -2190,7 +2249,9 @@ mod continuation_stack_tests {
         // The read accessor surfaces it as the former `open_windows` view.
         assert_eq!(state.open_windows().len(), 1);
         assert_eq!(
-            state.open_windows()[0].kind(),
+            state.open_windows()[0]
+                .as_resolution()
+                .and_then(ResolutionFrame::kind),
             Some(WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws)),
         );
     }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -813,6 +813,55 @@ impl Continuation {
             | Continuation::Effect(_) => None,
         }
     }
+
+    /// The resolution candidates of an open window/run on the stack —
+    /// whether a legacy [`Resolution`](Self::Resolution) frame (framework
+    /// windows during EmitEvent-frame Slice A-i, #433) or a
+    /// [`TimingPointWindow`](Self::TimingPointWindow) (event windows + the
+    /// #213 forced run). Lets the shared resolution driver read candidates
+    /// without caring which representation it is. `None` for any other frame.
+    #[must_use]
+    pub fn pending_candidates(&self) -> Option<&Vec<ResolutionCandidate>> {
+        match self {
+            Continuation::Resolution(w) => Some(&w.pending_triggers),
+            Continuation::TimingPointWindow { candidates, .. } => Some(candidates),
+            _ => None,
+        }
+    }
+
+    /// Mutable counterpart to [`Self::pending_candidates`].
+    pub fn pending_candidates_mut(&mut self) -> Option<&mut Vec<ResolutionCandidate>> {
+        match self {
+            Continuation::Resolution(w) => Some(&mut w.pending_triggers),
+            Continuation::TimingPointWindow { candidates, .. } => Some(candidates),
+            _ => None,
+        }
+    }
+
+    /// Whether the frame is the mandatory #213 forced run, in either
+    /// representation. `false` for reaction windows and non-window frames.
+    #[must_use]
+    pub fn is_forced(&self) -> bool {
+        match self {
+            Continuation::Resolution(w) => w.is_forced(),
+            Continuation::TimingPointWindow { mode, .. } => matches!(mode, TimingMode::Forced(_)),
+            _ => false,
+        }
+    }
+
+    /// The [`ForcedContinuation`] if this frame is the forced run, in either
+    /// representation; `None` for a reaction window or non-window frame.
+    #[must_use]
+    pub fn forced_continuation(&self) -> Option<ForcedContinuation> {
+        match self {
+            Continuation::Resolution(w) => w.forced_continuation(),
+            Continuation::TimingPointWindow {
+                mode: TimingMode::Forced(c),
+                ..
+            } => Some(*c),
+            _ => None,
+        }
+    }
 }
 
 /// The Mythos-phase child-pop boundary an anchor resumes at (slice 1a, #393).

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -29,7 +29,7 @@ pub use game_state::{
     ForcedContinuation, GameState, HandSizeDiscard, HunterChoice, InFlightSkillTest,
     InvestigationResume, MythosResume, PendingSkillModifier, PhaseStep, ResolutionCandidate,
     ResolutionFrame, ResolutionKind, RoundEndAdvance, SkillSubstitution, SkillTestFollowUp,
-    SkillTestStep, SpawnEngagePending, UpkeepResume, WindowBinding, WindowKind,
+    SkillTestStep, SpawnEngagePending, TimingMode, UpkeepResume, WindowBinding, WindowKind,
 };
 pub use investigator::{DefeatCause, Investigator, InvestigatorId, Status};
 pub use location::{Location, LocationId};

--- a/crates/game-core/tests/reaction_windows.rs
+++ b/crates/game-core/tests/reaction_windows.rs
@@ -267,19 +267,19 @@ fn matching_reaction_opens_window_and_suspends() {
         .top_reaction_window()
         .expect("reaction window must be populated while suspended");
     assert_eq!(
-        window.kind(),
+        window.window_kind(),
         Some(WindowKind::AfterEnemyDefeated {
             enemy: enemy_id,
             by: Some(inv_id),
         }),
     );
-    assert_eq!(window.pending_triggers.len(), 1);
-    assert_eq!(window.pending_triggers[0].controller, inv_id);
+    assert_eq!(window.pending_candidates().unwrap().len(), 1);
+    assert_eq!(window.pending_candidates().unwrap()[0].controller, inv_id);
     assert_eq!(
-        window.pending_triggers[0].source,
+        window.pending_candidates().unwrap()[0].source,
         game_core::state::CandidateSource::InPlay(CardInstanceId(1))
     );
-    assert_eq!(window.pending_triggers[0].ability_index, 0);
+    assert_eq!(window.pending_candidates().unwrap()[0].ability_index, 0);
 }
 
 #[test]
@@ -452,8 +452,11 @@ fn unqualified_pattern_matches_any_defeat() {
         .state
         .top_reaction_window()
         .expect("window must open for an unqualified pattern");
-    assert_eq!(window.pending_triggers.len(), 1);
-    assert_eq!(window.pending_triggers[0].controller, bystander);
+    assert_eq!(window.pending_candidates().unwrap().len(), 1);
+    assert_eq!(
+        window.pending_candidates().unwrap()[0].controller,
+        bystander
+    );
 
     let resumed = game_core::engine::apply(
         paused.state,
@@ -543,7 +546,8 @@ fn multiple_pending_triggers_resolve_one_at_a_time() {
             .state
             .top_reaction_window()
             .expect("window populated")
-            .pending_triggers
+            .pending_candidates()
+            .unwrap()
             .len(),
         2,
     );
@@ -568,7 +572,8 @@ fn multiple_pending_triggers_resolve_one_at_a_time() {
             .state
             .top_reaction_window()
             .expect("window still populated")
-            .pending_triggers
+            .pending_candidates()
+            .unwrap()
             .len(),
         1,
     );
@@ -870,21 +875,23 @@ fn pending_triggers_order_active_investigator_first_then_turn_order() {
         .top_reaction_window()
         .expect("window must populate when both investigators carry triggers");
 
-    assert_eq!(window.pending_triggers.len(), 2);
+    assert_eq!(window.pending_candidates().unwrap().len(), 2);
     assert_eq!(
-        window.pending_triggers[0].controller, active,
+        window.pending_candidates().unwrap()[0].controller,
+        active,
         "active investigator's trigger must come first",
     );
     assert_eq!(
-        window.pending_triggers[0].source,
+        window.pending_candidates().unwrap()[0].source,
         game_core::state::CandidateSource::InPlay(CardInstanceId(1))
     );
     assert_eq!(
-        window.pending_triggers[1].controller, other,
+        window.pending_candidates().unwrap()[1].controller,
+        other,
         "non-active investigator's trigger comes after, in turn order",
     );
     assert_eq!(
-        window.pending_triggers[1].source,
+        window.pending_candidates().unwrap()[1].source,
         game_core::state::CandidateSource::InPlay(CardInstanceId(2))
     );
 }
@@ -906,7 +913,8 @@ fn skip_after_firing_one_drops_remaining_optionals() {
             .state
             .top_reaction_window()
             .expect("window populated")
-            .pending_triggers
+            .pending_candidates()
+            .unwrap()
             .len(),
         2,
     );
@@ -997,10 +1005,10 @@ fn reaction_trigger_in_threat_area_opens_window() {
         .state
         .top_reaction_window()
         .expect("threat-area reaction must populate the window");
-    assert_eq!(window.pending_triggers.len(), 1);
-    assert_eq!(window.pending_triggers[0].controller, inv_id);
+    assert_eq!(window.pending_candidates().unwrap().len(), 1);
+    assert_eq!(window.pending_candidates().unwrap()[0].controller, inv_id);
     assert_eq!(
-        window.pending_triggers[0].source,
+        window.pending_candidates().unwrap()[0].source,
         game_core::state::CandidateSource::InPlay(CardInstanceId(7))
     );
 }
@@ -1027,7 +1035,10 @@ fn close_reaction_window_at_removes_reaction_window_not_empty_phase_gate_on_top(
     // Confirm the stack before the injection: one reaction window with
     // one pending trigger.
     assert_eq!(paused.state.open_windows().len(), 1);
-    assert!(!paused.state.open_windows()[0].pending_triggers.is_empty());
+    assert!(!paused.state.open_windows()[0]
+        .pending_candidates()
+        .unwrap()
+        .is_empty());
 
     // Inject an empty player-window gate on top to create the
     // [R (pending), B (empty)] shape.
@@ -1064,7 +1075,7 @@ fn close_reaction_window_at_removes_reaction_window_not_empty_phase_gate_on_top(
         resumed.state.open_windows(),
     );
     assert_eq!(
-        resumed.state.open_windows()[0].kind(),
+        resumed.state.open_windows()[0].window_kind(),
         Some(WindowKind::PlayerWindow(PhaseStep::InvestigatorTurnBegins)),
         "the surviving window must be the player-window gate, not the reaction window",
     );

--- a/crates/scenarios/tests/cover_up_interrupt.rs
+++ b/crates/scenarios/tests/cover_up_interrupt.rs
@@ -14,8 +14,7 @@ use game_core::event::{Event, TraumaKind};
 use game_core::scenario::{Resolution, ScenarioId};
 use game_core::state::{
     Act, CandidateSource, CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, Continuation,
-    FastActorScope, GameState, InvestigatorId, LocationId, Phase, ResolutionCandidate,
-    ResolutionFrame, WindowKind,
+    GameState, InvestigatorId, LocationId, Phase, ResolutionCandidate,
 };
 use game_core::test_support::{test_investigator, test_location, GameStateBuilder};
 use game_core::{Action, InputResponse, PlayerAction};
@@ -180,25 +179,24 @@ fn paused_before_discover_window(count: u8, loc_clues: u8, cover_up_clues: u8) -
         .with_active_investigator(INV)
         .with_turn_order([INV])
         .build();
-    // Mirror what `emit_event(WouldDiscoverClues)` builds: a reaction window
-    // offering Cover Up's first (reaction) ability. Built via the cross-crate
-    // constructors (`new_empty` + `ResolutionCandidate::new`) since the frame /
-    // candidate structs are `#[non_exhaustive]`.
-    let mut frame = ResolutionFrame::new_empty(
-        WindowKind::BeforeDiscoverClues {
+    // Mirror what `emit_event(WouldDiscoverClues)` builds (#433): a
+    // `TimingPointWindow` reaction window keyed by the `WouldDiscoverClues`
+    // timing event, offering Cover Up's first (reaction) ability. The candidate
+    // is built via `ResolutionCandidate::new` (the struct is `#[non_exhaustive]`).
+    state.continuations.push(Continuation::TimingPointWindow {
+        event: game_core::engine::TimingEvent::WouldDiscoverClues {
             investigator: INV,
             location: LOC,
             count,
         },
-        FastActorScope::Any,
-    );
-    frame.pending_triggers.push(ResolutionCandidate::new(
-        CardCode(SYNTH_COVER_UP_CODE.into()),
-        INV,
-        0,
-        CandidateSource::InPlay(CardInstanceId(1)),
-    ));
-    state.continuations.push(Continuation::Resolution(frame));
+        mode: game_core::state::TimingMode::Reaction,
+        candidates: vec![ResolutionCandidate::new(
+            CardCode(SYNTH_COVER_UP_CODE.into()),
+            INV,
+            0,
+            CandidateSource::InPlay(CardInstanceId(1)),
+        )],
+    });
     state
 }
 

--- a/crates/scenarios/tests/mythos_phase.rs
+++ b/crates/scenarios/tests/mythos_phase.rs
@@ -738,7 +738,7 @@ fn mythos_after_draws_window_stays_open_when_fast_event_in_hand() {
     assert!(
         matches!(
             result.state.open_windows().last(),
-            Some(w) if w.kind() == Some(WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws))
+            Some(w) if w.window_kind() == Some(WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws))
         ),
         "top open window must be MythosAfterDraws; got {:?}",
         result.state.open_windows().last()
@@ -836,9 +836,12 @@ fn mythos_after_draws_window_closed_by_skip_and_transitions_to_investigation() {
          MythosAfterDraws must be gone"
     );
     assert!(
-        skip_result.state.open_windows().last().is_some_and(
-            |w| w.kind() == Some(WindowKind::PlayerWindow(PhaseStep::InvestigationBegins))
-        ),
+        skip_result
+            .state
+            .open_windows()
+            .last()
+            .is_some_and(|w| w.window_kind()
+                == Some(WindowKind::PlayerWindow(PhaseStep::InvestigationBegins))),
         "top window must be InvestigationBegins; got {:?}",
         skip_result.state.open_windows().last()
     );

--- a/docs/superpowers/plans/2026-06-22-timing-point-window-a-i.md
+++ b/docs/superpowers/plans/2026-06-22-timing-point-window-a-i.md
@@ -86,59 +86,46 @@ PR1 — branch `engine/timing-point-window` (already created; the planning-docs 
 
 ---
 
-## Task 2: Migrate the forced run to `TimingPointWindow { mode: Forced }`
+## Task 2: Migrate event windows + forced run to `TimingPointWindow` (+ tests)
 
-PR2 — branch `engine/timing-point-forced` (off `main` after PR1 merges, or off PR1's branch if stacked). Self-contained: the forced run has no Fast plays and no per-`WindowKind` continuation — only a `ForcedContinuation`.
+PR2 — branch `engine/timing-point-forced`. **Re-cut from the original Task 2/Task 3 split:** the forced run and event reaction windows share one driver (`open_forced_resolution` calls `open_queued_reaction_window`, the same path reaction windows use; `advance_resolution` / `fire_pending_trigger` / `close_reaction_window_at` / `build_resolution_options` all key on `as_resolution()`, differing only by `kind: Window | Forced`). Splitting them would rework that driver twice, so they migrate together. The framework player windows (`WindowKind::PlayerWindow` / `SkillTestPlayerWindow`) are the genuinely separable piece and **stay on `Resolution`** until Slice A-ii — so the driver dual-handles `Resolution` (framework only) + `TimingPointWindow` (event + forced) for the duration of A-i.
 
-**Files:**
-- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` — `open_forced_resolution` (constructs `Resolution{Forced}`), `close_reaction_window_at` (the `forced_continuation()` branch → `resume_forced_continuation`), `advance_resolution`, `resume_window`/`resume_reaction_window`, and the forced-run reader in `skill_test::advance`'s teardown tail (`Some(Continuation::Resolution(f)) if f.is_forced()`).
-- Modify: `crates/game-core/src/engine/dispatch/mod.rs` — `resolve_input` routes the forced `TimingPointWindow` (replace the Task-1 stub for `mode: Forced`).
-- Test: `crates/cards/tests/retaliate_windows.rs` and any forced-run engine unit tests asserting on `Resolution{Forced}`.
-
-**Interfaces:**
-- Consumes: `Continuation::TimingPointWindow { event, mode: TimingMode::Forced(continuation), candidates }` from Task 1.
-- Produces: `open_forced_resolution(cx, event: TimingEvent, candidates, continuation)` — signature gains the `event` (the emit's `&TimingEvent`, cloned) so the frame carries it. Callers in `emit_event` pass the in-flight event.
-
-- [ ] **Step 1: Write/adjust the failing test.** In an engine unit test (or extend an existing forced-run test), assert that a 2+-simultaneous-forced emit parks a `Continuation::TimingPointWindow { mode: TimingMode::Forced(_), .. }` (not `Resolution`). Use the `TestGame` builder + a board producing 2 forced hits at one point (mirror the existing `open_forced_resolution` test setup — locate via `grep -rn 'open_forced_resolution\|is_forced' crates/game-core/src`).
-- [ ] **Step 2: Run it — verify it fails** (`Resolution` still constructed). Run the specific test; expect FAIL on the variant assertion.
-- [ ] **Step 3: Flip `open_forced_resolution`** to push `TimingPointWindow { event, mode: Forced(continuation), candidates }`. Thread `event: TimingEvent` from `emit_event` (it has `event: &TimingEvent`; clone it).
-- [ ] **Step 4: Flip the close/resume path.** `close_reaction_window_at` (and/or a new `TimingPointWindow`-aware close) reads `mode: Forced(continuation)` → `resume_forced_continuation(cx, continuation)`. Update `is_forced()` readers (`skill_test::advance` teardown tail, any `as_resolution().is_forced()`) to also recognise `TimingPointWindow { mode: Forced(..), .. }`. Introduce a small helper `fn top_forced_continuation(cx) -> Option<ForcedContinuation>` if the pattern repeats.
-- [ ] **Step 5: Route `resolve_input`.** Replace Task-1's `mode: Forced` stub: forced runs are not player-prompted for *which* (order only when 2+), so route to the existing forced resolve/advance logic — match the current `Resolution{Forced}` routing.
-- [ ] **Step 6: Run the failing test — verify PASS.**
-- [ ] **Step 7: Update broken tests** asserting `Resolution{Forced}` → `TimingPointWindow{Forced}`. Re-run `retaliate_windows.rs` + forced-run unit tests.
-- [ ] **Step 8: Full suite green** (`RUSTFLAGS="-D warnings" cargo test --all --all-features`) + clippy + fmt + doc.
-- [ ] **Step 9: Commit + CI gauntlet + push + PR** (`engine: migrate forced run to TimingPointWindow (Slice A-i task 2). Part of #433.`). **Checkpoint: stop for review before Task 3.**
-
----
-
-## Task 3: Migrate event reaction windows to `TimingPointWindow { mode: Reaction }` (+ tests)
-
-PR3 — branch `engine/timing-point-reaction-windows`. The larger of the three: flips the event-window queue + the `WindowKind`-keyed `eval_ctx` binding and continuation to key off `TimingEvent`. Framework `PlayerWindow`/`SkillTestPlayerWindow` stay on `Resolution`.
+**Strategy:** introduce a frame-agnostic accessor pair so the shared driver reads candidates + mode uniformly across both representations, then flip *construction* (forced + event) to `TimingPointWindow`. Keep `WindowOpened`/`WindowClosed { kind }` event payloads byte-identical (derive the `WindowKind` from the `TimingEvent` via `reaction_window()` at the emit/close site) so behaviour is preserved.
 
 **Files:**
-- Modify: `crates/game-core/src/engine/dispatch/emit.rs` — `emit_event` (line 302-329): `queue_reaction_window(cx, kind: WindowKind)` becomes pushing a `TimingPointWindow { event, mode: Reaction }`. `reaction_window()` currently maps `TimingEvent → WindowKind`; the migrated frame stores the `TimingEvent` itself, so the `Some(kind)` guard becomes a `if event.opens_reaction_window()` boolean check (add that predicate, or reuse `reaction_window().is_some()`).
 - Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs`:
-  - `queue_reaction_window` / `open_queued_reaction_window` — construct/emit the `TimingPointWindow` (event windows) while still handling `Resolution` (framework windows).
-  - `fire_pending_trigger` — the `eval_ctx` binding `match …kind() { AfterEnemyAttackDamagedAsset{enemy,..} => set_attacking_enemy, BeforeDiscoverClues{count,..} => set_clue_discovery_count }` re-keys off `TimingEvent::{EnemyAttackDamagedSelf{enemy,..}, WouldDiscoverClues{count,..}}`.
-  - `run_window_continuation(kind: WindowKind)` — for event windows, the per-kind close continuation (e.g. `BeforeDiscoverClues` → discover, `BeforeEnemyAttack` → proceed) keys off `TimingEvent` instead. `AfterEnemyDefeated`/`AfterSuccessfulInvestigate`/`AfterEnteredPlay`/`AfterEnemyAttackDamagedAsset` "simply pop" — confirm via the current arms.
-  - `build_resolution_options` / `advance_resolution` / `close_reaction_window_at` — handle both frame types (the `WindowClosed { kind }` event still needs a `WindowKind`; derive it from the `TimingEvent` via `reaction_window()` for the event so observability is unchanged).
-- Modify: `crates/game-core/src/engine/dispatch/mod.rs` — `resolve_input` routes the reaction `TimingPointWindow` to `resume_window`.
-- Test: `crates/cards/tests/{evidence,dodge,dodge_aoo,guard_dog_soak,roland_banks,play_card_aoo,fast_play,mind_over_matter,activate_ability_aoo}.rs` — update any `WindowKind::*` event-window assertions; the `Event::WindowOpened/Closed { kind }` payloads should stay identical (behaviour-preserving), so most assertions on *events* are unchanged — only assertions reaching into the *continuation stack* shape change.
+  - `open_forced_resolution(cx, event, candidates, continuation)` — gains `event: TimingEvent`; pushes `TimingPointWindow { event, mode: Forced(continuation), candidates }`.
+  - `queue_reaction_window` / `open_queued_reaction_window` — event windows push `TimingPointWindow { event, mode: Reaction, candidates }`; framework windows keep pushing `Resolution`.
+  - The shared driver (`advance_resolution`, `fire_pending_trigger`, `close_reaction_window_at`, `build_resolution_options`, `resume_window`/`resume_reaction_window`) reads through new accessors that handle both frames (see Interfaces).
+  - `fire_pending_trigger` `eval_ctx` binding — re-key off `TimingEvent::{EnemyAttackDamagedSelf{enemy,..}, EnemyAttacks{enemy,..}, WouldDiscoverClues{count,..}}` instead of the `WindowKind` fields.
+  - `run_window_continuation` — for event windows the per-event close continuation (`WouldDiscoverClues` → discover, `EnemyAttacks` → proceed-with-attack; the `After*` events just pop) keys off `TimingEvent`. The forced run's close path (`mode: Forced`) → `resume_forced_continuation(cx, continuation)`.
+- Modify: `crates/game-core/src/engine/dispatch/emit.rs` — `emit_event` (lines 302-329): `queue_reaction_window(cx, event.reaction_window())` becomes pushing the `TimingPointWindow{Reaction}` when `event.reaction_window().is_some()` (keep the `WindowKind` only to gate "does this open a window" + to fill the `WindowOpened` payload); `open_forced_resolution` gains the `event` arg (clone the in-flight `&TimingEvent`).
+- Modify: `crates/game-core/src/engine/dispatch/skill_test.rs` — the teardown-tail forced reader `Some(Continuation::Resolution(f)) if f.is_forced()` (line ~556) also recognises `TimingPointWindow { mode: Forced(..), .. }`.
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` — `resolve_input` routes both modes of `TimingPointWindow` to `resume_window` (replacing the Task-1 reject stub). Forced runs aren't prompted for *which* (order-only when 2+); reaction windows route exactly as `Resolution{Window}` does today.
+- Test: engine unit tests + `crates/cards/tests/{evidence,dodge,dodge_aoo,guard_dog_soak,roland_banks,play_card_aoo,fast_play,mind_over_matter,activate_ability_aoo,retaliate_windows}.rs` — update any assertions reaching into the *continuation-stack shape* (`Resolution{..}` → `TimingPointWindow{..}`). Event-payload assertions (`WindowOpened/Closed { kind }`) stay unchanged (payloads preserved).
 
 **Interfaces:**
-- Consumes: Task 1's `TimingPointWindow`, Task 2's forced migration (the close/route helpers now also serve reaction mode).
-- Produces: event reaction windows live as `TimingPointWindow { event, mode: Reaction, candidates }`. `WindowKind` is now constructed **only** for framework `PlayerWindow`/`SkillTestPlayerWindow` (+ derived transiently for the `WindowOpened/Closed` event payload). This is what Slice A-ii (FastWindow) and A-iii (delete `WindowKind`) build on.
+- Consumes: Task 1's `Continuation::TimingPointWindow { event, mode, candidates }` + `TimingMode`.
+- Produces: new accessors on `Continuation` (game_state.rs) so the driver is representation-agnostic, e.g.
+  ```rust
+  /// Candidates of an open window/run, whether `Resolution` (framework) or
+  /// `TimingPointWindow` (event/forced).
+  fn pending_candidates_mut(&mut self) -> Option<&mut Vec<ResolutionCandidate>>;
+  /// `Some(continuation)` iff this is a forced run (either representation).
+  fn forced_continuation(&self) -> Option<ForcedContinuation>;
+  fn is_forced(&self) -> bool;
+  ```
+  After this task `WindowKind` is constructed only for framework windows (+ derived transiently for `WindowOpened/Closed`). Forced runs + event windows live as `TimingPointWindow`. This is what A-ii (FastWindow) and A-iii (delete `WindowKind`) build on.
 
-- [ ] **Step 1: Write the failing test.** Engine unit test: a `SuccessfullyInvestigated` emit (Dr. Milan-style after-investigate window) parks a `Continuation::TimingPointWindow { event: TimingEvent::SuccessfullyInvestigated{..}, mode: TimingMode::Reaction, .. }`. Assert the firing behaviour (the reaction fires, `eval_ctx` bound) is unchanged via the event-assertion macros.
-- [ ] **Step 2: Run it — verify it fails** (still `Resolution{Window}`).
-- [ ] **Step 3: Flip the queue path.** `emit_event` + `queue_reaction_window` push `TimingPointWindow{event, mode: Reaction}` for event windows; framework windows untouched.
-- [ ] **Step 4: Re-key the `eval_ctx` binding** in `fire_pending_trigger` off `TimingEvent` (enemy from `EnemyAttackDamagedSelf`/`EnemyAttacks`, count from `WouldDiscoverClues`).
-- [ ] **Step 5: Re-key `run_window_continuation`** off `TimingEvent`; preserve the `WindowClosed { kind }` event payload by deriving `WindowKind` from the event (`event.reaction_window()`).
-- [ ] **Step 6: Route `resolve_input`** reaction `TimingPointWindow` → `resume_window`.
-- [ ] **Step 7: Run the failing test — verify PASS.**
-- [ ] **Step 8: Update broken card/unit tests** (enumerated above). Re-run each touched `crates/cards/tests/*.rs`.
-- [ ] **Step 9: Full suite green** + clippy + fmt + doc + wasm jobs.
-- [ ] **Step 10: Commit + CI gauntlet + push + PR** (`engine: migrate event reaction windows to TimingPointWindow (Slice A-i task 3). Part of #433.`). **Checkpoint: Slice A-i complete; reassess A-ii.**
+- [ ] **Step 1: Add the frame-agnostic accessors** (`pending_candidates`/`_mut`, `forced_continuation`, `is_forced`) on `Continuation`, handling both `Resolution` and `TimingPointWindow`. Behaviour-preserving (nothing constructs `TimingPointWindow` yet). Build green.
+- [ ] **Step 2: Route the shared driver through the accessors.** Replace direct `as_resolution()`/`is_forced()`/`forced_continuation()` reads in `advance_resolution`, `fire_pending_trigger`, `close_reaction_window_at`, `build_resolution_options`, `resume_window`, and `skill_test::advance`'s teardown tail. Still all on `Resolution` — full suite green (pure refactor checkpoint).
+- [ ] **Step 3: Write the failing tests.** (a) a 2+-simultaneous-forced emit parks `TimingPointWindow { mode: Forced(_), .. }`; (b) a `SuccessfullyInvestigated` emit parks `TimingPointWindow { event: SuccessfullyInvestigated{..}, mode: Reaction, .. }`. Assert firing behaviour unchanged via the event-assertion macros. Run — verify FAIL.
+- [ ] **Step 4: Flip construction.** `open_forced_resolution` → `TimingPointWindow{Forced}`; `queue_reaction_window`/`emit_event` → `TimingPointWindow{Reaction}` for event windows. Re-key the `eval_ctx` binding + `run_window_continuation` off `TimingEvent`; preserve `WindowOpened/Closed { kind }` via `event.reaction_window()`.
+- [ ] **Step 5: Route `resolve_input`** both `TimingPointWindow` modes → `resume_window` (replace Task-1 stub).
+- [ ] **Step 6: Run the new tests — verify PASS.**
+- [ ] **Step 7: Update broken stack-shape assertions** in the enumerated tests. Re-run each.
+- [ ] **Step 8: Full strict gauntlet green** (`RUSTFLAGS="-D warnings" cargo test --all --all-features`, host + wasm clippy, fmt, doc, wasm build).
+- [ ] **Step 9: Commit + CI gauntlet + push + PR** (`engine: migrate event windows + forced run to TimingPointWindow (Slice A-i task 2). Part of #433.`). **Checkpoint: Slice A-i nearly done — only A-iii (delete the now-unused `ResolutionKind::Forced` arm + dead WindowKind event variants) + A-ii (framework → FastWindow) remain.**
 
 ---
 
@@ -146,7 +133,7 @@ PR3 — branch `engine/timing-point-reaction-windows`. The larger of the three: 
 
 **Spec coverage (against `2026-06-22-emitevent-frame-arc-decomposition-design.md` §"Slice A detail" A-i):**
 - "TimingPointWindow replaces event windows + forced run" → Tasks 2 (forced) + 3 (event). ✓
-- "map event WindowKind → emit::TimingEvent" → Task 3 stores `TimingEvent` directly; mapping via existing `reaction_window()`. ✓
+- "map event WindowKind → emit::TimingEvent" → Task 2 stores `TimingEvent` directly; mapping via existing `reaction_window()`. ✓
 - "ForcedContinuation rides the mode: Forced close path" → Task 2 step 4. ✓
 - "imperative driving preserved (no drive arm yet)" → no `drive`-loop arm added; `resolve_input` + `advance_resolution`/`close_reaction_window_at` keep imperative re-entry. ✓
 - "framework windows stay on Resolution" → Tasks explicitly leave `PlayerWindow`/`SkillTestPlayerWindow` on `Resolution`. ✓
@@ -154,8 +141,8 @@ PR3 — branch `engine/timing-point-reaction-windows`. The larger of the three: 
 
 **Surfaced design decision (not in the spec, decided here):** `TimingEvent` must gain `Serialize`/`Deserialize` (Continuation serializes). It does **not** need to relocate to `state` — `Continuation::Effect`/`EffectFrame` already holds `crate::engine::EvalContext` (#345), so a `state` variant referencing the in-`engine` `TimingEvent` is established precedent. Reference-in-place avoids 59 sites of relocation churn. Folded into Task 1.
 
-**Placeholder scan:** none — every step names exact files/sites/commands. The per-site `eval_ctx`/continuation arms are enumerated by their existing `WindowKind` variants (Task 3 lists them); exact arm bodies are read from the current code at execution time (inline execution).
+**Placeholder scan:** none — every step names exact files/sites/commands. The per-site `eval_ctx`/continuation arms are enumerated by their existing `WindowKind` variants (Task 2 lists them); exact arm bodies are read from the current code at execution time (inline execution).
 
 **Type consistency:** `TimingEvent` (state), `TimingMode { Reaction, Forced(ForcedContinuation) }`, `TimingPointWindow { event, mode, candidates }` used consistently across tasks. `open_forced_resolution` gains `event: TimingEvent` (Task 2) consistent with the frame field.
 
-**Risk note:** Task 3's `run_window_continuation` re-key is the subtle step — the `Before*` windows (`BeforeDiscoverClues`, `BeforeEnemyAttack`) have real close continuations (discover / proceed-with-attack), unlike the `After*` windows that just pop. Verify each arm against the current `run_window_continuation` body before flipping, and keep a unit test per `Before*` window.
+**Risk note:** Task 2's `run_window_continuation` re-key is the subtle step — the `Before*` windows (`BeforeDiscoverClues`, `BeforeEnemyAttack`) have real close continuations (discover / proceed-with-attack), unlike the `After*` windows that just pop. Verify each arm against the current `run_window_continuation` body before flipping, and keep a unit test per `Before*` window.


### PR DESCRIPTION
## Summary

Slice A-i task 2 of the EmitEvent-frame window-taxonomy rework (#433, under umbrella #435): migrate the **event reaction windows** and the **#213 forced run** off the legacy `Continuation::Resolution` frame onto `Continuation::TimingPointWindow { event, mode, candidates }`. **Behaviour-preserving** — the full strict gauntlet is green and `WindowOpened`/`WindowClosed` payloads are byte-identical.

The framework player windows (`PlayerWindow` / `SkillTestPlayerWindow`) deliberately **stay on `Resolution`** until Slice A-ii, so the shared window driver dual-handles both representations for the duration of A-i.

## Why event + forced migrate together (re-cut)

Originally planned as two PRs (forced, then event), but reading the code showed they share one driver: `open_forced_resolution` calls `open_queued_reaction_window`, and `advance_resolution` / `fire_pending_trigger` / `close_reaction_window_at` / the `top_reaction_window*` + `top_window` + `open_windows` scan helpers all key on the frame, differing only by `kind: Window | Forced`. Splitting them would rework the driver twice, so they migrate in one PR (the re-cut is recorded in the plan + phase doc).

## What changed

- **`game_state.rs`** — the scan helpers (`windows` / `open_windows` / `top_window` / `top_reaction_window` / `_mut` / `_index`) become frame-agnostic (a frame is a window/run iff it carries a candidate list). New `Continuation` accessors handling both representations: `pending_candidates`(`_mut`), `is_forced`, `forced_continuation`, `window_kind`, `window_timing_event`, `permits_fast`.
- **`emit.rs`** — `emit_event` pushes `TimingPointWindow{Reaction}` for event windows and `{Forced}` for the lead-ordered run; `reaction_window()` is `pub(crate)` so the close path / fixtures can derive the `WindowKind`.
- **`reaction_windows.rs`** — the driver reads candidates / mode / kind through the accessors; the `eval_ctx` binding re-keys off `TimingEvent` (attacking enemy / clue-discovery count).
- **`evaluator.rs`** — the before-discover check + `Effect::Cancel`'s open-window assert recognise `TimingPointWindow`.
- **`skill_test.rs`** — the forced-run teardown tail recognises either representation.
- **`mod.rs`** — `resolve_input` routes both reps through the one window driver.
- **Tests + the `cover_up` fixture** build / assert against the new frame.

## Test notes

Behaviour-preserving migration. Full strict gauntlet green locally: `RUSTFLAGS="-D warnings" cargo test --all --all-features` (no failures), host + wasm clippy, `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc`, wasm build. The behaviour is exercised by the existing reaction-window / forced-run / Cover-Up / Guard-Dog / Dodge suites (a regression caught two real seams during development: the `Effect::Cancel` open-window assert and the forced-run skill-test teardown tail, both now representation-agnostic).

## Linked issues

Part of #433 (Slice A of #435). Does not close it — Slice A completes when A-ii (framework → `FastWindow`) + A-iii (delete the old taxonomy) land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011oqjdoNhbcH4kay8J3FEoJ
