### PR TITLE
engine: framework player windows → FastWindow (Slice A-ii)

### DIFF
--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -401,13 +401,15 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
         Some(Continuation::SubstitutionPrompt { .. }) => {
             skill_test::resume_substitution_choice(cx, response)
         }
-        // Both an event reaction window and the forced run (now
-        // `TimingPointWindow`, #433) resolve through the same window driver as
-        // the legacy framework `Resolution` windows — the driver reads
-        // candidates/mode through the frame-agnostic accessors.
-        Some(Continuation::Resolution(_) | Continuation::TimingPointWindow { .. }) => {
-            resume_window(cx, response)
-        }
+        // Event reaction windows + the forced run (`TimingPointWindow`) and the
+        // framework player windows (`FastWindow`, #433 A-ii) all resolve through
+        // the same window driver as the legacy `Resolution` windows — the driver
+        // reads candidates/mode through the frame-agnostic accessors.
+        Some(
+            Continuation::Resolution(_)
+            | Continuation::TimingPointWindow { .. }
+            | Continuation::FastWindow { .. },
+        ) => resume_window(cx, response),
         // An effect node suspended in place for a controller pick (#422): the
         // top `Continuation::Effect(Leaf)` frame *is* the prompt. Route its
         // `PickSingle` to the effect-choice resume. A non-suspending effect

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -17,9 +17,9 @@ use crate::card_registry;
 use crate::dsl::{EventPattern, EventTiming, Trigger};
 use crate::event::Event;
 use crate::state::{
-    CandidateSource, CardCode, CardInstanceId, Continuation, FastActorScope, ForcedContinuation,
-    GameState, InvestigatorId, Phase, ResolutionCandidate, ResolutionFrame, ResolutionKind,
-    SkillTestStep, Status, WindowBinding, WindowKind,
+    CandidateSource, CardCode, CardInstanceId, Continuation, FastActorScope, FastWindowKind,
+    ForcedContinuation, GameState, InvestigatorId, Phase, ResolutionCandidate, SkillTestStep,
+    Status, WindowKind,
 };
 
 use super::super::evaluator::{apply_effect, EvalContext};
@@ -1117,16 +1117,25 @@ pub(super) fn open_fast_window(cx: &mut Cx, kind: WindowKind) -> EngineOutcome {
 
     // Push first so any_fast_play_eligible's check_play_card call sees
     // this window in state.open_windows when evaluating permissive_window.
-    let pending_triggers = scan_pending_triggers(cx.state, kind);
-    cx.state
-        .continuations
-        .push(Continuation::Resolution(ResolutionFrame {
-            pending_triggers,
-            kind: ResolutionKind::Window(WindowBinding {
-                kind,
-                fast_actors: FastActorScope::Any,
-            }),
-        }));
+    // Framework windows are `FastWindow` (#433 A-ii); the `FastWindowKind`
+    // discriminant reproduces `kind` for the WindowClosed payload + routes the
+    // close continuation. Reaction windows admit any investigator's Fast plays.
+    let candidates = scan_pending_triggers(cx.state, kind);
+    let fast_kind = match kind {
+        WindowKind::PlayerWindow(step) => FastWindowKind::Phase(step),
+        WindowKind::SkillTestPlayerWindow { before_token } => {
+            FastWindowKind::SkillTest { before_token }
+        }
+        other => unreachable!(
+            "open_fast_window: only framework PlayerWindow / SkillTestPlayerWindow kinds \
+             open a fast window, got {other:?}"
+        ),
+    };
+    cx.state.continuations.push(Continuation::FastWindow {
+        candidates,
+        fast_actors: FastActorScope::Any,
+        kind: fast_kind,
+    });
 
     let has_pending = !cx
         .state

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -37,8 +37,8 @@ use std::collections::{BTreeMap, VecDeque};
 use crate::rng::RngState;
 use crate::scenario::ScenarioId;
 use crate::state::{
-    ChaosBag, Continuation, Counter, Enemy, EnemyId, FastActorScope, GameState, HandSizeDiscard,
-    Investigator, InvestigatorId, Location, LocationId, Phase, ResolutionFrame, TokenModifiers,
+    ChaosBag, Continuation, Counter, Enemy, EnemyId, FastActorScope, FastWindowKind, GameState,
+    HandSizeDiscard, Investigator, InvestigatorId, Location, LocationId, Phase, TokenModifiers,
     WindowKind,
 };
 
@@ -63,7 +63,7 @@ pub struct GameStateBuilder {
     mulligan_remaining: Option<Vec<InvestigatorId>>,
     mythos_draw_remaining: Option<Vec<InvestigatorId>>,
     hand_size_discard_pending: Option<HandSizeDiscard>,
-    open_windows: Vec<ResolutionFrame>,
+    open_windows: Vec<Continuation>,
     phase_anchor: Option<Continuation>,
     investigator_turn: Option<InvestigatorId>,
     scenario_id: Option<ScenarioId>,
@@ -258,15 +258,31 @@ impl GameStateBuilder {
         self
     }
 
-    /// Push a [`ResolutionFrame`] onto the build's window stack
-    /// for tests that need a specific window-state shape.
+    /// Push a framework [`FastWindow`](Continuation::FastWindow) onto the
+    /// build's window stack for tests that need a specific window-state shape.
     ///
-    /// The pushed window has no pending triggers (test paths that
+    /// The pushed window has no pending candidates (test paths that
     /// also need a reaction queue should manipulate `state` after
     /// `build()` rather than complicate this builder).
     pub fn with_open_window(mut self, kind: WindowKind, fast_actors: FastActorScope) -> Self {
-        self.open_windows
-            .push(ResolutionFrame::new_empty(kind, fast_actors));
+        // Framework player windows are `FastWindow` (#433 A-ii). The builder
+        // only constructs framework windows; event windows / the forced run
+        // (`TimingPointWindow`) are produced by the engine, not seeded here.
+        let fast_kind = match kind {
+            WindowKind::PlayerWindow(step) => FastWindowKind::Phase(step),
+            WindowKind::SkillTestPlayerWindow { before_token } => {
+                FastWindowKind::SkillTest { before_token }
+            }
+            other => panic!(
+                "with_open_window: only framework PlayerWindow / SkillTestPlayerWindow kinds \
+                 are supported, got {other:?}"
+            ),
+        };
+        self.open_windows.push(Continuation::FastWindow {
+            candidates: Vec::new(),
+            fast_actors,
+            kind: fast_kind,
+        });
         self
     }
 
@@ -329,7 +345,7 @@ impl GameStateBuilder {
                 ending: false,
             });
         }
