### PR TITLE
engine: investigator-card-as-permanent — unify health/sanity/soak onto the investigator card (#448)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Thumbs.db
 *.db-journal
 *.db-wal
 *.db-shm
+
+# Subagent worktrees (never commit)
+.claude/worktrees/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3160,6 +3160,7 @@ dependencies = [
 name = "web"
 version = "0.1.0"
 dependencies = [
+ "cards",
  "console_error_panic_hook",
  "futures",
  "game-core",

--- a/crates/cards/src/impls/roland_banks.rs
+++ b/crates/cards/src/impls/roland_banks.rs
@@ -17,8 +17,8 @@
 //! `[elder_sign]`. The elder-sign is a [`Trigger::ElderSign`] carrying
 //! `IntExpr::Count(Quantity::CluesAtControllerLocation)` — "+1 for each clue
 //! on your location" — which the skill-test resolution adds to the total when
-//! Roland's elder-sign token is drawn (#118). Reached via the investigator-card
-//! bridge (`Investigator.card_code`); sunset by #448.
+//! Roland's elder-sign token is drawn (#118). Reached via
+//! `investigator_card.code` after the bridge fields were retired (#448 cp3b).
 //!
 //! The reaction compiles to a [`Trigger::OnEvent`] with the
 //! [`EventPattern::EnemyDefeated`] pattern narrowed by
@@ -47,7 +47,7 @@ pub const CODE: &str = "01001";
 ///
 /// - `[reaction]` "After you defeat an enemy: Discover 1 clue at your
 ///   location. (Limit once per round.)"
-/// - `[elder_sign]` effect: "+1 for each clue on your location." (#118)
+/// - `[elder_sign]` effect: "+1 for each clue on your location."
 #[must_use]
 pub fn abilities() -> Vec<Ability> {
     vec![

--- a/crates/cards/tests/activate_ability_aoo.rs
+++ b/crates/cards/tests/activate_ability_aoo.rs
@@ -350,7 +350,11 @@ fn dodge_cancels_the_activations_aoo_then_the_ability_effect_resumes() {
 
     let mut investigator = test_investigator(1);
     investigator.current_location = Some(loc);
-    investigator.damage = 2; // something for First Aid to heal
+    // Use a real investigator code so max_health()/max_sanity() can read from
+    // the installed cards registry (test_investigator uses TEST_INV which only
+    // the game-core test registry knows about, #448 cp2a).
+    investigator.investigator_card.code = CardCode::new("01003"); // Skids O'Toole: 8/6
+    investigator.investigator_card.accumulated_damage = 2; // something for First Aid to heal
     investigator.hand = vec![CardCode::new(DODGE)];
     let mut first_aid = CardInPlay::enter_play(CardCode::new(FIRST_AID), kit);
     first_aid.uses.insert(UseKind::Supplies, 3);
@@ -439,7 +443,10 @@ fn aoo_that_defeats_the_actor_suppresses_the_ability_effect() {
 
     let mut investigator = test_investigator(1);
     investigator.current_location = Some(loc);
-    investigator.damage = 2;
+    // Use a real investigator code so max_health()/max_sanity() can read from
+    // the installed cards registry (#448 cp2a).
+    investigator.investigator_card.code = CardCode::new("01003"); // Skids O'Toole: 8/6
+    investigator.investigator_card.accumulated_damage = 2;
     let mut first_aid = CardInPlay::enter_play(CardCode::new(FIRST_AID), kit);
     first_aid.uses.insert(UseKind::Supplies, 3);
     investigator.cards_in_play = vec![first_aid];

--- a/crates/cards/tests/activate_ability_aoo.rs
+++ b/crates/cards/tests/activate_ability_aoo.rs
@@ -176,7 +176,8 @@ fn activating_a_non_fight_ability_while_engaged_provokes_an_aoo() {
         "AoO damage from the activation soaked onto Guard Dog"
     );
     assert_eq!(
-        state.investigators[&inv_id].damage, 0,
+        state.investigators[&inv_id].damage(),
+        0,
         "investigator took no AoO damage (soaked onto Guard Dog)"
     );
     // First Aid spent its supply (the cost paid before the AoO).
@@ -251,7 +252,8 @@ fn activating_a_fight_ability_while_engaged_provokes_no_aoo() {
         "no AoO soaked onto Guard Dog"
     );
     assert_eq!(
-        state.investigators[&inv_id].damage, 0,
+        state.investigators[&inv_id].damage(),
+        0,
         "no AoO damage to the investigator"
     );
     // The activation went straight to the Fight skill test.
@@ -315,7 +317,8 @@ fn activating_a_fast_ability_while_engaged_provokes_no_aoo() {
         result.outcome
     );
     assert_eq!(
-        state.investigators[&inv_id].damage, 0,
+        state.investigators[&inv_id].damage(),
+        0,
         "no AoO damage to the investigator"
     );
     // The fast ability's own effect resolved: the enemy took 1 damage.
@@ -388,7 +391,8 @@ fn dodge_cancels_the_activations_aoo_then_the_ability_effect_resumes() {
     // The AoO was cancelled — no damage — and the activation resumed into First
     // Aid's heal choice (the effect ran after the window closed).
     assert_eq!(
-        state.investigators[&inv_id].damage, 2,
+        state.investigators[&inv_id].damage(),
+        2,
         "the cancelled AoO dealt no damage"
     );
     assert!(
@@ -407,7 +411,8 @@ fn dodge_cancels_the_activations_aoo_then_the_ability_effect_resumes() {
     );
     let state = result.state;
     assert_eq!(
-        state.investigators[&inv_id].damage, 1,
+        state.investigators[&inv_id].damage(),
+        1,
         "First Aid healed 1 damage after the AoO was dodged and the effect resumed"
     );
     assert!(

--- a/crates/cards/tests/agenda_reverses.rs
+++ b/crates/cards/tests/agenda_reverses.rs
@@ -30,8 +30,13 @@ fn install_registry() {
 fn agenda_01105_reverse_choice_lead_takes_two_horror() {
     install_registry();
     let lead = InvestigatorId(1);
+    let mut inv = test_investigator(1);
+    // Use a real investigator code so max_sanity() can read from the installed
+    // cards registry; TEST_INV is only known to the game-core test registry
+    // (#448 cp2a). Skids O'Toole (01003, 8/6) — no implemented abilities.
+    inv.investigator_card.code = CardCode::new("01003");
     let mut state = GameStateBuilder::new()
-        .with_investigator(test_investigator(1))
+        .with_investigator(inv)
         .with_turn_order([lead])
         .build();
     assert_eq!(state.investigators[&lead].horror(), 0);

--- a/crates/cards/tests/agenda_reverses.rs
+++ b/crates/cards/tests/agenda_reverses.rs
@@ -34,7 +34,7 @@ fn agenda_01105_reverse_choice_lead_takes_two_horror() {
         .with_investigator(test_investigator(1))
         .with_turn_order([lead])
         .build();
-    assert_eq!(state.investigators[&lead].horror, 0);
+    assert_eq!(state.investigators[&lead].horror(), 0);
 
     // Firing the reverse suspends on the lead's choice (Choice frame pushed).
     let mut events = Vec::new();
@@ -53,7 +53,8 @@ fn agenda_01105_reverse_choice_lead_takes_two_horror() {
     );
     assert_eq!(result.outcome, EngineOutcome::Done);
     assert_eq!(
-        result.state.investigators[&lead].horror, 2,
+        result.state.investigators[&lead].horror(),
+        2,
         "branch 1 deals 2 horror to the lead investigator",
     );
     assert!(
@@ -100,7 +101,8 @@ fn agenda_01105_reverse_choice_random_discard_each() {
         "the discarded card landed in the discard pile",
     );
     assert_eq!(
-        result.state.investigators[&lead].horror, 0,
+        result.state.investigators[&lead].horror(),
+        0,
         "no horror branch"
     );
 }

--- a/crates/cards/tests/barricade.rs
+++ b/crates/cards/tests/barricade.rs
@@ -99,6 +99,10 @@ fn playing_barricade_attaches_one_card_and_does_not_discard_the_event() {
 fn map_with_barricade_at_b(enemy_code: &str) -> game_core::GameState {
     install();
     let mut inv = test_investigator(1);
+    // Use a real investigator code so max_health()/max_sanity() can read from
+    // the installed cards registry; TEST_INV is only in the game-core test
+    // registry (#448 cp2a). Skids O'Toole (01003, 8/6) — no implemented abilities.
+    inv.investigator_card.code = CardCode::new("01003");
     inv.current_location = Some(B);
     let mut a = test_location(1, "A");
     a.connections = vec![B];

--- a/crates/cards/tests/dodge.rs
+++ b/crates/cards/tests/dodge.rs
@@ -94,7 +94,7 @@ fn dodge_cancels_enemy_phase_attack_no_damage_attacker_exhausts() {
         result.outcome
     );
     // No damage dealt yet (the attack hasn't resolved).
-    assert_eq!(state.investigators[&inv_id].damage, 0);
+    assert_eq!(state.investigators[&inv_id].damage(), 0);
 
     // Play Dodge (the single offered candidate) → cancel the attack.
     let result = apply(
@@ -106,7 +106,8 @@ fn dodge_cancels_enemy_phase_attack_no_damage_attacker_exhausts() {
     state = result.state;
 
     assert_eq!(
-        state.investigators[&inv_id].damage, 0,
+        state.investigators[&inv_id].damage(),
+        0,
         "the cancelled attack dealt no damage"
     );
     assert!(
@@ -171,7 +172,8 @@ fn declining_the_before_attack_window_lets_the_attack_land() {
         result.events
     );
     assert_eq!(
-        state.investigators[&inv_id].damage, 2,
+        state.investigators[&inv_id].damage(),
+        2,
         "investigator carries the 2 damage"
     );
     assert!(

--- a/crates/cards/tests/dodge.rs
+++ b/crates/cards/tests/dodge.rs
@@ -52,6 +52,10 @@ fn dodge_state() -> (GameState, InvestigatorId, EnemyId) {
 
     let mut inv = test_investigator(1);
     inv.current_location = Some(loc_id);
+    // Use a real investigator code so max_health()/max_sanity() can read from
+    // the installed cards registry; TEST_INV is only in the game-core test
+    // registry (#448 cp2a). Skids O'Toole (01003, 8/6) — no implemented abilities.
+    inv.investigator_card.code = CardCode::new("01003");
     inv.hand = vec![CardCode::new(DODGE)];
     // A spare deck card so the round-ending cascade's upkeep step-4.4 draw has
     // something to draw. Without it, the empty deck reshuffles the discard —

--- a/crates/cards/tests/dodge_aoo.rs
+++ b/crates/cards/tests/dodge_aoo.rs
@@ -120,6 +120,9 @@ fn dodge_cancels_attack_of_opportunity_no_damage_move_completes_attacker_not_exh
 
     let mut investigator = test_investigator(1);
     investigator.current_location = Some(from);
+    // Use a real investigator code so max_health()/max_sanity() can read from
+    // the installed cards registry (#448 cp2a). Skids O'Toole (01003, 8/6).
+    investigator.investigator_card.code = CardCode::new("01003");
     investigator.hand = vec![CardCode::new(DODGE)];
 
     let attacker = engaged_attacker(7, inv_id, from, 2, 3);
@@ -274,6 +277,9 @@ fn skipping_before_attack_window_lets_aoo_land_and_move_still_completes() {
 
     let mut investigator = test_investigator(1);
     investigator.current_location = Some(from);
+    // Use a real investigator code so max_health()/max_sanity() can read from
+    // the installed cards registry (#448 cp2a). Skids O'Toole (01003, 8/6).
+    investigator.investigator_card.code = CardCode::new("01003");
     investigator.hand = vec![CardCode::new(DODGE)];
 
     let attacker = engaged_attacker(7, inv_id, from, 2, 5);

--- a/crates/cards/tests/dodge_aoo.rs
+++ b/crates/cards/tests/dodge_aoo.rs
@@ -151,7 +151,7 @@ fn dodge_cancels_attack_of_opportunity_no_damage_move_completes_attacker_not_exh
         result.outcome
     );
     // No damage yet; move not yet completed.
-    assert_eq!(state.investigators[&inv_id].damage, 0);
+    assert_eq!(state.investigators[&inv_id].damage(), 0);
     assert_eq!(
         state.investigators[&inv_id].current_location,
         Some(from),
@@ -176,11 +176,13 @@ fn dodge_cancels_attack_of_opportunity_no_damage_move_completes_attacker_not_exh
 
     // The AoO was cancelled: no damage/horror dealt.
     assert_eq!(
-        state.investigators[&inv_id].damage, 0,
+        state.investigators[&inv_id].damage(),
+        0,
         "the cancelled AoO dealt no damage"
     );
     assert_eq!(
-        state.investigators[&inv_id].horror, 0,
+        state.investigators[&inv_id].horror(),
+        0,
         "the cancelled AoO dealt no horror"
     );
     assert!(
@@ -318,7 +320,7 @@ fn skipping_before_attack_window_lets_aoo_land_and_move_still_completes() {
         "the un-cancelled AoO dealt its 2 damage: {:?}",
         result.events
     );
-    assert_eq!(state.investigators[&inv_id].damage, 2);
+    assert_eq!(state.investigators[&inv_id].damage(), 2);
 
     // Attacker never exhausts (AoO rule, RR p.7).
     assert!(
@@ -430,7 +432,7 @@ fn guard_dog_retaliates_against_aoo_and_move_completes() {
         dog_in_play.accumulated_damage, 2,
         "AoO damage soaked onto Guard Dog"
     );
-    assert_eq!(state.investigators[&inv_id].damage, 0);
+    assert_eq!(state.investigators[&inv_id].damage(), 0);
     // Move not yet resolved (parked on ActionResolution).
     assert_eq!(
         state.investigators[&inv_id].current_location,

--- a/crates/cards/tests/dynamite_blast.rs
+++ b/crates/cards/tests/dynamite_blast.rs
@@ -61,9 +61,17 @@ fn board() -> game_core::GameState {
     let mut inv = test_investigator(1);
     inv.current_location = Some(LOC_A);
     inv.hand = vec![CardCode::new(DYNAMITE)];
+    // Use a real investigator code so max_health()/max_sanity() can read from
+    // the installed cards registry (#448 cp2a). Roland Banks (01001): 9/5.
+    // Use Skids O'Toole (01003, 8 health / 6 sanity) — real code so
+    // max_health()/max_sanity() can read from the installed cards registry
+    // (#448 cp2a), no implemented abilities so no reaction windows fire.
+    inv.investigator_card.code = CardCode::new("01003");
 
     let mut inv2 = test_investigator(2);
     inv2.current_location = Some(LOC_B);
+    // Same reason as inv above.
+    inv2.investigator_card.code = CardCode::new("01003");
 
     let mut loc_a = test_location(10, "Cellar");
     loc_a.connections = vec![LOC_B];
@@ -153,6 +161,8 @@ fn auto_targets_and_discards_when_your_location_is_the_only_candidate() {
     let mut inv = test_investigator(1);
     inv.current_location = Some(LOC_A);
     inv.hand = vec![CardCode::new(DYNAMITE)];
+    // Real investigator code so max_health() reads from the cards registry (#448 cp2a).
+    inv.investigator_card.code = CardCode::new("01003"); // Skids O'Toole: 8/6
 
     let loc_a = test_location(10, "Cellar"); // no connections
     let mut enemy_a = test_enemy(100, "Ghoul A");

--- a/crates/cards/tests/dynamite_blast.rs
+++ b/crates/cards/tests/dynamite_blast.rs
@@ -119,7 +119,8 @@ fn blasts_only_the_chosen_location_then_discards_the_event() {
         "enemy at the blasted location was defeated and removed",
     );
     assert_eq!(
-        r.state.investigators[&INV].damage, 3,
+        r.state.investigators[&INV].damage(),
+        3,
         "the controller blasted its own location and took 3",
     );
     // LOC_B (not chosen): untouched.
@@ -128,7 +129,8 @@ fn blasts_only_the_chosen_location_then_discards_the_event() {
         "enemy at LOC_B untouched"
     );
     assert_eq!(
-        r.state.investigators[&INV2].damage, 0,
+        r.state.investigators[&INV2].damage(),
+        0,
         "investigator at LOC_B untouched",
     );
 
@@ -173,7 +175,7 @@ fn auto_targets_and_discards_when_your_location_is_the_only_candidate() {
         "single candidate → no suspend"
     );
     assert_eq!(r.state.enemies[&ENEMY_A].damage, 3, "enemy took 3");
-    assert_eq!(r.state.investigators[&INV].damage, 3, "controller took 3");
+    assert_eq!(r.state.investigators[&INV].damage(), 3, "controller took 3");
     assert_eq!(
         r.state.investigators[&INV].discard,
         vec![CardCode::new(DYNAMITE)],

--- a/crates/cards/tests/dynamite_blast.rs
+++ b/crates/cards/tests/dynamite_blast.rs
@@ -61,8 +61,6 @@ fn board() -> game_core::GameState {
     let mut inv = test_investigator(1);
     inv.current_location = Some(LOC_A);
     inv.hand = vec![CardCode::new(DYNAMITE)];
-    // Use a real investigator code so max_health()/max_sanity() can read from
-    // the installed cards registry (#448 cp2a). Roland Banks (01001): 9/5.
     // Use Skids O'Toole (01003, 8 health / 6 sanity) — real code so
     // max_health()/max_sanity() can read from the installed cards registry
     // (#448 cp2a), no implemented abilities so no reaction windows fire.

--- a/crates/cards/tests/enumerate_actions.rs
+++ b/crates/cards/tests/enumerate_actions.rs
@@ -32,6 +32,9 @@ fn open_turn_state(hand: &[&str], in_play: Vec<CardInPlay>) -> game_core::GameSt
     install_real_registry();
     let mut inv = test_investigator(1);
     inv.current_location = Some(LOC);
+    // Real investigator code so max_health()/max_sanity() reads from the
+    // installed cards registry (#448 cp2a). Skids O'Toole (01003, 8/6).
+    inv.investigator_card.code = CardCode::new("01003");
     inv.actions_remaining = 3;
     inv.resources = 9;
     inv.hand = hand.iter().map(|c| CardCode::new(*c)).collect();

--- a/crates/cards/tests/first_aid.rs
+++ b/crates/cards/tests/first_aid.rs
@@ -33,8 +33,9 @@ fn install() {
 fn board(supplies: u8) -> game_core::GameState {
     install();
     let mut inv = test_investigator(1);
-    inv.damage = 2;
-    inv.horror = 2;
+    // Harm accumulates on the investigator card after #448 cp2a.
+    inv.investigator_card.accumulated_damage = 2;
+    inv.investigator_card.accumulated_horror = 2;
     let mut kit = CardInPlay::enter_play(CardCode::new(FIRST_AID), KIT_INST);
     kit.uses.insert(UseKind::Supplies, supplies);
     inv.cards_in_play.push(kit);

--- a/crates/cards/tests/first_aid.rs
+++ b/crates/cards/tests/first_aid.rs
@@ -87,8 +87,8 @@ fn spends_a_supply_and_heals_one_damage_when_the_damage_branch_is_chosen() {
     // auto-binds, so this completes.
     let r = pick(r.state, 0);
     assert_eq!(r.outcome, EngineOutcome::Done);
-    assert_eq!(r.state.investigators[&INV].damage, 1, "1 damage healed");
-    assert_eq!(r.state.investigators[&INV].horror, 2, "horror untouched");
+    assert_eq!(r.state.investigators[&INV].damage(), 1, "1 damage healed");
+    assert_eq!(r.state.investigators[&INV].horror(), 2, "horror untouched");
     assert_event!(
         r.events,
         Event::Healed {
@@ -107,8 +107,8 @@ fn heals_one_horror_when_the_horror_branch_is_chosen() {
     // Branch 1 = heal horror.
     let r = pick(r.state, 1);
     assert_eq!(r.outcome, EngineOutcome::Done);
-    assert_eq!(r.state.investigators[&INV].horror, 1, "1 horror healed");
-    assert_eq!(r.state.investigators[&INV].damage, 2, "damage untouched");
+    assert_eq!(r.state.investigators[&INV].horror(), 1, "1 horror healed");
+    assert_eq!(r.state.investigators[&INV].damage(), 2, "damage untouched");
     assert_event!(
         r.events,
         Event::Healed {
@@ -139,5 +139,9 @@ fn spending_the_last_supply_discards_first_aid() {
     // left play).
     let r = pick(r.state, 0);
     assert_eq!(r.outcome, EngineOutcome::Done);
-    assert_eq!(r.state.investigators[&INV].damage, 1, "heal still applied");
+    assert_eq!(
+        r.state.investigators[&INV].damage(),
+        1,
+        "heal still applied"
+    );
 }

--- a/crates/cards/tests/guard_dog_soak.rs
+++ b/crates/cards/tests/guard_dog_soak.rs
@@ -27,7 +27,7 @@ use game_core::engine::{apply, ApplyResult, EngineOutcome, OptionId};
 use game_core::event::Event;
 use game_core::state::{
     CardCode, CardInPlay, CardInstanceId, Continuation, Enemy, EnemyId, InvestigatorId, LocationId,
-    Phase, Zone,
+    Phase, Status, Zone,
 };
 use game_core::test_support::{test_enemy, test_investigator, test_location};
 use game_core::{Action, InputResponse, PlayerAction};
@@ -726,5 +726,210 @@ fn move_attack_of_opportunity_guard_dog_retaliates_and_move_completes() {
         state.open_windows().is_empty(),
         "no windows stranded after Guard Dog reaction + move resume: {:?}",
         state.open_windows()
+    );
+}
+
+// ---------------------------------------------------------------------
+// Case 6 — the investigator card is the mandatory-remainder soaker
+// (#448 cp2b). An asset soaks to capacity (and is defeated); the
+// remainder lands on the *investigator card* via its `accumulated_damage`
+// (not a bespoke field), exactly as the RR's "all damage that cannot be
+// assigned to an asset must be assigned to the investigator" clause
+// requires. This is the soaker-side half of the soak/defeat unification.
+// ---------------------------------------------------------------------
+
+#[test]
+fn an_asset_soaks_first_then_the_investigator_card_takes_the_remainder() {
+    let dog = CardInstanceId(1);
+    let inv = InvestigatorId(1);
+    let loc = LocationId(101);
+    // Attack deals 5 damage. Guard Dog (printed health 3) soaks 3 and is
+    // defeated by reaching its printed health; the remaining 2 must be
+    // assigned to the investigator — landing on the investigator card's
+    // `accumulated_damage`. Skids O'Toole (01003) has 8 health, so 2 < 8 →
+    // the investigator survives.
+    let (mut state, inv_id, _) = soak_state(
+        vec![(GUARD_DOG, dog)],
+        vec![engaged_attacker(7, inv, loc, 5, 3)],
+    );
+
+    let result = apply(state, Action::Player(PlayerAction::EndTurn));
+    // Distribute soak-first: fill Guard Dog to capacity (3), then the rest
+    // onto the investigator.
+    let result = distribute_onto(result, dog);
+    state = result.state;
+
+    // Guard Dog reached printed health → defeated and discarded from play.
+    assert!(
+        !state.investigators[&inv_id]
+            .cards_in_play
+            .iter()
+            .any(|c| c.instance_id == dog),
+        "Guard Dog at accumulated 3 >= health 3 is discarded"
+    );
+    assert!(
+        result.events.iter().any(|e| matches!(
+            e,
+            Event::CardDiscarded { code, from, .. }
+                if *code == CardCode::new(GUARD_DOG) && *from == Zone::InPlay
+        )),
+        "Guard Dog discard emitted: {:?}",
+        result.events
+    );
+    // The mandatory remainder (2) landed on the investigator *card* —
+    // `investigator_card.accumulated_damage`, surfaced via `damage()`.
+    assert_eq!(
+        state.investigators[&inv_id]
+            .investigator_card
+            .accumulated_damage,
+        2,
+        "the 2-damage remainder lands on the investigator card's accumulated_damage"
+    );
+    assert_eq!(
+        state.investigators[&inv_id].damage(),
+        2,
+        "damage() reads the investigator card's accumulated_damage"
+    );
+    // The investigator is not defeated (2 < 8).
+    assert_eq!(
+        state.investigators[&inv_id].status,
+        Status::Active,
+        "investigator survives a sub-lethal remainder"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Case 7 — investigator-card overflow triggers investigator elimination,
+// not asset discard (#448 cp2b). The defeat half of the unification: the
+// investigator card uses the same `accumulated >= printed capacity` rule
+// as an asset, but the consequence is elimination (Status::Killed) rather
+// than discard-to-owner.
+// ---------------------------------------------------------------------
+
+#[test]
+fn investigator_card_overflow_eliminates_the_investigator() {
+    let dog = CardInstanceId(1);
+    let inv = InvestigatorId(1);
+    let loc = LocationId(101);
+    // Skids O'Toole (01003) has 8 health. Pre-load the investigator card
+    // with 7 damage (survived prior harm). A 4-damage attack: Guard Dog
+    // soaks 3 (defeated), the remaining 1 lands on the investigator card →
+    // 8 >= 8 → the investigator is eliminated (Killed), not the card
+    // discarded to a pile.
+    let (mut state, inv_id, _) = soak_state(
+        vec![(GUARD_DOG, dog)],
+        vec![engaged_attacker(7, inv, loc, 4, 3)],
+    );
+    state
+        .investigators
+        .get_mut(&inv_id)
+        .unwrap()
+        .investigator_card
+        .accumulated_damage = 7;
+
+    let result = apply(state, Action::Player(PlayerAction::EndTurn));
+    let result = distribute_onto(result, dog);
+    state = result.state;
+
+    // The investigator card reached its printed health → elimination, with
+    // the damage cause (Killed). The InvestigatorDefeated event fired.
+    assert_eq!(
+        state.investigators[&inv_id].status,
+        Status::Killed,
+        "investigator-card overflow eliminates (Killed), not asset-discards"
+    );
+    assert!(
+        result.events.iter().any(|e| matches!(
+            e,
+            Event::InvestigatorDefeated { investigator, cause }
+                if *investigator == inv_id && *cause == game_core::state::DefeatCause::Damage
+        )),
+        "InvestigatorDefeated {{ cause: Damage }} emitted: {:?}",
+        result.events
+    );
+    // The investigator card was NOT discarded to a pile as if it were an
+    // asset: no CardDiscarded for the investigator's own code, and the
+    // investigator card itself is never the subject of an asset-defeat
+    // discard (elimination removes the investigator's cards from the game
+    // instead).
+    assert!(
+        !result.events.iter().any(|e| matches!(
+            e,
+            Event::CardDiscarded { code, .. } if *code == CardCode::new("01003")
+        )),
+        "investigator card is eliminated, not discarded as an asset: {:?}",
+        result.events
+    );
+}
+
+// ---------------------------------------------------------------------
+// Case 8 — defeat ORDERING when the same attack overflows both an asset
+// and the investigator card (#448 cp2b). Load-bearing invariant: the
+// investigator-card overflow is resolved (elimination) *before* the asset
+// overflow sweep, because RR p.10 Elimination step 1 removes every card
+// the investigator controls *from the game* (into `removed_from_game`, NOT
+// the discard pile). So a co-overflowing asset is removed-from-game
+// silently — it never emits the asset-defeat `CardDiscarded`. This guards
+// against a future "fold the investigator card into one uniform post-asset
+// defeat sweep" refactor, which would emit that discard before elimination
+// removed the card — a behaviour change.
+// ---------------------------------------------------------------------
+
+#[test]
+fn co_overflowing_asset_is_removed_from_game_not_discarded_when_investigator_eliminated() {
+    let dog = CardInstanceId(1);
+    let inv = InvestigatorId(1);
+    let loc = LocationId(101);
+    // Skids O'Toole (01003): 8 health. Pre-load 5 onto the investigator card
+    // and 2 onto Guard Dog (printed health 3). A 4-damage attack distributed
+    // soak-first: Guard Dog takes 1 (→ 3 >= 3, would defeat) and the
+    // remaining 3 land on the investigator card (→ 8 >= 8, eliminated). The
+    // investigator is eliminated in step 2, draining cards_in_play to
+    // removed_from_game before the asset sweep runs.
+    let (mut state, inv_id, _) = soak_state(
+        vec![(GUARD_DOG, dog)],
+        vec![engaged_attacker(7, inv, loc, 4, 3)],
+    );
+    {
+        let inv_mut = state.investigators.get_mut(&inv_id).unwrap();
+        inv_mut.investigator_card.accumulated_damage = 5;
+        inv_mut.cards_in_play[0].accumulated_damage = 2;
+    }
+
+    let result = apply(state, Action::Player(PlayerAction::EndTurn));
+    let result = distribute_onto(result, dog);
+    state = result.state;
+
+    // Investigator eliminated (Killed).
+    assert_eq!(
+        state.investigators[&inv_id].status,
+        Status::Killed,
+        "investigator card overflow eliminates the investigator"
+    );
+    // Elimination step 1 removed all controlled cards from the game: the
+    // Guard Dog is in removed_from_game, NOT the discard pile.
+    assert!(
+        state.investigators[&inv_id]
+            .removed_from_game
+            .contains(&CardCode::new(GUARD_DOG)),
+        "co-overflowing Guard Dog removed from game by elimination: {:?}",
+        state.investigators[&inv_id].removed_from_game
+    );
+    assert!(
+        !state.investigators[&inv_id]
+            .discard
+            .contains(&CardCode::new(GUARD_DOG)),
+        "co-overflowing Guard Dog is NOT in the discard pile"
+    );
+    // Crucially: NO asset-defeat CardDiscarded for the Guard Dog. The asset
+    // sweep ran after elimination had already removed it from cards_in_play.
+    assert!(
+        !result.events.iter().any(|e| matches!(
+            e,
+            Event::CardDiscarded { code, from, .. }
+                if *code == CardCode::new(GUARD_DOG) && *from == Zone::InPlay
+        )),
+        "no asset-defeat discard for the co-overflowing Guard Dog: {:?}",
+        result.events
     );
 }

--- a/crates/cards/tests/guard_dog_soak.rs
+++ b/crates/cards/tests/guard_dog_soak.rs
@@ -211,7 +211,8 @@ fn enemy_attack_soaks_onto_guard_dog_then_retaliate_damages_attacker() {
         "Guard Dog soaked all 2 damage"
     );
     assert_eq!(
-        state.investigators[&inv_id].damage, 0,
+        state.investigators[&inv_id].damage(),
+        0,
         "investigator took no damage"
     );
     // No damage on the attacker yet (reaction not fired).
@@ -653,7 +654,8 @@ fn move_attack_of_opportunity_guard_dog_retaliates_and_move_completes() {
         "AoO damage soaked onto Guard Dog"
     );
     assert_eq!(
-        state.investigators[&inv_id].damage, 0,
+        state.investigators[&inv_id].damage(),
+        0,
         "investigator took no AoO damage (fully soaked)"
     );
     // Investigator has NOT moved yet (the ActionResolution frame is parked).

--- a/crates/cards/tests/guard_dog_soak.rs
+++ b/crates/cards/tests/guard_dog_soak.rs
@@ -82,6 +82,9 @@ fn soak_state(
     let loc_id = LocationId(101);
 
     let mut inv = test_investigator(1);
+    // Real investigator code so max_health()/max_sanity() reads from the
+    // installed cards registry (#448 cp2a). Skids O'Toole (01003, 8/6).
+    inv.investigator_card.code = CardCode::new("01003");
     inv.current_location = Some(loc_id);
     inv.cards_in_play = assets
         .into_iter()

--- a/crates/cards/tests/medical_texts.rs
+++ b/crates/cards/tests/medical_texts.rs
@@ -88,7 +88,7 @@ fn success_heals_one_damage_from_the_chosen_investigator() {
             ..
         }
     );
-    assert_eq!(r.state.investigators[&INV].damage, 1, "1 damage healed");
+    assert_eq!(r.state.investigators[&INV].damage(), 1, "1 damage healed");
 }
 
 #[test]
@@ -104,5 +104,5 @@ fn failure_deals_one_damage_to_the_chosen_investigator() {
             amount: 1,
         }
     );
-    assert_eq!(r.state.investigators[&INV].damage, 1, "1 damage dealt");
+    assert_eq!(r.state.investigators[&INV].damage(), 1, "1 damage dealt");
 }

--- a/crates/cards/tests/medical_texts.rs
+++ b/crates/cards/tests/medical_texts.rs
@@ -45,8 +45,12 @@ fn install() {
 fn board(intellect: i8, damage: u8) -> game_core::GameState {
     install();
     let mut inv = test_investigator(1);
+    // Real investigator code so max_health()/max_sanity() reads from the
+    // installed cards registry (#448 cp2a). Skids O'Toole (01003, 8/6).
+    inv.investigator_card.code = CardCode::new("01003");
     inv.skills.intellect = intellect;
-    inv.damage = damage;
+    // Harm accumulates on the investigator card after #448 cp2a.
+    inv.investigator_card.accumulated_damage = damage;
     inv.cards_in_play.push(CardInPlay::enter_play(
         CardCode::new(MEDICAL_TEXTS),
         BOOK_INST,

--- a/crates/cards/tests/non_attack_soak.rs
+++ b/crates/cards/tests/non_attack_soak.rs
@@ -30,6 +30,9 @@ fn install_registry() {
 /// `treachery` on top of the encounter deck and one rigged chaos token.
 fn board_with_soaker(treachery: &str, soaker: &str, token: ChaosToken) -> game_core::GameState {
     let mut inv = test_investigator(1);
+    // Real investigator code so max_health()/max_sanity() reads from the
+    // installed cards registry (#448 cp2a). Skids O'Toole (01003, 8/6).
+    inv.investigator_card.code = CardCode::new("01003");
     inv.cards_in_play = vec![CardInPlay::enter_play(
         CardCode::new(soaker),
         CardInstanceId(1),

--- a/crates/cards/tests/non_attack_soak.rs
+++ b/crates/cards/tests/non_attack_soak.rs
@@ -88,7 +88,7 @@ fn grasping_hands_distributes_both_points_onto_guard_dog() {
         "both points distributed; no soak reaction window for treachery harm",
     );
     let inv = &result.state.investigators[&InvestigatorId(1)];
-    assert_eq!(inv.damage, 0, "investigator took none (both soaked)");
+    assert_eq!(inv.damage(), 0, "investigator took none (both soaked)");
     assert_eq!(
         dog_damage(&result),
         Some(2),
@@ -109,7 +109,7 @@ fn grasping_hands_player_splits_across_soaker_and_self() {
     );
     assert_eq!(result.outcome, EngineOutcome::Done);
     let inv = &result.state.investigators[&InvestigatorId(1)];
-    assert_eq!(inv.damage, 1, "one point taken by the investigator");
+    assert_eq!(inv.damage(), 1, "one point taken by the investigator");
     assert_eq!(
         dog_damage(&result),
         Some(1),
@@ -129,7 +129,7 @@ fn rotting_remains_horror_distributes_onto_beat_cop() {
     );
     assert_eq!(result.outcome, EngineOutcome::Done);
     let inv = &result.state.investigators[&InvestigatorId(1)];
-    assert_eq!(inv.horror, 0, "horror soaked, investigator took none");
+    assert_eq!(inv.horror(), 0, "horror soaked, investigator took none");
     let cop = inv
         .cards_in_play
         .iter()

--- a/crates/cards/tests/play_card_aoo.rs
+++ b/crates/cards/tests/play_card_aoo.rs
@@ -112,6 +112,8 @@ fn playing_a_non_fast_event_while_engaged_provokes_an_aoo() {
     let loc = LocationId(101);
 
     let mut investigator = test_investigator(1);
+    // Real investigator code so max_health() reads from installed registry (#448 cp2a).
+    investigator.investigator_card.code = CardCode::new("01003"); // Skids O'Toole: 8/6
     investigator.current_location = Some(loc);
     investigator.hand = vec![CardCode::new(EMERGENCY_CACHE)];
     investigator.cards_in_play = vec![CardInPlay::enter_play(CardCode::new(GUARD_DOG), dog)];
@@ -181,6 +183,8 @@ fn playing_a_non_fast_event_spends_one_action() {
     let loc = LocationId(101);
 
     let mut investigator = test_investigator(1);
+    // Real investigator code so max_health() reads from installed registry (#448 cp2a).
+    investigator.investigator_card.code = CardCode::new("01003"); // Skids O'Toole: 8/6
     investigator.current_location = Some(loc);
     investigator.actions_remaining = 3;
     investigator.hand = vec![CardCode::new(EMERGENCY_CACHE)];
@@ -224,6 +228,8 @@ fn playing_a_non_fast_card_with_no_actions_is_rejected() {
     let loc = LocationId(101);
 
     let mut investigator = test_investigator(1);
+    // Real investigator code so max_health() reads from installed registry (#448 cp2a).
+    investigator.investigator_card.code = CardCode::new("01003"); // Skids O'Toole: 8/6
     investigator.current_location = Some(loc);
     investigator.actions_remaining = 0;
     investigator.hand = vec![CardCode::new(EMERGENCY_CACHE)];
@@ -273,6 +279,8 @@ fn playing_a_fast_event_while_engaged_provokes_no_aoo_and_spends_no_action() {
     let loc = LocationId(101);
 
     let mut investigator = test_investigator(1);
+    // Real investigator code so max_health() reads from installed registry (#448 cp2a).
+    investigator.investigator_card.code = CardCode::new("01003"); // Skids O'Toole: 8/6
     investigator.current_location = Some(loc);
     investigator.actions_remaining = 3;
     investigator.hand = vec![CardCode::new(WORKING_A_HUNCH)];
@@ -343,6 +351,8 @@ fn aoo_that_defeats_the_player_suppresses_the_event_effect() {
     let loc = LocationId(101);
 
     let mut investigator = test_investigator(1);
+    // Real investigator code so max_health() reads from installed registry (#448 cp2a).
+    investigator.investigator_card.code = CardCode::new("01003"); // Skids O'Toole: 8/6
     investigator.current_location = Some(loc);
     investigator.actions_remaining = 3;
     investigator.hand = vec![CardCode::new(EMERGENCY_CACHE)];
@@ -407,6 +417,8 @@ fn playing_a_non_fast_asset_provokes_an_aoo_then_enters_play() {
     let loc = LocationId(101);
 
     let mut investigator = test_investigator(1);
+    // Real investigator code so max_health() reads from installed registry (#448 cp2a).
+    investigator.investigator_card.code = CardCode::new("01003"); // Skids O'Toole: 8/6
     investigator.current_location = Some(loc);
     investigator.actions_remaining = 3;
     investigator.hand = vec![CardCode::new(MACHETE)];
@@ -482,6 +494,8 @@ fn aoo_that_defeats_the_player_mid_asset_play_leaves_no_asset_in_play() {
     let loc = LocationId(101);
 
     let mut investigator = test_investigator(1);
+    // Real investigator code so max_health() reads from installed registry (#448 cp2a).
+    investigator.investigator_card.code = CardCode::new("01003"); // Skids O'Toole: 8/6
     investigator.current_location = Some(loc);
     investigator.actions_remaining = 3;
     investigator.hand = vec![CardCode::new(MACHETE)];

--- a/crates/cards/tests/play_card_aoo.rs
+++ b/crates/cards/tests/play_card_aoo.rs
@@ -154,7 +154,8 @@ fn playing_a_non_fast_event_while_engaged_provokes_an_aoo() {
         "AoO damage from the play soaked onto Guard Dog"
     );
     assert_eq!(
-        state.investigators[&inv_id].damage, 0,
+        state.investigators[&inv_id].damage(),
+        0,
         "investigator took no AoO damage"
     );
     // The "gain 3 resources" effect has NOT run yet — it resolves only after the

--- a/crates/cards/tests/retaliate_windows.rs
+++ b/crates/cards/tests/retaliate_windows.rs
@@ -227,7 +227,8 @@ fn guard_dog_retaliates_against_retaliate_and_skill_test_ends() {
         "retaliate's 1 damage soaked onto Guard Dog"
     );
     assert_eq!(
-        state.investigators[&inv_id].damage, 0,
+        state.investigators[&inv_id].damage(),
+        0,
         "investigator took no damage from the retaliate (Guard Dog soaked it)"
     );
     // Guard Dog has not yet dealt its retaliate damage to the enemy.
@@ -334,11 +335,13 @@ fn dodge_cancels_retaliate_and_skill_test_ends() {
 
     // No damage yet; Dodge still in hand.
     assert_eq!(
-        state.investigators[&inv_id].damage, 0,
+        state.investigators[&inv_id].damage(),
+        0,
         "no damage before Dodge resolves"
     );
     assert_eq!(
-        state.investigators[&inv_id].horror, 0,
+        state.investigators[&inv_id].horror(),
+        0,
         "no horror before Dodge resolves"
     );
     assert!(
@@ -368,11 +371,13 @@ fn dodge_cancels_retaliate_and_skill_test_ends() {
 
     // The retaliate was cancelled: no damage or horror dealt to the investigator.
     assert_eq!(
-        state.investigators[&inv_id].damage, 0,
+        state.investigators[&inv_id].damage(),
+        0,
         "Dodge cancelled the retaliate: no damage to the investigator"
     );
     assert_eq!(
-        state.investigators[&inv_id].horror, 0,
+        state.investigators[&inv_id].horror(),
+        0,
         "Dodge cancelled the retaliate: no horror to the investigator"
     );
     assert!(

--- a/crates/cards/tests/revelation_treacheries.rs
+++ b/crates/cards/tests/revelation_treacheries.rs
@@ -44,8 +44,12 @@ fn reveal_top(state: game_core::GameState) -> game_core::ApplyResult {
 /// Common board: one investigator at a location, the named treachery on
 /// top of the encounter deck, and a single rigged chaos token.
 fn board_with(treachery: &str, token: ChaosToken) -> game_core::GameState {
+    let mut inv = test_investigator(1);
+    // Real investigator code so max_health()/max_sanity() reads from the
+    // installed cards registry (#448 cp2a). Skids O'Toole (01003, 8/6).
+    inv.investigator_card.code = CardCode::new("01003");
     let mut state = GameStateBuilder::new()
-        .with_investigator_at(test_investigator(1), LocationId(20))
+        .with_investigator_at(inv, LocationId(20))
         .with_location(test_location(20, "Here"))
         .with_turn_order([InvestigatorId(1)])
         .build();

--- a/crates/cards/tests/revelation_treacheries.rs
+++ b/crates/cards/tests/revelation_treacheries.rs
@@ -61,7 +61,7 @@ fn grasping_hands_deals_one_damage_per_point_failed_then_discards() {
     let result = reveal_top(board_with("01162", ChaosToken::Numeric(-2)));
     assert_eq!(result.outcome, EngineOutcome::Done);
     assert_eq!(
-        result.state.investigators[&InvestigatorId(1)].damage,
+        result.state.investigators[&InvestigatorId(1)].damage(),
         2,
         "1 damage per point failed (failed by 2)",
     );
@@ -84,7 +84,7 @@ fn grasping_hands_fail_by_two_is_single_deal_of_two_damage() {
     // Agility 3 + Numeric(-2) = 1 vs difficulty 3 → fail by 2.
     let result = reveal_top(board_with("01162", ChaosToken::Numeric(-2)));
     assert_eq!(result.outcome, EngineOutcome::Done);
-    assert_eq!(result.state.investigators[&InvestigatorId(1)].damage, 2);
+    assert_eq!(result.state.investigators[&InvestigatorId(1)].damage(), 2);
     // Exactly one DamageTaken event, with amount == 2.
     game_core::assert_event_count!(result.events, 1, Event::DamageTaken { .. });
     game_core::assert_event!(
@@ -103,7 +103,7 @@ fn rotting_remains_fail_by_two_is_single_deal_of_two_horror() {
     // Willpower 3 + Numeric(-2) = 1 vs difficulty 3 → fail by 2.
     let result = reveal_top(board_with("01163", ChaosToken::Numeric(-2)));
     assert_eq!(result.outcome, EngineOutcome::Done);
-    assert_eq!(result.state.investigators[&InvestigatorId(1)].horror, 2);
+    assert_eq!(result.state.investigators[&InvestigatorId(1)].horror(), 2);
     // Exactly one HorrorTaken event, with amount == 2.
     game_core::assert_event_count!(result.events, 1, Event::HorrorTaken { .. });
     game_core::assert_event!(
@@ -121,7 +121,7 @@ fn crypt_chill_with_no_asset_takes_two_damage_then_discards() {
     let result = reveal_top(board_with("01167", ChaosToken::Numeric(0)));
     assert_eq!(result.outcome, EngineOutcome::Done);
     assert_eq!(
-        result.state.investigators[&InvestigatorId(1)].damage,
+        result.state.investigators[&InvestigatorId(1)].damage(),
         2,
         "no asset controlled → 2 damage fallback",
     );
@@ -151,7 +151,7 @@ fn crypt_chill_with_an_asset_discards_the_asset_not_damage() {
     let result = reveal_top(state);
     assert_eq!(result.outcome, EngineOutcome::Done);
     let inv = &result.state.investigators[&InvestigatorId(1)];
-    assert_eq!(inv.damage, 0, "controlled an asset → no damage");
+    assert_eq!(inv.damage(), 0, "controlled an asset → no damage");
     assert!(
         inv.cards_in_play.is_empty(),
         "the asset was discarded out of play",
@@ -205,7 +205,11 @@ fn crypt_chill_with_two_assets_suspends_and_discards_the_chosen_one() {
 
     assert_eq!(result.outcome, EngineOutcome::Done);
     let inv = &result.state.investigators[&InvestigatorId(1)];
-    assert_eq!(inv.damage, 0, "an asset was discarded → no damage fallback");
+    assert_eq!(
+        inv.damage(),
+        0,
+        "an asset was discarded → no damage fallback"
+    );
     // The chosen asset (Magnifying Glass) is gone; the other stays in play.
     assert!(
         inv.discard.contains(&CardCode::new("01030")),

--- a/crates/cards/tests/roland_banks_seated.rs
+++ b/crates/cards/tests/roland_banks_seated.rs
@@ -1,7 +1,7 @@
 //! Roland Banks (01001) reacts from a **roster-seated** investigator — his
 //! `[reaction]` fires with NO manual `cards_in_play` injection, sourced from
-//! `Investigator.card_code` via the new `scan_investigator_card_reactions`.
-//! Caps once per round through `Investigator.ability_usage`.
+//! the investigator card via the unified `controlled_card_instances()` scan
+//! (#448 cp3a). Caps once per round through `investigator_card.ability_usage`.
 //!
 //! Card text (`data/arkhamdb-snapshot/pack/core/core.json`, 01001):
 //! > [reaction] After you defeat an enemy: Discover 1 clue at your
@@ -104,23 +104,27 @@ fn seated_roland_reaction_fires_with_no_in_play_injection() {
     assert_eq!(result.state.locations[&loc_id].clues, 1);
     assert_eq!(result.state.investigators[&inv_id].clues, 1);
 
-    // Usage bumped on the INVESTIGATOR (not a CardInPlay): ability index 0, round 0.
+    // Usage bumped on the investigator CARD (#448 cp3a — the unified scan fires
+    // it via `controlled_card_instances()`, so usage lives on the card's own
+    // `ability_usage`, not `Investigator.ability_usage`): ability index 0, round 0.
     let inv = &result.state.investigators[&inv_id];
     assert_eq!(
-        inv.ability_usage.get(&0),
+        inv.investigator_card.ability_usage.get(&0),
         Some(&AbilityUsageRecord::new(0, 1)),
-        "seated Roland's reaction recorded one fire on Investigator.ability_usage",
+        "seated Roland's reaction recorded one fire on investigator_card.ability_usage",
     );
 }
 
 #[test]
 fn seated_roland_reaction_capped_once_per_round() {
     let (inv_id, enemy_id, loc_id, mut state) = seated_roland_with_enemy(0);
-    // Pretend Roland already reacted this round.
+    // Pretend Roland already reacted this round — bump the investigator CARD's
+    // usage (#448 cp3a: the unified scan reads `investigator_card.ability_usage`).
     state
         .investigators
         .get_mut(&inv_id)
         .unwrap()
+        .investigator_card
         .bump_ability_usage(0, 0);
 
     let result = apply_no_commits(state, fight_action(inv_id, enemy_id));

--- a/crates/cards/tests/roland_banks_seated.rs
+++ b/crates/cards/tests/roland_banks_seated.rs
@@ -44,7 +44,7 @@ fn seated_roland_with_enemy(
     let loc_id = LocationId(10);
 
     let mut inv = test_investigator(1);
-    inv.card_code = game_core::state::CardCode::new(ROLAND);
+    // After #448 cp2a the scanner reads investigator_card.code, not card_code.
     inv.investigator_card.code = game_core::state::CardCode::new(ROLAND);
     inv.current_location = Some(loc_id);
     inv.skills.combat = 4;

--- a/crates/cards/tests/roland_banks_seated.rs
+++ b/crates/cards/tests/roland_banks_seated.rs
@@ -45,6 +45,7 @@ fn seated_roland_with_enemy(
 
     let mut inv = test_investigator(1);
     inv.card_code = game_core::state::CardCode::new(ROLAND);
+    inv.investigator_card.code = game_core::state::CardCode::new(ROLAND);
     inv.current_location = Some(loc_id);
     inv.skills.combat = 4;
     assert!(

--- a/crates/cards/tests/roland_elder_sign.rs
+++ b/crates/cards/tests/roland_elder_sign.rs
@@ -38,6 +38,7 @@ fn run_elder_sign_test(clues: u8) -> Vec<Event> {
 
     let mut inv = test_investigator(1);
     inv.card_code = CardCode::new(ROLAND);
+    inv.investigator_card.code = CardCode::new(ROLAND);
     inv.current_location = Some(loc_id);
     inv.skills.willpower = 3; // base 3
     assert!(

--- a/crates/cards/tests/roland_elder_sign.rs
+++ b/crates/cards/tests/roland_elder_sign.rs
@@ -37,13 +37,13 @@ fn run_elder_sign_test(clues: u8) -> Vec<Event> {
     let loc_id = LocationId(10);
 
     let mut inv = test_investigator(1);
-    inv.card_code = CardCode::new(ROLAND);
+    // After #448 cp2a the elder-sign scanner reads investigator_card.code, not card_code.
     inv.investigator_card.code = CardCode::new(ROLAND);
     inv.current_location = Some(loc_id);
     inv.skills.willpower = 3; // base 3
     assert!(
         inv.cards_in_play.is_empty(),
-        "the bonus must come from the investigator-card elder-sign bridge (card_code), \
+        "the bonus must come from the investigator-card elder-sign bridge (investigator_card.code), \
          not a played card — guard against a fixture change pre-populating cards_in_play",
     );
 

--- a/crates/cards/tests/roster_seating.rs
+++ b/crates/cards/tests/roster_seating.rs
@@ -58,8 +58,8 @@ fn seats_roland_with_corpus_stats_and_payload_deck() {
             agility: 2
         }
     );
-    assert_eq!(inv.max_health, 9);
-    assert_eq!(inv.max_sanity, 5);
+    assert_eq!(inv.max_health(), 9);
+    assert_eq!(inv.max_sanity(), 5);
     // Deck + hand together account for the 2 supplied cards (the 5-card
     // opening-hand draw takes only what's available).
     assert_eq!(inv.deck.len() + inv.hand.len(), deck.len());
@@ -100,7 +100,7 @@ fn seated_investigator_carries_its_card_code() {
         .investigators
         .get(&InvestigatorId(1))
         .expect("Roland seated at id 1");
-    assert_eq!(inv.card_code, CardCode::new("01001"));
+    assert_eq!(inv.investigator_card.code, CardCode::new("01001"));
 }
 
 #[test]

--- a/crates/cards/tests/soak_distribution.rs
+++ b/crates/cards/tests/soak_distribution.rs
@@ -41,6 +41,9 @@ fn attack_state(
     let inv_id = InvestigatorId(1);
     let loc_id = LocationId(101);
     let mut inv = test_investigator(1);
+    // Real investigator code so max_health()/max_sanity() reads from the
+    // installed cards registry (#448 cp2a). Skids O'Toole (01003, 8/6).
+    inv.investigator_card.code = CardCode::new("01003");
     inv.current_location = Some(loc_id);
     inv.cards_in_play = assets
         .into_iter()

--- a/crates/cards/tests/soak_distribution.rs
+++ b/crates/cards/tests/soak_distribution.rs
@@ -133,7 +133,8 @@ fn two_damage_attack_splits_one_to_guard_dog_one_to_self() {
         "1 damage soaked onto Guard Dog"
     );
     assert_eq!(
-        r3.state.investigators[&inv].damage, 1,
+        r3.state.investigators[&inv].damage(),
+        1,
         "1 damage taken by the investigator"
     );
     // Guard Dog took damage and survived → its retaliate window opens (not a
@@ -160,7 +161,8 @@ fn player_may_decline_to_soak_taking_all_damage() {
     let r3 = resolve(r2.state, pick(&r2.outcome, "Investigator"));
 
     assert_eq!(
-        r3.state.investigators[&inv].damage, 2,
+        r3.state.investigators[&inv].damage(),
+        2,
         "investigator took all 2 damage"
     );
     assert_eq!(
@@ -193,7 +195,8 @@ fn a_full_soaker_drops_out_of_the_next_prompt() {
         r2.outcome
     );
     assert_eq!(
-        r2.state.investigators[&inv].damage, 1,
+        r2.state.investigators[&inv].damage(),
+        1,
         "the overflow point went to the investigator"
     );
     assert!(

--- a/crates/game-core/src/card_registry.rs
+++ b/crates/game-core/src/card_registry.rs
@@ -197,25 +197,25 @@ mod tests {
     /// global-touching tests; we serialize via a single test that
     /// owns the global. Subsequent calls to `install` should fail
     /// (idempotent-by-error semantics of `OnceLock::set`).
+    ///
+    /// NOTE (#448 cp2a): this test uses `install_test_registry()` to
+    /// ensure the process-global slot is always occupied by the
+    /// standard test registry (which knows `TEST_INV`). Using a
+    /// bespoke `fake_registry()` here would race with other tests that
+    /// depend on `install_test_registry()` — whichever wins the
+    /// `OnceLock` would silently starve the other.
     #[test]
     fn install_is_idempotent_and_current_reflects_installed_value() {
-        // If a prior test already installed something, that's fine —
-        // we just check the contract by attempting another install
-        // and observing both outcomes.
-        let first_attempt = super::install(fake_registry());
+        // The test registry is the canonical game-core test registry.
+        // Install it (idempotent) to ensure `current()` returns Some.
+        crate::test_support::install_test_registry();
         let installed = super::current().expect("registry should be present after install");
-        // Verify the installed registry resolves our fake code.
-        let code = CardCode::new("TEST1");
-        // Whoever installed first wins; their `metadata_for` may not
-        // be ours (if a parallel test got there first). Just check
-        // the lookup *function* runs and behaves consistently.
-        let _ = (installed.metadata_for)(&code);
-        // A second install attempt must return Err regardless of
-        // which test won the race.
-        if first_attempt.is_ok() {
-            assert!(super::install(fake_registry()).is_err());
-        }
+        // A second install attempt must return Err (already set).
+        assert!(super::install(fake_registry()).is_err());
         // Sanity: `current()` keeps returning Some.
         assert!(REGISTRY.get().is_some());
+        // Verify `installed` resolves the TEST_INV code that the test
+        // registry knows about.
+        let _ = (installed.metadata_for)(&CardCode::new(crate::test_support::TEST_INV));
     }
 }

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -845,11 +845,15 @@ mod actions_tests {
         let l2 = LocationId(11);
         let enemy_id = EnemyId(100);
 
+        crate::test_support::install_test_registry();
         let mut inv = test_investigator(1);
         inv.current_location = Some(l1);
         inv.actions_remaining = 3;
-        inv.max_health = inv_health;
-        inv.damage = 0;
+        // After #448 cp2a: max_health() reads from the registry (TEST_INV = 8).
+        // Pre-load accumulated_damage so the old `inv_health` parameter still
+        // determines defeat: total = (8 - inv_health) + attack_damage >= 8
+        // ⟺ attack_damage >= inv_health (same condition as before).
+        inv.investigator_card.accumulated_damage = 8_u8.saturating_sub(inv_health);
 
         let mut loc1 = test_location(10, "L1");
         loc1.connections = vec![l2];
@@ -978,6 +982,8 @@ mod actions_tests {
         inv_health: u8,
         attack_damage: u8,
     ) -> (InvestigatorId, LocationId, EnemyId, crate::state::GameState) {
+        // Registry needed for max_health()/max_sanity() after cp2a.
+        crate::test_support::install_test_registry();
         let inv_id = InvestigatorId(1);
         let loc_id = LocationId(10);
         let enemy_id = EnemyId(200);
@@ -985,8 +991,9 @@ mod actions_tests {
         let mut inv = test_investigator(1);
         inv.current_location = Some(loc_id);
         inv.actions_remaining = 3;
-        inv.max_health = inv_health;
-        inv.damage = 0;
+        // Pre-load accumulated_damage so that max_health() (8 from TEST_INV) minus
+        // accumulated_damage equals inv_health (the "remaining health" the test intended).
+        inv.investigator_card.accumulated_damage = 8_u8.saturating_sub(inv_health);
 
         let mut loc = test_location(10, "Study");
         loc.clues = 2;
@@ -1099,6 +1106,8 @@ mod actions_tests {
         attack_damage: u8,
         inv_health: u8,
     ) -> (InvestigatorId, EnemyId, crate::state::GameState) {
+        // Registry needed for max_health()/max_sanity() after cp2a.
+        crate::test_support::install_test_registry();
         let inv_id = InvestigatorId(1);
         let loc_id = LocationId(10);
         let enemy_id = EnemyId(300);
@@ -1106,8 +1115,9 @@ mod actions_tests {
         let mut inv = test_investigator(1);
         inv.current_location = Some(loc_id);
         inv.actions_remaining = 3;
-        inv.max_health = inv_health;
-        inv.damage = 0;
+        // Pre-load accumulated_damage so that max_health() (8 from TEST_INV) minus
+        // accumulated_damage equals inv_health (the "remaining health" the test intended).
+        inv.investigator_card.accumulated_damage = 8_u8.saturating_sub(inv_health);
         inv.resources = 0;
 
         let loc = test_location(10, "Study");
@@ -1280,6 +1290,8 @@ mod actions_tests {
         inv_health: u8,
         aoo_damage: u8,
     ) -> (InvestigatorId, EnemyId, EnemyId, crate::state::GameState) {
+        // Registry needed for max_health()/max_sanity() after cp2a.
+        crate::test_support::install_test_registry();
         let inv_id = InvestigatorId(1);
         let loc_id = LocationId(10);
         let target_id = EnemyId(400);
@@ -1288,8 +1300,9 @@ mod actions_tests {
         let mut inv = test_investigator(1);
         inv.current_location = Some(loc_id);
         inv.actions_remaining = 3;
-        inv.max_health = inv_health;
-        inv.damage = 0;
+        // Pre-load accumulated_damage so that max_health() (8 from TEST_INV) minus
+        // accumulated_damage equals inv_health (the "remaining health" the test intended).
+        inv.investigator_card.accumulated_damage = 8_u8.saturating_sub(inv_health);
 
         let loc = test_location(10, "Study");
 

--- a/crates/game-core/src/engine/dispatch/actions.rs
+++ b/crates/game-core/src/engine/dispatch/actions.rs
@@ -956,7 +956,8 @@ mod actions_tests {
         );
         // AoO damage is visible.
         assert_eq!(
-            result.state.investigators[&inv_id].damage, 1,
+            result.state.investigators[&inv_id].damage(),
+            1,
             "investigator damage == 1 after nonlethal AoO"
         );
         // Engaged enemy moved with investigator to L2.
@@ -1047,7 +1048,8 @@ mod actions_tests {
         );
         // Investigator took 1 damage.
         assert_eq!(
-            outcome.state.investigators[&inv_id].damage, 1,
+            outcome.state.investigators[&inv_id].damage(),
+            1,
             "investigator must have taken 1 damage from AoO"
         );
         // AoO does not exhaust the attacker (RR p.7).
@@ -1213,7 +1215,8 @@ mod actions_tests {
         );
         // Investigator took the AoO damage.
         assert_eq!(
-            result.state.investigators[&inv_id].damage, 1,
+            result.state.investigators[&inv_id].damage(),
+            1,
             "investigator damage == 1 after nonlethal AoO"
         );
     }
@@ -1371,7 +1374,8 @@ mod actions_tests {
         );
         // Investigator took 1 damage.
         assert_eq!(
-            result.state.investigators[&inv_id].damage, 1,
+            result.state.investigators[&inv_id].damage(),
+            1,
             "investigator damage == 1 after nonlethal AoO"
         );
         // AoO attacker is not exhausted (RR p.7).

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -859,11 +859,12 @@ mod draw_one_with_deckout_tests {
 
     #[test]
     fn draw_one_with_deckout_empty_deck_reshuffles_and_takes_horror() {
+        crate::test_support::install_test_registry();
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
         inv.deck.clear();
         inv.discard = vec![CardCode::new("01000"), CardCode::new("01001")];
-        inv.horror = 0;
+        // After #448 cp2a: horror accumulates on investigator_card, accessor reads it.
         let hand_before = inv.hand.len();
         let mut state = GameStateBuilder::default().with_investigator(inv).build();
         let mut events = Vec::new();

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -882,7 +882,8 @@ mod draw_one_with_deckout_tests {
             "drew 1"
         );
         assert_eq!(
-            state.investigators[&id].horror, 1,
+            state.investigators[&id].horror(),
+            1,
             "deck-out costs 1 horror"
         );
         assert!(events

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -358,7 +358,7 @@ pub(super) fn apply_damage_numeric(cx: &mut Cx, investigator: InvestigatorId, am
         return false;
     }
     inv.damage = inv.damage.saturating_add(amount);
-    let lethal = inv.damage >= inv.max_health;
+    let lethal = inv.damage() >= inv.max_health();
     cx.events.push(Event::DamageTaken {
         investigator,
         amount,
@@ -388,7 +388,7 @@ pub(super) fn apply_horror_numeric(cx: &mut Cx, investigator: InvestigatorId, am
         return false;
     }
     inv.horror = inv.horror.saturating_add(amount);
-    let lethal = inv.horror >= inv.max_sanity;
+    let lethal = inv.horror() >= inv.max_sanity();
     cx.events.push(Event::HorrorTaken {
         investigator,
         amount,
@@ -1383,8 +1383,8 @@ mod combat_tests {
         let survivors = super::soak_and_place(&mut cx, id, 2, 1);
         assert!(survivors.is_empty(), "no soakers → no survivors");
 
-        assert_eq!(state.investigators[&id].damage, 2, "all damage on inv");
-        assert_eq!(state.investigators[&id].horror, 1, "all horror on inv");
+        assert_eq!(state.investigators[&id].damage(), 2, "all damage on inv");
+        assert_eq!(state.investigators[&id].horror(), 1, "all horror on inv");
         assert_event!(events, Event::DamageTaken { investigator, amount: 2 } if *investigator == id);
         assert_event!(events, Event::HorrorTaken { investigator, amount: 1 } if *investigator == id);
         assert!(
@@ -1543,7 +1543,8 @@ mod combat_tests {
         assert_eq!(card.accumulated_damage, 1, "asset soaked 1 damage");
         assert_eq!(card.accumulated_horror, 1, "asset soaked 1 horror");
         assert_eq!(
-            state.investigators[&id].damage, 1,
+            state.investigators[&id].damage(),
+            1,
             "investigator took overflow damage"
         );
         assert_eq!(
@@ -1676,7 +1677,8 @@ mod combat_tests {
         let _ = super::resume_enemy_attack(&mut cx);
 
         assert_eq!(
-            state.investigators[&inv_id].damage, 0,
+            state.investigators[&inv_id].damage(),
+            0,
             "cancelled attack deals no damage"
         );
         assert!(
@@ -1729,7 +1731,8 @@ mod combat_tests {
         let _ = super::resume_enemy_attack(&mut cx);
 
         assert_eq!(
-            state.investigators[&inv_id].damage, 1,
+            state.investigators[&inv_id].damage(),
+            1,
             "an un-cancelled attack deals its damage"
         );
         assert!(state.enemies[&attacker].exhausted, "attacker exhausted");
@@ -1762,7 +1765,8 @@ mod combat_tests {
             "retaliate must not exhaust (RR p.18)"
         );
         assert_eq!(
-            cx.state.investigators[&inv_id].damage, 1,
+            cx.state.investigators[&inv_id].damage(),
+            1,
             "retaliate dealt 1 damage"
         );
         assert_event!(events, Event::DamageTaken { .. });
@@ -1795,7 +1799,8 @@ mod combat_tests {
             "AoO must not exhaust the attacker (RR p.7)"
         );
         assert_eq!(
-            cx.state.investigators[&inv_id].damage, 1,
+            cx.state.investigators[&inv_id].damage(),
+            1,
             "AoO damage landed on the investigator"
         );
         // Enemy attack fires DamageTaken (no EnemyAttacked event exists); verify

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -151,7 +151,16 @@ pub(super) struct Soaker {
 ///
 /// Fills `soakers` (already ordered by the caller, by `CardInstanceId`
 /// to match the codebase's other simultaneous loops) up to each one's
-/// remaining capacity, then the investigator absorbs the remainder.
+/// remaining capacity, then the **investigator card** absorbs the
+/// remainder. The investigator card is the always-eligible,
+/// mandatory-remainder soaker (RR: "all damage/horror that cannot be
+/// assigned to an asset must be assigned to the investigator") — it takes
+/// whatever the assets cannot, *uncapped* (overflowing its own capacity is
+/// exactly how the investigator is defeated). Its share rides
+/// `Assignment::investigator_damage/horror` (not `asset_*`) so
+/// [`place_assignment`] routes it onto `investigator_card.accumulated_*`
+/// via the numeric helpers, keeping the [`Event::DamageTaken`] /
+/// [`Event::HorrorTaken`] emission and the elimination wiring intact.
 /// Damage and horror are assigned **independently** — an asset with
 /// only health soaks damage, an asset with only sanity soaks horror.
 ///
@@ -199,7 +208,7 @@ fn find_controlled_mut(
         .find(|c| c.instance_id == inst)
 }
 
-/// Discard every controlled asset whose accumulated damage/horror has
+/// Discard every controlled **asset** whose accumulated damage/horror has
 /// reached its printed health/sanity (C5b #237).
 ///
 /// Reads printed health/sanity from the card registry; an asset whose
@@ -208,6 +217,19 @@ fn find_controlled_mut(
 /// `cards_in_play` and emit [`Event::CardDiscarded`] with
 /// `from: Zone::InPlay` (matching the discard event shape used elsewhere
 /// — see `dispatch/cards.rs`).
+///
+/// The **investigator card** is the other soaker subject to the same
+/// `accumulated >= printed capacity` defeat rule (#448), but it is
+/// deliberately *not* swept here: it lives in `investigator_card`, not
+/// `cards_in_play`, and its overflow consequence is *elimination*, not a
+/// discard. That defeat is resolved one step earlier — in
+/// [`place_assignment`] step 2, *before* this asset sweep — and the order
+/// is load-bearing: elimination (RR p.10 step 1) removes every controlled
+/// card *from the game* (`removed_from_game`, no `CardDiscarded`), so an
+/// asset that co-overflows with the investigator card is already gone
+/// from `cards_in_play` by the time this sweep runs and never emits an
+/// asset-defeat discard. Folding the investigator card into this sweep
+/// would reverse that order and emit a spurious discard — do not.
 fn defeat_overflowed_assets(cx: &mut Cx, investigator: InvestigatorId) {
     let Some(reg) = crate::card_registry::current() else {
         return;
@@ -261,10 +283,18 @@ fn defeat_overflowed_assets(cx: &mut Cx, investigator: InvestigatorId) {
 /// Steps, in order:
 /// 1. Accumulate the soaked damage/horror onto each asset's
 ///    `accumulated_*` fields.
-/// 2. Place the investigator's share via the numeric helpers (which emit
-///    [`Event::DamageTaken`] / [`Event::HorrorTaken`] and report
-///    lethality), then apply investigator defeat if either crossed — so
-///    both stats land before any defeat check, per RR p.7.
+/// 2. Place the investigator card's share (the mandatory remainder — RR:
+///    "all damage/horror that cannot be assigned to an asset must be
+///    assigned to the investigator") via the numeric helpers, which write
+///    `investigator_card.accumulated_*` and emit [`Event::DamageTaken`] /
+///    [`Event::HorrorTaken`], then apply investigator defeat if either
+///    crossed (`accumulated >= max_health()/max_sanity()` — the same
+///    `accumulated >= printed capacity` rule as an asset, but the
+///    consequence is *elimination*, not discard). Both stats land before
+///    the defeat check, per RR p.7. This runs *before* the asset sweep so
+///    elimination's "remove controlled cards from the game" step (RR p.10)
+///    pre-empts any co-overflowing asset's discard (see
+///    [`defeat_overflowed_assets`]).
 /// 3. Defeat overflowed assets (`accumulated >= printed stat` →
 ///    discard).
 ///

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -357,7 +357,10 @@ pub(super) fn apply_damage_numeric(cx: &mut Cx, investigator: InvestigatorId, am
     if inv.status != Status::Active {
         return false;
     }
-    inv.damage = inv.damage.saturating_add(amount);
+    inv.investigator_card.accumulated_damage = inv
+        .investigator_card
+        .accumulated_damage
+        .saturating_add(amount);
     let lethal = inv.damage() >= inv.max_health();
     cx.events.push(Event::DamageTaken {
         investigator,
@@ -387,7 +390,10 @@ pub(super) fn apply_horror_numeric(cx: &mut Cx, investigator: InvestigatorId, am
     if inv.status != Status::Active {
         return false;
     }
-    inv.horror = inv.horror.saturating_add(amount);
+    inv.investigator_card.accumulated_horror = inv
+        .investigator_card
+        .accumulated_horror
+        .saturating_add(amount);
     let lethal = inv.horror() >= inv.max_sanity();
     cx.events.push(Event::HorrorTaken {
         investigator,
@@ -1368,10 +1374,12 @@ mod combat_tests {
         // of 2 damage / 1 horror against an investigator controlling no
         // soak-bearing assets must land entirely on the investigator, just
         // as the pre-rewrite direct apply_damage/horror_numeric path did.
+        crate::test_support::install_test_registry();
         let id = InvestigatorId(1);
-        let mut inv = test_investigator(1);
-        inv.max_health = 10;
-        inv.max_sanity = 10;
+        let inv = test_investigator(1);
+        // max_health()/max_sanity() now read from the registry (TEST_INV = 8/8).
+        // 2 damage and 1 horror both land below capacity, so no defeat fires.
+        // The old explicit max_health = 10 / max_sanity = 10 are vestigial.
 
         let mut state = GameStateBuilder::new().with_investigator(inv).build();
         let mut events = Vec::new();
@@ -1503,20 +1511,19 @@ mod combat_tests {
 
     #[test]
     fn place_assignment_accumulates_on_asset_and_returns_damaged_list() {
-        // Pre-construct an Assignment placing 1 damage + 1 horror on an
-        // in-play asset and 1 damage on the investigator. No registry is
-        // installed, so the asset is NOT defeated (printed health/sanity
-        // unreadable) — accumulation + the returned damaged-survivors list
-        // are what's verified here. Defeat-on-overflow needs registry
-        // metadata and is covered by the EU5 integration test.
         use crate::state::{CardCode, CardInPlay, CardInstanceId};
         use std::collections::BTreeMap;
+        // Pre-construct an Assignment placing 1 damage + 1 horror on an
+        // in-play asset and 1 damage on the investigator. Registry installed
+        // so max_health() / max_sanity() can resolve; TEST_INV = 8/8 and the
+        // investigator damage is 1 < 8, so no defeat fires.
+        // Asset defeat-on-overflow needs the real `cards` registry and is
+        // covered by the EU5 integration test.
+        crate::test_support::install_test_registry();
 
         let id = InvestigatorId(1);
         let inst = CardInstanceId(7);
         let mut inv = test_investigator(1);
-        inv.max_health = 10;
-        inv.max_sanity = 10;
         inv.cards_in_play = vec![CardInPlay::enter_play(CardCode::new("01021"), inst)];
 
         let mut state = GameStateBuilder::new().with_investigator(inv).build();
@@ -1557,6 +1564,7 @@ mod combat_tests {
 
     #[test]
     fn resume_enemy_attack_drains_remaining_attacker_and_advances_cursor() {
+        use crate::state::{AttackLoopStage, Continuation, EnemyAttackSource, InvestigatorId};
         // EU5 deferral: firing Guard Dog's reaction end-to-end needs the real
         // `cards` registry (so `trigger_matches` finds the ability and a soak
         // window genuinely opens mid-loop) — that is the EU5 integration test.
@@ -1566,8 +1574,10 @@ mod combat_tests {
         // the attacker (exhausting it) and advances the enemy-phase cursor past
         // the (sole) investigator to `None`. One attacker, not two: with 2+
         // remaining the drain would re-prompt for the player attack order (#143),
-        // which the order-pick tests cover.
-        use crate::state::{AttackLoopStage, Continuation, EnemyAttackSource, InvestigatorId};
+        // which the order-pick tests cover. The test registry (TEST_INV) is
+        // installed so max_health()/max_sanity() resolve (#448 cp2a); the test
+        // registry has no abilities so no soak reaction window fires.
+        crate::test_support::install_test_registry();
 
         let inv_id = InvestigatorId(1);
         let second = EnemyId(2);
@@ -1604,7 +1614,7 @@ mod combat_tests {
         let outcome = super::resume_enemy_attack(&mut cx);
 
         // The parked attacker resolved and exhausted; the parked frame is popped.
-        // No registry → no new soak window, no re-suspend.
+        // Test registry has no abilities → no new soak window, no re-suspend.
         assert!(
             !state
                 .continuations
@@ -1698,6 +1708,7 @@ mod combat_tests {
     #[test]
     fn resume_before_attack_without_cancel_deals_damage() {
         use crate::state::{AttackLoopStage, Continuation, EnemyAttackSource, InvestigatorId};
+        crate::test_support::install_test_registry();
 
         let inv_id = InvestigatorId(1);
         let attacker = EnemyId(2);
@@ -1741,6 +1752,7 @@ mod combat_tests {
     #[test]
     fn drive_retaliate_deals_damage_but_does_not_exhaust_the_attacker() {
         // RR p.18: a retaliate attack does not exhaust the attacker.
+        crate::test_support::install_test_registry();
         let inv_id = InvestigatorId(1);
         let mut enemy = test_enemy(100, "Retaliator");
         enemy.retaliate = true;
@@ -1776,6 +1788,7 @@ mod combat_tests {
     #[test]
     fn drive_aoo_deals_damage_but_does_not_exhaust_the_attacker() {
         // RR p.7: an enemy does not exhaust while making an attack of opportunity.
+        crate::test_support::install_test_registry();
         let inv_id = InvestigatorId(1);
         let mut enemy = test_enemy(100, "Ghoul");
         enemy.engaged_with = Some(inv_id);
@@ -1815,7 +1828,9 @@ mod combat_tests {
         // order pick, parking the AttackLoop frame as the top frame with the AoO
         // source + PickOrder stage (so it spans the whole AoO, #143). Picking the
         // higher-id enemy first proves the pick overrides EnemyId order; neither
-        // AoO attacker exhausts (RR p.7).
+        // AoO attacker exhausts (RR p.7). Registry installed so max_health() /
+        // max_sanity() resolve (#448 cp2a); total AoO damage = 3 < 8 = TEST_INV.
+        crate::test_support::install_test_registry();
         let inv_id = InvestigatorId(1);
         let mut e_a = test_enemy(5, "A"); // EnemyId(5), dmg 1
         e_a.engaged_with = Some(inv_id);
@@ -1825,11 +1840,7 @@ mod combat_tests {
         e_b.attack_damage = 2;
 
         let mut state = GameStateBuilder::new()
-            .with_investigator({
-                let mut inv = test_investigator(1);
-                inv.max_health = 100;
-                inv
-            })
+            .with_investigator(test_investigator(1))
             .with_enemy(e_a)
             .with_enemy(e_b)
             .build();
@@ -1962,5 +1973,33 @@ mod combat_tests {
         assert!(!assignment.asset_horror.contains_key(&a));
         assert_eq!(assignment.investigator_damage, 0);
         assert_eq!(assignment.investigator_horror, 0);
+    }
+
+    #[test]
+    fn damage_application_accumulates_on_the_investigator_card() {
+        crate::test_support::install_test_registry();
+        let id = InvestigatorId(1);
+        let mut state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .build();
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+        let defeated = super::apply_damage_numeric(&mut cx, id, 3);
+        assert_eq!(
+            state.investigators[&id]
+                .investigator_card
+                .accumulated_damage,
+            3,
+            "damage must accumulate on the investigator_card, not the legacy field"
+        );
+        assert_eq!(
+            state.investigators[&id].damage(),
+            3,
+            "damage() accessor must read from investigator_card"
+        );
+        assert!(!defeated, "3 < 8 health — investigator not defeated");
     }
 }

--- a/crates/game-core/src/engine/dispatch/elimination.rs
+++ b/crates/game-core/src/engine/dispatch/elimination.rs
@@ -268,7 +268,6 @@ mod elimination_tests {
     fn elimination_step1_removes_controlled_and_owned_cards() {
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
-        inv.max_health = 1;
         inv.hand = vec![CardCode("h1".into()), CardCode("h2".into())];
         inv.deck = vec![CardCode("d1".into())];
         inv.discard = vec![CardCode("x1".into())];
@@ -312,7 +311,6 @@ mod elimination_tests {
         let id = InvestigatorId(1);
         let loc_id = LocationId(1);
         let mut inv = test_investigator(1);
-        inv.max_health = 1;
         inv.current_location = Some(loc_id);
         inv.clues = 2;
         inv.resources = 4;
@@ -357,7 +355,6 @@ mod elimination_tests {
         let loc = LocationId(1);
 
         let mut dying = test_investigator(1);
-        dying.max_health = 1;
         dying.current_location = Some(loc);
 
         let mut survivor = test_investigator(2);
@@ -410,7 +407,6 @@ mod elimination_tests {
         let loc = LocationId(1);
 
         let mut dying = test_investigator(1);
-        dying.max_health = 1;
         dying.current_location = Some(loc);
 
         let enemy = {
@@ -492,7 +488,6 @@ mod elimination_tests {
         let loc = LocationId(1);
 
         let mut dying = test_investigator(1);
-        dying.max_sanity = 1;
         dying.current_location = Some(loc);
         dying.clues = 1;
 
@@ -541,7 +536,6 @@ mod elimination_tests {
         let loc = LocationId(1);
 
         let mut dying = test_investigator(1);
-        dying.max_health = 1;
         dying.current_location = Some(loc);
 
         let mut survivor = test_investigator(2);
@@ -586,7 +580,6 @@ mod elimination_tests {
         // investigator) and zero resources without panicking.
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
-        inv.max_health = 1;
         inv.current_location = None;
         inv.clues = 3;
         inv.resources = 2;

--- a/crates/game-core/src/engine/dispatch/elimination.rs
+++ b/crates/game-core/src/engine/dispatch/elimination.rs
@@ -451,9 +451,12 @@ mod elimination_tests {
     fn last_investigator_defeated_latches_lost_resolution() {
         // Single investigator; defeat them and assert the no-remaining-players
         // resolution latch is set (Rules Reference p.10 step 6).
+        crate::test_support::install_test_registry();
         let inv = InvestigatorId(1);
         let mut investigator = test_investigator(1);
-        investigator.max_sanity = 1;
+        // After #448 cp2a: max_sanity() reads from the registry (TEST_INV = 8).
+        // Pre-load 7 horror so 1 more = 8 = max_sanity → lethal horror.
+        investigator.investigator_card.accumulated_horror = 7;
         let mut state = GameStateBuilder::new()
             .with_phase(Phase::Investigation)
             .with_investigator(investigator)
@@ -462,7 +465,7 @@ mod elimination_tests {
             .build();
         let mut events = Vec::new();
 
-        // Apply lethal horror through the standard defeat path.
+        // Apply the final point of lethal horror through the standard defeat path.
         take_horror(
             &mut Cx {
                 state: &mut state,

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -48,7 +48,7 @@ fn measure_value(
     let (base, stat) = match measure {
         PreyMeasure::Skill(kind) => (i32::from(inv.skills.value(kind)), skill_to_stat(kind)),
         PreyMeasure::RemainingHealth => (
-            i32::from(inv.max_health) - i32::from(inv.damage),
+            i32::from(inv.max_health()) - i32::from(inv.damage()),
             Stat::MaxHealth,
         ),
     };

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -633,14 +633,13 @@ mod resolve_prey_tests {
 
     #[test]
     fn resolve_prey_lowest_remaining_health_picks_min() {
-        // inv1: max_health 5, damage 4 → remaining 1.
-        // inv2: max_health 5, damage 0 → remaining 5. inv1 is lowest.
+        // max_health() = 8 (TEST_INV registry, #448 cp2a).
+        // hurt: accumulated_damage 6 → remaining 2.
+        // healthy: accumulated_damage 0 → remaining 8. hurt is lowest.
+        crate::test_support::install_test_registry();
         let mut hurt = test_investigator(1);
-        hurt.max_health = 5;
-        hurt.damage = 4;
-        let mut healthy = test_investigator(2);
-        healthy.max_health = 5;
-        healthy.damage = 0;
+        hurt.investigator_card.accumulated_damage = 6;
+        let healthy = test_investigator(2);
         let state = GameStateBuilder::new()
             .with_investigator(hurt)
             .with_investigator(healthy)
@@ -658,13 +657,14 @@ mod resolve_prey_tests {
 
     #[test]
     fn resolve_prey_lowest_remaining_health_tie_is_tie() {
-        // inv1: 5 − 2 = 3 remaining. inv2: 4 − 1 = 3 remaining. Tie.
+        // max_health() = 8 (TEST_INV registry, #448 cp2a).
+        // a: accumulated_damage 3 → remaining 5.
+        // b: accumulated_damage 3 → remaining 5. Tie.
+        crate::test_support::install_test_registry();
         let mut a = test_investigator(1);
-        a.max_health = 5;
-        a.damage = 2;
+        a.investigator_card.accumulated_damage = 3;
         let mut b = test_investigator(2);
-        b.max_health = 4;
-        b.damage = 1;
+        b.investigator_card.accumulated_damage = 3;
         let state = GameStateBuilder::new()
             .with_investigator(a)
             .with_investigator(b)
@@ -726,8 +726,10 @@ mod measure_value_tests {
     /// `state.investigators[inv.id].cards_in_play`, so the investigator
     /// must be in the state, not merely passed by reference).
     fn state_with(cards: &[&str], damage: u8) -> GameState {
-        let mut inv = test_investigator(1); // combat 3, max_health 8
-        inv.damage = damage;
+        crate::test_support::install_test_registry();
+        let mut inv = test_investigator(1); // combat 3, max_health() = 8 from TEST_INV registry
+                                            // After #448 cp2a harm accumulates on the investigator card.
+        inv.investigator_card.accumulated_damage = damage;
         inv.cards_in_play = cards
             .iter()
             .enumerate()

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -2983,6 +2983,8 @@ mod enemy_phase_tests {
 
     #[test]
     fn resolve_attacks_for_investigator_early_breaks_when_target_defeated_mid_loop() {
+        // Registry needed for max_health()/max_sanity() after cp2a.
+        crate::test_support::install_test_registry();
         let inv_id = InvestigatorId(1);
 
         // EnemyId(1) deals the killing blow on its attack.
@@ -2998,7 +3000,9 @@ mod enemy_phase_tests {
         let mut state = GameStateBuilder::default()
             .with_investigator({
                 let mut inv = test_investigator(1);
-                inv.max_health = 1; // e1's attack defeats
+                // Pre-load accumulated_damage so remaining health = 1 (lethal with attack_damage=1).
+                // max_health()=8 from TEST_INV; 7+1=8=defeated.
+                inv.investigator_card.accumulated_damage = 7;
                 inv
             })
             .with_turn_order([inv_id])

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -34,8 +34,12 @@ pub(super) fn start_scenario(cx: &mut Cx, roster: &[RosterEntry]) -> EngineOutco
 
     // Validate-first: resolve every roster entry's stats from card data
     // before mutating anything. Any failure rejects with state unchanged.
+    // Capacity (health/sanity) is no longer copied into Investigator fields
+    // (#448 cp4) — the accessors read from the registry directly via
+    // `investigator_card.code`. We still validate that the code resolves to a
+    // `CardKind::Investigator` here so seating rejects non-investigators.
     let registry = crate::card_registry::current();
-    let mut resolved: Vec<(Skills, u8, u8, String, Vec<CardCode>, CardCode)> =
+    let mut resolved: Vec<(Skills, String, Vec<CardCode>, CardCode)> =
         Vec::with_capacity(roster.len());
     for entry in roster {
         let Some(reg) = registry else {
@@ -48,13 +52,7 @@ pub(super) fn start_scenario(cx: &mut Cx, roster: &[RosterEntry]) -> EngineOutco
                 reason: format!("unknown investigator code {}", entry.investigator).into(),
             };
         };
-        let CardKind::Investigator {
-            skills,
-            health,
-            sanity,
-            ..
-        } = meta.kind
-        else {
+        let CardKind::Investigator { skills, .. } = meta.kind else {
             return EngineOutcome::Rejected {
                 reason: format!("card {} is not a seatable investigator", entry.investigator)
                     .into(),
@@ -62,8 +60,6 @@ pub(super) fn start_scenario(cx: &mut Cx, roster: &[RosterEntry]) -> EngineOutco
         };
         resolved.push((
             skills,
-            health,
-            sanity,
             meta.name.clone(),
             entry.deck.clone(),
             entry.investigator.clone(),
@@ -94,7 +90,7 @@ pub(super) fn start_scenario(cx: &mut Cx, roster: &[RosterEntry]) -> EngineOutco
     // (set by setup()). None leaves them unplaced — the pre-seated path.
     let start = cx.state.starting_location;
 
-    for (idx, (skills, health, sanity, name, deck, card_code)) in resolved.into_iter().enumerate() {
+    for (idx, (skills, name, deck, card_code)) in resolved.into_iter().enumerate() {
         let id = InvestigatorId(u32::try_from(idx).unwrap_or(0) + 1);
         let inv_card_id = cx.state.card_instance_ids.mint();
         let investigator_card = CardInPlay::enter_play(card_code, inv_card_id);
@@ -105,10 +101,6 @@ pub(super) fn start_scenario(cx: &mut Cx, roster: &[RosterEntry]) -> EngineOutco
                 name,
                 current_location: start,
                 skills,
-                max_health: health,
-                damage: 0,
-                max_sanity: sanity,
-                horror: 0,
                 clues: 0,
                 resources: 5,
                 actions_remaining: 0,
@@ -2899,6 +2891,7 @@ mod enemy_phase_tests {
     #[test]
     fn resolve_attacks_for_investigator_pick_overrides_enemy_id_order() {
         use crate::engine::OptionId;
+        crate::test_support::install_test_registry();
 
         let inv_id = InvestigatorId(1);
 
@@ -2911,11 +2904,7 @@ mod enemy_phase_tests {
         e_higher.attack_damage = 2;
 
         let mut state = GameStateBuilder::default()
-            .with_investigator({
-                let mut inv = test_investigator(1);
-                inv.max_health = 100; // survive both attacks
-                inv
-            })
+            .with_investigator(test_investigator(1)) // TEST_INV: 8 health; 1+2=3 total damage < 8
             .with_turn_order([inv_id])
             .with_enemy(e_higher) // inserted non-id order: BTreeMap still snapshots 2 then 10
             .with_enemy(e_lower)

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -11,7 +11,7 @@ use crate::state::{
 
 use crate::action::RosterEntry;
 use crate::card_data::CardKind;
-use crate::state::{Investigator, Skills, Status};
+use crate::state::{CardInPlay, Investigator, Skills, Status};
 
 use super::Cx;
 
@@ -96,6 +96,8 @@ pub(super) fn start_scenario(cx: &mut Cx, roster: &[RosterEntry]) -> EngineOutco
 
     for (idx, (skills, health, sanity, name, deck, card_code)) in resolved.into_iter().enumerate() {
         let id = InvestigatorId(u32::try_from(idx).unwrap_or(0) + 1);
+        let inv_card_id = cx.state.card_instance_ids.mint();
+        let investigator_card = CardInPlay::enter_play(card_code.clone(), inv_card_id);
         cx.state.investigators.insert(
             id,
             Investigator {
@@ -120,6 +122,7 @@ pub(super) fn start_scenario(cx: &mut Cx, roster: &[RosterEntry]) -> EngineOutco
                 removed_from_game: Vec::new(),
                 ability_usage: std::collections::BTreeMap::new(),
                 action_surcharge_spent_this_round: std::collections::BTreeSet::new(),
+                investigator_card,
             },
         );
         cx.state.turn_order.push(id);

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -97,12 +97,11 @@ pub(super) fn start_scenario(cx: &mut Cx, roster: &[RosterEntry]) -> EngineOutco
     for (idx, (skills, health, sanity, name, deck, card_code)) in resolved.into_iter().enumerate() {
         let id = InvestigatorId(u32::try_from(idx).unwrap_or(0) + 1);
         let inv_card_id = cx.state.card_instance_ids.mint();
-        let investigator_card = CardInPlay::enter_play(card_code.clone(), inv_card_id);
+        let investigator_card = CardInPlay::enter_play(card_code, inv_card_id);
         cx.state.investigators.insert(
             id,
             Investigator {
                 id,
-                card_code,
                 name,
                 current_location: start,
                 skills,
@@ -120,7 +119,6 @@ pub(super) fn start_scenario(cx: &mut Cx, roster: &[RosterEntry]) -> EngineOutco
                 cards_in_play: Vec::new(),
                 threat_area: Vec::new(),
                 removed_from_game: Vec::new(),
-                ability_usage: std::collections::BTreeMap::new(),
                 action_surcharge_spent_this_round: std::collections::BTreeSet::new(),
                 investigator_card,
             },

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -384,10 +384,10 @@ fn scan_investigator_card_reactions(
             continue;
         };
         // Empty sentinel ⇒ pre-seated path, no investigator-card abilities.
-        if inv.card_code.as_str().is_empty() {
+        if inv.investigator_card.code.as_str().is_empty() {
             continue;
         }
-        let Some(abilities) = (reg.abilities_for)(&inv.card_code) else {
+        let Some(abilities) = (reg.abilities_for)(&inv.investigator_card.code) else {
             continue;
         };
         for (idx, ability) in abilities.iter().enumerate() {
@@ -413,7 +413,7 @@ fn scan_investigator_card_reactions(
                 continue;
             }
             hits.push(ResolutionCandidate {
-                code: inv.card_code.clone(),
+                code: inv.investigator_card.code.clone(),
                 controller: id,
                 ability_index,
                 source: CandidateSource::Investigator(id),

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -276,8 +276,11 @@ fn scan_pending_triggers(
                 if card.is_usage_exhausted(ability_index, ability.usage_limit, state.round) {
                     continue;
                 }
-                // Reaction candidates always have a source instance (an
-                // in-play / threat-area card); abilities resolve by `code`.
+                // Reaction candidates always have a source instance — an
+                // in-play / threat-area card, or the investigator card itself
+                // (#448 cp3a, now folded into `controlled_card_instances()`);
+                // abilities resolve by `code`. `bump_usage_counter` resolves
+                // the instance against all three zones.
                 pending.push(ResolutionCandidate {
                     code: card.code.clone(),
                     controller: id,
@@ -288,7 +291,6 @@ fn scan_pending_triggers(
         }
     }
     pending.extend(scan_act_agenda_reactions(state, event, bucket));
-    pending.extend(scan_investigator_card_reactions(state, event, bucket));
     pending
 }
 
@@ -344,79 +346,6 @@ fn scan_act_agenda_reactions(
                 controller: lead,
                 ability_index,
                 source: CandidateSource::Board,
-            });
-        }
-    }
-    hits
-}
-
-/// Scan every investigator's **own card** (by `Investigator.card_code`) for
-/// `Trigger::OnEvent` reaction abilities matching `event` at `bucket` — makes
-/// Roland Banks's `[reaction]` fire from a *seated* investigator, whose card is
-/// not in any `cards_in_play` zone (so `scan_pending_triggers`' per-instance
-/// loop can't reach it). Mirrors [`scan_act_agenda_reactions`]: candidate keyed
-/// by `code`, `CandidateSource::Investigator(id)`, the per-period usage check
-/// pointed at `Investigator.ability_usage`. Skips empty sentinel codes (the
-/// pre-seated `test_support` path) and uninstalled registry / non-matching
-/// abilities. **Bridge (#118), sunset by #448.**
-fn scan_investigator_card_reactions(
-    state: &GameState,
-    event: &TimingEvent,
-    bucket: EventTiming,
-) -> Vec<ResolutionCandidate> {
-    let Some(reg) = card_registry::current() else {
-        return Vec::new();
-    };
-    // Active-investigator-first / turn-order order, matching `scan_pending_triggers`.
-    let mut order: Vec<InvestigatorId> = Vec::with_capacity(state.turn_order.len());
-    if let Some(active) = state.active_investigator {
-        order.push(active);
-    }
-    for id in &state.turn_order {
-        if Some(*id) != state.active_investigator {
-            order.push(*id);
-        }
-    }
-
-    let mut hits = Vec::new();
-    for id in order {
-        let Some(inv) = state.investigators.get(&id) else {
-            continue;
-        };
-        // Empty sentinel ⇒ pre-seated path, no investigator-card abilities.
-        if inv.investigator_card.code.as_str().is_empty() {
-            continue;
-        }
-        let Some(abilities) = (reg.abilities_for)(&inv.investigator_card.code) else {
-            continue;
-        };
-        for (idx, ability) in abilities.iter().enumerate() {
-            let Trigger::OnEvent {
-                pattern,
-                timing,
-                kind,
-            } = &ability.trigger
-            else {
-                continue;
-            };
-            if *kind != TriggerKind::Reaction
-                || *timing != bucket
-                || !trigger_matches(event, pattern, *timing, id)
-            {
-                continue;
-            }
-            let ability_index = u8::try_from(idx)
-                .expect("abilities vec exceeds u8::MAX — card-impl bug, abilities are tiny");
-            // "Limit X per [period]" — skip if the investigator-card counter has
-            // hit the cap this round (Roland's reaction is Limit 1 per round).
-            if inv.is_usage_exhausted(ability_index, ability.usage_limit, state.round) {
-                continue;
-            }
-            hits.push(ResolutionCandidate {
-                code: inv.investigator_card.code.clone(),
-                controller: id,
-                ability_index,
-                source: CandidateSource::Investigator(id),
             });
         }
     }
@@ -618,9 +547,7 @@ fn build_resolution_options(candidates: &[ResolutionCandidate]) -> Vec<ChoiceOpt
         .map(|(i, cand)| {
             let label = match cand.source {
                 CandidateSource::Hand => format!("Play {} from hand", cand.code),
-                CandidateSource::InPlay(_)
-                | CandidateSource::Board
-                | CandidateSource::Investigator(_) => {
+                CandidateSource::InPlay(_) | CandidateSource::Board => {
                     format!("Resolve reaction: {}", cand.code)
                 }
             };
@@ -974,10 +901,12 @@ pub(super) fn advance_resolution(cx: &mut Cx) -> EngineOutcome {
 /// whose `usage_limit` is `Some(_)`; for abilities with no limit
 /// nothing tracks them.
 ///
-/// Routes on [`CandidateSource`]: `InPlay` bumps the `CardInPlay` instance,
-/// `Investigator` bumps `Investigator.ability_usage` (Roland Banks's seated
-/// `[reaction]`). `Board` and `Hand` candidates carry no usage limits and are
-/// `unreachable!` here.
+/// Routes on [`CandidateSource`]: `InPlay` bumps the `CardInPlay` instance —
+/// the investigator card, a card in play, or a threat-area card, resolved by
+/// instance id over all three zones (#448 cp3a folded the investigator card,
+/// e.g. Roland Banks's seated `[reaction]`, onto this path; its usage now lives
+/// on `investigator_card.ability_usage`). `Board` and `Hand` candidates carry
+/// no usage limits and are `unreachable!` here.
 ///
 /// **TODO (cancellation-counts-against-limit).** Rules Reference
 /// page 14: *"If the effects of a card or ability with a limit or
@@ -1001,33 +930,26 @@ fn bump_usage_counter(state: &mut GameState, trigger: &ResolutionCandidate) {
                         ctl = trigger.controller,
                     )
                 });
-            let card = inv
-                .cards_in_play
-                .iter_mut()
+            // Search the investigator card first, then cards in play, then the
+            // threat area — the same zones `controlled_card_instances()` scans,
+            // so an investigator-card reaction (Roland Banks) resolves here.
+            let card = std::iter::once(&mut inv.investigator_card)
+                .chain(inv.cards_in_play.iter_mut())
                 .chain(inv.threat_area.iter_mut())
                 .find(|c| c.instance_id == instance_id)
                 .unwrap_or_else(|| {
                     unreachable!(
                         "bump_usage_counter: instance {instance_id:?} vanished from controller \
-                         {ctl:?}'s cards_in_play / threat area while reaction window was open; \
-                         state-corruption invariant violation",
+                         {ctl:?}'s investigator card / cards_in_play / threat area while reaction \
+                         window was open; state-corruption invariant violation",
                         ctl = trigger.controller,
                     )
                 });
             card.bump_ability_usage(trigger.ability_index, current_round);
         }
-        CandidateSource::Investigator(id) => {
-            let inv = state.investigators.get_mut(&id).unwrap_or_else(|| {
-                unreachable!(
-                    "bump_usage_counter: investigator {id:?} vanished while reaction window \
-                     was open; state-corruption invariant violation"
-                )
-            });
-            inv.bump_ability_usage(trigger.ability_index, current_round);
-        }
         CandidateSource::Board | CandidateSource::Hand => unreachable!(
-            "bump_usage_counter: a usage-limited candidate must be an in-play instance or an \
-             investigator card (board / hand candidates carry no usage limits); candidate {trigger:?}"
+            "bump_usage_counter: a usage-limited candidate must be an in-play instance \
+             (board / hand candidates carry no usage limits); candidate {trigger:?}"
         ),
     }
 }

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -1511,7 +1511,8 @@ mod tests {
         let out = super::super::drive(&mut cx, out);
         assert_eq!(out, EngineOutcome::Done);
         assert_eq!(
-            state.investigators[&inv].horror, 1,
+            state.investigators[&inv].horror(),
+            1,
             "on_success effect ran on the passing draw",
         );
     }

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -1920,10 +1920,9 @@ pub fn constant_skill_modifier(
 
 /// The controller's **elder-sign** skill-test modifier: the
 /// `IntExpr` on their investigator card's `Trigger::ElderSign { modifier }`
-/// ability, evaluated for the controller. Returns `0` when the controller has
-/// no investigator card (empty sentinel `card_code`), the card isn't in the
-/// registry, or it carries no elder-sign ability — so every investigator
-/// without an elder-sign resolves exactly as before.
+/// ability, evaluated for the controller. Returns `0` when the controller is
+/// not found, the card isn't in the registry, or it carries no elder-sign
+/// ability — so every investigator without an elder-sign resolves as 0.
 ///
 /// Called from the skill-test resolution's `TokenResolution::ElderSign` arm
 /// (`skill_test.rs`); the bonus flows through the existing `Modifier` total.
@@ -1940,9 +1939,6 @@ pub(crate) fn elder_sign_modifier(
     let Some(inv) = state.investigators.get(&controller) else {
         return 0;
     };
-    if inv.investigator_card.code.as_str().is_empty() {
-        return 0;
-    }
     let Some(abilities) = (registry.abilities_for)(&inv.investigator_card.code) else {
         return 0;
     };
@@ -4897,7 +4893,6 @@ mod tests {
         let inv_id = InvestigatorId(1);
         let loc_id = crate::state::LocationId(10);
         let mut inv = test_investigator(1);
-        inv.card_code = CardCode::new("ES");
         inv.investigator_card.code = CardCode::new("ES");
         inv.current_location = Some(loc_id);
         let mut loc = test_location(10, "Study");
@@ -4912,7 +4907,6 @@ mod tests {
         // An investigator whose card has no elder-sign ability → 0.
         let inv_id2 = InvestigatorId(2);
         let mut inv2 = test_investigator(2);
-        inv2.card_code = CardCode::new("PLAIN");
         inv2.investigator_card.code = CardCode::new("PLAIN");
         let state2 = GameStateBuilder::new().with_investigator(inv2).build();
         assert_eq!(super::elder_sign_modifier(&state2, &registry, inv_id2), 0);

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -1940,10 +1940,10 @@ pub(crate) fn elder_sign_modifier(
     let Some(inv) = state.investigators.get(&controller) else {
         return 0;
     };
-    if inv.card_code.as_str().is_empty() {
+    if inv.investigator_card.code.as_str().is_empty() {
         return 0;
     }
-    let Some(abilities) = (registry.abilities_for)(&inv.card_code) else {
+    let Some(abilities) = (registry.abilities_for)(&inv.investigator_card.code) else {
         return 0;
     };
     let ctx = EvalContext::for_controller(controller);
@@ -3965,7 +3965,7 @@ mod tests {
             ctx(1),
         );
         assert_eq!(outcome, EngineOutcome::Done);
-        assert_eq!(state.investigators[&InvestigatorId(1)].horror, 0);
+        assert_eq!(state.investigators[&InvestigatorId(1)].horror(), 0);
         assert_event!(
             events,
             Event::Healed {
@@ -4014,7 +4014,7 @@ mod tests {
         );
         assert_eq!(outcome, EngineOutcome::Done);
         assert_eq!(
-            state.investigators[&InvestigatorId(1)].damage,
+            state.investigators[&InvestigatorId(1)].damage(),
             1,
             "sole co-located target healed"
         );
@@ -4676,7 +4676,7 @@ mod tests {
             EvalContext::for_controller(InvestigatorId(1)),
         );
         assert_eq!(outcome, EngineOutcome::Done);
-        assert_eq!(state.investigators[&InvestigatorId(1)].damage, 2);
+        assert_eq!(state.investigators[&InvestigatorId(1)].damage(), 2);
         assert_event!(
             events,
             Event::DamageTaken { investigator, amount: 2 } if *investigator == InvestigatorId(1)
@@ -4700,7 +4700,7 @@ mod tests {
             EvalContext::for_controller(InvestigatorId(1)),
         );
         assert_eq!(outcome, EngineOutcome::Done);
-        assert_eq!(state.investigators[&InvestigatorId(1)].horror, 1);
+        assert_eq!(state.investigators[&InvestigatorId(1)].horror(), 1);
         assert_event!(
             events,
             Event::HorrorTaken { investigator, amount: 1 } if *investigator == InvestigatorId(1)
@@ -4755,7 +4755,7 @@ mod tests {
         eval_ctx.set_failed_by(2);
         let outcome = run(&mut cx, &effect, eval_ctx);
         assert_eq!(outcome, EngineOutcome::Done);
-        assert_eq!(state.investigators[&InvestigatorId(1)].damage, 2);
+        assert_eq!(state.investigators[&InvestigatorId(1)].damage(), 2);
         // Deal evaluates the IntExpr once and applies the result in a single hit;
         // fail-by 2 → amount 2 → one DamageTaken event with amount 2.
         assert_event!(events, Event::DamageTaken { investigator, amount: 2 } if *investigator == InvestigatorId(1));
@@ -4857,6 +4857,7 @@ mod tests {
         let loc_id = crate::state::LocationId(10);
         let mut inv = test_investigator(1);
         inv.card_code = CardCode::new("ES");
+        inv.investigator_card.code = CardCode::new("ES");
         inv.current_location = Some(loc_id);
         let mut loc = test_location(10, "Study");
         loc.clues = 2;
@@ -4871,6 +4872,7 @@ mod tests {
         let inv_id2 = InvestigatorId(2);
         let mut inv2 = test_investigator(2);
         inv2.card_code = CardCode::new("PLAIN");
+        inv2.investigator_card.code = CardCode::new("PLAIN");
         let state2 = GameStateBuilder::new().with_investigator(inv2).build();
         assert_eq!(super::elder_sign_modifier(&state2, &registry, inv_id2), 0);
     }

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -1485,8 +1485,8 @@ fn heal_effect(
         };
     };
     let current = match kind {
-        HarmKind::Damage => &mut inv.damage,
-        HarmKind::Horror => &mut inv.horror,
+        HarmKind::Damage => &mut inv.investigator_card.accumulated_damage,
+        HarmKind::Horror => &mut inv.investigator_card.accumulated_horror,
     };
     let healed = (*current).min(count);
     *current -= healed;
@@ -3946,6 +3946,7 @@ mod tests {
 
     #[test]
     fn heal_reduces_horror_saturating_and_emits_event() {
+        crate::test_support::install_test_registry();
         let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
@@ -3953,7 +3954,8 @@ mod tests {
             .investigators
             .get_mut(&InvestigatorId(1))
             .unwrap()
-            .horror = 1;
+            .investigator_card
+            .accumulated_horror = 1;
         let mut events = Vec::new();
         let outcome = run(
             &mut Cx {
@@ -3978,6 +3980,7 @@ mod tests {
 
     #[test]
     fn heal_target_chosen_at_your_location_auto_binds() {
+        crate::test_support::install_test_registry();
         let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .with_investigator(test_investigator(2))
@@ -3998,7 +4001,8 @@ mod tests {
             .investigators
             .get_mut(&InvestigatorId(1))
             .unwrap()
-            .damage = 2;
+            .investigator_card
+            .accumulated_damage = 2;
         let mut events = Vec::new();
         let outcome = run(
             &mut Cx {
@@ -4709,13 +4713,15 @@ mod tests {
 
     #[test]
     fn deal_damage_at_max_health_defeats_investigator() {
-        // Build an investigator with a known low max_health (3), then
-        // apply exactly 3 damage via Effect::Deal and assert the
-        // investigator is Killed and InvestigatorDefeated is emitted.
         use crate::state::Status;
+        // Apply damage that exactly reaches max_health (8 from TEST_INV) via
+        // Effect::Deal and assert the investigator is Killed and
+        // InvestigatorDefeated is emitted. Pre-load 5 accumulated_damage so
+        // 5 + 3 = 8 = defeated with a 3-damage deal.
+        crate::test_support::install_test_registry();
         let id = InvestigatorId(1);
         let mut inv = test_investigator(1);
-        inv.max_health = 3;
+        inv.investigator_card.accumulated_damage = 5;
         let mut state = GameStateBuilder::new().with_investigator(inv).build();
         let mut events = Vec::new();
         let outcome = run(

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -2105,8 +2105,10 @@ pub fn pending_action_surcharge(
 
 /// Shared core of [`constant_skill_modifier`] and
 /// [`unconditional_constant_stat_modifier`]: sum the `delta` of every
-/// `Trigger::Constant` `Effect::Modify` on `controller`'s cards in play
-/// whose scope and stat both satisfy the given predicates. Silently skips
+/// `Trigger::Constant` `Effect::Modify` on every instance `controller`
+/// controls — the investigator card, cards in play, and the threat area
+/// (via [`controlled_card_instances`](crate::state::Investigator::controlled_card_instances),
+/// #448 cp3a) — whose scope and stat both satisfy the given predicates. Silently skips
 /// cards whose code the registry can't resolve (same policy as the
 /// callers — the deck-import gate keeps unimplemented codes out of play).
 fn sum_constant_modify(
@@ -2120,7 +2122,7 @@ fn sum_constant_modify(
         return 0;
     };
     let mut total: i8 = 0;
-    for in_play in &inv.cards_in_play {
+    for in_play in inv.controlled_card_instances() {
         let Some(abilities) = (registry.abilities_for)(&in_play.code) else {
             continue;
         };
@@ -4085,6 +4087,14 @@ mod tests {
                 2,
                 ModifierScope::WhileInPlay,
             ))]),
+            // A standalone fake investigator card carrying a constant +2
+            // willpower — used to prove the unified `controlled_card_instances()`
+            // scan now sums the investigator card (not just `cards_in_play`).
+            "inv-willpower-plus-2" => Some(vec![constant(modify(
+                Stat::Willpower,
+                2,
+                ModifierScope::WhileInPlay,
+            ))]),
             "intellect-plus-1-while-investigating" => Some(vec![constant(modify(
                 Stat::Intellect,
                 1,
@@ -4366,6 +4376,31 @@ mod tests {
         assert_eq!(
             constant_skill_modifier(&state, &reg, id, SkillKind::Willpower, SkillTestKind::Plain),
             0
+        );
+    }
+
+    #[test]
+    fn a_seated_investigator_card_constant_modifier_is_summed() {
+        // The investigator card lives in `investigator_card`, NOT in
+        // `cards_in_play`. After cp3a the constant-modifier scan walks
+        // `controlled_card_instances()`, which yields the investigator card
+        // first, so its `Trigger::Constant` modifier must be summed without any
+        // `cards_in_play` injection.
+        let (mut state, id) = state_with_cards_in_play(&[]);
+        state
+            .investigators
+            .get_mut(&id)
+            .unwrap()
+            .investigator_card
+            .code = CardCode::new("inv-willpower-plus-2");
+        let reg = fake_registry();
+        assert!(
+            state.investigators[&id].cards_in_play.is_empty(),
+            "the modifier must come from the investigator card, not cards_in_play"
+        );
+        assert_eq!(
+            constant_skill_modifier(&state, &reg, id, SkillKind::Willpower, SkillTestKind::Plain),
+            2
         );
     }
 

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -3216,7 +3216,8 @@ mod tests {
         // highest-damage enemy first to prove the pick overrides EnemyId order.
         let (inv_id, _, b, state) = move_scenario();
         let mut state = state;
-        state.investigators.get_mut(&inv_id).unwrap().max_health = 100; // survive all three
+        // TEST_INV has 8 health; total enemy damage = 1+2+4 = 7 < 8, so investigator survives.
+        // (max_health is now read from the registry, not a field — see #448 cp4.)
         for (id, dmg) in [(300, 1), (301, 2), (302, 4)] {
             let mut e = test_enemy(id, "");
             e.engaged_with = Some(inv_id);

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -952,6 +952,8 @@ mod tests {
         clues: u8,
         shroud: u8,
     ) -> (InvestigatorId, crate::state::LocationId, GameState) {
+        // Registry needed for max_health()/max_sanity() after cp2a.
+        crate::test_support::install_test_registry();
         let inv_id = InvestigatorId(1);
         let loc_id = crate::state::LocationId(10);
         let mut inv = test_investigator(1);
@@ -1570,6 +1572,8 @@ mod tests {
         crate::state::LocationId,
         GameState,
     ) {
+        // Registry needed for max_health()/max_sanity() after cp2a.
+        crate::test_support::install_test_registry();
         let inv_id = InvestigatorId(1);
         let a = crate::state::LocationId(10);
         let b = crate::state::LocationId(11);
@@ -3303,9 +3307,9 @@ mod tests {
 
     /// Build a Move scenario with one ready engaged enemy at the
     /// origin. The investigator is configured to be defeated by the
-    /// enemy's `AoO`: `max_health = 1`, `damage = 0`, enemy
-    /// `attack_damage = 1`. Returns (inv id, origin, dest, enemy id,
-    /// state).
+    /// enemy's `AoO`: `accumulated_damage` pre-loaded to 7 (leaving 1
+    /// health remaining), enemy `attack_damage = 1`. Returns (inv id,
+    /// origin, dest, enemy id, state).
     fn move_scenario_with_lethal_aoo() -> (
         InvestigatorId,
         crate::state::LocationId,
@@ -3314,7 +3318,14 @@ mod tests {
         GameState,
     ) {
         let (inv_id, a, b, enemy_id, mut state) = move_scenario_with_engaged_enemy();
-        state.investigators.get_mut(&inv_id).unwrap().max_health = 1;
+        // Pre-load accumulated_damage so remaining health = 1 (lethal with attack_damage=1).
+        // max_health() = 8 from TEST_INV; 7 + 1 = 8 = defeated.
+        state
+            .investigators
+            .get_mut(&inv_id)
+            .unwrap()
+            .investigator_card
+            .accumulated_damage = 7;
         // attack_damage = 1 is already the default from
         // move_scenario_with_engaged_enemy, but be explicit.
         state.enemies.get_mut(&enemy_id).unwrap().attack_damage = 1;
@@ -3366,10 +3377,17 @@ mod tests {
     #[test]
     fn aoo_lethal_horror_defeats_investigator_during_investigate_and_cancels_test() {
         // Set up Investigate with an engaged enemy whose attack is
-        // pure horror. Investigator's max_sanity = 1, so 1 horror
-        // drives them insane.
+        // pure horror. Investigator has 1 sanity remaining (accumulated_horror=7),
+        // so 1 horror drives them insane.
         let (inv_id, loc_id, mut state) = investigate_scenario(2, 2);
-        state.investigators.get_mut(&inv_id).unwrap().max_sanity = 1;
+        // Pre-load accumulated_horror so remaining sanity = 1 (lethal with attack_horror=1).
+        // max_sanity() = 8 from TEST_INV; 7 + 1 = 8 = defeated.
+        state
+            .investigators
+            .get_mut(&inv_id)
+            .unwrap()
+            .investigator_card
+            .accumulated_horror = 7;
         let enemy_id = EnemyId(400);
         let mut enemy = test_enemy(400, "Tormenting Shade");
         enemy.current_location = Some(loc_id);
@@ -3407,9 +3425,8 @@ mod tests {
         // Sanity check: AoO that doesn't reach max_health leaves the
         // investigator Active. Same as the existing AoO test but
         // explicit on the status field and absence of defeat events.
-        let (inv_id, _, b, _, mut state) = move_scenario_with_engaged_enemy();
-        // Bump max_health above the AoO damage (which is 1).
-        state.investigators.get_mut(&inv_id).unwrap().max_health = 5;
+        // After cp2a max_health()=8 from TEST_INV registry; attack_damage=1 < 8 → survives.
+        let (inv_id, _, b, _, state) = move_scenario_with_engaged_enemy();
         let result = apply(
             state,
             Action::Player(PlayerAction::Move {
@@ -3427,12 +3444,19 @@ mod tests {
     #[test]
     fn defeated_investigator_does_not_take_further_damage() {
         // Two engaged ready enemies, both with attack_damage = 5.
-        // Investigator has max_health = 1. With 2 engaged, the Move's AoO
-        // suspends on the order pick (#143); the chosen first attacker defeats
-        // the investigator, so the active-check at the loop top early-breaks
-        // before the second attacks (no re-prompt).
+        // Investigator has 1 health remaining (accumulated_damage=7). With 2
+        // engaged, the Move's AoO suspends on the order pick (#143); the
+        // chosen first attacker defeats the investigator, so the active-check
+        // at the loop top early-breaks before the second attacks (no re-prompt).
         let (inv_id, _, b, _, mut state) = move_scenario_with_engaged_enemy();
-        state.investigators.get_mut(&inv_id).unwrap().max_health = 1;
+        // Pre-load accumulated_damage so remaining health = 1 (lethal with attack_damage=5).
+        // max_health()=8 from TEST_INV; 7 + 5 = 12 >= 8 = defeated.
+        state
+            .investigators
+            .get_mut(&inv_id)
+            .unwrap()
+            .investigator_card
+            .accumulated_damage = 7;
         state.enemies.get_mut(&EnemyId(200)).unwrap().attack_damage = 5;
         // Add a second engaged ready enemy.
         let mut e2 = test_enemy(201, "Second Ghoul");
@@ -3459,8 +3483,9 @@ mod tests {
         // InvestigatorDefeated; the second enemy never attacks (early-break).
         assert_event_count!(r2.events, 1, Event::DamageTaken { .. });
         assert_event_count!(r2.events, 1, Event::InvestigatorDefeated { .. });
-        // Damage saturates at the first AoO's amount; the second AoO is skipped.
-        assert_eq!(r2.state.investigators[&inv_id].damage(), 5);
+        // Only one AoO fired: pre-loaded 7 + first AoO's 5 = 12; if the
+        // second AoO had fired too, damage() would be 17 instead.
+        assert_eq!(r2.state.investigators[&inv_id].damage(), 12);
         // The actor was defeated mid-action → the Move's primary effect is
         // suppressed by the re-validation gate (#293 keystone).
         assert_no_event!(r2.events, Event::InvestigatorMoved { .. });
@@ -3472,9 +3497,15 @@ mod tests {
         // attack are applied simultaneously. Lethal damage MUST NOT
         // short-circuit the horror application.
         let (inv_id, _, b, enemy_id, mut state) = move_scenario_with_engaged_enemy();
-        state.investigators.get_mut(&inv_id).unwrap().max_health = 5;
-        // Plenty of sanity headroom so the horror is sub-lethal.
-        state.investigators.get_mut(&inv_id).unwrap().max_sanity = 8;
+        // Pre-load accumulated_damage so remaining health = 5 (lethal with attack_damage=5).
+        // max_health()=8 from TEST_INV; 3 + 5 = 8 = defeated.
+        // Sanity headroom: max_sanity()=8, attack_horror=1 → 0+1=1 < 8 → sub-lethal.
+        state
+            .investigators
+            .get_mut(&inv_id)
+            .unwrap()
+            .investigator_card
+            .accumulated_damage = 3;
         let enemy = state.enemies.get_mut(&enemy_id).unwrap();
         enemy.attack_damage = 5;
         enemy.attack_horror = 1;
@@ -3495,7 +3526,8 @@ mod tests {
             result.events,
             Event::HorrorTaken { investigator, amount: 1 } if *investigator == inv_id
         );
-        assert_eq!(result.state.investigators[&inv_id].damage(), 5);
+        // Pre-loaded 3 + attack 5 = 8; horror 0 + 1 = 1.
+        assert_eq!(result.state.investigators[&inv_id].damage(), 8);
         assert_eq!(result.state.investigators[&inv_id].horror(), 1);
         // Exactly one InvestigatorDefeated, caused by Damage.
         assert_event_count!(result.events, 1, Event::InvestigatorDefeated { .. });
@@ -3514,8 +3546,15 @@ mod tests {
         // Symmetric to the lethal-damage case: lethal horror MUST NOT
         // short-circuit the damage application.
         let (inv_id, _, b, enemy_id, mut state) = move_scenario_with_engaged_enemy();
-        state.investigators.get_mut(&inv_id).unwrap().max_health = 8;
-        state.investigators.get_mut(&inv_id).unwrap().max_sanity = 1;
+        // Pre-load accumulated_horror so remaining sanity = 1 (lethal with attack_horror=5 would be
+        // 7+5=12 >= 8; but we want sub-lethal damage (1 < 8) and lethal horror).
+        // remaining sanity = 8 - 3 = 5, and 3 + 5 = 8 = defeated.
+        state
+            .investigators
+            .get_mut(&inv_id)
+            .unwrap()
+            .investigator_card
+            .accumulated_horror = 3;
         let enemy = state.enemies.get_mut(&enemy_id).unwrap();
         enemy.attack_damage = 1;
         enemy.attack_horror = 5;
@@ -3535,8 +3574,9 @@ mod tests {
             result.events,
             Event::HorrorTaken { investigator, amount: 5 } if *investigator == inv_id
         );
+        // damage: 0 + 1 = 1; horror: pre-loaded 3 + attack 5 = 8.
         assert_eq!(result.state.investigators[&inv_id].damage(), 1);
-        assert_eq!(result.state.investigators[&inv_id].horror(), 5);
+        assert_eq!(result.state.investigators[&inv_id].horror(), 8);
         assert_event_count!(result.events, 1, Event::InvestigatorDefeated { .. });
         assert_event!(
             result.events,
@@ -3555,8 +3595,20 @@ mod tests {
         // DefeatCause::Damage (Rules Reference is silent on the
         // simultaneous-lethal case; damage-first is the convention).
         let (inv_id, _, b, enemy_id, mut state) = move_scenario_with_engaged_enemy();
-        state.investigators.get_mut(&inv_id).unwrap().max_health = 1;
-        state.investigators.get_mut(&inv_id).unwrap().max_sanity = 1;
+        // Pre-load both counters so remaining health and sanity = 1 each.
+        // max_health()=max_sanity()=8 from TEST_INV; 7+1=8 = defeated for both.
+        state
+            .investigators
+            .get_mut(&inv_id)
+            .unwrap()
+            .investigator_card
+            .accumulated_damage = 7;
+        state
+            .investigators
+            .get_mut(&inv_id)
+            .unwrap()
+            .investigator_card
+            .accumulated_horror = 7;
         let enemy = state.enemies.get_mut(&enemy_id).unwrap();
         enemy.attack_damage = 1;
         enemy.attack_horror = 1;
@@ -3568,8 +3620,9 @@ mod tests {
             }),
         );
         assert_eq!(result.outcome, EngineOutcome::Done);
-        assert_eq!(result.state.investigators[&inv_id].damage(), 1);
-        assert_eq!(result.state.investigators[&inv_id].horror(), 1);
+        // Pre-loaded 7 + attack 1 = 8 each.
+        assert_eq!(result.state.investigators[&inv_id].damage(), 8);
+        assert_eq!(result.state.investigators[&inv_id].horror(), 8);
         assert_event_count!(result.events, 1, Event::InvestigatorDefeated { .. });
         assert_event!(
             result.events,
@@ -3585,10 +3638,14 @@ mod tests {
     fn all_investigators_defeated_fires_only_when_last_active_falls() {
         // Two investigators, one defeated, then the second defeated.
         // AllInvestigatorsDefeated should fire only on the second.
+        // Registry needed for max_health()/max_sanity() after cp2a.
+        crate::test_support::install_test_registry();
         let inv1 = InvestigatorId(1);
         let inv2 = InvestigatorId(2);
         let mut i1 = test_investigator(1);
-        i1.max_health = 1;
+        // Pre-load accumulated_damage so remaining health = 1 (lethal with attack_damage=1).
+        // max_health()=8 from TEST_INV; 7+1=8=defeated.
+        i1.investigator_card.accumulated_damage = 7;
         i1.actions_remaining = 3;
         let i2 = test_investigator(2);
         // i2 stays at default 8/8.
@@ -3719,6 +3776,8 @@ mod tests {
     /// phase, active, 3 actions. The caller mutates deck/hand/discard
     /// before the test.
     fn draw_scenario() -> (InvestigatorId, GameState) {
+        // Registry needed for max_health()/max_sanity() after cp2a.
+        crate::test_support::install_test_registry();
         let id = InvestigatorId(1);
         let a = crate::state::LocationId(10);
         let mut inv = test_investigator(1);
@@ -3902,7 +3961,9 @@ mod tests {
         // flow correctly composes with the defeat helpers.
         let (id, mut state) = draw_scenario();
         let inv = state.investigators.get_mut(&id).unwrap();
-        inv.max_sanity = 1;
+        // Pre-load accumulated_horror so remaining sanity = 1 (lethal with the 1-horror penalty).
+        // max_sanity()=8 from TEST_INV; 7+1=8=defeated.
+        inv.investigator_card.accumulated_horror = 7;
         let result = apply(
             state,
             Action::Player(PlayerAction::Draw { investigator: id }),

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -1971,8 +1971,8 @@ mod tests {
         // Retaliate attack lands (damage + horror, simultaneously).
         assert_event!(result.events, Event::DamageTaken { investigator, amount: 1 } if *investigator == inv_id);
         assert_event!(result.events, Event::HorrorTaken { investigator, amount: 1 } if *investigator == inv_id);
-        assert_eq!(result.state.investigators[&inv_id].damage, 1);
-        assert_eq!(result.state.investigators[&inv_id].horror, 1);
+        assert_eq!(result.state.investigators[&inv_id].damage(), 1);
+        assert_eq!(result.state.investigators[&inv_id].horror(), 1);
         // Enemy does NOT exhaust after a retaliate attack (RR p.18).
         assert!(!result.state.enemies[&enemy_id].exhausted);
         // Failed fight dealt no damage to the enemy.
@@ -2001,7 +2001,7 @@ mod tests {
         assert_event!(result.events, Event::SkillTestSucceeded { .. });
         assert_no_event!(result.events, Event::DamageTaken { .. });
         assert_no_event!(result.events, Event::HorrorTaken { .. });
-        assert_eq!(result.state.investigators[&inv_id].damage, 0);
+        assert_eq!(result.state.investigators[&inv_id].damage(), 0);
     }
 
     #[test]
@@ -2024,7 +2024,7 @@ mod tests {
 
         assert_event!(result.events, Event::SkillTestFailed { .. });
         assert_no_event!(result.events, Event::DamageTaken { .. });
-        assert_eq!(result.state.investigators[&inv_id].damage, 0);
+        assert_eq!(result.state.investigators[&inv_id].damage(), 0);
     }
 
     #[test]
@@ -2045,7 +2045,7 @@ mod tests {
 
         assert_event!(result.events, Event::SkillTestFailed { .. });
         assert_no_event!(result.events, Event::DamageTaken { .. });
-        assert_eq!(result.state.investigators[&inv_id].damage, 0);
+        assert_eq!(result.state.investigators[&inv_id].damage(), 0);
     }
 
     #[test]
@@ -2067,7 +2067,7 @@ mod tests {
 
         assert_event!(result.events, Event::SkillTestFailed { .. });
         assert_no_event!(result.events, Event::DamageTaken { .. });
-        assert_eq!(result.state.investigators[&inv_id].damage, 0);
+        assert_eq!(result.state.investigators[&inv_id].damage(), 0);
     }
 
     #[test]
@@ -2092,7 +2092,7 @@ mod tests {
         assert_eq!(result.outcome, EngineOutcome::Done);
         assert_event!(result.events, Event::SkillTestFailed { .. });
         // Retaliate damage landed.
-        assert_eq!(result.state.investigators[&inv_id].damage, 1);
+        assert_eq!(result.state.investigators[&inv_id].damage(), 1);
         // Enemy must remain ready (not exhausted) after the retaliate (RR p.18).
         assert!(!result.state.enemies[&enemy_id].exhausted);
         assert_no_event!(result.events, Event::EnemyExhausted { .. });
@@ -2481,7 +2481,7 @@ mod tests {
             "AoO DamageTaken (idx {damage_idx}) must precede InvestigatorMoved (idx {moved_idx})"
         );
         // Investigator damaged.
-        assert_eq!(result.state.investigators[&inv_id].damage, 1);
+        assert_eq!(result.state.investigators[&inv_id].damage(), 1);
         // Investigator moved.
         assert_eq!(
             result.state.investigators[&inv_id].current_location,
@@ -2513,7 +2513,7 @@ mod tests {
         assert_eq!(result.outcome, EngineOutcome::Done);
         assert_no_event!(result.events, Event::DamageTaken { .. });
         assert_no_event!(result.events, Event::HorrorTaken { .. });
-        assert_eq!(result.state.investigators[&inv_id].damage, 0);
+        assert_eq!(result.state.investigators[&inv_id].damage(), 0);
         // Exhausted enemy still follows the investigator.
         assert_eq!(result.state.enemies[&enemy_id].current_location, Some(b));
     }
@@ -2579,7 +2579,7 @@ mod tests {
 
         assert_eq!(result.outcome, EngineOutcome::Done);
         // AoO fired: investigator took 1 damage, but the resource is still gained.
-        assert_eq!(result.state.investigators[&inv_id].damage, 1);
+        assert_eq!(result.state.investigators[&inv_id].damage(), 1);
         assert_eq!(result.state.investigators[&inv_id].resources, 6);
         assert_event!(
             result.events,
@@ -2783,7 +2783,7 @@ mod tests {
         assert_eq!(result.outcome, EngineOutcome::Done);
         // The OTHER engaged enemy made the AoO; the target (not engaged at
         // AoO time) did not. Target ends engaged; investigator took 1 damage.
-        assert_eq!(result.state.investigators[&inv_id].damage, 1);
+        assert_eq!(result.state.investigators[&inv_id].damage(), 1);
         assert_eq!(result.state.enemies[&target_id].engaged_with, Some(inv_id));
         assert_event!(
             result.events,
@@ -2969,7 +2969,7 @@ mod tests {
         );
 
         assert_eq!(result.outcome, EngineOutcome::Done);
-        assert_eq!(result.state.investigators[&inv_id].damage, 1);
+        assert_eq!(result.state.investigators[&inv_id].damage(), 1);
         assert_event!(
             result.events,
             Event::DamageTaken { investigator, amount: 1 } if *investigator == inv_id
@@ -3122,7 +3122,7 @@ mod tests {
         );
         // Skill test still runs after AoO.
         assert_event!(result.events, Event::SkillTestStarted { .. });
-        assert_eq!(result.state.investigators[&inv_id].horror, 1);
+        assert_eq!(result.state.investigators[&inv_id].horror(), 1);
     }
 
     #[test]
@@ -3148,8 +3148,8 @@ mod tests {
         assert_eq!(result.outcome, EngineOutcome::Done);
         assert_no_event!(result.events, Event::DamageTaken { .. });
         assert_no_event!(result.events, Event::HorrorTaken { .. });
-        assert_eq!(result.state.investigators[&inv_id].damage, 0);
-        assert_eq!(result.state.investigators[&inv_id].horror, 0);
+        assert_eq!(result.state.investigators[&inv_id].damage(), 0);
+        assert_eq!(result.state.investigators[&inv_id].horror(), 0);
     }
 
     #[test]
@@ -3171,7 +3171,7 @@ mod tests {
         assert_eq!(result.outcome, EngineOutcome::Done);
         assert_no_event!(result.events, Event::DamageTaken { .. });
         assert_no_event!(result.events, Event::HorrorTaken { .. });
-        assert_eq!(result.state.investigators[&inv_id].damage, 0);
+        assert_eq!(result.state.investigators[&inv_id].damage(), 0);
     }
 
     #[test]
@@ -3266,7 +3266,7 @@ mod tests {
             vec![4, 2, 1],
             "chosen order: 302 (dmg4), 301 (dmg2), 300 (dmg1)"
         );
-        assert_eq!(r3.state.investigators[&inv_id].damage, 7);
+        assert_eq!(r3.state.investigators[&inv_id].damage(), 7);
         // The Move completed once the AoO loop drained.
         assert_event!(r3.events, Event::InvestigatorMoved { .. });
     }
@@ -3293,8 +3293,8 @@ mod tests {
         assert_eq!(result.outcome, EngineOutcome::Done);
         assert_no_event!(result.events, Event::DamageTaken { .. });
         assert_no_event!(result.events, Event::HorrorTaken { .. });
-        assert_eq!(result.state.investigators[&inv_id].damage, 0);
-        assert_eq!(result.state.investigators[&inv_id].horror, 0);
+        assert_eq!(result.state.investigators[&inv_id].damage(), 0);
+        assert_eq!(result.state.investigators[&inv_id].horror(), 0);
     }
 
     // ------------------------------------------------------------------
@@ -3460,7 +3460,7 @@ mod tests {
         assert_event_count!(r2.events, 1, Event::DamageTaken { .. });
         assert_event_count!(r2.events, 1, Event::InvestigatorDefeated { .. });
         // Damage saturates at the first AoO's amount; the second AoO is skipped.
-        assert_eq!(r2.state.investigators[&inv_id].damage, 5);
+        assert_eq!(r2.state.investigators[&inv_id].damage(), 5);
         // The actor was defeated mid-action → the Move's primary effect is
         // suppressed by the re-validation gate (#293 keystone).
         assert_no_event!(r2.events, Event::InvestigatorMoved { .. });
@@ -3495,8 +3495,8 @@ mod tests {
             result.events,
             Event::HorrorTaken { investigator, amount: 1 } if *investigator == inv_id
         );
-        assert_eq!(result.state.investigators[&inv_id].damage, 5);
-        assert_eq!(result.state.investigators[&inv_id].horror, 1);
+        assert_eq!(result.state.investigators[&inv_id].damage(), 5);
+        assert_eq!(result.state.investigators[&inv_id].horror(), 1);
         // Exactly one InvestigatorDefeated, caused by Damage.
         assert_event_count!(result.events, 1, Event::InvestigatorDefeated { .. });
         assert_event!(
@@ -3535,8 +3535,8 @@ mod tests {
             result.events,
             Event::HorrorTaken { investigator, amount: 5 } if *investigator == inv_id
         );
-        assert_eq!(result.state.investigators[&inv_id].damage, 1);
-        assert_eq!(result.state.investigators[&inv_id].horror, 5);
+        assert_eq!(result.state.investigators[&inv_id].damage(), 1);
+        assert_eq!(result.state.investigators[&inv_id].horror(), 5);
         assert_event_count!(result.events, 1, Event::InvestigatorDefeated { .. });
         assert_event!(
             result.events,
@@ -3568,8 +3568,8 @@ mod tests {
             }),
         );
         assert_eq!(result.outcome, EngineOutcome::Done);
-        assert_eq!(result.state.investigators[&inv_id].damage, 1);
-        assert_eq!(result.state.investigators[&inv_id].horror, 1);
+        assert_eq!(result.state.investigators[&inv_id].damage(), 1);
+        assert_eq!(result.state.investigators[&inv_id].horror(), 1);
         assert_event_count!(result.events, 1, Event::InvestigatorDefeated { .. });
         assert_event!(
             result.events,
@@ -3812,7 +3812,7 @@ mod tests {
         assert_eq!(inv.hand.len(), 1);
         assert_eq!(inv.deck.len(), 2);
         assert!(inv.discard.is_empty());
-        assert_eq!(inv.horror, 1);
+        assert_eq!(inv.horror(), 1);
     }
 
     #[test]
@@ -3836,7 +3836,7 @@ mod tests {
         );
         assert_no_event!(result.events, Event::DeckShuffled { .. });
         let inv = &result.state.investigators[&id];
-        assert_eq!(inv.horror, 1);
+        assert_eq!(inv.horror(), 1);
         assert_eq!(inv.actions_remaining, 2);
         assert!(inv.hand.is_empty());
         assert!(inv.deck.is_empty());

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -1520,27 +1520,19 @@ pub enum CandidateSource {
     /// A Fast event in the controller's hand (Axis C) — *played* rather than
     /// fired. No instance until it would enter play (events never do).
     Hand,
-    /// An ability on an investigator's **own card** (Roland Banks's seated
-    /// `[reaction]`). Carries the controller id — the investigator card is
-    /// not a `CardInPlay`, so it has no `CardInstanceId`; usage-limit checks
-    /// and bumps point at `Investigator.ability_usage` instead. Fires by
-    /// `code` like `Board`. **Bridge (#118), sunset by #448.**
-    Investigator(InvestigatorId),
 }
 
 impl CandidateSource {
-    /// The firing in-play instance, if any — `Some` for [`InPlay`](Self::InPlay),
-    /// `None` for [`Board`](Self::Board) (scenario card), [`Hand`](Self::Hand)
-    /// (event not yet in play), and [`Investigator`](Self::Investigator)
-    /// (investigator card is not a `CardInPlay`). Feeds
+    /// The firing in-play instance, if any — `Some` for [`InPlay`](Self::InPlay)
+    /// (a card in play, a threat-area card, or the investigator card, which is a
+    /// real `CardInPlay` since #448), `None` for [`Board`](Self::Board)
+    /// (scenario card) and [`Hand`](Self::Hand) (event not yet in play). Feeds
     /// [`EvalContext::for_controller_with_optional_source`](crate::engine::EvalContext::for_controller_with_optional_source).
     #[must_use]
     pub fn instance(self) -> Option<CardInstanceId> {
         match self {
             CandidateSource::InPlay(id) => Some(id),
-            CandidateSource::Board | CandidateSource::Hand | CandidateSource::Investigator(_) => {
-                None
-            }
+            CandidateSource::Board | CandidateSource::Hand => None,
         }
     }
 }

--- a/crates/game-core/src/state/investigator.rs
+++ b/crates/game-core/src/state/investigator.rs
@@ -133,6 +133,13 @@ pub struct Investigator {
     /// instance so multiple surcharge sources track independently. Required
     /// on the wire (#453).
     pub action_surcharge_spent_this_round: std::collections::BTreeSet<CardInstanceId>,
+    /// The investigator's own card as a real in-play permanent: it holds the
+    /// investigator's health/sanity capacity (from `CardKind::Investigator`
+    /// metadata) and is the default damage/horror soaker via its
+    /// `accumulated_damage` / `accumulated_horror`. Lives here rather than in
+    /// `cards_in_play` so loops over "cards the player played" never touch it
+    /// (#448). Required on the wire.
+    pub investigator_card: CardInPlay,
 }
 
 impl Investigator {
@@ -238,6 +245,7 @@ mod threat_area_tests {
             "removed_from_game",
             "ability_usage",
             "action_surcharge_spent_this_round",
+            "investigator_card",
         ] {
             let mut v = full.clone();
             v.as_object_mut()
@@ -310,5 +318,19 @@ mod removed_from_game_tests {
     fn new_investigator_has_empty_removed_pile() {
         let inv = crate::test_support::test_investigator(1);
         assert!(inv.removed_from_game.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod investigator_card_tests {
+    #[test]
+    fn test_investigator_has_an_investigator_card_with_the_synthetic_code() {
+        let inv = crate::test_support::test_investigator(1);
+        assert_eq!(
+            inv.investigator_card.code.as_str(),
+            crate::test_support::TEST_INV
+        );
+        assert_eq!(inv.investigator_card.accumulated_damage, 0);
+        assert_eq!(inv.investigator_card.accumulated_horror, 0);
     }
 }

--- a/crates/game-core/src/state/investigator.rs
+++ b/crates/game-core/src/state/investigator.rs
@@ -172,6 +172,33 @@ impl Investigator {
     pub fn bump_ability_usage(&mut self, ability_index: u8, current_round: u32) {
         bump_usage(&mut self.ability_usage, ability_index, current_round);
     }
+
+    /// Physical damage currently on the investigator. Reads the investigator
+    /// card's accumulated damage once harm moves there (#448 cp2); during the
+    /// seam it delegates to the legacy field.
+    #[must_use]
+    pub fn damage(&self) -> u8 {
+        self.damage
+    }
+
+    /// Horror currently on the investigator. See [`Self::damage`].
+    #[must_use]
+    pub fn horror(&self) -> u8 {
+        self.horror
+    }
+
+    /// Maximum health (printed). Reads `CardKind::Investigator` metadata once
+    /// the seam closes (#448 cp2); during the seam it delegates to the field.
+    #[must_use]
+    pub fn max_health(&self) -> u8 {
+        self.max_health
+    }
+
+    /// Maximum sanity (printed). See [`Self::max_health`].
+    #[must_use]
+    pub fn max_sanity(&self) -> u8 {
+        self.max_sanity
+    }
 }
 
 /// Whether an investigator is still active in the scenario, and if not,
@@ -318,6 +345,20 @@ mod removed_from_game_tests {
     fn new_investigator_has_empty_removed_pile() {
         let inv = crate::test_support::test_investigator(1);
         assert!(inv.removed_from_game.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod harm_accessor_tests {
+    #[test]
+    fn harm_accessors_match_the_underlying_fields_during_the_seam() {
+        let mut inv = crate::test_support::test_investigator(1);
+        inv.damage = 2;
+        inv.horror = 1;
+        assert_eq!(inv.damage(), 2);
+        assert_eq!(inv.horror(), 1);
+        assert_eq!(inv.max_health(), inv.max_health);
+        assert_eq!(inv.max_sanity(), inv.max_sanity);
     }
 }
 

--- a/crates/game-core/src/state/investigator.rs
+++ b/crates/game-core/src/state/investigator.rs
@@ -144,13 +144,22 @@ pub struct Investigator {
 
 impl Investigator {
     /// Every in-play card instance this investigator controls that can
-    /// carry a triggerable ability: cards in play, then threat-area
-    /// cards. The single definition both the reaction-window scan and
-    /// the forced instance-scan walk, so the threat area is covered by
-    /// both dispatch paths without a duplicate walk. This is the
-    /// shared scan source #212 later absorbs.
+    /// carry a triggerable ability: the **investigator card** first, then
+    /// cards in play, then threat-area cards. The single definition both
+    /// the reaction-window scan and the forced instance-scan walk, so the
+    /// investigator card and threat area are covered by both dispatch paths
+    /// without a duplicate walk (#448 cp3a folds the investigator card into
+    /// this iterator, retiring the bespoke `scan_investigator_card_reactions`
+    /// source). This is the shared scan source #212 later absorbs.
+    ///
+    /// The investigator card is deliberately *not* in `cards_in_play`, so
+    /// loops over "cards the player played" (asset queries, elimination
+    /// drain, discard-all, soak `build_soakers`) keep iterating
+    /// `cards_in_play` directly and never touch it.
     pub fn controlled_card_instances(&self) -> impl Iterator<Item = &CardInPlay> {
-        self.cards_in_play.iter().chain(self.threat_area.iter())
+        std::iter::once(&self.investigator_card)
+            .chain(self.cards_in_play.iter())
+            .chain(self.threat_area.iter())
     }
 
     /// Whether this investigator's own-card ability at `ability_index` has
@@ -303,8 +312,11 @@ mod threat_area_tests {
     }
 
     #[test]
-    fn controlled_card_instances_yields_in_play_then_threat_area() {
+    fn controlled_card_instances_yields_investigator_card_then_in_play_then_threat_area() {
+        // #448 cp3a: the investigator card is yielded first (so the unified
+        // scan fires its abilities), then `cards_in_play`, then `threat_area`.
         let mut inv = crate::test_support::test_investigator(1);
+        inv.investigator_card.code = CardCode::new("inv-card");
         inv.cards_in_play.push(CardInPlay::enter_play(
             CardCode::new("in-play"),
             CardInstanceId(1),
@@ -317,7 +329,7 @@ mod threat_area_tests {
             .controlled_card_instances()
             .map(|c| c.code.as_str())
             .collect();
-        assert_eq!(codes, vec!["in-play", "threat"]);
+        assert_eq!(codes, vec!["inv-card", "in-play", "threat"]);
     }
 }
 

--- a/crates/game-core/src/state/investigator.rs
+++ b/crates/game-core/src/state/investigator.rs
@@ -18,12 +18,13 @@ pub struct InvestigatorId(pub u32);
 ///
 /// # Invariants
 ///
-/// - `damage` may exceed `max_health` transiently — when that happens
-///   the apply loop's damage helpers flip `status` to [`Status::Killed`]
-///   and emit [`Event::InvestigatorDefeated`]. Symmetric for `horror`
-///   / `max_sanity` / [`Status::Insane`]. The numeric fields are
-///   `u8` so they don't wrap; the threshold check is what defines
-///   defeat.
+/// - Physical damage is tracked via
+///   [`investigator_card.accumulated_damage`](CardInPlay::accumulated_damage);
+///   when [`damage()`](Self::damage) reaches [`max_health()`](Self::max_health)
+///   the apply loop flips `status` to [`Status::Killed`] and emits
+///   [`Event::InvestigatorDefeated`]. Symmetric for horror /
+///   [`Status::Insane`]. The accessor methods are `u8` so they don't
+///   wrap; the threshold check is what defines defeat.
 /// - Once `status != Status::Active`, the investigator is "out of
 ///   play": damage / horror helpers no-op, the engine doesn't let
 ///   them take actions, and card effects targeting investigators
@@ -43,14 +44,6 @@ pub struct Investigator {
     pub current_location: Option<LocationId>,
     /// Skill values.
     pub skills: Skills,
-    /// Maximum health (physical hit points).
-    pub max_health: u8,
-    /// Current physical damage suffered.
-    pub damage: u8,
-    /// Maximum sanity.
-    pub max_sanity: u8,
-    /// Current horror suffered.
-    pub horror: u8,
     /// Clues currently held by the investigator.
     pub clues: u8,
     /// Resources currently held.
@@ -355,12 +348,18 @@ mod investigator_card_tests {
         assert_eq!(inv.investigator_card.accumulated_horror, 0);
     }
 
+    // `identity_is_read_from_the_investigator_card` removed: it was a
+    // duplicate of `test_investigator_has_an_investigator_card_with_the_synthetic_code`
+    // (cp4 cleanup per task-7-brief).
+
     #[test]
-    fn identity_is_read_from_the_investigator_card() {
-        let inv = crate::test_support::test_investigator(1);
-        assert_eq!(
-            inv.investigator_card.code.as_str(),
-            crate::test_support::TEST_INV
+    fn defeat_reads_capacity_from_the_card_not_a_field() {
+        crate::test_support::install_test_registry();
+        let mut inv = crate::test_support::test_investigator(1);
+        inv.investigator_card.accumulated_damage = 8; // == TEST_INV health
+        assert!(
+            inv.damage() >= inv.max_health(),
+            "defeat threshold reached via accessors"
         );
     }
 }

--- a/crates/game-core/src/state/investigator.rs
+++ b/crates/game-core/src/state/investigator.rs
@@ -173,31 +173,47 @@ impl Investigator {
         bump_usage(&mut self.ability_usage, ability_index, current_round);
     }
 
-    /// Physical damage currently on the investigator. Reads the investigator
-    /// card's accumulated damage once harm moves there (#448 cp2); during the
-    /// seam it delegates to the legacy field.
+    /// Physical damage currently on the investigator — reads
+    /// `investigator_card.accumulated_damage` (#448 cp2a).
     #[must_use]
     pub fn damage(&self) -> u8 {
-        self.damage
+        self.investigator_card.accumulated_damage
     }
 
     /// Horror currently on the investigator. See [`Self::damage`].
     #[must_use]
     pub fn horror(&self) -> u8 {
-        self.horror
+        self.investigator_card.accumulated_horror
     }
 
-    /// Maximum health (printed). Reads `CardKind::Investigator` metadata once
-    /// the seam closes (#448 cp2); during the seam it delegates to the field.
+    /// Maximum health (printed) — reads `CardKind::Investigator` metadata from
+    /// the installed registry (#448 cp2a). Panics if the registry is absent or
+    /// the investigator card's code is not a `CardKind::Investigator`.
     #[must_use]
     pub fn max_health(&self) -> u8 {
-        self.max_health
+        investigator_capacity(&self.investigator_card.code).0
     }
 
     /// Maximum sanity (printed). See [`Self::max_health`].
     #[must_use]
     pub fn max_sanity(&self) -> u8 {
-        self.max_sanity
+        investigator_capacity(&self.investigator_card.code).1
+    }
+}
+
+/// (health, sanity) printed capacity for an investigator card, from the
+/// installed registry. Panics if the registry is uninstalled or the code is
+/// not an investigator card — a state-shape invariant violation, surfaced
+/// rather than silently defaulted.
+fn investigator_capacity(code: &CardCode) -> (u8, u8) {
+    let reg = crate::card_registry::current()
+        .expect("investigator capacity read before a CardRegistry was installed");
+    match &(reg.metadata_for)(code)
+        .expect("investigator card code absent from registry")
+        .kind
+    {
+        crate::card_data::CardKind::Investigator { health, sanity, .. } => (*health, *sanity),
+        _ => panic!("investigator_card.code does not resolve to a CardKind::Investigator"),
     }
 }
 
@@ -350,15 +366,20 @@ mod removed_from_game_tests {
 
 #[cfg(test)]
 mod harm_accessor_tests {
+    // Seam test from cp1b (which delegated to legacy fields) is removed by
+    // cp2a: the accessors now read the investigator_card directly.
     #[test]
-    fn harm_accessors_match_the_underlying_fields_during_the_seam() {
+    fn harm_accessors_read_from_investigator_card() {
+        crate::test_support::install_test_registry();
         let mut inv = crate::test_support::test_investigator(1);
-        inv.damage = 2;
-        inv.horror = 1;
+        // Set accumulated harm directly on the card.
+        inv.investigator_card.accumulated_damage = 2;
+        inv.investigator_card.accumulated_horror = 1;
         assert_eq!(inv.damage(), 2);
         assert_eq!(inv.horror(), 1);
-        assert_eq!(inv.max_health(), inv.max_health);
-        assert_eq!(inv.max_sanity(), inv.max_sanity);
+        // Capacity reads from the registry (TEST_INV has 8/8).
+        assert_eq!(inv.max_health(), 8);
+        assert_eq!(inv.max_sanity(), 8);
     }
 }
 

--- a/crates/game-core/src/state/investigator.rs
+++ b/crates/game-core/src/state/investigator.rs
@@ -2,12 +2,9 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::card::{
-    bump_usage, usage_exhausted, AbilityUsageRecord, CardCode, CardInPlay, CardInstanceId,
-};
+use super::card::{CardCode, CardInPlay, CardInstanceId};
 use super::location::LocationId;
 use super::Skills;
-use std::collections::BTreeMap;
 
 /// Stable identifier for an investigator within a scenario.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
@@ -38,20 +35,6 @@ pub struct InvestigatorId(pub u32);
 pub struct Investigator {
     /// Stable identifier within this scenario.
     pub id: InvestigatorId,
-    /// The investigator's own `ArkhamDB` card code (01001 for Roland
-    /// Banks). Set at roster seating from `RosterEntry.investigator`;
-    /// the elder-sign firing path and the seated-reaction scan look the
-    /// investigator card's abilities up by this code
-    /// (`abilities_for(card_code)`). An empty sentinel (`CardCode::new("")`)
-    /// marks the pre-seated `test_support` / builder path — codepaths skip
-    /// empty codes, so those investigators carry no investigator-card
-    /// abilities. Required on the wire (#453): a payload omitting it is
-    /// rejected rather than silently degrading to the empty sentinel.
-    ///
-    /// **Bridge (#118), sunset by #448:** when the investigator card
-    /// becomes a real `CardInPlay` (health/sanity/soak), this field and
-    /// [`ability_usage`](Self::ability_usage) fold into the uniform path.
-    pub card_code: CardCode,
     /// Display name.
     pub name: String,
     /// Location the investigator is currently at, or `None` if they are
@@ -114,19 +97,6 @@ pub struct Investigator {
     /// pile and removed from the game. Stays empty for Active
     /// investigators. Required on the wire (#453).
     pub removed_from_game: Vec<CardCode>,
-    /// Per-ability "Limit X per \[period\]" usage records for this
-    /// investigator's **own card** abilities (Roland Banks's once-per-round
-    /// `[reaction]`). Mirrors [`CardInPlay::ability_usage`] — the investigator
-    /// card is not a `CardInPlay`, so it needs its own usage home. Keyed by
-    /// ability index within the investigator card's `abilities()`. Lazy
-    /// reset: a stale-round record reads as 0 (see [`CardInPlay::ability_usage`]
-    /// docs). Required on the wire (#453).
-    ///
-    /// **Bridge (#118), sunset by #448:** retired when the investigator card
-    /// becomes a real `CardInPlay`.
-    ///
-    /// [`CardInPlay::ability_usage`]: crate::state::CardInPlay::ability_usage
-    pub ability_usage: BTreeMap<u8, AbilityUsageRecord>,
     /// Source instances whose [`ExtraActionCost`](crate::dsl::Restriction::ExtraActionCost)
     /// with `first_each_round` has already surcharged an action this round
     /// (Frozen in Fear 01164). Cleared at the round boundary. Keyed by
@@ -160,26 +130,6 @@ impl Investigator {
         std::iter::once(&self.investigator_card)
             .chain(self.cards_in_play.iter())
             .chain(self.threat_area.iter())
-    }
-
-    /// Whether this investigator's own-card ability at `ability_index` has
-    /// reached its per-period [`UsageLimit`](crate::dsl::UsageLimit). Mirrors
-    /// [`CardInPlay::is_usage_exhausted`] over [`ability_usage`](Self::ability_usage).
-    #[must_use]
-    pub fn is_usage_exhausted(
-        &self,
-        ability_index: u8,
-        limit: Option<crate::dsl::UsageLimit>,
-        current_round: u32,
-    ) -> bool {
-        usage_exhausted(&self.ability_usage, ability_index, limit, current_round)
-    }
-
-    /// Record one firing of this investigator's own-card ability at
-    /// `ability_index` against the current period. Mirrors
-    /// [`CardInPlay::bump_ability_usage`].
-    pub fn bump_ability_usage(&mut self, ability_index: u8, current_round: u32) {
-        bump_usage(&mut self.ability_usage, ability_index, current_round);
     }
 
     /// Physical damage currently on the investigator — reads
@@ -282,22 +232,19 @@ mod threat_area_tests {
     #[test]
     fn omitting_any_required_field_is_rejected() {
         // Every field is required on the wire (#453): a payload missing one
-        // fails loudly rather than silently defaulting. `card_code` in
-        // particular — an absent identity field must not degrade to the empty
-        // sentinel (which would silently disable that investigator's
-        // elder-sign + seated reaction).
+        // fails loudly rather than silently defaulting. `investigator_card`
+        // in particular — an absent identity field must not degrade to some
+        // default that silently disables elder-sign + seated reaction.
         let inv = crate::test_support::test_investigator(1);
         let full = serde_json::to_value(&inv).expect("serialize");
         // The complete object still round-trips.
         serde_json::from_value::<Investigator>(full.clone()).expect("full object deserializes");
         // Each formerly-`#[serde(default)]` field is now mandatory.
         for field in [
-            "card_code",
+            "investigator_card",
             "threat_area",
             "removed_from_game",
-            "ability_usage",
             "action_surcharge_spent_this_round",
-            "investigator_card",
         ] {
             let mut v = full.clone();
             v.as_object_mut()
@@ -339,9 +286,9 @@ mod ability_usage_tests {
     use crate::state::AbilityUsageRecord;
 
     #[test]
-    fn new_investigator_has_empty_ability_usage() {
+    fn new_investigator_card_has_empty_ability_usage() {
         let inv = crate::test_support::test_investigator(1);
-        assert!(inv.ability_usage.is_empty());
+        assert!(inv.investigator_card.ability_usage.is_empty());
     }
 
     #[test]
@@ -352,18 +299,18 @@ mod ability_usage_tests {
             period: UsagePeriod::Round,
         });
         // Ability 0, round 5: not yet fired → not exhausted.
-        assert!(!inv.is_usage_exhausted(0, limit, 5));
+        assert!(!inv.investigator_card.is_usage_exhausted(0, limit, 5));
         // Fire once in round 5 → now exhausted in round 5.
-        inv.bump_ability_usage(0, 5);
-        assert!(inv.is_usage_exhausted(0, limit, 5));
+        inv.investigator_card.bump_ability_usage(0, 5);
+        assert!(inv.investigator_card.is_usage_exhausted(0, limit, 5));
         assert_eq!(
-            inv.ability_usage.get(&0),
+            inv.investigator_card.ability_usage.get(&0),
             Some(&AbilityUsageRecord::new(5, 1))
         );
         // Round 6: lazy reset → not exhausted (stored record is stale).
-        assert!(!inv.is_usage_exhausted(0, limit, 6));
+        assert!(!inv.investigator_card.is_usage_exhausted(0, limit, 6));
         // No limit (None) is never exhausted.
-        assert!(!inv.is_usage_exhausted(0, None, 5));
+        assert!(!inv.investigator_card.is_usage_exhausted(0, None, 5));
     }
 }
 
@@ -406,5 +353,14 @@ mod investigator_card_tests {
         );
         assert_eq!(inv.investigator_card.accumulated_damage, 0);
         assert_eq!(inv.investigator_card.accumulated_horror, 0);
+    }
+
+    #[test]
+    fn identity_is_read_from_the_investigator_card() {
+        let inv = crate::test_support::test_investigator(1);
+        assert_eq!(
+            inv.investigator_card.code.as_str(),
+            crate::test_support::TEST_INV
+        );
     }
 }

--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -20,7 +20,8 @@
 use crate::card_data::{ClueValue, Prey};
 use crate::engine::{EngineOutcome, InputRequest, ResumeToken};
 use crate::state::{
-    CardCode, Enemy, EnemyId, Investigator, InvestigatorId, Location, LocationId, Skills, Status,
+    CardCode, CardInPlay, CardInstanceId, Enemy, EnemyId, Investigator, InvestigatorId, Location,
+    LocationId, Skills, Status,
 };
 
 /// A stock investigator with reasonable defaults.
@@ -33,6 +34,10 @@ use crate::state::{
 /// Mutate fields directly after construction to customize.
 #[must_use]
 pub fn test_investigator(id: u32) -> Investigator {
+    let investigator_card = CardInPlay::enter_play(
+        CardCode::new(crate::test_support::TEST_INV),
+        CardInstanceId(u32::MAX - id),
+    );
     Investigator {
         id: InvestigatorId(id),
         card_code: CardCode::new(""),
@@ -60,6 +65,7 @@ pub fn test_investigator(id: u32) -> Investigator {
         removed_from_game: Vec::new(),
         ability_usage: std::collections::BTreeMap::new(),
         action_surcharge_spent_this_round: std::collections::BTreeSet::new(),
+        investigator_card,
     }
 }
 

--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -26,7 +26,7 @@ use crate::state::{
 
 /// A stock investigator with reasonable defaults.
 ///
-/// - 3/3/3/3 skills, 8 health, 8 sanity, no damage or horror.
+/// - 3/3/3/3 skills; capacity and harm live on `investigator_card` (TEST_INV: 8/8 health/sanity).
 /// - 5 starting resources, 0 clues.
 /// - 3 actions remaining.
 /// - Not placed at any location (`current_location: None`).
@@ -48,10 +48,6 @@ pub fn test_investigator(id: u32) -> Investigator {
             combat: 3,
             agility: 3,
         },
-        max_health: 8,
-        damage: 0,
-        max_sanity: 8,
-        horror: 0,
         clues: 0,
         resources: 5,
         actions_remaining: 3,

--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -40,7 +40,6 @@ pub fn test_investigator(id: u32) -> Investigator {
     );
     Investigator {
         id: InvestigatorId(id),
-        card_code: CardCode::new(""),
         name: format!("Test Investigator {id}"),
         current_location: None,
         skills: Skills {
@@ -63,7 +62,6 @@ pub fn test_investigator(id: u32) -> Investigator {
         cards_in_play: Vec::new(),
         threat_area: Vec::new(),
         removed_from_game: Vec::new(),
-        ability_usage: std::collections::BTreeMap::new(),
         action_surcharge_spent_this_round: std::collections::BTreeSet::new(),
         investigator_card,
     }

--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -26,7 +26,7 @@ use crate::state::{
 
 /// A stock investigator with reasonable defaults.
 ///
-/// - 3/3/3/3 skills; capacity and harm live on `investigator_card` (TEST_INV: 8/8 health/sanity).
+/// - 3/3/3/3 skills; capacity and harm live on `investigator_card` (`TEST_INV`: 8/8 health/sanity).
 /// - 5 starting resources, 0 clues.
 /// - 3 actions remaining.
 /// - Not placed at any location (`current_location: None`).

--- a/crates/game-core/src/test_support/mod.rs
+++ b/crates/game-core/src/test_support/mod.rs
@@ -13,6 +13,55 @@ pub mod assertions;
 pub mod fixtures;
 pub mod resolver;
 
+/// Synthetic investigator-card code for unit tests. Registered by
+/// [`install_test_registry`] with 8 health / 8 sanity (mirroring the legacy
+/// `test_investigator` capacity).
+pub const TEST_INV: &str = "TEST_INV";
+
+fn test_inv_metadata() -> &'static crate::card_data::CardMetadata {
+    use crate::card_data::{CardKind, CardMetadata, Class, Skills};
+    static M: std::sync::OnceLock<CardMetadata> = std::sync::OnceLock::new();
+    M.get_or_init(|| CardMetadata {
+        code: TEST_INV.to_owned(),
+        name: "Test Investigator".to_owned(),
+        traits: vec![],
+        text: None,
+        pack_code: "_test".to_owned(),
+        kind: CardKind::Investigator {
+            class: Class::Neutral,
+            skills: Skills {
+                willpower: 3,
+                intellect: 3,
+                combat: 3,
+                agility: 3,
+            },
+            health: 8,
+            sanity: 8,
+        },
+    })
+}
+
+/// Install a minimal game-core test registry that knows `TEST_INV` (and only
+/// it). Idempotent; safe to call from any test. Capacity-reading code
+/// (`max_health()` / `max_sanity()` / soak / defeat) needs this installed.
+pub fn install_test_registry() {
+    use crate::state::CardCode;
+    static INSTALL: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    INSTALL.get_or_init(|| {
+        fn metadata_for(code: &CardCode) -> Option<&'static crate::card_data::CardMetadata> {
+            (code.as_str() == TEST_INV).then(test_inv_metadata)
+        }
+        fn abilities_for(_: &CardCode) -> Option<Vec<crate::dsl::Ability>> {
+            None
+        }
+        let _ = crate::card_registry::install(crate::card_registry::CardRegistry {
+            metadata_for,
+            abilities_for,
+            native_effect_for: |_| None,
+        });
+    });
+}
+
 pub use crate::state::GameStateBuilder;
 pub use fixtures::{awaiting_commit_input, test_enemy, test_investigator, test_location};
 pub use resolver::{apply_no_commits, drive, ChoiceResolver, ScriptedResolver, TestSession};

--- a/crates/game-core/src/test_support/mod.rs
+++ b/crates/game-core/src/test_support/mod.rs
@@ -41,6 +41,29 @@ fn test_inv_metadata() -> &'static crate::card_data::CardMetadata {
     })
 }
 
+/// Metadata lookup for the synthetic `TEST_INV` investigator code.
+///
+/// Integration tests in `crates/game-core/tests/` install their own
+/// mock `CardRegistry` instead of calling [`install_test_registry`].
+/// When those mocks use `test_investigator`, the investigator's
+/// `investigator_card.code` is `TEST_INV`. Any code path that reads
+/// `max_health()` / `max_sanity()` (damage/horror application, defeat
+/// checks) calls `investigator_capacity(TEST_INV)` and needs the
+/// registry to know that code. Compose this into the mock's
+/// `metadata_for`:
+///
+/// ```ignore
+/// fn mock_metadata_for(code: &CardCode) -> Option<&'static CardMetadata> {
+///     game_core::test_support::metadata_for_test_inv(code)
+///         .or_else(|| /* mock-specific lookups */)
+/// }
+/// ```
+pub fn metadata_for_test_inv(
+    code: &crate::state::CardCode,
+) -> Option<&'static crate::card_data::CardMetadata> {
+    (code.as_str() == TEST_INV).then(test_inv_metadata)
+}
+
 /// Install a minimal game-core test registry that knows `TEST_INV` (and only
 /// it). Idempotent; safe to call from any test. Capacity-reading code
 /// (`max_health()` / `max_sanity()` / soak / defeat) needs this installed.

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -59,8 +59,11 @@ const END_OF_TURN_CARD: &str = "test-end-of-turn";
 /// Obscuring-Fog-shape (C4c), minus the location attachment.
 const AFTER_INVESTIGATE_CARD: &str = "test-after-investigate";
 
-fn mock_metadata_for(_: &CardCode) -> Option<&'static CardMetadata> {
-    None
+/// Returns metadata for `TEST_INV` (used by `test_investigator`) so that
+/// capacity reads (`max_health()` / `max_sanity()`) work when this registry
+/// is installed. All other codes return `None`.
+fn mock_metadata_for(code: &CardCode) -> Option<&'static CardMetadata> {
+    game_core::test_support::metadata_for_test_inv(code)
 }
 
 fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -141,7 +141,7 @@ fn forced_on_enter_resolves_immediately() {
     let outcome = fire_forced_on_enter(&mut state, &mut events, InvestigatorId(1), LocationId(10));
 
     assert_eq!(outcome, EngineOutcome::Done);
-    assert_eq!(state.investigators[&InvestigatorId(1)].horror, 1);
+    assert_eq!(state.investigators[&InvestigatorId(1)].horror(), 1);
     assert_event!(
         events,
         Event::HorrorTaken { investigator, amount: 1 } if *investigator == InvestigatorId(1)
@@ -189,7 +189,7 @@ fn move_into_forced_location_fires_its_effect() {
         result.state.investigators[&InvestigatorId(1)].current_location,
         Some(LocationId(11))
     );
-    assert_eq!(result.state.investigators[&InvestigatorId(1)].horror, 1);
+    assert_eq!(result.state.investigators[&InvestigatorId(1)].horror(), 1);
     assert!(
         result.events.iter().any(|e| matches!(
             e,
@@ -230,7 +230,7 @@ fn forced_on_enter_no_op_when_location_has_no_abilities() {
     let outcome = fire_forced_on_enter(&mut state, &mut events, InvestigatorId(1), LocationId(10));
 
     assert_eq!(outcome, EngineOutcome::Done);
-    assert_eq!(state.investigators[&InvestigatorId(1)].horror, 0);
+    assert_eq!(state.investigators[&InvestigatorId(1)].horror(), 0);
     assert!(
         events.is_empty(),
         "no events for a location with no forced abilities"
@@ -266,7 +266,7 @@ fn forced_on_enemy_phase_end_fires_agenda_ability() {
 
     assert_eq!(outcome, EngineOutcome::Done);
     assert_eq!(
-        state.investigators[&InvestigatorId(1)].horror,
+        state.investigators[&InvestigatorId(1)].horror(),
         1,
         "lead investigator should have taken 1 horror from agenda forced ability"
     );
@@ -287,7 +287,7 @@ fn forced_on_phase_end_wrong_phase_fires_nothing() {
 
     assert_eq!(outcome, EngineOutcome::Done);
     assert_eq!(
-        state.investigators[&InvestigatorId(1)].horror,
+        state.investigators[&InvestigatorId(1)].horror(),
         0,
         "no horror for a non-matching phase"
     );
@@ -314,7 +314,7 @@ fn dsl_phase_mapping_non_enemy_phases_produce_no_hits() {
             "expected Done for phase {phase:?}"
         );
         assert_eq!(
-            state.investigators[&InvestigatorId(1)].horror,
+            state.investigators[&InvestigatorId(1)].horror(),
             0,
             "no horror for phase {phase:?} (agenda keyed to Enemy only)"
         );
@@ -346,7 +346,7 @@ fn forced_on_phase_end_no_op_when_agenda_has_no_abilities() {
     let outcome = fire_forced_on_phase_end(&mut state, &mut events, Phase::Enemy);
 
     assert_eq!(outcome, EngineOutcome::Done);
-    assert_eq!(state.investigators[&InvestigatorId(1)].horror, 0);
+    assert_eq!(state.investigators[&InvestigatorId(1)].horror(), 0);
     assert!(events.is_empty(), "no events for agenda with no abilities");
 }
 
@@ -412,7 +412,7 @@ fn forced_on_phase_end_fires_act_ability() {
 
     assert_eq!(outcome, EngineOutcome::Done);
     assert_eq!(
-        state.investigators[&InvestigatorId(1)].horror,
+        state.investigators[&InvestigatorId(1)].horror(),
         1,
         "lead investigator should have taken 1 horror from act forced ability"
     );
@@ -443,7 +443,7 @@ fn fire_forced_at_end_of_turn_resolves_threat_area_ability() {
     let outcome = fire_forced_at_end_of_turn(&mut state, &mut events, InvestigatorId(1));
 
     assert_eq!(outcome, EngineOutcome::Done);
-    assert_eq!(state.investigators[&InvestigatorId(1)].horror, 1);
+    assert_eq!(state.investigators[&InvestigatorId(1)].horror(), 1);
     assert_event!(
         events,
         Event::HorrorTaken { investigator, amount: 1 } if *investigator == InvestigatorId(1)
@@ -462,7 +462,7 @@ fn fire_forced_at_end_of_turn_no_op_without_threat_area_card() {
     let outcome = fire_forced_at_end_of_turn(&mut state, &mut events, InvestigatorId(1));
 
     assert_eq!(outcome, EngineOutcome::Done);
-    assert_eq!(state.investigators[&InvestigatorId(1)].horror, 0);
+    assert_eq!(state.investigators[&InvestigatorId(1)].horror(), 0);
     assert!(events.is_empty());
 }
 
@@ -511,7 +511,7 @@ fn end_turn_fires_end_of_turn_forced_for_the_ending_investigator() {
         "EndOfTurn forced effect must fire during EndTurn; events = {:?}",
         result.events
     );
-    assert_eq!(result.state.investigators[&InvestigatorId(1)].horror, 1);
+    assert_eq!(result.state.investigators[&InvestigatorId(1)].horror(), 1);
 }
 
 // ── AfterLocationInvestigated tests ───────────────────────────────────────────
@@ -539,7 +539,7 @@ fn fire_forced_after_investigate_resolves_threat_area_ability() {
         fire_forced_after_location_investigated(&mut state, &mut events, InvestigatorId(1));
 
     assert_eq!(outcome, EngineOutcome::Done);
-    assert_eq!(state.investigators[&InvestigatorId(1)].horror, 1);
+    assert_eq!(state.investigators[&InvestigatorId(1)].horror(), 1);
     assert_event!(
         events,
         Event::HorrorTaken { investigator, amount: 1 } if *investigator == InvestigatorId(1)
@@ -564,7 +564,7 @@ fn fire_forced_after_investigate_no_op_without_threat_area_card() {
         fire_forced_after_location_investigated(&mut state, &mut events, InvestigatorId(1));
 
     assert_eq!(outcome, EngineOutcome::Done);
-    assert_eq!(state.investigators[&InvestigatorId(1)].horror, 0);
+    assert_eq!(state.investigators[&InvestigatorId(1)].horror(), 0);
     assert!(events.is_empty());
 }
 
@@ -615,7 +615,7 @@ fn successful_investigate_fires_after_location_investigated_forced() {
          investigate; events = {:?}",
         result.events
     );
-    assert_eq!(result.state.investigators[&InvestigatorId(1)].horror, 1);
+    assert_eq!(result.state.investigators[&InvestigatorId(1)].horror(), 1);
 }
 
 #[test]
@@ -659,7 +659,7 @@ fn two_simultaneous_forced_triggers_present_a_choice() {
         result.outcome,
     );
     assert_eq!(
-        result.state.investigators[&InvestigatorId(1)].horror,
+        result.state.investigators[&InvestigatorId(1)].horror(),
         0,
         "no forced effect resolves until the lead orders them",
     );
@@ -713,7 +713,7 @@ fn two_simultaneous_forced_triggers_resolved_in_lead_chosen_order() {
     // One forced resolved; the second is still pending (another choice or
     // its resolution), so the move isn't done yet.
     assert_eq!(
-        after_first.state.investigators[&InvestigatorId(1)].horror,
+        after_first.state.investigators[&InvestigatorId(1)].horror(),
         1
     );
     assert!(matches!(
@@ -729,7 +729,7 @@ fn two_simultaneous_forced_triggers_resolved_in_lead_chosen_order() {
         }),
     );
     assert_eq!(done.outcome, EngineOutcome::Done);
-    assert_eq!(done.state.investigators[&InvestigatorId(1)].horror, 2);
+    assert_eq!(done.state.investigators[&InvestigatorId(1)].horror(), 2);
 }
 
 // (Removed `two_simultaneous_forced_triggers_resolve_in_order`, Slice D #423: it

--- a/crates/game-core/tests/round_ended.rs
+++ b/crates/game-core/tests/round_ended.rs
@@ -148,7 +148,7 @@ fn two_round_end_forced_suspend_then_resume_the_upkeep_tail() {
         paused.state.agenda_doom, 0,
         "no forced resolves until ordered"
     );
-    assert_eq!(paused.state.investigators[&InvestigatorId(1)].horror, 0);
+    assert_eq!(paused.state.investigators[&InvestigatorId(1)].horror(), 0);
 
     // Resolve the first ordered forced; the second is still pending.
     let after_first = apply(
@@ -186,7 +186,7 @@ fn two_round_end_forced_suspend_then_resume_the_upkeep_tail() {
          placed its +1 doom — the upkeep tail ran through to the next phase",
     );
     assert_eq!(
-        done.state.investigators[&InvestigatorId(1)].horror,
+        done.state.investigators[&InvestigatorId(1)].horror(),
         1,
         "threat-area round-end forced resolved",
     );

--- a/crates/game-core/tests/round_ended.rs
+++ b/crates/game-core/tests/round_ended.rs
@@ -9,7 +9,9 @@ use card_dsl::dsl::{
 use game_core::card_data::CardMetadata;
 use game_core::card_registry::{self, CardRegistry, NativeEffectFn};
 use game_core::state::{Agenda, CardCode, InvestigatorId};
-use game_core::test_support::{fire_forced_on_round_end, test_investigator, GameStateBuilder};
+use game_core::test_support::{
+    fire_forced_on_round_end, metadata_for_test_inv, test_investigator, GameStateBuilder,
+};
 use game_core::{Cx, EngineOutcome, EvalContext};
 
 const AGENDA: &str = "TEST-AGENDA";
@@ -20,8 +22,10 @@ const AGENDA: &str = "TEST-AGENDA";
 /// Voices 01165's discard) so the lead orders both at round end (#213).
 const DISSONANT: &str = "TEST-DISSONANT";
 
-fn mock_metadata_for(_: &CardCode) -> Option<&'static CardMetadata> {
-    None
+/// Returns metadata for `TEST_INV` so capacity reads work when this registry
+/// is installed. All other codes return `None`.
+fn mock_metadata_for(code: &CardCode) -> Option<&'static CardMetadata> {
+    metadata_for_test_inv(code)
 }
 
 fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {

--- a/crates/game-core/tests/skill_test_outcome_timing.rs
+++ b/crates/game-core/tests/skill_test_outcome_timing.rs
@@ -108,7 +108,8 @@ fn general_timing_point_fires_for_non_investigate_test() {
             if *investigator == id
     );
     assert_eq!(
-        result.state.investigators[&id].horror, 1,
+        result.state.investigators[&id].horror(),
+        1,
         "the general SkillTestResolved timing point must fire the forced ability \
          on a passing Plain (non-Investigate) test",
     );
@@ -130,5 +131,5 @@ fn general_timing_point_opens_no_window_without_a_listener() {
         result.events,
         Event::SkillTestSucceeded { investigator, .. } if *investigator == id
     );
-    assert_eq!(result.state.investigators[&id].horror, 0);
+    assert_eq!(result.state.investigators[&id].horror(), 0);
 }

--- a/crates/game-core/tests/skill_test_outcome_timing.rs
+++ b/crates/game-core/tests/skill_test_outcome_timing.rs
@@ -22,7 +22,7 @@ use game_core::state::{
     SkillKind, TokenModifiers,
 };
 use game_core::test_support::{
-    apply_no_commits, test_investigator, test_location, GameStateBuilder,
+    apply_no_commits, metadata_for_test_inv, test_investigator, test_location, GameStateBuilder,
 };
 use game_core::{assert_event, Action, PlayerAction};
 
@@ -32,8 +32,10 @@ use game_core::{assert_event, Action, PlayerAction};
 /// reaction-window resolution needed to observe the timing point.
 const ANY_SUCCESS_FORCED: &str = "MOCK-STR-ANY-SUCCESS";
 
-fn mock_metadata_for(_: &CardCode) -> Option<&'static CardMetadata> {
-    None
+/// Returns metadata for `TEST_INV` so capacity reads work when this registry
+/// is installed. All other codes return `None`.
+fn mock_metadata_for(code: &CardCode) -> Option<&'static CardMetadata> {
+    metadata_for_test_inv(code)
 }
 
 fn mock_abilities_for(code: &CardCode) -> Option<Vec<Ability>> {

--- a/crates/scenarios/src/test_fixtures/synth_cards.rs
+++ b/crates/scenarios/src/test_fixtures/synth_cards.rs
@@ -299,6 +299,11 @@ fn synth_cover_up_trauma(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
 }
 
 /// `metadata_for` function pointer used by [`TEST_REGISTRY`].
+///
+/// Falls through to `game_core::test_support::metadata_for_test_inv` for
+/// the synthetic investigator code (`TEST_INV`) used by `test_investigator()`.
+/// After cp2a `max_health()`/`max_sanity()` read from the registry; the
+/// fallthrough makes capacity reads work without installing a separate registry.
 fn metadata_for(code: &CardCode) -> Option<&'static CardMetadata> {
     match code.as_str() {
         SYNTH_TREACHERY_CODE => Some(synth_treachery_metadata_static()),
@@ -307,7 +312,7 @@ fn metadata_for(code: &CardCode) -> Option<&'static CardMetadata> {
         SYNTH_CHOICE_TREACHERY_CODE => Some(synth_choice_treachery_metadata_static()),
         SYNTH_FAST_EVENT_CODE => Some(synth_fast_event_metadata_static()),
         SYNTH_COVER_UP_CODE => Some(synth_cover_up_metadata_static()),
-        _ => None,
+        _ => game_core::test_support::metadata_for_test_inv(code),
     }
 }
 

--- a/crates/scenarios/tests/the_gathering.rs
+++ b/crates/scenarios/tests/the_gathering.rs
@@ -180,8 +180,12 @@ fn attic_forced_enter_deals_one_horror() {
     // isn't reachable until C1b's Door-on-the-Floor transition).
     let mut attic = test_location(20, "Attic");
     attic.code = CardCode("01113".into());
+    // Use Skids O'Toole (01003) as the investigator card code: a real corpus
+    // code known to cards::REGISTRY (installed here) with capacity data.
+    let mut inv = test_investigator(1);
+    inv.investigator_card.code = CardCode::new("01003");
     let mut state = GameStateBuilder::new()
-        .with_investigator_at(test_investigator(1), LocationId(20))
+        .with_investigator_at(inv, LocationId(20))
         .with_location(attic)
         .build();
     let mut events = Vec::new();
@@ -204,8 +208,12 @@ fn cellar_forced_enter_deals_one_damage() {
     install_registries();
     let mut cellar = test_location(21, "Cellar");
     cellar.code = CardCode("01114".into());
+    // Use Skids O'Toole (01003) as the investigator card code: a real corpus
+    // code known to cards::REGISTRY (installed here) with capacity data.
+    let mut inv = test_investigator(1);
+    inv.investigator_card.code = CardCode::new("01003");
     let mut state = GameStateBuilder::new()
-        .with_investigator_at(test_investigator(1), LocationId(21))
+        .with_investigator_at(inv, LocationId(21))
         .with_location(cellar)
         .build();
     let mut events = Vec::new();

--- a/crates/scenarios/tests/the_gathering.rs
+++ b/crates/scenarios/tests/the_gathering.rs
@@ -189,7 +189,11 @@ fn attic_forced_enter_deals_one_horror() {
     let outcome = fire_forced_on_enter(&mut state, &mut events, InvestigatorId(1), LocationId(20));
     assert!(matches!(outcome, EngineOutcome::Done));
     assert_eq!(
-        state.investigators.get(&InvestigatorId(1)).unwrap().horror,
+        state
+            .investigators
+            .get(&InvestigatorId(1))
+            .unwrap()
+            .horror(),
         1,
         "entering the Attic deals 1 horror to the entering investigator",
     );
@@ -209,7 +213,11 @@ fn cellar_forced_enter_deals_one_damage() {
     let outcome = fire_forced_on_enter(&mut state, &mut events, InvestigatorId(1), LocationId(21));
     assert!(matches!(outcome, EngineOutcome::Done));
     assert_eq!(
-        state.investigators.get(&InvestigatorId(1)).unwrap().damage,
+        state
+            .investigators
+            .get(&InvestigatorId(1))
+            .unwrap()
+            .damage(),
         1,
         "entering the Cellar deals 1 damage to the entering investigator",
     );

--- a/crates/scenarios/tests/the_gathering_resolutions.rs
+++ b/crates/scenarios/tests/the_gathering_resolutions.rs
@@ -88,10 +88,11 @@ fn enemy_attack_defeats_roland_and_latches_lost() {
 
     let mut state = seated_roland();
 
-    // Seed: Roland one hit from death (health 9 → damage 8).
+    // Seed: Roland one hit from death. After cp2a, accumulated_damage is the
+    // source of truth; max_health() reads from cards::REGISTRY (9 for Roland).
     {
         let roland = state.investigators.get_mut(&INV).expect("Roland seated");
-        roland.damage = roland.max_health() - 1;
+        roland.investigator_card.accumulated_damage = roland.max_health() - 1;
     }
     let loc = state.investigators[&INV]
         .current_location

--- a/crates/scenarios/tests/the_gathering_resolutions.rs
+++ b/crates/scenarios/tests/the_gathering_resolutions.rs
@@ -91,7 +91,7 @@ fn enemy_attack_defeats_roland_and_latches_lost() {
     // Seed: Roland one hit from death (health 9 → damage 8).
     {
         let roland = state.investigators.get_mut(&INV).expect("Roland seated");
-        roland.damage = roland.max_health - 1;
+        roland.damage = roland.max_health() - 1;
     }
     let loc = state.investigators[&INV]
         .current_location

--- a/crates/scenarios/tests/the_gathering_symbols.rs
+++ b/crates/scenarios/tests/the_gathering_symbols.rs
@@ -31,6 +31,9 @@ fn gathering_state(token: ChaosToken, ghouls: u8) -> game_core::state::GameState
     let inv = InvestigatorId(1);
     let loc = LocationId(1);
     let mut investigator = test_investigator(1);
+    // Use Skids O'Toole (01003): a real corpus code known to cards::REGISTRY
+    // (installed here) with capacity data, so max_health()/max_sanity() work.
+    investigator.investigator_card.code = CardCode::new("01003");
     investigator.current_location = Some(loc);
     let mut state = GameStateBuilder::new()
         .with_investigator(investigator)

--- a/crates/scenarios/tests/the_gathering_symbols.rs
+++ b/crates/scenarios/tests/the_gathering_symbols.rs
@@ -265,7 +265,7 @@ fn tablet_immediate_damage_suspends_on_soak_without_redrawing() {
 
     assert_eq!(r.outcome, EngineOutcome::Done);
     let inv = &r.state.investigators[&InvestigatorId(1)];
-    assert_eq!(inv.damage, 0, "damage soaked, investigator took none");
+    assert_eq!(inv.damage(), 0, "damage soaked, investigator took none");
     let dog = inv
         .cards_in_play
         .iter()

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 game-core = { path = "../game-core" }
 protocol = { path = "../protocol" }
+cards = { path = "../cards" }
 leptos = { version = "0.8", features = ["csr"] }
 console_error_panic_hook = "0.1"
 

--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -103,8 +103,8 @@ fn investigators_panel(game: &GameState) -> impl IntoView {
                     <span class="inv-location">{location}</span>
                     <span class="inv-actions">"actions " {inv.actions_remaining}</span>
                     <span class="inv-resources">"resources " {inv.resources}</span>
-                    <span class="inv-health">"health " {inv.damage} "/" {inv.max_health}</span>
-                    <span class="inv-sanity">"sanity " {inv.horror} "/" {inv.max_sanity}</span>
+                    <span class="inv-health">"health " {inv.damage()} "/" {inv.max_health()}</span>
+                    <span class="inv-sanity">"sanity " {inv.horror()} "/" {inv.max_sanity()}</span>
                     <span class="inv-clues">"clues " {inv.clues}</span>
                     <span class="inv-status">{format!("{:?}", inv.status)}</span>
                     <div class="hand"><h4>"Hand"</h4><ul>{hand}</ul></div>

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -2,5 +2,8 @@
 
 fn main() {
     console_error_panic_hook::set_once();
+    // Install the card registry so `max_health()` / `max_sanity()` can resolve
+    // investigator-card capacity during board rendering (#448).
+    let _ = game_core::card_registry::install(cards::REGISTRY);
     leptos::mount::mount_to_body(web::app::App);
 }

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -27,6 +27,10 @@ fn body_html() -> String {
 /// carrying `state`. Ticks once so CSR effects flush, then returns the
 /// rendered body HTML.
 async fn render_state(state: game_core::state::GameState) -> String {
+    // Rendering an investigator panel reads `max_health()` / `max_sanity()`,
+    // which resolve the investigator card's capacity from the registry (#448).
+    // Install the synthetic `TEST_INV` (8/8) registry so those reads succeed.
+    game_core::test_support::install_test_registry();
     let store = RwSignal::new(ClientState::default());
     leptos::mount::mount_to_body(move || {
         provide_context(store);
@@ -105,8 +109,8 @@ async fn investigators_panel_renders_stats_and_hand() {
 
     let mut inv = test_investigator(1);
     inv.name = "Roland Banks".to_string();
-    inv.damage = 2; // 2/8
-    inv.horror = 1; // 1/8
+    inv.investigator_card.accumulated_damage = 2; // 2/8
+    inv.investigator_card.accumulated_horror = 1; // 1/8
     inv.clues = 3;
     inv.resources = 4;
     inv.actions_remaining = 2;

--- a/crates/web/tests/registry_smoke.rs
+++ b/crates/web/tests/registry_smoke.rs
@@ -1,0 +1,28 @@
+//! Smoke test: `cards::REGISTRY` is installed at startup so investigator
+//! capacity resolves without panic during board rendering (#448 C1).
+//!
+//! This binary installs the real `cards::REGISTRY` (not the synthetic one used
+//! by `board.rs`). Each `tests/` file is a separate wasm-pack binary with its
+//! own `OnceLock`, so the two registries do not collide.
+#![cfg(target_arch = "wasm32")]
+
+use game_core::state::CardCode;
+use game_core::test_support::fixtures::test_investigator;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+/// Install `cards::REGISTRY` (the real corpus) and verify that
+/// `max_health()` / `max_sanity()` resolve correctly for Roland Banks (01001).
+/// Stats verified against `data/arkhamdb-snapshot/pack/core/core.json`:
+///   Roland Banks (01001): health = 9, sanity = 5.
+#[wasm_bindgen_test]
+fn roland_banks_capacity_resolves_with_real_registry() {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+
+    let mut inv = test_investigator(1);
+    inv.investigator_card.code = CardCode::new("01001");
+
+    assert_eq!(inv.max_health(), 9, "Roland Banks health should be 9");
+    assert_eq!(inv.max_sanity(), 5, "Roland Banks sanity should be 5");
+}

--- a/crates/web/tests/store.rs
+++ b/crates/web/tests/store.rs
@@ -22,6 +22,10 @@ fn body_html() -> String {
 
 #[wasm_bindgen_test]
 async fn hello_renders_state_present() {
+    // Rendering the investigator panel reads `max_health()`/`max_sanity()`,
+    // which resolve the investigator card's capacity from the registry (#448).
+    // The fixture investigator uses the synthetic `TEST_INV` code (8/8).
+    game_core::test_support::install_test_registry();
     let store = leptos::prelude::RwSignal::new(ClientState::default());
     // Provide the same signal the component reads, then mount the board;
     // it stays mounted (attached to the DOM) for the assertions.

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -69,8 +69,14 @@ enemy; you just forfeit the sole-engaged damage bonus).
   Folded in the **investigator-card bridge** (`Investigator.card_code` at seating +
   `ability_usage` + a `scan_investigator_card_reactions` source / `CandidateSource::
   Investigator`), which also fixes Roland's **reaction** firing from a *seated*
-  investigator (previously only via test card-injection). Bridge is sunset by **#448**;
-  **#453 ✅ shipped (PR #456)** removed the `#[serde(default)]` convention the new fields
+  investigator (previously only via test card-injection). **Bridge retired by #448 ✅
+  shipped (PR #457)** — the investigator card is now a real `CardInPlay`
+  (`Investigator.investigator_card`) holding health/sanity + harm + identity + usage, so
+  `card_code` / `ability_usage` / the bespoke `scan_investigator_card_reactions` source all
+  collapse into the uniform `controlled_card_instances()` scan; this also fully resolves
+  #453's `card_code`-sentinel question (no field left to default) and made the web client a
+  registry host (`cards::REGISTRY` installed at startup, since capacity now reads from
+  metadata). **#453 ✅ shipped (PR #456)** removed the `#[serde(default)]` convention the new fields
   follow — the non-`Option` fields are now required on the wire (a stale payload errors
   rather than silently degrading `card_code` to the empty sentinel); the two `Option`
   fields (`pending_played_event`, `usage_limit`) stay implicitly optional because serde

--- a/docs/superpowers/plans/2026-06-25-investigator-card-as-permanent.md
+++ b/docs/superpowers/plans/2026-06-25-investigator-card-as-permanent.md
@@ -1,0 +1,543 @@
+# Investigator-card-as-permanent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Represent each seated investigator's investigator card as a real `CardInPlay` holding health/sanity and acting as the default damage/horror soaker, deleting the four bespoke `Investigator` harm/capacity fields and the two #118-bridge fields.
+
+**Architecture:** A new dedicated `Investigator.investigator_card: CardInPlay` field (not in `cards_in_play`, not `Option`). Harm lives in its `accumulated_damage`/`accumulated_horror`; capacity is read from `CardKind::Investigator { health, sanity }` metadata via the registry (uniform with assets). A unified `controlled_card_instances()` iterator that prepends the investigator card wires its abilities/reactions/constant-modifiers in for free. The six deleted fields become accessor methods. Migrated behind an **accessor seam**: accessors delegate to the old fields first (Checkpoint 1), then swap to read the card (Checkpoint 2), so every checkpoint stays green and behaviour-identical.
+
+**Tech Stack:** Rust, `serde`, the game-core kernel (`crates/game-core`), the card DSL (`crates/card-dsl`), the web client (`crates/web`).
+
+## Global Constraints
+
+- CI runs seven jobs, all warnings-as-errors. Every checkpoint must pass the full local gauntlet before commit:
+  - `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo fmt --check`
+  - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
+  - `cargo build -p web --target wasm32-unknown-unknown`
+  - `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`
+- **Validate-first / mutate-second** dispatch contract (CLAUDE.md): handlers check all preconditions before mutating.
+- **Behaviour-preserving:** no rules-behaviour change. Any latent bug surfaced gets its own issue, not a silent fix.
+- One feature branch `engine/investigator-card-permanent`; four checkpoints = four (or more) commits, each green. The branch already carries the design-spec commit.
+- **Never hand-edit `crates/cards/src/generated/cards.rs`** (generated).
+- Design spec: `docs/superpowers/specs/2026-06-25-investigator-card-as-permanent-design.md`.
+
+---
+
+## CHECKPOINT 1 — The accessor seam (the card exists; reads go through accessors)
+
+Goal: introduce `investigator_card` + a synthetic test registry, mint the card everywhere an `Investigator` is built, and route every read of the four harm/capacity fields (and `card_code`) through accessor methods that *delegate to the existing fields*. No behaviour change — pure seam introduction.
+
+### Task 1: Add the `investigator_card` field + synthetic test-registry infrastructure
+
+**Files:**
+- Modify: `crates/game-core/src/state/investigator.rs` (struct + a constructor helper)
+- Modify: `crates/game-core/src/test_support/fixtures.rs` (mint the card in `test_investigator`)
+- Create/Modify: `crates/game-core/src/test_support/mod.rs` (a `test_registry` install helper + synthetic `TEST_INV` metadata)
+- Modify: `crates/game-core/src/engine/dispatch/phases.rs:97–126` (mint the card at seating)
+- Modify: any other site that constructs an `Investigator` literal (compiler will list them)
+
+**Interfaces:**
+- Produces: `Investigator.investigator_card: CardInPlay`; `const TEST_INV: &str = "TEST_INV"`; `fn install_test_registry()` in `test_support` registering `TEST_INV` with `health: 8, sanity: 8` and skills; `test_investigator(id)` now mints `investigator_card` with `code == TEST_INV`, instance id `CardInstanceId(u32::MAX - id)` (a high, collision-free id distinct from gameplay instances).
+- Consumes: `CardInPlay::enter_play(code, instance_id)` (existing), `card_registry::install` (existing), `CardKind::Investigator { skills, health, sanity }` (existing metadata variant).
+
+- [ ] **Step 1: Write the failing test** (in `crates/game-core/src/state/investigator.rs` tests)
+
+```rust
+#[test]
+fn test_investigator_has_an_investigator_card_with_the_synthetic_code() {
+    let inv = crate::test_support::test_investigator(1);
+    assert_eq!(inv.investigator_card.code.as_str(), crate::test_support::TEST_INV);
+    assert_eq!(inv.investigator_card.accumulated_damage, 0);
+    assert_eq!(inv.investigator_card.accumulated_horror, 0);
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p game-core test_investigator_has_an_investigator_card -- --nocapture`
+Expected: FAIL — no field `investigator_card` on `Investigator` (compile error).
+
+- [ ] **Step 3: Add the field to the struct**
+
+In `crates/game-core/src/state/investigator.rs`, add to `struct Investigator` (keep all existing fields for now):
+
+```rust
+    /// The investigator's own card as a real in-play permanent: it holds the
+    /// investigator's health/sanity capacity (from `CardKind::Investigator`
+    /// metadata) and is the default damage/horror soaker via its
+    /// `accumulated_damage` / `accumulated_horror`. Lives here rather than in
+    /// `cards_in_play` so loops over "cards the player played" never touch it
+    /// (#448). Required on the wire.
+    pub investigator_card: CardInPlay,
+```
+
+- [ ] **Step 4: Add the synthetic test card + registry helper**
+
+In `crates/game-core/src/test_support/mod.rs` (follow the existing `weapon_fight.rs` mock-registry pattern; define a `static` metadata and a `OnceLock`-guarded install):
+
+```rust
+/// Synthetic investigator-card code for unit tests. Registered by
+/// [`install_test_registry`] with 8 health / 8 sanity (mirroring the legacy
+/// `test_investigator` capacity).
+pub const TEST_INV: &str = "TEST_INV";
+
+fn test_inv_metadata() -> &'static crate::card_data::CardMetadata {
+    use crate::card_data::{CardKind, CardMetadata, Skills};
+    static M: std::sync::OnceLock<CardMetadata> = std::sync::OnceLock::new();
+    M.get_or_init(|| CardMetadata {
+        code: TEST_INV.to_owned(),
+        name: "Test Investigator".to_owned(),
+        traits: vec![],
+        text: None,
+        pack_code: "_test".to_owned(),
+        kind: CardKind::Investigator {
+            skills: Skills { willpower: 3, intellect: 3, combat: 3, agility: 3 },
+            health: 8,
+            sanity: 8,
+        },
+    })
+}
+
+/// Install a minimal game-core test registry that knows `TEST_INV` (and only
+/// it). Idempotent; safe to call from any test. Capacity-reading code
+/// (`max_health()` / `max_sanity()` / soak / defeat) needs this installed.
+pub fn install_test_registry() {
+    use crate::state::CardCode;
+    static INSTALL: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    INSTALL.get_or_init(|| {
+        fn metadata_for(code: &CardCode) -> Option<&'static crate::card_data::CardMetadata> {
+            (code.as_str() == TEST_INV).then(test_inv_metadata)
+        }
+        fn abilities_for(_: &CardCode) -> Option<Vec<crate::dsl::Ability>> { None }
+        let _ = crate::card_registry::install(crate::card_registry::CardRegistry {
+            metadata_for,
+            abilities_for,
+            native_effect_for: |_| None,
+        });
+    });
+}
+```
+
+> NOTE: confirm the exact `CardKind::Investigator { .. }` and `CardMetadata` field shape against `crates/card-dsl/src/card_data.rs` before writing — copy the real field set verbatim. If a registry is already installed by another test in the same binary, `install` is a no-op (OnceLock); that is fine because `TEST_INV` only needs to resolve where capacity is actually read.
+
+- [ ] **Step 5: Mint the card in `test_investigator`**
+
+In `crates/game-core/src/test_support/fixtures.rs`, inside `test_investigator(id)`, build the card and set the field (keep `max_health: 8` etc. as-is for the seam):
+
+```rust
+    let mut investigator_card =
+        CardInPlay::enter_play(CardCode::new(TEST_INV), CardInstanceId(u32::MAX - id));
+    investigator_card.accumulated_damage = 0;
+    investigator_card.accumulated_horror = 0;
+    // … in the returned struct literal:
+    //     investigator_card,
+```
+
+- [ ] **Step 6: Mint the card at seating**
+
+In `crates/game-core/src/engine/dispatch/phases.rs` (the `start_scenario` mutate loop ~`:97–126`), where each `Investigator` is built from the roster entry's `card_code`, also mint its `investigator_card` from the **same** code with a freshly minted instance id (`state.card_instance_ids.mint()`), emitting **no** `EnteredPlay`/play event:
+
+```rust
+    let inv_card_id = state.card_instance_ids.mint();
+    let investigator_card = CardInPlay::enter_play(card_code.clone(), inv_card_id);
+    // … set `investigator_card` in the Investigator literal alongside the existing fields.
+```
+
+- [ ] **Step 7: Fix remaining construction sites**
+
+Run `cargo build -p game-core` and add `investigator_card` to every `Investigator { .. }` literal the compiler flags (mostly tests). For test literals not going through `test_investigator`, mint with `CardInPlay::enter_play(CardCode::new(TEST_INV), CardInstanceId(u32::MAX - <id>))`.
+
+- [ ] **Step 8: Run the test to verify it passes**
+
+Run: `cargo test -p game-core test_investigator_has_an_investigator_card -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 9: Full gauntlet + commit**
+
+Run the six gauntlet commands from Global Constraints. Then:
+
+```bash
+git add -A
+git commit -m "engine: add Investigator.investigator_card field + test registry (#448 cp1a)"
+```
+
+### Task 2: Route reads through accessor methods (delegating to the old fields)
+
+**Files:**
+- Modify: `crates/game-core/src/state/investigator.rs` (accessor methods)
+- Modify: every read site of `inv.damage` / `inv.horror` / `inv.max_health` / `inv.max_sanity` / `inv.card_code` across `crates/game-core`, `crates/web`, `crates/scenarios`, `crates/server` (compiler-guided after the fields are made private — see Step 4).
+
+**Interfaces:**
+- Produces: `Investigator::{damage(&self) -> u8, horror(&self) -> u8, max_health(&self) -> u8, max_sanity(&self) -> u8}`; identity read via `inv.investigator_card.code`. In Checkpoint 1 the four accessors **delegate to the existing fields** (no card/registry reads yet).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn harm_accessors_match_the_underlying_fields_during_the_seam() {
+    let mut inv = crate::test_support::test_investigator(1);
+    inv.damage = 2;
+    inv.horror = 1;
+    assert_eq!(inv.damage(), 2);
+    assert_eq!(inv.horror(), 1);
+    assert_eq!(inv.max_health(), inv.max_health);
+    assert_eq!(inv.max_sanity(), inv.max_sanity);
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p game-core harm_accessors_match_the_underlying_fields`
+Expected: FAIL — no method `damage` on `Investigator`.
+
+- [ ] **Step 3: Add the delegating accessors**
+
+In `impl Investigator`:
+
+```rust
+    /// Physical damage currently on the investigator. Reads the investigator
+    /// card's accumulated damage once harm moves there (#448 cp2); during the
+    /// seam it delegates to the legacy field.
+    #[must_use]
+    pub fn damage(&self) -> u8 { self.damage }
+    /// Horror currently on the investigator. See [`Self::damage`].
+    #[must_use]
+    pub fn horror(&self) -> u8 { self.horror }
+    /// Maximum health (printed). Reads `CardKind::Investigator` metadata once
+    /// the seam closes (#448 cp2); during the seam it delegates to the field.
+    #[must_use]
+    pub fn max_health(&self) -> u8 { self.max_health }
+    /// Maximum sanity (printed). See [`Self::max_health`].
+    #[must_use]
+    pub fn max_sanity(&self) -> u8 { self.max_sanity }
+```
+
+- [ ] **Step 4: Migrate read sites (compiler-guided)**
+
+Temporarily rename the fields to force the compiler to enumerate every read: in the struct, rename `pub damage` → `damage` (drop `pub`) one at a time, `cargo build --all`, and for each `field is private` / external-read error replace `X.damage` with `X.damage()` (and likewise horror/max_health/max_sanity). For `inv.card_code` reads, replace with `inv.investigator_card.code` / `&inv.investigator_card.code`. **Do not** convert *write* sites (`inv.damage = …`) yet — those stay as field writes through Checkpoint 1; keep those four fields assignable within the crate (leave them `pub` for now and instead grep: `rg -n "\.damage\b" crates --type rust` and convert reads by hand, leaving assignments). Use the web crate too: `crates/web/src/board.rs:106–107` → `inv.damage()` / `inv.max_health()` / `inv.horror()` / `inv.max_sanity()`.
+
+> Guidance: the clean mechanical rule is "every *read* of the four fields and of `card_code` becomes the accessor; every *write* stays a field assignment until its Checkpoint." Reads vastly outnumber writes (writes are the handful in the consumer-surface appendix).
+
+- [ ] **Step 5: Run the test + full suite**
+
+Run: `cargo test -p game-core harm_accessors_match_the_underlying_fields` then `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: PASS, all green.
+
+- [ ] **Step 6: Full gauntlet + commit**
+
+```bash
+git add -A
+git commit -m "engine: route investigator harm/capacity reads through accessors (#448 cp1b)"
+```
+
+---
+
+## CHECKPOINT 2 — Move harm, soak, and defeat onto the investigator card
+
+Goal: make the investigator card the source of truth for harm and a real soaker; swap the accessor internals from the fields to the card; defeat reads the card. The four old fields become vestigial (still present, no readers/writers) until Checkpoint 4.
+
+### Task 3: Move harm writes + healing onto the card; swap accessor internals
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/combat.rs:343–397` (`apply_damage_numeric` / `apply_horror_numeric`)
+- Modify: `crates/game-core/src/engine/evaluator.rs:1461–1501` (`heal_effect`)
+- Modify: `crates/game-core/src/engine/dispatch/actions.rs:852,988,1108,1289` and `cards.rs:866` (the `inv.damage = 0` / `inv.horror = 0` resets)
+- Modify: `crates/game-core/src/state/investigator.rs` (accessor bodies)
+
+**Interfaces:**
+- Consumes: `inv.investigator_card.accumulated_damage` / `accumulated_horror` (mutable), `inv.max_health()` / `max_sanity()`.
+- Produces: `damage()` now reads `self.investigator_card.accumulated_damage`; `horror()` reads `accumulated_horror`; `max_health()`/`max_sanity()` read `CardKind::Investigator` metadata via `card_registry::current()`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn damage_application_accumulates_on_the_investigator_card() {
+    crate::test_support::install_test_registry();
+    let mut inv = crate::test_support::test_investigator(1);
+    // Drive the harm entry point used by attacks/effects (adjust to the real
+    // signature found in combat.rs):
+    let defeated = crate::engine::dispatch::combat::apply_damage_numeric(&mut inv, 3);
+    assert_eq!(inv.investigator_card.accumulated_damage, 3);
+    assert_eq!(inv.damage(), 3);
+    assert!(!defeated, "3 < 8 health");
+}
+```
+
+> Adjust the call to the real `apply_damage_numeric` signature/visibility (it may take `&mut Cx` / an id). If it is not unit-callable, write the test at the existing harness level used by the current damage tests in `combat.rs`.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p game-core damage_application_accumulates_on_the_investigator_card`
+Expected: FAIL — `accumulated_damage` stays 0 (harm still writes the field).
+
+- [ ] **Step 3: Move the harm writes**
+
+In `apply_damage_numeric`, replace `inv.damage = inv.damage.saturating_add(amount)` with `inv.investigator_card.accumulated_damage = inv.investigator_card.accumulated_damage.saturating_add(amount)`, and change the defeat check from `inv.damage >= inv.max_health` to `inv.investigator_card.accumulated_damage >= inv.max_health()`. Mirror for `apply_horror_numeric` (horror/sanity). In `heal_effect`, reduce `inv.investigator_card.accumulated_damage` / `accumulated_horror`. Convert the `inv.damage = 0` / `inv.horror = 0` resets to `inv.investigator_card.accumulated_damage = 0` / `accumulated_horror = 0`.
+
+- [ ] **Step 4: Swap the accessor internals**
+
+```rust
+    pub fn damage(&self) -> u8 { self.investigator_card.accumulated_damage }
+    pub fn horror(&self) -> u8 { self.investigator_card.accumulated_horror }
+    pub fn max_health(&self) -> u8 { investigator_capacity(&self.investigator_card.code).0 }
+    pub fn max_sanity(&self) -> u8 { investigator_capacity(&self.investigator_card.code).1 }
+```
+
+Add a private helper that reads the metadata (panicking loudly if the registry/metadata is absent — no silent default, per project norms):
+
+```rust
+/// (health, sanity) printed capacity for an investigator card, from the
+/// installed registry. Panics if the registry is uninstalled or the code is
+/// not an investigator card — a state-shape invariant violation, surfaced
+/// rather than silently defaulted.
+fn investigator_capacity(code: &CardCode) -> (u8, u8) {
+    let reg = crate::card_registry::current()
+        .expect("investigator capacity read before a CardRegistry was installed");
+    match &(reg.metadata_for)(code)
+        .expect("investigator card code absent from registry")
+        .kind
+    {
+        crate::card_data::CardKind::Investigator { health, sanity, .. } => (*health, *sanity),
+        _ => panic!("investigator_card.code does not resolve to a CardKind::Investigator"),
+    }
+}
+```
+
+- [ ] **Step 5: Run the test + suite**
+
+Run: `cargo test -p game-core damage_application_accumulates_on_the_investigator_card` then the full test job.
+Expected: PASS. Fix any test that built an unseated investigator and read capacity without `install_test_registry()` — add the install call.
+
+- [ ] **Step 6: Full gauntlet + commit**
+
+```bash
+git add -A
+git commit -m "engine: move investigator harm + capacity onto the investigator card (#448 cp2a)"
+```
+
+### Task 4: Make the investigator card a soaker; unify defeat (overflow → eliminate)
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/combat.rs:457–495` (`build_soakers`), `:164–185` (`assign_attack`), `:211–256` (`defeat_overflowed_assets`), `:278–322` (`place_assignment`)
+
+**Interfaces:**
+- Consumes: the investigator card as a soaker with `(remaining_health, remaining_sanity) = (max_health() − accumulated_damage, max_sanity() − accumulated_horror)`.
+- Produces: `build_soakers` returns the investigator card as the always-eligible default soaker (filled per RR after assets); `defeat_overflowed_assets` (or its caller) runs investigator elimination when the *investigator card* overflows instead of discarding it.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn an_asset_soaks_first_then_the_investigator_card_takes_the_remainder() {
+    crate::test_support::install_test_registry();
+    // Build a seated investigator with one 1-health soaker asset in play, deal
+    // 3 damage: asset takes 1 (and is defeated), investigator card takes 2.
+    // (Use the existing soak-test harness in combat.rs as the template.)
+    // assert asset discarded; assert inv.investigator_card.accumulated_damage == 2.
+}
+```
+
+> Flesh this out from the nearest existing soak test in `combat.rs` (search `build_soakers` / `soak_and_place` tests). The assertion that matters: remainder lands on `investigator_card.accumulated_damage`, not a field.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p game-core an_asset_soaks_first_then_the_investigator_card`
+Expected: FAIL (investigator card not yet a soaker / remainder mis-routed).
+
+- [ ] **Step 3: Add the investigator card to `build_soakers`**
+
+In `build_soakers`, after collecting asset soakers from `cards_in_play`, append a soaker entry for `inv.investigator_card` whose remaining capacity is `inv.max_health() − accumulated_damage` / `inv.max_sanity() − accumulated_horror`, flagged as the default/mandatory-remainder target. Remove the `assign_attack` branch that dumped the remainder onto the investigator field; the remainder now flows into the investigator-card soaker like any other (it is just always last/always eligible per the RR "must be assigned to the investigator" clause).
+
+- [ ] **Step 4: Branch defeat on the investigator card**
+
+In `defeat_overflowed_assets` (or `place_assignment`'s post-apply defeat sweep), when the overflowed instance is the investigator card (`instance_id == inv.investigator_card.instance_id`), call the existing investigator-elimination path (`apply_investigator_defeat` with the right `DefeatCause`) instead of discarding to the owner's pile.
+
+- [ ] **Step 5: Run the test + suite**
+
+Run the soak test then the full test job.
+Expected: PASS. Re-run the existing soak/defeat tests — they should still pass with harm on the card.
+
+- [ ] **Step 6: Full gauntlet + commit**
+
+```bash
+git add -A
+git commit -m "engine: investigator card is the default soaker; unify defeat (#448 cp2b)"
+```
+
+---
+
+## CHECKPOINT 3 — Wire abilities/reactions/constant-mods; retire the #118 bridge
+
+### Task 5: Unify `controlled_card_instances()` and migrate the scans onto it
+
+**Files:**
+- Modify: `crates/game-core/src/state/investigator.rs:145–147` (`controlled_card_instances`)
+- Modify: `crates/game-core/src/engine/evaluator.rs:2112–2140` (`sum_constant_modify`)
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs:222–288` (`scan_pending_triggers`) and `:362–424` (delete `scan_investigator_card_reactions`)
+- Modify: wherever `CandidateSource::Investigator` is defined/matched (delete it)
+
+**Interfaces:**
+- Produces: `controlled_card_instances()` now yields the investigator card first, then `cards_in_play`, then `threat_area`. `sum_constant_modify` and the reaction scan iterate it. `scan_investigator_card_reactions` / `CandidateSource::Investigator` removed.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn a_seated_investigator_card_constant_modifier_is_summed() {
+    // Register a test investigator card whose abilities() include a
+    // Trigger::Constant Effect::Modify (+1 to some skill), seat it, and assert
+    // sum_constant_modify picks it up WITHOUT injecting the card into
+    // cards_in_play. (Use a bespoke test registry variant returning abilities
+    // for a dedicated code.)
+}
+```
+
+> If wiring a full constant-mod test is heavy, the equivalent observable is the existing Roland reaction / elder-sign integration tests in `crates/cards/tests/roland_banks_seated.rs` — Task 6 covers that path. Prefer a focused game-core test here on `controlled_card_instances()` ordering plus a `sum_constant_modify` unit test.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Expected: FAIL — the investigator card's ability is not summed (scan ignores it).
+
+- [ ] **Step 3: Prepend the investigator card to the iterator**
+
+```rust
+    pub fn controlled_card_instances(&self) -> impl Iterator<Item = &CardInPlay> {
+        std::iter::once(&self.investigator_card)
+            .chain(self.cards_in_play.iter())
+            .chain(self.threat_area.iter())
+    }
+```
+
+- [ ] **Step 4: Migrate the bypassing consumers**
+
+In `sum_constant_modify`, change the iteration from `inv.cards_in_play.iter()` to `inv.controlled_card_instances()`. In `scan_pending_triggers`, confirm it iterates `controlled_card_instances()` (it does, per the surface map) so the investigator card is now scanned; delete `scan_investigator_card_reactions` and its call site, and remove the `CandidateSource::Investigator` variant (replace its construction with the normal in-play-instance candidate carrying the investigator card's instance id).
+
+> **Care point:** audit every *other* `cards_in_play.iter()` in the engine. Leave on `cards_in_play` any loop meaning "cards the player played" (asset queries, elimination drain, discard-all). Only ability/reaction/constant-modifier *scans* move to the unified iterator.
+
+- [ ] **Step 5: Run the test + suite**
+
+Expected: PASS; existing reaction/elder-sign tests still green.
+
+- [ ] **Step 6: Full gauntlet + commit**
+
+```bash
+git add -A
+git commit -m "engine: unify controlled_card_instances; scans include the investigator card (#448 cp3a)"
+```
+
+### Task 6: Retire the #118 bridge fields
+
+**Files:**
+- Modify: `crates/game-core/src/state/investigator.rs` (delete `card_code`, `ability_usage`, `is_usage_exhausted`, `bump_ability_usage`)
+- Modify: `crates/game-core/src/engine/evaluator.rs:1935–1960` (`elder_sign_modifier` → `investigator_card.code`)
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (usage checks → `investigator_card.is_usage_exhausted` / `bump_ability_usage`)
+- Modify: any remaining reader of `inv.card_code` / `inv.ability_usage`
+
+**Interfaces:**
+- Produces: identity exclusively via `inv.investigator_card.code`; per-period usage exclusively via `inv.investigator_card` (the `CardInPlay` methods). `Investigator.card_code` and `Investigator.ability_usage` no longer exist.
+
+- [ ] **Step 1: Write the failing test (or reuse the seated-Roland integration test)**
+
+The load-bearing behaviour is already covered by `crates/cards/tests/roland_banks_seated.rs` (elder-sign + seated reaction). Add a game-core unit assertion that `Investigator` has no `card_code` field by switching the seated-identity read:
+
+```rust
+#[test]
+fn identity_is_read_from_the_investigator_card() {
+    let inv = crate::test_support::test_investigator(1);
+    assert_eq!(inv.investigator_card.code.as_str(), crate::test_support::TEST_INV);
+}
+```
+
+- [ ] **Step 2: Run it / build to verify the bridge is still present**
+
+Run: `cargo build -p game-core`
+Expected: still compiles (bridge present). The "fail" here is the existence of the now-redundant fields; proceed to delete.
+
+- [ ] **Step 3: Delete the bridge fields + wrappers**
+
+Remove `card_code`, `ability_usage`, `is_usage_exhausted`, `bump_ability_usage` from `Investigator`. `cargo build --all` and migrate every flagged reader: `inv.card_code` → `inv.investigator_card.code`; `inv.ability_usage` / `inv.is_usage_exhausted(..)` / `inv.bump_ability_usage(..)` → `inv.investigator_card.ability_usage` / `inv.investigator_card.is_usage_exhausted(..)` / `inv.investigator_card.bump_ability_usage(..)`. In `elder_sign_modifier`, look abilities up via `investigator_card.code` (drop the empty-sentinel skip — a seated investigator always has a real code; an unseated test investigator simply has no elder-sign ability for `TEST_INV`).
+
+- [ ] **Step 4: Update the #453 serde test**
+
+The `omitting_any_required_field_is_rejected` investigator test lists `card_code` / `ability_usage` — remove those two from its field list (they no longer exist) and add `investigator_card`.
+
+- [ ] **Step 5: Run the suite**
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: PASS, including `crates/cards/tests/roland_banks_seated.rs`.
+
+- [ ] **Step 6: Full gauntlet + commit**
+
+```bash
+git add -A
+git commit -m "engine: retire the #118 investigator-card bridge fields (#448 cp3b)"
+```
+
+---
+
+## CHECKPOINT 4 — Delete the vestigial fields and finalize
+
+### Task 7: Delete the four old fields; finalize web + fixtures
+
+**Files:**
+- Modify: `crates/game-core/src/state/investigator.rs` (delete `damage`, `horror`, `max_health`, `max_sanity`)
+- Modify: `crates/game-core/src/test_support/fixtures.rs` (drop the old-field sets)
+- Modify: `crates/game-core/src/engine/dispatch/phases.rs` (drop the old-field sets at seating)
+- Modify: any remaining `Investigator { .. }` literal (compiler-guided)
+- Verify: `crates/web/src/board.rs` already on accessors (Checkpoint 1)
+
+**Interfaces:**
+- Produces: `Investigator` with no `damage` / `horror` / `max_health` / `max_sanity` fields; all access via the accessors backed by `investigator_card`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn defeat_reads_capacity_from_the_card_not_a_field() {
+    crate::test_support::install_test_registry();
+    let mut inv = crate::test_support::test_investigator(1);
+    inv.investigator_card.accumulated_damage = 8; // == TEST_INV health
+    assert!(inv.damage() >= inv.max_health(), "defeat threshold reached via accessors");
+}
+```
+
+- [ ] **Step 2: Run it to verify it passes already (accessors)** then proceed to delete fields.
+
+Run: `cargo test -p game-core defeat_reads_capacity_from_the_card_not_a_field`
+Expected: PASS (accessors already back onto the card). This test guards the post-deletion state.
+
+- [ ] **Step 3: Delete the four fields**
+
+Remove `pub damage`, `pub horror`, `pub max_health`, `pub max_sanity` from `Investigator`. `cargo build --all` and remove every now-dangling field write/set the compiler flags (the `inv.damage = …` writes were all converted to `inv.investigator_card.accumulated_* = …` in Checkpoint 2, so remaining hits are construction literals — drop those keys).
+
+- [ ] **Step 4: Update the #453 serde test field list**
+
+Remove `damage`/`horror`/`max_health`/`max_sanity` from any JSON-literal field list that enumerated them; the `omitting_any_required_field_is_rejected` test should now include `investigator_card` among required fields.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+Expected: PASS.
+
+- [ ] **Step 6: Full gauntlet + commit**
+
+```bash
+git add -A
+git commit -m "engine: delete the four bespoke investigator harm/capacity fields (#448 cp4)"
+```
+
+---
+
+## Finalization (after all checkpoints green)
+
+- [ ] Update `docs/phases/phase-7-the-gathering.md`: mark #448 shipped, note the bridge retirement closes the #118 sunset and the #453 `card_code`-sentinel question. (Final commit, after CI is green on the opened PR — per the repo PR procedure.)
+- [ ] Open the PR mapping commit → checkpoint, with a design-decisions paragraph linking the spec. `Closes #448.`
+
+## Self-review notes (coverage against the spec)
+
+- §1 target model → Tasks 1, 2, 7. §2 unified iteration → Task 5. §3 soak/defeat → Tasks 3, 4. §4 seating/suppression → Task 1 (Step 6). §5 bridge retirement → Task 6. §6 test strategy → Task 1 (Steps 4–5) + `install_test_registry`. §7 four checkpoints → the four-checkpoint structure.
+- No `Option<CardCode>` redesign (out of scope, per spec).
+- Open risk carried into execution: the §2 "care point" iterator-classification audit (Task 5, Step 4) is the highest-judgment step — every `cards_in_play.iter()` must be classified.

--- a/docs/superpowers/specs/2026-06-25-investigator-card-as-permanent-design.md
+++ b/docs/superpowers/specs/2026-06-25-investigator-card-as-permanent-design.md
@@ -1,0 +1,239 @@
+# Investigator-card-as-permanent: unify health/sanity/soak onto the investigator card
+
+**Issue:** [#448](https://github.com/talelburg/eldritch/issues/448) · **Date:** 2026-06-25 · **Status:** design approved, pre-implementation
+
+A foundational, **behaviour-preserving** state-model migration: represent each seated
+investigator's **investigator card** as a real `CardInPlay` that holds the investigator's
+health/sanity and is the default damage/horror soaker. The four bespoke fields on
+`Investigator` (`damage`, `horror`, `max_health`, `max_sanity`) plus the two #118-bridge
+fields (`card_code`, `ability_usage`) collapse onto that card.
+
+## Motivation — what it dissolves
+
+The investigator's physical/mental state being four ad-hoc fields forces several special
+cases that all disappear once the investigator card is "just a permanent in play":
+
+- **Investigator-card abilities fire for free.** The reaction scan and the constant-modifier
+  sum already walk in-play instances; the investigator card simply joins that walk, so
+  Roland's reaction + elder-sign stop needing test-only card injection.
+- **Usage tracking is free.** A `CardInPlay` already carries `ability_usage`; the bespoke
+  `Investigator.ability_usage` home goes away.
+- **Soak stops being special-cased.** The investigator card becomes a normal soaker with
+  real capacity, so the distribution pipeline treats it uniformly with asset soakers
+  instead of dumping the "remainder" on a field — no phantom-soaker hazard, because it is
+  the real soaker.
+
+This also **retires the #118 bridge** the engine deliberately shipped as scaffolding (the
+`card_code` + `ability_usage` fields, the `scan_investigator_card_reactions` source, and the
+direct `elder_sign_modifier` lookup).
+
+## Rules grounding
+
+Rules Reference, "Dealing Damage/Horror" and defeat (quoted verbatim):
+
+> "When an investigator is dealt damage or horror, that investigator may assign it to
+> eligible asset cards he or she controls." … "All damage/horror that cannot be assigned to
+> an asset must be assigned to the investigator."
+
+> "After applying damage/horror, if an investigator has as much or more damage on it as it
+> has health (or as much or more horror on it as it has sanity), that investigator is
+> defeated." … "if an asset has damage equal to or higher than its health or horror equal to
+> or higher than its sanity, it is defeated and placed in its owner's discard pile."
+
+The investigator's own health/sanity capacity *is* the investigator card. The "must be
+assigned to the investigator" clause makes that card the **always-eligible, mandatory-
+remainder soaker**, and investigator defeat is the same `accumulated ≥ printed` shape as
+asset defeat — only the consequence differs (eliminate vs discard). This is what makes the
+unification behaviour-preserving.
+
+## Keystone decisions (settled)
+
+1. **Placement: a dedicated `Investigator.investigator_card: CardInPlay` field (not in
+   `cards_in_play`, not `Option`).** Keeps `cards_in_play` meaning "cards the player played,"
+   so elimination/defeat/asset loops over it never accidentally touch the investigator card.
+   The trade is unifying the currently-inconsistent scan iterators onto one
+   `controlled_card_instances()` that prepends the investigator card (see §2).
+
+2. **Capacity read from metadata (uniform with assets).** `max_health()`/`max_sanity()`
+   read `CardKind::Investigator { health, sanity }` from the registry, exactly as
+   `build_soakers` reads asset capacity. Defeat collapses to `accumulated ≥ printed`
+   identically for the investigator card and assets; no capacity is stored on the card. The
+   accepted cost: capacity reads require an installed registry, so capacity/defeat tests
+   register a synthetic investigator card (see §6).
+
+## §1 — Target state model
+
+```rust
+pub struct Investigator {
+    pub investigator_card: CardInPlay,   // NEW — the player-character permanent
+    // DELETED: damage, horror, max_health, max_sanity, card_code, ability_usage
+    …
+}
+```
+
+`CardInPlay` is **not** modified — it already carries everything the investigator card needs:
+`accumulated_damage` / `accumulated_horror` (harm), `ability_usage` (usage), `code`
+(identity). The six deleted fields become accessors:
+
+| Old field | New accessor | Source | Registry? |
+|---|---|---|---|
+| `inv.damage` | `inv.damage()` | `investigator_card.accumulated_damage` | no |
+| `inv.horror` | `inv.horror()` | `investigator_card.accumulated_horror` | no |
+| `inv.max_health` | `inv.max_health()` | `metadata_for(code)` → `Investigator { health }` | yes |
+| `inv.max_sanity` | `inv.max_sanity()` | same → `{ sanity }` | yes |
+| `inv.card_code` | `inv.investigator_card.code` | direct | no |
+| `inv.ability_usage` | `investigator_card.ability_usage` + its methods | direct | no |
+
+Mutating harm goes through `&mut inv.investigator_card.accumulated_*` (or a thin
+`apply_damage`/`heal` helper on `Investigator`), preserving the validate-first/mutate-second
+contract at the existing call sites.
+
+## §2 — Unified iteration (ability / reaction / constant-mod wiring)
+
+`controlled_card_instances()` becomes the single "triggerable in-play instances" iterator,
+prepending the investigator card:
+
+```rust
+pub fn controlled_card_instances(&self) -> impl Iterator<Item = &CardInPlay> {
+    std::iter::once(&self.investigator_card)
+        .chain(self.cards_in_play.iter())
+        .chain(self.threat_area.iter())
+}
+```
+
+Then migrate the two consumers that bypass it today onto it:
+- **`sum_constant_modify`** (`evaluator.rs`, currently iterates `inv.cards_in_play` directly).
+- **the reaction scan** (`scan_pending_triggers` / `reaction_windows.rs`).
+
+Net effect: the investigator card's `Trigger::Constant` modifiers, `OnEvent` reactions, and
+`ElderSign` trigger all participate automatically. The bespoke
+`scan_investigator_card_reactions` source and `CandidateSource::Investigator` are **deleted**
+(subsumed). `elder_sign_modifier` reads abilities via `investigator_card.code`.
+
+**Care point:** any consumer that means "assets/events the player played" (not "every
+triggerable instance") must keep iterating `cards_in_play`, not the unified iterator. Audit
+each call site during the migration and classify it.
+
+## §3 — Soak + defeat unification
+
+- **`build_soakers`** gains a `CardKind::Investigator { health, sanity }` arm and adds the
+  investigator card as the **always-eligible default soaker**, replacing the `assign_attack`
+  "remainder-to-the-investigator-field" special case. Per the RR, the investigator card takes
+  whatever can't be assigned to an asset.
+- **Defeat** uses the asset rule uniformly: `investigator_card.accumulated_damage ≥
+  max_health()` (resp. horror/sanity). The single investigator-specific branch: when the
+  *investigator card* overflows, run **investigator elimination** (`Status::Killed` /
+  `Insane`, carrying `DefeatCause`) instead of asset discard. `defeat_overflowed_assets` /
+  `apply_{damage,horror}_numeric` / `place_assignment` route harm to
+  `investigator_card.accumulated_*` and branch on "is this the investigator card?".
+- **Healing** (`heal_effect`) reduces `investigator_card.accumulated_*`.
+
+## §4 — Seating + event suppression
+
+At `start_scenario`, mint `investigator_card` as a `CardInPlay` (mint an instance id, set
+`.code` from the roster entry). **No `EnteredPlay` / play events are emitted** — this is
+scenario setup placement, not a played card (matching how investigators are minted today and
+how `ScenarioStarted` is the only timing point at seating). The card is created *before* any
+harm/ability path can reference it. Capacity is not stamped (read on demand from metadata).
+
+## §5 — Bridge retirement (#118)
+
+Folded into this epic, as the bridge's documented sunset:
+- Delete `Investigator.card_code` → identity is `investigator_card.code`.
+- Delete `Investigator.ability_usage` (+ `is_usage_exhausted`/`bump_ability_usage` wrappers)
+  → use the card's own `ability_usage` + `CardInPlay` methods.
+- Delete `scan_investigator_card_reactions` / `CandidateSource::Investigator` → unified scan.
+- `elder_sign_modifier` looks abilities up by `investigator_card.code`.
+
+## §6 — Test / unseated investigators
+
+Every investigator now owns an `investigator_card`. Approach (no `Option`, per decision):
+- `test_investigator(id)` mints an `investigator_card` with a fixed synthetic code
+  (`"TEST_INV"`), `accumulated_* = 0`.
+- `test_support` provides an opt-in **game-core test registry** that registers `TEST_INV`
+  with `health/sanity = 8/8` (mirroring today's `max_health: 8`), plus a
+  `seated_test_investigator()` / builder helper for tests that read capacity or exercise
+  defeat. (One process shares one `OnceLock` registry, as today — the test registry covers
+  the synthetic code used across game-core unit tests.)
+- `damage()` / `horror()` and harm/soak-routing remain registry-free; only capacity/defeat
+  tests install the test registry — consistent with soak tests already needing asset
+  metadata.
+
+## §7 — Migration: one branch, four green checkpoints
+
+One feature branch (`engine/investigator-card-permanent`), four sequential commits, each
+leaving the full gauntlet green so the branch is reviewable commit-by-commit. Behaviour-
+preserving throughout; transient dual-write keeps early checkpoints green.
+
+1. **Scaffold + dual-write.** Add `investigator_card` + accessors; mint the card at seating;
+   keep the four old fields and keep them in sync with the card. No reads migrated yet — this
+   only makes the card *exist* before anything depends on it. Update `test_support` (§6).
+2. **Harm + soak + defeat.** Route damage/horror writes, soak distribution, and defeat onto
+   the investigator card (§3). The investigator card becomes a real soaker; defeat reads the
+   card. Old fields still dual-written but no longer the source of truth for harm.
+3. **Abilities + reactions + constant-mods + bridge retirement.** Unify
+   `controlled_card_instances()` and migrate `sum_constant_modify` + the reaction scan onto
+   it (§2); retire the bridge (§5).
+4. **Delete + finalize.** Remove the six old fields and the dual-write; flip every remaining
+   read to the accessors; update the web wire format (`crates/web/src/board.rs`) and all
+   fixtures.
+
+Each checkpoint runs the full CI gauntlet (`-D warnings` test, host clippy, fmt, doc, wasm
+build, wasm clippy). The PR description maps commit → checkpoint for review.
+
+## Consumer surface (implementation appendix)
+
+File:line anchors gathered during scoping (verify before editing — line numbers drift):
+
+- **Field defs:** `state/investigator.rs:64,66,68,70`. **Seating mint:**
+  `engine/dispatch/phases.rs:97–126` (reads `health`/`sanity` from metadata at `:51–56`).
+  **Fixture:** `test_support/fixtures.rs:35–64`.
+- **Damage writes:** `dispatch/combat.rs:360` (`apply_damage_numeric`), `:296`
+  (`place_assignment`), `:413–422` (`soak_and_place`); `dispatch/elimination.rs:204–209`
+  (`take_damage`); `dispatch/actions.rs:852,988,1108,1289` (`inv.damage = 0` resets);
+  `evaluator.rs:1488` (heal). **Damage reads:** `combat.rs:361` (defeat), `hunters.rs:50–51`
+  (prey), `web/board.rs:106`.
+- **Horror writes:** `combat.rs:390` (`apply_horror_numeric`), `:297`; `elimination.rs:187–193`
+  (`take_horror`); `cards.rs:866` (reset); `evaluator.rs:1489` (heal). **Horror reads:**
+  `combat.rs:391` (defeat), `web/board.rs:107`.
+- **Capacity reads:** `combat.rs:361,391` (defeat thresholds); `hunters.rs:50–53` (remaining
+  health); `web/board.rs:106–107`.
+- **Soak pipeline:** `combat.rs:413–422` (`soak_and_place`), `:433–455`
+  (`soak_and_distribute`/K5b), `:457–495` (`build_soakers`), `:164–185` (`assign_attack` —
+  the investigator remainder special-case to remove), `:211–256`
+  (`defeat_overflowed_assets`), `:278–322` (`place_assignment`), `:872–950`
+  (`resume_damage_assignment`).
+- **Elimination/defeat:** `elimination.rs:18–51` (`apply_investigator_defeat`), `:56–165`
+  (steps), `:235–250` (`check_all_defeated`).
+- **Bridge:** `state/investigator.rs:41–54` (`card_code`), `:129` (`ability_usage`),
+  `:149–167` (usage methods); `reaction_windows.rs:362–424`
+  (`scan_investigator_card_reactions`, skips empty code `:387`); `evaluator.rs:1935–1960`
+  (`elder_sign_modifier`); folded at `skill_test.rs:314`.
+- **Unified-iteration consumers:** `state/investigator.rs:145–147`
+  (`controlled_card_instances`); `evaluator.rs:2112–2140` (`sum_constant_modify`, iterates
+  `cards_in_play` directly — migrate); `evaluator.rs:2061–2104` (`pending_action_surcharge`,
+  already uses `controlled_card_instances`); `reaction_windows.rs:222–288`
+  (`scan_pending_triggers`).
+- **Asset-soak model to mirror:** `combat.rs:478–481` (reads `CardKind::Asset { health,
+  sanity }`), `:228–230` (asset defeat); `state/card.rs:130–136`
+  (`accumulated_damage`/`accumulated_horror`).
+
+## Out of scope / non-goals
+
+- No rules-behaviour change — purely a state-model migration. (If any latent bug surfaces, it
+  gets its own issue, not a silent fix here.)
+- No `Option<CardCode>` redesign of identity beyond what folding onto `investigator_card.code`
+  already gives (the #453 sentinel question is fully resolved by this epic: there is no
+  separate `card_code` field to default).
+- Capacity-modifying effects (cards that raise max health/sanity) remain unmodelled, as today.
+- Horror-soak ≠ max-sanity boost (#44) is unaffected.
+
+## Risks
+
+- **Iterator-classification errors (§2):** migrating a `cards_in_play` loop that meant
+  "played cards" onto the unified iterator would wrongly include the investigator card.
+  Mitigation: audit + classify every call site; the dedicated-field choice means the default
+  (leaving a loop on `cards_in_play`) is safe.
+- **Registry-coupled capacity in tests (§6):** mitigated by the synthetic-card test registry;
+  watch for game-core tests that read capacity without seating.
+- **Single large branch:** mitigated by four independently-green checkpoints mapped in the PR.

--- a/docs/superpowers/specs/2026-06-25-investigator-card-as-permanent-design.md
+++ b/docs/superpowers/specs/2026-06-25-investigator-card-as-permanent-design.md
@@ -116,16 +116,37 @@ each call site during the migration and classify it.
 
 ## §3 — Soak + defeat unification
 
-- **`build_soakers`** gains a `CardKind::Investigator { health, sanity }` arm and adds the
-  investigator card as the **always-eligible default soaker**, replacing the `assign_attack`
-  "remainder-to-the-investigator-field" special case. Per the RR, the investigator card takes
-  whatever can't be assigned to an asset.
+> **Amended after implementation (cp2b).** The original plan was to add the investigator
+> card to `build_soakers` as a `Soaker` struct entry and delete the `assign_attack`
+> remainder tail. Implementation (and an independent review) found that refactor is **not
+> behaviour-preserving** and would re-implement byte-identical behaviour with *more* code: an
+> asset `Soaker` is capped at its remaining capacity, but the investigator's remainder is
+> **uncapped** (overflowing capacity is precisely how the investigator is defeated); the asset
+> apply-path (`find_controlled_mut`) scans only `cards_in_play`, so routing the investigator
+> card through it would drop the harm and emit no `DamageTaken`; and investigator elimination
+> must run **before** the asset-overflow sweep (elimination drains co-overflowing assets to
+> `removed_from_game` with no `CardDiscarded`). So the unification is achieved via the
+> **already-correct remainder path** (delivered by §1/cp2a moving harm onto the card), not a
+> `Soaker` entry. Mechanism below reflects the shipped state.
+
+- **Soaking:** the investigator card is the **always-eligible, uncapped, mandatory-remainder
+  soaker**. `assign_attack` fills each asset `Soaker` to its capacity, then assigns the
+  uncapped leftover to the investigator; `place_assignment` routes that leftover through
+  `apply_{damage,horror}_numeric`, which (since cp2a) write `investigator_card.accumulated_*`
+  and emit `DamageTaken`/`HorrorTaken`. Per the RR, the investigator card takes whatever can't
+  be assigned to an asset. It is the **real** soaker (real capacity from metadata, real
+  accumulated harm) — the phantom-soaker hazard is dissolved — even though it is not a
+  `Soaker` struct value. (A `defeat_overflowed_assets` doc-comment warns future refactorers
+  not to fold the investigator card into that asset-only sweep.)
 - **Defeat** uses the asset rule uniformly: `investigator_card.accumulated_damage ≥
-  max_health()` (resp. horror/sanity). The single investigator-specific branch: when the
-  *investigator card* overflows, run **investigator elimination** (`Status::Killed` /
-  `Insane`, carrying `DefeatCause`) instead of asset discard. `defeat_overflowed_assets` /
-  `apply_{damage,horror}_numeric` / `place_assignment` route harm to
-  `investigator_card.accumulated_*` and branch on "is this the investigator card?".
+  max_health()` (resp. horror/sanity). The investigator-specific branch lives in
+  `place_assignment` step 2: when the investigator's accumulated harm reaches capacity, run
+  **investigator elimination** (`Status::Killed` / `Insane`, carrying `DefeatCause`) *before*
+  the asset-overflow sweep, instead of asset discard. `defeat_overflowed_assets` scans only
+  `cards_in_play`, so the investigator card (in its own field) is never asset-discarded.
+- Locked by three characterization tests (`crates/cards/tests/guard_dog_soak.rs`): asset-soaks-
+  first-then-investigator-remainder, investigator-overflow→elimination (not discard), and the
+  defeat-before-asset-sweep ordering invariant.
 - **Healing** (`heal_effect`) reduces `investigator_card.accumulated_*`.
 
 ## §4 — Seating + event suppression


### PR DESCRIPTION
## Summary

Foundational, **behaviour-preserving** state-model migration: each seated investigator's **investigator card** is now a real `CardInPlay` that holds the investigator's health/sanity and is the default damage/horror soaker. The four bespoke `Investigator` fields (`damage`, `horror`, `max_health`, `max_sanity`) and the two #118-bridge fields (`card_code`, `ability_usage`) are deleted — their state folds onto the card. Closes the #118 bridge sunset and resolves the #453 `card_code`-sentinel question (there's no longer a separate field to default).

## Architecture

- **Dedicated field, not in `cards_in_play`:** `Investigator.investigator_card: CardInPlay` (keystone decision). `cards_in_play` keeps meaning "cards the player played," so elimination/defeat/asset loops never touch the investigator card.
- **Capacity from metadata (uniform with assets):** `max_health()`/`max_sanity()` read `CardKind::Investigator { health, sanity }` from the registry; harm reads `investigator_card.accumulated_*`. The six deleted fields became accessor methods.
- **Unified iterator:** `controlled_card_instances()` now prepends the investigator card; `sum_constant_modify` + the reaction scan migrated onto it, so the card's constant modifiers / reactions / elder-sign fire for free. The bespoke `scan_investigator_card_reactions` source + `CandidateSource::Investigator` are deleted.

## Checkpoints (commit → checkpoint, each green)

- **cp1a/cp1b** — add `investigator_card` + a synthetic test registry; route all reads through accessors (delegating to the old fields — the seam).
- **cp2a** — move harm writes + healing + capacity onto the card; swap accessor internals (fail-loud panic if the registry is absent).
- **cp2b** — soak/defeat unification. **Spec §3 was amended** (ratified): the prescribed `build_soakers`/`Soaker`-entry refactor is *not* behaviour-preserving (the investigator remainder is uncapped, routes different events, and elimination must precede the asset sweep), so the unification rides the existing remainder path; locked by 3 characterization tests.
- **cp3a** — unify `controlled_card_instances()` + scan migration (the `cards_in_play` classification audit was independently re-verified).
- **cp3b** — retire the #118 bridge fields; elder-sign reads via `investigator_card.code` (empty-sentinel skip removed).
- **cp4** — delete the four bespoke fields; finalize.

## Notable deviations (both ratified)

- **§3 soak mechanism** — see cp2b above; the design spec's §3 was amended in-branch to describe the shipped mechanism.
- **Web client installs `cards::REGISTRY`** — the final whole-branch review caught a Critical: `board.rs` renders capacity via the now-registry-backed accessors, but the production WASM client installed no registry (and didn't depend on `cards`) → it would panic on the first render of a seated game. Fixed by making the web client a proper host that installs `cards::REGISTRY` at startup (the layering permits web→cards, mirroring the server). Guarded by a new `crates/web/tests/registry_smoke.rs`. Bundle-size note: pulling the corpus into the wasm bundle grows the dev bundle (~99 MB unoptimized; release `wasm-opt` shrinks it) — accepted as the tradeoff of the capacity-from-registry decision, optimizable later.

## Test notes

- TDD throughout; each checkpoint ran the full local gauntlet. Characterization tests in `crates/cards/tests/guard_dog_soak.rs` lock the soak remainder / overflow→elimination / defeat-before-asset-sweep ordering invariants. `crates/cards/tests/roland_banks_seated.rs` covers the seated elder-sign + reaction via the unified path. `crates/web/tests/registry_smoke.rs` verifies the client resolves real corpus investigator capacity (Roland `01001` = 9/5, verified against the snapshot).
- Per-task reviews + an opus whole-branch review (which caught the C1 web panic). Full gauntlet green locally (host test/clippy/fmt/doc + wasm-build + wasm-clippy); wasm-test runs in CI.
- Design spec + plan committed under `docs/superpowers/{specs,plans}/2026-06-25-investigator-card-as-permanent*`.

Closes #448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)