### PR TITLE
engine: trigger-level eligibility predicate — suppress unaffordable reactions (#368, closes #470)

### DIFF
--- a/crates/card-dsl/src/dsl.rs
+++ b/crates/card-dsl/src/dsl.rs
@@ -558,6 +558,13 @@ pub struct Ability {
     /// serde treats a missing `Option` field as `None`, the genuine
     /// absent-by-design case.
     pub usage_limit: Option<UsageLimit>,
+    /// Native eligibility-predicate tag (resolved via the registry's
+    /// `native_eligibility_for`). When set, the reaction/fast scan suppresses
+    /// this ability unless the predicate holds (RR p.2: an ability can't
+    /// initiate if its effect won't change game state). `None` for the common
+    /// no-gate case; stays implicitly optional on the wire (#453 per-field
+    /// carve-out, like `usage_limit`).
+    pub eligibility: Option<String>,
 }
 
 impl Ability {
@@ -569,6 +576,14 @@ impl Ability {
     #[must_use]
     pub fn with_usage_limit(mut self, limit: UsageLimit) -> Self {
         self.usage_limit = Some(limit);
+        self
+    }
+
+    /// Attach a native eligibility-predicate tag (see [`Self::eligibility`]).
+    /// Builder-style sugar, chainable off the `on_event(...)` constructors.
+    #[must_use]
+    pub fn with_eligibility(mut self, tag: impl Into<String>) -> Self {
+        self.eligibility = Some(tag.into());
         self
     }
 }
@@ -1208,6 +1223,7 @@ pub fn constant(effect: Effect) -> Ability {
         costs: Vec::new(),
         effect,
         usage_limit: None,
+        eligibility: None,
     }
 }
 
@@ -1222,6 +1238,7 @@ pub fn on_play(effect: Effect) -> Ability {
         costs: Vec::new(),
         effect,
         usage_limit: None,
+        eligibility: None,
     }
 }
 
@@ -1234,6 +1251,7 @@ pub fn on_commit(effect: Effect) -> Ability {
         costs: Vec::new(),
         effect,
         usage_limit: None,
+        eligibility: None,
     }
 }
 
@@ -1248,6 +1266,7 @@ pub fn on_skill_test_resolution(outcome: TestOutcome, effect: Effect) -> Ability
         costs: Vec::new(),
         effect,
         usage_limit: None,
+        eligibility: None,
     }
 }
 
@@ -1270,6 +1289,7 @@ pub fn on_event(
         costs: Vec::new(),
         effect,
         usage_limit: None,
+        eligibility: None,
     }
 }
 
@@ -1299,6 +1319,7 @@ pub fn revelation(effect: Effect) -> Ability {
         costs: Vec::new(),
         effect,
         usage_limit: None,
+        eligibility: None,
     }
 }
 
@@ -1318,6 +1339,7 @@ pub fn activated(action_cost: u8, costs: Vec<Cost>, effect: Effect) -> Ability {
         costs,
         effect,
         usage_limit: None,
+        eligibility: None,
     }
 }
 
@@ -1338,6 +1360,7 @@ pub fn elder_sign(modifier: IntExpr) -> Ability {
         costs: Vec::new(),
         effect: Effect::Seq(Vec::new()),
         usage_limit: None,
+        eligibility: None,
     }
 }
 
@@ -1593,6 +1616,15 @@ pub fn skill_test(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn with_eligibility_sets_the_tag_and_default_is_none() {
+        let bare = reaction_on_event(EventPattern::RoundEnded, EventTiming::When, Effect::Cancel);
+        assert_eq!(bare.eligibility, None);
+        let gated = reaction_on_event(EventPattern::RoundEnded, EventTiming::When, Effect::Cancel)
+            .with_eligibility("01109:can_advance");
+        assert_eq!(gated.eligibility.as_deref(), Some("01109:can_advance"));
+    }
 
     /// Holy Rosary's "while in play, +1 willpower" ability.
     #[test]

--- a/crates/cards/src/impls/cover_up.rs
+++ b/crates/cards/src/impls/cover_up.rs
@@ -20,8 +20,9 @@ use card_dsl::dsl::{
     forced_on_event, native, put_into_threat_area_with_clues, reaction_on_event, revelation,
     Ability, Effect, EventPattern, EventTiming,
 };
-use game_core::card_registry::NativeEffectFn;
+use game_core::card_registry::{EligibilityFn, NativeEffectFn};
 use game_core::event::TraumaKind;
+use game_core::state::GameState;
 use game_core::{Cx, EngineOutcome, EvalContext, Event};
 
 /// `ArkhamDB` code for Cover Up.
@@ -31,6 +32,10 @@ pub const CODE: &str = "01007";
 const DISCARD_TAG: &str = "01007:discard_clues";
 /// Native tag: suffer 1 mental trauma at game end if clues remain.
 const TRAUMA_TAG: &str = "01007:trauma";
+/// Eligibility tag: the discover-replacement reaction may be offered only while
+/// Cover Up still holds clues to discard (RR p.2 potential gate). Replaces the
+/// former hardcoded `card.clues == 0` stand-in in `scan_pending_triggers`.
+const HAS_CLUES_TAG: &str = "01007:has_clues";
 
 #[must_use]
 pub fn abilities() -> Vec<Ability> {
@@ -44,7 +49,8 @@ pub fn abilities() -> Vec<Ability> {
             // (Axis D #336). The before-discover window's continuation skips
             // the deferred discovery when `pending_cancellation` is set.
             Effect::Seq(vec![native(DISCARD_TAG), Effect::Cancel]),
-        ),
+        )
+        .with_eligibility(HAS_CLUES_TAG),
         forced_on_event(
             EventPattern::GameEnd,
             EventTiming::After,
@@ -58,6 +64,28 @@ pub fn native_effect_for(tag: &str) -> Option<NativeEffectFn> {
     match tag {
         DISCARD_TAG => Some(discard_clues),
         TRAUMA_TAG => Some(trauma),
+        _ => None,
+    }
+}
+
+/// True while the Cover Up instance (the firing source) still holds clues to
+/// discard. Read-only mirror of [`discard_clues`]'s instance lookup.
+fn has_clues(state: &GameState, ctx: &EvalContext) -> bool {
+    let Some(source) = ctx.source else {
+        return false;
+    };
+    state.investigators.get(&ctx.controller).is_some_and(|inv| {
+        inv.threat_area
+            .iter()
+            .chain(inv.cards_in_play.iter())
+            .any(|c| c.instance_id == source && c.clues > 0)
+    })
+}
+
+/// Resolve Cover Up's eligibility tag.
+pub(crate) fn native_eligibility_for(tag: &str) -> Option<EligibilityFn> {
+    match tag {
+        HAS_CLUES_TAG => Some(has_clues as EligibilityFn),
         _ => None,
     }
 }
@@ -158,5 +186,37 @@ mod tests {
         assert!(native_effect_for(DISCARD_TAG).is_some());
         assert!(native_effect_for(TRAUMA_TAG).is_some());
         assert!(native_effect_for("nope").is_none());
+    }
+
+    #[test]
+    fn has_clues_predicate_gates_on_source_instance_clues() {
+        use game_core::state::{CardInPlay, CardInstanceId, GameStateBuilder, InvestigatorId};
+
+        // The WouldDiscoverClues reaction now carries the eligibility tag.
+        let abilities = super::abilities();
+        assert_eq!(
+            abilities[1].eligibility.as_deref(),
+            Some("01007:has_clues"),
+            "the discover-replacement reaction declares the potential gate"
+        );
+
+        // Predicate: true while the source instance holds clues, false at 0.
+        let pred = super::native_eligibility_for("01007:has_clues").expect("registered");
+        let mut inv = game_core::test_support::test_investigator(1);
+        let mut card =
+            CardInPlay::enter_play(game_core::state::CardCode::new("01007"), CardInstanceId(0));
+        card.clues = 3;
+        inv.threat_area.push(card);
+        let mut state = GameStateBuilder::new().with_investigator(inv).build();
+        let ctx = EvalContext::for_controller_with_source(InvestigatorId(1), CardInstanceId(0));
+        assert!(pred(&state, &ctx), "3 clues → eligible");
+
+        state
+            .investigators
+            .get_mut(&InvestigatorId(1))
+            .unwrap()
+            .threat_area[0]
+            .clues = 0;
+        assert!(!pred(&state, &ctx), "0 clues → ineligible");
     }
 }

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -181,3 +181,10 @@ pub fn native_effect_for(tag: &str) -> Option<game_core::card_registry::NativeEf
         .or_else(|| crypt_chill::native_effect_for(tag))
         .or_else(|| obscuring_fog::native_effect_for(tag))
 }
+
+/// Dispatch a native eligibility-predicate tag to its card-local handler.
+/// Per-card branches are added by their consumer tasks; `None` for now.
+#[must_use]
+pub fn native_eligibility_for(_tag: &str) -> Option<game_core::card_registry::EligibilityFn> {
+    None
+}

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -182,9 +182,9 @@ pub fn native_effect_for(tag: &str) -> Option<game_core::card_registry::NativeEf
         .or_else(|| obscuring_fog::native_effect_for(tag))
 }
 
-/// Dispatch a native eligibility-predicate tag to its card-local handler.
-/// Per-card branches are added by their consumer tasks; `None` for now.
+/// Dispatch a native eligibility-predicate tag to its card-local handler;
+/// returns `None` for unregistered tags.
 #[must_use]
