### PR TITLE
engine/ui: InputKind discriminator on InputRequest — render Confirm/Skip controls, unblock the Mythos-draw gate (#205)

### DIFF
--- a/crates/cards/tests/evidence.rs
+++ b/crates/cards/tests/evidence.rs
@@ -111,6 +111,13 @@ fn after_defeat_window_opens_and_offers_evidence_with_no_in_play_reaction() {
                 request.options.iter().any(|o| o.label.contains(EVIDENCE)),
                 "after-defeat window must offer the Evidence! hand play; request = {request:?}",
             );
+            // A non-forced reaction window is a PickSingle the player may pass:
+            // the client must offer a Skip control.
+            assert_eq!(request.kind, game_core::InputKind::PickSingle);
+            assert!(
+                request.skippable,
+                "a non-forced reaction window must be skippable; request = {request:?}",
+            );
         }
         other => panic!("after-defeat window must open (AwaitingInput); got {other:?}"),
     }

--- a/crates/game-core/src/action.rs
+++ b/crates/game-core/src/action.rs
@@ -124,7 +124,7 @@ pub enum InputResponse {
     /// Decline / skip the prompted optional action.
     Skip,
     /// Pick one option from a structured choice prompt
-    /// ([`InputRequest::choice`](crate::engine::InputRequest::choice)),
+    /// ([`InputRequest::pick_single`](crate::engine::InputRequest::pick_single)),
     /// echoing back its [`OptionId`](crate::engine::OptionId). The
     /// single-selection family (umbrella §3): the Axis-A choice machinery, and
     /// the location/investigator-pick windows (hunter move/engage, spawn engage)

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -290,7 +290,7 @@ pub(super) fn prompt_mulligan(cx: &mut Cx, remaining: Vec<InvestigatorId>) -> En
         .continuations
         .push(crate::state::Continuation::Mulligan { remaining });
     EngineOutcome::AwaitingInput {
-        request: InputRequest::prompt(format!(
+        request: InputRequest::pick_multiple(format!(
             "Setup mulligan: {next:?} may mulligan; submit InputResponse::PickMultiple with the \
              hand indices (as option ids) to redraw (an empty selection keeps the hand).",
         )),

--- a/crates/game-core/src/engine/dispatch/choice.rs
+++ b/crates/game-core/src/engine/dispatch/choice.rs
@@ -46,7 +46,7 @@ pub(crate) fn awaiting_choice(prompt: impl Into<String>, labels: Vec<String>) ->
         })
         .collect();
     EngineOutcome::AwaitingInput {
-        request: InputRequest::choice(prompt, options),
+        request: InputRequest::pick_single(prompt, options),
         resume_token: ResumeToken(0),
     }
 }

--- a/crates/game-core/src/engine/dispatch/combat.rs
+++ b/crates/game-core/src/engine/dispatch/combat.rs
@@ -894,7 +894,7 @@ fn prompt_current_point(cx: &mut Cx, investigator: InvestigatorId) -> EngineOutc
          ({rd} damage / {rh} horror left)"
     );
     EngineOutcome::AwaitingInput {
-        request: InputRequest::choice(prompt, super::hunters::candidate_options(&targets)),
+        request: InputRequest::pick_single(prompt, super::hunters::candidate_options(&targets)),
         resume_token: ResumeToken(0),
     }
 }
