### PR TITLE
engine: IntExpr dynamic-value cluster (Quantity/Count/Compare) + #426 + #300

### DIFF
--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -649,12 +649,6 @@ pub enum Effect {
         /// `on_success` — success and margin-keyed-failure are separate axes.
         on_fail: Option<Box<Effect>>,
     },
-    /// Run `body` once per point the just-resolved skill test was failed
-    /// by ("for each point you fail by, …"). Reads the failure margin
-    /// from the evaluator context; a `0` margin (or no margin in context)
-    /// runs `body` zero times. Only meaningful inside an
-    /// [`Effect::SkillTest`]'s `on_fail`.
-    ForEachPointFailed(Box<Effect>),
     /// Discard the firing card instance (the evaluator context's
     /// `source`). Locates the instance in a threat area or location
     /// attachment, removes it, and discards it to the encounter discard.
@@ -1548,13 +1542,6 @@ pub fn skill_test(
     }
 }
 
-/// Build an [`Effect::ForEachPointFailed`] running `body` once per point
-/// the just-resolved skill test was failed by.
-#[must_use]
-pub fn for_each_point_failed(body: Effect) -> Effect {
-    Effect::ForEachPointFailed(Box::new(body))
-}
-
 // ---- tests ----------------------------------------------------
 
 #[cfg(test)]
@@ -1939,26 +1926,6 @@ mod tests {
             pat,
             serde_json::from_str::<EventPattern>(&json).expect("de")
         );
-    }
-
-    /// `Effect::SkillTest` (treachery-Revelation test) with a margin-keyed
-    /// `Effect::ForEachPointFailed` failure branch round-trips through serde
-    /// — both new #286 variants in one tree.
-    #[test]
-    fn skill_test_and_for_each_point_failed_round_trip() {
-        use crate::card_data::SkillKind;
-        let effect = skill_test(
-            SkillKind::Agility,
-            3,
-            None,
-            Some(for_each_point_failed(deal_damage(
-                InvestigatorTarget::You,
-                1u8,
-            ))),
-        );
-        let json = serde_json::to_string(&effect).expect("serialize");
-        let back: Effect = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(effect, back);
     }
 
     /// Roland-Banks-shaped reaction: "after you defeat an enemy,

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -573,7 +573,7 @@ pub enum Effect {
     Deal {
         kind: HarmKind,
         target: InvestigatorTarget,
-        amount: u8,
+        amount: IntExpr,
     },
     /// Deal `amount` direct (non-test) damage to the resolved enemy
     /// `target`, applying the defeat cascade (Beat Cop 01018). Typed (not
@@ -707,7 +707,7 @@ pub enum Effect {
         /// Combat modifier for this attack, resolved against state at eval.
         combat_modifier: IntExpr,
         /// Bonus damage beyond the base 1 (.38 Special: +1).
-        extra_damage: u8,
+        extra_damage: IntExpr,
     },
     /// Draw `count` cards for the resolved target investigator —
     /// "draw 1 card" (Guts 01089, Perception 01090, Overpower 01091,
@@ -1317,11 +1317,11 @@ pub fn discover_clue(from: LocationTarget, count: u8) -> Effect {
 
 /// Build an [`Effect::Deal`] dealing `amount` damage to `target`.
 #[must_use]
-pub fn deal_damage(target: InvestigatorTarget, amount: u8) -> Effect {
+pub fn deal_damage(target: InvestigatorTarget, amount: impl Into<IntExpr>) -> Effect {
     Effect::Deal {
         kind: HarmKind::Damage,
         target,
-        amount,
+        amount: amount.into(),
     }
 }
 
@@ -1359,11 +1359,11 @@ pub fn heal_horror(target: InvestigatorTarget, count: u8) -> Effect {
 
 /// Build an [`Effect::Deal`] dealing `amount` horror to `target`.
 #[must_use]
-pub fn deal_horror(target: InvestigatorTarget, amount: u8) -> Effect {
+pub fn deal_horror(target: InvestigatorTarget, amount: impl Into<IntExpr>) -> Effect {
     Effect::Deal {
         kind: HarmKind::Horror,
         target,
-        amount,
+        amount: amount.into(),
     }
 }
 
@@ -1505,12 +1505,12 @@ pub fn put_into_threat_area_with_clues(code: impl Into<String>, clues: u8) -> Ef
 }
 
 /// Build an [`Effect::Fight`] with the given combat modifier and bonus
-/// damage (.38 Special: `fight(IntExpr::cond(Condition::Compare { quantity: Quantity::CluesAtControllerLocation, op: CmpOp::Gt, value: 0 }, 3, 1), 1)`).
+/// damage (.38 Special: `fight(IntExpr::cond(Condition::Compare { quantity: Quantity::CluesAtControllerLocation, op: CmpOp::Gt, value: 0 }, 3, 1), 1u8)`).
 #[must_use]
-pub fn fight(combat_modifier: IntExpr, extra_damage: u8) -> Effect {
+pub fn fight(combat_modifier: impl Into<IntExpr>, extra_damage: impl Into<IntExpr>) -> Effect {
     Effect::Fight {
-        combat_modifier,
-        extra_damage,
+        combat_modifier: combat_modifier.into(),
+        extra_damage: extra_damage.into(),
     }
 }
 
@@ -1832,14 +1832,14 @@ mod tests {
 
     #[test]
     fn deal_builders_produce_the_kinded_effect_and_round_trip() {
-        let dmg = deal_damage(InvestigatorTarget::You, 2);
-        let hor = deal_horror(InvestigatorTarget::You, 3);
+        let dmg = deal_damage(InvestigatorTarget::You, 2u8);
+        let hor = deal_horror(InvestigatorTarget::You, 3u8);
         assert_eq!(
             dmg,
             Effect::Deal {
                 kind: HarmKind::Damage,
                 target: InvestigatorTarget::You,
-                amount: 2,
+                amount: IntExpr::Lit(2),
             }
         );
         assert_eq!(
@@ -1847,7 +1847,7 @@ mod tests {
             Effect::Deal {
                 kind: HarmKind::Horror,
                 target: InvestigatorTarget::You,
-                amount: 3,
+                amount: IntExpr::Lit(3),
             }
         );
         for e in [dmg, hor] {
@@ -1953,7 +1953,7 @@ mod tests {
             None,
             Some(for_each_point_failed(deal_damage(
                 InvestigatorTarget::You,
-                1,
+                1u8,
             ))),
         );
         let json = serde_json::to_string(&effect).expect("serialize");

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -1513,10 +1513,12 @@ pub fn fight(combat_modifier: impl Into<IntExpr>, extra_damage: impl Into<IntExp
 
 /// Build an [`Effect::Investigate`] applying `shroud_modifier` to the
 /// controller's location difficulty for this investigation (Flashlight 01087:
-/// `investigate(IntExpr::Lit(-2))`).
+/// `investigate(-2i8)`).
 #[must_use]
-pub fn investigate(shroud_modifier: IntExpr) -> Effect {
-    Effect::Investigate { shroud_modifier }
+pub fn investigate(shroud_modifier: impl Into<IntExpr>) -> Effect {
+    Effect::Investigate {
+        shroud_modifier: shroud_modifier.into(),
+    }
 }
 
 /// Build an [`Effect::Restrict`] carrying a constant [`Restriction`].

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -1094,6 +1094,29 @@ pub enum Condition {
     LocationHasClues,
 }
 
+/// A non-negative count read off game state, usable as a value
+/// ([`IntExpr::Count`]) or compared in a predicate ([`Condition::Compare`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Quantity {
+    /// Clues on the controller's current location.
+    CluesAtControllerLocation,
+    /// Enemies engaged with the controller.
+    EngagedEnemies,
+    /// Failure margin of the resolving skill test (0 outside one).
+    SkillTestFailedBy,
+}
+
+/// Comparison operator for [`Condition::Compare`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum CmpOp {
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+}
+
 /// An integer computed at effect-evaluation time. Lets a numeric field
 /// carry a condition-gated value without duplicating the surrounding
 /// effect — ".38 Special" reads its combat modifier as

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -27,8 +27,11 @@
 //!   from the Dunwich cycle). Need `Trigger::OnLeavePlay` plus
 //!   ability-specific effect machinery.
 //! - **Stat-comparison / location-state conditions** (`AnyEnemyEngaged`,
-//!   `SkillSucceededByAtLeast(N)`). [`Condition::Compare`] now covers
-//!   clue counts and engaged-enemy counts.
+//!   `SkillSucceededByAtLeast(N)`). Note: [`Condition::Compare`] already
+//!   covers clue-count and engaged-enemy-count comparisons — these are
+//!   expressible today. What remains unexpressible are conditions keyed on
+//!   location state, success margin, or other quantities not yet in
+//!   [`Quantity`].
 //!
 //! # Has DSL surface but not yet engine support
 //!

--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -26,9 +26,9 @@
 //!   Harold Walsted leaves play: Remove him from the game and add...`
 //!   from the Dunwich cycle). Need `Trigger::OnLeavePlay` plus
 //!   ability-specific effect machinery.
-//! - **Stat-comparison / location-state conditions** (`LocationHasClues`,
-//!   `AnyEnemyEngaged`, `SkillSucceededByAtLeast(N)`). [`Condition`]
-//!   today only covers skill-test outcome and kind.
+//! - **Stat-comparison / location-state conditions** (`AnyEnemyEngaged`,
+//!   `SkillSucceededByAtLeast(N)`). [`Condition::Compare`] now covers
+//!   clue counts and engaged-enemy counts.
 //!
 //! # Has DSL surface but not yet engine support
 //!
@@ -1071,7 +1071,7 @@ impl EnemyTarget {
 /// A boolean predicate guarding an [`Effect::If`].
 ///
 /// Phase-2 minimal set; later phases will add things like
-/// `LocationHasClues`, `AnyEnemyEngaged`, comparisons against
+/// `Compare { CluesAtControllerLocation, Gt, 0 }`, `AnyEnemyEngaged`, comparisons against
 /// stat values, etc.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Condition {
@@ -1089,9 +1089,13 @@ pub enum Condition {
     /// there's an in-flight test whose kind matches; rejects when
     /// no test is in flight.
     SkillTestKind(SkillTestKind),
-    /// Holds when the controller's current location has ≥1 clue.
-    /// ".38 Special": "if there are 1 or more clues on your location".
-    LocationHasClues,
+    /// Compare a [`Quantity`] against `value` under `op`.
+    /// Replaces the old `LocationHasClues` (now `Compare { CluesAtControllerLocation, Gt, 0 }`).
+    Compare {
+        quantity: Quantity,
+        op: CmpOp,
+        value: i8,
+    },
 }
 
 /// A non-negative count read off game state, usable as a value
@@ -1120,8 +1124,8 @@ pub enum CmpOp {
 /// An integer computed at effect-evaluation time. Lets a numeric field
 /// carry a condition-gated value without duplicating the surrounding
 /// effect — ".38 Special" reads its combat modifier as
-/// `IntExpr::cond(LocationHasClues, 3, 1)` rather than an
-/// [`Effect::If`] wrapping two near-identical `fight(…)` nodes.
+/// `IntExpr::cond(Condition::Compare { quantity: Quantity::CluesAtControllerLocation, op: CmpOp::Gt, value: 0 }, 3, 1)`
+/// rather than an [`Effect::If`] wrapping two near-identical `fight(…)` nodes.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum IntExpr {
     /// A literal value.
@@ -1135,6 +1139,8 @@ pub enum IntExpr {
         /// Value when it does not.
         otherwise: i8,
     },
+    /// A state-read count ([`Quantity`]).
+    Count(Quantity),
 }
 
 impl IntExpr {
@@ -1146,6 +1152,18 @@ impl IntExpr {
             then,
             otherwise,
         }
+    }
+}
+
+impl From<i8> for IntExpr {
+    fn from(n: i8) -> Self {
+        IntExpr::Lit(n)
+    }
+}
+
+impl From<u8> for IntExpr {
+    fn from(n: u8) -> Self {
+        IntExpr::Lit(i8::try_from(n).unwrap_or(i8::MAX))
     }
 }
 
@@ -1487,7 +1505,7 @@ pub fn put_into_threat_area_with_clues(code: impl Into<String>, clues: u8) -> Ef
 }
 
 /// Build an [`Effect::Fight`] with the given combat modifier and bonus
-/// damage (.38 Special: `fight(IntExpr::cond(LocationHasClues, 3, 1), 1)`).
+/// damage (.38 Special: `fight(IntExpr::cond(Condition::Compare { quantity: Quantity::CluesAtControllerLocation, op: CmpOp::Gt, value: 0 }, 3, 1), 1)`).
 #[must_use]
 pub fn fight(combat_modifier: IntExpr, extra_damage: u8) -> Effect {
     Effect::Fight {

--- a/crates/cards/src/impls/attic.rs
+++ b/crates/cards/src/impls/attic.rs
@@ -24,13 +24,15 @@ pub fn abilities() -> Vec<Ability> {
     vec![forced_on_event(
         EventPattern::EnteredLocation,
         EventTiming::After,
-        deal_horror(InvestigatorTarget::You, 1),
+        deal_horror(InvestigatorTarget::You, 1u8),
     )]
 }
 
 #[cfg(test)]
 mod tests {
-    use card_dsl::dsl::{Effect, EventPattern, EventTiming, HarmKind, InvestigatorTarget, Trigger};
+    use card_dsl::dsl::{
+        Effect, EventPattern, EventTiming, HarmKind, IntExpr, InvestigatorTarget, Trigger,
+    };
 
     #[test]
     fn abilities_are_one_forced_enter_horror() {
@@ -49,7 +51,7 @@ mod tests {
             Effect::Deal {
                 kind: HarmKind::Horror,
                 target: InvestigatorTarget::You,
-                amount: 1,
+                amount: IntExpr::Lit(1),
             }
         ));
     }

--- a/crates/cards/src/impls/automatic_45.rs
+++ b/crates/cards/src/impls/automatic_45.rs
@@ -26,7 +26,7 @@ pub fn abilities() -> Vec<Ability> {
             kind: UseKind::Ammo,
             count: 1,
         }],
-        fight(IntExpr::Lit(1), 1),
+        fight(IntExpr::Lit(1), 1u8),
     )]
 }
 
@@ -55,7 +55,7 @@ mod tests {
             panic!("expected Effect::Fight");
         };
         assert_eq!(*combat_modifier, IntExpr::Lit(1));
-        assert_eq!(*extra_damage, 1);
+        assert_eq!(*extra_damage, IntExpr::Lit(1));
     }
 
     /// Catches a `pub mod` rename or a fat-fingered match arm in

--- a/crates/cards/src/impls/automatic_45.rs
+++ b/crates/cards/src/impls/automatic_45.rs
@@ -13,7 +13,7 @@
 //! inspectable `Effect::Fight`, dealing `1 + 1` damage on success.
 
 use card_dsl::card_data::UseKind;
-use card_dsl::dsl::{activated, fight, Ability, Cost, IntExpr};
+use card_dsl::dsl::{activated, fight, Ability, Cost};
 
 /// `ArkhamDB` code for the .45 Automatic (original-Core printing).
 pub const CODE: &str = "01016";
@@ -26,14 +26,14 @@ pub fn abilities() -> Vec<Ability> {
             kind: UseKind::Ammo,
             count: 1,
         }],
-        fight(IntExpr::Lit(1), 1u8),
+        fight(1u8, 1u8),
     )]
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use card_dsl::dsl::{Effect, Trigger};
+    use card_dsl::dsl::{Effect, IntExpr, Trigger};
 
     #[test]
     fn one_activated_fight_ability_spending_ammo() {

--- a/crates/cards/src/impls/cellar.rs
+++ b/crates/cards/src/impls/cellar.rs
@@ -22,13 +22,15 @@ pub fn abilities() -> Vec<Ability> {
     vec![forced_on_event(
         EventPattern::EnteredLocation,
         EventTiming::After,
-        deal_damage(InvestigatorTarget::You, 1),
+        deal_damage(InvestigatorTarget::You, 1u8),
     )]
 }
 
 #[cfg(test)]
 mod tests {
-    use card_dsl::dsl::{Effect, EventPattern, EventTiming, HarmKind, InvestigatorTarget, Trigger};
+    use card_dsl::dsl::{
+        Effect, EventPattern, EventTiming, HarmKind, IntExpr, InvestigatorTarget, Trigger,
+    };
 
     #[test]
     fn abilities_are_one_forced_enter_damage() {
@@ -47,7 +49,7 @@ mod tests {
             Effect::Deal {
                 kind: HarmKind::Damage,
                 target: InvestigatorTarget::You,
-                amount: 1,
+                amount: IntExpr::Lit(1),
             }
         ));
     }

--- a/crates/cards/src/impls/flashlight.rs
+++ b/crates/cards/src/impls/flashlight.rs
@@ -25,7 +25,7 @@
 //! affecting First Aid / Medical Texts); fixed engine-wide in #361.
 
 use card_dsl::card_data::UseKind;
-use card_dsl::dsl::{activated, investigate, Ability, Cost, IntExpr};
+use card_dsl::dsl::{activated, investigate, Ability, Cost};
 
 /// `ArkhamDB` code for Flashlight (original-Core printing).
 pub const CODE: &str = "01087";
@@ -39,14 +39,14 @@ pub fn abilities() -> Vec<Ability> {
             kind: UseKind::Supplies,
             count: 1,
         }],
-        investigate(IntExpr::Lit(-2)),
+        investigate(-2i8),
     )]
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use card_dsl::dsl::{Effect, Trigger};
+    use card_dsl::dsl::{Effect, IntExpr, Trigger};
 
     #[test]
     fn one_action_ability_spending_a_supply_to_investigate_minus_two_shroud() {

--- a/crates/cards/src/impls/grasping_hands.rs
+++ b/crates/cards/src/impls/grasping_hands.rs
@@ -5,11 +5,11 @@
 //! ```
 //!
 //! Pure DSL: `Trigger::Revelation` → `Effect::SkillTest` whose `on_fail`
-//! deals 1 damage per point the test was failed by (#286 machinery).
+//! deals `Count(SkillTestFailedBy)` damage in a single `Deal` (#426).
 
 use card_dsl::card_data::SkillKind;
 use card_dsl::dsl::{
-    deal_damage, for_each_point_failed, revelation, skill_test, Ability, InvestigatorTarget,
+    deal_damage, revelation, skill_test, Ability, IntExpr, InvestigatorTarget, Quantity,
 };
 
 /// `ArkhamDB` code for Grasping Hands.
@@ -21,17 +21,17 @@ pub fn abilities() -> Vec<Ability> {
         SkillKind::Agility,
         3,
         None,
-        Some(for_each_point_failed(deal_damage(
+        Some(deal_damage(
             InvestigatorTarget::You,
-            1u8,
-        ))),
+            IntExpr::Count(Quantity::SkillTestFailedBy),
+        )),
     ))]
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use card_dsl::dsl::{Effect, HarmKind, IntExpr};
+    use card_dsl::dsl::{Effect, HarmKind, IntExpr, Quantity};
 
     #[test]
     fn revelation_tests_agility_3_then_damage_per_point() {
@@ -51,8 +51,11 @@ mod tests {
         assert!(on_success.is_none(), "no success-side effect");
         assert!(matches!(
             on_fail.as_deref(),
-            Some(Effect::ForEachPointFailed(b))
-                if matches!(**b, Effect::Deal { kind: HarmKind::Damage, amount: IntExpr::Lit(1), .. })
+            Some(Effect::Deal {
+                kind: HarmKind::Damage,
+                amount: IntExpr::Count(Quantity::SkillTestFailedBy),
+                ..
+            })
         ));
     }
 }

--- a/crates/cards/src/impls/grasping_hands.rs
+++ b/crates/cards/src/impls/grasping_hands.rs
@@ -23,7 +23,7 @@ pub fn abilities() -> Vec<Ability> {
         None,
         Some(for_each_point_failed(deal_damage(
             InvestigatorTarget::You,
-            1,
+            1u8,
         ))),
     ))]
 }
@@ -31,7 +31,7 @@ pub fn abilities() -> Vec<Ability> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use card_dsl::dsl::{Effect, HarmKind};
+    use card_dsl::dsl::{Effect, HarmKind, IntExpr};
 
     #[test]
     fn revelation_tests_agility_3_then_damage_per_point() {
@@ -52,7 +52,7 @@ mod tests {
         assert!(matches!(
             on_fail.as_deref(),
             Some(Effect::ForEachPointFailed(b))
-                if matches!(**b, Effect::Deal { kind: HarmKind::Damage, amount: 1, .. })
+                if matches!(**b, Effect::Deal { kind: HarmKind::Damage, amount: IntExpr::Lit(1), .. })
         ));
     }
 }

--- a/crates/cards/src/impls/knife.rs
+++ b/crates/cards/src/impls/knife.rs
@@ -34,10 +34,10 @@ pub const CODE: &str = "01086";
 pub fn abilities() -> Vec<Ability> {
     vec![
         // [action]: Fight. You get +1 [combat] for this attack.
-        activated(1, vec![], fight(IntExpr::Lit(1), 0)),
+        activated(1, vec![], fight(IntExpr::Lit(1), 0u8)),
         // [action] Discard Knife: Fight. You get +2 [combat] for this attack.
         // This attack deals +1 damage.
-        activated(1, vec![Cost::DiscardSelf], fight(IntExpr::Lit(2), 1)),
+        activated(1, vec![Cost::DiscardSelf], fight(IntExpr::Lit(2), 1u8)),
     ]
 }
 
@@ -65,7 +65,7 @@ mod tests {
             panic!("expected Effect::Fight at index 0");
         };
         assert_eq!(*combat_modifier, IntExpr::Lit(1));
-        assert_eq!(*extra_damage, 0);
+        assert_eq!(*extra_damage, IntExpr::Lit(0));
 
         // Index 1: [action] Discard Knife Fight, +2 combat, +1 damage.
         assert_eq!(abilities[1].trigger, Trigger::Activated { action_cost: 1 });
@@ -78,7 +78,7 @@ mod tests {
             panic!("expected Effect::Fight at index 1");
         };
         assert_eq!(*combat_modifier, IntExpr::Lit(2));
-        assert_eq!(*extra_damage, 1);
+        assert_eq!(*extra_damage, IntExpr::Lit(1));
     }
 
     /// Catches a `pub mod` rename or a fat-fingered match arm in

--- a/crates/cards/src/impls/knife.rs
+++ b/crates/cards/src/impls/knife.rs
@@ -23,7 +23,7 @@
 //! (`resolve_activated_ability` indexes the raw abilities vec and rejects
 //! any non-`Activated` trigger).
 
-use card_dsl::dsl::{activated, fight, Ability, Cost, IntExpr};
+use card_dsl::dsl::{activated, fight, Ability, Cost};
 
 /// `ArkhamDB` code for Knife (original-Core printing).
 pub const CODE: &str = "01086";
