### PR TITLE
engine: EventTiming::{When, At, After} (Slice B-i)

### DIFF
--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -320,7 +320,7 @@ pub enum EventPattern {
     AfterLocationInvestigated,
     /// An investigator is about to discover one or more clues. Matched
     /// **only** by the clue-discovery interrupt seam in `discover_clue`
-    /// (paired with [`EventTiming::Before`]), never by the general
+    /// (paired with [`EventTiming::When`]), never by the general
     /// reaction-window pipeline — `trigger_matches` returns `false` for
     /// it, like the forced-only patterns above. First consumer: Cover Up
     /// 01007's "`[reaction]` When you would discover 1 or more clues at your
@@ -398,19 +398,20 @@ pub enum Phase {
     Upkeep,
 }
 
-/// When an [`Trigger::OnEvent`] ability fires relative to the
-/// triggering event finalizing.
+/// When an [`Trigger::OnEvent`] ability fires relative to the triggering
+/// event finalizing — the RR "when → at → after" timing axis (the order
+/// simultaneous abilities sharing a triggering condition resolve in).
 ///
-/// Most reaction cards use [`After`](Self::After) ("After you defeat
-/// an enemy …"). [`Before`](Self::Before) is the "Forced — when …
-/// would …" timing that lets an effect interpose on an in-progress
-/// event; no card uses it in the Phase-3 scope yet, but the variant
-/// is included so #52's reaction-window machinery can hang both
-/// windows off the same trigger surface.
+/// - [`When`](Self::When) — the "Forced — when … would …" interrupt timing
+///   that lets an effect interpose on an in-progress event (Dodge 01023's
+///   cancel, Cover Up 01007's replacement).
+/// - [`After`](Self::After) — most reaction cards ("After you defeat an
+///   enemy …").
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum EventTiming {
-    /// Resolves before the triggering event finalizes.
-    Before,
+    /// Resolves as the triggering event would finalize (interrupt /
+    /// replacement timing — "when … would …").
+    When,
     /// Resolves after the triggering event has finalized.
     After,
 }
@@ -1978,31 +1979,31 @@ mod tests {
             timing: EventTiming::After,
             kind: TriggerKind::Reaction,
         };
-        let before_controller = Trigger::OnEvent {
+        let when_controller = Trigger::OnEvent {
             pattern: EventPattern::EnemyDefeated {
                 by_controller: true,
                 code: None,
             },
-            timing: EventTiming::Before,
+            timing: EventTiming::When,
             kind: TriggerKind::Reaction,
         };
         assert_ne!(after_any, Trigger::Constant);
         assert_ne!(after_any, Trigger::OnPlay);
         assert_ne!(after_any, Trigger::OnCommit);
         assert_ne!(after_any, after_controller);
-        assert_ne!(after_controller, before_controller);
+        assert_ne!(after_controller, when_controller);
     }
 
     /// An `OnEvent`-triggered ability round-trips through `serde_json`
     /// — struct-variant × serde derive can surprise; pin the wire
     /// shape now so #52's persistence doesn't re-discover problems
-    /// later. Both [`EventTiming`] variants (`After` and `Before`) are
+    /// later. Both [`EventTiming`] variants (`When` and `After`) are
     /// exercised independently since unit-variant × serde can fail on
     /// either alone (very rare, but the test rationale explicitly
     /// covers this surface).
     #[test]
     fn on_event_ability_round_trips_through_serde_json() {
-        for timing in [EventTiming::After, EventTiming::Before] {
+        for timing in [EventTiming::When, EventTiming::After] {
             let original = on_event(
                 EventPattern::EnemyDefeated {
                     by_controller: true,

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -405,6 +405,9 @@ pub enum Phase {
 /// - [`When`](Self::When) — the "Forced — when … would …" interrupt timing
 ///   that lets an effect interpose on an in-progress event (Dodge 01023's
 ///   cancel, Cover Up 01007's replacement).
+/// - [`At`](Self::At) — "at the …" timing, resolving between `when` and
+///   `after` abilities sharing a triggering condition. Dormant: no ability
+///   is tagged `At` until Slice B-iii.
 /// - [`After`](Self::After) — most reaction cards ("After you defeat an
 ///   enemy …").
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -412,6 +415,10 @@ pub enum EventTiming {
     /// Resolves as the triggering event would finalize (interrupt /
     /// replacement timing — "when … would …").
     When,
+    /// Resolves between `when` and `after` abilities with the same
+    /// triggering condition ("at the …"). Dormant until Slice B-iii
+    /// re-tags the round-end doom onto it.
+    At,
     /// Resolves after the triggering event has finalized.
     After,
 }
@@ -1997,13 +2004,13 @@ mod tests {
     /// An `OnEvent`-triggered ability round-trips through `serde_json`
     /// — struct-variant × serde derive can surprise; pin the wire
     /// shape now so #52's persistence doesn't re-discover problems
-    /// later. Both [`EventTiming`] variants (`When` and `After`) are
-    /// exercised independently since unit-variant × serde can fail on
-    /// either alone (very rare, but the test rationale explicitly
-    /// covers this surface).
+    /// later. All three [`EventTiming`] variants (`When`, `At`, `After`)
+    /// are exercised independently since unit-variant × serde can fail on
+    /// any alone (very rare, but the test rationale explicitly covers this
+    /// surface).
     #[test]
     fn on_event_ability_round_trips_through_serde_json() {
-        for timing in [EventTiming::When, EventTiming::After] {
+        for timing in [EventTiming::When, EventTiming::At, EventTiming::After] {
             let original = on_event(
                 EventPattern::EnemyDefeated {
                     by_controller: true,

--- a/crates/cards/src/impls/cover_up.rs
+++ b/crates/cards/src/impls/cover_up.rs
@@ -38,7 +38,7 @@ pub fn abilities() -> Vec<Ability> {
         revelation(put_into_threat_area_with_clues(CODE, 3)),
         reaction_on_event(
             EventPattern::WouldDiscoverClues,
-            EventTiming::Before,
+            EventTiming::When,
             // "Discard that many clues from Cover Up instead": run the discard,
             // then cancel the discovery — cancel = degenerate replacement
             // (Axis D #336). The before-discover window's continuation skips
@@ -135,7 +135,7 @@ mod tests {
             abilities[1].trigger,
             Trigger::OnEvent {
                 pattern: EventPattern::WouldDiscoverClues,
-                timing: EventTiming::Before,
+                timing: EventTiming::When,
                 ..
             }
         ));

--- a/crates/cards/src/impls/dodge.rs
+++ b/crates/cards/src/impls/dodge.rs
@@ -30,7 +30,7 @@ pub const CODE: &str = "01023";
 pub fn abilities() -> Vec<Ability> {
     vec![reaction_on_event(
         EventPattern::EnemyAttacks,
-        EventTiming::Before,
+        EventTiming::When,
         Effect::Cancel,
     )]
 }
@@ -47,7 +47,7 @@ mod tests {
             abilities[0].trigger,
             Trigger::OnEvent {
                 pattern: EventPattern::EnemyAttacks,
-                timing: EventTiming::Before,
+                timing: EventTiming::When,
                 kind: TriggerKind::Reaction,
             },
         );

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -373,9 +373,10 @@ fn push_matching(
             pattern, timing, ..
         } = &ability.trigger
         {
-            // Only `After` timing is handled in this slice; no in-scope
-            // Forced card uses `Before` ("when X would Y") timing.
-            // Revisit when such a card lands.
+            // Only `After` timing is handled in this slice; no in-scope Forced
+            // card uses `When` ("when X would Y") timing, and `At`-timed forced
+            // abilities don't exist until Slice B-iii routes them through the
+            // EmitEvent coordinator. Revisit the filter there.
             if *timing == EventTiming::After && want(pattern) {
                 out.push(ResolutionCandidate {
                     code: code.clone(),

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -346,7 +346,9 @@ fn trigger_matches(
                 )
             );
         }
-        EventTiming::After => {}
+        // No `At`-timed reaction exists until Slice B-iii; treat it like
+        // `After` (fall through to pattern matching). Dormant.
+        EventTiming::At | EventTiming::After => {}
     }
     match (kind, pattern) {
         (

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -322,19 +322,19 @@ fn scan_hand_fast_events(state: &GameState, kind: WindowKind) -> Vec<ResolutionC
 ///   [`EventTiming::After`]. The `by_controller` qualifier narrows to
 ///   defeats credited to this ability's controller.
 ///
-/// `EventTiming::Before` doesn't fire on these windows yet — the
-/// "Forced — when X would Y" timing needs a separate pre-event
-/// scanning hook when the first such card lands.
+/// `EventTiming::When` interrupt timing ("Forced — when X would Y") fires
+/// only on the Before-windows matched below; the general after-event
+/// reaction pipeline ignores it.
 fn trigger_matches(
     kind: WindowKind,
     pattern: &EventPattern,
     timing: EventTiming,
     controller: InvestigatorId,
 ) -> bool {
-    // Before-timing windows fire only for their exact pattern pairing (Axis D
+    // When-timing windows fire only for their exact pattern pairing (Axis D
     // #336); the "at your location" / eligibility scoping lives in the scans.
     match timing {
-        EventTiming::Before => {
+        EventTiming::When => {
             return matches!(
                 (kind, pattern),
                 (
@@ -1661,7 +1661,7 @@ mod trigger_matches_tests {
                 investigator: inv
             },
             &EventPattern::EnemyAttacks,
-            EventTiming::Before,
+            EventTiming::When,
             inv,
         ));
         assert!(trigger_matches(
@@ -1671,7 +1671,7 @@ mod trigger_matches_tests {
                 count: 1
             },
             &EventPattern::WouldDiscoverClues,
-            EventTiming::Before,
+            EventTiming::When,
             inv,
         ));
         // Wrong timing for the pairing → no match.
@@ -1691,7 +1691,7 @@ mod trigger_matches_tests {
                 investigator: inv
             },
             &EventPattern::WouldDiscoverClues,
-            EventTiming::Before,
+            EventTiming::When,
             inv,
         ));
     }
@@ -1759,7 +1759,7 @@ mod trigger_matches_tests {
             !trigger_matches(
                 kind,
                 &EventPattern::EnemyAttackDamagedSelf,
-                EventTiming::Before,
+                EventTiming::When,
                 controller
             ),
             "Before timing must never match this After-only window/pattern pair"

--- a/crates/scenarios/src/test_fixtures/synth_cards.rs
+++ b/crates/scenarios/src/test_fixtures/synth_cards.rs
@@ -328,7 +328,7 @@ fn abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
         SYNTH_COVER_UP_CODE => Some(vec![
             reaction_on_event(
                 EventPattern::WouldDiscoverClues,
-                EventTiming::Before,
+                EventTiming::When,
                 // Discard from self, then cancel the discovery (Axis D #336) —
                 // mirrors the real Cover Up 01007 (`cover_up`).
                 Effect::Seq(vec![native(SYNTH_COVER_UP_DISCARD_TAG), Effect::Cancel]),
@@ -411,7 +411,7 @@ mod tests {
             abilities[0].trigger,
             game_core::dsl::Trigger::OnEvent {
                 pattern: game_core::dsl::EventPattern::WouldDiscoverClues,
-                timing: game_core::dsl::EventTiming::Before,
+                timing: game_core::dsl::EventTiming::When,
                 ..
             }
         ));

--- a/docs/superpowers/plans/2026-06-23-slice-b-i-eventtiming-when-at.md
+++ b/docs/superpowers/plans/2026-06-23-slice-b-i-eventtiming-when-at.md
@@ -1,0 +1,326 @@
+# Slice B-i — `EventTiming::{When, At, After}` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename `EventTiming::Before → When` and add a dormant `At` variant, so the
+card DSL carries the RR `when → at → after` timing axis as a first-class enum — the
+enabler for the Slice-B coordinators. Behaviour-preserving.
+
+**Architecture:** Pure enum-variant rename (compiler-enforced across the workspace) plus
+one new dormant variant. No ability is tagged `At` yet — the round-end doom re-tag and the
+coordinator that scans by bucket land in Slice B-iii. The forced scanner's hardcoded
+`timing == After` filter is left untouched (correct while `At`/`When` forced abilities don't
+exist); its bucket-parameterization defers to B-iii where a caller actually varies the
+bucket.
+
+**Tech Stack:** Rust workspace (`card-dsl`, `game-core`, `cards`, `scenarios`). Serde
+derive on the enum (wire shape pinned by a round-trip test).
+
+**Parent spec:** [`2026-06-23-emitevent-frame-slice-b-coordinators-design.md`](../specs/2026-06-23-emitevent-frame-slice-b-coordinators-design.md)
+§"Why the DSL rework" + §"Sub-slicing → B-i". Issue: [#434](https://github.com/talelburg/eldritch/issues/434).
+
+## Global Constraints
+
+- **Behaviour-preserving.** No game-outcome or event-log change in this sub-slice. The full
+  suite stays green; the only intended diffs are the rename and the dormant variant.
+- **CI gauntlet before push** (warnings-as-errors), all from repo root:
+  - `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo fmt --check`
+  - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
+  - `cargo build -p web --target wasm32-unknown-unknown`
+  - `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`
+- **Never hand-edit `crates/cards/src/generated/`** (none touched here).
+- **Variant order `When, At, After`** in the enum (matches RR ordering; serde keys on the
+  name, not position, so this is cosmetic but load-bearing for readers).
+- Branch: `engine/slice-b-coordinators` (current); commits accumulate for the B-i PR.
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `crates/card-dsl/src/dsl.rs` | the `EventTiming` enum + builders + unit tests | rename variant, add `At`, update docs + serde test |
+| `crates/game-core/src/engine/dispatch/reaction_windows.rs` | reaction-window candidate matching (`trigger_matches`) + tests | rename arm, add `At` arm, update doc + 4 test sites |
+| `crates/game-core/src/engine/dispatch/forced_triggers.rs` | forced-trigger scan (`push_matching`) | rename one comment reference (filter unchanged) |
+| `crates/cards/src/impls/dodge.rs` | Dodge 01023 ability | rename 2 construction sites |
+| `crates/cards/src/impls/cover_up.rs` | Cover Up 01007 ability | rename 2 construction sites |
+| `crates/scenarios/src/test_fixtures/synth_cards.rs` | synthetic test cards | rename 2 construction sites |
+
+---
+
+### Task 1: Rename `EventTiming::Before → When` workspace-wide
+
+A variant rename does not compile until **every** site is updated, so this task edits all
+sites and the green checkpoint is a clean workspace build. After this task the enum has
+exactly two variants (`When`, `After`) — `At` is added in Task 2.
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs` (enum def + 3 doc refs + 2 test sites)
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (`trigger_matches` arm + doc + 4 tests)
+- Modify: `crates/game-core/src/engine/dispatch/forced_triggers.rs` (1 comment)
+- Modify: `crates/cards/src/impls/dodge.rs` (2 sites)
+- Modify: `crates/cards/src/impls/cover_up.rs` (2 sites)
+- Modify: `crates/scenarios/src/test_fixtures/synth_cards.rs` (2 sites)
+
+**Interfaces:**
+- Produces: `card_dsl::dsl::EventTiming::When` (replaces `::Before`), same
+  `#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]`. Serde wire
+  string changes `"Before" → "When"` (no persisted corpus depends on it — generated cards
+  carry no `EventTiming::Before`).
+
+- [ ] **Step 1: Rename the enum variant + update its doc.** In `crates/card-dsl/src/dsl.rs`,
+  replace the `EventTiming` doc block + `Before` variant:
+
+```rust
+/// When an [`Trigger::OnEvent`] ability fires relative to the triggering
+/// event finalizing — the RR "when → at → after" timing axis (the order
+/// simultaneous abilities sharing a triggering condition resolve in).
+///
+/// - [`When`](Self::When) — the "Forced — when … would …" interrupt timing
+///   that lets an effect interpose on an in-progress event (Dodge 01023's
+///   cancel, Cover Up 01007's replacement).
+/// - [`After`](Self::After) — most reaction cards ("After you defeat an
+///   enemy …").
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum EventTiming {
+    /// Resolves as the triggering event would finalize (interrupt /
+    /// replacement timing — "when … would …").
+    When,
+    /// Resolves after the triggering event has finalized.
+    After,
+}
+```
+
+- [ ] **Step 2: Update the two DSL doc references to `Before`.** In the same file, line ~323
+  (the `WouldDiscoverClues` pattern doc): `(paired with [`EventTiming::Before`])` →
+  `(paired with [`EventTiming::When`])`. There are no other prose `Before` references to the
+  variant outside the test (Step 4).
+
+- [ ] **Step 3: Rename the `trigger_matches` arm + its doc.** In
+  `crates/game-core/src/engine/dispatch/reaction_windows.rs`, the doc comment line ~325
+  `/// `EventTiming::Before` doesn't fire on these windows yet …` →
+  `/// `EventTiming::When` interrupt timing fires only on the Before-windows below …`, and the
+  match arm (~337):
+
+```rust
+    match timing {
+        EventTiming::When => {
+            return matches!(
+                (kind, pattern),
+                (
+                    WindowKind::BeforeEnemyAttack { .. },
+                    EventPattern::EnemyAttacks
+                ) | (
+                    WindowKind::BeforeDiscoverClues { .. },
+                    EventPattern::WouldDiscoverClues
+                )
+            );
+        }
+        EventTiming::After => {}
+    }
+```
+
+- [ ] **Step 4: Rename the remaining construction/test sites.** Replace `EventTiming::Before`
+  with `EventTiming::When` at each:
+  - `crates/cards/src/impls/dodge.rs:33` and `:50`
+  - `crates/cards/src/impls/cover_up.rs:41` and `:138`
+  - `crates/scenarios/src/test_fixtures/synth_cards.rs:331` and `:414` (the latter is
+    `game_core::dsl::EventTiming::Before` → `::When`)
+  - `crates/game-core/src/engine/dispatch/reaction_windows.rs:1664`, `:1674`, `:1694`, `:1762`
+  - `crates/card-dsl/src/dsl.rs:1986` — also rename the local binding `before_controller` →
+    `when_controller` (and the `assert_ne!(after_controller, before_controller)` ~line 1994).
+  - `crates/card-dsl/src/dsl.rs:2005` — the serde-test loop array `[EventTiming::After,
+    EventTiming::Before]` → `[EventTiming::When, EventTiming::After]`, and its doc comment
+    (~line 1999) `Both [`EventTiming`] variants (`After` and `Before`)` → `Both [`EventTiming`]
+    variants (`When` and `After`)`.
+
+- [ ] **Step 5: Update the forced-scanner comment.** In
+  `crates/game-core/src/engine/dispatch/forced_triggers.rs` (~line 376), replace the comment
+  above the `if *timing == EventTiming::After` filter:
+
+```rust
+            // Only `After` timing is handled in this slice; no in-scope Forced
+            // card uses `When` ("when X would Y") timing, and `At`-timed forced
+            // abilities don't exist until Slice B-iii routes them through the
+            // EmitEvent coordinator. Revisit the filter there.
+```
+
+  (The `if *timing == EventTiming::After && want(pattern)` line itself is unchanged.)
+
+- [ ] **Step 6: Build the workspace to confirm the rename is complete.**
+
+Run: `cargo build --all --all-features`
+Expected: clean build. A `no variant named `Before`` error means a site was missed — grep
+`rg "EventTiming::Before" crates` should return nothing.
+
+- [ ] **Step 7: Run the full test suite (behaviour-preserving check).**
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: PASS — same counts as before the rename (the serde round-trip test now exercises
+`When` instead of `Before`).
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+engine: rename EventTiming::Before → When (Slice B-i task 1)
+
+The "Forced — when … would …" interrupt timing is the RR `when` bucket;
+rename it so the DSL names the when/at/after axis directly. Pure rename,
+compiler-enforced across the workspace, behaviour-preserving.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_011oqjdoNhbcH4kay8J3FEoJ
+EOF
+)"
+```
+
+---
+
+### Task 2: Add the dormant `At` variant
+
+`At` is the RR "at the …" bucket, ordered between `When` and `After`. No ability is tagged
+`At` in this sub-slice — the round-end doom re-tag is B-iii. This task adds the variant, its
+exhaustive-match handling, and serde coverage, proving it round-trips and is unused.
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs` (enum + serde test)
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (`trigger_matches` arm)
+
+**Interfaces:**
+- Consumes: `EventTiming::{When, After}` from Task 1.
+- Produces: `EventTiming::At` — constructible, serde-round-trippable, ordered second. No
+  forced/reaction scan matches it yet (`trigger_matches` treats it like `After`; the forced
+  filter's `== After` excludes it).
+
+- [ ] **Step 1: Extend the serde round-trip test to cover `At` (write the failing test
+  first).** In `crates/card-dsl/src/dsl.rs`, change the serde-test loop array to include `At`:
+
+```rust
+        for timing in [EventTiming::When, EventTiming::At, EventTiming::After] {
+```
+
+  and update its doc comment (~line 1999) `Both [`EventTiming`] variants (`When` and `After`)`
+  → `All three [`EventTiming`] variants (`When`, `At`, `After`)`.
+
+- [ ] **Step 2: Run the test to verify it fails.**
+
+Run: `cargo test -p card-dsl on_event_ability_round_trips_through_serde_json`
+Expected: FAIL — compile error `no variant named `At`` (the variant doesn't exist yet).
+
+- [ ] **Step 3: Add the `At` variant to the enum.** In `crates/card-dsl/src/dsl.rs`, insert
+  `At` between `When` and `After`, and extend the enum doc block to mention it:
+
+```rust
+    /// Resolves as the triggering event would finalize (interrupt /
+    /// replacement timing — "when … would …").
+    When,
+    /// Resolves between `when` and `after` abilities with the same
+    /// triggering condition ("at the …"). Dormant until Slice B-iii
+    /// re-tags the round-end doom onto it.
+    At,
+    /// Resolves after the triggering event has finalized.
+    After,
+```
+
+  And add to the doc block (after the `When` bullet, before `After`):
+
+```rust
+/// - [`At`](Self::At) — "at the …" timing, resolving between `when` and
+///   `after` abilities sharing a triggering condition. Dormant: no ability
+///   is tagged `At` until Slice B-iii.
+```
+
+- [ ] **Step 4: Make `trigger_matches` exhaustive over `At`.** In
+  `crates/game-core/src/engine/dispatch/reaction_windows.rs`, combine `At` with the `After`
+  arm (behaviour-preserving — no `At`-timed reaction exists, so it never reaches a window):
+
+```rust
+        EventTiming::When => {
+            return matches!(
+                (kind, pattern),
+                (
+                    WindowKind::BeforeEnemyAttack { .. },
+                    EventPattern::EnemyAttacks
+                ) | (
+                    WindowKind::BeforeDiscoverClues { .. },
+                    EventPattern::WouldDiscoverClues
+                )
+            );
+        }
+        // No `At`-timed reaction exists until Slice B-iii; treat it like
+        // `After` (fall through to pattern matching). Dormant.
+        EventTiming::At | EventTiming::After => {}
+```
+
+- [ ] **Step 5: Build to confirm exhaustiveness is satisfied everywhere.**
+
+Run: `cargo build --all --all-features`
+Expected: clean build. A `non-exhaustive patterns: `EventTiming::At` not covered` error names
+any other `match timing` site that needs the same `At | After` treatment — apply it there.
+
+- [ ] **Step 6: Run the serde test (now passing) + the full suite.**
+
+Run: `cargo test -p card-dsl on_event_ability_round_trips_through_serde_json`
+Expected: PASS (all three variants round-trip).
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: PASS — unchanged behaviour; `At` is exercised only by the serde test.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+engine: add dormant EventTiming::At variant (Slice B-i task 2)
+
+Adds the RR "at the …" bucket between When and After. No ability is tagged
+At yet — the round-end doom re-tag and bucket-scanning coordinator land in
+Slice B-iii. trigger_matches treats At like After (no At reaction exists);
+the forced scanner's `== After` filter excludes it. Serde round-trip now
+covers all three variants.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_011oqjdoNhbcH4kay8J3FEoJ
+EOF
+)"
+```
+
+---
+
+### Task 3: CI gauntlet + PR
+
+**Files:** none (verification + PR).
+
+- [ ] **Step 1: Run the full CI gauntlet** (all six jobs from Global Constraints). Expected:
+  all green. Fix any clippy/doc/fmt finding with a follow-up edit before proceeding.
+
+- [ ] **Step 2: Push the branch.**
+
+```bash
+git push -u origin engine/slice-b-coordinators
+```
+
+- [ ] **Step 3: Open the PR** with `gh pr create` using the repo template. Title:
+  `engine: EventTiming::{When, At, After} (Slice B-i)`. Body: one design-decisions paragraph
+  — the rename names the RR `when` bucket; `At` is dormant (B-iii populates it); the forced
+  scanner's `== After` filter is intentionally left for B-iii. Reference the parent spec and
+  note "Part of #434 (Slice B-i)."
+
+- [ ] **Step 4: Watch CI** via `gh pr checks <PR#> --watch` (background); fix failures with
+  follow-up commits to the same branch.
+
+- [ ] **Step 5: Phase-doc update is deferred** — B-i is one sub-slice of Slice B (#434); the
+  `docs/phases/phase-7-the-gathering.md` Ordering step 6 + Slice-A note get updated when the
+  whole of Slice B lands, not per sub-slice. (Do **not** edit the phase doc here.)
+
+## Self-Review notes
+
+- **Spec coverage:** B-i = "rename Before→When; add At (dormant); forced filter unchanged." ✅
+  Tasks 1–2 cover the rename + dormant variant; the filter generalization is explicitly
+  deferred to B-iii (documented in Task 1 Step 5's comment and the plan header).
+- **No `At` consumer in B-i:** confirmed — `At` appears only in the enum, the serde test, and
+  the dormant `trigger_matches` arm. The forced scanner cannot fire it (`== After`).
+- **Exhaustiveness safety net:** `cargo build` (Task 2 Step 5) catches any `match timing` site
+  beyond `trigger_matches`. The only known exhaustive match is `trigger_matches`; the forced
+  scanner uses an `==` comparison, not a match.

--- a/docs/superpowers/specs/2026-06-23-emitevent-frame-slice-b-coordinators-design.md
+++ b/docs/superpowers/specs/2026-06-23-emitevent-frame-slice-b-coordinators-design.md
@@ -1,0 +1,228 @@
+# EmitEvent-frame Slice B — `EmitEvent`/`TimingPoint` coordinators
+
+**Status:** design (2026-06-23). Slice B of the EmitEvent-frame arc
+([#434](https://github.com/talelburg/eldritch/issues/434), umbrella
+[#435](https://github.com/talelburg/eldritch/issues/435)). Follows Slice A
+(#433, PRs #436–#439); precedes Slice C (#431) + D (#423).
+
+**Parent specs (load-bearing):**
+- Arc decomposition: [`2026-06-22-emitevent-frame-arc-decomposition-design.md`](2026-06-22-emitevent-frame-arc-decomposition-design.md)
+- North-star: [`2026-06-20-unified-control-flow-model-design.md`](2026-06-20-unified-control-flow-model-design.md)
+  §"Named end-states → EmitEvent-frame detail".
+
+**Scope note vs. the arc decomposition:** that spec sketched Slice B as "`EmitEvent` +
+`TimingPoint` coordinators + the inherited `WindowKind` deletion." This design **expands**
+it with a DSL timing rework (`EventTiming::{When, At, After}`) — the enabler that lets the
+coordinator scan buckets uniformly and dissolves the round-end framework special-case
+rather than relocating it. The expansion is deliberate (see "Why the DSL rework").
+
+## Problem
+
+`emit_event` (the T5a chokepoint, PR #342) models the RR p.2 **forced → reaction** axis:
+it queues the reaction window, then resolves forced abilities (0/1 synchronously, 2+ via
+the #213 lead-ordering run). That axis is structural.
+
+The orthogonal RR "At" axis — **`when` → `at` → `after`** — is **not** structural, for a
+root reason at the *ability* level: `EventTiming` is only `Before | After`, and the forced
+scanner fires on `After` only (`forced_triggers.rs:379`: `if *timing == EventTiming::After`).
+So "at the end of the round" abilities (agenda 01107's doom, Dissonant Voices 01165) are
+tagged `After`, indistinguishable from genuine after-event reactions — the `when/at/after`
+axis is **collapsed**. With no bucket to read, ordering can only be hand-threaded.
+
+It is hand-threaded at exactly one site: the upkeep round-end. There, two buckets coincide,
+with content from two *different* mechanisms:
+
+- **`when` the round ends** → act 01109's clue-spend advancement, today a bespoke framework
+  field `Act.round_end_advance` read by `upkeep_phase_end`, resolved through
+  `Continuation::ActRoundEnd(ActRoundEndPending)` + `resume_act_round_end_advance`.
+- **`at` the end of the round** → `emit_event(TimingEvent::RoundEnded)`, the agenda 01107
+  doom — a **registry forced ability** scanned via `EventPattern::RoundEnded` (tagged
+  `After`).
+
+`phases.rs` hand-threads them: `upkeep_phase_end` opens the act window, then
+`resume_act_round_end_advance` calls `upkeep_round_end_at_and_after` →
+`emit_event(RoundEnded)` → `upkeep_round_end_teardown`. **That hand-thread is the "#212
+smell," and getting its order backwards was the §G bug** (fixed standalone in PR #396 by
+reordering those calls — but the ordering stays hand-enforced, not structural).
+
+Every *other* `emit_event` site is single-bucket: each `TimingEvent` sits in one fixed
+bucket, so there is no ordering to thread.
+
+**Two asymmetries this slice resolves:**
+1. The `at` cell (agenda doom) is a scanned registry ability; the `when` cell (act
+   advancement) is a hardcoded framework field. Even within the act crate this is
+   inconsistent — act 01110's advancement is *already* a registry ability
+   (`cards::what_have_you_done`'s Forced `EnemyDefeated`); only 01109's is a field.
+2. The `when/at/after` ordering is hand-enforced per site rather than structural.
+
+## Goal
+
+Reify the `when → at → after × forced → reaction` matrix as two `drive`-dispatched
+coordinator frames, with the bucket made first-class at the ability level so the coordinator
+scans every cell uniformly. Behaviour-preserving except for: (a) the per-cell eligibility
+re-scan (new ordering correctness, only changes outcomes in cases no in-scope card hits —
+synthetic regression test), and (b) the deliberate `WindowKind` event-log change (B-iv).
+
+## Why the DSL rework (`EventTiming::{When, At, After}`)
+
+The alternative — keeping `round_end_advance` a framework field and special-casing the
+round-end `when` cell in the coordinator — **relocates** the irregularity (a heterogeneous
+coordinator cell, or a new `CandidateSource` variant for a framework option) rather than
+removing it. The clean fix is to give abilities a bucket to self-declare, so act 01109 and
+agenda 01107 each name their own timing and the coordinator scans them identically.
+
+**The rework:**
+- `EventTiming::Before` → **`When`** (rename; the cancel/replacement interrupt timing *is*
+  the RR `when ... would` bucket — Dodge, Cover Up). ~15 sites, mechanical.
+- Add **`At`** (new; "at the end of the round" — between `when` and `after`).
+- Result: `EventTiming = { When, At, After }`, matching the RR ordering exactly.
+
+**Cancel-vs-when subtlety (not a blocker):** a `When`-timed ability may or may not cancel
+the event. Dodge (`When` + `Effect::Cancel`) cancels; act 01109 (`When`, no cancel) does
+not. The cancel behaviour is a property of the *effect* and the specific Before-timing
+points (`EnemyAttacks`, `WouldDiscoverClues` open cancel windows), **not** of the timing
+label — so the rename is safe; `When` does not imply "cancels."
+
+**Forced scanning becomes bucket-aware:** the `timing == After` filter generalizes to "the
+bucket currently being scanned" — `forced_point(bucket)` collects forced abilities whose
+`EventTiming == bucket`; `reaction_window(bucket)` likewise for reactions. This is the
+mechanism that lets the coordinator place each ability in its cell.
+
+The DSL exposing `When/At/After` is *not* a speculative primitive: it names the RR timing
+axis the engine already needs to order correctly, with live consumers in both the `When`
+(Dodge/Cover Up, 15 sites) and `At` (round-end doom) buckets.
+
+## Data model
+
+The coordinator's bucket cursor **reuses `EventTiming`** directly (game-core already depends
+on and re-exports `card_dsl`) — no parallel enum; "an ability's timing *is* its bucket" is
+then an identity, not a mapping.
+
+```rust
+enum TimingSub { Forced, Reaction }
+
+/// Coordinator: iterate When → At → After for one game event. `bucket` is the cursor.
+Continuation::EmitEvent { event: TimingEvent, bucket: EventTiming }
+
+/// Coordinator: one bucket, run forced then reaction. `sub` is the cursor.
+Continuation::TimingPoint { event: TimingEvent, bucket: EventTiming, sub: TimingSub }
+```
+
+`emit_event(event)` becomes: **push `EmitEvent { event, bucket: When }` and return** — the
+`drive` loop takes over.
+
+**`EmitEvent` dispatch (on a child pop):**
+1. Re-scan eligibility *for the current bucket* (board state may have changed in the prior
+   bucket — see "Per-cell re-scan").
+2. If the bucket is populated, push `TimingPoint { event, bucket, sub: Forced }`, yield.
+3. On the `TimingPoint` child's pop, advance the cursor `When → At → After`; repeat.
+4. After `After` completes, pop `EmitEvent`.
+
+**`TimingPoint` dispatch:** runs `sub: Forced` (scan abilities of `EventTiming == bucket` +
+the #213 lead-ordering run for 2+), then `sub: Reaction` (the `TimingPointWindow` from
+Slice A, scanning reactions of `EventTiming == bucket`), then pops — "exactly what T5a's
+`emit_event` does today, made frame-resumable" and parameterized by bucket.
+
+**Bucket population** is `forced_point(bucket)` / `reaction_window(bucket)` (today's
+functions gain a bucket parameter, filtering scanned abilities by `EventTiming`). Every
+existing event populates exactly one bucket, so its `EmitEvent` is a degenerate single-cell
+iteration — behaviour-identical to today; round-end is the sole multi-cell case.
+
+## The round-end composite — uniform remodel (no special-case)
+
+With the bucket first-class, the round-end `when` and `at` cells are both **scanned registry
+abilities**; the coordinator dispatches them identically.
+
+- **`when` cell — act 01109 advancement, remodeled to a registry ability.** Act 01109 gains
+  an `abilities()` impl: a `When`-timed `OnEvent { RoundEnded }` **reaction** (the printed
+  "investigators … *may* … spend clues to advance" — optional ⇒ reaction) whose effect is
+  `Effect::Native { tag: "act_round_end_advance" }`. The native effect reuses the existing
+  group clue-spend (`spend_clues_from(contributors, threshold)` + advance); the
+  `ActRoundEndPending` logic moves *into* it, surfaced as the `when`-bucket reaction window's
+  candidate (a group Confirm/Skip). The contributor location (the Hallway, 01112) is printed
+  on 01109, so it is card text the ability carries — not scenario plumbing.
+- **`at` cell — agenda 01107 doom + Dissonant Voices 01165**, re-tagged `After → At` (RR
+  "at the end of the round"). Behaviour-preserving: they fire at the same point, after the
+  `when` cell, with no competing `After`-RoundEnded ability in scope.
+- **Delete** `Act.round_end_advance`, `RoundEndAdvance`, `Continuation::ActRoundEnd` /
+  `ActRoundEndPending`, `resume_act_round_end_advance`, and the `round_end_advance_window`
+  check in `upkeep_phase_end`. The framework wart is **removed**, not relocated.
+- `upkeep_phase_end` becomes: emit `PhaseEnded { Upkeep }`, push the `RoundEnded` `EmitEvent`
+  coordinator; `upkeep_round_end_teardown` (expire until-end-of-round effects, Upkeep →
+  Mythos) runs after the coordinator pops.
+
+## Per-cell eligibility re-scan (the one new-behaviour correctness)
+
+The cursor re-scans eligibility *entering each cell*: a `when`-cell that mutates board state
+can change whether the `at`-cell fires — "a `when` reaction can change whether an `at`
+forced even fires," so the grid is **not** pre-computed. The nested frames make "enter each
+cell fresh, re-scan" structural.
+
+The conceptual precedent already in the engine: a `When` cancel (Dodge) suppresses the
+event, so downstream `At`/`After` cells never fire — same shape. But no in-scope card
+exercises a *cross-bucket suppression at one round-end emit*, so this is covered by a
+**synthetic test-only act/agenda fixture** (the §G class): a `when`-cell advance that flips
+an `at`-cell forced ability's eligibility, asserting the `at` forced does *not* fire after
+the `when` cell changes its precondition. Does not wait on a corpus card.
+
+## `WindowKind` deletion + observability redesign (inherited from Slice A)
+
+Slice A kept `WindowKind` alive *only* as the `Event::WindowOpened/Closed` descriptor
+(deleting it changes the observable event log — the one genuine behaviour change of the
+taxonomy rework, deferred here). Slice B owns it:
+
+- **Event windows** → `WindowOpened/Closed` carries the `TimingEvent` (+ `mode`/bucket),
+  which the `TimingPoint` frame already holds; the per-window payload (which enemy /
+  investigator / count) is derivable from it.
+- **Fast windows** → flow-position read from the anchor beneath; **`PhaseStep` dropped** from
+  the payload.
+- `WindowKind` is deleted outright.
+
+**Deliberate event-log fidelity change** (accepted): the log loses the explicit per-step
+fast-window label (`PlayerWindow(MythosAfterDraws)` etc.); it becomes derivable-from-anchor.
+Touches the ~46 `WindowOpened/Closed` test assertions. Irreversible-ish for replay
+consumers — hence its own sub-slice.
+
+## Sub-slicing (each independently green)
+
+- **B-i — DSL timing rework.** `EventTiming::Before → When` (rename, ~15 sites); add `At`
+  (variant present, not yet assigned to any ability). Generalize the forced scanner's
+  `timing == After` filter to be bucket-passed (still only `After` is populated, so
+  behaviour-preserving). Pure rename + dormant variant.
+- **B-ii — `TimingPoint` frame.** Reify `emit_event`'s forced→reaction into the
+  frame-resumable `TimingPoint`; `emit_event` pushes a lone `TimingPoint` for the event's
+  single bucket. `EmitEvent` not yet introduced. Behaviour-preserving. Largest mechanical PR.
+- **B-iii — `EmitEvent` coordinator + round-end remodel + re-scan + §G test.** Introduce
+  `EmitEvent`; make `forced_point`/`reaction_window` bucket-parameterized; remodel act 01109
+  as a `When` reaction ability + re-tag the round-end doom abilities to `At` (deleting
+  `round_end_advance` / `ActRoundEnd`); per-cell re-scan; the synthetic §G regression test.
+  The new-behaviour PR.
+- **B-iv — `WindowKind` deletion + observability redesign.** Delete `WindowKind`; redesign
+  `WindowOpened/Closed` (read-from-anchor, drop `PhaseStep`); update the ~46 assertions. The
+  event-log-change PR.
+
+## Testing strategy
+
+- **B-i / B-ii / B-iv: behaviour-preserving** (B-iv changes window *payload*, no game
+  outcome). Full engine + integration suite green at each boundary.
+- **B-iii: new behaviour** in the §G re-scan only — covered by the synthetic act/agenda
+  fixture. The 01109 remodel is behaviour-preserving (same group spend, same `when→at`
+  order), backstopped by `crates/game-core/tests/act_round_end.rs`,
+  `crates/cards/tests/act_advancement.rs`, `crates/cards/tests/the_barrier.rs`, and
+  `crates/scenarios/tests/the_gathering*.rs`.
+- Match the full CI gauntlet (fmt / clippy / test / doc / wasm) before each push.
+
+## What "done" looks like
+
+`EventTiming` is `When | At | After`; the `when/at/after` axis is frame-driven
+(`EmitEvent`/`TimingPoint` coordinators scanning each cell by ability timing), not
+hand-threaded per emit site; per-cell eligibility is re-scanned with a regression test; act
+01109's round-end advancement is a `When` registry ability (no `round_end_advance` framework
+field), and the round-end doom is `At`; `WindowKind` is deleted and `WindowOpened/Closed`
+reads flow-position from the anchor. Unblocks Slice C (#431) and D (#423).
+
+## Open questions
+
+None blocking. If a second round-end-window card appears (Dunwich+), revisit whether the
+group clue-spend native effect warrants promotion to a shared `Effect` variant (the repo's
+≥2-reuse rule); single consumer today, so it stays `Effect::Native`.


### PR DESCRIPTION
## Summary

Slice B-i of the EmitEvent-frame arc (#434): rename `EventTiming::Before → When` and add a dormant `At` variant, so the card DSL carries the RR `when → at → after` timing axis as a first-class enum. This is the enabler for the Slice-B coordinators — once the bucket is first-class, the coordinator scans every timing-point cell uniformly and the round-end framework special-case dissolves (B-iii).

Behaviour-preserving: pure rename (compiler-enforced) + one unused variant.

This PR also lands the **Slice B design spec** (`docs/superpowers/specs/2026-06-23-emitevent-frame-slice-b-coordinators-design.md`) and the **B-i implementation plan** (`docs/superpowers/plans/2026-06-23-slice-b-i-eventtiming-when-at.md`) — the arc's first PR carries its design.

## What changed

- `EventTiming::Before → When` across the workspace (14 sites): the enum + `dodge.rs`, `cover_up.rs`, `synth_cards.rs`, `dsl.rs` tests, `reaction_windows.rs` (`trigger_matches` arm + 4 tests), plus doc references.
- Added dormant `EventTiming::At`, ordered between `When` and `After` (RR order). `trigger_matches` treats `At` like `After` (no `At`-timed reaction exists); the forced scanner's `== After` filter excludes it.
- Serde round-trip test now exercises all three variants.

## Design decisions

- **`Before → When` is safe** even though `Before` opened cancel windows: the cancel behaviour is a property of the *effect* (`Effect::Cancel`) and the specific Before-timing points, **not** the timing label — so `When` does not imply "cancels."
- **The forced scanner's `== After` filter is intentionally left as-is.** No caller varies the bucket in B-i, so bucket-parameterizing the scan is deferred to B-iii where the `EmitEvent` coordinator actually passes other buckets — a cleaner sub-slice boundary than parameterizing speculatively here.

## Test notes

Full CI gauntlet green locally (test / fmt / clippy-host / doc / wasm-build / wasm-clippy). Behaviour-preserving — existing suite unchanged; the serde test now covers `When`/`At`/`After`.

## Linked issues

Part of #434 (Slice B-i). Does not close it — Slice B completes with B-ii…B-iv.