### PR TITLE
engine: Effect::Fight picks among engaged enemies (multi-target weapon activation)

### DIFF
--- a/crates/cards/src/impls/machete.rs
+++ b/crates/cards/src/impls/machete.rs
@@ -10,15 +10,11 @@
 //! enemy is the sole engaged enemy, encoded as
 //! `IntExpr::cond(EngagedEnemies == 1, 1, 0)`.
 //!
-//! Note: the `+0` branch is correct modelling but not yet *reachable*. This is
-//! not a Machete-specific limit — the engine cannot yet resolve **any**
-//! activated `Effect::Fight` while 2+ enemies are engaged (it auto-targets the
-//! single engaged enemy and rejects the ambiguous case pre-cost; multi-target
-//! attack-selection is the deferred work). Per the rules a Fight weapon *can*
-//! be activated against any one engaged enemy of several — so once that
-//! selection lands, Machete activates normally and `EngagedEnemies == 1` (not
-//! activation) gates the `+1`. Until then the condition always holds whenever
-//! the Fight resolves, so only the `+1` branch is exercised.
+//! Both branches are reachable: `Effect::Fight` picks among the engaged
+//! enemies (#449) — with one engaged it auto-targets (and `EngagedEnemies == 1`
+//! ⇒ `+1`); with two or more the player picks which to attack, and
+//! `EngagedEnemies` is then ≥ 2 ⇒ `+0`. The candidate scope is engaged-only for
+//! now (#451 widens it to any co-located enemy).
 
 use card_dsl::dsl::{activated, fight, Ability, CmpOp, Condition, IntExpr, Quantity};
 

--- a/crates/cards/tests/weapon_machete.rs
+++ b/crates/cards/tests/weapon_machete.rs
@@ -2,8 +2,10 @@
 //!
 //! Verifies that a successful Machete Fight deals `1 + 1 = 2` damage when the
 //! attacked enemy is the sole enemy engaged with the actor ("sole-engaged" bonus
-//! active), and that with two enemies engaged the activation is rejected by the
-//! engine's current pre-#401 gate (which defers multi-target selection).
+//! active), and covers the multi-target activation path (#449): with 2 enemies
+//! engaged the activation suspends for a target pick (`AwaitingInput`), and after
+//! resuming with the first enemy chosen the Fight resolves against that enemy
+//! for `1 + 0 = 1` damage (`extra_damage` is 0 because `EngagedEnemies` == 2).
 //!
 //! Own process → installs `cards::REGISTRY`.
 