-pub fn native_eligibility_for(_tag: &str) -> Option<game_core::card_registry::EligibilityFn> {
-    None
+pub fn native_eligibility_for(tag: &str) -> Option<game_core::card_registry::EligibilityFn> {
+    cover_up::native_eligibility_for(tag)
 }

--- a/crates/cards/src/impls/mod.rs
+++ b/crates/cards/src/impls/mod.rs
@@ -186,5 +186,5 @@ pub fn native_effect_for(tag: &str) -> Option<game_core::card_registry::NativeEf
 /// returns `None` for unregistered tags.
 #[must_use]
 pub fn native_eligibility_for(tag: &str) -> Option<game_core::card_registry::EligibilityFn> {
-    cover_up::native_eligibility_for(tag)
+    cover_up::native_eligibility_for(tag).or_else(|| the_barrier::native_eligibility_for(tag))
 }

--- a/crates/cards/src/impls/the_barrier.rs
+++ b/crates/cards/src/impls/the_barrier.rs
@@ -46,10 +46,11 @@
 use card_dsl::dsl::{
     forced_on_event, native, reaction_on_event, Ability, EventPattern, EventTiming,
 };
-use game_core::card_registry::NativeEffectFn;
+use game_core::card_registry::{EligibilityFn, NativeEffectFn};
+use game_core::state::GameState;
 use game_core::{
-    location_id_by_code, reveal_location, round_end_advance, spawn_set_aside_enemy, Cx,
-    EngineOutcome, EvalContext,
+    location_id_by_code, reveal_location, round_end_advance, round_end_advance_affordable,
+    spawn_set_aside_enemy, Cx, EngineOutcome, EvalContext,
 };
 
 /// `ArkhamDB` code for Act 2, "The Barrier".
@@ -63,6 +64,12 @@ const REVERSE: &str = "01109:reverse";
 /// spend the requisite number of clues to advance").
 pub(crate) const ROUND_END_ADVANCE: &str = "01109:round_end_advance";
 
+/// Eligibility tag: the round-end advance may be offered only when the Hallway
+/// group can afford the act's clue threshold (RR p.2 potential gate). Restores
+/// the affordability gate the offer scan lost in the #434 coordinator remodel
+/// (#470).
+const CAN_ADVANCE: &str = "01109:can_advance";
+
 /// Printed codes the reverse touches.
 const GHOUL_PRIEST: &str = "01116";
 const HALLWAY: &str = "01112";
@@ -73,7 +80,10 @@ const PARLOR: &str = "01115";
 ///   Hallway may, as a group, spend the requisite number of clues to advance":
 ///   a `When`-timed `RoundEnded` reaction. The round-end `When` window offers
 ///   this as a single candidate (`PickSingle` = advance, Skip = decline); the
-///   native spends + advances. Affordability is gated in the reaction scan.
+///   native spends + advances. Affordability is gated by the `01109:can_advance`
+///   eligibility predicate (shared with the resolve-side
+///   [`round_end_advance_affordable`]), so the candidate isn't offered when the
+///   Hallway group can't afford the clue threshold (#470).
 /// - the **reverse** — a Forced on-advance ability (reveal the Parlor + spawn
 ///   the Priest) that fires when the act advances.
 #[must_use]
@@ -88,7 +98,8 @@ pub fn abilities() -> Vec<Ability> {
             EventPattern::RoundEnded,
             EventTiming::When,
             native(ROUND_END_ADVANCE),
-        ),
+        )
+        .with_eligibility(CAN_ADVANCE),
     ]
 }
 
@@ -100,6 +111,21 @@ pub(crate) fn native_effect_for(tag: &str) -> Option<NativeEffectFn> {
         ROUND_END_ADVANCE => Some(advance_via_clue_spend as NativeEffectFn),
         _ => None,
     }
+}
+
+/// Resolve 01109's eligibility tag. The round-end advance is offered only when
+/// the Hallway (01112) group can afford the act's clue threshold.
+pub(crate) fn native_eligibility_for(tag: &str) -> Option<EligibilityFn> {
+    match tag {
+        CAN_ADVANCE => Some(can_advance as EligibilityFn),
+        _ => None,
+    }
+}
+
+/// True when the Hallway group can afford the current act's clue threshold —
+/// the offer-side gate shared with the resolve-side `round_end_advance`.
+fn can_advance(state: &GameState, _ctx: &EvalContext) -> bool {
+    round_end_advance_affordable(state, HALLWAY)
 }
 
 /// Front-objective native: spend the act's `clue_threshold` from Hallway

--- a/crates/cards/src/lib.rs
+++ b/crates/cards/src/lib.rs
@@ -89,6 +89,11 @@ fn registry_native_effect_for(tag: &str) -> Option<game_core::card_registry::Nat
     impls::native_effect_for(tag)
 }
 
+/// Adapter from an eligibility tag to its card-local predicate.
+fn registry_native_eligibility_for(tag: &str) -> Option<game_core::card_registry::EligibilityFn> {
+    impls::native_eligibility_for(tag)
+}
+
 /// Ready-made [`CardRegistry`] backed by this crate's corpus and
 /// implementations. The host installs it once at startup with
 /// [`game_core::card_registry::install`]; engine code then calls
@@ -97,6 +102,7 @@ pub const REGISTRY: CardRegistry = CardRegistry {
     metadata_for: registry_metadata_for,
     abilities_for: registry_abilities_for,
     native_effect_for: registry_native_effect_for,
+    native_eligibility_for: registry_native_eligibility_for,
 };
 
 #[cfg(test)]

--- a/crates/cards/tests/reject_rollback.rs
+++ b/crates/cards/tests/reject_rollback.rs
@@ -72,6 +72,7 @@ fn install_probe_registry() {
         metadata_for: probe_metadata,
         abilities_for: probe_abilities,
         native_effect_for: |_| None,
+        native_eligibility_for: |_| None,
     });
 }
 

--- a/crates/cards/tests/the_barrier_eligibility.rs
+++ b/crates/cards/tests/the_barrier_eligibility.rs
@@ -1,0 +1,54 @@
+//! #470: The Barrier's round-end advance is gated by an eligibility predicate
+//! that must reject when the Hallway group can't afford the act's clue
+//! threshold. Exercises the predicate through the installed `cards::REGISTRY` —
+//! the same `native_eligibility_for("01109:can_advance")` lookup the reaction
+//! scan performs in `scan_act_agenda_reactions`.
+
+use game_core::card_registry;
+use game_core::state::{Act, CardCode, GameStateBuilder, InvestigatorId, LocationId};
+use game_core::test_support::{test_investigator, test_location};
+use game_core::EvalContext;
+
+#[test]
+fn barrier_advance_eligibility_gates_on_hallway_affordability() {
+    let _ = card_registry::install(cards::REGISTRY);
+    let reg = card_registry::current().expect("registry installed");
+    let pred = (reg.native_eligibility_for)("01109:can_advance")
+        .expect("01109:can_advance is registered by The Barrier");
+
+    // The Barrier's contributor location is the Hallway (01112).
+    let mut hall = test_location(1, "Hallway");
+    hall.code = CardCode("01112".into());
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(LocationId(1));
+    let mut state = GameStateBuilder::new()
+        .with_location(hall)
+        .with_investigator(inv)
+        .with_turn_order([InvestigatorId(1)])
+        .build();
+    state.act_deck = vec![Act {
+        code: CardCode("01109".into()),
+        clue_threshold: 3,
+        resolution: None,
+    }];
+    state.act_index = 0;
+
+    let ctx = EvalContext::for_controller(InvestigatorId(1));
+
+    state
+        .investigators
+        .get_mut(&InvestigatorId(1))
+        .unwrap()
+        .clues = 0;
+    assert!(
+        !pred(&state, &ctx),
+        "#470: not offered at 0/3 clues (Hallway group can't afford)"
+    );
+
+    state
+        .investigators
+        .get_mut(&InvestigatorId(1))
+        .unwrap()
+        .clues = 3;
+    assert!(pred(&state, &ctx), "offered at 3/3 clues");
+}

--- a/crates/game-core/src/card_registry.rs
+++ b/crates/game-core/src/card_registry.rs
@@ -37,7 +37,7 @@ use std::sync::OnceLock;
 use crate::card_data::CardMetadata;
 use crate::dsl::Ability;
 use crate::engine::{Cx, EngineOutcome, EvalContext};
-use crate::state::CardCode;
+use crate::state::{CardCode, GameState};
 
 /// A card-local Rust effect: mutates state and emits events through the
 /// effect-resolution context, returning the resolution outcome. Provided
@@ -46,6 +46,14 @@ use crate::state::CardCode;
 ///
 /// [`Effect::Native`]: crate::dsl::Effect::Native
 pub type NativeEffectFn = fn(&mut Cx, &EvalContext) -> EngineOutcome;
+
+/// A card-local read-only eligibility predicate: returns whether a reaction
+/// ability whose [`Ability::eligibility`](crate::dsl::Ability::eligibility) names
+/// this tag may be offered (RR p.2: an ability can't initiate if its effect
+/// won't change game state). Receives the same [`EvalContext`] native effects do
+/// (controller + source). Dispatched from the reaction scan via
+/// [`CardRegistry::native_eligibility_for`].
+pub type EligibilityFn = fn(&GameState, &EvalContext) -> bool;
 
 /// Bundle of card-lookup function pointers.
 ///
@@ -65,6 +73,10 @@ pub struct CardRegistry {
     ///
     /// [`Effect::Native`]: crate::dsl::Effect::Native
     pub native_effect_for: fn(&str) -> Option<NativeEffectFn>,
+    /// Look up a card-local eligibility predicate by its
+    /// [`Ability::eligibility`](crate::dsl::Ability::eligibility) tag. Returns
+    /// `None` for unregistered tags.
+    pub native_eligibility_for: fn(&str) -> Option<EligibilityFn>,
 }
 
 static REGISTRY: OnceLock<CardRegistry> = OnceLock::new();
@@ -159,6 +171,7 @@ mod tests {
             metadata_for: fake_metadata_for,
             abilities_for: fake_abilities_for,
             native_effect_for: |_| None,
+            native_eligibility_for: |_| None,
         }
     }
 

--- a/crates/game-core/src/engine/dispatch/act_agenda.rs
+++ b/crates/game-core/src/engine/dispatch/act_agenda.rs
@@ -258,34 +258,45 @@ pub(crate) fn spend_clues_from(state: &mut GameState, ids: &[InvestigatorId], am
     debug_assert_eq!(remaining, 0, "spend_clues_from called without enough clues");
 }
 
+/// Whether the current act's round-end group clue-spend advance is affordable:
+/// investigators at `contributor_location_code` hold at least the current act's
+/// `clue_threshold`. Shared by the offer-side eligibility predicate (act 01109's
+/// `01109:can_advance`) and the resolve-side [`round_end_advance`], so the two
+/// can't drift. `false` when there is no current act or the location isn't in
+/// play (the "investigators in the Hallway" condition is subsumed — 0
+/// contributors ⇒ 0 clues ⇒ not affordable).
+#[must_use]
+pub fn round_end_advance_affordable(state: &GameState, contributor_location_code: &str) -> bool {
+    let Some(act) = state.act_deck.get(state.act_index) else {
+        return false;
+    };
+    let threshold = act.clue_threshold;
+    let Some(loc) = crate::engine::location_id_by_code(state, contributor_location_code) else {
+        return false;
+    };
+    clues_held(state, &investigators_at(state, loc)) >= u32::from(threshold)
+}
+
 /// Round-end group clue-spend act advance — the generic mechanics behind act
 /// 01109's "investigators in the Hallway may, as a group, spend the requisite
 /// number of clues to advance" (the only card-specific datum is the contributor
-/// location, passed in). Resolves `contributor_location_code` to its in-play
-/// location and, if the investigators there hold at least the **current act's**
-/// `clue_threshold`, spends it from them (turn order) and advances the act.
+/// location, passed in). If [`round_end_advance_affordable`], spends the act's
+/// `clue_threshold` from the contributors (turn order) and advances the act.
 ///
