### PR TITLE
web: surface client/server version mismatch instead of hanging silently (#463)

### DIFF
--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -21,6 +21,7 @@ pub fn BoardView() -> impl IntoView {
         ConnStatus::Reconnecting => "reconnecting",
         ConnStatus::Failed => "failed",
         ConnStatus::AwaitingRoster => "awaiting-roster",
+        ConnStatus::VersionMismatch => "version mismatch — restart the server and reload",
     };
     let rejection = move || store.get().last_rejection.unwrap_or_default();
 

--- a/crates/web/src/store.rs
+++ b/crates/web/src/store.rs
@@ -15,6 +15,9 @@ pub enum ConnStatus {
     Failed,
     /// No saved game and no roster chosen yet — render the picker.
     AwaitingRoster,
+    /// A server frame failed to deserialize — the client and server binaries
+    /// disagree on the wire format. Terminal: restart the server and reload.
+    VersionMismatch,
 }
 
 /// Everything the UI renders. `game`/`outcome`/`last_rejection` come

--- a/crates/web/src/transport.rs
+++ b/crates/web/src/transport.rs
@@ -46,6 +46,9 @@ async fn run(
 
     loop {
         match connect_once(&store, &game_id, &mut rx).await {
+            // A wire-format skew: the status is already set to VersionMismatch.
+            // Stop the loop entirely — retrying just hits the same stale server.
+            ConnectOutcome::VersionMismatch => return,
             // Opened, but the server closed before any Hello: a valid game
             // always sends Hello immediately, so the id is unknown to the
             // server (e.g. a DB reset). Discard it and create a fresh game.
@@ -83,6 +86,11 @@ enum ConnectOutcome {
     /// Connected, saw `Hello`, then the socket closed: a normal
     /// disconnect. Keep the id and reconnect.
     Disconnected,
+    /// A server frame failed to deserialize — the client and server binaries
+    /// disagree on the wire format. Terminal: do not retry (a retry hits the
+    /// same stale server). The status is set to `VersionMismatch` before this
+    /// is returned.
+    VersionMismatch,
 }
 
 /// Resolve a game id: reuse a saved one, else await a roster from the picker
@@ -141,6 +149,7 @@ async fn connect_once(
     let (mut write, read) = ws.split();
     let mut read = read.fuse();
     let mut saw_hello = false;
+    let mut version_mismatch = false;
 
     loop {
         select! {
@@ -149,6 +158,12 @@ async fn connect_once(
                     if let Ok(msg) = serde_json::from_str::<ServerMessage>(&txt) {
                         saw_hello |= matches!(msg, ServerMessage::Hello { .. });
                         store.update(|s| reduce(s, msg));
+                    } else {
+                        // A frame we can't parse from a server that IS talking
+                        // to us is a wire-format skew, not a transient glitch.
+                        store.update(|s| s.status = ConnStatus::VersionMismatch);
+                        version_mismatch = true;
+                        break;
                     }
                 }
                 Some(Ok(Message::Bytes(_))) => {}
@@ -163,7 +178,9 @@ async fn connect_once(
             }
         }
     }
-    if saw_hello {
+    if version_mismatch {
+        ConnectOutcome::VersionMismatch
+    } else if saw_hello {
         ConnectOutcome::Disconnected
     } else {
         ConnectOutcome::StaleId

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -256,3 +256,35 @@ async fn resolution_banner_renders_lost() {
         "lost reason missing: {html}"
     );
 }
+
+#[wasm_bindgen_test]
+async fn version_mismatch_status_renders_actionable_message() {
+    use web::store::ConnStatus;
+    let store = RwSignal::new(ClientState::default());
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        leptos::view! { <BoardView/> }
+    });
+    store.update(|s| s.status = ConnStatus::VersionMismatch);
+    leptos::task::tick().await;
+
+    // Scope to the last mounted .status line (DOM accumulates across tests).
+    let lines = leptos::prelude::document()
+        .query_selector_all(".status")
+        .expect("query_selector_all");
+    let html = lines
+        .item(lines.length() - 1)
+        .expect("at least one .status line")
+        .dyn_ref::<web_sys::Element>()
+        .expect("Element")
+        .inner_html();
+
+    assert!(
+        html.contains("version mismatch"),
+        "status line must name the version mismatch: {html}"
+    );
+    assert!(
+        html.contains("restart the server"),
+        "status line must tell the user what to do: {html}"
+    );
+}

--- a/docs/superpowers/plans/2026-06-26-transport-version-mismatch.md
+++ b/docs/superpowers/plans/2026-06-26-transport-version-mismatch.md
@@ -1,0 +1,359 @@
+# Transport Version-Mismatch Surfacing (#463) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the browser client receives a server frame it can't deserialize (a client/server wire-format skew), show an actionable status instead of silently hanging on `<no game>`, and stop the reconnect loop.
+
+**Architecture:** Add a terminal `ConnStatus::VersionMismatch` state rendered on `BoardView`'s existing status line; in `connect_once`, handle the deserialization `Err` (currently silently dropped) by setting that status and returning a new `ConnectOutcome::VersionMismatch`; the reconnect loop returns on that outcome, leaving the status visible.
+
+**Tech Stack:** Rust, Leptos (`crates/web`, wasm32), `wasm-bindgen-test` (headless Firefox).
+
+## Global Constraints
+
+- **YAGNI:** no protocol version tag / handshake (detect from the deserialization `Err`); no dedicated banner UI (reuse the existing `.status` line).
+- **CI gauntlet before push** (all seven jobs, warnings-as-errors); `wasm-build`/`wasm-test`/`wasm-clippy` matter since this is `crates/web`:
+  - `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo fmt --check`
+  - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
+  - `cargo build -p web --target wasm32-unknown-unknown`
+  - `wasm-pack test --headless --firefox crates/web`
+  - `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`
+- **Branch:** `web/transport-version-mismatch` (already created; spec committed). One branch, follow-up commits, no force-push.
+- Spec of record: `docs/superpowers/specs/2026-06-26-transport-version-mismatch-design.md`.
+
+---
+
+### Task 1: `ConnStatus::VersionMismatch` + board rendering
+
+The variant and its rendering ship together: `BoardView`'s `status` closure is the only exhaustive `match` on `ConnStatus` (`board.rs:18`), so adding the variant requires adding the arm in the same change. This is the user-visible contract and is TDD'd.
+
+**Files:**
+- Modify: `crates/web/src/store.rs` (add the `ConnStatus::VersionMismatch` variant)
+- Modify: `crates/web/src/board.rs:18-24` (add the status-string arm)
+- Test: `crates/web/tests/board.rs` (new wasm test asserting the status text)
+
+**Interfaces:**
+- Produces (consumed by Task 2): `ConnStatus::VersionMismatch` (in `web::store`).
+
+- [ ] **Step 1: Write the failing wasm test**
+
+In `crates/web/tests/board.rs`, add this test at the end of the file. It drives the store's `status` directly (the field `reduce` never sets) and asserts the actionable text renders on the `.status` line:
+
+```rust
+#[wasm_bindgen_test]
+async fn version_mismatch_status_renders_actionable_message() {
+    use web::store::ConnStatus;
+    let store = RwSignal::new(ClientState::default());
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        leptos::view! { <BoardView/> }
+    });
+    store.update(|s| s.status = ConnStatus::VersionMismatch);
+    leptos::task::tick().await;
+
+    // Scope to the last mounted .status line (DOM accumulates across tests).
+    let lines = leptos::prelude::document()
+        .query_selector_all(".status")
+        .expect("query_selector_all");
+    let html = lines
+        .item(lines.length() - 1)
+        .expect("at least one .status line")
+        .dyn_ref::<web_sys::Element>()
+        .expect("Element")
+        .inner_html();
+
+    assert!(
+        html.contains("version mismatch"),
+        "status line must name the version mismatch: {html}"
+    );
+    assert!(
+        html.contains("restart the server"),
+        "status line must tell the user what to do: {html}"
+    );
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `wasm-pack test --headless --firefox crates/web --test board`
+Expected: FAIL to compile — `ConnStatus::VersionMismatch` does not exist yet.
+
+- [ ] **Step 3: Add the `VersionMismatch` variant**
+
+In `crates/web/src/store.rs`, add the variant to the `ConnStatus` enum (after `AwaitingRoster`):
+
+```rust
+    /// No saved game and no roster chosen yet — render the picker.
+    AwaitingRoster,
+    /// A server frame failed to deserialize — the client and server binaries
+    /// disagree on the wire format. Terminal: restart the server and reload.
+    VersionMismatch,
+```
+
+- [ ] **Step 4: Add the board status arm**
+
+In `crates/web/src/board.rs`, add the arm to the `status` closure's match (after the `AwaitingRoster` arm):
+
+```rust
+        ConnStatus::AwaitingRoster => "awaiting-roster",
+        ConnStatus::VersionMismatch => "version mismatch — restart the server and reload",
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `wasm-pack test --headless --firefox crates/web --test board`
+Expected: PASS (the new test plus the existing board tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/web/src/store.rs crates/web/src/board.rs crates/web/tests/board.rs
+git commit -m "web: ConnStatus::VersionMismatch + actionable status-line rendering
+
+A terminal connection state for a client/server wire-format skew, rendered on
+BoardView's existing status line so the mismatch is visible instead of a silent
+<no game>. Wired into the transport in the next commit.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Detect the skew in `connect_once` and stop the reconnect loop
+
+Wires Task 1's variant into the transport: handle the deserialization `Err` (today silently dropped), classify the connection as `VersionMismatch`, and exit the reconnect loop. This is wasm-only async control flow over a live `WebSocket` with no test harness (the rest of `transport.rs` is likewise not unit-tested), so it is verified by build + wasm-clippy + review, not a fabricated socket test.
+
+**Files:**
+- Modify: `crates/web/src/transport.rs` — `ConnectOutcome` enum (~76-86), `connect_once` (~145-170), the `start` reconnect loop (~47-67)
+
+**Interfaces:**
+- Consumes (from Task 1): `ConnStatus::VersionMismatch`.
+- Produces: `ConnectOutcome::VersionMismatch` (module-private).
+
+- [ ] **Step 1: Add the `ConnectOutcome::VersionMismatch` variant**
+
+In `crates/web/src/transport.rs`, add the variant to the `ConnectOutcome` enum. Replace:
+
+```rust
+enum ConnectOutcome {
+    /// `WebSocket::open` failed: the server is unreachable (down or
+    /// restarting). Keep the id and retry.
+    Unreachable,
+    /// Opened, but the server closed before sending any `Hello` — the id
+    /// is stale (unknown to the server). Discard it and recreate.
+    StaleId,
+    /// Connected, saw `Hello`, then the socket closed: a normal
+    /// disconnect. Keep the id and reconnect.
+    Disconnected,
+}
+```
+
+with:
+
+```rust
+enum ConnectOutcome {
+    /// `WebSocket::open` failed: the server is unreachable (down or
+    /// restarting). Keep the id and retry.
+    Unreachable,
+    /// Opened, but the server closed before sending any `Hello` — the id
+    /// is stale (unknown to the server). Discard it and recreate.
+    StaleId,
+    /// Connected, saw `Hello`, then the socket closed: a normal
+    /// disconnect. Keep the id and reconnect.
+    Disconnected,
+    /// A server frame failed to deserialize — the client and server binaries
+    /// disagree on the wire format. Terminal: do not retry (a retry hits the
+    /// same stale server). The status is set to `VersionMismatch` before this
+    /// is returned.
+    VersionMismatch,
+}
+```
+
+- [ ] **Step 2: Handle the deserialization `Err` in `connect_once`**
+
+In `connect_once`, add the mismatch flag beside `saw_hello`. Replace:
+
+```rust
+    let (mut write, read) = ws.split();
+    let mut read = read.fuse();
+    let mut saw_hello = false;
+```
+
+with:
+
+```rust
+    let (mut write, read) = ws.split();
+    let mut read = read.fuse();
+    let mut saw_hello = false;
+    let mut version_mismatch = false;
+```
+
+Then replace the silent text-frame branch:
+
+```rust
+                Some(Ok(Message::Text(txt))) => {
+                    if let Ok(msg) = serde_json::from_str::<ServerMessage>(&txt) {
+                        saw_hello |= matches!(msg, ServerMessage::Hello { .. });
+                        store.update(|s| reduce(s, msg));
+                    }
+                }
+```
+
+with explicit `Err` handling that sets the status and breaks:
+
+```rust
+                Some(Ok(Message::Text(txt))) => {
+                    match serde_json::from_str::<ServerMessage>(&txt) {
+                        Ok(msg) => {
+                            saw_hello |= matches!(msg, ServerMessage::Hello { .. });
+                            store.update(|s| reduce(s, msg));
+                        }
+                        // A frame we can't parse from a server that IS talking
+                        // to us is a wire-format skew, not a transient glitch.
+                        Err(_) => {
+                            store.update(|s| s.status = ConnStatus::VersionMismatch);
+                            version_mismatch = true;
+                            break;
+                        }
+                    }
+                }
+```
+
+- [ ] **Step 3: Classify the outcome (mismatch wins)**
+
+Replace the post-loop classification at the end of `connect_once`:
+
+```rust
+    if saw_hello {
+        ConnectOutcome::Disconnected
+    } else {
+        ConnectOutcome::StaleId
+    }
+```
+
+with:
+
+```rust
+    if version_mismatch {
+        ConnectOutcome::VersionMismatch
+    } else if saw_hello {
+        ConnectOutcome::Disconnected
+    } else {
+        ConnectOutcome::StaleId
+    }
+```
+
+- [ ] **Step 4: Exit the reconnect loop on `VersionMismatch`**
+
+In `start`, add the terminal arm to the `match connect_once(...)`. Replace:
+
+```rust
+        match connect_once(&store, &game_id, &mut rx).await {
+            // Opened, but the server closed before any Hello: a valid game
+            // always sends Hello immediately, so the id is unknown to the
+            // server (e.g. a DB reset). Discard it and create a fresh game.
+            ConnectOutcome::StaleId => {
+```
+
+with:
+
+```rust
+        match connect_once(&store, &game_id, &mut rx).await {
+            // A wire-format skew: the status is already set to VersionMismatch.
+            // Stop the loop entirely — retrying just hits the same stale server.
+            ConnectOutcome::VersionMismatch => return,
+            // Opened, but the server closed before any Hello: a valid game
+            // always sends Hello immediately, so the id is unknown to the
+            // server (e.g. a DB reset). Discard it and create a fresh game.
+            ConnectOutcome::StaleId => {
+```
+
+(The `return` exits before the `status = Reconnecting` line at the loop's foot, leaving the `VersionMismatch` status visible.)
+
+- [ ] **Step 5: Build + wasm-clippy to verify the wiring compiles cleanly**
+
+Run: `cargo build -p web --target wasm32-unknown-unknown`
+Expected: clean (the `ConnectOutcome` match in `start` is now exhaustive over four variants).
+
+Run: `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 6: Re-run the wasm board tests (no regression)**
+
+Run: `wasm-pack test --headless --firefox crates/web --test board`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/web/src/transport.rs
+git commit -m "web: surface wire-format skew + stop reconnect loop on it
+
+connect_once handles the previously-silent deserialization Err: it sets
+ConnStatus::VersionMismatch and returns ConnectOutcome::VersionMismatch, on which
+the reconnect loop returns (a retry hits the same stale server). Closes the
+invisible <no game> hang from a stale server binary + new client.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Full CI gauntlet, push, PR
+
+- [ ] **Step 1: Run the complete local gauntlet**
+
+Run each, expecting all green:
+```bash
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+wasm-pack test --headless --firefox crates/web
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+If `cargo fmt --check` flags anything, run `cargo fmt` and fold into the relevant commit.
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+git push -u origin web/transport-version-mismatch
+gh pr create --fill
+```
+PR body: short design-decisions paragraph (detect from the deserialization `Err`, no protocol version tag; `VersionMismatch` is terminal — stop retrying; reuse the existing status line). Quote the silent-hang failure mode it fixes. Ensure the body has `Closes #463.`
+
+- [ ] **Step 3: Watch CI**
+
+Run: `gh pr checks <PR#> --watch`
+Fix any failures with follow-up commits to the same branch (no force-push).
+
+- [ ] **Step 4: Phase doc**
+
+No phase-7 doc change required: #463 is a `p2-later` dev-ergonomics fix, not a gate item. The phase-7 doc's dev-loop note (added in PR #462) already mentions this hardening as a possible follow-up; updating it is optional and not required for this PR. Skip unless a quick one-line "(done in #463)" feels worth it.
+
+- [ ] **Step 5: Merge only after explicit user approval**
+
+Do not merge autonomously. Surface CI-green, and wait. On approval:
+```bash
+gh pr merge <PR#> --squash --delete-branch
+```
+Then confirm #463 auto-closed and `git pull` on `main`.
+
+## Self-Review
+
+**Spec coverage:**
+- `ConnStatus::VersionMismatch` → Task 1, Step 3. ✓
+- `ConnectOutcome::VersionMismatch` → Task 2, Step 1. ✓
+- Detection (handle the `Err`) → Task 2, Step 2. ✓
+- Classification (mismatch wins) → Task 2, Step 3. ✓
+- Loop exit / stop retrying → Task 2, Step 4. ✓
+- Surface on the existing `.status` line → Task 1, Step 4. ✓
+- YAGNI (no version tag, no banner UI) → Global Constraints; nothing in the tasks adds them. ✓
+- wasm test on board status rendering → Task 1, Steps 1–5. ✓
+- Honest note that `connect_once` control flow isn't unit-tested → Task 2 preamble. ✓
+
+**Placeholder scan:** No "TBD"/"handle errors"/"similar to" — every code step carries full before/after code and exact commands. ✓
+
+**Type consistency:** `ConnStatus::VersionMismatch` (Task 1) is the exact name consumed in Task 2's detection and board arm; `ConnectOutcome::VersionMismatch` (Task 2 Step 1) matches the arm added in Step 4; `version_mismatch` flag named consistently across Steps 2–3. ✓

--- a/docs/superpowers/specs/2026-06-26-transport-version-mismatch-design.md
+++ b/docs/superpowers/specs/2026-06-26-transport-version-mismatch-design.md
@@ -1,0 +1,158 @@
+# #463 — Surface client/server version mismatch instead of hanging silently
+
+**Date:** 2026-06-26
+**Issue:** #463 (web: transport silently drops un-parseable server messages)
+**Follow-up from:** #205 / PR #462 (the wire-format change that exposed this)
+
+## Problem
+
+The browser transport silently swallows any `ServerMessage` it can't deserialize,
+turning a client/server **version skew** into an invisible hang: the board renders
+`<no game>` forever with no error.
+
+In `crates/web/src/transport.rs`, `connect_once` does:
+
+```rust
+Some(Ok(Message::Text(txt))) => {
+    if let Ok(msg) = serde_json::from_str::<ServerMessage>(&txt) {
+        saw_hello |= matches!(msg, ServerMessage::Hello { .. });
+        store.update(|s| reduce(s, msg));
+    }
+    // else: dropped silently
+}
+```
+
+When a freshly-rebuilt client connects to a **stale server binary** (e.g. forgetting
+to restart `cargo run -p server` after a wire-format change), every `Hello`/`Applied`
+the old server sends is in the old shape. `from_str::<ServerMessage>` returns `Err`,
+the frame is dropped, `game` stays `None`, `saw_hello` stays false — but the socket
+is still open, so the connection never breaks and never reaches the `StaleId`
+self-heal. The user sits on a blank `<no game>` page indefinitely.
+
+This was discovered while shipping #205: a running pre-change server + a hot-reloaded
+client reproduced the silent hang, and the invisible failure mode cost real debugging
+time.
+
+## Solution
+
+Detect the un-parseable frame, surface it as an actionable status, and stop retrying
+(a retry just hits the same stale server).
+
+### 1. `ConnStatus::VersionMismatch` (`crates/web/src/store.rs`)
+
+A new terminal variant on the connection-lifecycle enum:
+
+```rust
+pub enum ConnStatus {
+    #[default]
+    Connecting,
+    Connected,
+    Reconnecting,
+    Failed,
+    AwaitingRoster,
+    /// A server frame failed to deserialize — the client and server binaries
+    /// disagree on the wire format. Terminal: restart the server and reload.
+    VersionMismatch,
+}
+```
+
+### 2. `ConnectOutcome::VersionMismatch` (`crates/web/src/transport.rs`)
+
+A new outcome variant so `connect_once` can tell the reconnect loop to stop:
+
+```rust
+enum ConnectOutcome {
+    Unreachable,
+    StaleId,
+    Disconnected,
+    /// A frame failed to deserialize (wire-format skew). Terminal — do not retry.
+    VersionMismatch,
+}
+```
+
+### 3. Detection (`connect_once`)
+
+Replace the silent `if let Ok(msg)` with explicit `Err` handling. On the first
+un-parseable text frame, set the status, break the read loop, and return
+`VersionMismatch`:
+
+```rust
+Some(Ok(Message::Text(txt))) => match serde_json::from_str::<ServerMessage>(&txt) {
+    Ok(msg) => {
+        saw_hello |= matches!(msg, ServerMessage::Hello { .. });
+        store.update(|s| reduce(s, msg));
+    }
+    Err(_) => {
+        store.update(|s| s.status = ConnStatus::VersionMismatch);
+        version_mismatch = true;
+        break;
+    }
+},
+```
+
+with a `let mut version_mismatch = false;` alongside `saw_hello`, and the post-loop
+classification ordered so the mismatch wins:
+
+```rust
+if version_mismatch {
+    ConnectOutcome::VersionMismatch
+} else if saw_hello {
+    ConnectOutcome::Disconnected
+} else {
+    ConnectOutcome::StaleId
+}
+```
+
+Rationale: a frame we can't parse from a server that *is* talking to us is a
+wire-format skew, not a transient glitch — there's no value in continuing to read.
+
+### 4. Loop behavior (`start`)
+
+Add a match arm that exits the reconnect loop entirely, *before* the
+`status = Reconnecting` line, leaving the `VersionMismatch` status visible:
+
+```rust
+match connect_once(&store, &game_id, &mut rx).await {
+    ConnectOutcome::VersionMismatch => return, // terminal; leave the status set
+    ConnectOutcome::StaleId => { /* unchanged self-heal */ }
+    ConnectOutcome::Unreachable | ConnectOutcome::Disconnected => {}
+}
+```
+
+### 5. Surface (`crates/web/src/board.rs`)
+
+`BoardView` already renders an always-present `.status` line that maps each
+`ConnStatus` to a string. Add the arm with an actionable message:
+
+```rust
+ConnStatus::VersionMismatch => "version mismatch — restart the server and reload",
+```
+
+No new DOM element — reuse the existing `.status` line. This is the minimal,
+in-keeping win the issue asks for ("don't hang silently — show *something*").
+
+## Out of scope (YAGNI)
+
+- **No protocol version tag / handshake.** Inferring the skew from the
+  deserialization `Err` is sufficient and needs no protocol change. #463 lists the
+  version tag as optional; skip it.
+- **No dedicated banner UI / styling.** The existing status line carries the message.
+
+## Testing
+
+- **wasm test** (extends `crates/web/tests/board.rs`): drive the store to
+  `status = ConnStatus::VersionMismatch` and assert `BoardView`'s `.status` line
+  renders the actionable text. This guards the user-visible contract.
+- The `connect_once` detection + loop-exit is wasm-only async control flow over a
+  live `WebSocket` with no existing test harness (the rest of `transport.rs` is
+  likewise not unit-tested). Covered by implementation review, not a fabricated
+  socket harness — called out honestly rather than papered over.
+- Full CI gauntlet (all seven jobs, strict flags) before push; `wasm-test` /
+  `wasm-clippy` matter since this is `crates/web`.
+
+## Done criteria
+
+- A client receiving an un-parseable server frame shows
+  `status: version mismatch — restart the server and reload` instead of a silent
+  `<no game>`, and stops reconnect-looping.
+- All seven CI jobs green.


### PR DESCRIPTION
## What & why

Follow-up from #205 (PR #462). The browser transport **silently dropped** any `ServerMessage` it couldn't deserialize, so a client/server **wire-format skew** (e.g. a freshly-rebuilt client against a stale server binary after a wire change) turned into an invisible hang: the board sat on `<no game>` forever, the socket stayed open, and the reconnect loop never broke. This cost real debugging time while shipping #205.

Now the client detects the un-parseable frame, shows an actionable status, and stops retrying.

## Changes

- **`ConnStatus::VersionMismatch`** — a terminal connection state, rendered on `BoardView`'s existing `.status` line as `version mismatch — restart the server and reload`.
- **`connect_once`** handles the deserialization `Err` (previously the silent `else`): sets the status, and returns a new **`ConnectOutcome::VersionMismatch`** (which wins over `saw_hello`/`StaleId` in the post-loop classifier).
- The **reconnect loop returns** on `VersionMismatch` — a retry just hits the same stale server, so the loop stops with the status visible.

## Design decisions

- **Detect from the deserialization `Err`, no protocol version tag.** Inferring the skew is sufficient and needs no protocol change (YAGNI).
- **`VersionMismatch` is terminal** — stop retrying rather than loop against an unchanging stale server.
- **Reuse the existing status line** — no dedicated banner UI; the minimal "don't hang silently — show something" win.

## Testing

- wasm test (`tests/board.rs`): `BoardView` with `status = VersionMismatch` renders the actionable text.
- The `connect_once` detection + loop-exit is wasm-only async control flow over a live `WebSocket` with no existing test harness (the rest of `transport.rs` is likewise not unit-tested) — verified by build + wasm-clippy + review, not a fabricated socket test.
- Full local gauntlet (all seven CI jobs, strict flags) green.

Closes #463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
