### PR TITLE
engine: make formerly-#[serde(default)] state/DSL fields required on the wire (#453)

### DIFF
--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -549,15 +549,14 @@ pub enum UsagePeriod {
 #[non_exhaustive]
 pub struct Ability {
     pub trigger: Trigger,
-    /// Payment costs (besides action cost). Defaults to empty on
-    /// deserialize so older saved logs still load cleanly.
-    #[serde(default)]
+    /// Payment costs (besides action cost). Empty for abilities with no
+    /// non-action payment. Required on the wire (#453).
     pub costs: Vec<Cost>,
     pub effect: Effect,
     /// "Limit X per \[period\]" cap. `None` for abilities with no
-    /// printed cap. Defaults to `None` on deserialize so older saved
-    /// logs still load cleanly.
-    #[serde(default)]
+    /// printed cap. Stays implicitly optional (#453 per-field reassessment):
+    /// serde treats a missing `Option` field as `None`, the genuine
+    /// absent-by-design case.
     pub usage_limit: Option<UsageLimit>,
 }
 
@@ -2076,6 +2075,44 @@ mod tests {
             let recovered: Ability = serde_json::from_str(&json).expect("deserialize");
             assert_eq!(original, recovered);
         }
+    }
+
+    #[test]
+    fn omitting_any_required_ability_field_is_rejected() {
+        // `costs` is required on the wire (#453): a payload missing it fails
+        // loudly rather than silently defaulting. `usage_limit` is an `Option`
+        // and stays implicitly optional (handled separately below).
+        let ability = on_event(
+            EventPattern::EnemyDefeated {
+                by_controller: true,
+                code: None,
+            },
+            EventTiming::When,
+            TriggerKind::Reaction,
+            discover_clue(LocationTarget::YourLocation, 1),
+        );
+        let full = serde_json::to_value(&ability).expect("serialize");
+        serde_json::from_value::<Ability>(full.clone()).expect("full object deserializes");
+        // `costs` is required; omitting it is rejected, not defaulted.
+        let mut v = full.clone();
+        v.as_object_mut()
+            .expect("ability serializes to a JSON object")
+            .remove("costs")
+            .expect("`costs` present in serialized form");
+        assert!(
+            serde_json::from_value::<Ability>(v).is_err(),
+            "omitting `costs` must be rejected, not defaulted"
+        );
+        // `usage_limit` stays implicitly optional (it is an `Option`; serde
+        // defaults a missing one to `None`) — by design, see its doc.
+        let mut v = full;
+        v.as_object_mut()
+            .unwrap()
+            .remove("usage_limit")
+            .expect("present in serialized form");
+        let back =
+            serde_json::from_value::<Ability>(v).expect("absent Option deserializes to None");
+        assert!(back.usage_limit.is_none());
     }
 
     /// `Trigger::ElderSign` is a config-on-trigger variant (like