-/// Affordability is gated by the round-end `When` reaction scan (the candidate
-/// is offered only when affordable), so the insufficient-clues branch is a
-/// defensive reject. Exposed for the `cards` registry's 01109 native handler.
+/// Affordability is gated at the offer side by act 01109's `01109:can_advance`
+/// eligibility predicate (which calls [`round_end_advance_affordable`]), so the
+/// insufficient-clues branch here is a defensive backstop. Exposed for the
+/// `cards` registry's 01109 native handler.
 pub fn round_end_advance(cx: &mut Cx, contributor_location_code: &str) -> EngineOutcome {
-    let Some(act) = cx.state.act_deck.get(cx.state.act_index) else {
-        return EngineOutcome::Rejected {
-            reason: "round_end_advance: no current act".into(),
-        };
-    };
-    let threshold = act.clue_threshold;
-    let Some(loc) = crate::engine::location_id_by_code(cx.state, contributor_location_code) else {
-        return EngineOutcome::Rejected {
-            reason: "round_end_advance: contributor location not in play".into(),
-        };
-    };
-    let contributors = investigators_at(cx.state, loc);
-    if clues_held(cx.state, &contributors) < u32::from(threshold) {
+    if !round_end_advance_affordable(cx.state, contributor_location_code) {
         return EngineOutcome::Rejected {
             reason: "round_end_advance: contributors no longer hold enough clues".into(),
         };
     }
+    let threshold = cx.state.act_deck[cx.state.act_index].clue_threshold;
+    let loc = crate::engine::location_id_by_code(cx.state, contributor_location_code)
+        .expect("affordable ⇒ contributor location in play");
+    let contributors = investigators_at(cx.state, loc);
     spend_clues_from(cx.state, &contributors, threshold);
     advance_act(cx);
     EngineOutcome::Done
@@ -509,6 +520,48 @@ mod advance_act_tests {
     use crate::state::{InvestigatorId, Phase};
     use crate::test_support::{take_turn_action, test_investigator, GameStateBuilder};
     use crate::{assert_event, assert_no_event};
+
+    #[test]
+    fn round_end_advance_affordable_tracks_hallway_clues_vs_threshold() {
+        use crate::state::{Act, CardCode, LocationId};
+        use crate::test_support::test_location;
+
+        // A location coded "HALL"; the investigator stands on it.
+        let mut hall = test_location(1, "Hallway");
+        hall.code = CardCode("HALL".into());
+        let mut investigator = test_investigator(1);
+        investigator.current_location = Some(LocationId(1));
+        let mut state = GameStateBuilder::new()
+            .with_location(hall)
+            .with_investigator(investigator)
+            .with_turn_order([InvestigatorId(1)])
+            .build();
+        state.act_deck = vec![Act {
+            code: CardCode("_act".into()),
+            clue_threshold: 3,
+            resolution: None,
+        }];
+        state.act_index = 0;
+
+        state
+            .investigators
+            .get_mut(&InvestigatorId(1))
+            .unwrap()
+            .clues = 2;
+        assert!(
+            !super::round_end_advance_affordable(&state, "HALL"),
+            "2 < 3 → not affordable"
+        );
+        state
+            .investigators
+            .get_mut(&InvestigatorId(1))
+            .unwrap()
+            .clues = 3;
+        assert!(
+            super::round_end_advance_affordable(&state, "HALL"),
+            "3 >= 3 → affordable"
+        );
+    }
 
     #[test]
     fn advance_act_rejects_when_clues_insufficient() {

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -719,6 +719,7 @@ mod measure_value_tests {
             metadata_for: no_metadata,
             abilities_for: fake_abilities,
             native_effect_for: |_| None,
+            native_eligibility_for: |_| None,
         }
     }
 

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -14,7 +14,7 @@ use std::borrow::Cow;
 use crate::action::InputResponse;
 use crate::card_data::{CardMetadata, CardType};
 use crate::card_registry;
-use crate::dsl::{EventPattern, EventTiming, Trigger, TriggerKind};
+use crate::dsl::{Ability, EventPattern, EventTiming, Trigger, TriggerKind};
 use crate::engine::TimingEvent;
 use crate::state::TimingMode;
 use crate::state::{
@@ -162,6 +162,30 @@ fn same_location(state: &GameState, a: InvestigatorId, b: InvestigatorId) -> boo
 ///
 /// Returns an empty vec when the registry isn't installed (tests that
 /// don't touch card data) or no cards match.
+/// Whether a reaction `ability` may be offered, per its
+/// [`Ability::eligibility`] tag (RR p.2: an ability can't initiate if its
+/// effect won't change game state). No tag → eligible. A tag with no
+/// resolvable predicate (registry absent / unknown tag) → suppressed, so a
+/// half-installed host never offers a gated reaction it can't evaluate.
+fn ability_eligible(
+    state: &GameState,
+    ability: &Ability,
+    source: CandidateSource,
+    controller: InvestigatorId,
+) -> bool {
+    let Some(tag) = ability.eligibility.as_deref() else {
+        return true;
+    };
+    let Some(reg) = card_registry::current() else {
+        return false;
+    };
+    let Some(pred) = (reg.native_eligibility_for)(tag) else {
+        return false;
+    };
+    let ctx = EvalContext::for_controller_with_optional_source(controller, source.instance());
+    pred(state, &ctx)
+}
+
 fn scan_pending_triggers(
     state: &GameState,
     event: &TimingEvent,
@@ -276,6 +300,16 @@ fn scan_pending_triggers(
                 if card.is_usage_exhausted(ability_index, ability.usage_limit, state.round) {
                     continue;
                 }
+                // Eligibility gate (RR p.2): suppress a reaction whose effect
+                // can't change state (e.g. an emptied Cover Up 01007).
+                if !ability_eligible(
+                    state,
+                    ability,
+                    CandidateSource::InPlay(card.instance_id),
+                    id,
+                ) {
+                    continue;
+                }
                 // Reaction candidates always have a source instance — an
                 // in-play / threat-area card, or the investigator card itself
                 // (#448 cp3a, now folded into `controlled_card_instances()`);
@@ -337,6 +371,12 @@ fn scan_act_agenda_reactions(
                 || *timing != bucket
                 || !trigger_matches(event, pattern, *timing, lead)
             {
+                continue;
+            }
+            // Eligibility gate (RR p.2): suppress an act/agenda reaction whose
+            // effect can't change state (e.g. The Barrier 01109's round-end
+            // advance when the Hallway group can't afford the clue threshold).
+            if !ability_eligible(state, ability, CandidateSource::Board, lead) {
                 continue;
             }
             let ability_index = u8::try_from(idx)

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -262,13 +262,6 @@ fn scan_pending_triggers(
                     continue;
                 }
             }
-            // Potential-gate stand-in for Cover Up (RR p.2 "an ability cannot
-            // initiate if its effect won't change the game state"; TODO(#368)):
-            // only a source still holding clues to discard can replace the
-            // discovery — an emptied Cover Up would otherwise prompt forever.
-            if matches!(event, TimingEvent::WouldDiscoverClues { .. }) && card.clues == 0 {
-                continue;
-            }
             let Some(abilities) = (reg.abilities_for)(&card.code) else {
                 continue;
             };

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -4143,6 +4143,7 @@ mod tests {
             metadata_for: mock_registry,
             abilities_for: fake_abilities_for,
             native_effect_for: |_| None,
+            native_eligibility_for: |_| None,
         }
     }
 
@@ -4888,6 +4889,7 @@ mod tests {
             metadata_for,
             abilities_for,
             native_effect_for: |_| None,
+            native_eligibility_for: |_| None,
         };
 
         let inv_id = InvestigatorId(1);

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -18,7 +18,9 @@ pub mod evaluator;
 mod outcome;
 pub(crate) mod pathfinding;
 
-pub use dispatch::act_agenda::{place_doom_on_current_agenda, round_end_advance};
+pub use dispatch::act_agenda::{
+    place_doom_on_current_agenda, round_end_advance, round_end_advance_affordable,
+};
 pub use dispatch::cards::discard_random_from_hand;
 pub use dispatch::choice::{resolve_choice_count, suspend_for_native_choice, ChoiceResolution};
 pub use dispatch::combat::deal_damage_to_enemy;

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -46,8 +46,8 @@ pub use engine::{
     apply, attach_to_location, deal_damage_to_enemy, discard_random_from_hand, effective_shroud,
     enemy_can_enter_location, legal_actions, location_id_by_code, place_doom_on_current_agenda,
     place_in_threat_area, reshuffle_encounter_discard, resolve_choice_count,
-    resolve_encounter_card, reveal_location, round_end_advance, seat_and_open,
-    shortest_first_steps, shortest_first_steps_with, spawn_set_aside_enemy,
+    resolve_encounter_card, reveal_location, round_end_advance, round_end_advance_affordable,
+    seat_and_open, shortest_first_steps, shortest_first_steps_with, spawn_set_aside_enemy,
     suspend_for_native_choice, take_damage, ApplyResult, ChoiceOption, ChoiceResolution, Cx,
     EngineOutcome, EvalContext, InputKind, InputRequest, OptionId, ResumeToken, TurnAction,
 };

--- a/crates/game-core/src/test_support/mod.rs
+++ b/crates/game-core/src/test_support/mod.rs
@@ -81,6 +81,7 @@ pub fn install_test_registry() {
             metadata_for,
             abilities_for,
             native_effect_for: |_| None,
+            native_eligibility_for: |_| None,
         });
     });
 }

--- a/crates/game-core/tests/act_round_end.rs
+++ b/crates/game-core/tests/act_round_end.rs
@@ -48,6 +48,7 @@ fn install() {
             metadata_for: mock_metadata_for,
             abilities_for: mock_abilities_for,
             native_effect_for: mock_native_for,
+            native_eligibility_for: |_| None,
         });
     });
 }

--- a/crates/game-core/tests/activate_ability.rs
+++ b/crates/game-core/tests/activate_ability.rs
@@ -97,6 +97,7 @@ fn install_mock_registry() {
             metadata_for: mock_metadata_for,
             abilities_for: mock_abilities_for,
             native_effect_for: |_| None,
+            native_eligibility_for: |_| None,
         });
     });
 }

--- a/crates/game-core/tests/commit_attack_buff.rs
+++ b/crates/game-core/tests/commit_attack_buff.rs
@@ -71,6 +71,7 @@ fn install_mock_registry() {
             metadata_for: mock_metadata_for,
             abilities_for: mock_abilities_for,
             native_effect_for: |_| None,
+            native_eligibility_for: |_| None,
         });
     });
 }

--- a/crates/game-core/tests/discard_self.rs
+++ b/crates/game-core/tests/discard_self.rs
@@ -145,6 +145,7 @@ fn install_mock_registry() {
             metadata_for: mock_metadata_for,
             abilities_for: mock_abilities_for,
             native_effect_for: |_| None,
+            native_eligibility_for: |_| None,
         });
     });
 }

--- a/crates/game-core/tests/enemy_encounter_spawn.rs
+++ b/crates/game-core/tests/enemy_encounter_spawn.rs
@@ -71,6 +71,7 @@ fn install() {
             metadata_for: mock_metadata_for,
             abilities_for: mock_abilities_for,
             native_effect_for: mock_native_for,
+            native_eligibility_for: |_| None,
         });
     });
 }