-        continuations.extend(self.open_windows.into_iter().map(Continuation::Resolution));
+        continuations.extend(self.open_windows);
         if let Some(hsd) = self.hand_size_discard_pending {
             continuations.push(Continuation::HandSizeDiscard(hsd));
         }
@@ -413,12 +429,13 @@ mod with_open_window_tests {
             )
             .build();
         assert_eq!(state.open_windows().len(), 1);
-        assert_eq!(
-            state.open_windows()[0]
-                .as_resolution()
-                .and_then(ResolutionFrame::fast_actors),
-            Some(&FastActorScope::Any)
-        );
+        assert!(matches!(
+            state.open_windows()[0],
+            Continuation::FastWindow {
+                fast_actors: FastActorScope::Any,
+                ..
+            }
+        ));
         assert!(state.open_windows()[0]
             .pending_candidates()
             .unwrap()

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -436,6 +436,25 @@ pub enum Continuation {
         /// active-investigator-first for a reaction window).
         candidates: Vec<ResolutionCandidate>,
     },
+    /// A framework "red-box" player window — a Rules-Reference timing step
+    /// that gates Fast actions and runs a per-step continuation on close
+    /// (EmitEvent-frame Slice A-ii, #433). Replaces the framework-window uses
+    /// of [`Resolution`](Self::Resolution) (`WindowKind::PlayerWindow` /
+    /// `SkillTestPlayerWindow`). The [`FastWindowKind`] discriminant reproduces
+    /// the exact [`WindowKind`] for the `WindowOpened`/`WindowClosed` event
+    /// payload and routes the close continuation (`Phase` → the `*Phase`
+    /// anchor's `on_child_pop`; `SkillTest` → the skill-test driver). Carries no
+    /// `TimingEvent` — framework windows are not event-driven.
+    FastWindow {
+        /// Fast-play candidates (hand Fast events admitted at this window).
+        /// Usually empty (a pure Fast-gate) — non-empty only for an
+        /// Axis-C hand play offered at a framework step.
+        candidates: Vec<ResolutionCandidate>,
+        /// Which investigators may submit Fast actions here.
+        fast_actors: FastActorScope,
+        /// The framework step this window gates (and its event-payload kind).
+        kind: FastWindowKind,
+    },
     /// A skill test is mid-resolution. Carries the in-flight test's data
     /// directly (the former `GameState::in_flight_skill_test` singleton, folded
     /// onto the frame — #348). Pushed at test start; popped when the test fully
@@ -747,7 +766,16 @@ impl Continuation {
     #[must_use]
     pub fn awaits_input(&self) -> bool {
         match self {
-            Continuation::Resolution(f) => !f.pending_triggers.is_empty(),
+            // A window/run awaits a mandatory `ResolveInput` iff it has
+            // candidates to resolve. An empty framework Fast-gate window
+            // (`FastWindow` / legacy `Resolution` with no pending plays) is
+            // *permissive* — the player may act but is not required to, so it
+            // does not block other actions.
+            Continuation::Resolution(_)
+            | Continuation::TimingPointWindow { .. }
+            | Continuation::FastWindow { .. } => {
+                self.pending_candidates().is_some_and(|c| !c.is_empty())
+            }
             // Neither is a mandatory ResolveInput prompt. The open turn takes
             // typed actions (Move/Investigate/Fight/…), not ResolveInput (slice
             // 2a-i, #393). The parked attack loop is internal sequencing: the
@@ -784,6 +812,7 @@ impl Continuation {
             | Continuation::EnemyPhase { .. }
             | Continuation::UpkeepPhase { .. }
             | Continuation::TimingPointWindow { .. }
+            | Continuation::FastWindow { .. }
             | Continuation::Effect(_) => None,
         }
     }
@@ -810,6 +839,7 @@ impl Continuation {
             | Continuation::EnemyPhase { .. }
             | Continuation::UpkeepPhase { .. }
             | Continuation::TimingPointWindow { .. }
+            | Continuation::FastWindow { .. }
             | Continuation::Effect(_) => None,
         }
     }
@@ -824,7 +854,8 @@ impl Continuation {
     pub fn pending_candidates(&self) -> Option<&Vec<ResolutionCandidate>> {
         match self {
             Continuation::Resolution(w) => Some(&w.pending_triggers),
-            Continuation::TimingPointWindow { candidates, .. } => Some(candidates),
+            Continuation::TimingPointWindow { candidates, .. }
+            | Continuation::FastWindow { candidates, .. } => Some(candidates),
             _ => None,
         }
     }
@@ -833,7 +864,8 @@ impl Continuation {
     pub fn pending_candidates_mut(&mut self) -> Option<&mut Vec<ResolutionCandidate>> {
         match self {
             Continuation::Resolution(w) => Some(&mut w.pending_triggers),
-            Continuation::TimingPointWindow { candidates, .. } => Some(candidates),
+            Continuation::TimingPointWindow { candidates, .. }
+            | Continuation::FastWindow { candidates, .. } => Some(candidates),
             _ => None,
         }
     }
@@ -893,6 +925,7 @@ impl Continuation {
                 mode: TimingMode::Reaction,
                 ..
             } => event.reaction_window(),
+            Continuation::FastWindow { kind, .. } => Some(kind.window_kind()),
             _ => None,
         }
     }
@@ -910,6 +943,7 @@ impl Continuation {
             Continuation::Resolution(w) => {
                 w.fast_actors().is_some_and(|fa| fa.permits(investigator))
             }
+            Continuation::FastWindow { fast_actors, .. } => fast_actors.permits(investigator),
             Continuation::TimingPointWindow {
                 mode: TimingMode::Reaction,
                 ..
@@ -1232,6 +1266,43 @@ pub enum FastActorScope {
     /// or Phase-4 site constructs this variant yet; the variant
     /// exists so future cards can grow it without engine churn.
     Specific(std::collections::BTreeSet<InvestigatorId>),
+}
+
+/// The framework step a [`FastWindow`](Continuation::FastWindow) gates — the
+/// discriminant that survived the #433 migration off [`WindowKind`]'s
+/// `PlayerWindow` / `SkillTestPlayerWindow` variants. Routes the close
+/// continuation and reproduces the exact `WindowKind` for the
+/// `WindowOpened`/`WindowClosed` event payload (Slice A keeps `WindowKind` as
+/// the pure event descriptor; its deletion is Slice B).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FastWindowKind {
+    /// A Rules-Reference timing-step player window
+    /// ([`WindowKind::PlayerWindow`]). Close routes to the `*Phase` anchor
+    /// beneath via `anchor_on_child_pop`; the [`PhaseStep`] is retained only to
+    /// reproduce the event payload (the anchor's `resume` is the real
+    /// continuation key, slice 1a #393).
+    Phase(PhaseStep),
+    /// A skill-test player window (#374,
+    /// [`WindowKind::SkillTestPlayerWindow`]). Close re-enters the skill-test
+    /// driver.
+    SkillTest {
+        /// ST.1 (pre-commit) vs ST.2 (pre-token) — carried for the event payload.
+        before_token: bool,
+    },
+}
+
+impl FastWindowKind {
+    /// The [`WindowKind`] this framework window reports in its
+    /// `WindowOpened`/`WindowClosed` events.
+    #[must_use]
+    pub fn window_kind(self) -> WindowKind {
+        match self {
+            FastWindowKind::Phase(step) => WindowKind::PlayerWindow(step),
+            FastWindowKind::SkillTest { before_token } => {
+                WindowKind::SkillTestPlayerWindow { before_token }
+            }
+        }
+    }
 }
 
 impl FastActorScope {
@@ -2232,9 +2303,9 @@ mod continuation_stack_tests {
     }
 
     #[test]
-    fn open_window_lives_on_the_continuation_stack_as_a_resolution_frame() {
-        // Axis-B T3: a window is a `Continuation::Resolution` frame on the
-        // one stack — there is no separate `open_windows` Vec.
+    fn open_window_lives_on_the_continuation_stack_as_a_fast_window() {
+        // A framework window is a `Continuation::FastWindow` frame on the one
+        // stack (#433 A-ii) — there is no separate `open_windows` Vec.
         let state = GameStateBuilder::new()
             .with_open_window(
                 WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws),
@@ -2244,14 +2315,12 @@ mod continuation_stack_tests {
         assert_eq!(state.continuations.len(), 1);
         assert!(matches!(
             state.continuations[0],
-            Continuation::Resolution(_)
+            Continuation::FastWindow { .. }
         ));
         // The read accessor surfaces it as the former `open_windows` view.
         assert_eq!(state.open_windows().len(), 1);
         assert_eq!(
-            state.open_windows()[0]
-                .as_resolution()
-                .and_then(ResolutionFrame::kind),
+            state.open_windows()[0].window_kind(),
             Some(WindowKind::PlayerWindow(PhaseStep::MythosAfterDraws)),
         );
     }

--- a/crates/game-core/src/state/mod.rs
+++ b/crates/game-core/src/state/mod.rs
@@ -26,10 +26,11 @@ pub use enemy::{Enemy, EnemyId};
 pub use game_state::{
     Act, ActRoundEndPending, ActionResume, Agenda, Assignment, AttackLoopStage, CandidateSource,
     Continuation, DamageSource, EffectFrame, EnemyAttackSource, EnemyResume, FastActorScope,
-    ForcedContinuation, GameState, HandSizeDiscard, HunterChoice, InFlightSkillTest,
-    InvestigationResume, MythosResume, PendingSkillModifier, PhaseStep, ResolutionCandidate,
-    ResolutionFrame, ResolutionKind, RoundEndAdvance, SkillSubstitution, SkillTestFollowUp,
-    SkillTestStep, SpawnEngagePending, TimingMode, UpkeepResume, WindowBinding, WindowKind,
+    FastWindowKind, ForcedContinuation, GameState, HandSizeDiscard, HunterChoice,
+    InFlightSkillTest, InvestigationResume, MythosResume, PendingSkillModifier, PhaseStep,
+    ResolutionCandidate, ResolutionFrame, ResolutionKind, RoundEndAdvance, SkillSubstitution,
+    SkillTestFollowUp, SkillTestStep, SpawnEngagePending, TimingMode, UpkeepResume, WindowBinding,
+    WindowKind,
 };
 pub use investigator::{DefeatCause, Investigator, InvestigatorId, Status};
 pub use location::{Location, LocationId};

--- a/docs/superpowers/specs/2026-06-22-emitevent-frame-arc-decomposition-design.md
+++ b/docs/superpowers/specs/2026-06-22-emitevent-frame-arc-decomposition-design.md
@@ -149,22 +149,45 @@ it. Sub-slice it; each sub-slice is independently green.
   driving preserved** (no `drive` arm yet) — pure data-structure swap, behaviour-
   preserving. Largest mechanical PR. **This is the first chunk to start.**
 - **A-ii — `FastWindow` replaces framework player windows.** `WindowKind::PlayerWindow`
-  + `SkillTestPlayerWindow` → anchor-pushed `FastWindow`; drop `PhaseStep`. (Confirm
-  nothing binds to `PhaseStep` — the spec asserts no `EventPattern` matches one.)
-- **A-iii — delete the old taxonomy.** Remove `Continuation::Resolution`,
-  `ResolutionFrame`, `ResolutionKind`, `WindowKind`, `WindowBinding` once A-i/A-ii
-  cover every case.
+  + `SkillTestPlayerWindow` → `Continuation::FastWindow { candidates, fast_actors, kind:
+  FastWindowKind }`, where `FastWindowKind = Phase(PhaseStep) | SkillTest { before_token }`.
+  **Re-sliced (see "WindowKind's two roles" below): the discriminant is kept, not
+  dropped.** It reproduces the exact `WindowKind` for the `Event::WindowOpened/Closed`
+  payload (so the event log is byte-identical) and routes the close continuation
+  (`Phase → anchor_on_child_pop`, `SkillTest → skill_test::advance`). Behaviour-preserving.
+  After A-ii, `Continuation::Resolution` is unused.
+- **A-iii — delete the frame-level legacy taxonomy.** Remove `Continuation::Resolution`,
+  `ResolutionFrame`, `ResolutionKind`, `WindowBinding` once A-i/A-ii cover every case.
+  **Keep `WindowKind`** as the pure `Event::WindowOpened/Closed` observability descriptor,
+  derived from `TimingPointWindow`'s `TimingEvent` (`reaction_window()`) + `FastWindow`'s
+  `FastWindowKind`. Behaviour-preserving — event log byte-identical.
 - **A-iv — `drive`-loop arms.** Add top-frame-dispatch resume for `TimingPointWindow`
   + `FastWindow`; retire the window-side imperative re-entry that doesn't entangle
   skill-test. (The skill-test/encounter re-entry is Slice C.)
 
+**WindowKind's two roles — and the deferral into Slice B (load-bearing reference for the
+EmitEvent-frame / coordinator work).** `WindowKind` is load-bearing in *two independent*
+roles: (1) the **frame representation** (`Resolution{Window(WindowBinding{kind})}`, which
+A-i/A-ii migrate off), and (2) the **`Event::WindowOpened/Closed` descriptor** (observability;
+~46 test assertions depend on it, e.g. `phases.rs` asserts `PlayerWindow(PhaseStep::…)`).
+The #393 end-state deletes `WindowKind` entirely and has `WindowOpened/Closed` observability
+*read flow-position from the anchor's `resume`* rather than carry a kind — **but that changes
+the observable event log**, the only genuine *behaviour* change in the taxonomy rework. To
+keep all of Slice A behaviour-preserving, **Slice A deletes only the frame-level taxonomy and
+keeps `WindowKind` alive as the event descriptor.** **Deferred to Slice B (#434) / the
+EmitEvent-frame coordinator work:** delete `WindowKind` outright and redesign
+`Event::WindowOpened/Closed` off it (read-from-anchor observability, drop `PhaseStep`). When
+implementing Slice B, this is the place that change lands — it is *not* done in Slice A.
+
 **Acceptance (Slice A):**
-- [ ] `Continuation::Resolution`, `ResolutionFrame`, `ResolutionKind`, `WindowKind`,
-  `WindowBinding` are gone; replaced by `FastWindow` + `TimingPointWindow{event, mode}`.
+- [ ] `Continuation::Resolution`, `ResolutionFrame`, `ResolutionKind`, `WindowBinding` are
+  gone; windows are `FastWindow` + `TimingPointWindow{event, mode}`. `WindowKind` survives
+  **only** as the `Event::WindowOpened/Closed` descriptor (its deletion is Slice B).
 - [ ] The `drive` loop dispatches `FastWindow` + `TimingPointWindow` (window resumption
   after a child pops is top-frame dispatch, not imperative re-entry — except the
   skill-test seam, deferred to C).
-- [ ] Behaviour-preserving; full suite green at each sub-slice boundary.
+- [ ] Behaviour-preserving throughout — **event log byte-identical at every sub-slice
+  boundary** (no `WindowOpened/Closed` payload change in Slice A).
 
 ## Slice B / C / D scope (sketches; each gets its own plan when started)
 
@@ -174,6 +197,14 @@ it. Sub-slice it; each sub-slice is independently green.
   reaction` with **per-cell eligibility re-scan**. New regression tests for the
   ordering (the §G class). Acceptance: the `when/at/after` axis is frame-driven, not
   hand-threaded per site; a `when`-reaction-changes-an-`at`-forced case is covered.
+  **Inherited from Slice A (see "WindowKind's two roles"):** Slice A deliberately kept
+  `WindowKind` alive as the `Event::WindowOpened/Closed` descriptor. **Slice B owns its
+  deletion** + the observability redesign — `WindowOpened/Closed` reads flow-position
+  from the anchor's `resume` / the `TimingEvent`, drops `PhaseStep`, and stops carrying
+  `WindowKind`. This is the one event-log *behaviour* change of the taxonomy rework; it
+  rides Slice B's coordinator work (the `EmitEvent`/`TimingPoint` frames are where the
+  window's timing context already lives), not Slice A. Touches the ~46 `WindowOpened/Closed`
+  test assertions.
 - **C — [#431](https://github.com/talelburg/eldritch/issues/431).** Make `EncounterCard`
   disposal loop/frame-driven (retire the `resolve_input` chokepoint), add the `drive`-loop
   `SkillTest` arm, retire the five synchronous skill-test re-entry sites


### PR DESCRIPTION
## Summary

Slice A-ii of the EmitEvent-frame window-taxonomy rework (#433, under umbrella #435): migrate the **framework "red-box" player windows** (`WindowKind::PlayerWindow` / `SkillTestPlayerWindow`, the `open_fast_window` path) off `Continuation::Resolution` onto `Continuation::FastWindow { candidates, fast_actors, kind: FastWindowKind }`. **Behaviour-preserving** — full strict gauntlet green and the **event log is byte-identical**. After this, `Continuation::Resolution` is unused (A-iii deletes it).

## The re-slice (why this stays behaviour-preserving)

`WindowKind` is load-bearing in two independent roles — the **frame representation** and the **`Event::WindowOpened/Closed` descriptor** (~46 test assertions). Deleting it forces an event-log redesign, the only genuine *behaviour* change in the taxonomy rework. So Slice A was re-sliced to keep all of it behaviour-preserving (design recorded in the arc spec under "WindowKind's two roles" + on #434):

- **A-ii (this PR):** `FastWindowKind { Phase(PhaseStep), SkillTest { before_token } }` is kept on `FastWindow` — it reproduces the exact `WindowKind` for the `WindowOpened`/`WindowClosed` payload and routes the close continuation (`Phase → anchor_on_child_pop`, `SkillTest → skill_test::advance`).
- **A-iii (next):** delete only the frame-level `Resolution`/`ResolutionFrame`/`ResolutionKind`/`WindowBinding`; **keep `WindowKind` as the pure `Event` descriptor**.
- **Slice B (#434):** delete `WindowKind` outright + the read-from-anchor observability redesign (the one event-log change), recorded there as a reference.

## What changed

- **`game_state.rs`** — `FastWindowKind` enum (+ `window_kind()`), the `Continuation::FastWindow` variant, the frame-agnostic accessors extended (`pending_candidates`, `window_kind`, `permits_fast`). **`awaits_input`:** an empty Fast-gate window is *permissive* (a window awaits input iff it has non-empty candidates) — the old `other => !is_phase_anchor()` wildcard wrongly treated `FastWindow` as a blocking prompt, which rejected Fast plays during a permissive window.
- **`reaction_windows.rs`** — `open_fast_window` pushes `FastWindow` (maps `kind → FastWindowKind`); drops the now-unused `ResolutionFrame`/`ResolutionKind`/`WindowBinding` imports.
- **`mod.rs`** — `resolve_input` routes `FastWindow` through the shared window driver.
- **`builder.rs`** — `with_open_window` builds `FastWindow` (framework windows only).
- Tests updated to assert against `FastWindow`.

## Test notes

Behaviour-preserving migration. Full strict gauntlet green locally: `RUSTFLAGS="-D warnings" cargo test --all --all-features` (no failures), host + wasm clippy, `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc`, wasm build. The `awaits_input` seam was caught by the existing `fast_play` permissive-window tests; the framework-window stack-shape assertions were updated.

## Linked issues

Part of #433 (Slice A of #435). Does not close it — Slice A completes when A-iii (delete the frame-level legacy taxonomy) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011oqjdoNhbcH4kay8J3FEoJ