@@ -34,17 +34,17 @@ pub const CODE: &str = "01086";
 pub fn abilities() -> Vec<Ability> {
     vec![
         // [action]: Fight. You get +1 [combat] for this attack.
-        activated(1, vec![], fight(IntExpr::Lit(1), 0u8)),
+        activated(1, vec![], fight(1u8, 0u8)),
         // [action] Discard Knife: Fight. You get +2 [combat] for this attack.
         // This attack deals +1 damage.
-        activated(1, vec![Cost::DiscardSelf], fight(IntExpr::Lit(2), 1u8)),
+        activated(1, vec![Cost::DiscardSelf], fight(2u8, 1u8)),
     ]
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use card_dsl::dsl::{Effect, Trigger};
+    use card_dsl::dsl::{Effect, IntExpr, Trigger};
 
     #[test]
     fn two_action_fight_abilities() {

--- a/crates/cards/src/impls/machete.rs
+++ b/crates/cards/src/impls/machete.rs
@@ -8,7 +8,14 @@
 //! A bare `[action]` Fight (no exhaust, no uses) with a flat `+1` combat
 //! modifier. The bonus damage is conditional: `+1` only when the attacked
 //! enemy is the sole engaged enemy, encoded as
-//! `IntExpr::Cond(EngagedEnemies == 1, 1, 0)`.
+//! `IntExpr::cond(EngagedEnemies == 1, 1, 0)`.
+//!
+//! Note: activated `Effect::Fight` currently requires *exactly one* engaged
+//! enemy (2+ engaged is rejected pre-cost, pending multi-target selection /
+//! [#401](https://github.com/talelburg/eldritch/issues/401)). As a result the
+//! `EngagedEnemies == 1` condition always holds whenever the Fight resolves
+//! today — the `+0` branch is correct modelling but only becomes reachable
+//! once 2-engaged activated Fight lands.
 
 use card_dsl::dsl::{activated, fight, Ability, CmpOp, Condition, IntExpr, Quantity};
 

--- a/crates/cards/src/impls/machete.rs
+++ b/crates/cards/src/impls/machete.rs
@@ -10,12 +10,15 @@
 //! enemy is the sole engaged enemy, encoded as
 //! `IntExpr::cond(EngagedEnemies == 1, 1, 0)`.
 //!
-//! Note: activated `Effect::Fight` currently requires *exactly one* engaged
-//! enemy (2+ engaged is rejected pre-cost, pending multi-target selection /
-//! [#401](https://github.com/talelburg/eldritch/issues/401)). As a result the
-//! `EngagedEnemies == 1` condition always holds whenever the Fight resolves
-//! today — the `+0` branch is correct modelling but only becomes reachable
-//! once 2-engaged activated Fight lands.
+//! Note: the `+0` branch is correct modelling but not yet *reachable*. This is
+//! not a Machete-specific limit — the engine cannot yet resolve **any**
+//! activated `Effect::Fight` while 2+ enemies are engaged (it auto-targets the
+//! single engaged enemy and rejects the ambiguous case pre-cost; multi-target
+//! attack-selection is the deferred work). Per the rules a Fight weapon *can*
+//! be activated against any one engaged enemy of several — so once that
+//! selection lands, Machete activates normally and `EngagedEnemies == 1` (not
+//! activation) gates the `+1`. Until then the condition always holds whenever
+//! the Fight resolves, so only the `+1` branch is exercised.
 
 use card_dsl::dsl::{activated, fight, Ability, CmpOp, Condition, IntExpr, Quantity};
 

--- a/crates/cards/src/impls/machete.rs
+++ b/crates/cards/src/impls/machete.rs
@@ -33,7 +33,7 @@ pub const CODE: &str = "01020";
 
 #[must_use]
 pub fn abilities() -> Vec<Ability> {
-    vec![activated(1, vec![], fight(IntExpr::Lit(1), 1))]
+    vec![activated(1, vec![], fight(IntExpr::Lit(1), 1u8))]
 }
 
 #[cfg(test)]
@@ -59,7 +59,7 @@ mod tests {
         };
         assert_eq!(*combat_modifier, IntExpr::Lit(1));
         // Unconditional +1 — see the module doc-comment / TODO(#300).
-        assert_eq!(*extra_damage, 1);
+        assert_eq!(*extra_damage, IntExpr::Lit(1));
     }
 
     /// Catches a `pub mod` rename or a fat-fingered match arm in

--- a/crates/cards/src/impls/machete.rs
+++ b/crates/cards/src/impls/machete.rs
@@ -6,34 +6,33 @@
 //! ```
 //!
 //! A bare `[action]` Fight (no exhaust, no uses) with a flat `+1` combat
-//! modifier, dealing `1 + 1` damage on success.
-//!
-//! # The conditional `+1` damage is modeled as unconditional — on purpose
-//!
-//! Machete's bonus damage is printed as conditional on the attacked enemy
-//! being "the only enemy engaged with you." We encode it as an
-//! **unconditional** `extra_damage: 1`. This is exact under today's engine,
-//! not an approximation: [`Effect::Fight`](card_dsl::dsl::Effect::Fight)
-//! auto-targets the single engaged enemy, and `effect_initiates_fight`
-//! rejects a fight with ≠1 engaged enemy **before** any cost is paid — so
-//! at the moment Machete resolves, the attacked enemy is *necessarily* the
-//! only enemy engaged with the controller, and the condition always holds.
-//!
-//! TODO(#300): when multi-target Fight lands (the #212/#213 cluster, where
-//! the player chooses which engaged enemy to attack), this stops being
-//! equivalent — Machete must then grant `+1` only when the attacked enemy
-//! is the sole engaged one. At that point `Effect::Fight.extra_damage`
-//! needs to become conditional (an `IntExpr` gated on a "sole engaged
-//! enemy" `Condition`) and this impl updated.
+//! modifier. The bonus damage is conditional: `+1` only when the attacked
+//! enemy is the sole engaged enemy, encoded as
+//! `IntExpr::Cond(EngagedEnemies == 1, 1, 0)`.
 
-use card_dsl::dsl::{activated, fight, Ability, IntExpr};
+use card_dsl::dsl::{activated, fight, Ability, CmpOp, Condition, IntExpr, Quantity};
 
 /// `ArkhamDB` code for Machete (original-Core printing).
 pub const CODE: &str = "01020";
 
 #[must_use]
 pub fn abilities() -> Vec<Ability> {
-    vec![activated(1, vec![], fight(IntExpr::Lit(1), 1u8))]
+    vec![activated(
+        1,
+        vec![],
+        fight(
+            1u8,
+            IntExpr::cond(
+                Condition::Compare {
+                    quantity: Quantity::EngagedEnemies,
+                    op: CmpOp::Eq,
+                    value: 1,
+                },
+                1,
+                0,
+            ),
+        ),
+    )]
 }
 
 #[cfg(test)]
@@ -58,8 +57,19 @@ mod tests {
             panic!("expected Effect::Fight");
         };
         assert_eq!(*combat_modifier, IntExpr::Lit(1));
-        // Unconditional +1 — see the module doc-comment / TODO(#300).
-        assert_eq!(*extra_damage, IntExpr::Lit(1));
+        // +1 only when the attacked enemy is the sole engaged enemy (#300).
+        assert_eq!(
+            *extra_damage,
+            IntExpr::cond(
+                Condition::Compare {
+                    quantity: Quantity::EngagedEnemies,
+                    op: CmpOp::Eq,
+                    value: 1,
+                },
+                1,
+                0,
+            )
+        );
     }
 
     /// Catches a `pub mod` rename or a fat-fingered match arm in

--- a/crates/cards/src/impls/medical_texts.rs
+++ b/crates/cards/src/impls/medical_texts.rs
@@ -56,7 +56,7 @@ pub fn abilities() -> Vec<Ability> {
             )),
             Some(deal_damage(
                 InvestigatorTarget::chosen_at_your_location(),
-                1,
+                1u8,
             )),
         ),
     )]
@@ -97,7 +97,7 @@ mod tests {
         );
         assert_eq!(
             on_fail.as_deref(),
-            Some(&deal_damage(target, 1)),
+            Some(&deal_damage(target, 1u8)),
             "failure deals 1 damage to the chosen investigator",
         );
     }

--- a/crates/cards/src/impls/roland_38_special.rs
+++ b/crates/cards/src/impls/roland_38_special.rs
@@ -39,7 +39,7 @@ pub fn abilities() -> Vec<Ability> {
                 3,
                 1,
             ),
-            1,
+            1u8,
         ),
     )]
 }
@@ -68,7 +68,7 @@ mod tests {
         else {
             panic!("expected Effect::Fight");
         };
-        assert_eq!(*extra_damage, 1);
+        assert_eq!(*extra_damage, IntExpr::Lit(1));
         assert_eq!(
             *combat_modifier,
             IntExpr::cond(

--- a/crates/cards/src/impls/roland_38_special.rs
+++ b/crates/cards/src/impls/roland_38_special.rs
@@ -12,10 +12,11 @@
 //! parsed); the ability spends 1 per use via `Cost::SpendUses` and fights
 //! through `Effect::Fight`, whose combat modifier is `+3` when the
 //! investigator's location holds a clue and `+1` otherwise (`IntExpr::cond`
-//! over `Condition::LocationHasClues`), dealing `1 + 1` damage on success.
+//! over `Condition::Compare { CluesAtControllerLocation, Gt, 0 }`),
+//! dealing `1 + 1` damage on success.
 
 use card_dsl::card_data::UseKind;
-use card_dsl::dsl::{activated, fight, Ability, Condition, Cost, IntExpr};
+use card_dsl::dsl::{activated, fight, Ability, CmpOp, Condition, Cost, IntExpr, Quantity};
 
 /// `ArkhamDB` code for Roland's .38 Special.
 pub const CODE: &str = "01006";
@@ -28,7 +29,18 @@ pub fn abilities() -> Vec<Ability> {
             kind: UseKind::Ammo,
             count: 1,
         }],
-        fight(IntExpr::cond(Condition::LocationHasClues, 3, 1), 1),
+        fight(
+            IntExpr::cond(
+                Condition::Compare {
+                    quantity: Quantity::CluesAtControllerLocation,
+                    op: CmpOp::Gt,
+                    value: 0,
+                },
+                3,
+                1,
+            ),
+            1,
+        ),
     )]
 }
 
@@ -59,7 +71,15 @@ mod tests {
         assert_eq!(*extra_damage, 1);
         assert_eq!(
             *combat_modifier,
-            IntExpr::cond(Condition::LocationHasClues, 3, 1)
+            IntExpr::cond(
+                Condition::Compare {
+                    quantity: Quantity::CluesAtControllerLocation,
+                    op: CmpOp::Gt,
+                    value: 0,
+                },
+                3,
+                1,
+            )
         );
     }
 }

--- a/crates/cards/src/impls/rotting_remains.rs
+++ b/crates/cards/src/impls/rotting_remains.rs
@@ -5,11 +5,11 @@
 //! ```
 //!
 //! Pure DSL: `Trigger::Revelation` → `Effect::SkillTest` whose `on_fail`
-//! deals 1 horror per point the test was failed by (#286 machinery).
+//! deals `Count(SkillTestFailedBy)` horror in a single `Deal` (#426).
 
 use card_dsl::card_data::SkillKind;
 use card_dsl::dsl::{
-    deal_horror, for_each_point_failed, revelation, skill_test, Ability, InvestigatorTarget,
+    deal_horror, revelation, skill_test, Ability, IntExpr, InvestigatorTarget, Quantity,
 };
 
 /// `ArkhamDB` code for Rotting Remains.
@@ -21,17 +21,17 @@ pub fn abilities() -> Vec<Ability> {
         SkillKind::Willpower,
         3,
         None,
-        Some(for_each_point_failed(deal_horror(
+        Some(deal_horror(
             InvestigatorTarget::You,
-            1u8,
-        ))),
+            IntExpr::Count(Quantity::SkillTestFailedBy),
+        )),
     ))]
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use card_dsl::dsl::{Effect, HarmKind, IntExpr};
+    use card_dsl::dsl::{Effect, HarmKind, IntExpr, Quantity};
 
     #[test]
     fn revelation_tests_willpower_3_then_horror_per_point() {
@@ -51,8 +51,11 @@ mod tests {
         assert!(on_success.is_none(), "no success-side effect");
         assert!(matches!(
             on_fail.as_deref(),
-            Some(Effect::ForEachPointFailed(b))
-                if matches!(**b, Effect::Deal { kind: HarmKind::Horror, amount: IntExpr::Lit(1), .. })
+            Some(Effect::Deal {
+                kind: HarmKind::Horror,
+                amount: IntExpr::Count(Quantity::SkillTestFailedBy),
+                ..
+            })
         ));
     }
 }

--- a/crates/cards/src/impls/rotting_remains.rs
+++ b/crates/cards/src/impls/rotting_remains.rs
@@ -23,7 +23,7 @@ pub fn abilities() -> Vec<Ability> {
         None,
         Some(for_each_point_failed(deal_horror(
             InvestigatorTarget::You,
-            1,
+            1u8,
         ))),
     ))]
 }
@@ -31,7 +31,7 @@ pub fn abilities() -> Vec<Ability> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use card_dsl::dsl::{Effect, HarmKind};
+    use card_dsl::dsl::{Effect, HarmKind, IntExpr};
 
     #[test]
     fn revelation_tests_willpower_3_then_horror_per_point() {
@@ -52,7 +52,7 @@ mod tests {
         assert!(matches!(
             on_fail.as_deref(),
             Some(Effect::ForEachPointFailed(b))
-                if matches!(**b, Effect::Deal { kind: HarmKind::Horror, amount: 1, .. })
+                if matches!(**b, Effect::Deal { kind: HarmKind::Horror, amount: IntExpr::Lit(1), .. })
         ));
     }
 }

--- a/crates/cards/src/impls/whats_going_on.rs
+++ b/crates/cards/src/impls/whats_going_on.rs
@@ -47,7 +47,7 @@ pub fn abilities() -> Vec<Ability> {
             native(RANDOM_DISCARD_EACH),
             // Branch B: the lead (`You`, bound to the lead by `AgendaAdvanced`)
             // takes 2 horror.
-            deal_horror(InvestigatorTarget::You, 2),
+            deal_horror(InvestigatorTarget::You, 2u8),
         ]),
     )]
 }
@@ -100,7 +100,7 @@ mod tests {
                 Effect::Deal {
                     kind: HarmKind::Horror,
                     target: card_dsl::dsl::InvestigatorTarget::You,
-                    amount: 2
+                    amount: card_dsl::dsl::IntExpr::Lit(2)
                 }
             ),
             "branch B is the lead taking 2 horror",

--- a/crates/cards/tests/non_attack_soak.rs
+++ b/crates/cards/tests/non_attack_soak.rs
@@ -1,9 +1,11 @@
 //! K5b-2 (#44 / #422): non-attack damage/horror from card/treachery effects is
 //! distributed **interactively** across controlled soakers + self. Each point a
 //! soaker can take opens a per-point `PickSingle` prompt; the multi-point case
-//! (Grasping Hands' `ForEachPointFailed(deal 1)`) suspends per point and resumes
-//! without losing iterations — the case the old suspend-and-replay model dropped.
-//! Driven through the real `apply` revelation path against the corpus registry.
+//! (Grasping Hands deals `Count(SkillTestFailedBy)` damage) suspends per point
+//! and resumes without losing iterations — the case the old suspend-and-replay
+//! model dropped (#422 / #44). Driven through the real `apply` revelation path.
+//! After #426 the damage is one `Deal { amount: N }` not N×`Deal { amount: 1 }`;
+//! the per-point prompt loop still fires via the `DamageAssignment` frame.
 
 use std::sync::Once;
 