--- a/crates/game-core/tests/forced_triggers.rs
+++ b/crates/game-core/tests/forced_triggers.rs
@@ -124,6 +124,7 @@ fn install_mock_registry() {
             metadata_for: mock_metadata_for,
             abilities_for: mock_abilities_for,
             native_effect_for: |_| None,
+            native_eligibility_for: |_| None,
         });
     });
 }

--- a/crates/game-core/tests/native_effect.rs
+++ b/crates/game-core/tests/native_effect.rs
@@ -61,6 +61,7 @@ fn install() {
             metadata_for: mock_metadata_for,
             abilities_for: mock_abilities_for,
             native_effect_for: mock_native_for,
+            native_eligibility_for: |_| None,
         });
     });
 }

--- a/crates/game-core/tests/on_skill_test_resolution.rs
+++ b/crates/game-core/tests/on_skill_test_resolution.rs
@@ -79,6 +79,7 @@ fn install_mock_registry() {
             metadata_for: mock_metadata_for,
             abilities_for: mock_abilities_for,
             native_effect_for: |_| None,
+            native_eligibility_for: |_| None,
         });
     });
 }

--- a/crates/game-core/tests/reaction_windows.rs
+++ b/crates/game-core/tests/reaction_windows.rs
@@ -108,6 +108,7 @@ fn install_mock_registry() {
             metadata_for: mock_metadata_for,
             abilities_for: mock_abilities_for,
             native_effect_for: |_| None,
+            native_eligibility_for: |_| None,
         });
     });
 }

--- a/crates/game-core/tests/round_end_rescan.rs
+++ b/crates/game-core/tests/round_end_rescan.rs
@@ -86,6 +86,7 @@ fn install() {
             metadata_for: mock_metadata_for,
             abilities_for: mock_abilities_for,
             native_effect_for: mock_native_for,
+            native_eligibility_for: |_| None,
         });
     });
 }

--- a/crates/game-core/tests/round_ended.rs
+++ b/crates/game-core/tests/round_ended.rs
@@ -62,6 +62,7 @@ fn install() {
             metadata_for: mock_metadata_for,
             abilities_for: mock_abilities_for,
             native_effect_for: mock_native_for,
+            native_eligibility_for: |_| None,
         });
     });
 }

--- a/crates/game-core/tests/skill_test_outcome_timing.rs
+++ b/crates/game-core/tests/skill_test_outcome_timing.rs
@@ -59,6 +59,7 @@ fn install_mock_registry() {
             metadata_for: mock_metadata_for,
             abilities_for: mock_abilities_for,
             native_effect_for: |_| None,
+            native_eligibility_for: |_| None,
         });
     });
 }

--- a/crates/game-core/tests/weapon_fight.rs
+++ b/crates/game-core/tests/weapon_fight.rs
@@ -86,6 +86,7 @@ fn install_mock_registry() {
             metadata_for: mock_metadata_for,
             abilities_for: mock_abilities_for,
             native_effect_for: |_| None,
+            native_eligibility_for: |_| None,
         });
     });
 }

--- a/crates/scenarios/src/test_fixtures/synth_cards.rs
+++ b/crates/scenarios/src/test_fixtures/synth_cards.rs
@@ -372,6 +372,7 @@ pub const TEST_REGISTRY: CardRegistry = CardRegistry {
     metadata_for,
     abilities_for,
     native_effect_for,
+    native_eligibility_for: |_| None,
 };
 
 #[cfg(test)]

--- a/crates/scenarios/src/test_fixtures/synth_cards.rs
+++ b/crates/scenarios/src/test_fixtures/synth_cards.rs
@@ -18,7 +18,7 @@ use std::sync::OnceLock;
 use game_core::card_data::{
     CardKind, CardMetadata, Class, HealthValue, Prey, SkillIcons, Spawn, SpawnLocation,
 };
-use game_core::card_registry::{CardRegistry, NativeEffectFn};
+use game_core::card_registry::{CardRegistry, EligibilityFn, NativeEffectFn};
 use game_core::dsl::{
     choose_one, forced_on_event, gain_resources, native, on_play, reaction_on_event, revelation,
     Ability, Effect, EventPattern, EventTiming, InvestigatorTarget,
@@ -88,6 +88,11 @@ pub const SYNTH_COVER_UP_DISCARD_TAG: &str = "_synth_cover_up:discard_clues";
 /// Native-effect tag: suffer 1 mental trauma at game end if the synthetic
 /// Cover Up still holds clues (C5a #236).
 pub const SYNTH_COVER_UP_TRAUMA_TAG: &str = "_synth_cover_up:trauma";
+
+/// Eligibility tag: the synthetic Cover Up's discover-replacement reaction may
+/// be offered only while it still holds clues (RR p.2 potential gate; #368).
+/// Mirrors the real Cover Up's `01007:has_clues`.
+pub const SYNTH_COVER_UP_HAS_CLUES_TAG: &str = "_synth_cover_up:has_clues";
 
 /// Static metadata for the synthetic treachery. Only `code`/`name`/the
 /// `Treachery` kind carry meaning for the tests.
@@ -337,7 +342,8 @@ fn abilities_for(code: &CardCode) -> Option<Vec<Ability>> {
                 // Discard from self, then cancel the discovery (Axis D #336) —
                 // mirrors the real Cover Up 01007 (`cover_up`).
                 Effect::Seq(vec![native(SYNTH_COVER_UP_DISCARD_TAG), Effect::Cancel]),
-            ),
+            )
+            .with_eligibility(SYNTH_COVER_UP_HAS_CLUES_TAG),
             forced_on_event(
                 EventPattern::GameEnd,
                 EventTiming::After,
@@ -360,6 +366,28 @@ fn native_effect_for(tag: &str) -> Option<NativeEffectFn> {
     }
 }
 
+/// True while the synthetic Cover Up instance (the firing source) still holds
+/// clues to discard — read-only mirror of [`synth_cover_up_discard`]'s lookup.
+fn synth_cover_up_has_clues(state: &game_core::state::GameState, ctx: &EvalContext) -> bool {
+    let Some(source) = ctx.source else {
+        return false;
+    };
+    state.investigators.get(&ctx.controller).is_some_and(|inv| {
+        inv.threat_area
+            .iter()
+            .chain(inv.cards_in_play.iter())
+            .any(|c| c.instance_id == source && c.clues > 0)
+    })
+}
+
+/// `native_eligibility_for` function pointer used by [`TEST_REGISTRY`].
+fn native_eligibility_for(tag: &str) -> Option<EligibilityFn> {
+    match tag {
+        SYNTH_COVER_UP_HAS_CLUES_TAG => Some(synth_cover_up_has_clues as EligibilityFn),
+        _ => None,
+    }
+}
+
 /// Ready-made [`CardRegistry`] backed by this module's synthetic
 /// cards. Integration tests install this via
 /// [`game_core::card_registry::install`] instead of `cards::REGISTRY`
@@ -372,7 +400,7 @@ pub const TEST_REGISTRY: CardRegistry = CardRegistry {
     metadata_for,
     abilities_for,
     native_effect_for,
-    native_eligibility_for: |_| None,
+    native_eligibility_for,
 };
 
 #[cfg(test)]

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -84,12 +84,21 @@ enemy; you just forfeit the sole-engaged damage bonus).
   `pending_played_event` is only partially met (forcing it needs a custom deserializer,
   deferred). His signature is in the "done" criteria.
 