--- a/crates/game-core/src/state/card.rs
+++ b/crates/game-core/src/state/card.rs
@@ -136,9 +136,8 @@ pub struct CardInPlay {
     pub accumulated_horror: u8,
     /// Clues sitting on this card instance (Cover Up 01007 enters the
     /// threat area "with 3 clues on it"). Distinct from the investigator
-    /// and location clue pools; defaults to 0. Most cards never carry
-    /// clues, so absent on the wire → 0.
-    #[serde(default)]
+    /// and location clue pools. Most cards never carry clues (0). Required
+    /// on the wire (#453).
     pub clues: u8,
     /// Per-ability usage counter for "Limit X per \[period\]" caps. Key
     /// is the ability index within the card's `abilities()`; value
@@ -152,10 +151,10 @@ pub struct CardInPlay {
     /// no round-cycling framework yet — rounds tick by a test or future
     /// scenario action mutating `state.round`.
     ///
-    /// Empty for cards with no [`UsageLimit`] on any ability.
+    /// Empty for cards with no [`UsageLimit`] on any ability. Required on the
+    /// wire (#453).
     ///
     /// [`UsageLimit`]: crate::dsl::UsageLimit
-    #[serde(default)]
     pub ability_usage: BTreeMap<u8, AbilityUsageRecord>,
 }
 
@@ -292,15 +291,22 @@ mod tests {
     }
 
     #[test]
-    fn card_in_play_deserializes_when_clues_field_absent() {
-        // A state serialized before `clues` existed must still load (field
-        // defaults to 0), mirroring the `ability_usage` serde-default test.
-        let json = r#"{
-            "code": "_x", "instance_id": 1, "exhausted": false,
-            "uses": {}, "accumulated_damage": 0, "accumulated_horror": 0,
-            "ability_usage": {}
-        }"#;
-        let c: CardInPlay = serde_json::from_str(json).expect("deserialize");
-        assert_eq!(c.clues, 0);
+    fn omitting_any_required_field_is_rejected() {
+        // `clues` and `ability_usage` are required on the wire (#453): a
+        // payload missing one fails loudly rather than silently defaulting.
+        let c = CardInPlay::enter_play(CardCode("_x".into()), CardInstanceId(1));
+        let full = serde_json::to_value(&c).expect("serialize");
+        serde_json::from_value::<CardInPlay>(full.clone()).expect("full object deserializes");
+        for field in ["clues", "ability_usage"] {
+            let mut v = full.clone();
+            v.as_object_mut()
+                .expect("card serializes to a JSON object")
+                .remove(field)
+                .unwrap_or_else(|| panic!("`{field}` should be present in the serialized form"));
+            assert!(
+                serde_json::from_value::<CardInPlay>(v).is_err(),
+                "omitting `{field}` must be rejected, not defaulted"
+            );
+        }
     }
 }

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -135,10 +135,8 @@ pub struct GameState {
     /// frame is resumed by `resolve_input`, taking priority over the
     /// legacy `pending_*` modes. Open reaction/fast windows live here as
     /// `TimingPointWindow` / `FastWindow` frames (the former `open_windows` Vec,
-    /// absorbed into the one stack). `#[serde(default)]` so pre-field
-    /// states still load. Inspect windows via [`Self::open_windows`] /
-    /// [`Self::top_window`].
-    #[serde(default)]
+    /// absorbed into the one stack). Required on the wire (#453). Inspect
+    /// windows via [`Self::open_windows`] / [`Self::top_window`].
     pub continuations: Vec<Continuation>,
     /// Identifier of the scenario this state belongs to, if any.
     ///
@@ -164,7 +162,7 @@ pub struct GameState {
     /// to skip the prevented impact (Axis D #336). A bool suffices because
     /// Before-windows do not nest in scope — exactly one cancellable impact is
     /// ever in flight. TODO(#367): typed marker once Before-windows can nest.
-    #[serde(default)]
+    /// Required on the wire (#453).
     pub pending_cancellation: bool,
     // The former `pending_revelation_discard: Option<CardCode>` side-channel is
     // removed (#380): a drawn treachery's disposal now rides a
@@ -181,13 +179,16 @@ pub struct GameState {
     /// moved onto the [`EncounterCard`](Continuation::EncounterCard) frame
     /// (a sibling side-channel, folded similarly in a future cycle). `None`
     /// outside an in-flight event play.
-    #[serde(default)]
+    ///
+    /// Stays implicitly optional (#453 per-field reassessment): serde treats a
+    /// missing `Option` field as `None`, and forcing presence would need a
+    /// custom `deserialize_with` not worth it for a field the live wire always
+    /// serializes. `None`-when-absent is the genuine absent-by-design case.
     pub pending_played_event: Option<(InvestigatorId, CardCode)>,
     /// Active round-scoped skill substitutions (Mind over Matter 01036).
     /// While present, the owning investigator may make a `for_skills` test as
     /// a `use_skill` test instead (offered at test initiation). Cleared at the
-    /// round boundary ("until the end of the round").
-    #[serde(default)]
+    /// round boundary ("until the end of the round"). Required on the wire (#453).
     pub skill_substitutions: Vec<SkillSubstitution>,
     /// Shared encounter deck (top = front). Built at scenario setup
     /// from encounter-set codes; drawn from during Mythos. When the
@@ -2010,18 +2011,39 @@ mod continuation_stack_tests {
     }
 
     #[test]
-    fn continuations_default_empty_and_absent_field_loads() {
+    fn omitting_any_required_field_is_rejected() {
+        // The non-`Option` formerly-`#[serde(default)]` fields are now required
+        // on the wire (#453): a payload missing one fails loudly rather than
+        // silently defaulting (e.g. an absent `continuations` would drop every
+        // open window). The `Option` field is handled separately below.
         let s = GameStateBuilder::new().build();
-        assert!(s.continuations.is_empty());
-
-        // A pre-field serialized state (no `continuations` key) still loads,
-        // defaulting to an empty stack (`#[serde(default)]`).
-        let mut v = serde_json::to_value(&s).expect("serialize");
+        let full = serde_json::to_value(&s).expect("serialize");
+        serde_json::from_value::<GameState>(full.clone()).expect("full object deserializes");
+        for field in [
+            "continuations",
+            "pending_cancellation",
+            "skill_substitutions",
+        ] {
+            let mut v = full.clone();
+            v.as_object_mut()
+                .expect("state serializes to a JSON object")
+                .remove(field)
+                .unwrap_or_else(|| panic!("`{field}` should be present in the serialized form"));
+            assert!(
+                serde_json::from_value::<GameState>(v).is_err(),
+                "omitting `{field}` must be rejected, not defaulted"
+            );
+        }
+        // `pending_played_event` stays implicitly optional (it is an `Option`;
+        // serde defaults a missing one to `None`) — by design, see its doc.
+        let mut v = full;
         v.as_object_mut()
-            .expect("state serializes to a JSON object")
-            .remove("continuations");
-        let back: GameState = serde_json::from_value(v).expect("deserialize without the field");
-        assert!(back.continuations.is_empty());
+            .unwrap()
+            .remove("pending_played_event")
+            .expect("present in serialized form");
+        let back =
+            serde_json::from_value::<GameState>(v).expect("absent Option deserializes to None");
+        assert!(back.pending_played_event.is_none());
     }
 
     #[test]

--- a/crates/game-core/src/state/investigator.rs
+++ b/crates/game-core/src/state/investigator.rs
@@ -45,12 +45,12 @@ pub struct Investigator {
     /// (`abilities_for(card_code)`). An empty sentinel (`CardCode::new("")`)
     /// marks the pre-seated `test_support` / builder path — codepaths skip
     /// empty codes, so those investigators carry no investigator-card
-    /// abilities. Defaults to empty for backward-compatible deserialization.
+    /// abilities. Required on the wire (#453): a payload omitting it is
+    /// rejected rather than silently degrading to the empty sentinel.
     ///
     /// **Bridge (#118), sunset by #448:** when the investigator card
     /// becomes a real `CardInPlay` (health/sanity/soak), this field and
     /// [`ability_usage`](Self::ability_usage) fold into the uniform path.
-    #[serde(default)]
     pub card_code: CardCode,
     /// Display name.
     pub name: String,
@@ -103,20 +103,16 @@ pub struct Investigator {
     /// cards there are at the investigator's location). Mirrors
     /// [`cards_in_play`](Self::cards_in_play) — same `CardInPlay`
     /// per-instance state — but holds scenario-bag content rather than
-    /// player cards. Defaults to empty for backward-compat: states
-    /// serialized before this field was added still deserialize.
+    /// player cards. Required on the wire (#453).
     ///
     /// [`cards_in_play`]: Self::cards_in_play
-    #[serde(default)]
     pub threat_area: Vec<CardInPlay>,
     /// Cards removed from the game (Rules Reference p.10, "Elimination,"
     /// step 1). When this investigator is eliminated, every card they
     /// control in play (`cards_in_play`) and every card they own in an
     /// out-of-play area (`hand`, `deck`, `discard`) is drained into this
     /// pile and removed from the game. Stays empty for Active
-    /// investigators. Defaults to empty for backward-compat: states
-    /// serialized before this field was added still deserialize.
-    #[serde(default)]
+    /// investigators. Required on the wire (#453).
     pub removed_from_game: Vec<CardCode>,
     /// Per-ability "Limit X per \[period\]" usage records for this
     /// investigator's **own card** abilities (Roland Banks's once-per-round
@@ -124,20 +120,18 @@ pub struct Investigator {
     /// card is not a `CardInPlay`, so it needs its own usage home. Keyed by
     /// ability index within the investigator card's `abilities()`. Lazy
     /// reset: a stale-round record reads as 0 (see [`CardInPlay::ability_usage`]
-    /// docs). Defaults to empty for backward-compatible deserialization.
+    /// docs). Required on the wire (#453).
     ///
     /// **Bridge (#118), sunset by #448:** retired when the investigator card
     /// becomes a real `CardInPlay`.
     ///
     /// [`CardInPlay::ability_usage`]: crate::state::CardInPlay::ability_usage
-    #[serde(default)]
     pub ability_usage: BTreeMap<u8, AbilityUsageRecord>,
     /// Source instances whose [`ExtraActionCost`](crate::dsl::Restriction::ExtraActionCost)
     /// with `first_each_round` has already surcharged an action this round
     /// (Frozen in Fear 01164). Cleared at the round boundary. Keyed by
-    /// instance so multiple surcharge sources track independently. Defaults
-    /// to empty for backward-compatible deserialization.
-    #[serde(default)]
+    /// instance so multiple surcharge sources track independently. Required
+    /// on the wire (#453).
     pub action_surcharge_spent_this_round: std::collections::BTreeSet<CardInstanceId>,
 }
 
@@ -227,19 +221,34 @@ mod threat_area_tests {
     }
 
     #[test]
-    fn deserializes_when_threat_area_field_absent() {
-        // A state serialized before `threat_area` existed must still
-        // parse (serde default), proving backward-compat.
-        let json = r#"{
-            "id": 1, "name": "Test", "current_location": null,
-            "skills": {"willpower":3,"intellect":3,"combat":3,"agility":3},
-            "max_health": 8, "damage": 0, "max_sanity": 8, "horror": 0,
-            "clues": 0, "resources": 0, "actions_remaining": 3,
-            "status": "Active", "deck": [], "hand": [], "discard": [],
-            "cards_in_play": []
-        }"#;
-        let inv: Investigator = serde_json::from_str(json).expect("deserialize");
-        assert!(inv.threat_area.is_empty());
+    fn omitting_any_required_field_is_rejected() {
+        // Every field is required on the wire (#453): a payload missing one
+        // fails loudly rather than silently defaulting. `card_code` in
+        // particular — an absent identity field must not degrade to the empty
+        // sentinel (which would silently disable that investigator's
+        // elder-sign + seated reaction).
+        let inv = crate::test_support::test_investigator(1);
+        let full = serde_json::to_value(&inv).expect("serialize");
+        // The complete object still round-trips.
+        serde_json::from_value::<Investigator>(full.clone()).expect("full object deserializes");
+        // Each formerly-`#[serde(default)]` field is now mandatory.
+        for field in [
+            "card_code",
+            "threat_area",
+            "removed_from_game",
+            "ability_usage",
+            "action_surcharge_spent_this_round",
+        ] {
+            let mut v = full.clone();
+            v.as_object_mut()
+                .expect("investigator serializes to a JSON object")
+                .remove(field)
+                .unwrap_or_else(|| panic!("`{field}` should be present in the serialized form"));
+            assert!(
+                serde_json::from_value::<Investigator>(v).is_err(),
+                "omitting `{field}` must be rejected, not defaulted"
+            );
+        }
     }
 
     #[test]
@@ -297,27 +306,9 @@ mod ability_usage_tests {
 
 #[cfg(test)]
 mod removed_from_game_tests {
-    use super::*;
-
     #[test]
     fn new_investigator_has_empty_removed_pile() {
         let inv = crate::test_support::test_investigator(1);
-        assert!(inv.removed_from_game.is_empty());
-    }
-
-    #[test]
-    fn deserializes_when_field_absent() {
-        // A JSON object missing `removed_from_game` must still parse
-        // (serde default), proving forward-compat for pre-field states.
-        let json = r#"{
-            "id": 1, "name": "Test", "current_location": null,
-            "skills": {"willpower":3,"intellect":3,"combat":3,"agility":3},
-            "max_health": 8, "damage": 0, "max_sanity": 8, "horror": 0,
-            "clues": 0, "resources": 0, "actions_remaining": 3,
-            "status": "Active", "deck": [], "hand": [], "discard": [],
-            "cards_in_play": []
-        }"#;
-        let inv: Investigator = serde_json::from_str(json).expect("deserialize");
         assert!(inv.removed_from_game.is_empty());
     }
 }

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -70,8 +70,13 @@ enemy; you just forfeit the sole-engaged damage bonus).
   `ability_usage` + a `scan_investigator_card_reactions` source / `CandidateSource::
   Investigator`), which also fixes Roland's **reaction** firing from a *seated*
   investigator (previously only via test card-injection). Bridge is sunset by **#448**;
-  **#453** tracks removing the `#[serde(default)]` convention the new fields follow.
-  His signature is in the "done" criteria.
+  **#453 ✅ shipped (PR #456)** removed the `#[serde(default)]` convention the new fields
+  follow — the non-`Option` fields are now required on the wire (a stale payload errors
+  rather than silently degrading `card_code` to the empty sentinel); the two `Option`
+  fields (`pending_played_event`, `usage_limit`) stay implicitly optional because serde
+  defaults a missing `Option` to `None` regardless, so #453's concern #2 for
+  `pending_played_event` is only partially met (forcing it needs a custom deserializer,
+  deferred). His signature is in the "done" criteria.
 
 **2. #368 — before-discover eligibility (p1-next, needs-design).** Lift the
 hardcoded scan-suppression stand-ins (Cover Up 01007 `card.clues == 0`; act 01109


### PR DESCRIPTION
## Summary

The ~13 fields carrying `#[serde(default)]` used it as a "backward-compatible deserialization for late-added fields" convention. That justification is **dormant** — persistence is event-sourced (the action log replays to re-derive state, including `card_code`), and state snapshots (#174) are deferred/unused, so nothing persists a struct serialized before a field existed. Meanwhile the convention **degrades silently instead of failing loudly**: defaulting a meaningful field (e.g. `Investigator.card_code` → empty sentinel) turns a malformed/stale payload into a subtly-wrong state. This makes the fields required on the wire.

## What changed

Removed `#[serde(default)]` from:
- `Investigator::{card_code, threat_area, removed_from_game, ability_usage, action_surcharge_spent_this_round}`
- `CardInPlay::{clues, ability_usage}`
- `GameState::{continuations, pending_cancellation, pending_played_event, skill_substitutions}`
- `Ability::{costs, usage_limit}`

Behaviour-preserving for the live path: the server always serializes a full `GameState` to the client, and action-log replay re-derives state — so only hand-omitted JSON-literal payloads now error.

## ⚠️ Scope caveat — the two `Option` fields stay optional

**serde defaults a *missing* `Option<T>` field to `None` regardless of `#[serde(default)]`.** So removing the attribute does **not** make `GameState::pending_played_event` or `Ability::usage_limit` required — they remain implicitly optional. Forcing presence would need a custom `deserialize_with`, disproportionate for fields the live wire always serializes and that #448 reworks.

**This means #453's concern #2 for `pending_played_event` (a stale payload silently yielding `None`) is only _partially_ addressed** — consciously deferred, not forced. It's documented on the field and asserted in its test. Flagging explicitly so the `Closes #453` below isn't read as "every field now fails loudly": the **non-`Option`** fields do; the two `Option` fields keep serde's absent-→-`None` semantics by design.

## Design notes

- **`card_code`** keeps its `CardCode` + empty-string sentinel (the "pre-seated test path" marker). The suggested `Option<CardCode>` redesign (issue's "Consider whether…") is left to **#448**, which deletes the field outright when the investigator card becomes a real `CardInPlay` — so investing in the `Option` refactor now would be throwaway.

## Test notes

- The four old "deserializes when field absent" tests (which asserted the *old* backward-compat behaviour) are rewritten to pin the *new* contract: serialize a real value (`test_investigator`, `CardInPlay::enter_play`, `GameStateBuilder::build`, a real `on_event` ability) → remove each required key → assert `from_value` errors. The `.expect()` on each `remove` also guards against a silent field rename.
- Each test adds a positive assertion that an absent `Option` field still deserializes to `None`, pinning the deliberate optionality.
- Field doc-comments drop the now-false "defaults to empty for backward-compat" claims.
- Full local gauntlet green: `RUSTFLAGS=-D warnings` test, host clippy, fmt, doc, wasm build, wasm clippy.

## Linked issues

Closes #453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)