@@ -72,9 +74,10 @@ fn dog_damage(result: &game_core::ApplyResult) -> Option<u8> {
 fn grasping_hands_distributes_both_points_onto_guard_dog() {
     install_registry();
     // Agility 3 + Numeric(-2) = 1 vs difficulty 3 → fail by 2 → 2 damage, dealt
-    // as ForEachPointFailed(deal 1): two independent per-point suspensions. The
-    // player assigns both to Guard Dog (option 1 = the asset; option 0 = self).
-    // The old replay model lost the second point here — this proves no loss.
+    // as a single Deal { amount: 2 }. Two per-point prompts still fire via the
+    // DamageAssignment frame. The player assigns both to Guard Dog
+    // (option 1 = the asset; option 0 = self). The old replay model lost the
+    // second point here — this proves no loss (#422).
     let result = reveal_distributing(
         board_with_soaker("01162", "01021", ChaosToken::Numeric(-2)),
         &[1, 1],

--- a/crates/cards/tests/revelation_treacheries.rs
+++ b/crates/cards/tests/revelation_treacheries.rs
@@ -76,6 +76,44 @@ fn grasping_hands_deals_one_damage_per_point_failed_then_discards() {
 }
 
 #[test]
+fn grasping_hands_fail_by_two_is_single_deal_of_two_damage() {
+    install_registry();
+    // #426: Count(SkillTestFailedBy) deals all N damage in one Deal evaluation,
+    // emitting a single DamageTaken { amount: 2 } event — not two separate
+    // DamageTaken { amount: 1 } events.
+    // Agility 3 + Numeric(-2) = 1 vs difficulty 3 → fail by 2.
+    let result = reveal_top(board_with("01162", ChaosToken::Numeric(-2)));
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_eq!(result.state.investigators[&InvestigatorId(1)].damage, 2);
+    // Exactly one DamageTaken event, with amount == 2.
+    game_core::assert_event_count!(result.events, 1, Event::DamageTaken { .. });
+    game_core::assert_event!(
+        result.events,
+        Event::DamageTaken { investigator, amount: 2 }
+            if *investigator == InvestigatorId(1)
+    );
+}
+
+#[test]
+fn rotting_remains_fail_by_two_is_single_deal_of_two_horror() {
+    install_registry();
+    // #426: Count(SkillTestFailedBy) deals all N horror in one Deal evaluation,
+    // emitting a single HorrorTaken { amount: 2 } event — not two separate
+    // HorrorTaken { amount: 1 } events.
+    // Willpower 3 + Numeric(-2) = 1 vs difficulty 3 → fail by 2.
+    let result = reveal_top(board_with("01163", ChaosToken::Numeric(-2)));
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_eq!(result.state.investigators[&InvestigatorId(1)].horror, 2);
+    // Exactly one HorrorTaken event, with amount == 2.
+    game_core::assert_event_count!(result.events, 1, Event::HorrorTaken { .. });
+    game_core::assert_event!(
+        result.events,
+        Event::HorrorTaken { investigator, amount: 2 }
+            if *investigator == InvestigatorId(1)
+    );
+}
+
+#[test]
 fn crypt_chill_with_no_asset_takes_two_damage_then_discards() {
     install_registry();
     // Willpower 3 + Numeric(0) = 3 vs difficulty 4 → fail; no asset in

--- a/crates/cards/tests/weapon_machete.rs
+++ b/crates/cards/tests/weapon_machete.rs
@@ -1,0 +1,109 @@
+//! #300 behaviour test: Machete (01020) conditional extra damage.
+//!
+//! Verifies that a successful Machete Fight deals `1 + 1 = 2` damage when the
+//! attacked enemy is the sole enemy engaged with the actor ("sole-engaged" bonus
+//! active), and that with two enemies engaged the activation is rejected by the
+//! engine's current pre-#401 gate (which defers multi-target selection).
+//!
+//! Own process → installs `cards::REGISTRY`.
+
+use std::sync::Once;
+
+use game_core::engine::EngineOutcome;
+use game_core::event::Event;
+use game_core::state::{
+    CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, EnemyId, InvestigatorId,
+    LocationId, Phase, TokenModifiers,
+};
+use game_core::test_support::{
+    apply_no_commits, test_enemy, test_investigator, test_location, GameStateBuilder,
+};
+use game_core::{assert_event, Action, PlayerAction};
+
+const MACHETE: &str = "01020";
+const INV: InvestigatorId = InvestigatorId(1);
+const LOC: LocationId = LocationId(10);
+const MACHETE_INST: CardInstanceId = CardInstanceId(0);
+
+static INSTALL: Once = Once::new();
+fn install() {
+    INSTALL.call_once(|| {
+        let _ = game_core::card_registry::install(cards::REGISTRY);
+    });
+}
+
+/// Board with Machete in play, `enemy_count` enemies engaged with the actor.
+///
+/// `combat 4 vs fight 3` with a `Numeric(0)` bag → always succeeds.
+fn board(enemy_count: u32) -> game_core::GameState {
+    install();
+    let mut inv = test_investigator(1);
+    inv.skills.combat = 4;
+    let machete = CardInPlay::enter_play(CardCode::new(MACHETE), MACHETE_INST);
+    inv.cards_in_play.push(machete);
+
+    let location = test_location(10, "Study");
+
+    let mut builder = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator_at(inv, LOC)
+        .with_location(location)
+        .with_active_investigator(INV)
+        .with_turn_order([INV])
+        .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
+        .with_token_modifiers(TokenModifiers::default());
+
+    for n in 0..enemy_count {
+        let mut enemy = test_enemy(100 + n, "Ghoul");
+        enemy.fight = 3;
+        enemy.max_health = 3;
+        enemy.engaged_with = Some(INV);
+        builder = builder.with_enemy(enemy);
+    }
+
+    builder.build()
+}
+
+fn activate_machete(state: game_core::GameState) -> game_core::engine::ApplyResult {
+    apply_no_commits(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: INV,
+            instance_id: MACHETE_INST,
+            ability_index: 0,
+        }),
+    )
+}
+
+/// With exactly one enemy engaged, a successful Machete Fight deals
+/// `1 (base) + 1 (sole-engaged) = 2` damage.
+#[test]
+fn sole_engaged_enemy_gets_bonus_damage() {
+    let r = activate_machete(board(1));
+    assert_eq!(r.outcome, EngineOutcome::Done);
+    assert_event!(r.events, Event::EnemyDamaged { amount: 2, .. });
+    assert_eq!(r.state.enemies[&EnemyId(100)].damage, 2);
+}
+
+/// With two enemies engaged the activation is rejected by the pre-#401
+/// multi-target gate — nothing is charged and no damage is dealt.
+///
+/// Once multi-target Fight (#401) lands this test should be replaced with
+/// one that verifies the attack deals `1 + 0 = 1` damage (`extra_damage` is
+/// 0 because `EngagedEnemies` == 2, not 1).
+#[test]
+fn two_enemies_engaged_activation_is_rejected() {
+    let state = board(2);
+    let actions_before = state.investigators[&INV].actions_remaining;
+    let r = activate_machete(state);
+    assert!(
+        matches!(r.outcome, EngineOutcome::Rejected { .. }),
+        "expected Rejected; got {:?}",
+        r.outcome
+    );
+    // No cost paid: actions unchanged.
+    assert_eq!(
+        r.state.investigators[&INV].actions_remaining,
+        actions_before
+    );
+}

--- a/crates/game-core/src/engine/dispatch/abilities.rs
+++ b/crates/game-core/src/engine/dispatch/abilities.rs
@@ -412,7 +412,7 @@ mod tests {
         use crate::dsl::{Effect, IntExpr};
         let fight = Effect::Fight {
             combat_modifier: IntExpr::Lit(0),
-            extra_damage: 0,
+            extra_damage: IntExpr::Lit(0),
         };
         let non_fight = Effect::Native { tag: "heal".into() };
 

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -966,9 +966,9 @@ pub(super) fn resume_damage_assignment(
             }
         }
         // K5b-2 (effect/treachery path): place this point's drained assignment,
-        // then resume the parked effect walk — the parent `ForEachPointFailed`/
-        // `Seq` frame is now on top, so the remaining iterations run (and may
-        // prompt again) with no point lost (#422 / #44).
+        // then resume the parked effect walk — the parent `Seq` or `Leaf` frame
+        // is now on top, so subsequent effects run (and may prompt again) with
+        // no point lost (#422 / #44).
         DamageSource::Effect => {
             let _ = place_assignment(cx, investigator, &assignment);
             super::choice::resume_effect_walk(cx)

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -527,8 +527,8 @@ fn apply_result_effect_step(cx: &mut Cx, investigator: InvestigatorId) {
             push_effect(cx, effect, card_ctx(investigator));
         }
     } else if let Some(effect) = &on_fail {
-        // Thread the failure margin so `Effect::ForEachPointFailed`
-        // (Grasping Hands 01162) can scale.
+        // Thread the failure margin so `IntExpr::Count(Quantity::SkillTestFailedBy)`
+        // (Grasping Hands 01162, Rotting Remains 01163) can scale.
         let mut ctx = card_ctx(investigator);
         ctx.set_failed_by(failed_by);
         push_effect(cx, effect, ctx);

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -1312,12 +1312,12 @@ fn symbol_effects_to_effect(
             TokenEffect::Damage(n) => Effect::Deal {
                 kind: HarmKind::Damage,
                 target: InvestigatorTarget::You,
-                amount: *n,
+                amount: (*n).into(),
             },
             TokenEffect::Horror(n) => Effect::Deal {
                 kind: HarmKind::Horror,
                 target: InvestigatorTarget::You,
-                amount: *n,
+                amount: (*n).into(),
             },
         })
         .collect();
@@ -1421,7 +1421,7 @@ mod tests {
             Some(Effect::Deal {
                 kind: HarmKind::Horror,
                 target: InvestigatorTarget::You,
-                amount: 1,
+                amount: crate::dsl::IntExpr::Lit(1),
             }),
         );
 
@@ -1491,7 +1491,7 @@ mod tests {
             SkillTestKind::Plain,
             2,
             SkillTestFollowUp::None,
-            Some(deal_horror(InvestigatorTarget::You, 1)),
+            Some(deal_horror(InvestigatorTarget::You, 1u8)),
             None,
             None,
             0,

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -61,7 +61,7 @@ use serde::{Deserialize, Serialize};
 use crate::card_registry::CardRegistry;
 use crate::dsl::{
     Condition, Effect, EnemyTarget, HarmKind, IntExpr, InvestigatorTarget, LocationTarget,
-    ModifierScope, SkillTestKind, Stat, Trigger,
+    ModifierScope, Quantity, SkillTestKind, Stat, Trigger,
 };
 use crate::event::Event;
 use crate::state::{GameState, InvestigatorId, SkillKind};
@@ -444,7 +444,7 @@ fn step_leaf(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) -> EngineOutco
             then,
             else_,
         } => {
-            let holds = match eval_condition(cx.state, eval_ctx.controller, condition) {
+            let holds = match eval_condition(cx.state, &eval_ctx, condition) {
                 Ok(b) => b,
                 Err(reason) => {
                     return EngineOutcome::Rejected {
@@ -816,7 +816,7 @@ fn apply_fight(
     combat_modifier: &IntExpr,
     extra_damage: u8,
 ) -> EngineOutcome {
-    let modifier = match eval_int_expr(cx.state, eval_ctx.controller, combat_modifier) {
+    let modifier = match eval_int_expr(cx.state, eval_ctx, combat_modifier) {
         Ok(m) => m,
         Err(reason) => {
             return EngineOutcome::Rejected {
@@ -870,7 +870,7 @@ fn apply_investigate(
     eval_ctx: &EvalContext,
     shroud_modifier: &IntExpr,
 ) -> EngineOutcome {
-    let delta = match eval_int_expr(cx.state, eval_ctx.controller, shroud_modifier) {
+    let delta = match eval_int_expr(cx.state, eval_ctx, shroud_modifier) {
         Ok(d) => d,
         Err(reason) => {
             return EngineOutcome::Rejected {
@@ -1045,9 +1045,10 @@ fn discard_self(cx: &mut Cx, eval_ctx: &EvalContext) -> EngineOutcome {
 /// turns those into [`EngineOutcome::Rejected`].
 fn eval_condition(
     state: &GameState,
-    controller: InvestigatorId,
+    eval_ctx: &EvalContext,
     condition: &Condition,
 ) -> Result<bool, String> {
+    let controller = eval_ctx.controller;
     match condition {
         Condition::SkillTestKind(kind) => {
             let t = state.current_skill_test().ok_or_else(|| {
@@ -1081,23 +1082,43 @@ fn eval_condition(
     }
 }
 
+/// Resolve a [`Quantity`] against current state for the controller.
+/// Always non-negative; returned as `i8` to compose in [`IntExpr`].
+// Called from tests now; will be wired into `eval_int_expr`'s `Count` arm and
+// `eval_condition`'s `Compare` arm in Task 2 (IntExpr::Count / Condition::Compare).
+#[allow(dead_code)]
+fn eval_quantity(state: &GameState, eval_ctx: &EvalContext, q: Quantity) -> i8 {
+    let controller = eval_ctx.controller;
+    let n: usize = match q {
+        Quantity::CluesAtControllerLocation => state
+            .investigators
+            .get(&controller)
+            .and_then(|inv| inv.current_location)
+            .and_then(|loc| state.locations.get(&loc))
+            .map_or(0, |l| usize::from(l.clues)),
+        Quantity::EngagedEnemies => state
+            .enemies
+            .values()
+            .filter(|e| e.engaged_with == Some(controller))
+            .count(),
+        Quantity::SkillTestFailedBy => usize::from(eval_ctx.failed_by().unwrap_or(0)),
+    };
+    i8::try_from(n).unwrap_or(i8::MAX)
+}
+
 /// Resolve an [`IntExpr`] against the current state for `controller`.
 ///
 /// [`IntExpr::Cond`] evaluates its [`Condition`] (reusing
 /// [`eval_condition`]); an unexpressible condition propagates as `Err`,
 /// which the caller turns into [`EngineOutcome::Rejected`].
-fn eval_int_expr(
-    state: &GameState,
-    controller: InvestigatorId,
-    expr: &IntExpr,
-) -> Result<i8, String> {
+fn eval_int_expr(state: &GameState, eval_ctx: &EvalContext, expr: &IntExpr) -> Result<i8, String> {
     match expr {
         IntExpr::Lit(n) => Ok(*n),
         IntExpr::Cond {
             when,
             then,
             otherwise,
-        } => Ok(if eval_condition(state, controller, when)? {
+        } => Ok(if eval_condition(state, eval_ctx, when)? {
             *then
         } else {
             *otherwise
@@ -2113,8 +2134,8 @@ mod tests {
     use crate::{assert_event, assert_event_count, assert_no_event};
 
     use super::{
-        constant_skill_modifier, effective_shroud, eval_condition, push_effect, step_effect_frame,
-        unconditional_constant_stat_modifier, EngineOutcome, EvalContext,
+        constant_skill_modifier, effective_shroud, eval_condition, eval_quantity, push_effect,
+        step_effect_frame, unconditional_constant_stat_modifier, EngineOutcome, EvalContext,
     };
     use crate::dsl::Condition;
     use crate::engine::Cx;
@@ -2196,6 +2217,19 @@ mod tests {
         }
     }
 
+    /// Build a `GameState` with `clue_count` clues at `InvestigatorId(1)`'s location.
+    fn with_clues(clue_count: u8) -> crate::state::GameState {
+        let loc_id = LocationId(1);
+        let mut inv = test_investigator(1);
+        inv.current_location = Some(loc_id);
+        let mut loc = test_location(1, "Study");
+        loc.clues = clue_count;
+        GameStateBuilder::new()
+            .with_investigator(inv)
+            .with_location(loc)
+            .build()
+    }
+
     /// Assert the top frame is an effect node suspended in place for a pick.
     #[track_caller]
     fn assert_suspended_leaf(state: &crate::state::GameState) {
@@ -2227,13 +2261,43 @@ mod tests {
         };
         // Condition tracks clue presence at the controller's location.
         assert_eq!(
-            eval_condition(&with_clues(1), inv_id, &Condition::LocationHasClues),
+            eval_condition(
+                &with_clues(1),
+                &EvalContext::for_controller(inv_id),
+                &Condition::LocationHasClues
+            ),
             Ok(true)
         );
         assert_eq!(
-            eval_condition(&with_clues(0), inv_id, &Condition::LocationHasClues),
+            eval_condition(
+                &with_clues(0),
+                &EvalContext::for_controller(inv_id),
+                &Condition::LocationHasClues
+            ),
             Ok(false)
         );
+    }
+
+    #[test]
+    fn eval_quantity_reads_clues_engaged_and_margin() {
+        use card_dsl::dsl::Quantity;
+        // clues at location
+        let (state, inv) = state_with_cards_in_play(&[]);
+        let ctx = EvalContext::for_controller(inv);
+        // helper `with_clues(n)` already exists in this module; reuse it:
+        assert_eq!(
+            eval_quantity(&with_clues(2), &ctx, Quantity::CluesAtControllerLocation),
+            2
+        );
+        assert_eq!(
+            eval_quantity(&with_clues(0), &ctx, Quantity::CluesAtControllerLocation),
+            0
+        );
+        // failure margin from the ctx binding
+        let mut ctx2 = EvalContext::for_controller(inv);
+        ctx2.set_failed_by(3);
+        assert_eq!(eval_quantity(&state, &ctx2, Quantity::SkillTestFailedBy), 3);
+        assert_eq!(eval_quantity(&state, &ctx, Quantity::SkillTestFailedBy), 0);
     }
 
     #[test]

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -209,7 +209,7 @@ impl EvalContext {
 
 impl EvalContext {
     /// Just-resolved skill test's failure margin (bound only while running an
-    /// `on_fail` effect). See [`Effect::ForEachPointFailed`].
+    /// `on_fail` effect). Consumed by `IntExpr::Count(Quantity::SkillTestFailedBy)`.
     #[must_use]
     pub fn failed_by(&self) -> Option<u8> {
         self.skill_test.map(|b| b.failed_by)
@@ -318,11 +318,6 @@ fn frame_of(effect: &Effect, ctx: EvalContext) -> crate::state::EffectFrame {
             next: 0,
             ctx,
         },
-        Effect::ForEachPointFailed(body) => EffectFrame::ForEachPointFailed {
-            remaining: ctx.failed_by().unwrap_or(0),
-            body: body.clone(),
-            ctx,
-        },
         _ => EffectFrame::Leaf {
             effect: Box::new(effect.clone()),
             ctx,
@@ -356,24 +351,6 @@ pub(crate) fn step_effect_frame(cx: &mut Cx) -> EngineOutcome {
             }
             EngineOutcome::Done
         }
-        EffectFrame::ForEachPointFailed {
-            remaining,
-            body,
-            ctx,
-        } => {
-            if remaining > 0 {
-                let child = frame_of(&body, ctx);
-                cx.state.continuations.push(Continuation::Effect(
-                    EffectFrame::ForEachPointFailed {
-                        remaining: remaining - 1,
-                        body,
-                        ctx,
-                    },
-                ));
-                cx.state.continuations.push(Continuation::Effect(child));
-            }
-            EngineOutcome::Done
-        }
         EffectFrame::Leaf { effect, ctx } => step_leaf(cx, &effect, ctx),
     }
 }
@@ -395,9 +372,9 @@ fn suspend_leaf_in_place(cx: &mut Cx, effect: &Effect, ctx: EvalContext) {
 /// step). Grounds any `*::Chosen` target, then dispatches: a terminal effect
 /// runs; `If` pushes its chosen branch; `ChooseOne`/`SearchDeck`/`Native` push a
 /// branch or **suspend in place** (re-pushing this `Leaf` so resume re-steps it
-/// with `ctx.chosen_option` set). Control nodes (`Seq`/`ForEachPointFailed`) are
-/// normally routed to their own frames by [`frame_of`]; if one reaches here it
-/// is pushed as its frame. The `Leaf` itself was already popped by the caller.
+/// with `ctx.chosen_option` set). Control nodes (`Seq`) are normally routed to
+/// their own frames by [`frame_of`]; if one reaches here it is pushed as its
+/// frame. The `Leaf` itself was already popped by the caller.
 // A single exhaustive dispatch over every `Effect` variant; splitting it would
 // only obscure the dispatch (it mirrors the former `apply_effect_inner`).
 #[allow(clippy::too_many_lines)]
@@ -440,7 +417,7 @@ fn step_leaf(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) -> EngineOutco
             target,
             count,
         } => heal_effect(cx, eval_ctx, *kind, *target, *count),
-        Effect::Seq(_) | Effect::ForEachPointFailed(_) => {
+        Effect::Seq(_) => {
             cx.state
                 .continuations
                 .push(crate::state::Continuation::Effect(frame_of(
@@ -2145,16 +2122,16 @@ mod tests {
     use crate::card_registry::CardRegistry;
     use crate::dsl::{
         boost_attack_damage, constant, deal_damage, deal_damage_to_enemy, deal_horror,
-        discover_clue, draw_cards, for_each_point_failed, gain_resources, heal, modify, on_play,
-        seq, Ability, Choose, Effect, EnemyTarget, HarmKind, InvestigatorTarget, LocationSet,
-        LocationTarget, ModifierScope, SkillTestKind, Stat,
+        discover_clue, draw_cards, gain_resources, heal, modify, on_play, seq, Ability, Choose,
+        Effect, EnemyTarget, HarmKind, InvestigatorTarget, LocationSet, LocationTarget,
+        ModifierScope, SkillTestKind, Stat,
     };
     use crate::event::Event;
     use crate::state::{
         CardCode, CardInPlay, CardInstanceId, EnemyId, InvestigatorId, LocationId, SkillKind,
     };
     use crate::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
-    use crate::{assert_event, assert_event_count, assert_no_event};
+    use crate::{assert_event, assert_no_event};
 
     use super::{
         constant_skill_modifier, effective_shroud, eval_condition, eval_int_expr, eval_quantity,
@@ -4612,52 +4589,6 @@ mod tests {
             events,
             Event::DamageTaken { investigator, amount: 2 } if *investigator == InvestigatorId(1)
         );
-    }
-
-    #[test]
-    fn for_each_point_failed_scales_body_by_margin() {
-        let mut state = GameStateBuilder::new()
-            .with_investigator(test_investigator(1))
-            .with_active_investigator(InvestigatorId(1))
-            .build();
-        let mut events = Vec::new();
-        let mut cx = Cx {
-            state: &mut state,
-            events: &mut events,
-        };
-        // Margin 2 → run Deal{Damage,You,1} twice → 2 damage, 2 events.
-        let mut eval_ctx = EvalContext::for_controller(InvestigatorId(1));
-        eval_ctx.set_failed_by(2);
-        let outcome = run(
-            &mut cx,
-            &for_each_point_failed(deal_damage(InvestigatorTarget::You, 1u8)),
-            eval_ctx,
-        );
-        assert_eq!(outcome, EngineOutcome::Done);
-        assert_eq!(state.investigators[&InvestigatorId(1)].damage, 2);
-        assert_event_count!(events, 2, Event::DamageTaken { .. });
-    }
-
-    #[test]
-    fn for_each_point_failed_with_no_margin_is_a_noop() {
-        let mut state = GameStateBuilder::new()
-            .with_investigator(test_investigator(1))
-            .with_active_investigator(InvestigatorId(1))
-            .build();
-        let mut events = Vec::new();
-        let mut cx = Cx {
-            state: &mut state,
-            events: &mut events,
-        };
-        // failed_by None (no test in context) → zero iterations.
-        let outcome = run(
-            &mut cx,
-            &for_each_point_failed(deal_damage(InvestigatorTarget::You, 1u8)),
-            EvalContext::for_controller(InvestigatorId(1)),
-        );
-        assert_eq!(outcome, EngineOutcome::Done);
-        assert_eq!(state.investigators[&InvestigatorId(1)].damage, 0);
-        assert_no_event!(events, Event::DamageTaken { .. });
     }
 
     #[test]

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -797,6 +797,10 @@ fn boost_attack_damage_effect(cx: &mut Cx, amount: u8) -> EngineOutcome {
 /// `1 + extra_damage`. The activation check has already guaranteed
 /// exactly one engaged enemy, so a missing target here is a state-shape
 /// violation rejected loudly rather than silently no-oped.
+///
+/// Both `combat_modifier` and `extra_damage` are evaluated from an
+/// `&IntExpr` (board-state-dependent AST, same path); `extra_damage` is
+/// then clamped to `u8` (negative results treated as 0).
 fn apply_fight(
     cx: &mut Cx,
     eval_ctx: &EvalContext,

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -60,7 +60,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::card_registry::CardRegistry;
 use crate::dsl::{
-    Condition, Effect, EnemyTarget, HarmKind, IntExpr, InvestigatorTarget, LocationTarget,
+    CmpOp, Condition, Effect, EnemyTarget, HarmKind, IntExpr, InvestigatorTarget, LocationTarget,
     ModifierScope, Quantity, SkillTestKind, Stat, Trigger,
 };
 use crate::event::Event;
@@ -1048,7 +1048,6 @@ fn eval_condition(
     eval_ctx: &EvalContext,
     condition: &Condition,
 ) -> Result<bool, String> {
-    let controller = eval_ctx.controller;
     match condition {
         Condition::SkillTestKind(kind) => {
             let t = state.current_skill_test().ok_or_else(|| {
@@ -1056,14 +1055,21 @@ fn eval_condition(
             })?;
             Ok(t.kind == *kind)
         }
-        Condition::LocationHasClues => {
-            let has = state
-                .investigators
-                .get(&controller)
-                .and_then(|inv| inv.current_location)
-                .and_then(|loc| state.locations.get(&loc))
-                .is_some_and(|l| l.clues > 0);
-            Ok(has)
+        Condition::Compare {
+            quantity,
+            op,
+            value,
+        } => {
+            let lhs = eval_quantity(state, eval_ctx, *quantity);
+            let rhs = *value;
+            Ok(match op {
+                CmpOp::Eq => lhs == rhs,
+                CmpOp::Ne => lhs != rhs,
+                CmpOp::Lt => lhs < rhs,
+                CmpOp::Le => lhs <= rhs,
+                CmpOp::Gt => lhs > rhs,
+                CmpOp::Ge => lhs >= rhs,
+            })
         }
         Condition::SkillTest { outcome } => {
             // Inside an [`Trigger::OnSkillTestResolution`] effect, the
@@ -1084,9 +1090,7 @@ fn eval_condition(
 
 /// Resolve a [`Quantity`] against current state for the controller.
 /// Always non-negative; returned as `i8` to compose in [`IntExpr`].
-// Called from tests now; will be wired into `eval_int_expr`'s `Count` arm and
-// `eval_condition`'s `Compare` arm in Task 2 (IntExpr::Count / Condition::Compare).
-#[allow(dead_code)]
+/// Used by [`IntExpr::Count`] and [`Condition::Compare`].
 fn eval_quantity(state: &GameState, eval_ctx: &EvalContext, q: Quantity) -> i8 {
     let controller = eval_ctx.controller;
     let n: usize = match q {
@@ -1123,6 +1127,7 @@ fn eval_int_expr(state: &GameState, eval_ctx: &EvalContext, expr: &IntExpr) -> R
         } else {
             *otherwise
         }),
+        IntExpr::Count(q) => Ok(eval_quantity(state, eval_ctx, *q)),
     }
 }
 
@@ -2134,8 +2139,9 @@ mod tests {
     use crate::{assert_event, assert_event_count, assert_no_event};
 
     use super::{
-        constant_skill_modifier, effective_shroud, eval_condition, eval_quantity, push_effect,
-        step_effect_frame, unconditional_constant_stat_modifier, EngineOutcome, EvalContext,
+        constant_skill_modifier, effective_shroud, eval_condition, eval_int_expr, eval_quantity,
+        push_effect, step_effect_frame, unconditional_constant_stat_modifier, EngineOutcome,
+        EvalContext,
     };
     use crate::dsl::Condition;
     use crate::engine::Cx;
@@ -2247,9 +2253,10 @@ mod tests {
 
     #[test]
     fn location_has_clues_condition_tracks_clue_count() {
+        use card_dsl::dsl::{CmpOp, Quantity};
         let inv_id = InvestigatorId(1);
         let loc_id = LocationId(1);
-        let with_clues = |clue_count: u8| {
+        let with_clues_local = |clue_count: u8| {
             let mut inv = test_investigator(1);
             inv.current_location = Some(loc_id);
             let mut loc = test_location(1, "Study");
@@ -2259,20 +2266,25 @@ mod tests {
                 .with_location(loc)
                 .build()
         };
+        let has_clues = Condition::Compare {
+            quantity: Quantity::CluesAtControllerLocation,
+            op: CmpOp::Gt,
+            value: 0,
+        };
         // Condition tracks clue presence at the controller's location.
         assert_eq!(
             eval_condition(
-                &with_clues(1),
+                &with_clues_local(1),
                 &EvalContext::for_controller(inv_id),
-                &Condition::LocationHasClues
+                &has_clues
             ),
             Ok(true)
         );
         assert_eq!(
             eval_condition(
-                &with_clues(0),
+                &with_clues_local(0),
                 &EvalContext::for_controller(inv_id),
-                &Condition::LocationHasClues
+                &has_clues
             ),
             Ok(false)
         );
@@ -2298,6 +2310,31 @@ mod tests {
         ctx2.set_failed_by(3);
         assert_eq!(eval_quantity(&state, &ctx2, Quantity::SkillTestFailedBy), 3);
         assert_eq!(eval_quantity(&state, &ctx, Quantity::SkillTestFailedBy), 0);
+    }
+
+    #[test]
+    fn eval_count_and_compare_over_clues() {
+        use card_dsl::dsl::{CmpOp, Condition, IntExpr, Quantity};
+        let (_s, inv) = state_with_cards_in_play(&[]);
+        let ctx = EvalContext::for_controller(inv);
+        // Count
+        assert_eq!(
+            eval_int_expr(
+                &with_clues(2),
+                &ctx,
+                &IntExpr::Count(Quantity::CluesAtControllerLocation)
+            )
+            .unwrap(),
+            2
+        );
+        // Compare: clues > 0
+        let has = Condition::Compare {
+            quantity: Quantity::CluesAtControllerLocation,
+            op: CmpOp::Gt,
+            value: 0,
+        };
+        assert!(eval_condition(&with_clues(1), &ctx, &has).unwrap());
+        assert!(!eval_condition(&with_clues(0), &ctx, &has).unwrap());
     }
 
     #[test]

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -421,7 +421,17 @@ fn step_leaf(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) -> EngineOutco
             kind,
             target,
             amount,
-        } => deal_effect(cx, eval_ctx, *kind, *target, *amount),
+        } => {
+            let n = match eval_int_expr(cx.state, &eval_ctx, amount) {
+                Ok(v) => u8::try_from(v.max(0)).unwrap_or(u8::MAX),
+                Err(reason) => {
+                    return EngineOutcome::Rejected {
+                        reason: reason.into(),
+                    }
+                }
+            };
+            deal_effect(cx, eval_ctx, *kind, *target, n)
+        }
         Effect::DealDamageToEnemy { target, amount } => {
             deal_damage_to_enemy_effect(cx, eval_ctx, *target, *amount)
         }
@@ -514,7 +524,7 @@ fn step_leaf(cx: &mut Cx, effect: &Effect, eval_ctx: EvalContext) -> EngineOutco
         Effect::Fight {
             combat_modifier,
             extra_damage,
-        } => apply_fight(cx, &eval_ctx, combat_modifier, *extra_damage),
+        } => apply_fight(cx, &eval_ctx, combat_modifier, extra_damage),
         Effect::BoostAttackDamage(amount) => boost_attack_damage_effect(cx, *amount),
         Effect::DrawCards { target, count } => draw_cards_effect(cx, eval_ctx, *target, *count),
         Effect::Investigate { shroud_modifier } => {
@@ -814,10 +824,18 @@ fn apply_fight(
     cx: &mut Cx,
     eval_ctx: &EvalContext,
     combat_modifier: &IntExpr,
-    extra_damage: u8,
+    extra_damage: &IntExpr,
 ) -> EngineOutcome {
     let modifier = match eval_int_expr(cx.state, eval_ctx, combat_modifier) {
         Ok(m) => m,
+        Err(reason) => {
+            return EngineOutcome::Rejected {
+                reason: reason.into(),
+            }
+        }
+    };
+    let extra_damage_n = match eval_int_expr(cx.state, eval_ctx, extra_damage) {
+        Ok(v) => u8::try_from(v.max(0)).unwrap_or(u8::MAX),
         Err(reason) => {
             return EngineOutcome::Rejected {
                 reason: reason.into(),
@@ -848,7 +866,7 @@ fn apply_fight(
         fight_difficulty,
         crate::state::SkillTestFollowUp::Fight {
             enemy: enemy_id,
-            extra_damage,
+            extra_damage: extra_damage_n,
         },
         None,
         None,
@@ -4585,7 +4603,7 @@ mod tests {
         };
         let outcome = run(
             &mut cx,
-            &deal_damage(InvestigatorTarget::You, 2),
+            &deal_damage(InvestigatorTarget::You, 2u8),
             EvalContext::for_controller(InvestigatorId(1)),
         );
         assert_eq!(outcome, EngineOutcome::Done);
@@ -4612,7 +4630,7 @@ mod tests {
         eval_ctx.set_failed_by(2);
         let outcome = run(
             &mut cx,
-            &for_each_point_failed(deal_damage(InvestigatorTarget::You, 1)),
+            &for_each_point_failed(deal_damage(InvestigatorTarget::You, 1u8)),
             eval_ctx,
         );
         assert_eq!(outcome, EngineOutcome::Done);
@@ -4634,7 +4652,7 @@ mod tests {
         // failed_by None (no test in context) → zero iterations.
         let outcome = run(
             &mut cx,
-            &for_each_point_failed(deal_damage(InvestigatorTarget::You, 1)),
+            &for_each_point_failed(deal_damage(InvestigatorTarget::You, 1u8)),
             EvalContext::for_controller(InvestigatorId(1)),
         );
         assert_eq!(outcome, EngineOutcome::Done);
@@ -4655,7 +4673,7 @@ mod tests {
         };
         let outcome = run(
             &mut cx,
-            &deal_horror(InvestigatorTarget::You, 1),
+            &deal_horror(InvestigatorTarget::You, 1u8),
             EvalContext::for_controller(InvestigatorId(1)),
         );
         assert_eq!(outcome, EngineOutcome::Done);
@@ -4682,7 +4700,7 @@ mod tests {
                 state: &mut state,
                 events: &mut events,
             },
-            &deal_damage(InvestigatorTarget::You, 3),
+            &deal_damage(InvestigatorTarget::You, 3u8),
             EvalContext::for_controller(id),
         );
         assert_eq!(outcome, EngineOutcome::Done);
@@ -4691,6 +4709,33 @@ mod tests {
             events,
             Event::InvestigatorDefeated { investigator, .. } if *investigator == id
         );
+    }
+
+    #[test]
+    fn deal_amount_can_be_a_count_of_failure_margin() {
+        use crate::dsl::{IntExpr, Quantity};
+        // Build a Deal whose amount is the failure margin; fail-by 2 → 2 damage.
+        let effect = deal_damage(
+            InvestigatorTarget::You,
+            IntExpr::Count(Quantity::SkillTestFailedBy),
+        );
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .with_active_investigator(InvestigatorId(1))
+            .build();
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+        let mut eval_ctx = EvalContext::for_controller(InvestigatorId(1));
+        eval_ctx.set_failed_by(2);
+        let outcome = run(&mut cx, &effect, eval_ctx);
+        assert_eq!(outcome, EngineOutcome::Done);
+        assert_eq!(state.investigators[&InvestigatorId(1)].damage, 2);
+        // Deal evaluates the IntExpr once and applies the result in a single hit;
+        // fail-by 2 → amount 2 → one DamageTaken event with amount 2.
+        assert_event!(events, Event::DamageTaken { investigator, amount: 2 } if *investigator == InvestigatorId(1));
     }
 
     #[test]

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -707,17 +707,6 @@ pub enum EffectFrame {
         /// The evaluation context for this sequence.
         ctx: crate::engine::EvalContext,
     },
-    /// A `ForEachPointFailed(body)` in progress: run `body` `remaining` more
-    /// times, decrementing on each child pop. Holds its own count on the stack
-    /// so each iteration may suspend independently (fixes Grasping Hands).
-    ForEachPointFailed {
-        /// Iterations still to run.
-        remaining: u8,
-        /// The per-iteration body effect.
-        body: Box<card_dsl::dsl::Effect>,
-        /// The evaluation context for this loop.
-        ctx: crate::engine::EvalContext,
-    },
     /// A single effect node to evaluate. A terminal effect runs and pops;
     /// `ChooseOne` pushes its chosen branch; `Effect::Deal` may push a
     /// `DamageAssignment` (K5b-2); `Effect::Native { tag }` runs the native fn.
@@ -1088,9 +1077,8 @@ pub struct ResolvedTest {
     /// Whether the test passed (`total >= difficulty`, no `AutoFail`).
     pub succeeded: bool,
     /// Failure margin (`difficulty - total`, clamped ≥ 0); `0` on success.
-    /// Read by an `on_fail` effect's
-    /// [`Effect::ForEachPointFailed`](crate::dsl::Effect::ForEachPointFailed)
-    /// (Grasping Hands 01162).
+    /// Read by `IntExpr::Count(Quantity::SkillTestFailedBy)` in an `on_fail`
+    /// effect (Grasping Hands 01162, Rotting Remains 01163).
     pub failed_by: u8,
     /// Success margin (`total - difficulty`, ≥ 0 on success); supplied to the
     /// logged [`SkillTestSucceeded`](crate::Event::SkillTestSucceeded) at the

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -68,7 +68,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
         Some(vec![forced_on_event(
             EventPattern::EnteredLocation,
             EventTiming::After,
-            deal_horror(InvestigatorTarget::You, 1),
+            deal_horror(InvestigatorTarget::You, 1u8),
         )])
     } else if code.as_str() == DOOM_AGENDA || code.as_str() == DOOM_ACT {
         Some(vec![forced_on_event(
@@ -76,7 +76,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
                 phase: DslPhase::Enemy,
             },
             EventTiming::After,
-            deal_horror(InvestigatorTarget::You, 1),
+            deal_horror(InvestigatorTarget::You, 1u8),
         )])
     } else if code.as_str() == DOUBLE_FORCED {
         // Two distinct forced `EnteredLocation` abilities at the same timing
@@ -85,19 +85,19 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
             forced_on_event(
                 EventPattern::EnteredLocation,
                 EventTiming::After,
-                deal_horror(InvestigatorTarget::You, 1),
+                deal_horror(InvestigatorTarget::You, 1u8),
             ),
             forced_on_event(
                 EventPattern::EnteredLocation,
                 EventTiming::After,
-                deal_horror(InvestigatorTarget::You, 1),
+                deal_horror(InvestigatorTarget::You, 1u8),
             ),
         ])
     } else if code.as_str() == END_OF_TURN_CARD {
         Some(vec![forced_on_event(
             EventPattern::EndOfTurn,
             EventTiming::After,
-            deal_horror(InvestigatorTarget::You, 1),
+            deal_horror(InvestigatorTarget::You, 1u8),
         )])
     } else if code.as_str() == AFTER_INVESTIGATE_CARD {
         Some(vec![forced_on_event(
@@ -106,7 +106,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
                 kind: Some(SkillTestKind::Investigate),
             },
             EventTiming::After,
-            deal_horror(InvestigatorTarget::You, 1),
+            deal_horror(InvestigatorTarget::You, 1u8),
         )])
     } else {
         None

--- a/crates/game-core/tests/round_ended.rs
+++ b/crates/game-core/tests/round_ended.rs
@@ -35,7 +35,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
         Some(vec![forced_on_event(
             EventPattern::RoundEnded,
             EventTiming::At,
-            deal_horror(InvestigatorTarget::You, 1),
+            deal_horror(InvestigatorTarget::You, 1u8),
         )])
     } else {
         None

--- a/crates/game-core/tests/skill_test_outcome_timing.rs
+++ b/crates/game-core/tests/skill_test_outcome_timing.rs
@@ -44,7 +44,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
                 kind: None,
             },
             EventTiming::After,
-            deal_horror(InvestigatorTarget::You, 1),
+            deal_horror(InvestigatorTarget::You, 1u8),
         )]
     })
 }

--- a/crates/game-core/tests/weapon_fight.rs
+++ b/crates/game-core/tests/weapon_fight.rs
@@ -70,7 +70,7 @@ fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
                 kind: UseKind::Ammo,
                 count: 1,
             }],
-            fight(IntExpr::Lit(1), 1),
+            fight(IntExpr::Lit(1), 1u8),
         )]),
         _ => None,
     }

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -56,9 +56,11 @@ wired into `Effect::Fight.combat_modifier`; see Architecture). Each item *adds a
   shipped `Condition::LocationHasClues` is binary; elder-sign is per-clue), and
   `IntExpr` into `Effect::Modify` (`delta` is still `i8`). His signature is in the
   "done" criteria.
-- **#300 — Machete** sole-engaged +1. Multi-target Fight has landed (#401), so the
-  unconditional `extra_damage: 1` is now a real divergence with 2+ engaged enemies:
-  make `extra_damage` an `IntExpr` gated on a new "sole engaged enemy" `Condition`.
+- **#300 — Machete** sole-engaged +1. Make `extra_damage` an `IntExpr` gated on a
+  "sole engaged enemy" `Condition` (`EngagedEnemies == 1`). Activated `Effect::Fight`
+  still requires exactly one engaged enemy (2+ is rejected pre-cost, pending
+  multi-target selection / #401), so the conditional is **correct card-text modelling**
+  but its `+0` branch is not yet reachable — it becomes load-bearing when #401 lands.
 - **#426 — Grasping Hands 01162 / Rotting Remains 01163** "take 1 per point you
   fail by": make `Effect::Deal`'s amount an `IntExpr` + a `SkillTestFailedBy` term,
   replacing `for_each_point_failed(deal 1)` so it deals one simultaneous N-point
@@ -191,9 +193,15 @@ enum) is **Phase 9** — including the first real Peril/Surge cards (Hunting Sha
 ## Open questions
 
 - **Roland elder-sign DSL surface (#118).** Mostly answered: the `IntExpr` AST
-  exists (.38 Special is the live consumer). The remaining design is narrow — the
-  clue-*count* `IntExpr` term + plumbing it into the skill-test-total path
-  (`Effect::Modify.delta` is `i8`) + the `Trigger::ElderSign` / ST.4 firing path.
+  exists (.38 Special is the live consumer) and the design spec is settled (see
+  `docs/superpowers/specs/2026-06-24-intexpr-dynamic-value-cluster-design.md`
+  Section 2). The remaining work is the clue-*count* `IntExpr` term
+  (`IntExpr::Count(Quantity::CluesAtControllerLocation)`), the `Trigger::ElderSign`
+  / ST.4 firing path, and the `Investigator.card_code` bridge. The elder-sign bonus
+  flows through the existing chaos-token `Modifier` total path (sourced from the
+  investigator card) — **not** through `Effect::Modify` or a new
+  `Effect::ModifySkillTestTotal`; `Effect::Modify.delta` stays `i8` and is not
+  touched by #118.
 - **Solo-with-2 UX** — how one client presents two investigators. See Future slices.
 
 ## Dependencies

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -2,367 +2,209 @@
 
 ## Status
 
-**Slice 1 — Roland through The Gathering — is shipped.** Solo Roland plays the
-scenario end-to-end to genuine Won + Lost resolutions against the real
-registries (kickoff [#216](https://github.com/talelburg/eldritch/issues/216),
-gate [#245](https://github.com/talelburg/eldritch/issues/245)/PR #326). The
-engine spine, scenario plumbing, all Group C content (C1–C7), and the
-five-axis trigger-dispatch rework (#212/#213 + Axes A–D + the choice-cluster
-completion sub-slice) all landed — the detail lives in the closed issues and
-git history; only the architecture a future PR builds on survives in
-**Architecture to build on** below. Slice-1 design specs are in
-`docs/superpowers/specs/2026-06-1*`.
+**The engine foundation for the solo gate is complete.** Slice 1 (solo Roland
+playing The Gathering end-to-end to Won + Lost, kickoff #216 / gate #245 /
+PR #326) shipped, and so did every architectural arc the gate needed (see
+**What shipped** below). What remains is a small **rules-correctness cluster**
+plus the **browser capstone** — the detail is in **Remaining gate work**.
 
-**Now: Phase 7 is the 1-player solo rules-correctness gate.** The remaining
-work is every place solo play diverges from the rules. Scope is deliberately
-narrow — **1 player, 1 investigator, Standard** — and the categorized,
-dependency-ordered plan is **The solo correctness gate** below. Investigator
-breadth, difficulty, solo-2, and optional content are **Future slices**.
+**Phase 7 is the 1-player solo rules-correctness gate.** Scope is deliberately
+narrow — **1 player, 1 investigator, Standard**. Investigator breadth,
+difficulty, solo-2, and optional content are **Future slices**.
 
 ## Goal
 
 A solo human, in the browser, picks an investigator, sets up The Gathering,
 and plays it to a resolution — **rules-correct for 1-player Standard**.
 
-## The solo correctness gate
+## What shipped (retrospective)
 
-In scope: anything that makes **1 player / 1 investigator / Standard** play
-wrong. Out: multiplayer, solo-2, perf, refactor, later-scenario, UI. The
-Gathering's encounter deck carries no Surge/Peril, so #138/#139 are not gated
-here.
+The blow-by-blow lives in the closed issues, git history, and the
+`docs/superpowers/specs/2026-06-*` design docs; only the load-bearing residue is
+in **Architecture to build on**. In dependency order, the arcs that landed:
 
-### Tier 1 — the work
+1. **Continuation-stack cleanup** (#345/#348/#380) — normalized the
+   `InputResponse` channel (`PickSingle`/`PickMultiple`/`Confirm`/`Skip`), folded
+   every `*_pending` side-channel onto continuation frames.
+2. **#393 unified control-flow model** (C checkpoint) — every suspending/looping
+   step is a continuation frame; the main loop's one rule is **handle the top
+   frame**. `InvestigatorTurn` re-emits legal actions as `OptionId`s, so the stack
+   is non-empty during play. (`AttackLoop` cursor-lift, PR #412.)
+3. **Keystone — mid-action park/resume** (K1–K5b, #293/#379/#361/#378/#143/#44) —
+   AoO, retaliate, activated-ability & non-fast card-play AoO, player attack-order,
+   and interactive damage/horror soak distribution all park their triggering action
+   on an `ActionResolution`/`AttackLoop`/`DamageAssignment` frame and resume under a
+   re-validation gate. PR #424 reified the **effect evaluator as continuation
+   frames** (retiring suspend-and-replay + `DecisionCursor` + `Continuation::Choice`).
+4. **Skill-test player windows** — #374 (ST.1/ST.2 fast-play windows; Hyperawareness,
+   Magnifying Glass) and #64 (after-resolution reaction window; Dr. Milan 01033).
+5. **EmitEvent-frame arc A→D** (#435 umbrella, #433/#434/#431/#423) — event
+   emission, windows, and the `when/at/after × forced/reaction` matrix are all
+   `drive`-loop-dispatched frames. Final slice PR #446 deleted `apply_effect` /
+   `drive_effect_to_base`; every effect site is now top-frame dispatched.
 
-**A. Missing basic actions** — ✅ **shipped (PR #383).** `PlayerAction::Resource`
-([#141](https://github.com/talelburg/eldritch/issues/141), closed) + the
-basic-action half of [#77](https://github.com/talelburg/eldritch/issues/77)
-(`PlayerAction::Engage`). Both fire attacks of opportunity (RR p.5 exempts only
-fight/evade/parley/resign); the pre-existing **Draw** AoO gap was fixed alongside,
-and the shared five-check prologue extracted into `validate_basic_action`.
-**Resign and Parley are NOT basic actions** (verified RR p.5: "Activate, Play,
-Resign, and Parley are not basic actions") — they are action *types* granted only
-by card/location abilities, so they live with the optional content in
-[#258](https://github.com/talelburg/eldritch/issues/258) (the Parlor's Resign,
-Lita's Parley), **not** the gate. #77 stays open for its Parley half.
+## Remaining gate work
 
-**B. Attacks of opportunity + non-enemy-phase attack windows** — one cluster,
-one shared mechanism (mid-action park/resume), now a sub-sliced arc **K1→K5**
-(see Ordering step 4 + its design spec). **The foundation shipped:**
-- ✅ [#293](https://github.com/talelburg/eldritch/issues/293) — AoO open cancel/soak windows (Guard Dog, Dodge). **Shipped — K1, PR #413** (`ActionResolution` frame + `drive_aoo`).
-- ✅ [#379](https://github.com/talelburg/eldritch/issues/379) — Retaliate opens cancel/soak windows (Guard Dog, Dodge). **Shipped — K2, PR #414** (`drive_retaliate`; resume re-enters `drive_skill_test`).
-- ✅ [#361](https://github.com/talelburg/eldritch/issues/361) — activated abilities provoke AoO (First Aid, Flashlight, Medical Texts, Old Book of Lore; Fight weapons exempt). **Shipped — K3, PR #415** (`provokes_aoo` gate + `ActionResume::ActivateAbility`).
-- ✅ [#378](https://github.com/talelburg/eldritch/issues/378) — playing a non-fast card (asset or event) provokes AoO + costs an action (Dynamite Blast, Emergency Cache; the missing non-fast play-action charge folded in). **Shipped — K3, PR #416** (`ActionResume::PlayCard` + `check_play_action_available`).
+In dependency-friendly order.
 
-**C. Enemy-attack-loop player agency:**
-- ✅ [#143](https://github.com/talelburg/eldritch/issues/143) — player picks attack order with 2+ engaged enemies. **Shipped — K4, PR #419** (`AttackLoopStage::PickOrder` + `resume_attack_order_pick`; interleaved pick in the shared `drive_attack_loop`, both sites; enemy-phase frame now spans step 3.3).
-- [#44](https://github.com/talelburg/eldritch/issues/44) — player chooses damage/horror distribution across soakers + self. **K5a shipped (PR #420):** non-attack damage/horror now soaks via the shared `soak_and_place` entry (treachery harm — Grasping Hands, Rotting Remains — soaks like attacks did). **K5b-1 shipped (PR #421):** interactive per-point distribution for **enemy attacks** (`Continuation::DamageAssignment` + per-point `PickSingle`, gated to prompt only when a soaker can take the point). **K5b-2 (effect/treachery path) — ✅ shipped (PR #425; closes [#422](https://github.com/talelburg/eldritch/issues/422)).** The blocker was the evaluator's single-pass suspend-and-replay model: `Effect::Deal` harm is dealt via `ForEachPointFailed(deal 1)`, and replay forbade suspending after a side effect (`apply_seq`'s loud reject; the #346 limitation), so a multi-point treachery (Grasping Hands 2 damage) lost points on resume. **[#422](https://github.com/talelburg/eldritch/issues/422) reified the effect evaluator as continuation frames (substrate PR #424)** — retiring replay (and `DecisionCursor`, `Continuation::Choice`, the #346/#334 guards); a choice after a `Seq` step now resumes with no double-apply. **K5b-2 (PR #425):** `Effect::Deal` distributes interactively via `combat::soak_and_distribute` + the `DamageSource::Effect` resume (`resume_effect_walk`), mirroring the K5b-1 attack-path gating; the multi-point `ForEachPointFailed` walk suspends per point with no iteration lost. The same substrate is the basis for the deferred loop sites (Dynamite Blast's per-investigator loop, chaos-symbol effects, the draw-deckout penalty — still on the K5a auto-soak wrappers) and for migrating effect-invocation call sites off the bounded `apply_effect` entry to pure top-frame dispatch ([#423](https://github.com/talelburg/eldritch/issues/423), with item 5). The multi-soak-window drain stays separately deferred (unconstructible — single Ally-slot reactor; `park_on_soak_window` guard stays).
+**1. `IntExpr` correctness cluster (p1-next) — share substrate, can land together.**
+The dynamic-expression AST already ships (`IntExpr::{Lit, Cond}` over `Condition`,
+wired into `Effect::Fight.combat_modifier`; see Architecture). Each item *adds an
+`IntExpr` term + plumbs `IntExpr` into one more `Effect` field*:
+- **#118 — Roland's elder-sign** ("+1 per clue on your location"). Needs a
+  `Trigger::ElderSign` + ST.4 firing path, a clue-*count* `IntExpr` term (the
+  shipped `Condition::LocationHasClues` is binary; elder-sign is per-clue), and
+  `IntExpr` into `Effect::Modify` (`delta` is still `i8`). His signature is in the
+  "done" criteria.
+- **#300 — Machete** sole-engaged +1. Multi-target Fight has landed (#401), so the
+  unconditional `extra_damage: 1` is now a real divergence with 2+ engaged enemies:
+  make `extra_damage` an `IntExpr` gated on a new "sole engaged enemy" `Condition`.
+- **#426 — Grasping Hands 01162 / Rotting Remains 01163** "take 1 per point you
+  fail by": make `Effect::Deal`'s amount an `IntExpr` + a `SkillTestFailedBy` term,
+  replacing `for_each_point_failed(deal 1)` so it deals one simultaneous N-point
+  instance (observable now that soak distribution prompts interactively).
 
-**D. Skill-test player windows:**
-[#374](https://github.com/talelburg/eldritch/issues/374) (ST.1/ST.2 fast-play
-windows) + [#64](https://github.com/talelburg/eldritch/issues/64)
-(after-resolution reaction window).
-**Driver-reification substrate shipped (PR #430):** `drive_skill_test` →
-single driver `advance` (the `FinishContinuation` cursor → `SkillTestStep`,
-`+Resolving`), the commit prompt emitted from `advance`'s `AwaitingCommit`
-arm; #374/#64 land as cursor-step insertions inside `advance`, not new
-`Continuation` variants.
-**✅ #374 shipped (PR #432):** the two RR p.26 framework player windows open
-in `advance` (`PreCommitWindow`/`PreTokenWindow`) via
-`WindowKind::SkillTestPlayerWindow`, auto-skipping when nothing is Fast-eligible
-and parking when a Fast play is available (Hyperawareness, Magnifying Glass
-exercise it today). The transitional `WindowKind` dissolves into the generic
-`FastWindow` in **Slice A** of the EmitEvent-frame arc
-([#433](https://github.com/talelburg/eldritch/issues/433) under umbrella
-[#435](https://github.com/talelburg/eldritch/issues/435)). Fire Axe (02032)
-is a *during-test* consumer (its "spend 1 resource: You get +2 for this skill
-test" ability fires in the ST.1/ST.2 windows, **before** resolution) — so it
-belongs to #374, not #64. **#64 remains** (#423 ✅ done — see below); #64's first
-real consumer is **Rabbit's Foot (01075)** ("After you fail a skill test, exhaust:
-Draw 1 card" — an after-resolution reaction), and **#64 is deferred until Rabbit's
-Foot is needed**. The **EmitEvent-frame arc ([#435]) is complete** — A→B→C→D all
-shipped (C-coordinators PR #444; **D / #423 Slice D ✅ PR #446**). See Ordering step 6.
+**2. #368 — before-discover eligibility (p1-next, needs-design).** Lift the
+hardcoded scan-suppression stand-ins (Cover Up 01007 `card.clues == 0`; act 01109
+round-end clue-threshold) into a declarative **trigger-level eligibility
+`Condition`** (RR p.2: an ability can't initiate if its effect won't change game
+state). Two consumers already; designed when the 3rd lands (Lone Wolf 02188,
+Burned Ruins 02205). Item 2 (capped discovery count) is independent and latent.
 
-**E. Roland's signature:**
-[#118](https://github.com/talelburg/eldritch/issues/118) — elder-sign "+1 per
-clue" is stubbed; needs the dynamic skill-test-modifier DSL surface
-(needs-design; see Open questions).
+**3. Browser capstone — the gate-closer.** Positioned last so it designs against
+the now-stable set of input shapes:
+- **#447 — 2b: typed `PlayerAction` elimination** (engine half). Route open-turn
+  gameplay through `ResolveInput(PickSingle(OptionId))` only; id→action map fully
+  internal. The committed/scheduled #393 end-state (§E), pairs with #205.
+- **#205 — structured input rendering** (client half). Render the right control per
+  offered option from the structured `InputRequest.options`, not prompt-string
+  heuristics. Needs-design (client metadata schema).
+- **Investigator/scenario picker.** Seating (#221) + registry swap (#244) exist
+  engine-side; the browser picker driving `StartScenario` is the remaining UI.
+- **End-to-end browser playthrough** of The Gathering to a resolution.
 
-**F. Conditional / edge correctness:**
-[#300](https://github.com/talelburg/eldritch/issues/300) (Machete only-engaged-enemy +1),
-[#368](https://github.com/talelburg/eldritch/issues/368) (before-discover eligibility + count cap),
-[#353](https://github.com/talelburg/eldritch/issues/353) (uses-depletion timing).
+**Deferred past the gate:** #353 (uses-depletion — no Gathering card; gated on
+Forbidden Knowledge / Grotesque Statue), #294 (multi-soak-window drain —
+unconstructible in scope, `debug_assert` guards it), #427/#429 (native-loop soak
+residue — rare in 1p), #119/#26 (behaviour-preserving cleanups — fold in
+opportunistically).
 
-### Ordering, dependencies, simplifications
+## Frame-model end-states (#393)
 
-1. ~~**Basic actions first** (#141, #77)~~ — ✅ shipped (PR #383); Engage also unblocks #300's condition. (Resign/Parley aren't basic actions — see Tier-1 A.)
-2. **§1 continuation-stack cleanup — ✅ done.** #345 (PR #385) + #348 via parts 2a–2c + #380 (PRs #386–#392). The last piece, **#347** (token-routed resume / stale-submit rejection), **folds into #393** rather than landing standalone: the literal "token on `ResolveInput`, validated in the engine" is a ~145-site churn that #393 would rework, and stale-submit rejection is properly a *session* concern — the engine emits deterministic token *values*, the **server** rejects stale client echoes at the network boundary (the engine's `apply`/action-log stays token-free for replay). So token-routing is designed on #393's unified resume channel, at the right layer. (#348/#347 closed → #393.)
-3. **Unified control-flow model (#393) — the foundation arc, before the rest of Tier-1. ✅ designed** ([`2026-06-20-unified-control-flow-model-design.md`](../superpowers/specs/2026-06-20-unified-control-flow-model-design.md)). Reify *every* step of control flow as a continuation frame (phases, turns, the open-action choice), so the main loop collapses to a single rule: **handle the top frame.** The `InvestigatorTurn` frame re-emits the player's legal actions as `OptionId`s while actions remain — so the stack is never empty during play (empty only at bootstrap and the terminal resolution). The spec scopes a **C checkpoint** (a step is a frame *iff* it suspends or loops; net-new surface = four per-phase anchors + `InvestigatorTurn` + `AttackLoop`) and three sequenced post-C **end-states**: **B** (every step a frame, reached content-driven), **2b** (eliminate typed `PlayerAction` → gameplay is `ResolveInput(OptionId)` only; committed for UX/#205), and the **EmitEvent-frame** (the `when/at/after × forced/reaction` ordering axis as nested frames; #212 successor). It **subsumes** the keystone's substrate, the three framework cursors (`enemy_attack_pending` / `pending_end_turn` / `pending_enemy_attack`), #384's engine half (#384 closed → #393), and **token-routing / stale-submit rejection (#347, folded in → server-side)**. The engine emits `OptionId`s + keeps the id→action map internal; option metadata / browser rendering is #205 at the capstone. Build the model **before** the rest of Tier-1 so each item lands on the final engine shape.
-   - **Slice 3 — `AttackLoop` frame (cursor lift). ✅ shipped (PR #412, closes #411).** Lifted the last two framework cursors onto the stack: the parked enemy-attack loop is now a `Continuation::AttackLoop` frame (inserted *beneath* the reaction window it suspends on), and the per-investigator cursor is the `EnemyPhase` anchor's `attacking: Option<InvestigatorId>` field. Behaviour-preserving. **Deliberately Shape A:** the `AttackLoop` frame spans only the *parked suspension*, not the whole per-investigator step 3.3 — see the keystone caveat below.
-4. **The keystone: mid-action suspend/resume — ✅ done (K1–K5b all shipped; K5b-2 closed [#422](https://github.com/talelburg/eldritch/issues/422) via PR #425 on the substrate PR #424).** Designed in its own spec ([`2026-06-20-phase-7-keystone-mid-action-park-design.md`](../superpowers/specs/2026-06-20-phase-7-keystone-mid-action-park-design.md)) — §D of #393 expanded into a sub-sliced arc **K1→K5** collapsing #293/#379/#361/#378/#143/#44, the highest-leverage item in the phase. (#119 was decoupled — see Refactor triage.) The action parks its *triggering action* on a `Continuation::ActionResolution` frame (above `InvestigatorTurn`) with the AoO `AttackLoop` (slice 3 / #411) as its child; on the loop's pop an `on_child_pop` re-validation gate (actor-Active + the primary's target precondition) resumes the action's primary effect, aborting cleanly on a mid-action lapse.
-   - **K1 — AoO open cancel/soak windows (#293). ✅ shipped (PR #413).** `ActionResolution` frame + `drive_aoo`; the five basic actions fire AoO through `drive_attack_loop`, so Dodge cancels and Guard Dog retaliates against an AoO; `fire_attacks_of_opportunity` deleted. RR p.7 AoO-non-exhaust source-gated.
-   - **K2 — Retaliate opens cancel/soak windows (#379). ✅ shipped (PR #414).** `drive_retaliate` routes the failed-Fight retaliate through `drive_attack_loop` under `EnemyAttackSource::Retaliate`; the resume re-enters `drive_skill_test` (the retaliate's park point is the existing `SkillTest` frame, not an `ActionResolution` frame).
-   - **K3 ✅ #361 (PR #415)** AoO from activated abilities (Fight-exempt by effect root; effect snapshotted on the resume frame) · **✅ #378 (PR #416)** non-fast card-play AoO + the folded-in play-action charge (`ActionResume::PlayCard`; both gate on `!is_fast`) · **K4 ✅ #143 (PR #419)** player attack-order — interleaved one-at-a-time pick at the top of the shared `drive_attack_loop` (`AttackLoopStage::PickOrder`), covering both the enemy phase and AoO; extends the enemy-phase `AttackLoop` to span the whole step 3.3 (resolved slice 3's Shape-A caveat) and confirmed the attacker snapshot frozen at loop entry · **K5a ✅ #44 (PR #420)** non-attack damage/horror routed through the shared `soak_and_place` entry (treachery harm soaks like attacks) · **K5b-1 ✅ #44 (PR #421)** interactive per-point distribution for enemy attacks (`Continuation::DamageAssignment` + per-point `PickSingle`) · **K5b-2 ✅ #44 (PR #425, closes [#422](https://github.com/talelburg/eldritch/issues/422))** — substrate PR #424 reified the effect evaluator as continuation frames (retiring suspend-and-replay + `DecisionCursor` + `Continuation::Choice` + the #346/#334 guards); PR #425 added interactive `Effect::Deal` distribution (`soak_and_distribute` + the `DamageSource::Effect` resume), so multi-point treachery harm distributes per point with no loss. The deferred loop sites stay on the K5a auto-soak wrappers; the multi-soak-window drain is separately deferred (unconstructible in scope). Each rides the K1 substrate.
-5. **Skill-test windows** (#374 + #64) — one reaction-window work-stream, offered as frame options on the #393 model. **Driver-reification substrate ✅ shipped (PR #430)** ([spec](../superpowers/specs/2026-06-22-skill-test-driver-frame-reification-design.md)): the inline `FinishContinuation` cursor became `SkillTestStep` driven by the single `advance` (rename of `drive_skill_test`); the commit prompt is emitted from `advance`'s `AwaitingCommit` arm (the frame's "awaiting" logic); the teardown tail (forced-run sibling #213 + end-of-turn resume) moved into the `PostOnResolution` arm. **#374/#64 now insert windows as cursor-step boundaries inside `advance`, not new `Continuation` variants.** **#374 ✅ shipped (PR #432)** ([spec](../superpowers/specs/2026-06-22-skill-test-st1-st2-player-windows-design.md)): the two RR p.26 ST.1/ST.2 framework windows open via `PreCommitWindow`/`PreTokenWindow` + `WindowKind::SkillTestPlayerWindow` (auto-skip when nothing's Fast-eligible; park when a Fast play is available — Hyperawareness / Magnifying Glass exercise it). The `WindowKind` is transitional — it dissolves into the generic `FastWindow` in **Slice A** of the EmitEvent-frame arc ([#433](https://github.com/talelburg/eldritch/issues/433)), where "which window" is read from the `SkillTest` cursor beneath it. **#64 is deferred (no in-scope consumer yet): its first real card is Rabbit's Foot (01075) — "After you fail a skill test, exhaust: Draw 1 card", an after-resolution reaction — which isn't gate-required, so #64 waits until it's needed. Fire Axe (02032) is NOT a #64 card: its "spend 1 resource: You get +2 for this skill test" ability fires *during* the test (ST.1/ST.2, #374). So the EmitEvent-frame arc (#435) is the next objective.** Two decisions a future PR-author must respect (else they'll reintroduce a bug the substrate avoided): the **five imperative re-entry sites stay synchronous** (kept, renamed to `advance`) and there is **no `drive`-loop `SkillTest` arm** — both because routing skill-test resumption through the loop strands a treachery-Revelation test's `EncounterCard` (the `resolve_input` disposal runs on the commit resume's `Done`, *before* teardown; the loop's `_ => Done` arm never disposes). Eliminating the re-entry sites is the EmitEvent-frame arc's job (now scoped — see step 6), not this work-stream's. **(Superseded by C-plumbing, PR #443: the `drive`-loop `SkillTest` arm + a loop-driven `EncounterCard` disposal arm landed *together* — the disposal-stranding hazard described here is exactly why they had to be atomic. The five re-entry sites are now gone. See step 6's Slice C.)** **[#423](https://github.com/talelburg/eldritch/issues/423) does NOT complete here:** it was filed as "complete here (or right after)" on the premise that #374 reified the reaction-window/skill-test drivers as frames — but #374 only inserted windows inside the still-Shape-A `advance`. Migrating effect sites off `apply_effect` needs their parent frames (`Resolution`, `SkillTest`, `EncounterCard`) to be `drive`-dispatched, which is the EmitEvent-frame arc (step 6). So #423 is **Slice D** of that arc, gated behind A–C.
-6. **EmitEvent-frame arc — A→B→C→D ✅ done (complete).** Scoped + sliced in [`2026-06-22-emitevent-frame-arc-decomposition-design.md`](../superpowers/specs/2026-06-22-emitevent-frame-arc-decomposition-design.md); the named end-state from #393. Reify event emission, windows, and the timing matrix as `drive`-dispatched frames so the loop drives **every** frame. Four sequenced slices: **A** ([#433](https://github.com/talelburg/eldritch/issues/433)) window-taxonomy rework ✅ → **B** ([#434](https://github.com/talelburg/eldritch/issues/434)) `EmitEvent`/`TimingPoint` coordinators — the `when/at/after × forced/reaction` matrix, the one slice with new ordering behaviour; re-sliced so the coordinator *frames* landed in **C-coordinators (PR #444, closes #434)** ✅ → **C** ([#431](https://github.com/talelburg/eldritch/issues/431)) loop-driven encounter-card disposal + `SkillTest` drive arm + retire the 5 synchronous re-entry sites + the window-frame `drive`-loop arms ✅ → **D** ([#423](https://github.com/talelburg/eldritch/issues/423)) effect call-site migration off `apply_effect` — **✅ done (PR #446)**: every effect site is top-frame dispatched; `apply_effect` + `drive_effect_to_base` deleted (the bounded driver survives only as a test helper). Umbrella for A+B is [#435](https://github.com/talelburg/eldritch/issues/435). Dependency order **A → B → C → D**; the §G Upkeep ordering pre-req shipped (PR #396).
-   - **Slice A ✅ shipped (closes #433):** A-i `TimingPointWindow` for event windows (PR #436) + forced run (PR #437); A-ii framework windows → `FastWindow` (PR #438); A-iii delete the frame-level legacy taxonomy `Resolution`/`ResolutionFrame`/`ResolutionKind`/`WindowBinding` (PR #439). **Behaviour-preserving throughout — event log byte-identical.** Two load-bearing decisions: (1) **`WindowKind` survives** as the pure `Event::WindowOpened/Closed` descriptor (derived from `TimingPointWindow`'s `TimingEvent` + `FastWindow`'s `FastWindowKind`); deleting it + the observability redesign is the one event-log *behaviour* change, **deferred to Slice B**. (2) The window-frame **`drive`-loop arms (former A-iv) folded into Slice C (#431)** — same "loop drives every frame" concern as the `SkillTest` arm; Slice A leaves the windows imperatively driven. This supersedes the loose "#431 = the whole EmitEvent-frame slice" framing in the triage below.
-   - **Slice B ✅ shipped — but NOT the coordinator frames (re-scoped 2026-06-23).** Reading the real `emit_event`/window machinery showed the `EmitEvent`/`TimingPoint` *stack frames* + per-cell re-scan + the §G test only earn their place once the `drive` loop dispatches them — building them as imperatively-driven scaffolding in `emit_event` (the highest-blast-radius fn) would be premature, and reaction-window *opening* is deferred across ~6 sites. So **those move to Slice C ([#431])** with the other "loop drives every frame" work. What Slice B *did* ship, behaviour-preserving except the event-log deletion: **B-i** (PR #440) `EventTiming::{When, At, After}` — rename `Before→When`, add `At`, the timing axis first-class in the DSL; **B-ii** (PR #441) the round-end remodel — act 01109's advance is now a registry `When`-`RoundEnded` ability (its native does the group clue-spend), the doom abilities re-tagged `After→At`, fixing the framework-vs-registry asymmetry (`Act.round_end_advance` kept as a pure-data field for the affordability gate); **B-iii** (PR #442) delete `Event::WindowOpened`/`WindowClosed` + `WindowKind` outright (pure output, no consumer, 1:1 redundant with the `AwaitingInput` channel) — scan eligibility + close-routing migrated onto `TimingEvent`/`FastWindowKind`. **#434/#435 stay open** for the coordinator frames now living in Slice C. Specs: [`2026-06-23-emitevent-frame-slice-b-coordinators-design.md`](../superpowers/specs/2026-06-23-emitevent-frame-slice-b-coordinators-design.md).
-   - **Slice C — C-plumbing ✅ (PR #443) + C-coordinators ✅ (PR #444, closes #434).** [#431](https://github.com/talelburg/eldritch/issues/431) split in two. **C-plumbing (PR #443)** made the `drive` loop dispatch **every** frame by uniform top-frame dispatch (arms for `TimingPointWindow`/`FastWindow`/`SkillTest`/`EncounterCard`); every driver returns `Done` and the loop re-dispatches `continuations.last()`. Retired the reach-down accessors (`top_reaction_window_index`/`_mut`/`top_reaction_window`), `advance`'s `win_idx > st` self-location, the 5 synchronous skill-test re-entry sites, and the `resolve_input` encounter-disposal chokepoint — on the invariant that **the stack is the resolution order, so `last()` is always what resolves next**. Behaviour-preserving. **C-coordinators (PR #444)** reified the `when → at → after` axis as `drive`-loop-dispatched `Continuation::EmitEvent`/`TimingPoint` frames: `emit_event(RoundEnded)` cedes to a coordinator that walks the buckets (forced-then-reaction via `TimingSub`) **re-scanning each cell fresh** (the §G per-cell re-scan — covered by `crates/game-core/tests/round_end_rescan.rs`). The round-end `when`-advance (act 01109) + `at`-doom are now uniformly-scanned registry abilities (the forced/reaction scans filter by `TriggerKind`, now that one `(event, bucket)` is scanned for both); teardown runs on the Upkeep anchor's `AfterRoundEnd` resume. This deleted the `ActRoundEnd` hand-thread + `Act.round_end_advance` field, folded `EndOfTurn`'s 2+-forced resume onto the `InvestigatorTurn { ending }` frame, and **deleted `ForcedContinuation` outright** (every variant became a no-op once round-end/EndOfTurn resumed via their own frames). **D ([#423](https://github.com/talelburg/eldritch/issues/423)) ✅ done (PR #446)** — the effect call-site migration off `apply_effect`: `resume_effect_walk` cedes to the global loop, `apply_effect` + `drive_effect_to_base` are deleted, every effect site is top-frame dispatched. The arc (A→B→C→D) is complete. Specs: [C-plumbing](../superpowers/specs/2026-06-23-emitevent-frame-slice-c-loop-driving-design.md), [C-coordinators](../superpowers/specs/2026-06-23-emitevent-frame-c-coordinators-design.md), [D effect-frame call-site migration](../superpowers/specs/2026-06-23-effect-frame-callsite-migration-design.md).
-7. **Roland elder-sign** (#118).
-8. **Edge correctness** (#300 after Engage, then #368, #353).
-9. **Browser playable surface** (capstone) — once the above stabilizes; renders the enumerated actions / #205. See below.
-
-**Simplifications:**
-- **#300 does not need #363 (general fan-out).** Once Engage (#77) exists, Machete's "only enemy engaged with you" is a count==1 read — gate `extra_damage` on it; don't wait for multi-target Fight.
-- **#367 is likely a wontfix for this gate** — Before-windows don't nest in 1-player scope, so the `bool` cancellation marker suffices.
-- **#380 folds into #348** (continuation-stack cleanup) — see Refactor triage.
-
-### Browser playable surface (the former "Slice D") — capstone
-
-The gate's "done" is a solo human playing in the *browser*, not just a green
-integration test. Once the Tier-1 fixes stabilize, this is the first follow-on:
-the web client (shipped Phase 6) must drive the **real** Gathering scenario.
-
-- **#205 — structured `AwaitingInput` discrimination + action rendering
-  (load-bearing, needs-design).** The engine side is provided by #393: every
-  player decision — including the open-turn's *enumerated legal actions* —
-  surfaces as a frame offering `OptionId`s on the normalized `InputResponse` set
-  (`PickSingle` / `PickMultiple` / `Confirm` / `Skip`). #205 is the **client
-  half**: decide what option *metadata* the engine surfaces (labels, per-variant
-  controls, action parameters — #393 keeps the id→action map internal for now)
-  and render the right control per option, not prompt-string heuristics. (Absorbs
-  the former #384 client half.) Keystone of the surface; pairs with #393's
-  token-routing (#347, folded in → server-side stale-submit rejection).
-- **Investigator / scenario picker.** The seating protocol (B2 #221) + registry
-  swap (C7a #244) exist engine-side; the browser picker driving `StartScenario`
-  with a chosen investigator is the remaining UI.
-- **End-to-end browser playthrough** of The Gathering to a resolution, driven
-  through the client (the C7b coverage, but via the browser).
-
-Positioned **after** Tier 1: every new Tier-1 input site (AoO targeting, attack
-order, damage distribution, skill-test windows) adds an `AwaitingInput` shape the
-surface must render, so building #205 before they exist designs against a moving
-target.
-
-### Refactor / tech-debt triage
-
-Not rules bugs, but several simplify or de-risk the Tier-1 work — pull these in
-rather than deferring wholesale:
-
-- **§1 continuation-stack cleanup — ✅ done (#345 + #348 + #380); #347 folds
-  into #393.** Designed in
-  `docs/superpowers/specs/2026-06-19-continuation-stack-cleanup-design.md`.
-  **Progress:** #345 shipped (PR #385); #348 landed incrementally (parts
-  2a–2c via PRs #386–#391) — the `InputResponse` channel is now normalized
-  (`CommitCards`/`DiscardCards` → `PickMultiple`, `PickLocation`/`PickInvestigator`
-  → `PickSingle`, `Mulligan` → `PickMultiple`, `DrawEncounterCard` → `Confirm`),
-  every player-facing suspension resumes through `ResolveInput`, and the bespoke
-  `mulligan_pending`/`mythos_draw_pending` cursors + `in_flight_skill_test` are
-  folded onto continuation frames. #380 (the `pending_revelation_discard`
-  side-channel → an `EncounterCard` frame, PR #392) has also landed. The last
-  piece, **#347** (token-routed resume), **folds into #393** rather than landing
-  standalone (engine-level `ResolveInput.token` is ~145-site churn #393 would
-  rework; stale-submit rejection is a session concern — engine emits token
-  *values*, the server rejects stale echoes, the action log stays replay-clean).
-  Likewise the **remaining framework cursors — `enemy_attack_pending` /
-  `pending_end_turn` / `pending_enemy_attack` — move to #393** (the unified
-  control-flow model, the foundation arc that follows §1 — see Ordering step 3):
-  internal sequencing, never player-facing, they fall out when #393 reifies the
-  phase/turn/attack-loop drivers as frames.
-  #348 collapsed the
-  fragile `if pending_X.is_some()` `resolve_input` cascade **and** the parallel
-  `apply_player_action` guard ladder into top-frame dispatch
-  (`clue_interrupt_pending` is already a window); #345 makes
-  `EvalContext` serializable with **grouped optional bindings** snapshotted
-  per-frame (the Vec / per-frame-enum / global-stack alternatives were evaluated
-  and rejected — spec §D; innermost-only is corpus-moot, no TODO) so migrated
-  frames snapshot context instead of re-storing ingredient tuples; #380 removed
-  the `pending_revelation_discard` side-channel by making encounter-card
-  resolution a frame whose framework teardown disposes of the card. **Token-
-  routing (#347 → #393)** stays valuable for the browser surface — #205's client
-  can submit against a superseded prompt and be rejected cleanly — but lands as
-  part of #393's unified resume channel, at the session layer, rather than as a
-  standalone engine pass.
-- **EmitEvent-frame arc — ✅ scoped + filed (now Ordering step 6, the active
-  objective).** Decomposition spec
-  [`2026-06-22-emitevent-frame-arc-decomposition-design.md`](../superpowers/specs/2026-06-22-emitevent-frame-arc-decomposition-design.md);
-  umbrella [#435](https://github.com/talelburg/eldritch/issues/435) (#212
-  successor) over children A [#433](https://github.com/talelburg/eldritch/issues/433)
-  (window-taxonomy rework) + B [#434](https://github.com/talelburg/eldritch/issues/434)
-  (the `when/at/after × forced/reaction` coordinators), then C #431 + D #423.
-  Supersedes the earlier loose "#431 = the whole EmitEvent-frame slice" framing:
-  #431 is only Slice C (skill-test/encounter loop-driving); the window-taxonomy
-  rework + fast-window simplification is Slice A, the coordinators are Slice B.
-- **Upkeep round-end `when→at` ordering bug — surfaced by the #393 design; fix
-  before the Upkeep-anchor slice.** `upkeep_phase_end` fires agenda 01107's `at`-
-  the-end-of-round doom **before** act 01109's `when`-the-round-ends clue-spend
-  window — inverted vs. the RR "At" rule (`when → at → after`). Consequential when
-  the doom advances the agenda (loss on agenda 3). Cheap reorder + regression test
-  (agenda-3 + act-2 at round end); file its own bug issue. (Spec §G.)
-- **#119 — decoupled from #44, rescoped, deferred post-K5.** Storage unification
-  turned out unjustified by any in-scope interaction (no card treats damage,
-  horror, and clues as one token; symmetric *targeting* lives in the `Assignment`
-  layer, which already exists — not symmetric *storage*). #119 was rescoped to a
-  post-K5 behaviour-preserving `deal_damage`/`deal_horror` helper consolidation
-  that K5 does **not** depend on (clues left out — poor fit, revisit when future
-  cards add cases). K5 builds on the existing `soak_and_place`/`place_assignment`
-  pipeline.
-- **Trigger-eligibility gate consolidation ([#368](https://github.com/talelburg/eldritch/issues/368)) — now ≥2 consumers; consolidate during the EmitEvent-frame scan rework.** RR p.2 ("an ability cannot initiate if its effect won't change the game state") means a *reaction/Fast* ability must be **suppressed at scan time** when a board-state precondition fails — distinct from a Forced `if X` ability, which can just no-op in the effect (`Effect::If` / a native guard, e.g. Cover Up 01007's game-end trauma `if has_clues`). The scan-suppression gate is currently **hardcoded per card** in two places: Cover Up 01007's reaction (`scan_pending_triggers`, `card.clues == 0`) and — new in B-ii — act 01109's round-end advance (`round_end_advance_window`, Hallway clues ≥ `clue_threshold`). Pending snapshot consumers: Lone Wolf 02188 (`if there are no other investigators at your location`), Burned Ruins 02205 (`[fast] if there are no clues here`). **Because the EmitEvent-frame arc (#435) reworks the same scan/coordinator code, lifting these bespoke `if matches!(kind, …) && <check>` arms into a declarative trigger-level eligibility `Condition` (growing the DSL `Condition` enum past `LocationHasClues`) belongs with that rework — it removes per-card special-casing from the scan rather than adding more.** Designed under #368 when the 3rd consumer lands.
-- **Defer (no gate consumer):** #290 (mint encounter instances at reveal —
-  simplifies #373/#371 but no 1p correctness need), #373 (Obscuring Fog
-  attach-unify — single card, pairs with #290), #346 (two-pass for
-  choice-after-`Seq` — **now superseded by [#422](https://github.com/talelburg/eldritch/issues/422)**, effect-evaluator-as-frames, which K5b-2 needs), #363 (general fan-out — #300's
-  simplification avoids it; Dunwich-era), #366 (replace-with-different-impact — no
-  in-scope card).
-
-### Housekeeping
-- **Close #56** (the Study location is built and played end-to-end) and **#294** (unconstructible in scope — its own `debug_assert` guards it).
-
-### Out of scope (defer past the gate)
-- **Solo-2** (one player, two investigators): #65, #381, #359, #153, #371.
-- **Phase 8 multiplayer:** #146, #151, #206.
-- **Later scenarios:** #138, #139 (no Surge/Peril in The Gathering).
-- **Perf / infra:** #117, #174, #224, #26, #31.
-- **Optional content:** #258 (Lita parley / Parlor — minus the Resign action above).
-
-(Refactor / tech-debt issues are triaged above, not here — several are pull-ins.)
+For a future author who sees the partial state and wonders what's "missing":
+- **C checkpoint** ✅ and **EmitEvent-frame** (3rd checkpoint) ✅ — both shipped.
+- **2b** (typed `PlayerAction` → `OptionId`-only) — outstanding, **#447**, lands
+  with the capstone.
+- **B** (every straight-line step a frame) — **intentionally dormant**, reached
+  *content-driven* (a card making a step a decision). No Core+Dunwich card forces
+  it; B's marginal frames "earn nothing operationally." The visible remnant is the
+  intra-skill-test `SkillTestStep` cursor — **not a gap**, leave it until a card
+  puts a decision mid-test.
 
 ## Architecture to build on
 
-Only the facts a future PR-author needs that aren't obvious from the code or
-the issues.
+Only the durable facts a future PR-author needs that aren't obvious from the code.
 
-**Attack loop (keystone for Tier-1 B/C).** `enemy_attack` does `assign → place
-→ defeat`, soak-first by `CardInstanceId` order (the #44 replacement point);
-window-queuing lives in the caller `drive_attack_loop`, which parks remaining
+**Attack loop (keystone for damage/soak work).** `enemy_attack` does `assign →
+place → defeat`; window-queuing lives in `drive_attack_loop`, which parks remaining
 attackers as a `Continuation::AttackLoop` frame *beneath* the window (#411) and
-returns `AwaitingInput`, resuming via `resume_enemy_attack` (which pops the frame;
-the per-investigator cursor is the `EnemyPhase` anchor's `attacking` field,
-advanced once via `after_enemy_phase_attacks`). **K4 (PR #419) lifted the enemy-phase
-frame off Shape A in the multi-enemy case:** with 2+ engaged enemies `drive_attack_loop`
-suspends on the player's attack-order pick (`AttackLoopStage::PickOrder`,
-`resume_attack_order_pick`) before the first attack, so the `AttackLoop` frame spans
-the whole step 3.3; the single-enemy case stays Shape A (frame pushed only on a
-window suspend). The order pick reorders the stored `remaining_attackers` (snapshotted
-in `EnemyId` order at loop entry), never re-scanning. **K1 (PR #413) shipped the AoO
-half:** `fire_attacks_of_opportunity` is
-gone; the five basic actions (Draw, Resource, Move, Investigate, Engage) now run as
-a `Continuation::ActionResolution` frame and fire AoO via **`drive_aoo`** →
-`drive_attack_loop` (so `EnemyAttackSource::AttackOfOpportunity` is now live), opening
-the cancel (Dodge) and soak (Guard Dog) windows; on the loop's pop the `drive` loop
-resumes the action frame under an actor-Active + target re-validation gate.
-**K2 (PR #414) routed `fire_retaliate_if_any` through `drive_retaliate` →
-`drive_attack_loop` (`EnemyAttackSource::Retaliate`), so a failed-Fight retaliate now
-opens the cancel/soak windows too; its resume returns `Done` and the loop dispatches
-the now-top `SkillTest` (the retaliate's park point is the `SkillTest` frame; the
-direct `advance` re-entry was retired by C-plumbing, PR #443). No direct-`enemy_attack`
-window bypass remains.** Exhaust rules differ by source:
-enemy-phase always exhausts (cancelled too — RR p.6/p.25); AoO never (RR p.7 —
-source-gated in `process_attacker_dealing`); Retaliate never (RR p.18).
-**K3 added the activated-ability (PR #415) and card-play (PR #416) AoO sites:** a
-non-fight action-cost activation parks its effect on an `ActionResolution` frame
-and fires AoO via `drive_aoo` (the `provokes_aoo` gate exempts `Effect::Fight`
-weapons; fast abilities never provoke); playing a **non-fast** card (asset or
-event) likewise spends an action and parks on `ActionResume::PlayCard` before
-firing AoO, with the card's effect resolving on resume. Fast plays stay free and
-provoke nothing (both sites gate on `!is_fast`).
+resumes via `resume_enemy_attack`. With 2+ engaged enemies the player picks attack
+order first (`AttackLoopStage::PickOrder`), so the frame spans the whole enemy-phase
+step 3.3; single-enemy stays Shape A. The five basic actions + activated abilities +
+non-fast card plays park on a `Continuation::ActionResolution` frame and fire AoO via
+`drive_aoo` → `drive_attack_loop`; retaliate routes via `drive_retaliate`. Exhaust
+differs by source: enemy-phase always (even cancelled, RR p.6/p.25); AoO never
+(RR p.7); Retaliate never (RR p.18). `provokes_aoo` exempts `Effect::Fight` weapons;
+fast plays/abilities provoke nothing (gate on `!is_fast`). Soak-first by
+`CardInstanceId` order is the interactive-distribution entry point.
 
 **Trigger spine.** `emit_event` is the one dispatch chokepoint (two-phase
-forced-then-reaction, RR p.2). Simultaneous triggers resolve through a
-`TimingPointWindow { mode: Forced }` run (lead-ordered, RR p.17; the legacy
-`Continuation::Resolution`/`ResolutionFrame` taxonomy was deleted in Slice A,
-#439). Reentrancy across a forced/window effect that suspends into a skill test
-now resolves by **top-frame dispatch** (C-plumbing, PR #443): the loop dispatches
-whatever is on top — a mid-test window above the `SkillTest`, then the `SkillTest`,
-then a forced run beneath it — so no driver tells "above" from "below"
-(`advance`'s `win_idx > st` self-location is gone). Reaction/forced windows resume
-via `PickSingle(OptionId)` (the legacy `PickIndex` path is retired).
+forced-then-reaction, RR p.2; simultaneous triggers lead-ordered via a
+`TimingPointWindow { Forced }` run, RR p.17). Reentrancy resolves by **top-frame
+dispatch** (C-plumbing, PR #443): the loop dispatches whatever is on top — a mid-test
+window above the `SkillTest`, then the `SkillTest`, then a forced run beneath — so no
+driver distinguishes "above" from "below". Reaction/forced windows resume via
+`PickSingle(OptionId)`. The `when → at → after` axis is a `Continuation::EmitEvent`/
+`TimingPoint` coordinator that re-scans each cell fresh (the per-cell re-scan,
+`tests/round_end_rescan.rs`).
 
-**Choice & cancellation.** Interactive choice is single-pass suspend-and-replay
-on a `Continuation::Choice` frame: `resolve_choice_count` (0 ⇒ reject/printed
-fallback · 1 ⇒ auto-bind · 2+ ⇒ suspend), replayed pre-order via a
-`DecisionCursor`; DSL targets bind through `ground_chosen_targets`, native
-leaves read `EvalContext.chosen_option`. Spatial targets use the unified
-`Choose<S> { scope }` surface (`LocationSet { Here, Anywhere }` /
-`EntityScope`). Before-timing cancellation is a Before reaction window the
-caller suspends on + an `Effect::Cancel` leaf that sets `pending_cancellation`,
-which the emit site honors on window close; a `bool` suffices because
-Before-windows don't nest in scope (#367). A reaction event (Evidence! 01022)
-is a Fast event carried on the reaction window's candidate list and *played*
-when picked; it is window-only at the play gate (`TriggerKind::Reaction`
-`OnEvent`).
+**Choice & cancellation.** Interactive choice runs inside the **effect evaluator's
+`Continuation::Effect` frames** (#422 / PR #424): `resolve_choice_count` (0 ⇒
+reject/auto · 1 ⇒ auto-bind · 2+ ⇒ suspend); a node needing a choice **suspends in
+place** and resume **re-steps the same leaf** with `chosen_option` set — no replay,
+no `DecisionCursor`. DSL targets bind through `ground_chosen_targets`
+(`chosen_investigator`/`location`/`enemy`); native leaves read `chosen_option`.
+Spatial targets use `Choose<S> { scope }` (`LocationSet { Here, Anywhere }` /
+`EntityScope`). Before-timing cancellation is a Before window the caller suspends on
++ an `Effect::Cancel` leaf setting `pending_cancellation` (a `bool` suffices —
+Before-windows don't nest in scope, #367), honored on window close. A reaction event
+(Evidence! 01022) rides the window's candidate list and is *played* when picked
+(`TriggerKind::Reaction` `OnEvent`, window-only).
 
-**Skill-test player windows — ST.1/ST.2 modeled (#374, PR #432); after-resolution
-(#64) deferred.** The two RR p.26 framework player windows ship via
-`WindowKind::SkillTestPlayerWindow` (`PreCommitWindow`/`PreTokenWindow` in
-`advance`), so a player *can* play a Fast card before commit / before the token
-reveal (Hyperawareness, Magnifying Glass). The after-resolution reaction window
-(#64) is still absent — deferred (first consumer Rabbit's Foot 01075).
-`OnCommit` / `OnSkillTestResolution` card triggers fire regardless.
+**Skill-test control-flow shape.** Storage is on the stack (`InFlightSkillTest`
+folded onto the `Continuation::SkillTest` frame, #348). Dispatch is top-frame
+(C-plumbing): the `drive` loop's `SkillTest` arm calls `advance` when the frame is on
+top; a mid-test window makes `advance` yield `Done`, and the loop re-dispatches
+`SkillTest` on window close. **Intra-test sequencing is still an inline cursor** —
+the `SkillTestStep` enum (`PreCommitWindow → AwaitingCommit → PreTokenWindow →
+Resolving → …`) is a field advanced by a `loop` in `advance`. That's the remaining
+Shape-A compression (= the dormant end-state B); reifying each step is unpaid for
+until a card demands it. Two entry points: the commit hop (`finish_skill_test`) and
+the loop's `SkillTest` arm.
 
-**Skill-test control-flow shape (dispatch now top-frame; intra-test sequencing
-still a cursor).** Storage is on the stack — `InFlightSkillTest` folded onto the
-`Continuation::SkillTest` frame (#348), no `*_pending` side-channels — and after
-**C-plumbing (PR #443)** *dispatch* is too:
-- **Top-frame dispatched (C-plumbing).** The `drive` loop's `SkillTest` arm calls
-  `advance` when the frame is on top; a mid-test window makes `advance` return
-  `Done` (yield), and the loop re-dispatches `SkillTest` when the window closes.
-  The former reach-downs are **gone**: no `close_reaction_window → advance` hop, no
-  `rposition(SkillTest)` + `win_idx > st` self-location. The only deeper read left
-  is `current_skill_test` as **nesting context** (an effect reading its enclosing
-  test), not dispatch. (`AttackLoop` still re-enters via `resume_enemy_attack` —
-  not yet a loop arm, #411 Shape A.)
-- **Intra-test sequencing is still an inline cursor, not a frame per step.** The
-  `SkillTestStep` enum (`PreCommitWindow → AwaitingCommit → PreTokenWindow →
-  Resolving → PostFollowUp → PostRetaliate → PostOnResolution`) is a field on the
-  `SkillTest` frame, advanced by a `loop` in `advance`. This is the remaining
-  Shape-A compression; reifying each step as its own frame is the path to full
-  end-state B (with #374/#64 / C-coordinators), not done here.
-- **Two entry points into `advance`:** the commit hop (`finish_skill_test`, a
-  legitimate top-frame resume — `SkillTest` is on top at the commit prompt) and
-  the loop's `SkillTest` arm for every other resumption.
+**`IntExpr` dynamic-expression substrate.** Board-state-dependent values are an
+`IntExpr` AST (`card-dsl/src/dsl.rs`: `Lit(i8)` + `Cond { when: Condition, then,
+otherwise }`) — **shipped and wired into `Effect::Fight.combat_modifier`** (Roland's
+.38 Special 01006: `IntExpr::cond(Condition::LocationHasClues, 3, 1)`). So the
+"dynamic skill-test modifier surface" is a settled `IntExpr`, **not** a needs-design
+question. The #118/#300/#426 cluster each extend it the same way (add a `Condition`/
+term + plumb `IntExpr` into one more `Effect` field).
 
-**Content patterns (mostly later slices).** Card stats come from the corpus
-(`CardKind`; read via `cards::by_code` / `metadata_for`, never hand-typed) — a
-future enemy/card lands via a snapshot bump + regen, no impl. Single-use card
-logic is `Effect::Native { tag }` (promote to a shared `Effect` variant only at
-≥2 reuses). Scenario chaos-symbol / reference-card effects live on the
-`ScenarioModule.resolve_symbol` hook, not card `abilities()`.
+**Content patterns.** Card stats come from the corpus (`CardKind`; read via
+`cards::by_code` / `metadata_for`, never hand-typed) — a future enemy/card lands via
+a snapshot bump + regen, no impl. Single-use card logic is `Effect::Native { tag }`
+(promote to a shared `Effect` variant only at ≥2 reuses). Scenario chaos-symbol /
+reference-card effects live on the `ScenarioModule.resolve_symbol` hook, not card
+`abilities()`.
 
 ## Future slices (after the gate)
 
-- **Slice 2 — investigator breadth.** Daisy Walker, "Skids" O'Toole, Agnes
-  Baker, Wendy Adams — each with their signature asset/weakness pair + starter
-  deck, reusing the engine spine. Goal: all five picker-eligible. Not yet
-  specced.
-- **Difficulty selection.** Slice 1 ships Standard only; add Easy / Hard /
-  Expert chaos bags + a picker.
-- **Solo-with-2 UX.** One client driving two investigators — picker,
-  whose-turn, two boards vs. tabbed. Open design question; the Tier-2
-  correctness issues (#65, #381, #359, #153, #371) land here.
-- **Optional Gathering content.** Lita Chantler's parley/take-control + the
-  Parlor (01115) Resign action (#258).
+Captured but **unfiled** (no issues yet) — filed when the gate closes.
 
-Campaign sequencing beyond The Gathering (The Midnight Masks, The Devourer
-Below, campaign log + `Fact` enum) is **Phase 9**.
+- **Slice 2 — investigator breadth.** Daisy Walker, "Skids" O'Toole, Agnes Baker,
+  Wendy Adams — each with their signature asset/weakness pair + starter deck. Goal:
+  all five picker-eligible.
+- **Difficulty selection.** Add Easy / Hard / Expert chaos bags + a picker (Slice 1
+  is Standard only).
+- **Solo-with-2 UX.** One client driving two investigators (picker, whose-turn, two
+  boards vs. tabbed). Open design question; the Tier-2 correctness issues (#65, #381,
+  #359, #153, #371) land here.
+- **Optional Gathering content (#258).** Lita Chantler's parley/take-control + the
+  Parlor (01115) Resign action. #258 is also the home for the **Parley/Resign
+  action-type mechanisms** (not basic actions — RR p.5; both AoO-exempt), landing
+  with their first granting card.
+
+Campaign sequencing (The Midnight Masks, The Devourer Below, campaign log + `Fact`
+enum) is **Phase 9** — including the first real Peril/Surge cards (Hunting Shadow
+01135 et al.; #138/#139 re-milestoned there).
 
 ## Open questions
 
-- **Roland elder-sign DSL surface (#118).** The token effect is a *dynamic*,
-  board-state-dependent skill-test modifier ("+1 for each clue on your
-  location"); the DSL has no such surface yet. needs-design; gates Tier-1 E.
-- **Solo-with-2 UX** — how one client presents two investigators. See Future
-  slices.
+- **Roland elder-sign DSL surface (#118).** Mostly answered: the `IntExpr` AST
+  exists (.38 Special is the live consumer). The remaining design is narrow — the
+  clue-*count* `IntExpr` term + plumbing it into the skill-test-total path
+  (`Effect::Modify.delta` is `i8`) + the `Trigger::ElderSign` / ST.4 firing path.
+- **Solo-with-2 UX** — how one client presents two investigators. See Future slices.
 
 ## Dependencies
 
-Phases 4 (scenario module), 5 (server + persistence), 6 (web client) — all
-closed. Phase 3's Roland Banks (#55) shipped; the Study (#56) spilled here and
-is now playable (close it).
+Phases 4 (scenario module), 5 (server + persistence), 6 (web client) — all closed.
+Phase 3's Roland Banks (#55) shipped.
 
 ## What "done" looks like
 
-A solo human, in the browser, plays The Gathering to a resolution with
-**1-player Standard rules correctness**: every basic action available, attacks
-of opportunity / retaliate / soak resolving with proper player agency,
-skill-test windows open, and Roland's signature firing. Investigator breadth,
-difficulty, and solo-2 are Future slices.
+A solo human, in the browser, plays The Gathering to a resolution with **1-player
+Standard rules correctness**: every basic action available, attacks of opportunity /
+retaliate / soak resolving with proper player agency, skill-test windows open, and
+Roland's signature firing. Investigator breadth, difficulty, and solo-2 are Future
+slices.

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -47,26 +47,23 @@ in **Architecture to build on**. In dependency order, the arcs that landed:
 
 In dependency-friendly order.
 
-**1. `IntExpr` correctness cluster (p1-next) — share substrate, can land together.**
-The dynamic-expression AST already ships (`IntExpr::{Lit, Cond}` over `Condition`,
-wired into `Effect::Fight.combat_modifier`; see Architecture). Each item *adds an
-`IntExpr` term + plumbs `IntExpr` into one more `Effect` field*:
-- **#118 — Roland's elder-sign** ("+1 per clue on your location"). The clue-*count*
-  modifier term — `IntExpr::Count(Quantity::CluesAtControllerLocation)` — now ships
-  (this cluster, replacing the old binary `LocationHasClues`). #118 adds
-  `Trigger::ElderSign` + the ST.4 firing path (the bonus rides the chaos-token
-  `Modifier` total path, sourced from the investigator card — **not** `Effect::Modify`)
-  + the investigator-card-handle bridge (spec §2; PR 2). His signature is in the
-  "done" criteria.
-- **#300 — Machete** sole-engaged +1. Make `extra_damage` an `IntExpr` gated on a
-  "sole engaged enemy" `Condition` (`EngagedEnemies == 1`). Activated `Effect::Fight`
-  still requires exactly one engaged enemy (2+ is rejected pre-cost, pending
-  multi-target selection / #401), so the conditional is **correct card-text modelling**
-  but its `+0` branch is not yet reachable — it becomes load-bearing when #401 lands.
-- **#426 — Grasping Hands 01162 / Rotting Remains 01163** "take 1 per point you
-  fail by": make `Effect::Deal`'s amount an `IntExpr` + a `SkillTestFailedBy` term,
-  replacing `for_each_point_failed(deal 1)` so it deals one simultaneous N-point
-  instance (observable now that soak distribution prompts interactively).
+**1. `IntExpr` correctness cluster.** **DSL core + #300 + #426 ✅ shipped (PR #450).**
+A shared `Quantity` vocabulary (`CluesAtControllerLocation`, `EngagedEnemies`,
+`SkillTestFailedBy`) backs both `IntExpr::Count` (value) and `Condition::Compare`/
+`CmpOp` (predicate, retiring `LocationHasClues`); `Effect::Deal.amount` +
+`Effect::Fight.extra_damage` widened to `IntExpr` with `From`/`Into` builders
+(literals untouched). **#426** — Grasping Hands 01162 / Rotting Remains 01163 deal
+one `Count(SkillTestFailedBy)` instance (`ForEachPointFailed` deleted). **#300** —
+Machete is `+1` only vs the sole engaged enemy (`Compare(EngagedEnemies, Eq, 1)`);
+correct modelling, but its `+0` branch isn't *reachable* until activated `Effect::Fight`
+can resolve with 2+ engaged enemies (**#449** — give `Effect::Fight` a `Choose`-resolved
+target; a p1-next gate gap, separate from #401's basic-action fix).
+- **Remaining: #118 — Roland's elder-sign** ("+1 per clue on your location"). The
+  clue-*count* term `IntExpr::Count(Quantity::CluesAtControllerLocation)` already
+  ships (PR #450); #118 (PR 2) adds `Trigger::ElderSign` + the ST.4 firing path (the
+  bonus rides the chaos-token `Modifier` total path, sourced from the investigator
+  card — **not** `Effect::Modify`) + the investigator-card-handle bridge (spec §2).
+  His signature is in the "done" criteria.
 
 **2. #368 — before-discover eligibility (p1-next, needs-design).** Lift the
 hardcoded scan-suppression stand-ins (Cover Up 01007 `card.clues == 0`; act 01109

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -51,10 +51,12 @@ In dependency-friendly order.
 The dynamic-expression AST already ships (`IntExpr::{Lit, Cond}` over `Condition`,
 wired into `Effect::Fight.combat_modifier`; see Architecture). Each item *adds an
 `IntExpr` term + plumbs `IntExpr` into one more `Effect` field*:
-- **#118 — Roland's elder-sign** ("+1 per clue on your location"). Needs a
-  `Trigger::ElderSign` + ST.4 firing path, a clue-*count* `IntExpr` term (the
-  shipped `Condition::LocationHasClues` is binary; elder-sign is per-clue), and
-  `IntExpr` into `Effect::Modify` (`delta` is still `i8`). His signature is in the
+- **#118 — Roland's elder-sign** ("+1 per clue on your location"). The clue-*count*
+  modifier term — `IntExpr::Count(Quantity::CluesAtControllerLocation)` — now ships
+  (this cluster, replacing the old binary `LocationHasClues`). #118 adds
+  `Trigger::ElderSign` + the ST.4 firing path (the bonus rides the chaos-token
+  `Modifier` total path, sourced from the investigator card — **not** `Effect::Modify`)
+  + the investigator-card-handle bridge (spec §2; PR 2). His signature is in the
   "done" criteria.
 - **#300 — Machete** sole-engaged +1. Make `extra_damage` an `IntExpr` gated on a
   "sole engaged enemy" `Condition` (`EngagedEnemies == 1`). Activated `Effect::Fight`

--- a/docs/superpowers/plans/2026-06-24-intexpr-dsl-core-pr1.md
+++ b/docs/superpowers/plans/2026-06-24-intexpr-dsl-core-pr1.md
@@ -1,0 +1,494 @@
+# IntExpr DSL core + #426 + #300 (PR 1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the card DSL with state-reading dynamic values (`IntExpr::Count` over a shared `Quantity` vocabulary, `Condition::Compare`), then fix Grasping Hands / Rotting Remains (#426) and Machete (#300).
+
+**Architecture:** Add a `Quantity` enum read by one `eval_quantity` helper that backs both `IntExpr::Count` (value) and `Condition::Compare` (predicate). Widen the `Deal.amount` / `Fight.extra_damage` effect fields to `IntExpr` with `From`/`Into` builders so existing literal call-sites are untouched. Migrate the two failure-margin treacheries to a single `Count(SkillTestFailedBy)` deal and delete the now-dead `ForEachPointFailed`.
+
+**Tech Stack:** Rust workspace. DSL types in `crates/card-dsl`; evaluator in `crates/game-core`; cards in `crates/cards`.
+
+**Spec:** `docs/superpowers/specs/2026-06-24-intexpr-dynamic-value-cluster-design.md` (Sections 1 + 3). PR 2 (#118 + bridge, Section 2) is a separate plan.
+
+## Global Constraints
+
+- CI runs warnings-as-errors. Before any commit, the changed crates must pass: `RUSTFLAGS="-D warnings" cargo test --all --all-features` and `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check`.
+- DSL crate (`card-dsl`) is pure data — no I/O, no engine logic. `Quantity`/`CmpOp`/`IntExpr`/`Condition` derive `Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize` (match the existing `IntExpr` derives, `crates/card-dsl/src/dsl.rs:1101`).
+- Never hand-edit `crates/cards/src/generated/`. The cards touched here are hand-written impls under `crates/cards/src/impls/`.
+- Branch: `engine/intexpr-dynamic-values` (already created; the design commit is already on it).
+
+## File Structure
+
+- `crates/card-dsl/src/dsl.rs` — add `Quantity`, `CmpOp`; add `IntExpr::Count`; replace `Condition::LocationHasClues` with `Condition::Compare`; add `From<i8>/From<u8> for IntExpr`; widen `Effect::Deal.amount` + `Effect::Fight.extra_damage` to `IntExpr`; update `deal_damage`/`deal_horror`/`fight` builders to `impl Into<IntExpr>`; delete `Effect::ForEachPointFailed` + `for_each_point_failed`.
+- `crates/game-core/src/engine/evaluator.rs` — add `eval_quantity`; thread `&EvalContext` into `eval_int_expr`/`eval_condition`; add the `Count`/`Compare` arms; eval `Deal.amount`/`Fight.extra_damage`; delete the `ForEachPointFailed` frame arms.
+- `crates/game-core/src/state/game_state.rs` — delete `EffectFrame::ForEachPointFailed`.
+- `crates/cards/src/impls/roland_38_special.rs` — migrate `LocationHasClues` → `Compare`.
+- `crates/cards/src/impls/grasping_hands.rs`, `rotting_remains.rs` — `Count(SkillTestFailedBy)`.
+- `crates/cards/src/impls/machete.rs` — conditional `extra_damage`.
+
+---
+
+### Task 1: `Quantity` + `CmpOp` enums and the `eval_quantity` helper
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs` (after the `Condition` enum, ~line 1095)
+- Modify: `crates/game-core/src/engine/evaluator.rs` (thread `&EvalContext`; add `eval_quantity`)
+
+**Interfaces:**
+- Produces: `card_dsl::dsl::Quantity { CluesAtControllerLocation, EngagedEnemies, SkillTestFailedBy }`, `card_dsl::dsl::CmpOp { Eq, Ne, Lt, Le, Gt, Ge }`.
+- Produces: `fn eval_quantity(state: &GameState, eval_ctx: &EvalContext, q: Quantity) -> i8` (private to `evaluator.rs`).
+- Produces (changed): `fn eval_int_expr(state: &GameState, eval_ctx: &EvalContext, expr: &IntExpr) -> Result<i8, String>` and `fn eval_condition(state: &GameState, eval_ctx: &EvalContext, condition: &Condition) -> Result<bool, String>` — `controller` now read from `eval_ctx.controller`.
+
+- [ ] **Step 1: Add the enums to `dsl.rs`.** Immediately after the closing `}` of `enum Condition` (`dsl.rs:1095`):
+
+```rust
+/// A non-negative count read off game state, usable as a value
+/// ([`IntExpr::Count`]) or compared in a predicate ([`Condition::Compare`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Quantity {
+    /// Clues on the controller's current location.
+    CluesAtControllerLocation,
+    /// Enemies engaged with the controller.
+    EngagedEnemies,
+    /// Failure margin of the resolving skill test (0 outside one).
+    SkillTestFailedBy,
+}
+
+/// Comparison operator for [`Condition::Compare`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum CmpOp {
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+}
+```
+
+- [ ] **Step 2: Build (types only).**
+
+Run: `cargo build -p card-dsl`
+Expected: PASS (new enums unused yet — they're `pub`, no dead-code warning).
+
+- [ ] **Step 3: Write the failing `eval_quantity` test.** In `crates/game-core/src/engine/evaluator.rs` `#[cfg(test)]` module, add:
+
+```rust
+#[test]
+fn eval_quantity_reads_clues_engaged_and_margin() {
+    use card_dsl::dsl::Quantity;
+    // clues at location
+    let (state, inv) = state_with_cards_in_play(&[]);
+    let ctx = EvalContext::for_controller(inv);
+    // helper `with_clues(n)` already exists in this module; reuse it:
+    assert_eq!(eval_quantity(&with_clues(2), &ctx, Quantity::CluesAtControllerLocation), 2);
+    assert_eq!(eval_quantity(&with_clues(0), &ctx, Quantity::CluesAtControllerLocation), 0);
+    // failure margin from the ctx binding
+    let mut ctx2 = EvalContext::for_controller(inv);
+    ctx2.set_failed_by(3);
+    assert_eq!(eval_quantity(&state, &ctx2, Quantity::SkillTestFailedBy), 3);
+    assert_eq!(eval_quantity(&state, &ctx, Quantity::SkillTestFailedBy), 0);
+}
+```
+
+Note: `with_clues(n)` is the existing test helper used at `evaluator.rs:2230`; `state_with_cards_in_play` is at `evaluator.rs:3951`. If `with_clues` returns a state whose controller id differs from `inv`, use that state's controller id for `EvalContext::for_controller`.
+
+- [ ] **Step 4: Run it — verify it fails.**
+
+Run: `cargo test -p game-core eval_quantity_reads_clues_engaged_and_margin`
+Expected: FAIL — `eval_quantity` not found.
+
+- [ ] **Step 5: Thread `&EvalContext` into `eval_int_expr` / `eval_condition` and add `eval_quantity`.** In `evaluator.rs`:
+
+Change the signature of `eval_condition` (`:1046`) from `(state, controller: InvestigatorId, condition)` to:
+
+```rust
+fn eval_condition(
+    state: &GameState,
+    eval_ctx: &EvalContext,
+    condition: &Condition,
+) -> Result<bool, String> {
+```
+
+and inside it replace every use of `controller` with `eval_ctx.controller`. Change `eval_int_expr` (`:1089`) the same way (param `eval_ctx: &EvalContext`, body uses `eval_ctx.controller`); its `Cond` arm call becomes `eval_condition(state, eval_ctx, when)?`. Update the three callers:
+- `:447` `eval_condition(cx.state, eval_ctx.controller, condition)` → `eval_condition(cx.state, eval_ctx, condition)`
+- `:819` `eval_int_expr(cx.state, eval_ctx.controller, combat_modifier)` → `eval_int_expr(cx.state, eval_ctx, combat_modifier)`
+- `:873` `eval_int_expr(cx.state, eval_ctx.controller, shroud_modifier)` → `eval_int_expr(cx.state, eval_ctx, shroud_modifier)`
+
+Then add the helper (place it directly above `eval_int_expr`):
+
+```rust
+/// Resolve a [`Quantity`] against current state for the controller.
+/// Always non-negative; returned as `i8` to compose in [`IntExpr`].
+fn eval_quantity(state: &GameState, eval_ctx: &EvalContext, q: Quantity) -> i8 {
+    let controller = eval_ctx.controller;
+    let n: usize = match q {
+        Quantity::CluesAtControllerLocation => state
+            .investigators
+            .get(&controller)
+            .and_then(|inv| inv.current_location)
+            .and_then(|loc| state.locations.get(&loc))
+            .map_or(0, |l| usize::from(l.clues)),
+        Quantity::EngagedEnemies => state
+            .enemies
+            .values()
+            .filter(|e| e.engaged_with == Some(controller))
+            .count(),
+        Quantity::SkillTestFailedBy => usize::from(eval_ctx.failed_by().unwrap_or(0)),
+    };
+    i8::try_from(n).unwrap_or(i8::MAX)
+}
+```
+
+Add `Quantity` to the `card_dsl::dsl` import line at the top of `evaluator.rs` (the line importing `Condition, Effect, …`, `:63`).
+
+- [ ] **Step 6: Fix the two existing test call-sites.** At `evaluator.rs:2230` and `:2234`, the calls `eval_condition(&with_clues(1), inv_id, &Condition::LocationHasClues)` must become `eval_condition(&with_clues(1), &EvalContext::for_controller(inv_id), &Condition::Compare { quantity: Quantity::CluesAtControllerLocation, op: CmpOp::Gt, value: 0 })`. (These are migrated fully in Task 2; for now just change the signature to pass a context and keep `LocationHasClues` — i.e. `eval_condition(&with_clues(1), &EvalContext::for_controller(inv_id), &Condition::LocationHasClues)`.)
+
+- [ ] **Step 7: Run the new test + the crate.**
+
+Run: `cargo test -p game-core eval_quantity_reads_clues_engaged_and_margin`
+Expected: PASS.
+Run: `RUSTFLAGS="-D warnings" cargo test -p game-core`
+Expected: PASS.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add crates/card-dsl/src/dsl.rs crates/game-core/src/engine/evaluator.rs
+git commit -m "engine: Quantity vocabulary + eval_quantity; thread EvalContext into eval helpers"
+```
+
+---
+
+### Task 2: `IntExpr::Count` + `Condition::Compare` (retire `LocationHasClues`) + `From`/`Into`
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs`
+- Modify: `crates/game-core/src/engine/evaluator.rs`
+- Modify: `crates/cards/src/impls/roland_38_special.rs`
+
+**Interfaces:**
+- Produces: `IntExpr::Count(Quantity)`; `Condition::Compare { quantity: Quantity, op: CmpOp, value: i8 }`; `impl From<i8> for IntExpr` / `impl From<u8> for IntExpr`.
+- Consumes: `Quantity`, `CmpOp`, `eval_quantity` (Task 1).
+
+- [ ] **Step 1: Write the failing eval test.** In `evaluator.rs` tests:
+
+```rust
+#[test]
+fn eval_count_and_compare_over_clues() {
+    use card_dsl::dsl::{CmpOp, Condition, IntExpr, Quantity};
+    let (_s, inv) = state_with_cards_in_play(&[]);
+    let ctx = EvalContext::for_controller(inv);
+    // Count
+    assert_eq!(eval_int_expr(&with_clues(2), &ctx, &IntExpr::Count(Quantity::CluesAtControllerLocation)).unwrap(), 2);
+    // Compare: clues > 0
+    let has = Condition::Compare { quantity: Quantity::CluesAtControllerLocation, op: CmpOp::Gt, value: 0 };
+    assert!(eval_condition(&with_clues(1), &ctx, &has).unwrap());
+    assert!(!eval_condition(&with_clues(0), &ctx, &has).unwrap());
+}
+```
+
+- [ ] **Step 2: Run — verify it fails.**
+
+Run: `cargo test -p game-core eval_count_and_compare_over_clues`
+Expected: FAIL — `IntExpr::Count` / `Condition::Compare` not found.
+
+- [ ] **Step 3: Update the DSL types in `dsl.rs`.**
+
+In `enum IntExpr`, add a variant after `Cond { … }`:
+
+```rust
+    /// A state-read count ([`Quantity`]).
+    Count(Quantity),
+```
+
+In `enum Condition`, **delete** the `LocationHasClues` variant (`:1093-1094`) and add:
+
+```rust
+    /// Compare a [`Quantity`] against `value` under `op`.
+    /// Replaces the old `LocationHasClues` (now `Compare { CluesAtControllerLocation, Gt, 0 }`).
+    Compare {
+        quantity: Quantity,
+        op: CmpOp,
+        value: i8,
+    },
+```
+
+After the `impl IntExpr` block, add:
+
+```rust
+impl From<i8> for IntExpr {
+    fn from(n: i8) -> Self {
+        IntExpr::Lit(n)
+    }
+}
+
+impl From<u8> for IntExpr {
+    fn from(n: u8) -> Self {
+        IntExpr::Lit(i8::try_from(n).unwrap_or(i8::MAX))
+    }
+}
+```
+
+- [ ] **Step 4: Add the eval arms in `evaluator.rs`.**
+
+In `eval_int_expr`, add to the match: `IntExpr::Count(q) => Ok(eval_quantity(state, eval_ctx, *q)),`.
+
+In `eval_condition`, **remove** the `Condition::LocationHasClues => { … }` arm and add:
+
+```rust
+        Condition::Compare { quantity, op, value } => {
+            let lhs = eval_quantity(state, eval_ctx, *quantity);
+            let rhs = *value;
+            Ok(match op {
+                CmpOp::Eq => lhs == rhs,
+                CmpOp::Ne => lhs != rhs,
+                CmpOp::Lt => lhs < rhs,
+                CmpOp::Le => lhs <= rhs,
+                CmpOp::Gt => lhs > rhs,
+                CmpOp::Ge => lhs >= rhs,
+            })
+        }
+```
+
+Add `CmpOp` to the `card_dsl::dsl` import at the top of `evaluator.rs`.
+
+- [ ] **Step 5: Migrate .38 Special.** In `crates/cards/src/impls/roland_38_special.rs`, change the import to add `CmpOp, Condition, Quantity` and replace the ability:
+
+```rust
+        fight(IntExpr::cond(
+            Condition::Compare {
+                quantity: Quantity::CluesAtControllerLocation,
+                op: CmpOp::Gt,
+                value: 0,
+            },
+            3,
+            1,
+        ), 1),
+```
+
+Update its unit test assertion (`roland_38_special.rs:62`) to the same `Condition::Compare { … }` expression.
+
+- [ ] **Step 6: Migrate the Task-1 test stubs.** At the two call-sites edited in Task 1 Step 6 (`evaluator.rs` ~2230/2234), replace `&Condition::LocationHasClues` with `&Condition::Compare { quantity: Quantity::CluesAtControllerLocation, op: CmpOp::Gt, value: 0 }`.
+
+- [ ] **Step 7: Run tests.**
+
+Run: `cargo test -p game-core eval_count_and_compare_over_clues`
+Expected: PASS.
+Run: `RUSTFLAGS="-D warnings" cargo test -p game-core -p cards -p card-dsl`
+Expected: PASS (`LocationHasClues` fully gone; .38 Special behaviour identical).
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add crates/card-dsl/src/dsl.rs crates/game-core/src/engine/evaluator.rs crates/cards/src/impls/roland_38_special.rs
+git commit -m "engine: IntExpr::Count + Condition::Compare over Quantity; retire LocationHasClues"
+```
+
+---
+
+### Task 3: Widen `Deal.amount` + `Fight.extra_damage` to `IntExpr`
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs` (field types + builders)
+- Modify: `crates/game-core/src/engine/evaluator.rs` (eval the fields)
+
+**Interfaces:**
+- Produces (changed): `Effect::Deal { kind, target, amount: IntExpr }`; `Effect::Fight { combat_modifier: IntExpr, extra_damage: IntExpr }`; `deal_damage(target, amount: impl Into<IntExpr>)`, `deal_horror(target, amount: impl Into<IntExpr>)`, `fight(combat_modifier: impl Into<IntExpr>, extra_damage: impl Into<IntExpr>)`.
+
+- [ ] **Step 1: Write the failing test (dynamic Deal amount).** In `evaluator.rs` tests:
+
+```rust
+#[test]
+fn deal_amount_can_be_a_count_of_failure_margin() {
+    use card_dsl::dsl::{deal_damage, IntExpr, Quantity, InvestigatorTarget};
+    // Build a Deal whose amount is the failure margin, fail-by 2 -> 2 damage.
+    let effect = deal_damage(InvestigatorTarget::You, IntExpr::Count(Quantity::SkillTestFailedBy));
+    // (Drive it through the evaluator with a ctx whose failed_by = 2 and assert 2 damage.
+    //  Mirror the existing for_each_point_failed_scales_body_by_margin test at evaluator.rs:4499,
+    //  which sets ctx.set_failed_by(2) and asserts inv.damage == 2.)
+    let _ = effect;
+}
+```
+
+Replace the comment body with the same harness as `for_each_point_failed_scales_body_by_margin` (`evaluator.rs:4499`), substituting the `deal_damage(You, IntExpr::Count(SkillTestFailedBy))` effect and asserting `inv.damage == 2`.
+
+- [ ] **Step 2: Run — verify it fails to compile.**
+
+Run: `cargo test -p game-core deal_amount_can_be_a_count_of_failure_margin`
+Expected: FAIL — `deal_damage` second arg type mismatch (still `u8`).
+
+- [ ] **Step 3: Change the field types in `dsl.rs`.**
+
+`Effect::Deal.amount: u8` → `amount: IntExpr`. `Effect::Fight.extra_damage: u8` → `extra_damage: IntExpr`.
+
+Update builders:
+
+```rust
+pub fn deal_damage(target: InvestigatorTarget, amount: impl Into<IntExpr>) -> Effect {
+    Effect::Deal { kind: HarmKind::Damage, target, amount: amount.into() }
+}
+pub fn deal_horror(target: InvestigatorTarget, amount: impl Into<IntExpr>) -> Effect {
+    Effect::Deal { kind: HarmKind::Horror, target, amount: amount.into() }
+}
+pub fn fight(combat_modifier: impl Into<IntExpr>, extra_damage: impl Into<IntExpr>) -> Effect {
+    Effect::Fight { combat_modifier: combat_modifier.into(), extra_damage: extra_damage.into() }
+}
+```
+
+(Existing callers like `fight(IntExpr::Lit(1), 1)` keep working — `IntExpr` Into-s to itself, `1: u8/i8` Into-s via Task 2's `From`.)
+
+- [ ] **Step 4: Eval the fields in `evaluator.rs`.**
+
+`Deal` dispatch (`:420-424`): the arm currently passes `*amount` to `deal_effect(cx, eval_ctx, *kind, *target, *amount)`. Replace with an eval that clamps to `u8`:
+
+```rust
+        Effect::Deal { kind, target, amount } => {
+            let n = match eval_int_expr(cx.state, eval_ctx, amount) {
+                Ok(v) => u8::try_from(v.max(0)).unwrap_or(u8::MAX),
+                Err(reason) => return EngineOutcome::Rejected { reason: reason.into() },
+            };
+            deal_effect(cx, eval_ctx, *kind, *target, n)
+        }
+```
+
+`apply_fight` (`:806+`): `extra_damage: u8` param becomes `extra_damage: &IntExpr`; eval it next to `combat_modifier` (clamp to `u8` as above) before building the Fight follow-up that deals `1 + extra_damage`. Update the call-site that passes `extra_damage` into `apply_fight` to pass the `&IntExpr`.
+
+- [ ] **Step 5: Run tests.**
+
+Run: `cargo test -p game-core deal_amount_can_be_a_count_of_failure_margin`
+Expected: PASS.
+Run: `RUSTFLAGS="-D warnings" cargo test -p game-core -p cards -p card-dsl`
+Expected: PASS — existing literal call-sites (`.45 Automatic`, Knife, Flashlight, Machete, the deal-damage cards) compile via `Into`/`From` and behave identically.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add crates/card-dsl/src/dsl.rs crates/game-core/src/engine/evaluator.rs
+git commit -m "engine: widen Deal.amount + Fight.extra_damage to IntExpr (Into builders, literals untouched)"
+```
+
+---
+
+### Task 4: #426 — `Count(SkillTestFailedBy)` deals + delete `ForEachPointFailed`
+
+**Files:**
+- Modify: `crates/cards/src/impls/grasping_hands.rs`, `crates/cards/src/impls/rotting_remains.rs`
+- Modify: `crates/card-dsl/src/dsl.rs` (delete `Effect::ForEachPointFailed` + `for_each_point_failed`)
+- Modify: `crates/game-core/src/engine/evaluator.rs` (delete frame arms)
+- Modify: `crates/game-core/src/state/game_state.rs` (delete `EffectFrame::ForEachPointFailed`)
+
+**Interfaces:**
+- Consumes: `deal_damage`/`deal_horror` with `impl Into<IntExpr>` (Task 3); `IntExpr::Count` (Task 2).
+- Removes: `Effect::ForEachPointFailed`, `for_each_point_failed`, `EffectFrame::ForEachPointFailed`.
+
+- [ ] **Step 1: Update Grasping Hands.** In `grasping_hands.rs`, change the import (drop `for_each_point_failed`, add `IntExpr, Quantity`) and the effect:
+
+```rust
+        Some(deal_damage(
+            InvestigatorTarget::You,
+            IntExpr::Count(Quantity::SkillTestFailedBy),
+        )),
+```
+
+Rewrite its unit test (`revelation_tests_agility_3_then_damage_per_point`) to assert `on_fail` is `Some(Effect::Deal { kind: HarmKind::Damage, amount: IntExpr::Count(Quantity::SkillTestFailedBy), .. })`.
+
+- [ ] **Step 2: Update Rotting Remains** identically in `rotting_remains.rs` with `deal_horror(... Count(SkillTestFailedBy))` and `HarmKind::Horror`.
+
+- [ ] **Step 3: Add a card test proving one simultaneous N-instance.** In each card's tests, add a behaviour test (mirror `crates/cards/tests/` patterns, e.g. `grasping_hands` integration if present, else an engine-level drive): fail the test by 2 → assert exactly 2 damage/horror applied and a single `Deal` resolution (no per-point loop). If the card has an integration test file under `crates/cards/tests/`, add the assertion there; otherwise assert via the evaluator harness used in Task 3 Step 1.
+
+- [ ] **Step 4: Run — the two cards still compile against the (about-to-be-removed) `ForEachPointFailed`? No — they no longer reference it.**
+
+Run: `cargo test -p cards grasping rotting`
+Expected: PASS for the two card unit tests.
+
+- [ ] **Step 5: Delete `ForEachPointFailed`.**
+- `dsl.rs`: delete the `ForEachPointFailed(Box<Effect>)` variant (`:657`) and the `for_each_point_failed` builder (`:1513-1515`).
+- `game_state.rs`: delete the `EffectFrame::ForEachPointFailed { … }` variant (`:713`).
+- `evaluator.rs`: delete the `Effect::ForEachPointFailed(body) => EffectFrame::ForEachPointFailed { … }` arm in `frame_of` (`:321`); delete the `EffectFrame::ForEachPointFailed { remaining, body, ctx } => { … }` driver arm (`:359`); in the `Effect::Seq(_) | Effect::ForEachPointFailed(_) =>` arm (`:433`) drop the `| Effect::ForEachPointFailed(_)` so it reads `Effect::Seq(_) =>`.
+- Delete the now-orphaned tests `for_each_point_failed_scales_body_by_margin` (`:4499`) and `for_each_point_failed_with_no_margin_is_a_noop` (`:4523`) — their coverage moved to Task 1/Task 3 (`eval_quantity` margin + dynamic `Deal`). Remove `for_each_point_failed` from the test import at `evaluator.rs:2104`.
+
+**Keep** `EvalContext::failed_by` / `set_failed_by` / `SkillTestBinding` — now consumed by `Quantity::SkillTestFailedBy`.
+
+- [ ] **Step 6: Run the strict gauntlet for the touched crates.**
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: PASS — no `ForEachPointFailed` references remain; clippy/dead-code clean.
+Run: `cargo clippy --all-targets --all-features -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add crates/cards/src/impls/grasping_hands.rs crates/cards/src/impls/rotting_remains.rs crates/card-dsl/src/dsl.rs crates/game-core/src/engine/evaluator.rs crates/game-core/src/state/game_state.rs
+git commit -m "card: Grasping Hands/Rotting Remains deal one Count(SkillTestFailedBy) instance; delete ForEachPointFailed (#426)"
+```
+
+---
+
+### Task 5: #300 — Machete conditional `extra_damage`
+
+**Files:**
+- Modify: `crates/cards/src/impls/machete.rs`
+
+**Interfaces:**
+- Consumes: `fight(impl Into<IntExpr>, impl Into<IntExpr>)` (Task 3); `IntExpr::cond` + `Condition::Compare` + `Quantity::EngagedEnemies` (Tasks 1–2).
+
+- [ ] **Step 1: Write the failing behaviour test.** In `machete.rs` tests (or `crates/cards/tests/` if Machete has an integration file), add: with exactly one enemy engaged with the actor, a successful Machete Fight deals `1 + 1 = 2` damage; with two enemies engaged, it deals `1 + 0 = 1`. Build the state with `test_enemy` fixtures engaged to the actor (`engaged_with = Some(actor)`), drive the activated Fight, assert enemy damage. Also keep/adjust the existing structural unit test to assert `extra_damage == IntExpr::cond(Condition::Compare { quantity: Quantity::EngagedEnemies, op: CmpOp::Eq, value: 1 }, 1, 0)`.
+
+- [ ] **Step 2: Run — verify it fails.**
+
+Run: `cargo test -p cards machete`
+Expected: FAIL — current impl is unconditional `extra_damage: 1`.
+
+- [ ] **Step 3: Update the impl.** In `machete.rs`, change the import to add `CmpOp, Condition, Quantity` and:
+
+```rust
+pub fn abilities() -> Vec<Ability> {
+    vec![activated(
+        1,
+        vec![],
+        fight(
+            1,
+            IntExpr::cond(
+                Condition::Compare {
+                    quantity: Quantity::EngagedEnemies,
+                    op: CmpOp::Eq,
+                    value: 1,
+                },
+                1,
+                0,
+            ),
+        ),
+    )]
+}
+```
+
+Remove the unconditional-damage doc-comment / `TODO(#300)` in the module header.
+
+- [ ] **Step 4: Run tests.**
+
+Run: `cargo test -p cards machete`
+Expected: PASS — +1 damage only when the attacked enemy is the sole engaged one.
+
+- [ ] **Step 5: Full strict gauntlet.**
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features && cargo clippy --all-targets --all-features -- -D warnings && cargo fmt --check`
+Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add crates/cards/src/impls/machete.rs
+git commit -m "card: Machete deals +1 damage only vs the sole engaged enemy (#300)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Sections 1 + 3):** `Quantity` + `eval_quantity` (T1) · `IntExpr::Count` (T2) · `Condition::Compare`/`CmpOp` + retire `LocationHasClues` (T2) · `From`/`Into` builders (T2/T3) · widen `Deal.amount` + `extra_damage` (T3) · .38 Special migration (T2) · #426 + delete `ForEachPointFailed` (T4) · #300 (T5). Section 2 (#118 + bridge) is deliberately out — PR 2. ✓
+
+**Placeholder scan:** T4 Step 3 and T5 Step 1 describe behaviour tests by reference to existing harnesses rather than full code — acceptable because they reuse named, located patterns (`for_each_point_failed_scales_body_by_margin` at `:4499`; `test_enemy` fixtures). All type/DSL/card edits show complete code. ✓
+
+**Type consistency:** `eval_int_expr`/`eval_condition` gain `eval_ctx: &EvalContext` in T1 and are called that way in T2–T3. `Quantity`/`CmpOp` variant names match across dsl.rs and evaluator arms. Builder signatures (`impl Into<IntExpr>`) consistent T3→T4→T5. ✓

--- a/docs/superpowers/specs/2026-06-24-intexpr-dynamic-value-cluster-design.md
+++ b/docs/superpowers/specs/2026-06-24-intexpr-dynamic-value-cluster-design.md
@@ -113,7 +113,7 @@ Elder-signs that also run an *effect* (Daisy's per-Tome draw, Agnes's optional d
 
 ### #300 Machete (01020)
 
-`machete.rs`: `fight(1, cond(Compare(EngagedEnemies, Eq, 1), 1, 0))` — `extra_damage` is `+1` iff the attacked enemy is the sole engaged one. Drops the unconditional-damage `TODO(#300)`. Multi-target Fight (#401) already landed, so the condition is load-bearing.
+`machete.rs`: `fight(1, cond(Compare(EngagedEnemies, Eq, 1), 1, 0))` — `extra_damage` is `+1` iff the attacked enemy is the sole engaged one. Drops the unconditional-damage `TODO(#300)`. Activated `Effect::Fight` still requires exactly one engaged enemy (2+ engaged is rejected pre-cost); #401 (multi-target selection) has not yet landed. The `EngagedEnemies == 1` condition is therefore **correct modelling** of the card text, but its `+0` branch is **not yet reachable** — it becomes load-bearing once 2-engaged activated Fight lands with #401.
 
 ### #426 Grasping Hands (01162) / Rotting Remains (01163)
 

--- a/docs/superpowers/specs/2026-06-24-intexpr-dynamic-value-cluster-design.md
+++ b/docs/superpowers/specs/2026-06-24-intexpr-dynamic-value-cluster-design.md
@@ -1,0 +1,152 @@
+# IntExpr dynamic-value cluster — design
+
+**Date:** 2026-06-24
+**Issues:** #118 (Roland elder-sign), #300 (Machete), #426 (Grasping Hands / Rotting Remains). Related: #448 (investigator-card-as-permanent epic — retires #118's bridge).
+
+## Motivation
+
+Three p1-next gate-correctness issues all need the same thing: **board-state-dependent numeric values** the DSL can't yet express. The `IntExpr` AST (`Lit`/`Cond`) already feeds `Effect::Fight.combat_modifier` and `Effect::Investigate.shroud_modifier` (Roland's .38 Special 01006 is the live consumer), but it can't read *counts* off state, and the other numeric `Effect` fields are literal. This spec extends `IntExpr` minimally, unifies conditions over a shared count vocabulary, and applies it to the three cards.
+
+A corpus survey (Core + Dunwich Legacy) confirmed a broad future trajectory (per-clue/resource/horror modifiers, success/failure margins, clamp, multiply) but **none of Clamp/Scaled is exercised by these three** — so they're deferred. This stays inside the repo's "no speculative DSL primitives; wait for 2+ consumers" norm.
+
+## Section 1 — core model
+
+### `Quantity` — a shared state-reading vocabulary
+
+```rust
+pub enum Quantity {
+    /// Clues on the controller's current location.
+    CluesAtControllerLocation,
+    /// Enemies engaged with the controller.
+    EngagedEnemies,
+    /// Failure margin of the resolving skill test (0 outside one).
+    SkillTestFailedBy,
+}
+```
+
+Backed by one helper, used by **both** consumers below:
+
+```rust
+fn eval_quantity(state, ctx: &EvalContext, controller, q: Quantity) -> i8
+// CluesAtControllerLocation -> clues at controller's current location
+// EngagedEnemies            -> count of enemies engaged with controller
+// SkillTestFailedBy         -> ctx.failed_by().unwrap_or(0)   (existing plumbing, evaluator.rs:214)
+```
+
+### `IntExpr` grows one variant
+
+```rust
+pub enum IntExpr {
+    Lit(i8),
+    Cond { when: Condition, then: i8, otherwise: i8 },
+    Count(Quantity),   // NEW
+}
+```
+
+`Clamp`/`Scaled` (multiply, min/max) are **deferred** — real future consumers (Shotgun, Chicago Typewriter, "I've got a plan!"), none among these three. The enum stays open for them.
+
+### `Condition` — comparisons over `Quantity`
+
+Replace the bespoke `LocationHasClues` with a comparison, so one `Quantity` vocabulary serves both value and predicate roles:
+
+```rust
+pub enum Condition {
+    SkillTestKind(SkillTestKind),
+    SkillTest { outcome: TestOutcome },        // (unchanged; still stubbed)
+    Compare { quantity: Quantity, op: CmpOp, value: i8 },   // NEW (replaces LocationHasClues)
+}
+
+pub enum CmpOp { Eq, Ne, Lt, Le, Gt, Ge }
+```
+
+`CmpOp` is the full small closed set — trivial, total, zero-risk to evaluate, and saves re-touching when no-clues (`Eq 0`) / margin-threshold (`Ge N`) cards land.
+
+`eval_condition`'s `Compare` arm evaluates `eval_quantity(quantity)` against `value` under `op`. `IntExpr::Cond { when }` reuses the same `Condition`, so `Cond` automatically gains `Compare`.
+
+### Field widening + builder ergonomics
+
+Widen the numeric `Effect` fields these issues drive to `IntExpr`:
+- `Effect::Deal.amount: u8 -> IntExpr` (#426)
+- `Effect::Fight.extra_damage: u8 -> IntExpr` (#300)
+
+`Effect::Modify.delta` stays `i8` (the elder-sign does **not** route through `Modify` — see Section 2; no other consumer among these three).
+
+Add `From<i8>`/`From<u8> for IntExpr` (→ `IntExpr::Lit`) and make the builders (`fight`, `deal_damage`, `deal_horror`) take `impl Into<IntExpr>`. **Every existing flat call keeps compiling** (`deal_damage(You, 1)` auto-converts); literals stay bare, no `Lit(..)` noise.
+
+### Migrate the existing consumer
+
+.38 Special (01006): `cond(LocationHasClues, 3, 1)` → `cond(Compare(CluesAtControllerLocation, Gt, 0), 3, 1)`. Behaviour-preserving; update its test.
+
+## Section 2 — Roland's elder-sign (#118)
+
+### Architecture — the elder-sign is the investigator's symbol
+
+Symbol tokens source their outcome from the scenario (`resolve_symbol_token` → `SymbolOutcome { modifier, immediate, on_fail }`, then `Some(o) => TokenResolution::Modifier(o.modifier)`). The elder-sign is the **investigator's** symbol — same pipeline, sourced from the **investigator card** instead of the scenario. The bonus flows through the existing `Modifier` total path; **no** `Effect::ModifySkillTestTotal`.
+
+### Representation
+
+```rust
+Trigger::ElderSign { modifier: IntExpr }   // config-on-trigger, like Activated { action_cost }
+```
+
+Roland's `abilities()` (01001) gains `Trigger::ElderSign { modifier: IntExpr::Count(Quantity::CluesAtControllerLocation) }`. Reached through the existing `abilities_for` — no new registry pointer.
+
+### Firing path (ST.4)
+
+The `TokenResolution::ElderSign` arm (currently `+0`, `skill_test.rs:309`) calls `elder_sign_modifier(state, reg, controller)`, which looks up the controller's investigator card directly (via the bridge handle below), reads its `Trigger::ElderSign { modifier }`, returns `eval_int_expr(modifier)` — **0 if none** (every other investigator resolves exactly as today). The arm becomes `(skill_value.saturating_add(bonus).max(0), Total)`, keeping the `ElderSign` resolution label for observability.
+
+### The bridge (#118 scope; retired by #448)
+
+The investigator's own card code is currently **dropped at seating** (`phases.rs:75-94` builds `Investigator` with no `card_code` and `cards_in_play: Vec::new()`), so investigator-card abilities don't fire in a seated game — Roland's *reaction* only fires today because tests hand-inject the card (`evidence.rs:232`). #118 adds the minimal handle and **folds in the seated-reaction fix**:
+
+- `Investigator.card_code: CardCode` — set at seating from `RosterEntry.investigator`. Elder-sign looks it up directly (`abilities_for(card_code)` → the `Trigger::ElderSign` ability); no scan.
+- `Investigator.ability_usage: BTreeMap<u8, AbilityUsageRecord>` — mirrors `CardInPlay.ability_usage`, a usage-tracking home for usage-limited investigator-card abilities (Roland's reaction is once-per-round).
+- A `scan_investigator_card_reactions` source in the reaction scan, **mirroring `scan_act_agenda_reactions`** (`reaction_windows.rs:302`) — candidate keyed by code, the usage check/bump pointed at `Investigator.ability_usage`. Makes Roland's reaction fire from a seated investigator.
+
+The investigator card stays **out of `cards_in_play`**, so none of soak / asset-slot / discard logic sees it (no phantom-soaker hazard). **#448** later unifies the investigator card as a real `CardInPlay` (health/sanity/soak too), retiring `card_code` + `ability_usage` + the bespoke scan source into the uniform path — #118's bridge is deliberately small and documented as sunset-by-#448.
+
+### Deferred (doc-comment notes)
+
+Elder-signs that also run an *effect* (Daisy's per-Tome draw, Agnes's optional damage) — the inline path handles only the modifier; when the first lands, consider building a full `SymbolOutcome` from the investigator card for uniformity with the scenario path (and possibly `IntExpr`-ifying symbol effects so the scenario hard-codes less). Substitute-test / reveal-another-token elder-signs are also deferred. Roland is pure-modifier, so none of this is needed now.
+
+## Section 3 — applications + cleanup
+
+### #300 Machete (01020)
+
+`machete.rs`: `fight(1, cond(Compare(EngagedEnemies, Eq, 1), 1, 0))` — `extra_damage` is `+1` iff the attacked enemy is the sole engaged one. Drops the unconditional-damage `TODO(#300)`. Multi-target Fight (#401) already landed, so the condition is load-bearing.
+
+### #426 Grasping Hands (01162) / Rotting Remains (01163)
+
+`grasping_hands.rs`: `deal_damage(You, Count(SkillTestFailedBy))`; `rotting_remains.rs`: `deal_horror(You, Count(SkillTestFailedBy))`. This deals **one simultaneous N-point instance** (the correctness fix) instead of N separate 1-point deals.
+
+### Delete `ForEachPointFailed` (now dead)
+
+After the #426 migration, `Effect::ForEachPointFailed`'s only consumers were those two cards. Delete:
+- `Effect::ForEachPointFailed` + the `for_each_point_failed` builder (`dsl.rs:657,1513`)
+- `EffectFrame::ForEachPointFailed` + its evaluator arms (`game_state.rs:713`, `evaluator.rs:321,359,433`)
+- its tests (replaced by `eval_quantity(SkillTestFailedBy)` tests)
+
+**Keep** the `failed_by` / `SkillTestBinding` margin plumbing — now consumed by `Quantity::SkillTestFailedBy`. Net: the per-point-loop machinery is replaced by a count-valued `Deal`, simplifying the evaluator. (Required regardless — warnings-as-errors would flag the dead builder/variant.)
+
+## Testing
+
+- **Per-card:** Roland elder-sign at 0/1/2 clues at his location; Machete sole-engaged (+1 dmg) vs 2-engaged (no +1); Grasping/Rotting fail-by 0/1/2 → exactly N as one instance.
+- **Engine:** `eval_quantity` per term; `eval_condition` `Compare` (`Eq`/`Gt`); .38 Special migration byte-identical; elder-sign firing (`0` when no elder-sign ability); the seated-reaction fold-in (Roland's reaction fires from a seated investigator with no manual injection, and respects once-per-round via `ability_usage`).
+- **Integration:** Roland seated → elder-sign token → total gains his location's clue count; his reaction fires seated.
+
+## Scope / ordering
+
+Implementation slices, dependency-ordered:
+1. **DSL core** (Section 1): `Quantity` + `eval_quantity`, `IntExpr::Count`, `Condition::Compare` + `CmpOp`, field widening + `From`/`Into` builders, .38 Special migration.
+2. **#426** + delete `ForEachPointFailed`.
+3. **#300** (adds `EngagedEnemies` eval — already in `Quantity`).
+4. **#118** + the bridge (the larger slice: `Trigger::ElderSign`, the ST.4 firing path, `card_code`/`ability_usage`/seated-reaction scan source).
+
+Slices 2/3 are pure DSL with no investigator-card dependency; slice 4 carries the bridge.
+
+## Deferred / out of scope
+
+- `IntExpr::Clamp`, `IntExpr::Scaled` (multiply) — future consumers, none here.
+- `Cond` branches as `IntExpr` (margin-gated "N instead of M") — future (Deduction reprint 02150); cheap to add then.
+- More `Quantity` terms (resources, horror-on-character, success-margin, etc.) — added one at a time per consumer.
+- #448 (investigator-card-as-permanent) — retires #118's bridge; its own design.


### PR DESCRIPTION
First of two PRs implementing the IntExpr dynamic-value cluster (spec: `docs/superpowers/specs/2026-06-24-intexpr-dynamic-value-cluster-design.md`, Sections 1 + 3). PR 2 is #118 (Roland's elder-sign) + the investigator-card bridge.

## What this does

- **Shared `Quantity` vocabulary** (`CluesAtControllerLocation`, `EngagedEnemies`, `SkillTestFailedBy`) read by one `eval_quantity` helper, backing both `IntExpr::Count` (value) and a new `Condition::Compare { quantity, op, value }` + `CmpOp` (predicate) — retiring the bespoke `Condition::LocationHasClues`.
- **Widen** `Effect::Deal.amount` and `Effect::Fight.extra_damage` to `IntExpr`, with `From<i8>/From<u8>` + `impl Into<IntExpr>` builders so every existing literal call-site is untouched (`fight(1u8, 1u8)`, `deal_damage(You, 1u8)`).
- **#426** — Grasping Hands (01162) / Rotting Remains (01163) deal **one** `Count(SkillTestFailedBy)` instance instead of N per-point deals (the rules-correct "one simultaneous instance"); the now-dead `Effect::ForEachPointFailed` is deleted.
- **#300** — Machete (01020) deals `+1` damage only when the attacked enemy is the sole engaged one (`IntExpr::cond(Compare(EngagedEnemies, Eq, 1), 1, 0)`).

## Design decisions

- **Conditions are comparisons over the same `Quantity` vocabulary**, not bespoke predicates — `LocationHasClues` becomes `Compare(CluesAtControllerLocation, Gt, 0)`, Machete's gate is `Compare(EngagedEnemies, Eq, 1)`. One state-reading helper serves both value and predicate roles, and the surface grows one `Quantity` at a time.
- **`Clamp`/`Scaled` (min/max, multiply) deferred** — real future consumers (Shotgun, Chicago Typewriter) but none among these three; stays inside the no-speculative-primitives norm.
- **#300's `+0` branch is correct modelling but not yet reachable**: activated `Effect::Fight` still rejects 2+ engaged enemies (no target field; auto-picks the sole engaged one). That gap is now tracked as **#449** (give `Effect::Fight` a `Choose`-resolved target) — a separate p1-next gate issue. The structural test pins the conditional; the behaviour tests cover the reachable (sole-engaged) path.

## Testing

Per-card (Roland .38 Special byte-identical migration; Grasping/Rotting fail-by-2 → exactly one Deal of 2; Machete sole-engaged → 2 damage) + evaluator unit tests for `eval_quantity` / `Count` / `Compare`. Full gauntlet green: `cargo test --all`, `clippy -D warnings`, `fmt --check`, `cargo doc -D warnings`.

Closes #300
Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)