-**2. #368 — before-discover eligibility (p1-next, needs-design).** Lift the
-hardcoded scan-suppression stand-ins (Cover Up 01007 `card.clues == 0`; act 01109
-round-end clue-threshold) into a declarative **trigger-level eligibility
-`Condition`** (RR p.2: an ability can't initiate if its effect won't change game
-state). Two consumers already; designed when the 3rd lands (Lone Wolf 02188,
-Burned Ruins 02205). Item 2 (capped discovery count) is independent and latent.
+**2. #368 — trigger-level eligibility ✅ shipped (PR #472, also closes #470).**
+The hardcoded scan-suppression stand-ins (Cover Up 01007 `card.clues == 0`; act
+01109 round-end clue-threshold — the latter actually *missing* from the offer
+scan post-#434, i.e. bug #470) are lifted into a per-ability **native eligibility
+predicate** evaluated at reaction-scan time (RR p.2: an ability can't initiate if
+its effect won't change game state). Resolved as a native hook (`Ability.
+eligibility` tag → `CardRegistry::native_eligibility_for` →
+`fn(&GameState, &EvalContext) -> bool`), **not** a declarative `Condition`: both
+live consumers are single-consumer + heterogeneous, so declarative DSL vocab
+would be speculative — promote to a `Condition` when a predicate recurs (Lone
+Wolf 02188, Burned Ruins 02205). The Barrier's offer + resolve share one
+`round_end_advance_affordable` helper so they can't drift. **Item 2 (capped
+discovery count) moved to #471** — it becomes live only once Deduction 01039 is
+fixed to modify a single discovery's count (FAQ-confirmed) rather than spawn a
+second discovery.
 
 **3. Browser capstone — the gate-closer.** Positioned last so it designs against
 the now-stable set of input shapes:

--- a/docs/superpowers/plans/2026-06-26-trigger-eligibility.md
+++ b/docs/superpowers/plans/2026-06-26-trigger-eligibility.md
@@ -1,0 +1,686 @@
+# Trigger-level Eligibility Predicate (#368) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-ability native eligibility predicate, evaluated at reaction-scan time, that suppresses a reaction when its effect can't change game state — replacing Cover Up 01007's hardcoded `card.clues == 0` stand-in and adding The Barrier 01109's missing Hallway-affordability gate (closing #470).
+
+**Architecture:** A `Ability.eligibility: Option<String>` tag → a registry `native_eligibility_for(tag) -> Option<EligibilityFn>` (where `EligibilityFn = fn(&GameState, &EvalContext) -> bool`) → a shared `ability_eligible(...)` helper consulted at both reaction-scan sites. Cards supply tiny Rust predicates; no declarative DSL vocabulary is added.
+
+**Tech Stack:** Rust workspace (`card-dsl`, `game-core`, `cards`), serde.
+
+## Global Constraints
+
+- **YAGNI:** no declarative `Condition` eligibility vocabulary; no fast-window wiring (no in-scope fast consumer); #368 item 2 is **out** (tracked in #471).
+- **Ordering keeps every task green:** the scan helper is wired *before* any hardcode is removed; Cover Up's tag+predicate land in the *same* task that deletes its `card.clues == 0` hardcode (no regression window).
+- **DRY:** The Barrier's affordability check is one helper (`round_end_advance_affordable`) shared by the offer predicate and the resolve handler, so they can't drift.
+- **CI gauntlet before push** (all seven jobs, warnings-as-errors):
+  - `RUSTFLAGS="-D warnings" cargo test --all --all-features`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo fmt --check`
+  - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
+  - `cargo build -p web --target wasm32-unknown-unknown`
+  - `wasm-pack test --headless --firefox crates/web`
+  - `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`
+- **Branch:** `engine/trigger-eligibility` (already created; spec committed). One branch, follow-up commits, no force-push.
+- Spec of record: `docs/superpowers/specs/2026-06-26-trigger-eligibility-design.md`.
+
+---
+
+### Task 1: Eligibility plumbing — DSL field + registry hook (inert)
+
+The whole mechanism scaffold: the `Ability` field + builder (`card-dsl`), and the registry function-pointer + `cards` wiring (`game-core`, `cards`). Inert until consumers declare a tag.
+
+**Files:**
+- Modify: `crates/card-dsl/src/dsl.rs` (struct field, builder, all `Ability { … }` literals)
+- Modify: `crates/game-core/src/card_registry.rs` (`EligibilityFn` type, struct field, fake registry)
+- Modify: `crates/cards/src/lib.rs` (REGISTRY const + adapter)
+- Modify: `crates/cards/src/impls/mod.rs` (empty `native_eligibility_for` dispatch)
+
+**Interfaces:**
+- Produces: `Ability { …, eligibility: Option<String> }`; `Ability::with_eligibility(self, tag) -> Self`; `game_core::card_registry::EligibilityFn = fn(&GameState, &EvalContext) -> bool`; `CardRegistry.native_eligibility_for: fn(&str) -> Option<EligibilityFn>`; `cards::impls::native_eligibility_for(tag) -> Option<EligibilityFn>` (returns `None` for now).
+
+- [ ] **Step 1: Write the failing DSL test**
+
+In `crates/card-dsl/src/dsl.rs`, in its `#[cfg(test)] mod tests` (or add one if absent — search for `mod tests` in the file and append):
+
+```rust
+#[test]
+fn with_eligibility_sets_the_tag_and_default_is_none() {
+    use super::{reaction_on_event, EventPattern, EventTiming};
+    let bare = reaction_on_event(EventPattern::RoundEnded, EventTiming::When, super::Effect::Cancel);
+    assert_eq!(bare.eligibility, None);
+    let gated = reaction_on_event(EventPattern::RoundEnded, EventTiming::When, super::Effect::Cancel)
+        .with_eligibility("01109:can_advance");
+    assert_eq!(gated.eligibility.as_deref(), Some("01109:can_advance"));
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p card-dsl with_eligibility_sets_the_tag`
+Expected: FAIL to compile — no field `eligibility`, no method `with_eligibility`.
+
+- [ ] **Step 3: Add the field + builder**
+
+In `crates/card-dsl/src/dsl.rs`, add the field to `struct Ability` (after `usage_limit`):
+```rust
+    pub usage_limit: Option<UsageLimit>,
+    /// Native eligibility-predicate tag (`native_eligibility_for`). When set,
+    /// the reaction/fast scan suppresses this ability unless the predicate
+    /// holds (RR p.2: an ability can't initiate if its effect won't change
+    /// game state). `None` for the common no-gate case; stays implicitly
+    /// optional on the wire (#453 per-field carve-out, like `usage_limit`).
+    pub eligibility: Option<String>,
+```
+Add the builder in `impl Ability` (next to `with_usage_limit`):
+```rust
+    /// Attach a native eligibility-predicate tag (see [`Self::eligibility`]).
+    #[must_use]
+    pub fn with_eligibility(mut self, tag: impl Into<String>) -> Self {
+        self.eligibility = Some(tag.into());
+        self
+    }
+```
+Then add `eligibility: None,` to **every** `Ability { … }` literal in the file — the constructor functions `on_event` (~1264), `constant` (~1206), `on_play` (~1220), `on_commit` (~1232), `on_skill_test_resolution` (~1246), the `~1264` activated-ability path, `revelation` (~1297), `activated` (~1316), `elder_sign` (~1336). The compiler lists each missing-field site; fix until `cargo build -p card-dsl` is clean.
+
+- [ ] **Step 4: Run the DSL test + serde round-trip**
+
+Run: `cargo test -p card-dsl with_eligibility_sets_the_tag`
+Expected: PASS.
+Run: `cargo build -p card-dsl` — clean (all literals updated).
+
+- [ ] **Step 5: Add the registry hook (game-core)**
+
+In `crates/game-core/src/card_registry.rs`: extend the imports to include `GameState`:
+```rust
+use crate::state::{CardCode, GameState};
+```
+Add the type alias near `NativeEffectFn`:
+```rust
+/// A card-local read-only eligibility predicate: returns whether a reaction
+/// ability whose [`Ability::eligibility`] names this tag may be offered.
+/// Receives the same [`EvalContext`] native effects do (controller + source).
+pub type EligibilityFn = fn(&GameState, &EvalContext) -> bool;
+```
+Add the field to `struct CardRegistry` (after `native_effect_for`):
+```rust
+    /// Look up a card-local eligibility predicate by its
+    /// [`Ability::eligibility`] tag. `None` for unregistered tags.
+    pub native_eligibility_for: fn(&str) -> Option<EligibilityFn>,
+```
+Update `fake_registry()` in the test module (and any other `CardRegistry { … }` literal — the compiler flags them) to add:
+```rust
+            native_eligibility_for: |_| None,
+```
+
+- [ ] **Step 6: Wire the `cards` registry**
+
+In `crates/cards/src/impls/mod.rs`, add (near `native_effect_for`):
+```rust
+/// Dispatch a native eligibility-predicate tag to its card-local handler.
+/// (Per-card branches are added by their consumer tasks.)
+#[must_use]
+pub fn native_eligibility_for(_tag: &str) -> Option<game_core::card_registry::EligibilityFn> {
+    None
+}
+```
+In `crates/cards/src/lib.rs`, add the adapter (near `registry_native_effect_for`):
+```rust
+/// Adapter from an eligibility tag to its card-local predicate.
+fn registry_native_eligibility_for(tag: &str) -> Option<game_core::card_registry::EligibilityFn> {
+    impls::native_eligibility_for(tag)
+}
+```
+and add the field to the `REGISTRY` const:
+```rust
+pub const REGISTRY: CardRegistry = CardRegistry {
+    metadata_for: registry_metadata_for,
+    abilities_for: registry_abilities_for,
+    native_effect_for: registry_native_effect_for,
+    native_eligibility_for: registry_native_eligibility_for,
+};
+```
+
+- [ ] **Step 7: Build the workspace + commit**
+
+Run: `RUSTFLAGS="-D warnings" cargo build --all --all-features`
+Expected: clean (all `Ability {}` / `CardRegistry {}` literals updated workspace-wide).
+Run: `cargo test -p card-dsl && cargo test -p game-core --lib card_registry`
+Expected: PASS.
+
+```bash
+git add crates/card-dsl/src/dsl.rs crates/game-core/src/card_registry.rs crates/cards/src/lib.rs crates/cards/src/impls/mod.rs
+git commit -m "engine: Ability.eligibility tag + native_eligibility_for registry hook (inert)
+
+Adds the per-ability eligibility-predicate plumbing: an Ability.eligibility
+tag, a with_eligibility builder, and a CardRegistry.native_eligibility_for
+function pointer (EligibilityFn = fn(&GameState, &EvalContext) -> bool). No
+consumer yet; wired into the scan and used by Cover Up / The Barrier next.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `ability_eligible` scan helper, wired into both reaction scans (inert)
+
+Adds the evaluator helper and consults it at both reaction-scan sites. Still inert (no ability declares a tag; Cover Up's `card.clues == 0` hardcode stays in place this task, so behaviour is unchanged).
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (`CandidateSource::instance()` helper)
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (`ability_eligible`; call at both scans)
+
+**Interfaces:**
+- Consumes: `CardRegistry.native_eligibility_for`, `EvalContext::for_controller_with_optional_source`.
+- Produces: `CandidateSource::instance(self) -> Option<CardInstanceId>`; `ability_eligible(state, ability, source, controller) -> bool` (module-private).
+
+- [ ] **Step 1: Write the failing helper test**
+
+In `crates/game-core/src/state/game_state.rs` test module (search `mod tests` near `CandidateSource`, or add one), add:
+```rust
+#[test]
+fn candidate_source_instance_projects_inplay_only() {
+    use super::{CandidateSource, CardInstanceId};
+    assert_eq!(CandidateSource::InPlay(CardInstanceId(4)).instance(), Some(CardInstanceId(4)));
+    assert_eq!(CandidateSource::Board.instance(), None);
+    assert_eq!(CandidateSource::Hand.instance(), None);
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p game-core --lib candidate_source_instance_projects_inplay_only`
+Expected: FAIL to compile — no method `instance`.
+
+- [ ] **Step 3: Add `CandidateSource::instance()`**
+
+In `crates/game-core/src/state/game_state.rs`, add an `impl CandidateSource` (after the enum):
+```rust
+impl CandidateSource {
+    /// The in-play instance backing this candidate, if any. `Board` /
+    /// `Hand` candidates have no instance.
+    #[must_use]
+    pub fn instance(self) -> Option<CardInstanceId> {
+        match self {
+            CandidateSource::InPlay(id) => Some(id),
+            CandidateSource::Board | CandidateSource::Hand => None,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p game-core --lib candidate_source_instance_projects_inplay_only`
+Expected: PASS.
+
+- [ ] **Step 5: Add `ability_eligible` and wire both scans**
+
+In `crates/game-core/src/engine/dispatch/reaction_windows.rs`, add the helper (place it near `scan_pending_triggers`):
+```rust
+/// Whether a reaction `ability` may be offered, per its
+/// [`Ability::eligibility`] tag (RR p.2: an ability can't initiate if its
+/// effect won't change game state). No tag → eligible. A tag with no
+/// resolvable predicate (registry absent / unknown tag) → suppressed, never
+/// offered on a half-installed host.
+fn ability_eligible(
+    state: &GameState,
+    ability: &Ability,
+    source: CandidateSource,
+    controller: InvestigatorId,
+) -> bool {
+    let Some(tag) = ability.eligibility.as_deref() else {
+        return true;
+    };
+    let Some(reg) = card_registry::current() else {
+        return false;
+    };
+    let Some(pred) = (reg.native_eligibility_for)(tag) else {
+        return false;
+    };
+    let ctx = crate::engine::evaluator::EvalContext::for_controller_with_optional_source(
+        controller,
+        source.instance(),
+    );
+    pred(state, &ctx)
+}
+```
+In `scan_pending_triggers`, after the existing trigger match guard (`if !trigger_matches(event, pattern, *timing, id) { continue }`), add:
+```rust
+                if !ability_eligible(state, ability, CandidateSource::InPlay(card.instance_id), id) {
+                    continue;
+                }
+```
+In `scan_act_agenda_reactions`, after its `if !trigger_matches(event, pattern, *timing, lead) { … continue }` guard and before pushing the `ResolutionCandidate`, add:
+```rust
+            if !ability_eligible(state, ability, CandidateSource::Board, lead) {
+                continue;
+            }
+```
+(`EvalContext` may need importing at the top of the file if not already in scope; the compiler will say so.)
+
+- [ ] **Step 6: Build + run the reaction-window tests (behaviour unchanged)**
+
+Run: `RUSTFLAGS="-D warnings" cargo test -p game-core --lib dispatch::reaction_windows`
+Expected: PASS — nothing declares an `eligibility` tag yet, so `ability_eligible` returns `true` everywhere; Cover Up's `card.clues == 0` hardcode is still present.
+Run: `cargo clippy -p game-core --all-targets --all-features -- -D warnings` — clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/game-core/src/state/game_state.rs crates/game-core/src/engine/dispatch/reaction_windows.rs
+git commit -m "engine: consult ability_eligible in both reaction scans (inert)
+
+Adds CandidateSource::instance() and an ability_eligible helper that evaluates
+an ability's eligibility tag via the registry, and calls it in
+scan_pending_triggers and scan_act_agenda_reactions. No ability declares a tag
+yet, so behaviour is unchanged; consumers migrate next.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Cover Up 01007 — declare eligibility, drop the hardcode
+
+**Files:**
+- Modify: `crates/cards/src/impls/cover_up.rs` (tag + predicate + dispatch)
+- Modify: `crates/cards/src/impls/mod.rs` (chain Cover Up into `native_eligibility_for`)
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (delete `card.clues == 0` hardcode)
+
+**Interfaces:**
+- Consumes: `EligibilityFn`, `ability_eligible` (already wired), `Ability::with_eligibility`.
+- Produces: `cover_up::native_eligibility_for(tag)`; tag `"01007:has_clues"`.
+
+- [ ] **Step 1: Write the failing card test**
+
+In `crates/cards/src/impls/cover_up.rs` test module, add:
+```rust
+#[test]
+fn has_clues_predicate_gates_on_source_instance_clues() {
+    use card_dsl::dsl::EventPattern;
+    use game_core::engine::EvalContext;
+    use game_core::state::{CardInPlay, CardInstanceId, GameStateBuilder, InvestigatorId};
+
+    // The reaction ability now carries the eligibility tag.
+    let abilities = super::abilities();
+    let reaction = abilities
+        .iter()
+        .find(|a| matches!(&a.trigger, card_dsl::dsl::Trigger::OnEvent { pattern: EventPattern::WouldDiscoverClues, .. }))
+        .expect("Cover Up has a WouldDiscoverClues reaction");
+    assert_eq!(reaction.eligibility.as_deref(), Some("01007:has_clues"));
+
+    // Predicate: true when the source instance holds clues, false at 0.
+    let pred = super::native_eligibility_for("01007:has_clues").expect("registered");
+    let mut inv = game_core::test_support::test_investigator(1);
+    let mut card = CardInPlay::enter_play(game_core::state::CardCode::new("01007"), CardInstanceId(0));
+    card.clues = 3;
+    inv.threat_area.push(card);
+    let state = GameStateBuilder::new().with_investigator(inv).build();
+    let ctx3 = EvalContext::for_controller_with_source(InvestigatorId(1), CardInstanceId(0));
+    assert!(pred(&state, &ctx3));
+
+    // Drain to 0 → ineligible.
+    let mut state0 = state.clone();
+    state0.investigators.get_mut(&InvestigatorId(1)).unwrap().threat_area[0].clues = 0;
+    assert!(!pred(&state0, &ctx3));
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p cards has_clues_predicate_gates_on_source_instance_clues`
+Expected: FAIL — `native_eligibility_for` missing on `cover_up`, and the ability has no eligibility tag.
+
+- [ ] **Step 3: Add the tag + predicate + dispatch (cover_up.rs)**
+
+In `crates/cards/src/impls/cover_up.rs`, add the tag constant near the others:
+```rust
+/// Eligibility tag: Cover Up may replace a discovery only while it still
+/// holds clues to discard (RR p.2 potential gate).
+const HAS_CLUES_TAG: &str = "01007:has_clues";
+```
+Chain `.with_eligibility(HAS_CLUES_TAG)` onto the `reaction_on_event(WouldDiscoverClues, …)` ability in `abilities()`:
+```rust
+        reaction_on_event(
+            EventPattern::WouldDiscoverClues,
+            EventTiming::When,
+            Effect::Seq(vec![native(DISCARD_TAG), Effect::Cancel]),
+        )
+        .with_eligibility(HAS_CLUES_TAG),
+```
+Add the predicate + dispatch (import `EligibilityFn`, `EvalContext`, `GameState`):
+```rust
+use game_core::card_registry::EligibilityFn;
+use game_core::{state::GameState, EvalContext};
+
+/// True while the Cover Up instance still holds clues to discard.
+fn has_clues(state: &GameState, ctx: &EvalContext) -> bool {
+    let Some(source) = ctx.source else { return false };
+    state.investigators.get(&ctx.controller).is_some_and(|inv| {
+        inv.threat_area
+            .iter()
+            .chain(inv.cards_in_play.iter())
+            .any(|c| c.instance_id == source && c.clues > 0)
+    })
+}
+
+/// Resolve Cover Up's eligibility tag.
+pub(crate) fn native_eligibility_for(tag: &str) -> Option<EligibilityFn> {
+    match tag {
+        HAS_CLUES_TAG => Some(has_clues as EligibilityFn),
+        _ => None,
+    }
+}
+```
+
+- [ ] **Step 4: Chain Cover Up into the dispatch (impls/mod.rs)**
+
+In `crates/cards/src/impls/mod.rs`, replace the empty `native_eligibility_for` body with:
+```rust
+#[must_use]
+pub fn native_eligibility_for(tag: &str) -> Option<game_core::card_registry::EligibilityFn> {
+    cover_up::native_eligibility_for(tag)
+}
+```
+
+- [ ] **Step 5: Delete the hardcoded stand-in (reaction_windows.rs)**
+
+In `crates/game-core/src/engine/dispatch/reaction_windows.rs`, **delete** the block:
+```rust
+            // Potential-gate stand-in for Cover Up (RR p.2 "an ability cannot
+            // initiate if its effect won't change the game state"; TODO(#368)):
+            // only a source still holding clues to discard can replace the
+            // discovery — an emptied Cover Up would otherwise prompt forever.
+            if matches!(event, TimingEvent::WouldDiscoverClues { .. }) && card.clues == 0 {
+                continue;
+            }
+```
+(Its job is now done by `ability_eligible` + Cover Up's tag.)
+
+- [ ] **Step 6: Run card + engine tests**
+
+Run: `cargo test -p cards has_clues_predicate_gates_on_source_instance_clues` — PASS.
+Run: `cargo test -p cards --test '*' 2>/dev/null; cargo test -p cards` — Cover Up's existing tests stay green.
+Run: `RUSTFLAGS="-D warnings" cargo test -p game-core --lib dispatch::reaction_windows` — green (the inline hardcode test, if any, was for the engine path; an integration test in `cards` now owns Cover Up's gating). If a game-core unit test asserted the old hardcode directly, port its intent to the `cover_up` predicate test above and delete the now-obsolete engine-level assertion.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/cards/src/impls/cover_up.rs crates/cards/src/impls/mod.rs crates/game-core/src/engine/dispatch/reaction_windows.rs
+git commit -m "cards: Cover Up 01007 declares 01007:has_clues eligibility; drop engine hardcode
+
+Cover Up's discover-replacement reaction now carries an eligibility tag whose
+predicate gates on the source instance still holding clues, replacing the
+hardcoded card.clues==0 branch in scan_pending_triggers.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: The Barrier 01109 — affordability gate (closes #470)
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/act_agenda.rs` (`round_end_advance_affordable`; reuse in `round_end_advance`)
+- Modify: `crates/game-core/src/lib.rs` (re-export `round_end_advance_affordable`)
+- Modify: `crates/cards/src/impls/the_barrier.rs` (tag + predicate + dispatch; doc fix)
+- Modify: `crates/cards/src/impls/mod.rs` (chain The Barrier)
+
+**Interfaces:**
+- Consumes: `EligibilityFn`, `ability_eligible`, `Ability::with_eligibility`, the `investigators_at` / `clues_held` helpers.
+- Produces: `game_core::round_end_advance_affordable(&GameState, &str) -> bool`; tag `"01109:can_advance"`.
+
+- [ ] **Step 1: Write the failing affordability test**
+
+In `crates/game-core/src/engine/dispatch/act_agenda.rs`, add to the test module that already imports `Act`/`CardCode` (the `advance_act_tests` mod near the bottom; add `test_location, LocationId` to its imports):
+```rust
+#[test]
+fn round_end_advance_affordable_tracks_hallway_clues_vs_threshold() {
+    use crate::state::{Act, CardCode, InvestigatorId, LocationId};
+    use crate::test_support::{test_investigator, test_location, GameStateBuilder};
+
+    // A location coded "HALL"; the investigator stands on it.
+    let mut hall = test_location(1, "Hallway");
+    hall.code = CardCode("HALL".into());
+    let mut investigator = test_investigator(1);
+    investigator.current_location = Some(LocationId(1));
+    let mut state = GameStateBuilder::new()
+        .with_location(hall)
+        .with_investigator(investigator)
+        .build();
+    state.act_deck = vec![Act { code: CardCode("_act".into()), clue_threshold: 3, resolution: None }];
+    state.act_index = 0;
+
+    state.investigators.get_mut(&InvestigatorId(1)).unwrap().clues = 2;
+    assert!(!super::round_end_advance_affordable(&state, "HALL"), "2 < 3 → not affordable");
+    state.investigators.get_mut(&InvestigatorId(1)).unwrap().clues = 3;
+    assert!(super::round_end_advance_affordable(&state, "HALL"), "3 >= 3 → affordable");
+}
+```
+(`test_location(id, name)` builds a revealed `Location` with `code = "_test_loc_{id}"`; we overwrite `.code` to `"HALL"` so `location_id_by_code` resolves it.)
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p game-core --lib round_end_advance_affordable_tracks`
+Expected: FAIL to compile — `round_end_advance_affordable` doesn't exist.
+
+- [ ] **Step 3: Add `round_end_advance_affordable` and reuse it in the resolver**
+
+In `crates/game-core/src/engine/dispatch/act_agenda.rs`, add (above `round_end_advance`):
+```rust
+/// Whether the current act's round-end group clue-spend advance is affordable:
+/// investigators at `contributor_location_code` hold at least the current act's
+/// `clue_threshold`. Shared by the offer-side eligibility predicate (01109's
+/// `with_eligibility`) and the resolve-side [`round_end_advance`], so the two
+/// can't drift. Returns `false` if there is no current act or the location is
+/// not in play (the "no investigators in the Hallway" case is subsumed — 0
+/// contributors ⇒ 0 clues ⇒ not affordable).
+#[must_use]
+pub fn round_end_advance_affordable(state: &GameState, contributor_location_code: &str) -> bool {
+    let Some(act) = state.act_deck.get(state.act_index) else {
+        return false;
+    };
+    let threshold = act.clue_threshold;
+    let Some(loc) = crate::engine::location_id_by_code(state, contributor_location_code) else {
+        return false;
+    };
+    clues_held(state, &investigators_at(state, loc)) >= u32::from(threshold)
+}
+```
+Refactor `round_end_advance`'s affordability branch to delegate — replace the inline `let threshold = …; let contributors = …; if clues_held(...) < threshold { reject }` portion so the gate reads:
+```rust
+    if !round_end_advance_affordable(cx.state, contributor_location_code) {
+        return EngineOutcome::Rejected {
+            reason: "round_end_advance: contributors no longer hold enough clues".into(),
+        };
+    }
+    // re-resolve loc + contributors for the spend (location is in play — affordable implies present)
+    let threshold = cx.state.act_deck[cx.state.act_index].clue_threshold;
+    let loc = crate::engine::location_id_by_code(cx.state, contributor_location_code)
+        .expect("affordable ⇒ contributor location in play");
+    let contributors = investigators_at(cx.state, loc);
+    spend_clues_from(cx.state, &contributors, threshold);
+    advance_act(cx);
+    EngineOutcome::Done
+```
+
+In `crates/game-core/src/lib.rs`, add `round_end_advance_affordable` to the `pub use engine::{ … }` re-export list (next to `round_end_advance`).
+
+- [ ] **Step 4: Run the affordability test**
+
+Run: `cargo test -p game-core --lib round_end_advance_affordable_tracks` — PASS.
+Run: `cargo test -p game-core --lib act_agenda` — existing `round_end_advance` tests stay green.
+
+- [ ] **Step 5: Declare the tag + predicate (the_barrier.rs) + fix docs**
+
+In `crates/cards/src/impls/the_barrier.rs`, add the tag constant:
+```rust
+/// Eligibility tag: the round-end advance may be offered only when the Hallway
+/// group can afford the act's clue threshold (RR p.2 potential gate).
+const CAN_ADVANCE_TAG: &str = "01109:can_advance";
+```
+Chain `.with_eligibility(CAN_ADVANCE_TAG)` onto the `reaction_on_event(RoundEnded, …)` ability in `abilities()`:
+```rust
+        reaction_on_event(
+            EventPattern::RoundEnded,
+            EventTiming::When,
+            native(ROUND_END_ADVANCE),
+        )
+        .with_eligibility(CAN_ADVANCE_TAG),
+```
+Add the predicate + dispatch (import `EligibilityFn`, `EvalContext`, `GameState`, `round_end_advance_affordable`):
+```rust
+use game_core::card_registry::EligibilityFn;
+use game_core::{round_end_advance_affordable, state::GameState, EvalContext};
+
+/// True when the Hallway group can afford the act's clue threshold.
+fn can_advance(state: &GameState, _ctx: &EvalContext) -> bool {
+    round_end_advance_affordable(state, HALLWAY)
+}
+
+/// Resolve The Barrier's eligibility tag.
+pub(crate) fn native_eligibility_for(tag: &str) -> Option<EligibilityFn> {
+    match tag {
+        CAN_ADVANCE_TAG => Some(can_advance as EligibilityFn),
+        _ => None,
+    }
+}
+```
+Correct the stale module/`advance_via_clue_spend` doc comments: replace "Affordability is gated in the reaction scan" / "the candidate is offered only when affordable" with an accurate description — affordability is gated by the `01109:can_advance` eligibility predicate (shared with the resolve-side `round_end_advance_affordable`); the resolve-side check is now a defensive backstop.
+
+- [ ] **Step 6: Chain The Barrier into the dispatch (impls/mod.rs)**
+
+In `crates/cards/src/impls/mod.rs`, extend the dispatch:
+```rust
+#[must_use]
+pub fn native_eligibility_for(tag: &str) -> Option<game_core::card_registry::EligibilityFn> {
+    cover_up::native_eligibility_for(tag).or_else(|| the_barrier::native_eligibility_for(tag))
+}
+```
+
+- [ ] **Step 7: Write the #470 regression integration test**
+
+In `crates/cards/tests/`, add `the_barrier_eligibility.rs` (new file; integration tests can `install(cards::REGISTRY)` without colliding). This drives the **decision point #470 hinges on** — the Barrier's eligibility predicate, resolved through the *installed* registry (the exact lookup `scan_act_agenda_reactions` performs via `ability_eligible`):
+```rust
+//! #470: The Barrier's round-end advance is gated by an eligibility predicate
+//! that must reject when the Hallway group can't afford the act's clue
+//! threshold. Exercises the predicate through the installed cards::REGISTRY —
+//! the same `native_eligibility_for("01109:can_advance")` lookup the reaction
+//! scan performs.
+use game_core::card_registry;
+use game_core::state::{Act, CardCode, GameStateBuilder, InvestigatorId, LocationId};
+use game_core::test_support::{test_investigator, test_location};
+use game_core::EvalContext;
+
+#[test]
+fn barrier_advance_eligibility_gates_on_hallway_affordability() {
+    let _ = card_registry::install(cards::REGISTRY);
+    let pred = card_registry::current()
+        .expect("registry installed")
+        .native_eligibility_for("01109:can_advance")
+        .expect("01109:can_advance is registered by The Barrier");
+
+    // The Barrier's contributor location is the Hallway (01112).
+    let mut hall = test_location(1, "Hallway");
+    hall.code = CardCode("01112".into());
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(LocationId(1));
+    let mut state = GameStateBuilder::new()
+        .with_location(hall)
+        .with_investigator(inv)
+        .build();
+    state.act_deck = vec![Act { code: CardCode("01109".into()), clue_threshold: 3, resolution: None }];
+    state.act_index = 0;
+
+    let ctx = EvalContext::for_controller(InvestigatorId(1));
+    state.investigators.get_mut(&InvestigatorId(1)).unwrap().clues = 0;
+    assert!(!pred(&state, &ctx), "#470: not offered at 0/3 clues (nobody can afford)");
+    state.investigators.get_mut(&InvestigatorId(1)).unwrap().clues = 3;
+    assert!(pred(&state, &ctx), "offered at 3/3 clues");
+}
+```
+This proves the tag is wired into `cards::REGISTRY` and the predicate gates correctly. The scan-side suppression itself is mechanical (`scan_act_agenda_reactions` → `ability_eligible` → this exact predicate, wired inert in Task 2), so this predicate-through-registry test is the #470 regression guard; a full round-end window drive is unnecessary belt-and-suspenders.
+
+- [ ] **Step 8: Run card + integration tests**
+
+Run: `cargo test -p cards --test the_barrier_eligibility` — PASS.
+Run: `cargo test -p cards` — The Barrier's existing tests stay green.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/act_agenda.rs crates/game-core/src/lib.rs crates/cards/src/impls/the_barrier.rs crates/cards/src/impls/mod.rs crates/cards/tests/the_barrier_eligibility.rs
+git commit -m "cards: The Barrier 01109 round-end advance eligibility gate (closes #470)
+
+Adds a shared round_end_advance_affordable helper (used by both the offer-side
+eligibility predicate and the resolve-side handler) and tags 01109's round-end
+reaction with 01109:can_advance, so the advance is no longer offered when the
+Hallway group can't afford the clue threshold. Corrects the stale 'gated in the
+scan' doc comments.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Gauntlet, push, PR, phase doc
+
+- [ ] **Step 1: Full local gauntlet**
+
+Run each (all green):
+```bash
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+wasm-pack test --headless --firefox crates/web
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+Fix `cargo fmt` diffs by running `cargo fmt` and folding into the relevant commit.
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+git push -u origin engine/trigger-eligibility
+gh pr create --fill
+```
+PR body: design-decisions paragraph (native eligibility predicate hook, not declarative Condition — both consumers single-consumer + heterogeneous; shared `round_end_advance_affordable` so offer/resolve can't drift; item 2 split to #471). Ensure the body has `Closes #368.` and `Closes #470.`
+
+- [ ] **Step 3: Watch CI**
+
+Run: `gh pr checks <PR#> --watch`. Fix failures with follow-up commits (no force-push).
+
+- [ ] **Step 4: Phase-7 doc (after CI green, final commit)**
+
+In `docs/phases/phase-7-the-gathering.md`, update **Remaining gate work** item 2 (the `#368` entry): mark #368 ✅ shipped (PR #N) and #470 ✅ shipped; note the eligibility predicate replaced both hardcoded stand-ins and that item 2 moved to #471. Add a **Decisions made** entry only if it passes the README test (e.g. "eligibility is a native predicate hook, not declarative Condition — promote to a Condition when a predicate recurs"). Commit:
+```bash
+git add docs/phases/phase-7-the-gathering.md
+git commit -m "docs: phase-7 — #368 eligibility predicate + #470 shipped"
+git push
+```
+
+- [ ] **Step 5: Merge only after explicit user approval**
+
+Do not merge autonomously. On approval:
+```bash
+gh pr merge <PR#> --squash --delete-branch
+```
+Confirm #368 and #470 auto-closed; `git pull` on `main`.
+
+## Self-Review
+
+**Spec coverage:**
+- `Ability.eligibility` + builder → Task 1. ✓
+- `EligibilityFn` + `native_eligibility_for` registry + cards wiring → Task 1. ✓
+- `CandidateSource::instance()` + `ability_eligible` + both scan sites → Task 2. ✓
+- Cover Up consumer + hardcode removal → Task 3. ✓
+- The Barrier consumer + shared `round_end_advance_affordable` + #470 fix + doc correction → Task 4. ✓
+- Out-of-scope (item 2, fast-window, declarative vocab) → Global Constraints; no task adds them. ✓
+- Tests: DSL/registry units, Cover Up gating, Barrier affordability + #470 integration → Tasks 1–4. ✓
+- Closes #368 + #470; phase doc → Task 5. ✓
+
+**Placeholder scan:** Clean — every code step carries complete, concrete code (Task 4's affordability unit test and the #470 integration test both use real fixtures: `test_location(id, name)` with an overwritten `.code`, `GameStateBuilder::with_location`/`with_investigator`, and the real tags/codes `"01109"`/`"01112"`). The `ability_eligible` no-tag→`true` path needs no dedicated test — every existing reaction-window test has no-tag abilities and stays green in Task 2 Step 6, which exercises exactly that path. No "TBD"/"handle errors"/"similar to Task N".
+
+**Type consistency:** `eligibility: Option<String>`, `EligibilityFn = fn(&GameState, &EvalContext) -> bool`, `native_eligibility_for`, `ability_eligible(state, ability, source, controller)`, `CandidateSource::instance()`, `round_end_advance_affordable(&GameState, &str)`, tags `"01007:has_clues"` / `"01109:can_advance"` — all used consistently across tasks. The ordering (helper wired Task 2 before hardcode removed Task 3; Cover Up tag + hardcode-removal same task) preserves green between tasks. ✓

--- a/docs/superpowers/specs/2026-06-26-trigger-eligibility-design.md
+++ b/docs/superpowers/specs/2026-06-26-trigger-eligibility-design.md
@@ -1,0 +1,116 @@
+# #368 — Trigger-level eligibility predicate (native hook)
+
+**Date:** 2026-06-26
+**Issues:** #368 (eligibility generalization) — and **closes #470** (The Barrier offered when ineligible).
+**Out of scope / split off:** #368 item 2 ("capped count") moved to **#471** (Deduction).
+
+## Problem
+
+A reaction ability must be **suppressed at scan time** when its effect can't change game state (RR p.2: *"An ability cannot initiate … if the resolution of its effect will not change the game state."*). The engine has no generic mechanism — it carries hardcoded, per-card stand-ins, and one is actually **missing**, which is a live bug:
+
+1. **Cover Up `01007`** — `scan_pending_triggers` hardcodes `if matches!(event, WouldDiscoverClues) && card.clues == 0 { continue }` (`reaction_windows.rs:245`). An emptied Cover Up would otherwise prompt a useless interrupt on every discovery.
+2. **The Barrier `01109`** (Act 2) — its round-end "investigators in the hallway may spend the requisite clues to advance" reaction has **no** affordability gate in the offer scan (`scan_act_agenda_reactions`). The resolve handler `round_end_advance` rejects on insufficient clues, but the candidate is offered regardless — **bug #470** (offered at 0/3 clues, investigator not in the Hallway). The doc comments in `the_barrier.rs` / `round_end_advance` claim "offered only when affordable" — stale; the gate was never implemented.
+
+## Solution
+
+A per-ability **native eligibility predicate**, evaluated at reaction-scan time. Chosen over a declarative `Condition` because both live consumers are single-consumer and heterogeneous (source-instance clues vs. location-group clues ≥ a dynamic act threshold), so declarative DSL vocabulary would be speculative (CLAUDE.md: no DSL primitives until 2+ cards share a pattern). A predicate is promoted to a declarative `Condition` later, when one recurs.
+
+### 1. DSL (`card-dsl`)
+
+One optional field on `Ability`:
+```rust
+pub struct Ability {
+    pub trigger: Trigger,
+    pub costs: Vec<Cost>,
+    pub effect: Effect,
+    pub usage_limit: Option<UsageLimit>,
+    pub eligibility: Option<String>,   // NEW — native eligibility tag
+}
+```
+`eligibility` is genuinely-optional (most abilities have none), so it stays implicitly-optional on the wire — serde defaults a missing `Option` to `None` (the #453 per-field carve-out, same as `usage_limit`). Plus a chaining builder:
+```rust
+impl Ability {
+    #[must_use]
+    pub fn with_eligibility(mut self, tag: impl Into<String>) -> Self {
+        self.eligibility = Some(tag.into());
+        self
+    }
+}
+```
+It lives on `Ability` (not inside the `Trigger::OnEvent` variant) — simpler than threading a field through the `Trigger` enum's many match sites, and it is only ever *consulted* in the reaction/fast scans, so it is inert on a forced ability. All existing `Ability` constructors set `eligibility: None`.
+
+### 2. Registry (`game-core` + `cards`)
+
+Parallel to `native_effect_for`:
+```rust
+// card_registry.rs
+pub type EligibilityFn = fn(&GameState, &EvalContext) -> bool;   // read-only; same EvalContext native effects receive
+
+pub struct CardRegistry {
+    // … existing …
+    pub native_eligibility_for: fn(&str) -> Option<EligibilityFn>,
+}
+// default registry: native_eligibility_for: |_| None
+```
+`cards::REGISTRY` provides a crate-level `native_eligibility_for(tag)` that dispatches to per-card fns (mirroring the existing `native_effect_for` dispatch).
+
+### 3. Scan wiring (`reaction_windows.rs`)
+
+A `CandidateSource::instance()` helper (`InPlay(id) => Some(id)`, `Board | Hand => None`) and one shared predicate evaluator:
+```rust
+fn ability_eligible(
+    state: &GameState,
+    ability: &Ability,
+    source: CandidateSource,
+    controller: InvestigatorId,
+) -> bool {
+    let Some(tag) = &ability.eligibility else { return true };          // no gate → eligible
+    let Some(reg) = card_registry::current() else { return false };     // can't verify → suppress
+    let Some(pred) = (reg.native_eligibility_for)(tag) else { return false };
+    let ctx = EvalContext::for_controller_with_optional_source(controller, source.instance());
+    pred(state, &ctx)
+}
+```
+Applied at **both** reaction-scan sites, after the trigger kind/timing/pattern match:
+- **`scan_pending_triggers`** (in-play cards → Cover Up): **delete** the hardcoded `WouldDiscoverClues && card.clues == 0` `continue`; instead `if !ability_eligible(state, ability, CandidateSource::InPlay(card.instance_id), id) { continue }`. Behaviour-preserving for Cover Up (its only reaction is the discover interrupt).
+- **`scan_act_agenda_reactions`** (acts/agendas → The Barrier): **add** `if !ability_eligible(state, ability, CandidateSource::Board, lead) { continue }`. This site has no eligibility check today — adding it is the **#470 fix**.
+
+(The fast-window scan `any_fast_play_eligible` is **not** wired now — no in-scope fast consumer; deferred until Burned Ruins 02205 lands.)
+
+### 4. Consumers
+
+**Cover Up `01007`** (`cover_up.rs`):
+- Its `reaction_on_event(WouldDiscoverClues, When, …)` ability gains `.with_eligibility("01007:has_clues")`.
+- `native_eligibility_for("01007:has_clues")` = a read-only predicate that finds the source instance via `ctx.source` (iterating the controller's `threat_area`/`cards_in_play`, as the discard native already does) and returns `clues > 0`.
+- The `card.clues == 0` hardcode leaves the engine.
+
+**The Barrier `01109`** (`the_barrier.rs`):
+- Its round-end `reaction_on_event(RoundEnded, When, …)` ability gains `.with_eligibility("01109:can_advance")`.
+- `native_eligibility_for("01109:can_advance")` = `|s, _ctx| round_end_advance_affordable(s, HALLWAY)`.
+- **New public helper** `round_end_advance_affordable(state: &GameState, contributor_location_code: &str) -> bool` (in `act_agenda.rs`, re-exported): resolves the location, sums `clues_held(investigators_at(loc))`, compares to the current act's `clue_threshold`. **`round_end_advance` (resolve) is refactored to call it**, so offer and resolve share one affordability check and cannot drift. The "investigators in the Hallway" condition is subsumed — no Hallway investigators ⇒ 0 clues ⇒ ineligible.
+- Correct the stale "offered only when affordable" doc comments to point at the real gate.
+
+### 5. What closes
+
+PR `Closes #368` (eligibility generalization complete; both stand-ins now declarative-tag-driven) **and `Closes #470`** (the Barrier offer is now suppressed when unaffordable).
+
+## Out of scope
+
+- **#368 item 2** (cap the discovery-count threaded to the interrupt) — moved to **#471**, where fixing Deduction makes it live.
+- **Pending snapshot consumers** Lone Wolf 02188 / Burned Ruins 02205 — not in corpus (Dunwich). The hook supports them later (Burned Ruins also needs fast-window wiring).
+- **Declarative `Condition` eligibility vocabulary** — deferred until a predicate recurs across 2+ cards.
+
+## Testing
+
+- **DSL/registry units:** `with_eligibility` sets the tag; default registry's `native_eligibility_for` returns `None`; `ability_eligible` returns `true` for a no-tag ability and `false` when the registry or predicate is absent.
+- **Cover Up (card/integration):** its discover interrupt is **offered** when Cover Up holds clues and **suppressed** when it holds 0 (replacing the old hardcode's coverage).
+- **The Barrier (integration, reproduces #470):** at clues `< threshold` (e.g. 0/3) the round-end advance reaction is **not** offered; at `≥ threshold` with investigators in the Hallway it **is**. A direct `round_end_advance_affordable` unit test for the boundary.
+- **Regression:** existing Cover Up and Barrier tests stay green (behaviour-preserving for the in-budget cases).
+- **CI gauntlet** (all seven jobs, strict flags) before push — touches `game-core`, `card-dsl`, `cards`.
+
+## Done criteria
+
+- The Barrier's round-end advance is not offered when the Hallway group can't afford the threshold (the #470 screenshot case no longer prompts).
+- Cover Up's interrupt is gated by a declared eligibility tag, not a hardcoded scan branch.
+- Both reaction-scan sites consult one shared `ability_eligible`; no per-card `clues`/threshold special-casing remains in the scan.
+- All seven CI jobs green.


### PR DESCRIPTION
## What & why

Reactions must be **suppressed at scan time** when their effect can't change game state (RR p.2). The engine had no generic mechanism — only hardcoded per-card stand-ins, and one was missing, which was a live bug:

- **The Barrier (Act 2, `01109`)** offered its round-end "spend the requisite clues to advance" reaction even at **0/3 clues** with nobody in the Hallway (**#470**) — the affordability gate was lost in the #434 coordinator remodel; only the resolve handler rejected.
- **Cover Up (`01007`)** carried a hardcoded `card.clues == 0` branch in `scan_pending_triggers`.

This adds a per-ability **native eligibility predicate** evaluated at reaction-scan time, and migrates both consumers to it.

## Changes

- **`Ability.eligibility: Option<String>`** + `with_eligibility(tag)` builder (card-dsl).
- **`CardRegistry.native_eligibility_for`** → `EligibilityFn = fn(&GameState, &EvalContext) -> bool` (the same `EvalContext` native effects receive), wired through `cards::REGISTRY`.
- **`ability_eligible(...)`** helper consulted in both reaction scans (`scan_pending_triggers`, `scan_act_agenda_reactions`); no tag → eligible, unresolvable tag → suppressed.
- **Cover Up** declares `01007:has_clues` (predicate: source instance still holds clues); the engine hardcode is deleted.
- **The Barrier** declares `01109:can_advance` (predicate: Hallway group affords the act threshold). A new shared `round_end_advance_affordable` backs **both** the offer predicate and the resolve handler so they can't drift. The synthetic Cover Up fixture mirrors the tag so engine-level interrupt-suppression coverage ports off the removed hardcode.

## Design decisions

- **Native predicate hook, not a declarative `Condition`.** Both live consumers are single-consumer and heterogeneous (source-instance clues vs. location-group clues ≥ a dynamic act threshold), so declarative DSL vocabulary would be speculative (CLAUDE.md: no DSL primitives until 2+ cards share a pattern). Promote to a `Condition` when a predicate recurs.
- **One shared affordability helper** for The Barrier's offer and resolve paths.

## Scope

- **#368 item 2** (cap the discovery count threaded to the interrupt) split to **#471** — it becomes live only once Deduction is fixed to a single count≥2 discovery.
- No fast-window wiring (no in-scope fast consumer); no declarative `Condition` vocabulary.

## Testing

- Cover Up predicate gating (unit + integration); The Barrier `01109:can_advance` gates on Hallway affordability (`round_end_advance_affordable` unit test + a **#470 regression integration test**); the synthetic-fixture interrupt-suppression test ports to the new mechanism.
- Full local gauntlet (all seven CI jobs, strict flags) green. Verified in-browser: The Barrier's advance no longer procs at 0 clues.

Closes #368.
Closes #470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