@@ -1136,7 +1136,7 @@ fn suspend_order_pick(
         stage: AttackLoopStage::PickOrder,
     });
     EngineOutcome::AwaitingInput {
-        request: InputRequest::choice(prompt, options),
+        request: InputRequest::pick_single(prompt, options),
         resume_token: ResumeToken(0),
     }
 }

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -455,7 +455,7 @@ pub(super) fn spawn_enemy_at(
                     },
                 ));
             EngineOutcome::AwaitingInput {
-                request: InputRequest::choice(
+                request: InputRequest::pick_single(
                     format!(
                         "Enemy {enemy_id:?} spawn engagement: lead investigator picks whom to \
                          engage among {tied:?}"
@@ -586,7 +586,7 @@ pub(super) fn prompt_encounter_draw(cx: &Cx) -> EngineOutcome {
         .current_encounter_drawer()
         .expect("prompt_encounter_draw: no EncounterDraw frame on the stack");
     EngineOutcome::AwaitingInput {
-        request: InputRequest::prompt(format!(
+        request: InputRequest::confirm(format!(
             "Mythos step 1.4: {drawer:?} draws an encounter card; submit InputResponse::Confirm.",
         )),
         resume_token: ResumeToken(0),

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -418,7 +418,7 @@ fn suspend_hunter_choice(cx: &mut Cx, choice: HunterChoice) -> EngineOutcome {
         .continuations
         .push(crate::state::Continuation::HunterMove(choice));
     EngineOutcome::AwaitingInput {
-        request: InputRequest::choice(prompt, options),
+        request: InputRequest::pick_single(prompt, options),
         resume_token: ResumeToken(0),
     }
 }

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -110,7 +110,7 @@ fn turn_menu(state: &crate::state::GameState) -> crate::engine::InputRequest {
             label: a.label(state),
         })
         .collect();
-    crate::engine::InputRequest::choice("Choose an action", options)
+    crate::engine::InputRequest::pick_single("Choose an action", options)
 }
 
 /// Apply a [`PlayerAction`] to the state, pushing events.

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -1115,7 +1115,7 @@ fn park_hand_size_discard(cx: &mut Cx, remaining: Vec<InvestigatorId>) -> Engine
             HandSizeDiscard { remaining },
         ));
     EngineOutcome::AwaitingInput {
-        request: InputRequest::prompt(format!(
+        request: InputRequest::pick_multiple(format!(
             "Upkeep step 4.5: {next:?} has more than {HAND_SIZE_LIMIT} cards in hand; \
              submit InputResponse::PickMultiple with the hand indices (as option ids) to \
              discard down to {HAND_SIZE_LIMIT}.",
@@ -1743,10 +1743,12 @@ mod mythos_phase_tests {
             events: &mut events,
         });
 
-        assert!(
-            matches!(outcome, EngineOutcome::AwaitingInput { .. }),
-            "mythos_phase opens the first encounter-draw prompt, got {outcome:?}"
-        );
+        let EngineOutcome::AwaitingInput { request, .. } = &outcome else {
+            panic!("mythos_phase opens the first encounter-draw prompt, got {outcome:?}");
+        };
+        // The draw is a binary acknowledge: kind Confirm, not skippable.
+        assert_eq!(request.kind, crate::engine::InputKind::Confirm);
+        assert!(!request.skippable);
         assert_eq!(state.current_encounter_drawer(), Some(InvestigatorId(1)));
         assert!(
             events.iter().any(|e| matches!(

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -583,15 +583,19 @@ pub(crate) fn open_queued_reaction_window(cx: &mut Cx) -> EngineOutcome {
             .pending_candidates()
             .expect("open_queued_reaction_window: top window has candidates"),
     );
-    EngineOutcome::AwaitingInput {
-        request: InputRequest::choice(
-            format!(
-                "Resolution window: {} option(s). \
-                 Submit InputResponse::PickSingle(OptionId) to resolve one{skip_hint}.",
-                options.len(),
-            ),
-            options,
+    let mut request = InputRequest::pick_single(
+        format!(
+            "Resolution window: {} option(s). \
+             Submit InputResponse::PickSingle(OptionId) to resolve one{skip_hint}.",
+            options.len(),
         ),
+        options,
+    );
+    if !window.is_forced() {
+        request = request.skippable();
+    }
+    EngineOutcome::AwaitingInput {
+        request,
         // No multi-window state to disambiguate — routing keys off
         // the top of `state.open_windows`. Conventional 0 like the
         // commit-window's resume token.
@@ -883,15 +887,19 @@ pub(super) fn advance_resolution(cx: &mut Cx) -> EngineOutcome {
         ", or InputResponse::Skip to close"
     };
     let options = build_resolution_options(candidates);
-    EngineOutcome::AwaitingInput {
-        request: InputRequest::choice(
-            format!(
-                "Resolution window: {} option(s). \
-                 Submit InputResponse::PickSingle(OptionId) to resolve one{skip_hint}.",
-                options.len(),
-            ),
-            options,
+    let mut request = InputRequest::pick_single(
+        format!(
+            "Resolution window: {} option(s). \
+             Submit InputResponse::PickSingle(OptionId) to resolve one{skip_hint}.",
+            options.len(),
         ),
+        options,
+    );
+    if !window.is_forced() {
+        request = request.skippable();
+    }
+    EngineOutcome::AwaitingInput {
+        request,
         resume_token: ResumeToken(0),
     }
 }

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -125,7 +125,7 @@ pub(in crate::engine) fn start_skill_test(
             .push(crate::state::Continuation::SubstitutionPrompt { investigator });
         let use_skill = SkillKind::Intellect; // sole substitution in scope
         return EngineOutcome::AwaitingInput {
-            request: InputRequest::choice(
+            request: InputRequest::pick_single(
                 format!(
                     "{investigator:?}: use {use_skill:?} in place of {skill:?} for this test? \
                      (PickSingle(0) = use {use_skill:?}, PickSingle(1) = keep {skill:?})",
@@ -591,7 +591,7 @@ fn emit_commit_window(cx: &Cx, investigator: InvestigatorId) -> EngineOutcome {
         (t.skill, t.difficulty)
     };
     EngineOutcome::AwaitingInput {
-        request: InputRequest::prompt(format!(
+        request: InputRequest::pick_multiple(format!(
             "Commit cards from hand for {investigator:?}'s {skill:?} skill test \
              (difficulty {difficulty}); submit InputResponse::PickMultiple with the \
              hand indices as option ids. Empty selection commits no cards.",

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -31,7 +31,7 @@ pub use dispatch::reveal::reveal_location;
 pub use dispatch::threat_area::{attach_to_location, place_in_threat_area};
 pub use enumerate::{legal_actions, TurnAction};
 pub use evaluator::{effective_shroud, location_id_by_code, EvalContext};
-pub use outcome::{ChoiceOption, EngineOutcome, InputRequest, OptionId, ResumeToken};
+pub use outcome::{ChoiceOption, EngineOutcome, InputKind, InputRequest, OptionId, ResumeToken};
 pub use pathfinding::{shortest_first_steps, shortest_first_steps_with};
 
 // Crate-internal re-exports for `test_support::fire_forced_on_enter`.

--- a/crates/game-core/src/engine/outcome.rs
+++ b/crates/game-core/src/engine/outcome.rs
@@ -60,41 +60,100 @@ pub struct ChoiceOption {
     pub label: String,
 }
 
+/// Which [`InputResponse`](crate::action::InputResponse) variant the host must
+/// echo back for a prompt. The variant names mirror `InputResponse` 1:1, so the
+/// `kind` *is* the expected response — the host renders the matching control
+/// without inspecting the prompt text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum InputKind {
+    /// Pick exactly one offered [`option`](InputRequest::options) →
+    /// [`InputResponse::PickSingle`](crate::action::InputResponse::PickSingle).
+    PickSingle,
+    /// Pick a subset (possibly empty) →
+    /// [`InputResponse::PickMultiple`](crate::action::InputResponse::PickMultiple).
+    PickMultiple,
+    /// A binary acknowledge with no choice →
+    /// [`InputResponse::Confirm`](crate::action::InputResponse::Confirm).
+    Confirm,
+}
+
 /// A prompt the engine emits when it needs player input.
 ///
-/// Carries free-form [`prompt`](Self::prompt) text plus, for the
-/// single-selection choice contract (Axis A + the Axis-C reaction-window
-/// migration), a structured [`options`](Self::options) list. Remaining
-/// prompt-only callers (commit windows, hand-size discard) leave `options`
-/// empty via [`InputRequest::prompt`].
+/// Carries free-form [`prompt`](Self::prompt) text, a [`kind`](Self::kind)
+/// discriminator naming the [`InputResponse`](crate::action::InputResponse) the
+/// host must send back, an optional structured [`options`](Self::options) list
+/// (for [`PickSingle`](InputKind::PickSingle)), and a
+/// [`skippable`](Self::skippable) flag for windows that may also be passed.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct InputRequest {
     /// Human-readable text describing what the player must choose.
     pub prompt: String,
-    /// Structured options for a single-selection choice. Empty for the
-    /// legacy free-form prompts that have not migrated to the structured
-    /// contract.
+    /// Offered options for a [`PickSingle`](InputKind::PickSingle) prompt.
+    /// Empty for [`PickMultiple`](InputKind::PickMultiple) (host derives
+    /// hand-card candidates) and [`Confirm`](InputKind::Confirm).
     pub options: Vec<ChoiceOption>,
+    /// Which response variant the host must send back.
+    pub kind: InputKind,
+    /// When true the host also offers a Skip/Pass control →
+    /// [`InputResponse::Skip`](crate::action::InputResponse::Skip). Orthogonal
+    /// to `kind` (e.g. a `PickSingle` reaction window that may also be passed).
+    pub skippable: bool,
 }
 
 impl InputRequest {
-    /// A legacy prompt-only request (no structured options).
+    /// A single-selection choice over `options` →
+    /// [`InputResponse::PickSingle`](crate::action::InputResponse::PickSingle).
     #[must_use]
-    pub fn prompt(text: impl Into<String>) -> Self {
-        Self {
-            prompt: text.into(),
-            options: Vec::new(),
-        }
-    }
-
-    /// A structured single-selection choice request.
-    #[must_use]
-    pub fn choice(text: impl Into<String>, options: Vec<ChoiceOption>) -> Self {
+    pub fn pick_single(text: impl Into<String>, options: Vec<ChoiceOption>) -> Self {
         Self {
             prompt: text.into(),
             options,
+            kind: InputKind::PickSingle,
+            skippable: false,
         }
+    }
+
+    /// A subset-selection prompt →
+    /// [`InputResponse::PickMultiple`](crate::action::InputResponse::PickMultiple).
+    ///
+    /// `options` is left empty: every current consumer (skill-test commit,
+    /// setup mulligan, hand-size discard) picks a subset of the *prompted
+    /// investigator's hand*, and the host derives candidates from the hand,
+    /// treating each `OptionId(i)` as hand index `i`. This hand-index
+    /// convention only holds while `PickMultiple` decisions are hand-scoped; a
+    /// future subset-pick over non-hand candidates (e.g. revealed cards,
+    /// enemies) would need to carry them in `options` and render from there,
+    /// like [`pick_single`](Self::pick_single).
+    #[must_use]
+    pub fn pick_multiple(text: impl Into<String>) -> Self {
+        Self {
+            prompt: text.into(),
+            options: Vec::new(),
+            kind: InputKind::PickMultiple,
+            skippable: false,
+        }
+    }
+
+    /// A binary acknowledge prompt →
+    /// [`InputResponse::Confirm`](crate::action::InputResponse::Confirm).
+    #[must_use]
+    pub fn confirm(text: impl Into<String>) -> Self {
+        Self {
+            prompt: text.into(),
+            options: Vec::new(),
+            kind: InputKind::Confirm,
+            skippable: false,
+        }
+    }
+
+    /// Mark this prompt skippable (host renders a Skip/Pass control →
+    /// [`InputResponse::Skip`](crate::action::InputResponse::Skip)).
+    #[must_use]
+    pub fn skippable(mut self) -> Self {
+        self.skippable = true;
+        self
     }
 }
 
@@ -114,8 +173,47 @@ mod tests {
     use super::*;
 
     #[test]
-    fn choice_input_request_round_trips() {
-        let req = InputRequest::choice(
+    fn pick_single_sets_kind_and_not_skippable() {
+        let req = InputRequest::pick_single(
+            "Choose one",
+            vec![ChoiceOption {
+                id: OptionId(0),
+                label: "A".into(),
+            }],
+        );
+        assert_eq!(req.kind, InputKind::PickSingle);
+        assert!(!req.skippable);
+        assert_eq!(req.options.len(), 1);
+    }
+
+    #[test]
+    fn pick_multiple_sets_kind_and_empty_options() {
+        let req = InputRequest::pick_multiple("Commit cards");
+        assert_eq!(req.kind, InputKind::PickMultiple);
+        assert!(!req.skippable);
+        assert!(req.options.is_empty());
+    }
+
+    #[test]
+    fn confirm_sets_kind_and_empty_options() {
+        let req = InputRequest::confirm("Draw");
+        assert_eq!(req.kind, InputKind::Confirm);
+        assert!(!req.skippable);
+        assert!(req.options.is_empty());
+    }
+
+    #[test]
+    fn skippable_flips_only_the_flag() {
+        let base = InputRequest::pick_single("w", vec![]);
+        let skip = InputRequest::pick_single("w", vec![]).skippable();
+        assert!(!base.skippable);
+        assert!(skip.skippable);
+        assert_eq!(skip.kind, InputKind::PickSingle);
+    }
+
+    #[test]
+    fn input_request_round_trips_with_kind_and_skippable() {
+        let req = InputRequest::pick_single(
             "Choose one",
             vec![
                 ChoiceOption {
@@ -127,17 +225,12 @@ mod tests {
                     label: "Each discards 1".into(),
                 },
             ],
-        );
+        )
+        .skippable();
         let json = serde_json::to_string(&req).expect("serialize");
         let back: InputRequest = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, req);
-        assert_eq!(back.options.len(), 2);
-        assert_eq!(back.options[1].id, OptionId(1));
-    }
-
-    #[test]
-    fn prompt_only_request_has_no_options() {
-        let req = InputRequest::prompt("Submit a response");
-        assert!(req.options.is_empty());
+        assert_eq!(back.kind, InputKind::PickSingle);
+        assert!(back.skippable);
     }
 }

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -49,7 +49,7 @@ pub use engine::{
     resolve_encounter_card, reveal_location, round_end_advance, seat_and_open,
     shortest_first_steps, shortest_first_steps_with, spawn_set_aside_enemy,
     suspend_for_native_choice, take_damage, ApplyResult, ChoiceOption, ChoiceResolution, Cx,
-    EngineOutcome, EvalContext, InputRequest, OptionId, ResumeToken, TurnAction,
+    EngineOutcome, EvalContext, InputKind, InputRequest, OptionId, ResumeToken, TurnAction,
 };
 pub use event::{Event, FailureReason, TraumaKind};
 pub use rng::RngState;

--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -128,7 +128,7 @@ pub fn test_enemy(id: u32, name: impl Into<String>) -> Enemy {
 #[must_use]
 pub fn awaiting_commit_input(prompt: impl Into<String>) -> EngineOutcome {
     EngineOutcome::AwaitingInput {
-        request: InputRequest::prompt(prompt),
+        request: InputRequest::pick_multiple(prompt),
         resume_token: ResumeToken(0),
     }
 }
@@ -144,7 +144,7 @@ pub fn awaiting_commit_input(prompt: impl Into<String>) -> EngineOutcome {
 #[must_use]
 pub fn awaiting_pick_single_input(prompt: impl Into<String>) -> EngineOutcome {
     EngineOutcome::AwaitingInput {
-        request: InputRequest::choice(
+        request: InputRequest::pick_single(
             prompt,
             vec![
                 ChoiceOption {

--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -161,6 +161,36 @@ pub fn awaiting_pick_single_input(prompt: impl Into<String>) -> EngineOutcome {
     }
 }
 
+/// A sample [`Confirm`](crate::InputKind::Confirm)
+/// [`AwaitingInput`](EngineOutcome::AwaitingInput) outcome, for client/UI
+/// fixtures. Models the Mythos encounter-draw prompt.
+#[must_use]
+pub fn awaiting_confirm_input(prompt: impl Into<String>) -> EngineOutcome {
+    EngineOutcome::AwaitingInput {
+        request: InputRequest::confirm(prompt),
+        resume_token: ResumeToken(0),
+    }
+}
+
+/// A sample skippable [`PickSingle`](crate::InputKind::PickSingle)
+/// [`AwaitingInput`](EngineOutcome::AwaitingInput) outcome, for client/UI
+/// fixtures. Models a non-forced reaction window: one option plus a Skip
+/// affordance.
+#[must_use]
+pub fn awaiting_skippable_pick_single_input(prompt: impl Into<String>) -> EngineOutcome {
+    EngineOutcome::AwaitingInput {
+        request: InputRequest::pick_single(
+            prompt,
+            vec![ChoiceOption {
+                id: OptionId(0),
+                label: "Resolve".into(),
+            }],
+        )
+        .skippable(),
+        resume_token: ResumeToken(0),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::awaiting_commit_input;

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -701,7 +701,9 @@ mod tests {
     }
 
     fn req(prompt: &str) -> InputRequest {
-        InputRequest::prompt(prompt)
+        // The resolver returns scripted responses regardless of `kind`; the
+        // constructor choice here is arbitrary.
+        InputRequest::confirm(prompt)
     }
 
     #[test]

--- a/crates/web/src/input.rs
+++ b/crates/web/src/input.rs
@@ -1,21 +1,27 @@
 //! `AwaitingInput` resolution UI (P6.6, wasm-only). Renders the engine's
 //! pending prompt and a control to resolve it.
 //!
-//! Two rendering branches:
+//! The control is chosen by the request's [`InputKind`](game_core::InputKind)
+//! discriminator (#205) — never by inspecting the prompt text or whether
+//! `options` is empty:
 //!
-//! - **`PickSingle` option-list** (`request.options` non-empty, #447): one
-//!   button per [`ChoiceOption`]; click submits
+//! - **`PickSingle`** — one button per [`ChoiceOption`]; click submits
 //!   `ResolveInput(PickSingle(id))`.
-//! - **`PickMultiple` commit window** (`request.options` empty): the
-//!   legacy hand-card commit UI for skill-test commit / mulligan prompts
-//!   (P6.6 / #205).
+//! - **`Confirm`** — a single "Confirm" button → `ResolveInput(Confirm)`
+//!   (e.g. the Mythos encounter draw).
+//! - **`PickMultiple`** — the hand-card commit UI for skill-test commit /
+//!   mulligan / hand-size discard → `ResolveInput(PickMultiple { selected })`.
+//!
+//! Orthogonally, when `request.skippable` is set (e.g. a non-forced reaction
+//! window), a "Skip" button → `ResolveInput(Skip)` renders alongside whichever
+//! control the `kind` selected.
 //!
 //! Nothing renders when the latest outcome is not `AwaitingInput`.
 
 use std::collections::BTreeSet;
 
 use game_core::state::GameState;
-use game_core::{ChoiceOption, EngineOutcome, InputResponse, OptionId, PlayerAction};
+use game_core::{ChoiceOption, EngineOutcome, InputKind, InputResponse, OptionId, PlayerAction};
 use leptos::prelude::*;
 use protocol::ClientMessage;
 
@@ -26,14 +32,14 @@ use crate::transport::OutboundTx;
 /// submits via the `OutboundTx` provided by the transport (absent in
 /// render-only contexts, so read as `Option`).
 ///
-/// Dispatches to one of two rendering branches based on whether the
-/// [`InputRequest`](game_core::InputRequest) carries structured
-/// [`options`](game_core::InputRequest::options):
-///
-/// - Non-empty `options` → [`PickSingle`](InputResponse::PickSingle)
-///   option-list (one button per option, #447).
-/// - Empty `options` → [`PickMultiple`](InputResponse::PickMultiple)
-///   hand-card commit UI (skill-test commit / mulligan, #205).
+/// Dispatches on the [`InputRequest`](game_core::InputRequest)'s
+/// [`kind`](game_core::InputRequest::kind): a `PickSingle` option-list, a
+/// `Confirm` button, or the `PickMultiple` hand-card commit UI — plus a "Skip"
+/// button when [`skippable`](game_core::InputRequest::skippable) (#205).
+// Three parallel `view!` rendering arms (PickSingle / Confirm / PickMultiple)
+// plus the Skip control; the length is inherent to the per-kind dispatch, not
+// extractable without fighting leptos's closure captures.
+#[allow(clippy::too_many_lines)]
 #[component]
 pub fn AwaitingInputView() -> impl IntoView {
     let store = use_store();
@@ -55,93 +61,162 @@ pub fn AwaitingInputView() -> impl IntoView {
                 return ().into_any();
             };
 
-            // Branch 1: structured PickSingle option-list (#447).
-            if !request.options.is_empty() {
+            // A Skip/Pass control, rendered (independent of `kind`) whenever the
+            // request is skippable — e.g. a non-forced reaction window.
+            let skippable = request.skippable;
+            let skip_button = {
                 let tx = tx.clone();
-                let buttons: Vec<_> = request
-                    .options
-                    .iter()
-                    .cloned()
-                    .map(|opt: ChoiceOption| {
-                        let ChoiceOption { id, label } = opt;
-                        let tx = tx.clone();
-                        view! {
+                move || {
+                    if !skippable {
+                        return ().into_any();
+                    }
+                    let tx = tx.clone();
+                    view! {
+                        <button
+                            class="skip"
+                            on:click=move |_| {
+                                if let Some(tx) = tx.clone() {
+                                    let _ = tx.unbounded_send(ClientMessage::Submit {
+                                        action: PlayerAction::ResolveInput {
+                                            response: InputResponse::Skip,
+                                        },
+                                    });
+                                }
+                            }
+                        >
+                            "Skip"
+                        </button>
+                    }
+                    .into_any()
+                }
+            };
+
+            match request.kind {
+                // One button per offered option → ResolveInput(PickSingle(id)).
+                InputKind::PickSingle => {
+                    let tx = tx.clone();
+                    let buttons: Vec<_> = request
+                        .options
+                        .iter()
+                        .cloned()
+                        .map(|opt: ChoiceOption| {
+                            let ChoiceOption { id, label } = opt;
+                            let tx = tx.clone();
+                            view! {
+                                <button
+                                    class="option"
+                                    on:click=move |_| {
+                                        if let Some(tx) = tx.clone() {
+                                            let _ = tx.unbounded_send(ClientMessage::Submit {
+                                                action: PlayerAction::ResolveInput {
+                                                    response: InputResponse::PickSingle(id),
+                                                },
+                                            });
+                                        }
+                                    }
+                                >
+                                    {label}
+                                </button>
+                            }
+                        })
+                        .collect();
+                    view! {
+                        <section class="awaiting-input">
+                            <p class="prompt">{request.prompt.clone()}</p>
+                            <div class="option-list">{buttons}</div>
+                            {skip_button()}
+                        </section>
+                    }
+                    .into_any()
+                }
+                // A single acknowledge button → ResolveInput(Confirm).
+                InputKind::Confirm => {
+                    let tx = tx.clone();
+                    view! {
+                        <section class="awaiting-input">
+                            <p class="prompt">{request.prompt.clone()}</p>
                             <button
-                                class="option"
+                                class="confirm"
                                 on:click=move |_| {
                                     if let Some(tx) = tx.clone() {
                                         let _ = tx.unbounded_send(ClientMessage::Submit {
                                             action: PlayerAction::ResolveInput {
-                                                response: InputResponse::PickSingle(id),
+                                                response: InputResponse::Confirm,
                                             },
                                         });
                                     }
                                 }
                             >
-                                {label}
+                                "Confirm"
                             </button>
+                            {skip_button()}
+                        </section>
+                    }
+                    .into_any()
+                }
+                // Hand-card multi-select → ResolveInput(PickMultiple { selected }).
+                // The host derives candidates from the prompted hand, treating
+                // each OptionId(i) as hand index i (see InputRequest::pick_multiple).
+                InputKind::PickMultiple => {
+                    let cards: Vec<_> = active_hand(&game)
+                        .into_iter()
+                        .enumerate()
+                        .map(|(idx, code)| {
+                            let i = u32::try_from(idx).expect("hand fits in u32");
+                            view! {
+                                <li>
+                                    <button
+                                        class="hand-card"
+                                        class:selected=move || selected.get().contains(&i)
+                                        on:click=move |_| selected.update(|s| {
+                                            if !s.remove(&i) {
+                                                s.insert(i);
+                                            }
+                                        })
+                                    >
+                                        {code}
+                                    </button>
+                                </li>
+                            }
+                        })
+                        .collect();
+
+                    let tx = tx.clone();
+                    let on_commit = move |_| {
+                        let selected_ids: Vec<OptionId> =
+                            selected.get().into_iter().map(OptionId).collect();
+                        if let Some(tx) = tx.clone() {
+                            let _ = tx.unbounded_send(ClientMessage::Submit {
+                                action: PlayerAction::ResolveInput {
+                                    response: InputResponse::PickMultiple {
+                                        selected: selected_ids,
+                                    },
+                                },
+                            });
                         }
-                    })
-                    .collect();
-                return view! {
+                        selected.set(BTreeSet::new());
+                    };
+
+                    view! {
+                        <section class="awaiting-input">
+                            <p class="prompt">{request.prompt}</p>
+                            <ul class="commit-hand">{cards}</ul>
+                            <button class="commit" on:click=on_commit>"Commit"</button>
+                            {skip_button()}
+                        </section>
+                    }
+                    .into_any()
+                }
+                // `InputKind` is `#[non_exhaustive]`; a future kind the client
+                // doesn't yet render falls back to the prompt + any Skip control.
+                _ => view! {
                     <section class="awaiting-input">
-                        <p class="prompt">{request.prompt.clone()}</p>
-                        <div class="option-list">{buttons}</div>
+                        <p class="prompt">{request.prompt}</p>
+                        {skip_button()}
                     </section>
                 }
-                .into_any();
+                .into_any(),
             }
-
-            // Branch 2: legacy PickMultiple hand-card commit window (skill-test
-            // commit / mulligan). `request.options` is empty for all prompt-only
-            // callers that have not yet migrated to the structured contract.
-            let cards: Vec<_> = active_hand(&game)
-                .into_iter()
-                .enumerate()
-                .map(|(idx, code)| {
-                    let i = u32::try_from(idx).expect("hand fits in u32");
-                    view! {
-                        <li>
-                            <button
-                                class="hand-card"
-                                class:selected=move || selected.get().contains(&i)
-                                on:click=move |_| selected.update(|s| {
-                                    if !s.remove(&i) {
-                                        s.insert(i);
-                                    }
-                                })
-                            >
-                                {code}
-                            </button>
-                        </li>
-                    }
-                })
-                .collect();
-
-            let tx = tx.clone();
-            let on_commit = move |_| {
-                let selected_ids: Vec<OptionId> =
-                    selected.get().into_iter().map(OptionId).collect();
-                if let Some(tx) = tx.clone() {
-                    let _ = tx.unbounded_send(ClientMessage::Submit {
-                        action: PlayerAction::ResolveInput {
-                            response: InputResponse::PickMultiple {
-                                selected: selected_ids,
-                            },
-                        },
-                    });
-                }
-                selected.set(BTreeSet::new());
-            };
-
-            view! {
-                <section class="awaiting-input">
-                    <p class="prompt">{request.prompt}</p>
-                    <ul class="commit-hand">{cards}</ul>
-                    <button class="commit" on:click=on_commit>"Commit"</button>
-                </section>
-            }
-            .into_any()
         }}
     }
 }

--- a/crates/web/tests/awaiting_input.rs
+++ b/crates/web/tests/awaiting_input.rs
@@ -10,7 +10,10 @@
 use futures::channel::mpsc;
 use game_core::state::GameStateBuilder;
 use game_core::state::InvestigatorId;
-use game_core::test_support::fixtures::{awaiting_pick_single_input, test_investigator};
+use game_core::test_support::fixtures::{
+    awaiting_confirm_input, awaiting_pick_single_input, awaiting_skippable_pick_single_input,
+    test_investigator,
+};
 use game_core::{InputResponse, OptionId, PlayerAction};
 use leptos::prelude::*;
 use protocol::{ClientMessage, ServerMessage};
@@ -109,6 +112,30 @@ fn pick_single_id(frame: ClientMessage) -> u32 {
     }
 }
 
+/// True if the frame is `ResolveInput(Confirm)`.
+fn is_confirm(frame: &ClientMessage) -> bool {
+    matches!(
+        frame,
+        ClientMessage::Submit {
+            action: PlayerAction::ResolveInput {
+                response: InputResponse::Confirm
+            },
+        }
+    )
+}
+
+/// True if the frame is `ResolveInput(Skip)`.
+fn is_skip(frame: &ClientMessage) -> bool {
+    matches!(
+        frame,
+        ClientMessage::Submit {
+            action: PlayerAction::ResolveInput {
+                response: InputResponse::Skip
+            },
+        }
+    )
+}
+
 // ---- Tests ------------------------------------------------------------------
 
 #[wasm_bindgen_test]
@@ -168,6 +195,76 @@ async fn pick_single_clicking_second_option_submits_pick_single_1() {
         .try_recv()
         .expect("a frame after tick — click handler must have fired");
     assert_eq!(pick_single_id(frame), 1, "expected OptionId(1)");
+}
+
+#[wasm_bindgen_test]
+async fn confirm_renders_confirm_button_and_submits_confirm() {
+    let mut rx = mount(
+        base_game(),
+        awaiting_confirm_input("Draw an encounter card"),
+    )
+    .await;
+    let section = last_section();
+
+    let confirm = section.query_selector(".confirm").expect("query");
+    assert!(
+        confirm.is_some(),
+        "Confirm prompt must render a .confirm button"
+    );
+    // No hand-commit UI for a Confirm prompt.
+    assert!(section
+        .query_selector(".commit-hand")
+        .expect("query")
+        .is_none());
+
+    click_in(&section, ".confirm", 0);
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame after clicking Confirm");
+    assert!(
+        is_confirm(&frame),
+        "expected ResolveInput(Confirm), got {frame:?}"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn skippable_window_renders_skip_button_and_submits_skip() {
+    let mut rx = mount(
+        base_game(),
+        awaiting_skippable_pick_single_input("Reaction window"),
+    )
+    .await;
+    let section = last_section();
+
+    assert!(
+        section.query_selector(".skip").expect("query").is_some(),
+        "skippable prompt must render a .skip button"
+    );
+    // The option list is still present for a PickSingle window.
+    assert_eq!(
+        section
+            .query_selector_all(".option")
+            .expect("query")
+            .length(),
+        1
+    );
+
+    click_in(&section, ".skip", 0);
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame after clicking Skip");
+    assert!(
+        is_skip(&frame),
+        "expected ResolveInput(Skip), got {frame:?}"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn non_skippable_pick_single_has_no_skip_button() {
+    let _rx = mount(base_game(), awaiting_pick_single_input("Choose an action")).await;
+    let section = last_section();
+    assert!(
+        section.query_selector(".skip").expect("query").is_none(),
+        "a non-skippable prompt must not render a .skip button"
+    );
 }
 
 #[wasm_bindgen_test]

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -102,13 +102,19 @@ the now-stable set of input shapes:
   gameplay path, re-enumerated at resolve (not cached). The test-only
   `PerformSkillTest` was removed too (→ `test_support::perform_skill_test*`). The
   web client lost its bespoke open-turn controls — gameplay renders through
-  `AwaitingInputView`'s `PickSingle` option list (flat for now; #205 enriches).
+  `AwaitingInputView`'s `PickSingle` option list (flat labels; richer per-option
+  metadata beyond `label` was explicitly out of #205's scope — a future enrichment).
   **Split out:** **#458** (deterministic resume-token, §F — `ResumeToken(0)` stays
   for now) and **#459 ✅ shipped (PR #461)** — see the picker bullet below.
-- **#205 — structured input rendering** (client half). Render the right control per
-  offered option from the structured `InputRequest.options`, not prompt-string
-  heuristics. Needs-design (client metadata schema). Now unblocked: the open-turn
-  menu (and every prompt) already arrives as `InputRequest.options`.
+- **#205 — structured input rendering ✅ shipped (PR #462).** `InputRequest` gained an
+  `InputKind { PickSingle, PickMultiple, Confirm }` discriminator (variant names mirror
+  `InputResponse` 1:1) plus an orthogonal `skippable: bool`; the ambiguous
+  `prompt`/`choice` constructors were replaced by `pick_single`/`pick_multiple`/`confirm`
+  + a chainable `.skippable()`, and every engine prompt site declares its kind.
+  `AwaitingInputView` switches on `kind` (Confirm → a Confirm button — the gate fix) and
+  renders a Skip button whenever `skippable` (the reaction/fast-window decline path, which
+  previously had no control). Richer per-option metadata beyond `label` is **not** in
+  scope — this PR is the discriminator only.
 - **Investigator/scenario picker ✅ shipped (PR #461 — #459 + #224).** Seating moved
   out of `PlayerAction::StartScenario` into the non-logged engine fn `seat_and_open`;
   the server seats at game-creation and persists the seated, mulligan-pending state as
@@ -124,14 +130,18 @@ the now-stable set of input shapes:
   and the ~37 `StartScenario` test sites migrated to `seat_and_open` (game-core's own
   tests seat synthetic `TEST_INV` via the test registry, preserving crate layering).
 - **End-to-end browser playthrough** of The Gathering to a resolution — the sole
-  remaining gate item, now **blocked on #205**. The picker → seating → mulligan →
-  investigation → Mythos flow all works in-browser (PR #461), but the playthrough
-  stalls at the first **Mythos encounter draw**: that prompt expects
-  `InputResponse::Confirm`, yet `AwaitingInputView` renders every empty-`options`
-  prompt as the legacy `PickMultiple` "Commit" control (no expected-response
-  discriminator on `InputRequest`), so it rejects. Purely a client-rendering gap —
-  the engine/persistence path is sound. #205 (the `InputKind` discriminator) is the
-  fix; see its issue comment for the root cause + design sketch.
+  remaining gate item. The Mythos-encounter-draw stall is **resolved** by #205's
+  `InputKind` discriminator (PR #462): the draw now renders a Confirm button and resolves,
+  and skippable windows render a Skip control. The picker → seating → mulligan →
+  investigation → Mythos flow all works in-browser (PR #461). What remains is *exercising*
+  the full playthrough to a resolution end-to-end — no known engine/client blocker.
+
+  > **Dev-loop note (not a gate blocker):** the wire-format change in #205 means a stale
+  > server binary + freshly-rebuilt client silently hangs at `<no game>` — the client drops
+  > the un-parseable old-shape `Hello` (`transport.rs` `if let Ok(msg)`), leaving `game:
+  > None`. Restart both processes after a wire change. Surfacing a visible
+  > version-mismatch status instead of the silent drop is a possible future hardening
+  > (out of #205 scope).
 
 **Deferred past the gate:** #353 (uses-depletion — no Gathering card; gated on
 Forbidden Knowledge / Grotesque Statue), #294 (multi-soak-window drain —

--- a/docs/superpowers/plans/2026-06-26-input-kind-discriminator.md
+++ b/docs/superpowers/plans/2026-06-26-input-kind-discriminator.md
@@ -1,0 +1,708 @@
+# InputKind Discriminator (#205) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `InputRequest` an explicit `kind: InputKind` discriminator (plus an orthogonal `skippable: bool`) so the web client renders the correct control per prompt instead of guessing from `options.is_empty()` — unblocking the Mythos encounter draw (the phase-7 gate) and the reaction-window Skip affordance.
+
+**Architecture:** Add an `InputKind` enum and two required fields to the single `InputRequest` struct (`crates/game-core/src/engine/outcome.rs`); replace the ambiguous `prompt()`/`choice()` constructors with typed `pick_single`/`pick_multiple`/`confirm` + a chainable `.skippable()`; migrate every engine construction site to the typed constructor that declares its kind; then switch `AwaitingInputView` on `kind` and render a Confirm button and a Skip button.
+
+**Tech Stack:** Rust (workspace), `serde`, Leptos (`crates/web`, wasm32), `wasm-bindgen-test` (headless Firefox).
+
+## Global Constraints
+
+- **Required-on-the-wire, no `serde(default)`.** The two new fields are required; a stale serialized `InputRequest` must error loudly, not silently degrade (matches #453). No new SQL migration — `seed_outcome` is opaque JSON; recreate the local SQLite file if a stale game row exists.
+- **CI gauntlet before push** (all seven jobs, warnings-as-errors). This touches `crates/web`, so `wasm-build`, `wasm-test`, and `wasm-clippy` all matter:
+  - `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo fmt --check`
+  - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
+  - `cargo build -p web --target wasm32-unknown-unknown`
+  - `wasm-pack test --headless --firefox crates/web`
+  - `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`
+- **Validate-first / mutate-second** is unaffected — this is a metadata-on-prompt change, no dispatch-handler control-flow changes.
+- **Branch:** `engine/input-kind-discriminator` (already created; spec committed). One branch, follow-up commits, no force-push.
+- Spec of record: `docs/superpowers/specs/2026-06-26-input-kind-discriminator-design.md`.
+
+---
+
+### Task 1: `InputKind` type, fields, constructors, and engine-wide migration
+
+This is one atomic compile unit: adding required fields to `InputRequest` forces every construction site to declare its kind, and removing the ambiguous `prompt`/`choice` constructors forces the rename through. The web client still compiles unchanged after this task (it branches on `options.is_empty()`, which the field addition does not break); it is migrated in Task 2.
+
+**Files:**
+- Modify: `crates/game-core/src/engine/outcome.rs` (add `InputKind`, two fields, constructors; update the in-file tests)
+- Modify: `crates/game-core/src/engine/dispatch/encounter.rs:589` (→ `confirm`)
+- Modify: `crates/game-core/src/engine/dispatch/skill_test.rs:594` (→ `pick_multiple`); `:128` (→ `pick_single`)
+- Modify: `crates/game-core/src/engine/dispatch/cards.rs:293` (→ `pick_multiple`)
+- Modify: `crates/game-core/src/engine/dispatch/phases.rs:1118` (→ `pick_multiple`)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs:113` (→ `pick_single`)
+- Modify: `crates/game-core/src/engine/dispatch/hunters.rs:421` (→ `pick_single`)
+- Modify: `crates/game-core/src/engine/dispatch/choice.rs:49` (→ `pick_single`)
+- Modify: `crates/game-core/src/engine/dispatch/combat.rs:897,1139` (→ `pick_single`)
+- Modify: `crates/game-core/src/engine/dispatch/encounter.rs:458` (→ `pick_single`)
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs:587,887` (→ `pick_single` + `.skippable()` gated on `!is_forced`)
+- Modify: `crates/game-core/src/test_support/fixtures.rs:131` (`awaiting_commit_input` → `pick_multiple`), `:147` (`awaiting_pick_single_input` → `pick_single`)
+- Modify: `crates/game-core/src/test_support/resolver.rs:704` (`req` helper → `confirm`)
+
+**Interfaces:**
+- Produces (consumed by Task 2):
+  - `pub enum InputKind { PickSingle, PickMultiple, Confirm }` (in `game_core::engine`, re-exported as `game_core::InputKind`)
+  - `InputRequest { pub prompt: String, pub options: Vec<ChoiceOption>, pub kind: InputKind, pub skippable: bool }`
+  - `InputRequest::pick_single(text: impl Into<String>, options: Vec<ChoiceOption>) -> Self`
+  - `InputRequest::pick_multiple(text: impl Into<String>) -> Self`
+  - `InputRequest::confirm(text: impl Into<String>) -> Self`
+  - `InputRequest::skippable(self) -> Self`
+
+- [ ] **Step 1: Write the failing constructor + serde tests**
+
+In `crates/game-core/src/engine/outcome.rs`, replace the existing `#[cfg(test)] mod tests` block's two tests with these (the old `choice_input_request_round_trips` / `prompt_only_request_has_no_options` referenced the now-removed constructors):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pick_single_sets_kind_and_not_skippable() {
+        let req = InputRequest::pick_single(
+            "Choose one",
+            vec![ChoiceOption { id: OptionId(0), label: "A".into() }],
+        );
+        assert_eq!(req.kind, InputKind::PickSingle);
+        assert!(!req.skippable);
+        assert_eq!(req.options.len(), 1);
+    }
+
+    #[test]
+    fn pick_multiple_sets_kind_and_empty_options() {
+        let req = InputRequest::pick_multiple("Commit cards");
+        assert_eq!(req.kind, InputKind::PickMultiple);
+        assert!(!req.skippable);
+        assert!(req.options.is_empty());
+    }
+
+    #[test]
+    fn confirm_sets_kind_and_empty_options() {
+        let req = InputRequest::confirm("Draw");
+        assert_eq!(req.kind, InputKind::Confirm);
+        assert!(!req.skippable);
+        assert!(req.options.is_empty());
+    }
+
+    #[test]
+    fn skippable_flips_only_the_flag() {
+        let base = InputRequest::pick_single("w", vec![]);
+        let skip = InputRequest::pick_single("w", vec![]).skippable();
+        assert!(!base.skippable);
+        assert!(skip.skippable);
+        assert_eq!(skip.kind, InputKind::PickSingle);
+    }
+
+    #[test]
+    fn input_request_round_trips_with_kind_and_skippable() {
+        let req = InputRequest::pick_single(
+            "Choose one",
+            vec![
+                ChoiceOption { id: OptionId(0), label: "Take 2 horror".into() },
+                ChoiceOption { id: OptionId(1), label: "Each discards 1".into() },
+            ],
+        )
+        .skippable();
+        let json = serde_json::to_string(&req).expect("serialize");
+        let back: InputRequest = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, req);
+        assert_eq!(back.kind, InputKind::PickSingle);
+        assert!(back.skippable);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p game-core --lib engine::outcome::tests`
+Expected: FAIL to compile — `InputKind` and the new constructors do not exist yet.
+
+- [ ] **Step 3: Add `InputKind`, the fields, and the constructors; remove `prompt`/`choice`**
+
+In `crates/game-core/src/engine/outcome.rs`, add the enum above the `InputRequest` struct:
+
+```rust
+/// Which [`InputResponse`](crate::action::InputResponse) variant the host must
+/// echo back for a prompt. The variant names mirror `InputResponse` 1:1, so the
+/// `kind` *is* the expected response — the host renders the matching control
+/// without inspecting the prompt text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum InputKind {
+    /// Pick exactly one offered [`option`](InputRequest::options) →
+    /// [`InputResponse::PickSingle`](crate::action::InputResponse::PickSingle).
+    PickSingle,
+    /// Pick a subset (possibly empty) →
+    /// [`InputResponse::PickMultiple`](crate::action::InputResponse::PickMultiple).
+    PickMultiple,
+    /// A binary acknowledge with no choice →
+    /// [`InputResponse::Confirm`](crate::action::InputResponse::Confirm).
+    Confirm,
+}
+```
+
+Replace the `InputRequest` struct definition's fields and its `impl` block (the doc comment above the struct can stay; tighten its last sentence about "Remaining prompt-only callers" since `prompt`/`choice` are gone):
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct InputRequest {
+    /// Human-readable text describing what the player must choose.
+    pub prompt: String,
+    /// Offered options for a [`PickSingle`](InputKind::PickSingle) prompt.
+    /// Empty for [`PickMultiple`](InputKind::PickMultiple) (host derives
+    /// hand-card candidates) and [`Confirm`](InputKind::Confirm).
+    pub options: Vec<ChoiceOption>,
+    /// Which response variant the host must send back.
+    pub kind: InputKind,
+    /// When true the host also offers a Skip/Pass control →
+    /// [`InputResponse::Skip`](crate::action::InputResponse::Skip). Orthogonal
+    /// to `kind` (e.g. a `PickSingle` reaction window that may also be passed).
+    pub skippable: bool,
+}
+
+impl InputRequest {
+    /// A single-selection choice over `options` →
+    /// [`InputResponse::PickSingle`](crate::action::InputResponse::PickSingle).
+    #[must_use]
+    pub fn pick_single(text: impl Into<String>, options: Vec<ChoiceOption>) -> Self {
+        Self { prompt: text.into(), options, kind: InputKind::PickSingle, skippable: false }
+    }
+
+    /// A subset-selection prompt →
+    /// [`InputResponse::PickMultiple`](crate::action::InputResponse::PickMultiple).
+    ///
+    /// `options` is left empty: every current consumer (skill-test commit,
+    /// setup mulligan, hand-size discard) picks a subset of the *prompted
+    /// investigator's hand*, and the host derives candidates from the hand,
+    /// treating each `OptionId(i)` as hand index `i`. This hand-index
+    /// convention only holds while `PickMultiple` decisions are hand-scoped; a
+    /// future subset-pick over non-hand candidates (e.g. revealed cards,
+    /// enemies) would need to carry them in `options` and render from there,
+    /// like [`pick_single`](Self::pick_single).
+    #[must_use]
+    pub fn pick_multiple(text: impl Into<String>) -> Self {
+        Self { prompt: text.into(), options: Vec::new(), kind: InputKind::PickMultiple, skippable: false }
+    }
+
+    /// A binary acknowledge prompt →
+    /// [`InputResponse::Confirm`](crate::action::InputResponse::Confirm).
+    #[must_use]
+    pub fn confirm(text: impl Into<String>) -> Self {
+        Self { prompt: text.into(), options: Vec::new(), kind: InputKind::Confirm, skippable: false }
+    }
+
+    /// Mark this prompt skippable (host renders a Skip/Pass control →
+    /// [`InputResponse::Skip`](crate::action::InputResponse::Skip)).
+    #[must_use]
+    pub fn skippable(mut self) -> Self {
+        self.skippable = true;
+        self
+    }
+}
+```
+
+- [ ] **Step 4: Migrate the engine construction sites**
+
+Apply these edits (constructor swap only; surrounding `format!`/args unchanged unless noted):
+
+`encounter.rs:589` — `InputRequest::prompt(format!(` → `InputRequest::confirm(format!(`
+
+`skill_test.rs:594` — `InputRequest::prompt(format!(` → `InputRequest::pick_multiple(format!(`
+`skill_test.rs:128` — `InputRequest::choice(` → `InputRequest::pick_single(`
+
+`cards.rs:293` — `InputRequest::prompt(format!(` → `InputRequest::pick_multiple(format!(`
+
+`phases.rs:1118` — `InputRequest::prompt(format!(` → `InputRequest::pick_multiple(format!(`
+
+`mod.rs:113` — `InputRequest::choice("Choose an action", options)` → `InputRequest::pick_single("Choose an action", options)`
+
+`hunters.rs:421`, `choice.rs:49`, `combat.rs:897`, `combat.rs:1139`, `encounter.rs:458` — `InputRequest::choice(` → `InputRequest::pick_single(`
+
+`reaction_windows.rs:587` and `:887` — swap `choice` → `pick_single` and append `.skippable()` gated on the *existing* `window.is_forced()` decision the `skip_hint` already computes. At `:586`–`:594`, replace:
+
+```rust
+    EngineOutcome::AwaitingInput {
+        request: InputRequest::choice(
+            format!(
+                "Resolution window: {} option(s). \
+                 Submit InputResponse::PickSingle(OptionId) to resolve one{skip_hint}.",
+                options.len(),
+            ),
+            options,
+        ),
+        resume_token: ResumeToken(0),
+    }
+```
+
+with (note `let mut request` + conditional `.skippable()`, reusing `window.is_forced()` so the button and the prompt's `skip_hint` cannot drift):
+
+```rust
+    let mut request = InputRequest::pick_single(
+        format!(
+            "Resolution window: {} option(s). \
+             Submit InputResponse::PickSingle(OptionId) to resolve one{skip_hint}.",
+            options.len(),
+        ),
+        options,
+    );
+    if !window.is_forced() {
+        request = request.skippable();
+    }
+    EngineOutcome::AwaitingInput {
+        request,
+        resume_token: ResumeToken(0),
+    }
+```
+
+Apply the identical transform at `:887` (its `skip_hint` text differs — `" (forced — cannot skip)"` — but the `window.is_forced()` gate is the same; keep that site's existing `format!` text).
+
+Then the test-support sites:
+- `fixtures.rs:131` — `InputRequest::prompt(prompt)` → `InputRequest::pick_multiple(prompt)`
+- `fixtures.rs:147` — `InputRequest::choice(` → `InputRequest::pick_single(`
+- `resolver.rs:704` — `InputRequest::prompt(prompt)` → `InputRequest::confirm(prompt)` (the resolver returns scripted responses regardless of `kind`; `confirm` is an arbitrary neutral choice)
+
+- [ ] **Step 5: Run the full game-core suite and strict gates**
+
+Run: `RUSTFLAGS="-D warnings" cargo test -p game-core --all-features`
+Expected: PASS (all existing dispatch/encounter/reaction tests green; the new constructor tests green).
+
+Run: `cargo clippy -p game-core --all-targets --all-features -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 6: Add an engine-level kind assertion to the existing Mythos-draw test**
+
+In `crates/game-core/src/engine/dispatch/encounter.rs`, find the test that prompts the encounter draw (around `:1904`, where `resume_encounter_draw` is exercised). Locate where it pattern-matches the `EngineOutcome::AwaitingInput { request, .. }` for the draw prompt and add, alongside the existing assertions:
+
+```rust
+assert_eq!(request.kind, crate::engine::InputKind::Confirm);
+assert!(!request.skippable);
+```
+
+If the existing test consumes the outcome without binding `request`, bind it (`EngineOutcome::AwaitingInput { request, .. }`) to assert. Run: `cargo test -p game-core --lib dispatch::encounter`
+Expected: PASS.
+
+- [ ] **Step 7: Add a reaction-window skippable assertion**
+
+In `crates/game-core/src/engine/dispatch/reaction_windows.rs` `#[cfg(test)]` tests, find (or add) a test that opens a non-forced resolution window via `open_queued_reaction_window` and assert the emitted request:
+
+```rust
+// Non-forced reaction window must offer Skip.
+assert_eq!(request.kind, crate::engine::InputKind::PickSingle);
+assert!(request.skippable);
+```
+
+If an existing test already drives a non-forced window to an `AwaitingInput`, extend it; otherwise add a focused test mirroring the nearest existing window-opening test in that module's test block. Run: `cargo test -p game-core --lib dispatch::reaction_windows`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/game-core/src/engine/outcome.rs \
+        crates/game-core/src/engine/dispatch/ \
+        crates/game-core/src/test_support/fixtures.rs \
+        crates/game-core/src/test_support/resolver.rs
+git commit -m "engine: InputKind discriminator on InputRequest; migrate prompt sites
+
+Replace the ambiguous prompt()/choice() constructors with typed
+pick_single/pick_multiple/confirm + an orthogonal .skippable(), so a prompt
+declares which InputResponse it expects instead of the host guessing from
+options-empty. Migrate every engine construction site. The Mythos encounter
+draw now emits kind: Confirm; non-forced reaction windows emit skippable: true.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Web client renders by `kind`, plus Confirm and Skip controls
+
+**Files:**
+- Modify: `crates/game-core/src/test_support/fixtures.rs` (add `awaiting_confirm_input`, `awaiting_skippable_pick_single_input` — needed because `ResumeToken`'s inner is `pub(crate)`, so wasm tests outside `game-core` cannot build `AwaitingInput` outcomes directly)
+- Modify: `crates/web/src/input.rs` (switch `AwaitingInputView` on `kind`; add Confirm + Skip controls; rewrite the module/`fn` doc comments)
+- Modify: `crates/web/tests/awaiting_input.rs` (add Confirm + Skip tests)
+
+**Interfaces:**
+- Consumes (from Task 1): `InputKind::{PickSingle, PickMultiple, Confirm}`, `InputRequest::{confirm, pick_single}`, `InputRequest::skippable`.
+- Produces: `AwaitingInputView` renders a `.confirm` button for `kind: Confirm` and a `.skip` button when `skippable`; fixtures `awaiting_confirm_input(prompt)` and `awaiting_skippable_pick_single_input(prompt)`.
+
+- [ ] **Step 1: Add the two fixtures**
+
+In `crates/game-core/src/test_support/fixtures.rs`, after `awaiting_pick_single_input`, add:
+
+```rust
+/// A sample [`Confirm`](crate::InputKind::Confirm)
+/// [`AwaitingInput`](EngineOutcome::AwaitingInput) outcome, for client/UI
+/// fixtures. Models the Mythos encounter-draw prompt.
+#[must_use]
+pub fn awaiting_confirm_input(prompt: impl Into<String>) -> EngineOutcome {
+    EngineOutcome::AwaitingInput {
+        request: InputRequest::confirm(prompt),
+        resume_token: ResumeToken(0),
+    }
+}
+
+/// A sample skippable [`PickSingle`](crate::InputKind::PickSingle)
+/// [`AwaitingInput`](EngineOutcome::AwaitingInput) outcome, for client/UI
+/// fixtures. Models a non-forced reaction window: one option plus a Skip
+/// affordance.
+#[must_use]
+pub fn awaiting_skippable_pick_single_input(prompt: impl Into<String>) -> EngineOutcome {
+    EngineOutcome::AwaitingInput {
+        request: InputRequest::pick_single(
+            prompt,
+            vec![ChoiceOption { id: OptionId(0), label: "Resolve".into() }],
+        )
+        .skippable(),
+        resume_token: ResumeToken(0),
+    }
+}
+```
+
+Run: `cargo test -p game-core --lib test_support::fixtures` (or `cargo build -p game-core`)
+Expected: compiles.
+
+- [ ] **Step 2: Write the failing wasm tests**
+
+In `crates/web/tests/awaiting_input.rs`, extend the imports on the `use game_core::test_support::fixtures::{...}` line to add `awaiting_confirm_input` and `awaiting_skippable_pick_single_input`. Add a helper next to `pick_single_id` to recognize `Confirm`/`Skip` frames:
+
+```rust
+/// True if the frame is `ResolveInput(Confirm)`.
+fn is_confirm(frame: &ClientMessage) -> bool {
+    matches!(
+        frame,
+        ClientMessage::Submit {
+            action: PlayerAction::ResolveInput { response: InputResponse::Confirm },
+        }
+    )
+}
+
+/// True if the frame is `ResolveInput(Skip)`.
+fn is_skip(frame: &ClientMessage) -> bool {
+    matches!(
+        frame,
+        ClientMessage::Submit {
+            action: PlayerAction::ResolveInput { response: InputResponse::Skip },
+        }
+    )
+}
+```
+
+Then add these tests at the end of the file:
+
+```rust
+#[wasm_bindgen_test]
+async fn confirm_renders_confirm_button_and_submits_confirm() {
+    let mut rx = mount(base_game(), awaiting_confirm_input("Draw an encounter card")).await;
+    let section = last_section();
+
+    let confirm = section.query_selector(".confirm").expect("query");
+    assert!(confirm.is_some(), "Confirm prompt must render a .confirm button");
+    // No hand-commit UI for a Confirm prompt.
+    assert!(section.query_selector(".commit-hand").expect("query").is_none());
+
+    click_in(&section, ".confirm", 0);
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame after clicking Confirm");
+    assert!(is_confirm(&frame), "expected ResolveInput(Confirm), got {frame:?}");
+}
+
+#[wasm_bindgen_test]
+async fn skippable_window_renders_skip_button_and_submits_skip() {
+    let mut rx = mount(
+        base_game(),
+        awaiting_skippable_pick_single_input("Reaction window"),
+    )
+    .await;
+    let section = last_section();
+
+    assert!(
+        section.query_selector(".skip").expect("query").is_some(),
+        "skippable prompt must render a .skip button"
+    );
+    // The option list is still present for a PickSingle window.
+    assert_eq!(
+        section.query_selector_all(".option").expect("query").length(),
+        1
+    );
+
+    click_in(&section, ".skip", 0);
+    leptos::task::tick().await;
+    let frame = rx.try_recv().expect("a frame after clicking Skip");
+    assert!(is_skip(&frame), "expected ResolveInput(Skip), got {frame:?}");
+}
+
+#[wasm_bindgen_test]
+async fn non_skippable_pick_single_has_no_skip_button() {
+    let _rx = mount(base_game(), awaiting_pick_single_input("Choose an action")).await;
+    let section = last_section();
+    assert!(
+        section.query_selector(".skip").expect("query").is_none(),
+        "a non-skippable prompt must not render a .skip button"
+    );
+}
+```
+
+- [ ] **Step 3: Run the wasm tests to verify they fail**
+
+Run: `wasm-pack test --headless --firefox crates/web --test awaiting_input`
+Expected: FAIL — no `.confirm`/`.skip` elements render (the client still branches on `options.is_empty()` and has no Confirm/Skip control).
+
+- [ ] **Step 4: Rewrite `AwaitingInputView` to switch on `kind`**
+
+In `crates/web/src/input.rs`, update the import to bring in `InputKind`:
+
+```rust
+use game_core::{ChoiceOption, EngineOutcome, InputKind, InputResponse, OptionId, PlayerAction};
+```
+
+Replace the two-branch body (the `if !request.options.is_empty() { ... }` PickSingle branch and the trailing PickMultiple branch) with a `match request.kind` that also renders a Skip button when `request.skippable`. Build a reusable Skip button first, then the per-kind body:
+
+```rust
+let skippable = request.skippable;
+let skip_button = {
+    let tx = tx.clone();
+    move || {
+        if !skippable {
+            return ().into_any();
+        }
+        let tx = tx.clone();
+        view! {
+            <button
+                class="skip"
+                on:click=move |_| {
+                    if let Some(tx) = tx.clone() {
+                        let _ = tx.unbounded_send(ClientMessage::Submit {
+                            action: PlayerAction::ResolveInput {
+                                response: InputResponse::Skip,
+                            },
+                        });
+                    }
+                }
+            >
+                "Skip"
+            </button>
+        }
+        .into_any()
+    }
+};
+
+match request.kind {
+    InputKind::PickSingle => {
+        let tx = tx.clone();
+        let buttons: Vec<_> = request
+            .options
+            .iter()
+            .cloned()
+            .map(|opt: ChoiceOption| {
+                let ChoiceOption { id, label } = opt;
+                let tx = tx.clone();
+                view! {
+                    <button
+                        class="option"
+                        on:click=move |_| {
+                            if let Some(tx) = tx.clone() {
+                                let _ = tx.unbounded_send(ClientMessage::Submit {
+                                    action: PlayerAction::ResolveInput {
+                                        response: InputResponse::PickSingle(id),
+                                    },
+                                });
+                            }
+                        }
+                    >
+                        {label}
+                    </button>
+                }
+            })
+            .collect();
+        view! {
+            <section class="awaiting-input">
+                <p class="prompt">{request.prompt.clone()}</p>
+                <div class="option-list">{buttons}</div>
+                {skip_button()}
+            </section>
+        }
+        .into_any()
+    }
+    InputKind::Confirm => {
+        let tx = tx.clone();
+        view! {
+            <section class="awaiting-input">
+                <p class="prompt">{request.prompt.clone()}</p>
+                <button
+                    class="confirm"
+                    on:click=move |_| {
+                        if let Some(tx) = tx.clone() {
+                            let _ = tx.unbounded_send(ClientMessage::Submit {
+                                action: PlayerAction::ResolveInput {
+                                    response: InputResponse::Confirm,
+                                },
+                            });
+                        }
+                    }
+                >
+                    "Confirm"
+                </button>
+                {skip_button()}
+            </section>
+        }
+        .into_any()
+    }
+    InputKind::PickMultiple => {
+        let cards: Vec<_> = active_hand(&game)
+            .into_iter()
+            .enumerate()
+            .map(|(idx, code)| {
+                let i = u32::try_from(idx).expect("hand fits in u32");
+                view! {
+                    <li>
+                        <button
+                            class="hand-card"
+                            class:selected=move || selected.get().contains(&i)
+                            on:click=move |_| selected.update(|s| {
+                                if !s.remove(&i) {
+                                    s.insert(i);
+                                }
+                            })
+                        >
+                            {code}
+                        </button>
+                    </li>
+                }
+            })
+            .collect();
+
+        let tx = tx.clone();
+        let on_commit = move |_| {
+            let selected_ids: Vec<OptionId> =
+                selected.get().into_iter().map(OptionId).collect();
+            if let Some(tx) = tx.clone() {
+                let _ = tx.unbounded_send(ClientMessage::Submit {
+                    action: PlayerAction::ResolveInput {
+                        response: InputResponse::PickMultiple { selected: selected_ids },
+                    },
+                });
+            }
+            selected.set(BTreeSet::new());
+        };
+
+        view! {
+            <section class="awaiting-input">
+                <p class="prompt">{request.prompt}</p>
+                <ul class="commit-hand">{cards}</ul>
+                <button class="commit" on:click=on_commit>"Commit"</button>
+                {skip_button()}
+            </section>
+        }
+        .into_any()
+    }
+}
+```
+
+Notes for the implementer:
+- The leptos closure/clone ergonomics above mirror the file's existing style (each `on:click` gets its own `tx` clone). If the borrow checker complains about `tx`/`skip_button` move order, clone `tx` once more per arm — match the existing pattern, do not restructure the component.
+- `#[non_exhaustive]` on `InputKind` means the `match` needs no catch-all *within this crate* for the three known variants, but a `_ => ().into_any()` arm may be required to satisfy the non-exhaustive lint across the crate boundary. Add it only if the compiler demands it, with a comment that it is the non-exhaustive guard.
+- Rewrite the module-level doc comment (lines 1–13) and the `AwaitingInputView` doc (lines 25–36): replace the "two rendering branches / options-empty heuristic" description with the three-way `kind` switch + the orthogonal `skippable` Skip affordance.
+
+- [ ] **Step 5: Run the wasm tests to verify they pass**
+
+Run: `wasm-pack test --headless --firefox crates/web --test awaiting_input`
+Expected: PASS (Confirm, Skip, non-skippable, and the existing PickSingle tests all green).
+
+Also confirm the PickMultiple branch still works:
+Run: `wasm-pack test --headless --firefox crates/web --test input`
+Expected: PASS.
+
+- [ ] **Step 6: Run the wasm clippy + build gates**
+
+Run: `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`
+Run: `cargo build -p web --target wasm32-unknown-unknown`
+Expected: both clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/game-core/src/test_support/fixtures.rs crates/web/src/input.rs crates/web/tests/awaiting_input.rs
+git commit -m "web: render AwaitingInput by InputKind; add Confirm + Skip controls
+
+Switch AwaitingInputView on request.kind instead of options-empty: Confirm
+prompts render a Confirm button (unblocking the Mythos encounter draw), and a
+Skip button renders whenever request.skippable (the reaction/fast-window decline
+path). PickSingle/PickMultiple branches unchanged in behavior.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Full CI gauntlet, push, PR, then phase-7 doc
+
+**Files:**
+- Modify: `docs/phases/phase-7-the-gathering.md` (the "End-to-end browser playthrough" bullet — stall resolved) — **final commit, only after CI is green on the opened PR**.
+
+- [ ] **Step 1: Run the complete local gauntlet**
+
+Run each, expecting all green:
+```bash
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+wasm-pack test --headless --firefox crates/web
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+If `cargo fmt --check` flags anything, run `cargo fmt` and fold into the relevant commit.
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+git push -u origin engine/input-kind-discriminator
+gh pr create --fill
+```
+PR body: include a short design-decisions paragraph (typed constructors replace the ambiguous `prompt`/`choice`; `skippable` orthogonal to `kind`; required fields / no `serde(default)` / no SQL migration per #453; quote the Mythos-draw rejection that motivated it). Ensure the body has `Closes #205.`
+
+- [ ] **Step 3: Watch CI**
+
+Run: `gh pr checks <PR#> --watch`
+Fix any failures with follow-up commits to the same branch (no force-push).
+
+- [ ] **Step 4: Update the phase-7 doc as the final commit (only once CI is green)**
+
+In `docs/phases/phase-7-the-gathering.md`, update the "**End-to-end browser playthrough**" bullet (the one describing the stall at the Mythos encounter draw): note the stall is resolved by #205's `InputKind` discriminator (`kind: Confirm` renders a Confirm button; `skippable` renders Skip), and flip its status from "blocked on #205" to done/the gate's final demonstration. Add a one-line **Decisions made** entry only if it passes the test in `docs/phases/README.md` ("would a future PR-author choose differently without this entry?") — e.g. the `kind`-mirrors-`InputResponse` + orthogonal-`skippable` shape. Remove #205 from remaining gate work.
+
+```bash
+git add docs/phases/phase-7-the-gathering.md
+git commit -m "docs: phase-7 — #205 closes the browser-playthrough stall"
+git push
+```
+
+- [ ] **Step 5: Merge only after explicit user approval**
+
+Do not merge autonomously. Surface CI-green + the review, and wait. On approval:
+```bash
+gh pr merge <PR#> --squash --delete-branch
+```
+Then confirm #205 auto-closed and `git pull` on `main`.
+
+## Self-Review
+
+**Spec coverage:**
+- `InputKind` + two fields + constructors → Task 1, Steps 1–3. ✓
+- `pick_multiple` hand-index caveat (plain note, no TODO) → Task 1, Step 3 (doc on the constructor). ✓
+- Engine call-site migration table (all 11 sites + fixtures + resolver) → Task 1, Step 4. ✓
+- Reaction-window `.skippable()` gated on `!is_forced` → Task 1, Step 4 + assertion Step 7. ✓
+- Mythos-draw `kind: Confirm` assertion → Task 1, Step 6. ✓
+- Client three-way `kind` switch + Confirm + Skip → Task 2, Step 4. ✓
+- Backcompat (required, no `serde(default)`, no migration, recreate DB) → Global Constraints. ✓
+- Tests: outcome serde/constructor units, engine assertions, wasm Confirm/Skip → Tasks 1–2. ✓
+- Phase-7 doc update as final commit → Task 3, Step 4. ✓
+
+**Placeholder scan:** No "TBD"/"handle edge cases"/"similar to" — every code step carries full code. The two "add the assertion to the existing test" steps (1.6, 1.7) name the file, approximate line, the exact assertion code, and a fallback if the binding is absent. ✓
+
+**Type consistency:** `InputKind::{PickSingle, PickMultiple, Confirm}`, `pick_single`/`pick_multiple`/`confirm`/`skippable`, `is_confirm`/`is_skip` used consistently across tasks. The web `match` consumes exactly the `InputKind` produced in Task 1. ✓

--- a/docs/superpowers/specs/2026-06-26-input-kind-discriminator-design.md
+++ b/docs/superpowers/specs/2026-06-26-input-kind-discriminator-design.md
@@ -1,0 +1,188 @@
+# #205 — Structured input rendering via an `InputKind` discriminator
+
+**Date:** 2026-06-26
+**Issue:** #205 (structured input rendering, client half)
+**Phase:** 7 — The Gathering. This is the **sole remaining gate item**: the
+in-browser end-to-end playthrough stalls at the first Mythos encounter draw.
+
+## Problem
+
+`InputRequest` (`crates/game-core/src/engine/outcome.rs`) carries only
+`{ prompt: String, options: Vec<ChoiceOption> }` — there is **no discriminator
+for which `InputResponse` variant the prompt expects**. So the web client
+(`AwaitingInputView`, `crates/web/src/input.rs`) chooses the control purely by
+whether `options` is empty:
+
+- `options` non-empty → `PickSingle` option-list — works.
+- `options` empty → the legacy `PickMultiple` hand-card "Commit" UI — the only
+  fallback.
+
+But empty-`options` prompts are **not** all `PickMultiple`. Three different
+responses hide behind empty options:
+
+| Prompt | Expected `InputResponse` | Source |
+|---|---|---|
+| Mythos encounter draw | `Confirm` | `encounter.rs::resume_encounter_draw` |
+| Skill-test commit / setup mulligan / hand-size discard | `PickMultiple` | `cards.rs`, `skill_test.rs`, `phases.rs` |
+
+The client renders `PickMultiple` for all of them, so the Mythos draw (which
+expects `Confirm`) rejects:
+
+> `ResolveInput: Mythos encounter draw expects InputResponse::Confirm, got PickMultiple`
+
+A **second, latent** instance of the same class of bug: the reaction / fast-play
+**resolution windows** (`reaction_windows.rs`) are `PickSingle` prompts that can
+*also* be declined with `Skip`, but the browser renders no Skip/Pass control —
+so an open window can't be passed. Not yet hit in the current playthrough (it
+stalls at the Mythos draw first), but the same root cause.
+
+A prompt-text heuristic (sniffing `"Confirm"` out of `prompt`) is explicitly
+**not** the fix — that is the heuristic this issue exists to remove.
+
+## Solution
+
+Add an expected-response discriminator to `InputRequest` so the client renders
+the right control with no heuristics.
+
+### Type changes (`crates/game-core/src/engine/outcome.rs`)
+
+A new enum, and two new **required** fields on the one struct:
+
+```rust
+/// Which `InputResponse` variant the client must echo back for a prompt.
+/// Names mirror the `InputResponse` variants 1:1 so the kind *is* the
+/// expected response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum InputKind {
+    PickSingle,   // -> InputResponse::PickSingle(id)        — single-option list
+    PickMultiple, // -> InputResponse::PickMultiple { selected } — subset select
+    Confirm,      // -> InputResponse::Confirm               — single button
+}
+
+pub struct InputRequest {
+    pub prompt: String,
+    pub options: Vec<ChoiceOption>,
+    pub kind: InputKind,   // NEW
+    pub skippable: bool,   // NEW
+}
+```
+
+`skippable` is **orthogonal** to `kind`: it is a flag, not a fourth kind. When
+true the client also renders a Skip/Pass button → `InputResponse::Skip`. This
+matches the issue's note that Skip is an affordance available *alongside* a
+window, not a standalone prompt.
+
+### Constructors
+
+Replace today's `prompt()` / `choice()` with typed constructors:
+
+- `InputRequest::pick_single(text, options)` → `kind: PickSingle`, `skippable: false`
+- `InputRequest::pick_multiple(text)` → `kind: PickMultiple`, empty `options`
+- `InputRequest::confirm(text)` → `kind: Confirm`, empty `options`
+- chainable `.skippable(self) -> Self` → sets `skippable = true` (for reaction /
+  fast windows)
+
+`pick_multiple` carries this doc caveat (a plain note, **no** `TODO`/issue — it
+is a "could happen", not a "will happen"):
+
+> `options` is left empty: every current consumer (skill-test commit, setup
+> mulligan, hand-size discard) picks a subset of the *prompted investigator's
+> hand*, and the client derives candidates from the hand, treating each
+> `OptionId(i)` as hand index `i`. This hand-index convention only holds while
+> `PickMultiple` decisions are hand-scoped; a future subset-pick over non-hand
+> candidates (e.g. revealed cards, enemies) would need to carry them in
+> `options` and render from there, like `pick_single`.
+
+### Engine call-site migration
+
+Mechanical swap to typed constructors; no behavior change beyond the new
+metadata:
+
+| Site | Today | Becomes |
+|---|---|---|
+| `encounter.rs:589` Mythos draw | `prompt` | `confirm(…)` ← **the gate fix** |
+| `skill_test.rs:594` commit window | `prompt` | `pick_multiple(…)` |
+| `cards.rs:293` setup mulligan | `prompt` | `pick_multiple(…)` |
+| `phases.rs:1118` hand-size discard | `prompt` | `pick_multiple(…)` |
+| `mod.rs:113` turn menu; `hunters.rs:421`; `choice.rs:49` DSL `ChooseOne`; `combat.rs:897/1139`; `skill_test.rs:128` substitution; `encounter.rs:458` | `choice` | `pick_single(…)` |
+| `reaction_windows.rs:587/887` resolution windows | `choice` | `pick_single(…)` + `.skippable()` **iff `!forced`** |
+
+The reaction-window sites already compute a `skip_hint` from
+`window.is_forced()`; reuse that **exact** condition to gate `.skippable()` so
+the button and the prompt text cannot drift.
+
+Test-support sites get the same swap: `test_support/fixtures.rs:131/147` and the
+`req()` helper in `test_support/resolver.rs`. The `ScriptedResolver` itself is
+FIFO-scripted (tests call `.confirm()` / `.skip()` / `.commit_cards()`
+explicitly), so it does **not** infer `kind` — no resolver logic changes.
+
+### Web client rendering (`crates/web/src/input.rs`)
+
+`AwaitingInputView` stops branching on `request.options.is_empty()` and switches
+on `request.kind`:
+
+- **`PickSingle`** → existing option-list (one button per `ChoiceOption` →
+  `ResolveInput(PickSingle(id))`). Unchanged.
+- **`PickMultiple`** → existing hand-card multi-select + "Commit" →
+  `ResolveInput(PickMultiple { selected })`. Unchanged behavior; now reached by
+  `kind`, not by emptiness.
+- **`Confirm`** → **new**: a single "Confirm" button → `ResolveInput(Confirm)`.
+  Unblocks the Mythos draw.
+
+Then, independent of kind: **if `request.skippable`, also render a "Skip"
+button** → `ResolveInput(Skip)`. Fixes the reaction / fast-window decline path.
+
+The module doc comment (currently describing the two-branch options-empty
+heuristic) is rewritten to describe the three-way `kind` switch + the skippable
+affordance.
+
+## Backward compatibility
+
+`seed_outcome` (server migration `0002`) is a **TEXT column holding a serialized
+`EngineOutcome`** — for a mulligan-pending seed that is
+`AwaitingInput { request: InputRequest { … } }`. The two new **required** fields
+change that JSON's shape, so existing rows fail to deserialize on `load`.
+
+Decision: **required fields, no `serde(default)`, no new SQL migration.**
+
+- Consistent with #453's established stance (fields required-on-the-wire; loud
+  errors beat silent degradation). A `serde(default)` on `kind` would
+  reintroduce exactly the silent-inference pattern #453 removed.
+- The **column** schema is unchanged (it is opaque JSON), so no `.sql` migration
+  is warranted; only stale row *content* is affected.
+- Pre-release, no real data: recreate the local SQLite file. There are two
+  existing migrations (`0001_init`, `0002_seed_outcome`), applied at startup via
+  `sqlx::migrate!`; we add none.
+
+## Testing
+
+- **`outcome.rs` serde round-trips** updated for the new fields; one unit test
+  per constructor asserting `kind` + `skippable`.
+- **Engine:** the existing Mythos-draw test (`encounter.rs:1904/1964`) already
+  exercises the `Confirm` round-trip and stays green; extend it to assert the
+  emitted request carries `kind: InputKind::Confirm`. Add an assertion that a
+  non-forced reaction window emits `skippable: true` and a forced one
+  `skippable: false`.
+- **wasm client:** add/extend a `crates/web` wasm test asserting
+  `AwaitingInputView` renders a Confirm button for `kind: Confirm`, and a Skip
+  button when `skippable` — the regression guard for the gate.
+- **CI gauntlet** (all seven jobs, strict flags) before push, including
+  `wasm-test` and `wasm-clippy`, since this touches `crates/web`.
+
+## Out of scope
+
+- **Structured options for `PickMultiple`** (carrying hand candidates in
+  `options` rather than client-derived hand indices) — deferred; see the
+  `pick_multiple` caveat above.
+- **Richer per-option metadata** beyond `label` (the broader `#205` enrichment
+  the open-turn menu wants) — separate concern; this PR is the discriminator
+  only.
+
+## Done criteria
+
+- The in-browser solo Gathering playthrough progresses past the first Mythos
+  encounter draw (Confirm renders and resolves).
+- Reaction / fast-play windows render a working Skip control.
+- All seven CI jobs green; phase-7 doc's "End-to-end browser playthrough" bullet
+  updated (stall resolved) as the final commit.


### PR DESCRIPTION
## What & why

The in-browser solo Gathering playthrough — the **sole remaining phase-7 gate item** — stalled at the first **Mythos encounter draw**. `InputRequest` carried only `{ prompt, options }` with **no discriminator for which `InputResponse` a prompt expects**, so the client chose its control purely by whether `options` was empty. Empty-`options` prompts are not all `PickMultiple`, so the draw (which expects `Confirm`) was rendered as the `PickMultiple` "Commit" control and rejected:

> `ResolveInput: Mythos encounter draw expects InputResponse::Confirm, got PickMultiple`

This adds an explicit `InputKind` discriminator and renders the right control from it — no prompt-text heuristics.

## Changes

- **`InputKind { PickSingle, PickMultiple, Confirm }`** + two required fields on `InputRequest` (`kind`, `skippable`). The variant names mirror `InputResponse` 1:1, so the `kind` *is* the expected response.
- Typed constructors `pick_single` / `pick_multiple` / `confirm` + a chainable `.skippable()` replace the ambiguous `prompt`/`choice`. Every engine construction site migrated to declare its kind; the two reaction-window sites add `.skippable()` gated on the existing `window.is_forced()` check (so the Skip button and the prompt's skip-hint can't drift).
- **Client (`AwaitingInputView`)** switches on `request.kind`: `Confirm` renders a Confirm button (the gate fix); a `Skip` button renders whenever `request.skippable` (fixes the latent reaction/fast-window decline path that had no control). `PickSingle`/`PickMultiple` behavior unchanged.

## Design decisions

- **Required fields, no `serde(default)`, no SQL migration.** `seed_outcome` is an opaque JSON TEXT column, so the column schema is unchanged; only stale row *content* is affected. Matching #453's stance (loud failure over silent degradation), a stale `InputRequest` errors on load rather than degrading. Pre-release: recreate the local SQLite file. (A stale persisted mulligan seed now fails to load; the web client already self-heals such a load failure to the picker.)
- **`skippable` is orthogonal to `kind`** (a flag), not a fourth kind — a `PickSingle` reaction window may also be passed.
- `pick_multiple` leaves `options` empty (client derives hand-card indices); a plain doc note flags that this hand-index convention only holds while `PickMultiple` is hand-scoped.

## Testing

- New constructor + serde round-trip unit tests (`outcome.rs`); the Mythos-phase test now asserts `kind: Confirm` + `!skippable`; the Evidence! reaction-window integration test asserts `kind: PickSingle` + `skippable: true`.
- New wasm coverage: Confirm renders+submits, skippable renders+submits Skip, non-skippable has no Skip button.
- Full local gauntlet (all seven CI jobs, strict flags) green.

Closes #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