@@ -18,7 +20,7 @@ use game_core::state::{
 use game_core::test_support::{
     apply_no_commits, test_enemy, test_investigator, test_location, GameStateBuilder,
 };
-use game_core::{assert_event, Action, PlayerAction};
+use game_core::{apply, assert_event, Action, InputResponse, OptionId, PlayerAction};
 
 const MACHETE: &str = "01020";
 const INV: InvestigatorId = InvestigatorId(1);
@@ -85,15 +87,69 @@ fn sole_engaged_enemy_gets_bonus_damage() {
     assert_eq!(r.state.enemies[&EnemyId(100)].damage, 2);
 }
 
-/// With two enemies engaged the activation is rejected by the pre-#401
-/// multi-target gate — nothing is charged and no damage is dealt.
-///
-/// Once multi-target Fight (#401) lands this test should be replaced with
-/// one that verifies the attack deals `1 + 0 = 1` damage (`extra_damage` is
-/// 0 because `EngagedEnemies` == 2, not 1).
+/// With two enemies engaged, activating Machete suspends for a target pick.
+/// After picking enemy 100 (OptionId(0)), the Fight resolves against it for
+/// `1 + 0 = 1` damage (`extra_damage` is 0 because `EngagedEnemies` == 2).
+/// Enemy 101 is untouched.
 #[test]
-fn two_enemies_engaged_activation_is_rejected() {
+fn two_enemies_engaged_suspends_for_pick_then_attacks_chosen() {
     let state = board(2);
+
+    // Step 1: activate → should suspend for enemy target pick (NOT rejected).
+    let r1 = apply(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: INV,
+            instance_id: MACHETE_INST,
+            ability_index: 0,
+        }),
+    );
+    assert!(
+        matches!(r1.outcome, EngineOutcome::AwaitingInput { .. }),
+        "expected AwaitingInput for target pick; got {:?}",
+        r1.outcome
+    );
+
+    // Step 2: pick enemy 100 (OptionId(0) — enemies in BTreeMap ascending order).
+    // Then drain the commit window (no commits) to Done.
+    let r2 = apply_no_commits(
+        r1.state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickSingle(OptionId(0)),
+        }),
+    );
+    assert_eq!(
+        r2.outcome,
+        EngineOutcome::Done,
+        "expected Done after pick + commit; got {:?}",
+        r2.outcome
+    );
+
+    // Enemy 100 (chosen) took 1 damage; enemy 101 (not chosen) took 0.
+    assert_event!(
+        r2.events,
+        Event::EnemyDamaged {
+            enemy: EnemyId(100),
+            amount: 1,
+            ..
+        }
+    );
+    assert_eq!(
+        r2.state.enemies[&EnemyId(100)].damage,
+        1,
+        "chosen enemy took 1 damage"
+    );
+    assert_eq!(
+        r2.state.enemies[&EnemyId(101)].damage,
+        0,
+        "unchosen enemy untouched"
+    );
+}
+
+/// With zero enemies engaged, the activation is rejected before any cost is paid.
+#[test]
+fn no_engaged_enemy_activation_is_rejected_precost() {
+    let state = board(0);
     let actions_before = state.investigators[&INV].actions_remaining;
     let r = activate_machete(state);
     assert!(

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -10,25 +10,19 @@ use crate::state::{
 
 use super::Cx;
 
-/// The single enemy currently engaged with `investigator`, or `None` if
-/// zero or 2+ are engaged. `Effect::Fight` auto-targets via this; the
-/// 2+ case is a deferred interactive choice (lands with the #212/#213
-/// interactive-choice cluster), so the activation check rejects it.
-pub(crate) fn single_engaged_enemy(
-    state: &GameState,
-    investigator: InvestigatorId,
-) -> Option<EnemyId> {
-    let mut engaged = state
+/// Every enemy currently engaged with `investigator`, in ascending [`EnemyId`]
+/// order (deterministic: `state.enemies` is a `BTreeMap`).
+///
+/// - 0 engaged → empty vec (activation gate rejects).
+/// - 1 engaged → singleton (auto-targeted, no suspend).
+/// - 2+ engaged → `resolve_grounded_choice` suspends for a `PickSingle`.
+pub(crate) fn engaged_enemies(state: &GameState, investigator: InvestigatorId) -> Vec<EnemyId> {
+    state
         .enemies
         .iter()
         .filter(|(_, e)| e.engaged_with == Some(investigator))
-        .map(|(id, _)| *id);
-    let first = engaged.next()?;
-    if engaged.next().is_some() {
-        None
-    } else {
-        Some(first)
-    }
+        .map(|(id, _)| *id)
+        .collect()
 }
 
 /// Enemies matching an [`EntityScope`](crate::dsl::EntityScope), in `BTreeMap`
@@ -1308,7 +1302,7 @@ pub(super) fn resume_attack_order_pick(
 #[cfg(test)]
 mod combat_tests {
     use super::super::Cx;
-    use super::single_engaged_enemy;
+    use super::engaged_enemies;
     use crate::engine::{EngineOutcome, OptionId};
     use crate::event::Event;
     use crate::state::{AttackLoopStage, Continuation, EnemyAttackSource, EnemyId, InvestigatorId};
@@ -1316,19 +1310,25 @@ mod combat_tests {
     use crate::{assert_event, assert_no_event};
 
     #[test]
-    fn single_engaged_enemy_some_for_one_none_for_zero_or_two() {
+    fn engaged_enemies_returns_all_in_ascending_id_order() {
         let inv_id = InvestigatorId(1);
         let mut e1 = test_enemy(100, "A");
         e1.engaged_with = Some(inv_id);
 
-        // Exactly one engaged → Some.
+        // Zero engaged → empty.
+        let s0 = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .build();
+        assert!(engaged_enemies(&s0, inv_id).is_empty());
+
+        // Exactly one engaged → singleton.
         let s1 = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_enemy(e1.clone())
             .build();
-        assert_eq!(single_engaged_enemy(&s1, inv_id), Some(EnemyId(100)));
+        assert_eq!(engaged_enemies(&s1, inv_id), vec![EnemyId(100)]);
 
-        // Two engaged → None (deferred multi-target selection).
+        // Two engaged → both ids in ascending EnemyId order.
         let mut e2 = test_enemy(101, "B");
         e2.engaged_with = Some(inv_id);
         let s2 = GameStateBuilder::new()
@@ -1336,13 +1336,10 @@ mod combat_tests {
             .with_enemy(e1)
             .with_enemy(e2)
             .build();
-        assert_eq!(single_engaged_enemy(&s2, inv_id), None);
-
-        // Zero engaged → None.
-        let s0 = GameStateBuilder::new()
-            .with_investigator(test_investigator(1))
-            .build();
-        assert_eq!(single_engaged_enemy(&s0, inv_id), None);
+        assert_eq!(
+            engaged_enemies(&s2, inv_id),
+            vec![EnemyId(100), EnemyId(101)]
+        );
     }
 
     #[test]

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -1376,8 +1376,8 @@ fn effect_initiates_fight(effect: &crate::dsl::Effect) -> bool {
 /// `any_fast_play_eligible` and `Effect::Fight` / `DealDamageToEnemy` can treat
 /// a missing target as an invariant violation.
 ///
-/// - **Fight:** needs exactly one engaged enemy (0 = no target; 2+ multi-target
-///   selection deferred to #212/#213).
+/// - **Fight:** needs ≥1 engaged enemy (0 = no target, rejected pre-cost;
+///   2+ suspends to a `PickSingle` target-pick in the evaluator).
 /// - **`DealDamageToEnemy`:** needs ≥1 enemy in the chosen scope (e.g. "at your
 ///   location"). ≥1 proceeds — 2+ suspends via the `Choose` resolver — so only
 ///   the empty case rejects here; this is why the effect is typed, not `Native`
@@ -1392,11 +1392,10 @@ fn check_effect_target_available(
     effect: &crate::dsl::Effect,
 ) -> Result<(), Cow<'static, str>> {
     if effect_initiates_fight(effect)
-        && super::combat::single_engaged_enemy(state, investigator).is_none()
+        && super::combat::engaged_enemies(state, investigator).is_empty()
     {
         return Err(
-            "ActivateAbility: a Fight ability needs exactly one engaged enemy \
-             (0 = no target; 2+ multi-target selection deferred with #212/#213)"
+            "ActivateAbility: a Fight ability needs an enemy engaged with you (none engaged)"
                 .into(),
         );
     }

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -791,12 +791,14 @@ fn boost_attack_damage_effect(cx: &mut Cx, amount: u8) -> EngineOutcome {
     EngineOutcome::Done
 }
 
-/// Resolve [`Effect::Fight`]: snapshot the combat modifier, auto-target
-/// the single engaged enemy, and start a Combat skill test (reusing the
-/// suspend/resume commit-window path) whose Fight follow-up deals
-/// `1 + extra_damage`. The activation check has already guaranteed
-/// exactly one engaged enemy, so a missing target here is a state-shape
-/// violation rejected loudly rather than silently no-oped.
+/// Resolve [`Effect::Fight`]: snapshot the combat modifier, read the target
+/// enemy from the evaluation context (grounded by `ground_chosen_targets`
+/// before this handler runs), and start a Combat skill test whose Fight
+/// follow-up deals `1 + extra_damage`. The activation check has already
+/// guaranteed ≥1 engaged enemy; `ground_chosen_targets` auto-selects on 1,
+/// suspends for a `PickSingle` on 2+, and `chosen_enemy()` is `None` only on
+/// 0 (caught pre-cost) — so a missing target here is a state-shape violation
+/// rejected loudly rather than silently no-oped.
 ///
 /// Both `combat_modifier` and `extra_damage` are evaluated from an
 /// `&IntExpr` (board-state-dependent AST, same path); `extra_damage` is
@@ -823,21 +825,21 @@ fn apply_fight(
             }
         }
     };
-    let Some(enemy_id) =
-        crate::engine::dispatch::combat::single_engaged_enemy(cx.state, eval_ctx.controller)
-    else {
+    // The target is bound by `ground_chosen_targets` before this handler
+    // runs; `None` here means 0 engaged enemies slipped past the pre-cost
+    // gate — reject defensively.
+    let Some(enemy_id) = eval_ctx.chosen_enemy() else {
         return EngineOutcome::Rejected {
-            reason: "Effect::Fight: expected exactly one engaged enemy (target check skipped?)"
-                .into(),
+            reason: "Effect::Fight: no engaged enemy chosen (target check skipped?)".into(),
         };
     };
-    // `enemy_id` came from `single_engaged_enemy` over this same map, so
+    // `enemy_id` came from `engaged_enemies` over this same map, so
     // it is present — a silent 0-difficulty default would mask corruption.
     let fight_difficulty = cx
         .state
         .enemies
         .get(&enemy_id)
-        .expect("single_engaged_enemy returned an id absent from state.enemies")
+        .expect("Fight chosen_enemy returned an id absent from state.enemies")
         .fight;
     crate::engine::dispatch::skill_test::start_skill_test(
         cx,
@@ -1575,6 +1577,12 @@ fn ground_chosen_targets(
         }
     }
 
+    if let Effect::Fight { .. } = effect {
+        if eval_ctx.chosen_enemy().is_none() {
+            return ground_engaged_enemy_choice(cx, eval_ctx);
+        }
+    }
+
     Ok(eval_ctx)
 }
 
@@ -1683,6 +1691,39 @@ fn ground_enemy_choice(
         &candidates,
         "Chosen enemy: no candidate in scope",
         "Choose an enemy",
+        |id| format!("{id:?}"),
+        |id| {
+            let mut ctx = eval_ctx;
+            ctx.set_chosen_enemy(id);
+            ctx.set_chosen_option(None);
+            ctx
+        },
+    )
+}
+
+/// Ground the [`Effect::Fight`] target against the engaged-enemy list.
+///
+/// Candidates are `combat::engaged_enemies` (all enemies engaged with the
+/// controller, in ascending [`EnemyId`] order). Delegates to
+/// [`resolve_grounded_choice`]:
+/// - 0 candidates → `Rejected` ("Fight: no enemy engaged").
+/// - 1 candidate → auto-bind (no suspend; preserves single-enemy behaviour).
+/// - 2+ candidates → suspend `AwaitingInput { PickSingle }`.
+///
+/// On resume the evaluator re-enters the same `Leaf` step; `chosen_option`
+/// is set and the right branch of `resolve_grounded_choice` picks from the
+/// same deterministic list.
+fn ground_engaged_enemy_choice(
+    cx: &mut Cx,
+    eval_ctx: EvalContext,
+) -> Result<EvalContext, EngineOutcome> {
+    let candidates =
+        crate::engine::dispatch::combat::engaged_enemies(cx.state, eval_ctx.controller);
+    resolve_grounded_choice(
+        eval_ctx,
+        &candidates,
+        "Fight: no enemy engaged",
+        "Choose an enemy to attack",
         |id| format!("{id:?}"),
         |id| {
             let mut ctx = eval_ctx;

--- a/crates/game-core/tests/weapon_fight.rs
+++ b/crates/game-core/tests/weapon_fight.rs
@@ -19,7 +19,7 @@ use game_core::state::{
     TokenModifiers,
 };
 use game_core::test_support::{apply_no_commits, test_enemy, test_investigator, GameStateBuilder};
-use game_core::{assert_event, Action, PlayerAction};
+use game_core::{apply, assert_event, Action, InputResponse, OptionId, PlayerAction};
 
 /// Mock firearm: `Uses (4 ammo)`, `[action] Spend 1 ammo: Fight. +1
 /// [combat], +1 damage.`
@@ -211,11 +211,15 @@ fn weapon_fight_rejects_when_no_enemy_engaged() {
 }
 
 #[test]
-fn weapon_fight_rejects_when_two_enemies_engaged() {
-    // 2+ engaged → deferred multi-target selection; reject, nothing charged.
+fn weapon_fight_with_two_enemies_suspends_for_pick_then_attacks_chosen() {
+    // 2+ engaged → suspends for target pick; after picking enemy 100
+    // (OptionId(0)), the Fight resolves for 1 + 1 = 2 damage (combat 3 + mod 1
+    // vs fight 3 → success; extra_damage == 1 because the weapon's `fight`
+    // hardcodes `1u8` as `extra_damage`, not "sole-engaged" conditional).
     let (state, id, weapon) = board_with_weapon(2);
-    let actions_before = state.investigators[&id].actions_remaining;
-    let result = apply_no_commits(
+
+    // Step 1: activation suspends for the target pick.
+    let r1 = apply(
         state,
         Action::Player(PlayerAction::ActivateAbility {
             investigator: id,
@@ -223,10 +227,36 @@ fn weapon_fight_rejects_when_two_enemies_engaged() {
             ability_index: 0,
         }),
     );
-    assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
-    assert_eq!(ammo_remaining(&result.state, id, weapon), 4);
-    assert_eq!(
-        result.state.investigators[&id].actions_remaining,
-        actions_before
+    assert!(
+        matches!(r1.outcome, EngineOutcome::AwaitingInput { .. }),
+        "expected AwaitingInput for target pick; got {:?}",
+        r1.outcome
     );
+
+    // Step 2: pick enemy 100 (OptionId(0)), then commit nothing to resolve the test.
+    let r2 = apply_no_commits(
+        r1.state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickSingle(OptionId(0)),
+        }),
+    );
+    assert_eq!(
+        r2.outcome,
+        EngineOutcome::Done,
+        "expected Done after pick + commit; got {:?}",
+        r2.outcome
+    );
+    // Enemy 100 was attacked (chosen); enemy 101 was not.
+    assert_event!(
+        r2.events,
+        Event::EnemyDamaged {
+            enemy: game_core::state::EnemyId(100),
+            amount: 2,
+            ..
+        }
+    );
+    assert_eq!(r2.state.enemies[&game_core::state::EnemyId(100)].damage, 2);
+    assert_eq!(r2.state.enemies[&game_core::state::EnemyId(101)].damage, 0);
+    // Ammo was spent on activation.
+    assert_eq!(ammo_remaining(&r2.state, id, weapon), 3);
 }

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -54,10 +54,12 @@ A shared `Quantity` vocabulary (`CluesAtControllerLocation`, `EngagedEnemies`,
 `Effect::Fight.extra_damage` widened to `IntExpr` with `From`/`Into` builders
 (literals untouched). **#426** — Grasping Hands 01162 / Rotting Remains 01163 deal
 one `Count(SkillTestFailedBy)` instance (`ForEachPointFailed` deleted). **#300** —
-Machete is `+1` only vs the sole engaged enemy (`Compare(EngagedEnemies, Eq, 1)`);
-correct modelling, but its `+0` branch isn't *reachable* until activated `Effect::Fight`
-can resolve with 2+ engaged enemies (**#449** — give `Effect::Fight` a `Choose`-resolved
-target; a p1-next gate gap, separate from #401's basic-action fix).
+Machete is `+1` only vs the sole engaged enemy (`Compare(EngagedEnemies, Eq, 1)`).
+**#449 ✅ shipped** — `Effect::Fight` now picks among the engaged enemies
+(auto-binds 1, suspends for a `PickSingle` on 2+; `single_engaged_enemy` retired),
+so an investigator swarmed by 2+ enemies can activate a weapon and Machete's `+0`
+branch is reachable. (#451 follows up: widen the candidate scope engaged → any
+co-located enemy, matching #401's basic-action fix.)
 - **Remaining: #118 — Roland's elder-sign** ("+1 per clue on your location"). The
   clue-*count* term `IntExpr::Count(Quantity::CluesAtControllerLocation)` already
   ships (PR #450); #118 (PR 2) adds `Trigger::ElderSign` + the ST.4 firing path (the


### PR DESCRIPTION
Fixes the gap where an investigator engaged with **2+ enemies cannot activate a Fight weapon** (Machete / .45 Automatic / .38 Special / Knife) against any of them — a real 1-player playability bug (getting swarmed by 2 Ghouls in The Gathering is routine).

## What this does

`Effect::Fight` now sources its target through the **existing enemy-choice machinery** (`resolve_grounded_choice`, the same suspend-for-pick path `Effect::DealDamageToEnemy` uses) instead of the old `single_engaged_enemy` auto-pick-or-reject:

- **0 engaged** → rejected pre-cost (unchanged).
- **1 engaged** → auto-binds, no prompt — **byte-for-byte the old behaviour** (all existing weapon Fights unchanged).
- **2+ engaged** → suspends for a `PickSingle` over the engaged enemies (ascending `EnemyId` order); the Fight resolves against the chosen one.

`single_engaged_enemy` is **retired** in favour of `engaged_enemies(state, controller) -> Vec<EnemyId>` (used by both the pre-cost gate and the target grounding).

## Design notes

- The fix is a surgical reuse: a new `Effect::Fight` arm in `ground_chosen_targets` calling `ground_engaged_enemy_choice`, structurally identical to the sibling `DealDamageToEnemy` arm. `apply_fight` reads `eval_ctx.chosen_enemy()` (the target is already threaded onto `SkillTestFollowUp::Fight`).
- **Candidate scope is engaged-only** for now; **#451** follows up to widen it to any co-located enemy (matching #401's basic-action fix) — out of scope here.
- This makes **#300**'s Machete `+0` branch reachable: with 2+ engaged, `EngagedEnemies != 1` ⇒ `+0`. The `weapon_machete.rs` test now drives activate → pick → attack and asserts the chosen enemy takes `1 + 0`, the other untouched.

## Testing

Per-card behaviour (Machete sole-engaged → 2 damage; 2-engaged → pick → 1 damage on the chosen, 0 on the other; 0-engaged → rejected pre-cost) + `weapon_fight.rs` multi-target test + `engaged_enemies` unit test. Full 7-job gauntlet green (host test/clippy/fmt/doc + wasm build/clippy). Reviewed on opus (all six correctness scrutiny points verified; 1-engaged path confirmed regression-free).

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)