### PR TITLE
engine: weapon Effect::Fight targets any co-located enemy, not only engaged ones (#451)

### DIFF
--- a/crates/cards/tests/weapon_38_special.rs
+++ b/crates/cards/tests/weapon_38_special.rs
@@ -44,6 +44,7 @@ fn board(loc_clues: u8) -> game_core::GameState {
     enemy.fight = 5;
     enemy.max_health = 3;
     enemy.engaged_with = Some(INV);
+    enemy.current_location = Some(LOC); // co-located: a weapon Fight targets enemies at your location
 
     let mut location = game_core::test_support::test_location(10, "Study");
     location.clues = loc_clues;

--- a/crates/cards/tests/weapon_machete.rs
+++ b/crates/cards/tests/weapon_machete.rs
@@ -60,6 +60,7 @@ fn board(enemy_count: u32) -> game_core::GameState {
         enemy.fight = 3;
         enemy.max_health = 3;
         enemy.engaged_with = Some(INV);
+        enemy.current_location = Some(LOC); // co-located: weapon Fight targets enemies at your location
         builder = builder.with_enemy(enemy);
     }
 
@@ -146,9 +147,10 @@ fn two_enemies_engaged_suspends_for_pick_then_attacks_chosen() {
     );
 }
 
-/// With zero enemies engaged, the activation is rejected before any cost is paid.
+/// With no enemy at your location, the activation is rejected before any cost
+/// is paid.
 #[test]
-fn no_engaged_enemy_activation_is_rejected_precost() {
+fn no_co_located_enemy_activation_is_rejected_precost() {
     let state = board(0);
     let actions_before = state.investigators[&INV].actions_remaining;
     let r = activate_machete(state);

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -10,19 +10,15 @@ use crate::state::{
 
 use super::Cx;
 
-/// Every enemy currently engaged with `investigator`, in ascending [`EnemyId`]
-/// order (deterministic: `state.enemies` is a `BTreeMap`).
-///
-/// - 0 engaged → empty vec (activation gate rejects).
-/// - 1 engaged → singleton (auto-targeted, no suspend).
-/// - 2+ engaged → `resolve_grounded_choice` suspends for a `PickSingle`.
-pub(crate) fn engaged_enemies(state: &GameState, investigator: InvestigatorId) -> Vec<EnemyId> {
-    state
-        .enemies
-        .iter()
-        .filter(|(_, e)| e.engaged_with == Some(investigator))
-        .map(|(id, _)| *id)
-        .collect()
+/// The scope of enemies a Fight (basic action or weapon `Effect::Fight`) may
+/// target: any enemy *at your location*. Per RR you choose an enemy at your
+/// location to attack and need not already be engaged, so this is co-located
+/// (`At(Here)`), not engaged-only (#451). Single source of truth shared by the
+/// activation pre-cost gate (`check_effect_target_available`) and the
+/// evaluator's target grounding (`ground_fight_target_choice`), so the two
+/// can't drift.
+pub(crate) fn fight_target_scope() -> crate::dsl::EntityScope {
+    crate::dsl::EntityScope::At(crate::dsl::LocationSet::Here)
 }
 
 /// Enemies matching an [`EntityScope`](crate::dsl::EntityScope), in `BTreeMap`
@@ -1302,45 +1298,11 @@ pub(super) fn resume_attack_order_pick(
 #[cfg(test)]
 mod combat_tests {
     use super::super::Cx;
-    use super::engaged_enemies;
     use crate::engine::{EngineOutcome, OptionId};
     use crate::event::Event;
     use crate::state::{AttackLoopStage, Continuation, EnemyAttackSource, EnemyId, InvestigatorId};
     use crate::test_support::{test_enemy, test_investigator, GameStateBuilder};
     use crate::{assert_event, assert_no_event};
-
-    #[test]
-    fn engaged_enemies_returns_all_in_ascending_id_order() {
-        let inv_id = InvestigatorId(1);
-        let mut e1 = test_enemy(100, "A");
-        e1.engaged_with = Some(inv_id);
-
-        // Zero engaged → empty.
-        let s0 = GameStateBuilder::new()
-            .with_investigator(test_investigator(1))
-            .build();
-        assert!(engaged_enemies(&s0, inv_id).is_empty());
-
-        // Exactly one engaged → singleton.
-        let s1 = GameStateBuilder::new()
-            .with_investigator(test_investigator(1))
-            .with_enemy(e1.clone())
-            .build();
-        assert_eq!(engaged_enemies(&s1, inv_id), vec![EnemyId(100)]);
-
-        // Two engaged → both ids in ascending EnemyId order.
-        let mut e2 = test_enemy(101, "B");
-        e2.engaged_with = Some(inv_id);
-        let s2 = GameStateBuilder::new()
-            .with_investigator(test_investigator(1))
-            .with_enemy(e1)
-            .with_enemy(e2)
-            .build();
-        assert_eq!(
-            engaged_enemies(&s2, inv_id),
-            vec![EnemyId(100), EnemyId(101)]
-        );
-    }
 
     #[test]
     fn defeating_victory_enemy_places_it_in_the_victory_display() {

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -1466,8 +1466,12 @@ fn effect_initiates_fight(effect: &crate::dsl::Effect) -> bool {
 /// `any_fast_play_eligible` and `Effect::Fight` / `DealDamageToEnemy` can treat
 /// a missing target as an invariant violation.
 ///
-/// - **Fight:** needs ≥1 engaged enemy (0 = no target, rejected pre-cost;
-///   2+ suspends to a `PickSingle` target-pick in the evaluator).
+/// - **Fight:** needs ≥1 enemy *at your location* (0 = no target, rejected
+///   pre-cost; 2+ suspends to a `PickSingle` target-pick in the evaluator).
+///   Scope is co-located, not engaged-only: per RR you choose an enemy at your
+///   location to attack and need not already be engaged (matches the basic
+///   Fight action — an Aloof enemy, or one engaged with another investigator
+///   in MP, is a legal weapon target). #451.
 /// - **`DealDamageToEnemy`:** needs ≥1 enemy in the chosen scope (e.g. "at your
 ///   location"). ≥1 proceeds — 2+ suspends via the `Choose` resolver — so only
 ///   the empty case rejects here; this is why the effect is typed, not `Native`
@@ -1482,10 +1486,11 @@ fn check_effect_target_available(
     effect: &crate::dsl::Effect,
 ) -> Result<(), Cow<'static, str>> {
     if effect_initiates_fight(effect)
-        && super::combat::engaged_enemies(state, investigator).is_empty()
+        && super::combat::enemies_in_scope(state, investigator, super::combat::fight_target_scope())
+            .is_empty()
     {
         return Err(
-            "ActivateAbility: a Fight ability needs an enemy engaged with you (none engaged)"
+            "ActivateAbility: a Fight ability needs an enemy at your location (none co-located)"
                 .into(),
         );
     }

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -795,7 +795,7 @@ fn boost_attack_damage_effect(cx: &mut Cx, amount: u8) -> EngineOutcome {
 /// enemy from the evaluation context (grounded by `ground_chosen_targets`
 /// before this handler runs), and start a Combat skill test whose Fight
 /// follow-up deals `1 + extra_damage`. The activation check has already
-/// guaranteed ≥1 engaged enemy; `ground_chosen_targets` auto-selects on 1,
+/// guaranteed ≥1 co-located enemy; `ground_chosen_targets` auto-selects on 1,
 /// suspends for a `PickSingle` on 2+, and `chosen_enemy()` is `None` only on
 /// 0 (caught pre-cost) — so a missing target here is a state-shape violation
 /// rejected loudly rather than silently no-oped.
@@ -826,14 +826,14 @@ fn apply_fight(
         }
     };
     // The target is bound by `ground_chosen_targets` before this handler
-    // runs; `None` here means 0 engaged enemies slipped past the pre-cost
+    // runs; `None` here means 0 co-located enemies slipped past the pre-cost
     // gate — reject defensively.
     let Some(enemy_id) = eval_ctx.chosen_enemy() else {
         return EngineOutcome::Rejected {
-            reason: "Effect::Fight: no engaged enemy chosen (target check skipped?)".into(),
+            reason: "Effect::Fight: no co-located enemy chosen (target check skipped?)".into(),
         };
     };
-    // `enemy_id` came from `engaged_enemies` over this same map, so
+    // `enemy_id` came from `enemies_in_scope` over this same map, so
     // it is present — a silent 0-difficulty default would mask corruption.
     let fight_difficulty = cx
         .state
@@ -1579,7 +1579,7 @@ fn ground_chosen_targets(
 
     if let Effect::Fight { .. } = effect {
         if eval_ctx.chosen_enemy().is_none() {
-            return ground_engaged_enemy_choice(cx, eval_ctx);
+            return ground_fight_target_choice(cx, eval_ctx);
         }
     }
 
@@ -1701,28 +1701,34 @@ fn ground_enemy_choice(
     )
 }
 
-/// Ground the [`Effect::Fight`] target against the engaged-enemy list.
+/// Ground the [`Effect::Fight`] target against the co-located-enemy list.
 ///
-/// Candidates are `combat::engaged_enemies` (all enemies engaged with the
-/// controller, in ascending [`EnemyId`] order). Delegates to
-/// [`resolve_grounded_choice`]:
-/// - 0 candidates → `Rejected` ("Fight: no enemy engaged").
+/// Candidates are `combat::enemies_in_scope` under
+/// [`combat::fight_target_scope`](crate::engine::dispatch::combat::fight_target_scope)
+/// — every enemy *at the controller's location* (not engaged-only), in
+/// ascending [`EnemyId`] order. Per RR you choose an enemy at your location to
+/// attack and need not already be engaged, matching the basic Fight action
+/// (#451). Delegates to [`resolve_grounded_choice`]:
+/// - 0 candidates → `Rejected` ("Fight: no enemy at your location").
 /// - 1 candidate → auto-bind (no suspend; preserves single-enemy behaviour).
 /// - 2+ candidates → suspend `AwaitingInput { PickSingle }`.
 ///
 /// On resume the evaluator re-enters the same `Leaf` step; `chosen_option`
 /// is set and the right branch of `resolve_grounded_choice` picks from the
 /// same deterministic list.
-fn ground_engaged_enemy_choice(
+fn ground_fight_target_choice(
     cx: &mut Cx,
     eval_ctx: EvalContext,
 ) -> Result<EvalContext, EngineOutcome> {
-    let candidates =
-        crate::engine::dispatch::combat::engaged_enemies(cx.state, eval_ctx.controller);
+    let candidates = crate::engine::dispatch::combat::enemies_in_scope(
+        cx.state,
+        eval_ctx.controller,
+        crate::engine::dispatch::combat::fight_target_scope(),
+    );
     resolve_grounded_choice(
         eval_ctx,
         &candidates,
-        "Fight: no enemy engaged",
+        "Fight: no enemy at your location",
         "Choose an enemy to attack",
         |id| format!("{id:?}"),
         |id| {

--- a/crates/game-core/tests/weapon_fight.rs
+++ b/crates/game-core/tests/weapon_fight.rs
@@ -15,10 +15,12 @@ use game_core::dsl::{activated, fight, Ability, Cost, IntExpr};
 use game_core::engine::EngineOutcome;
 use game_core::event::Event;
 use game_core::state::{
-    CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, InvestigatorId, Phase,
+    CardCode, CardInPlay, CardInstanceId, ChaosBag, ChaosToken, InvestigatorId, LocationId, Phase,
     TokenModifiers,
 };
-use game_core::test_support::{apply_no_commits, test_enemy, test_investigator, GameStateBuilder};
+use game_core::test_support::{
+    apply_no_commits, test_enemy, test_investigator, test_location, GameStateBuilder,
+};
 use game_core::{apply, assert_event, Action, InputResponse, OptionId, PlayerAction};
 
 /// Mock firearm: `Uses (4 ammo)`, `[action] Spend 1 ammo: Fight. +1
@@ -87,11 +89,28 @@ fn install_mock_registry() {
     });
 }
 
+/// The single location the controller and its enemies share. Co-location is
+/// load-bearing: a weapon Fight targets any enemy *at your location*
+/// (`EntityScope::At(Here)`), so the board must place everyone there.
+const LOC: LocationId = LocationId(1);
+
 /// Board: the weapon in play (instance 0) with a freshly-seeded 4-ammo
 /// pool, the controller active with combat 3 in the Investigation phase,
-/// engaged with `enemy_count` enemies (fight 3, health 3). A `Numeric(0)`
-/// chaos bag makes the combat total deterministic.
+/// at [`LOC`] and engaged with `enemy_count` enemies (fight 3, health 3) that
+/// are co-located there. A `Numeric(0)` chaos bag makes the combat total
+/// deterministic.
 fn board_with_weapon(enemy_count: u32) -> (game_core::GameState, InvestigatorId, CardInstanceId) {
+    board_with_enemies(enemy_count, true)
+}
+
+/// As [`board_with_weapon`], but `engaged` controls whether the co-located
+/// enemies are engaged with the controller. Unengaged-but-co-located is a
+/// legal weapon Fight target (an Aloof enemy, or one engaged with another
+/// investigator in MP) — #451.
+fn board_with_enemies(
+    enemy_count: u32,
+    engaged: bool,
+) -> (game_core::GameState, InvestigatorId, CardInstanceId) {
     install_mock_registry();
     let id = InvestigatorId(1);
     let weapon_inst = CardInstanceId(0);
@@ -105,16 +124,18 @@ fn board_with_weapon(enemy_count: u32) -> (game_core::GameState, InvestigatorId,
     let mut builder = GameStateBuilder::new()
         .with_phase(Phase::Investigation)
         .with_active_investigator(id)
+        .with_location(test_location(1, "Study"))
         .with_chaos_bag(ChaosBag::new([ChaosToken::Numeric(0)]))
         .with_token_modifiers(TokenModifiers::default());
     for n in 0..enemy_count {
         let mut enemy = test_enemy(100 + n, "Ghoul");
         enemy.fight = 3;
         enemy.max_health = 3;
-        enemy.engaged_with = Some(id);
+        enemy.current_location = Some(LOC);
+        enemy.engaged_with = engaged.then_some(id);
         builder = builder.with_enemy(enemy);
     }
-    let state = builder.with_investigator(inv).build();
+    let state = builder.with_investigator_at(inv, LOC).build();
     (state, id, weapon_inst)
 }
 
@@ -189,8 +210,101 @@ fn weapon_fight_spends_ammo_and_deals_bonus_damage() {
 }
 
 #[test]
-fn weapon_fight_rejects_when_no_enemy_engaged() {
-    // 0 engaged → illegal (no target); reject before charging anything.
+fn weapon_fight_targets_a_co_located_unengaged_enemy() {
+    // A co-located but unengaged enemy (e.g. Aloof, or engaged with another
+    // investigator in MP) is a legal weapon Fight target — RR: you choose an
+    // enemy *at your location* to attack; you need not already be engaged
+    // (#451). With exactly one such enemy the target auto-binds (no suspend),
+    // mirroring the single-engaged case.
+    let (state, id, weapon) = board_with_enemies(1, false);
+    assert_eq!(
+        state.enemies[&game_core::state::EnemyId(100)].engaged_with,
+        None,
+        "precondition: the enemy is co-located but NOT engaged"
+    );
+
+    let result = apply_no_commits(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id: weapon,
+            ability_index: 0,
+        }),
+    );
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_event!(result.events, Event::SkillTestStarted { difficulty: 3, .. });
+    assert_event!(
+        result.events,
+        Event::EnemyDamaged {
+            enemy: game_core::state::EnemyId(100),
+            amount: 2,
+            ..
+        }
+    );
+    assert_eq!(ammo_remaining(&result.state, id, weapon), 3);
+    assert_eq!(
+        result.state.enemies[&game_core::state::EnemyId(100)].damage,
+        2
+    );
+}
+
+#[test]
+fn weapon_fight_rejects_an_enemy_at_a_different_location() {
+    // The scope is co-located (`At(Here)`), NOT global: an enemy elsewhere is
+    // no target, even though it exists. Guards against widening past the basic
+    // Fight action (#451).
+    install_mock_registry();
+    let id = InvestigatorId(1);
+    let weapon_inst = CardInstanceId(0);
+    let other = LocationId(2);
+
+    let mut inv = test_investigator(1);
+    inv.skills.combat = 3;
+    let mut weapon = CardInPlay::enter_play(CardCode::new(WEAPON), weapon_inst);
+    weapon.uses.insert(UseKind::Ammo, 4);
+    inv.cards_in_play.push(weapon);
+
+    let mut enemy = test_enemy(100, "Ghoul");
+    enemy.fight = 3;
+    enemy.max_health = 3;
+    enemy.current_location = Some(other); // elsewhere, not the controller's LOC
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_active_investigator(id)
+        .with_location(test_location(1, "Study"))
+        .with_location(test_location(2, "Hallway"))
+        .with_enemy(enemy)
+        .with_investigator_at(inv, LOC)
+        .build();
+
+    let result = apply_no_commits(
+        state,
+        Action::Player(PlayerAction::ActivateAbility {
+            investigator: id,
+            instance_id: weapon_inst,
+            ability_index: 0,
+        }),
+    );
+    let EngineOutcome::Rejected { reason } = &result.outcome else {
+        panic!("expected Rejected; got {:?}", result.outcome);
+    };
+    assert!(
+        reason.contains("at your location"),
+        "should reject for the missing co-located target, not an unrelated \
+         precondition; got: {reason}"
+    );
+    assert_eq!(ammo_remaining(&result.state, id, weapon_inst), 4);
+    assert_eq!(
+        result.state.enemies[&game_core::state::EnemyId(100)].damage,
+        0
+    );
+}
+
+#[test]
+fn weapon_fight_rejects_when_no_co_located_enemy() {
+    // No enemy at your location → illegal (no target); reject before charging
+    // anything.
     let (state, id, weapon) = board_with_weapon(0);
     let actions_before = state.investigators[&id].actions_remaining;
     let result = apply_no_commits(

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -58,8 +58,11 @@ Machete is `+1` only vs the sole engaged enemy (`Compare(EngagedEnemies, Eq, 1)`
 **#449 ✅ shipped** — `Effect::Fight` now picks among the engaged enemies
 (auto-binds 1, suspends for a `PickSingle` on 2+; `single_engaged_enemy` retired),
 so an investigator swarmed by 2+ enemies can activate a weapon and Machete's `+0`
-branch is reachable. (#451 follows up: widen the candidate scope engaged → any
-co-located enemy, matching #401's basic-action fix.)
+branch is reachable. **#451 ✅ shipped (PR #455)** — widened that candidate scope
+engaged → any co-located enemy (`combat::fight_target_scope()` = `At(Here)`, shared
+by the pre-cost gate and the target grounding so they can't drift), matching #401's
+basic-action fix and Machete's FAQ (you *can* attack an Aloof / other-player-engaged
+enemy; you just forfeit the sole-engaged damage bonus).
 - **#118 — Roland's elder-sign ✅ shipped (PR #454).** `Trigger::ElderSign { modifier:
   IntExpr }` + an ST.4 firing path: the bonus rides the chaos-token `Modifier` total
   (sourced from the investigator card via `elder_sign_modifier` — **not** `Effect::Modify`).


### PR DESCRIPTION
## Summary

A weapon's `Effect::Fight` (Machete, .45 Automatic, .38 Special, Knife) only let you attack an enemy **engaged** with you, whereas the basic Fight action — fixed in #401 — already targets any enemy **at your location**. This widens the weapon path to match, so a co-located but non-engaged enemy (an Aloof enemy, or one engaged with another investigator in MP) can be attacked with a weapon.

## What changed

- New `combat::fight_target_scope()` → `EntityScope::At(LocationSet::Here)`, a **single source of truth** for the Fight legal-target set, consumed by both:
  - the pre-cost activation gate `check_effect_target_available` (`reaction_windows.rs`), and
  - the evaluator target grounding `ground_fight_target_choice` (`evaluator.rs`, renamed from `ground_engaged_enemy_choice`).
  Sharing one helper means the gate and the grounding can't drift.
- Both moved from `combat::engaged_enemies` (engaged-with-controller) to `combat::enemies_in_scope(…, fight_target_scope())` (co-located). Auto-bind-on-1 / suspend-on-2+ target selection is unchanged.
- Removed `combat::engaged_enemies` (and its unit test) — it had no other callers once both Fight sites moved off it. Its ascending-`EnemyId` ordering guarantee is now provided by `enemies_in_scope` (BTreeMap iteration) and still exercised by the two-enemy suspend test.

## Design / rules notes

- **Rules-correct, verified (not from memory):** RR p.12 — *"To fight an enemy at his or her location…"* — co-location, not engagement. Machete's ArkhamDB FAQ (01020) presupposes the widened behaviour: *"will not provide a damage bonus for attacking a disengaged enemy (evaded or **Aloof**), or an enemy engaged to another player."* You **can** fight such an enemy; you only forfeit the +1 damage bonus. The bonus's engagement check is a separate per-card concern and is **not** touched here.
- Widening is confined to Fight (`effect_initiates_fight` matches only `Effect::Fight`); `DealDamageToEnemy` keeps its own `choose.scope`. All other `engaged_with`-keyed sites (AoO, enemy-phase attacks, retaliate/elimination, `Quantity::EngagedEnemies`) are genuinely engagement-keyed and left untouched.

## Test notes

- Test boards in `weapon_fight.rs`, `weapon_machete.rs`, `weapon_38_special.rs` previously left `enemy.current_location` unset (the engaged-only scope ignored location). They now co-locate enemies so the location-keyed scope is exercised realistically — harmless under the old code, required under the new.
- **New (`weapon_fight.rs`):**
  - `weapon_fight_targets_a_co_located_unengaged_enemy` — asserts `engaged_with == None` precondition, then a successful Fight that auto-binds the lone co-located enemy (would have failed under engaged-only).
  - `weapon_fight_rejects_an_enemy_at_a_different_location` — enemy elsewhere is rejected with reason "at your location", guarding against over-widening to global scope.
- Full local gauntlet green: `RUSTFLAGS=-D warnings` test, host clippy, fmt, doc, wasm build, wasm clippy. (wasm-test is headless-firefox only; this change is engine-only and compiles to wasm cleanly.)

## Linked issues

Closes #451.

🤖 Generated with [Claude Code](https://claude.com/claude-code)