### PR TITLE
engine: surface parked Fast windows as a skippable choice (closes #476)

### DIFF
--- a/crates/cards/tests/fast_play.rs
+++ b/crates/cards/tests/fast_play.rs
@@ -31,8 +31,8 @@
 
 use game_core::engine::EngineOutcome;
 use game_core::state::{
-    CardCode, CardInPlay, CardInstanceId, FastActorScope, FastWindowKind, InvestigatorId,
-    LocationId, Phase, PhaseStep,
+    CardCode, CardInPlay, CardInstanceId, Continuation, FastActorScope, FastWindowKind,
+    InvestigatorId, LocationId, MythosResume, Phase, PhaseStep,
 };
 use game_core::test_support::{
     dispatch_turn_action_unchecked, test_investigator, test_location, GameStateBuilder,
@@ -46,12 +46,15 @@ fn install_cards_registry() {
 
 #[test]
 fn fast_asset_playable_by_owner_during_permissive_window() {
-    // Owner-as-active-investigator with a window open during a
-    // non-Investigation phase: the strict pre-#103 gate would reject
-    // (phase != Investigation), but the loosened gate must accept
-    // because the window permits and the owner IS the active
-    // investigator. This is the rules-correct positive case for
-    // Fast assets.
+    // Owner-as-active-investigator with a real permissive window (MythosAfterDraws)
+    // open during a non-Investigation phase: the strict pre-#103 gate would reject
+    // (phase != Investigation), but the loosened gate must accept because the
+    // window permits and the owner IS the active investigator. This is the
+    // rules-correct positive case for Fast assets. (#476: the window now surfaces
+    // the play as a choice and auto-closes once nothing remains, so the post-play
+    // drive cascades through the MythosPhase anchor to the next phase — hence the
+    // realistic anchor; the assertion is that the play executed, not the exact
+    // post-cascade outcome.)
     let mut a = test_investigator(1);
     a.resources = 5;
     a.hand.push(CardCode::new("01030")); // Magnifying Glass — Fast.
@@ -59,8 +62,11 @@ fn fast_asset_playable_by_owner_during_permissive_window() {
         .with_investigator(a)
         .with_phase(Phase::Mythos)
         .with_active_investigator(InvestigatorId(1))
+        .with_phase_anchor(Continuation::MythosPhase {
+            resume: MythosResume::AfterDraws,
+        })
         .with_open_window(
-            FastWindowKind::Phase(PhaseStep::InvestigatorTurnBegins),
+            FastWindowKind::Phase(PhaseStep::MythosAfterDraws),
             FastActorScope::Any,
         )
         .build();
@@ -72,14 +78,20 @@ fn fast_asset_playable_by_owner_during_permissive_window() {
         },
     );
     assert!(
-        matches!(result.outcome, EngineOutcome::Done),
+        !matches!(result.outcome, EngineOutcome::Rejected { .. }),
         "Magnifying Glass plays Fast for the owner (= active investigator) during a \
          permissive window in Mythos: {:?}",
         result.outcome,
     );
     let a_after = result.state.investigators.get(&InvestigatorId(1)).unwrap();
     assert_eq!(a_after.hand.len(), 0, "card should have left hand");
-    assert_eq!(a_after.cards_in_play.len(), 1, "card should be in play");
+    assert!(
+        a_after
+            .cards_in_play
+            .iter()
+            .any(|c| c.code == CardCode::new("01030")),
+        "Magnifying Glass should be in play",
+    );
 }
 
 #[test]
@@ -202,10 +214,13 @@ fn fast_activated_ability_usable_by_non_active_investigator_when_window_permits(
     let state = GameStateBuilder::new()
         .with_investigator(a)
         .with_investigator(b)
-        .with_phase(Phase::Investigation)
+        .with_phase(Phase::Mythos)
         .with_active_investigator(InvestigatorId(1))
+        .with_phase_anchor(Continuation::MythosPhase {
+            resume: MythosResume::AfterDraws,
+        })
         .with_open_window(
-            FastWindowKind::Phase(PhaseStep::InvestigatorTurnBegins),
+            FastWindowKind::Phase(PhaseStep::MythosAfterDraws),
             FastActorScope::Any,
         )
         .build();
@@ -217,12 +232,15 @@ fn fast_activated_ability_usable_by_non_active_investigator_when_window_permits(
             ability_index: 0,
         },
     );
+    // The ability activates (resource spent). After it, Hyperawareness is still
+    // 0-cost-eligible (B has resources left), so the #476 fast window re-prompts
+    // rather than reaching Done — assert the activation executed, not the exact
+    // post-activation outcome.
     assert!(
-        matches!(result.outcome, EngineOutcome::Done),
+        !matches!(result.outcome, EngineOutcome::Rejected { .. }),
         "Hyperawareness [fast] ability should activate from non-active investigator: {:?}",
         result.outcome,
     );
-    // Verify the resource was spent.
     let b_after = result.state.investigators.get(&InvestigatorId(2)).unwrap();
     assert_eq!(b_after.resources, 4, "1 resource should have been spent");
 }

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -231,6 +231,17 @@ pub(crate) fn drive(cx: &mut Cx, outcome: EngineOutcome) -> EngineOutcome {
                     other => return other,    // re-prompt, or a suspended continuation
                 }
             }
+            // A framework Fast window on top (empty reaction candidates, so it
+            // failed the guarded arm above): surface its eligible fast plays as a
+            // skippable choice, or close it when none remain (#476). Re-examined
+            // after each fast play resolves — the re-open loop — until the player
+            // Skips or runs out of plays.
+            Some(Continuation::FastWindow { .. }) => {
+                match reaction_windows::drive_fast_window(cx) {
+                    EngineOutcome::Done => {} // closed (no eligible plays); loop on
+                    other => return other,    // the skippable prompt, or a continuation prompt
+                }
+            }
             // A skill test re-exposed on top (a mid-test window/effect closed):
             // step its driver. By the invariant it is top — no `rposition` /
             // `win_idx > st` self-location.

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -475,15 +475,34 @@ fn resume_window(cx: &mut Cx, response: &InputResponse) -> EngineOutcome {
     if has_candidates {
         return reaction_windows::resume_reaction_window(cx, response);
     }
-    if matches!(response, InputResponse::Skip) {
-        return reaction_windows::close_reaction_window(cx);
-    }
-    EngineOutcome::Rejected {
-        reason: format!(
-            "ResolveInput: a Fast-play window is open (no pending triggers); \
-             submit InputResponse::Skip to close it, got {response:?}",
-        )
-        .into(),
+    // A framework Fast window (no reaction candidates): the player either plays an
+    // eligible fast card / ability (PickSingle into the re-enumerated list) or
+    // passes (Skip). After a pick, dispatch the play and return — the `drive` loop
+    // re-examines the still-top FastWindow and re-emits (play another) or closes
+    // (#476).
+    match response {
+        InputResponse::Skip => reaction_windows::close_reaction_window(cx),
+        InputResponse::PickSingle(opt) => {
+            let i = opt.0;
+            let plays = reaction_windows::enumerate_fast_plays(cx.state);
+            let Some(action) = plays.get(i as usize).cloned() else {
+                return EngineOutcome::Rejected {
+                    reason: format!(
+                        "ResolveInput: fast-window PickSingle({i}) out of range (0..{})",
+                        plays.len(),
+                    )
+                    .into(),
+                };
+            };
+            dispatch_turn_action(cx, &action)
+        }
+        other => EngineOutcome::Rejected {
+            reason: format!(
+                "ResolveInput: a Fast-play window is open; submit PickSingle(OptionId) to play, \
+                 or Skip to pass, got {other:?}",
+            )
+            .into(),
+        },
     }
 }
 

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -1646,16 +1646,6 @@ pub(super) fn any_fast_play_eligible(state: &GameState) -> bool {
     !enumerate_fast_plays(state).is_empty()
 }
 
-/// Collect every fast play currently eligible across all investigators: Fast
-/// cards in hand ([`check_play_card`] `Ok` + `is_fast`) and 0-action
-/// [`Trigger::Activated`] abilities on cards in play ([`check_activate_ability`]
-/// `Ok`). MUST be called with the `FastWindow` on top of the stack so
-/// `check_play_card`'s `permits_fast` gate applies to the right window (#476).
-///
-/// Returns the plays as [`TurnAction`]s in deterministic (investigator,
-/// hand-index / ability-index) order — the same shape the open-turn menu
-/// dispatches via `dispatch_turn_action`, so the #476 fast-window prompt reuses
-/// that dispatch path verbatim. Empty when the registry isn't installed.
 /// Drive a framework Fast window that is on top of the stack (#476): surface the
 /// currently-eligible fast plays as a **skippable** `PickSingle`, or close the
 /// window (running its continuation) when none remain. Called by the `drive`
@@ -1683,6 +1673,16 @@ pub(super) fn drive_fast_window(cx: &mut Cx) -> EngineOutcome {
     }
 }
 
+/// Collect every fast play currently eligible across all investigators: Fast
+/// cards in hand ([`check_play_card`] `Ok` + `is_fast`) and 0-action
+/// [`Trigger::Activated`] abilities on cards in play ([`check_activate_ability`]
+/// `Ok`). MUST be called with the `FastWindow` on top of the stack so
+/// `check_play_card`'s `permits_fast` gate applies to the right window (#476).
+///
+/// Returns the plays as [`TurnAction`]s in deterministic (investigator,
+/// hand-index / ability-index) order — the same shape the open-turn menu
+/// dispatches via `dispatch_turn_action`, so the #476 fast-window prompt reuses
+/// that dispatch path verbatim. Empty when the registry isn't installed.
 pub(super) fn enumerate_fast_plays(state: &GameState) -> Vec<TurnAction> {
     let mut out = Vec::new();
     let Some(reg) = crate::card_registry::current() else {

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -15,6 +15,7 @@ use crate::action::InputResponse;
 use crate::card_data::{CardMetadata, CardType};
 use crate::card_registry;
 use crate::dsl::{Ability, EventPattern, EventTiming, Trigger, TriggerKind};
+use crate::engine::enumerate::TurnAction;
 use crate::engine::TimingEvent;
 use crate::state::TimingMode;
 use crate::state::{
@@ -1642,18 +1643,36 @@ pub(crate) fn check_activate_ability(
 /// that don't touch card data) — same fallback as
 /// [`scan_pending_triggers`].
 pub(super) fn any_fast_play_eligible(state: &GameState) -> bool {
+    !enumerate_fast_plays(state).is_empty()
+}
+
+/// Collect every fast play currently eligible across all investigators: Fast
+/// cards in hand ([`check_play_card`] `Ok` + `is_fast`) and 0-action
+/// [`Trigger::Activated`] abilities on cards in play ([`check_activate_ability`]
+/// `Ok`). MUST be called with the `FastWindow` on top of the stack so
+/// `check_play_card`'s `permits_fast` gate applies to the right window (#476).
+///
+/// Returns the plays as [`TurnAction`]s in deterministic (investigator,
+/// hand-index / ability-index) order — the same shape the open-turn menu
+/// dispatches via `dispatch_turn_action`, so the #476 fast-window prompt reuses
+/// that dispatch path verbatim. Empty when the registry isn't installed.
+pub(super) fn enumerate_fast_plays(state: &GameState) -> Vec<TurnAction> {
+    let mut out = Vec::new();
     let Some(reg) = crate::card_registry::current() else {
-        return false;
+        return out;
     };
     for (&inv_id, inv) in &state.investigators {
         // Fast events / Fast assets in hand.
         for hand_idx_usize in 0..inv.hand.len() {
-            let Ok(hand_idx) = u8::try_from(hand_idx_usize) else {
+            let Ok(hand_index) = u8::try_from(hand_idx_usize) else {
                 break;
             };
-            if let Ok(result) = check_play_card(state, inv_id, hand_idx) {
+            if let Ok(result) = check_play_card(state, inv_id, hand_index) {
                 if result.is_fast {
-                    return true;
+                    out.push(TurnAction::PlayCard {
+                        investigator: inv_id,
+                        hand_index,
+                    });
                 }
             }
         }
@@ -1666,16 +1685,20 @@ pub(super) fn any_fast_play_eligible(state: &GameState) -> bool {
                 let Trigger::Activated { action_cost: 0 } = ability.trigger else {
                     continue;
                 };
-                let Ok(ab_idx_u8) = u8::try_from(ab_idx) else {
+                let Ok(ability_index) = u8::try_from(ab_idx) else {
                     break;
                 };
-                if check_activate_ability(state, inv_id, card.instance_id, ab_idx_u8).is_ok() {
-                    return true;
+                if check_activate_ability(state, inv_id, card.instance_id, ability_index).is_ok() {
+                    out.push(TurnAction::ActivateAbility {
+                        investigator: inv_id,
+                        instance_id: card.instance_id,
+                        ability_index,
+                    });
                 }
             }
         }
     }
-    false
+    out
 }
 
 #[cfg(test)]
@@ -1951,5 +1974,20 @@ mod open_fast_window_tests {
             events.is_empty(),
             "EnemyDefeated continuation must be a no-op; events = {events:?}"
         );
+    }
+
+    /// With no fast-playable card or 0-cost ability available, the enumeration is
+    /// empty (the auto-skip path). The positive case — a real Fast card becoming
+    /// a `PlayCard` candidate — is covered by the Task 5 integration regression,
+    /// because game-core's test registry exposes no playable cards.
+    #[test]
+    fn enumerate_fast_plays_empty_when_nothing_eligible() {
+        let inv = crate::state::InvestigatorId(1);
+        let state = GameStateBuilder::new()
+            .with_phase(crate::state::Phase::Investigation)
+            .with_active_investigator(inv)
+            .with_investigator(test_investigator(1))
+            .build();
+        assert!(enumerate_fast_plays(&state).is_empty());
     }
 }

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -1656,6 +1656,33 @@ pub(super) fn any_fast_play_eligible(state: &GameState) -> bool {
 /// hand-index / ability-index) order — the same shape the open-turn menu
 /// dispatches via `dispatch_turn_action`, so the #476 fast-window prompt reuses
 /// that dispatch path verbatim. Empty when the registry isn't installed.
+/// Drive a framework Fast window that is on top of the stack (#476): surface the
+/// currently-eligible fast plays as a **skippable** `PickSingle`, or close the
+/// window (running its continuation) when none remain. Called by the `drive`
+/// loop's `FastWindow` arm — both when the window first parks and each time it is
+/// re-exposed after a fast play resolves (the re-open loop). The window stays on
+/// top across the prompt; `resume_window` dispatches the pick, or closes on Skip.
+pub(super) fn drive_fast_window(cx: &mut Cx) -> EngineOutcome {
+    let plays = enumerate_fast_plays(cx.state);
+    if plays.is_empty() {
+        // Nothing (more) to play: close + run the window's continuation.
+        return close_reaction_window(cx);
+    }
+    let options = plays
+        .iter()
+        .enumerate()
+        .map(|(i, a)| ChoiceOption {
+            id: OptionId(u32::try_from(i).unwrap_or(u32::MAX)),
+            label: a.label(cx.state),
+        })
+        .collect::<Vec<_>>();
+    EngineOutcome::AwaitingInput {
+        request: InputRequest::pick_single("Fast window — play a card or pass", options)
+            .skippable(),
+        resume_token: ResumeToken(0),
+    }
+}
+
 pub(super) fn enumerate_fast_plays(state: &GameState) -> Vec<TurnAction> {
     let mut out = Vec::new();
     let Some(reg) = crate::card_registry::current() else {

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -338,16 +338,21 @@ fn drive_to_terminal_no_commits(first: ApplyResult) -> ApplyResult {
                 outcome,
             };
         }
-        // The only `AwaitingInput`s in a no-commits drive are the commit window
-        // (PickMultiple) and the #478 acknowledge pause (Confirm); a `Done`-idle
-        // with an open window is a parked Fast player window to decline. Anything
-        // else is terminal.
+        // The `AwaitingInput`s in a no-commits drive are: the commit window
+        // (PickMultiple), the #478 acknowledge pause (Confirm), and any skippable
+        // window (a #476 fast-window prompt, a reaction window) which the
+        // no-commits drive declines with Skip. A `Done`-idle with an open window is
+        // a parked window to decline. Anything else is terminal.
         let next = if let EngineOutcome::AwaitingInput { request, .. } = &outcome {
-            match request.kind {
-                InputKind::Confirm => InputResponse::Confirm,
-                _ => InputResponse::PickMultiple {
-                    selected: Vec::new(),
-                },
+            if request.skippable {
+                InputResponse::Skip
+            } else {
+                match request.kind {
+                    InputKind::Confirm => InputResponse::Confirm,
+                    _ => InputResponse::PickMultiple {
+                        selected: Vec::new(),
+                    },
+                }
             }
         } else if matches!(outcome, EngineOutcome::Done) && !state.open_windows().is_empty() {
             InputResponse::Skip

--- a/crates/scenarios/tests/issue_476_fast_window.rs
+++ b/crates/scenarios/tests/issue_476_fast_window.rs
@@ -1,9 +1,9 @@
 //! #476 regression: a framework Fast window no longer strands. Real registries,
 //! Roland (01001), Rotting Remains (01163) on the encounter deck, a forced
 //! Cultist bag, and Magnifying Glass (01030, a Fast asset) in hand. After the
-//! Mythos draw + failed willpower test resolve, the InvestigatorTurnBegins Fast
-//! window finds a fast play eligible and surfaces a SKIPPABLE PickSingle (not a
-//! Done-idle strand). Skipping reaches the open turn; picking the option plays
+//! Mythos draw + failed willpower test resolve, the `InvestigatorTurnBegins` Fast
+//! window finds a fast play eligible and surfaces a SKIPPABLE `PickSingle` (not a
+//! `Done`-idle strand). Skipping reaches the open turn; picking the option plays
 //! the asset.
 
 use game_core::action::RosterEntry;
@@ -21,7 +21,7 @@ fn install_registries() {
 
 /// Drive to the post-Mythos-draw fast window: Roland holds Magnifying Glass,
 /// fails the Rotting Remains willpower test (Cultist -1), and the
-/// InvestigatorTurnBegins fast window prompts. Returns the state + outcome there.
+/// `InvestigatorTurnBegins` fast window prompts. Returns the state + outcome there.
 fn to_fast_window() -> (GameState, EngineOutcome) {
     let roster = vec![RosterEntry {
         investigator: CardCode("01001".into()),

--- a/crates/scenarios/tests/issue_476_fast_window.rs
+++ b/crates/scenarios/tests/issue_476_fast_window.rs
@@ -1,0 +1,116 @@
+//! #476 regression: a framework Fast window no longer strands. Real registries,
+//! Roland (01001), Rotting Remains (01163) on the encounter deck, a forced
+//! Cultist bag, and Magnifying Glass (01030, a Fast asset) in hand. After the
+//! Mythos draw + failed willpower test resolve, the InvestigatorTurnBegins Fast
+//! window finds a fast play eligible and surfaces a SKIPPABLE PickSingle (not a
+//! Done-idle strand). Skipping reaches the open turn; picking the option plays
+//! the asset.
+
+use game_core::action::RosterEntry;
+use game_core::engine::{apply, seat_and_open, EngineOutcome};
+use game_core::state::{CardCode, ChaosToken, GameState, InvestigatorId, Phase};
+use game_core::test_support::take_turn_action;
+use game_core::{Action, InputKind, InputResponse, OptionId, PlayerAction, TurnAction};
+use scenarios::{the_gathering, REGISTRY};
+
+#[ctor::ctor]
+fn install_registries() {
+    let _ = game_core::scenario_registry::install(REGISTRY);
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+}
+
+/// Drive to the post-Mythos-draw fast window: Roland holds Magnifying Glass,
+/// fails the Rotting Remains willpower test (Cultist -1), and the
+/// InvestigatorTurnBegins fast window prompts. Returns the state + outcome there.
+fn to_fast_window() -> (GameState, EngineOutcome) {
+    let roster = vec![RosterEntry {
+        investigator: CardCode("01001".into()),
+        deck: vec![],
+    }];
+    let mut state = seat_and_open(the_gathering::setup(), &roster).state;
+    state = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickMultiple { selected: vec![] },
+        }),
+    )
+    .state;
+    state.encounter_deck = vec![CardCode("01163".into())].into();
+    state.encounter_discard.clear();
+    state.chaos_bag.tokens = vec![ChaosToken::Cultist];
+    state
+        .investigators
+        .get_mut(&InvestigatorId(1))
+        .unwrap()
+        .hand
+        .push(CardCode("01030".into()));
+
+    let state = take_turn_action(state, &TurnAction::EndTurn).state;
+    let state = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    )
+    .state;
+    let r = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickMultiple { selected: vec![] },
+        }),
+    );
+    (r.state, r.outcome)
+}
+
+#[test]
+fn parked_fast_window_prompts_instead_of_stranding() {
+    let (state, outcome) = to_fast_window();
+    let EngineOutcome::AwaitingInput { request, .. } = &outcome else {
+        panic!("expected a skippable fast-window prompt, got {outcome:?} (strand regression)");
+    };
+    assert_eq!(request.kind, InputKind::PickSingle, "{request:?}");
+    assert!(
+        request.skippable,
+        "the fast window must be skippable (pass): {request:?}"
+    );
+    assert!(
+        !request.options.is_empty(),
+        "the fast window lists the eligible fast plays: {request:?}"
+    );
+    assert_eq!(state.phase, Phase::Investigation);
+    assert_eq!(state.round, 2);
+}
+
+#[test]
+fn skipping_the_fast_window_reaches_the_open_turn() {
+    let (state, _) = to_fast_window();
+    let r = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Skip,
+        }),
+    );
+    let EngineOutcome::AwaitingInput { request, .. } = &r.outcome else {
+        panic!("Skip must reach the open turn, got {:?}", r.outcome);
+    };
+    assert_eq!(request.prompt, "Choose an action");
+}
+
+#[test]
+fn playing_the_fast_card_puts_magnifying_glass_in_play() {
+    let (state, _) = to_fast_window();
+    // Option 0 is the only eligible fast play (Magnifying Glass).
+    let r = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickSingle(OptionId(0)),
+        }),
+    );
+    assert!(
+        r.state.investigators[&InvestigatorId(1)]
+            .cards_in_play
+            .iter()
+            .any(|c| c.code == CardCode("01030".into())),
+        "Magnifying Glass entered play after the fast-window pick"
+    );
+}

--- a/crates/scenarios/tests/mythos_phase.rs
+++ b/crates/scenarios/tests/mythos_phase.rs
@@ -29,7 +29,7 @@ use game_core::state::{
 };
 use game_core::test_support::{take_turn_action, TEST_INV};
 use game_core::{
-    assert_event, assert_event_sequence, Action, InputResponse, PlayerAction, TurnAction,
+    assert_event, assert_event_sequence, Action, InputKind, InputResponse, PlayerAction, TurnAction,
 };
 use scenarios::test_fixtures::synth_cards::{
     SYNTH_ENEMY_CODE, SYNTH_FAST_EVENT_CODE, SYNTH_SURGE_TREACHERY_CODE, SYNTH_TREACHERY_CODE,
@@ -715,8 +715,9 @@ fn mythos_draw_rejects_when_initial_deck_and_discard_both_empty() {
 ///
 /// This test puts a synthetic Fast event in inv1's hand, drives
 /// `DrawEncounterCard` to trigger `open_fast_window`, and asserts that
-/// the window STAYS OPEN (not auto-skipped): it remains on
-/// `state.open_windows` and the phase has not yet advanced.
+/// the window STAYS OPEN (not auto-skipped) and — post-#476 — surfaces the
+/// eligible Fast event as a **skippable** `PickSingle` prompt rather than idling
+/// silently as `Done`.
 #[test]
 fn mythos_after_draws_window_stays_open_when_fast_event_in_hand() {
     let base = synthetic::setup();
@@ -741,12 +742,22 @@ fn mythos_after_draws_window_stays_open_when_fast_event_in_hand() {
         }),
     );
 
-    // DrawEncounterCard should complete normally (Done) — the window
-    // opens but doesn't block the draw action's completion.
-    assert_eq!(
-        result.outcome,
-        EngineOutcome::Done,
-        "DrawEncounterCard should return Done even when window stays open"
+    // #476: the MythosAfterDraws window now surfaces the eligible Fast event as a
+    // skippable choice instead of idling as Done — the player can play it or pass.
+    let EngineOutcome::AwaitingInput { request, .. } = &result.outcome else {
+        panic!(
+            "MythosAfterDraws must prompt the eligible Fast play, got {:?}",
+            result.outcome
+        );
+    };
+    assert_eq!(request.kind, InputKind::PickSingle, "{request:?}");
+    assert!(
+        request.skippable,
+        "the fast window is skippable (pass): {request:?}"
+    );
+    assert!(
+        !request.options.is_empty(),
+        "the prompt lists the eligible Fast event: {request:?}"
     );
 
     // The window must remain on the stack — it was NOT auto-skipped.
@@ -799,14 +810,19 @@ fn mythos_after_draws_window_closed_by_skip_and_transitions_to_investigation() {
         .hand
         .push(CardCode(SYNTH_FAST_EVENT_CODE.into()));
 
-    // Advance through the draw to land in the open-window state.
+    // Advance through the draw to land in the open-window state (post-#476 a
+    // skippable fast-window prompt, not Done-idle).
     let draw_result = apply(
         state,
         Action::Player(PlayerAction::ResolveInput {
             response: InputResponse::Confirm,
         }),
     );
-    assert_eq!(draw_result.outcome, EngineOutcome::Done);
+    assert!(
+        matches!(draw_result.outcome, EngineOutcome::AwaitingInput { .. }),
+        "the draw lands on the skippable fast-window prompt, got {:?}",
+        draw_result.outcome
+    );
     assert!(
         !draw_result.state.open_windows().is_empty(),
         "window must be open before Skip test"
@@ -820,18 +836,21 @@ fn mythos_after_draws_window_closed_by_skip_and_transitions_to_investigation() {
         }),
     );
 
-    assert_eq!(
-        skip_result.outcome,
-        EngineOutcome::Done,
-        "Skip must return Done after closing MythosAfterDraws"
+    // MythosAfterDraws is closed; investigation_phase then opens
+    // InvestigationBegins. Because there's a Fast card in hand, that window also
+    // surfaces a skippable prompt (#476) rather than idling.
+    let EngineOutcome::AwaitingInput { request, .. } = &skip_result.outcome else {
+        panic!(
+            "Skip closes MythosAfterDraws and InvestigationBegins prompts the Fast play, got {:?}",
+            skip_result.outcome
+        );
+    };
+    assert!(
+        request.skippable,
+        "the InvestigationBegins fast window is skippable: {request:?}"
     );
 
-    // MythosAfterDraws is closed; investigation_phase then opens
-    // InvestigationBegins. Because there's a Fast card in hand,
-    // InvestigationBegins does NOT auto-skip — it stays on the stack.
-    // (Defect B was: MythosAfterDraws could NOT be closed via Skip at all;
-    // that defect is still fixed — only the old "open_windows empty" shape
-    // changes now that investigation_phase opens its own window.)
+    // MythosAfterDraws is gone; InvestigationBegins is the one open window.
     assert_eq!(
         skip_result.state.open_windows().len(),
         1,

--- a/docs/superpowers/plans/2026-06-26-476-parked-fast-window-choice.md
+++ b/docs/superpowers/plans/2026-06-26-476-parked-fast-window-choice.md
@@ -1,0 +1,495 @@
+# Parked Fast-Window Choice (#476) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a framework Fast window would park (the player holds a fast-playable card/ability), the engine emits a skippable `PickSingle` of the eligible fast plays instead of returning `Done`-idle — fixing the "Investigation round 2, no controls" strand and enabling fast-play-in-windows, with no client change.
+
+**Architecture:** Refactor `any_fast_play_eligible` into `enumerate_fast_plays` (returns the eligible `TurnAction`s). Add a drive-loop arm for a top `FastWindow` that emits a skippable `PickSingle` of those plays (or closes the window when none remain). Route the resume: `PickSingle(OptionId)` dispatches the chosen fast play via the existing `dispatch_turn_action`, then the drive loop re-examines the still-top `FastWindow` and re-emits (play another) or closes — `Skip` keeps its existing "close + proceed" meaning.
+
+**Tech Stack:** Rust, `game-core` engine (no I/O, wasm32-compatible kernel), the existing `Continuation::FastWindow` / `open_fast_window` machinery, `TurnAction` enumeration + `dispatch_turn_action`.
+
+## Global Constraints
+
+- **CI gauntlet (warnings-as-errors).** Before pushing, run all of: `RUSTFLAGS="-D warnings" cargo test --all --all-features`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo fmt --check`; `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`; `cargo build -p web --target wasm32-unknown-unknown`; `wasm-pack test --headless --firefox crates/web`; `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`.
+- **Kernel purity.** `game-core` has no I/O and no presentation; this is a pure engine change. No client code changes (the existing skippable `PickSingle` rendering handles the new prompt).
+- **Validate-first / mutate-second.** Resume handlers check preconditions and return `Rejected` (state/events unchanged) before mutating; out-of-range `OptionId` rejects.
+- **`permits_fast` correctness.** `enumerate_fast_plays` MUST be called while the `FastWindow` is the top window (so `check_play_card`'s `top_window().permits_fast(investigator)` gate applies). Both call sites (drive loop, resume) satisfy this.
+- **No behavior change when no fast play is eligible.** A window with no eligible fast play still auto-skips to `Done`/next prompt exactly as today.
+
+---
+
+### Task 1: `enumerate_fast_plays` — collect eligible fast plays
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (`any_fast_play_eligible`, ~line 1219; imports near top)
+- Test: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Produces: `pub(super) fn enumerate_fast_plays(state: &GameState) -> Vec<crate::engine::enumerate::TurnAction>` — the eligible fast plays (Fast card plays + 0-cost activated abilities), in investigator/hand/ability order.
+- `any_fast_play_eligible(state)` is reimplemented as `!enumerate_fast_plays(state).is_empty()`.
+
+- [ ] **Step 1: Write the failing test**
+
+`game-core`'s own test registry (`install_test_registry`) returns `None` abilities and only knows the `TEST_INV` investigator code, so there is **no in-crate fast-playable card** to enumerate. The in-crate unit test therefore covers only the **empty** case; the positive enumeration (a real Fast card → `PlayCard` candidate) is covered by the integration regression in **Task 5** (real `cards` registry + Magnifying Glass). In `crates/game-core/src/engine/dispatch/reaction_windows.rs`'s `#[cfg(test)] mod tests`, add:
+
+```rust
+    /// With no fast-playable card or 0-cost ability available, the enumeration is
+    /// empty (the auto-skip path). The positive case — a real Fast card becoming
+    /// a `PlayCard` candidate — is covered by the Task 5 integration regression,
+    /// because game-core's test registry exposes no playable cards.
+    #[test]
+    fn enumerate_fast_plays_empty_when_nothing_eligible() {
+        let inv = crate::state::InvestigatorId(1);
+        let state = crate::test_support::GameStateBuilder::new()
+            .with_phase(crate::state::Phase::Investigation)
+            .with_active_investigator(inv)
+            .with_investigator(crate::test_support::fixtures::test_investigator(1))
+            .build();
+        assert!(enumerate_fast_plays(&state).is_empty());
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p game-core --lib enumerate_fast_plays`
+Expected: FAIL — `enumerate_fast_plays` not found.
+
+- [ ] **Step 3: Implement `enumerate_fast_plays`; reimplement `any_fast_play_eligible` on top**
+
+In `crates/game-core/src/engine/dispatch/reaction_windows.rs`, add `use crate::engine::enumerate::TurnAction;` to the imports if not present, then replace the body of `any_fast_play_eligible` (~line 1219) and add the new function. The new function mirrors the existing iteration exactly, but pushes `TurnAction`s instead of returning `true`:
+
+```rust
+/// Collect every fast play currently eligible across all investigators: Fast
+/// cards in hand (`check_play_card` Ok + `is_fast`) and 0-action `Activated`
+/// abilities on cards in play (`check_activate_ability` Ok). MUST be called with
+/// the `FastWindow` on top of the stack so `check_play_card`'s `permits_fast`
+/// gate applies to the right window (#476). Returns the plays as `TurnAction`s
+/// in deterministic (investigator, hand-index / ability-index) order — the same
+/// shape the open-turn menu dispatches via `dispatch_turn_action`.
+pub(super) fn enumerate_fast_plays(state: &GameState) -> Vec<TurnAction> {
+    let mut out = Vec::new();
+    let Some(reg) = crate::card_registry::current() else {
+        return out;
+    };
+    for (&inv_id, inv) in &state.investigators {
+        // Fast events / Fast assets in hand.
+        for hand_idx_usize in 0..inv.hand.len() {
+            let Ok(hand_index) = u8::try_from(hand_idx_usize) else {
+                break;
+            };
+            if let Ok(result) = check_play_card(state, inv_id, hand_index) {
+                if result.is_fast {
+                    out.push(TurnAction::PlayCard {
+                        investigator: inv_id,
+                        hand_index,
+                    });
+                }
+            }
+        }
+        // 0-action Activated abilities on cards in play.
+        for card in &inv.cards_in_play {
+            let Some(abilities) = (reg.abilities_for)(&card.code) else {
+                continue;
+            };
+            for (ab_idx, ability) in abilities.iter().enumerate() {
+                let Trigger::Activated { action_cost: 0 } = ability.trigger else {
+                    continue;
+                };
+                let Ok(ability_index) = u8::try_from(ab_idx) else {
+                    break;
+                };
+                if check_activate_ability(state, inv_id, card.instance_id, ability_index).is_ok() {
+                    out.push(TurnAction::ActivateAbility {
+                        investigator: inv_id,
+                        instance_id: card.instance_id,
+                        ability_index,
+                    });
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Whether any fast play is currently eligible (the boolean gate used by
+/// `open_fast_window`'s park-vs-skip decision). Thin wrapper over
+/// [`enumerate_fast_plays`].
+pub(super) fn any_fast_play_eligible(state: &GameState) -> bool {
+    !enumerate_fast_plays(state).is_empty()
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p game-core --lib enumerate_fast_plays any_fast_play`
+Expected: PASS.
+
+- [ ] **Step 5: Run the engine suite (no churn from the refactor)**
+
+Run: `RUSTFLAGS="-D warnings" cargo test -p game-core`
+Expected: PASS — `any_fast_play_eligible` keeps identical semantics.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/reaction_windows.rs
+git commit -m "engine: enumerate_fast_plays — collect eligible fast plays (#476)"
+```
+
+---
+
+### Task 2: Surface a parked Fast window as a skippable choice
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs` (add `drive_fast_window`; imports)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (drive loop, add a `FastWindow` arm after ~line 233)
+- Test: covered by Task 5's integration regression (a parked window needs the real registry + a real fast card); add a focused engine assertion here only if a synthetic fast card is available (see Task 1 note).
+
+**Interfaces:**
+- Consumes: `enumerate_fast_plays` (Task 1); `close_reaction_window` (existing).
+- Produces: `pub(super) fn drive_fast_window(cx: &mut Cx) -> EngineOutcome` — with a `FastWindow` on top: if `enumerate_fast_plays` is non-empty, return `AwaitingInput { PickSingle(plays), skippable }`; else `close_reaction_window(cx)` (pop + run continuation).
+
+- [ ] **Step 1: Implement `drive_fast_window`**
+
+In `crates/game-core/src/engine/dispatch/reaction_windows.rs`, add (ensure imports for `ChoiceOption`, `OptionId`, `InputRequest`, `ResumeToken`, `EngineOutcome`, `TurnAction` — most are already used in this file; add what's missing):
+
+```rust
+/// Drive a framework Fast window that is on top of the stack (#476): surface the
+/// currently-eligible fast plays as a **skippable** `PickSingle`, or close the
+/// window (running its continuation) when none remain. Called by the `drive`
+/// loop's `FastWindow` arm — both when the window first parks and each time it is
+/// re-exposed after a fast play resolves (the re-open loop). The window stays on
+/// top across the prompt; `resume_window` dispatches the pick or closes on Skip.
+pub(super) fn drive_fast_window(cx: &mut Cx) -> EngineOutcome {
+    let plays = enumerate_fast_plays(cx.state);
+    if plays.is_empty() {
+        // Nothing (more) to play: close + run the window's continuation.
+        return close_reaction_window(cx);
+    }
+    let options = plays
+        .iter()
+        .enumerate()
+        .map(|(i, a)| ChoiceOption {
+            id: OptionId(u32::try_from(i).unwrap_or(u32::MAX)),
+            label: a.label(cx.state),
+        })
+        .collect::<Vec<_>>();
+    EngineOutcome::AwaitingInput {
+        request: InputRequest::pick_single(
+            "Fast window — play a card or pass",
+            options,
+        )
+        .skippable(),
+        resume_token: ResumeToken(0),
+    }
+}
+```
+
+- [ ] **Step 2: Add the drive-loop `FastWindow` arm**
+
+In `crates/game-core/src/engine/dispatch/mod.rs`, in the `drive` loop's `match top`, immediately AFTER the existing guarded window arm (the `TimingPointWindow | FastWindow` arm ending ~line 233) and BEFORE the `SkillTest` arm, add:
+
+```rust
+            // A framework Fast window on top (empty reaction candidates, so it
+            // failed the guarded arm above): surface its eligible fast plays as a
+            // skippable choice, or close it when none remain (#476). Re-examined
+            // after each fast play resolves — the re-open loop — until the player
+            // Skips or runs out of plays.
+            Some(Continuation::FastWindow { .. }) => {
+                match reaction_windows::drive_fast_window(cx) {
+                    EngineOutcome::Done => {} // closed (no eligible plays); loop on
+                    other => return other,    // the skippable prompt, or a continuation prompt
+                }
+            }
+```
+
+- [ ] **Step 3: Verify it compiles and the engine suite still passes**
+
+Run: `RUSTFLAGS="-D warnings" cargo test -p game-core`
+Expected: PASS to compile. Some tests that drive a sequence where a fast window now PROMPTS (previously idled to `Done`) may now fail by reaching an unexpected `AwaitingInput` — that is the expected blast radius. Note any failures; they are fixed in Task 4 (the no-commits driver) and by driving one more `Skip` where a test asserted `Done`. If a failure is a test that legitimately expects the old `Done`, update it to drive the `Skip` (or assert the new prompt) — record each in the commit message.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/reaction_windows.rs crates/game-core/src/engine/dispatch/mod.rs
+git commit -m "engine: surface a parked Fast window as a skippable PickSingle (#476)"
+```
+
+---
+
+### Task 3: Resume — play the chosen fast card, or pass
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (`resume_window`, ~line 453)
+- Test: covered by Task 5's integration regression (needs a real fast card to dispatch).
+
+**Interfaces:**
+- Consumes: `enumerate_fast_plays` (Task 1); `dispatch_turn_action` (existing, mod.rs); `close_reaction_window` (existing).
+- Produces: `resume_window` handles a top framework `FastWindow` with `PickSingle(OptionId)` → dispatch the i-th fast play; `Skip` → close (existing).
+
+- [ ] **Step 1: Extend `resume_window`**
+
+In `crates/game-core/src/engine/dispatch/mod.rs`, replace the pure-Fast-gate tail of `resume_window` (the `if matches!(response, InputResponse::Skip) { … } else { Rejected }` block, ~line 467) with a `match` that also routes `PickSingle`:
+
+```rust
+    // A framework Fast window (no reaction candidates): the player either plays
+    // an eligible fast card / ability (PickSingle into the re-enumerated list) or
+    // passes (Skip). After a pick, dispatch the play and return — the `drive`
+    // loop re-examines the still-top FastWindow and re-emits (play another) or
+    // closes (#476).
+    match response {
+        InputResponse::Skip => reaction_windows::close_reaction_window(cx),
+        InputResponse::PickSingle(OptionId(i)) => {
+            let plays = reaction_windows::enumerate_fast_plays(cx.state);
+            let Some(action) = plays.get(*i as usize).cloned() else {
+                return EngineOutcome::Rejected {
+                    reason: format!(
+                        "ResolveInput: fast-window PickSingle({i}) out of range (0..{})",
+                        plays.len(),
+                    )
+                    .into(),
+                };
+            };
+            dispatch_turn_action(cx, &action)
+        }
+        other => EngineOutcome::Rejected {
+            reason: format!(
+                "ResolveInput: a Fast-play window is open; submit PickSingle(OptionId) to \
+                 play, or Skip to pass, got {other:?}",
+            )
+            .into(),
+        },
+    }
+```
+
+(Keep the `has_candidates` reaction-window branch above this unchanged. Add `use crate::engine::OptionId;` to the file's imports if not already in scope — `OptionId` is used elsewhere in mod.rs, so it likely is.)
+
+- [ ] **Step 2: Verify compile + engine suite**
+
+Run: `RUSTFLAGS="-D warnings" cargo test -p game-core`
+Expected: compiles; same blast-radius notes as Task 2 Step 3 (fixed in Task 4 + Task 5).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/mod.rs
+git commit -m "engine: resume a Fast window — play the chosen fast card or pass (#476)"
+```
+
+---
+
+### Task 4: Test-support — Skip skippable prompts in the no-commits driver
+
+**Files:**
+- Modify: `crates/game-core/src/test_support/resolver.rs` (`drive_to_terminal_no_commits`, the `let next = …` block)
+- Test: `crates/game-core/src/test_support/resolver.rs` (`#[cfg(test)] mod tests`) — optional focused test; primarily exercised by Task 5.
+
+**Interfaces:**
+- Consumes: the new fast-window prompt (Tasks 2–3) is a `skippable` `AwaitingInput`.
+- Produces: `drive_to_terminal_no_commits` answers any `skippable` `AwaitingInput` with `Skip`.
+
+- [ ] **Step 1: Update the response selection**
+
+In `crates/game-core/src/test_support/resolver.rs`, in `drive_to_terminal_no_commits`, change the `AwaitingInput` branch so a skippable prompt is declined with `Skip` (a no-commits drive declines every optional window). Replace the `let next = if let EngineOutcome::AwaitingInput { request, .. } = &outcome { … }` head:
+
+```rust
+        let next = if let EngineOutcome::AwaitingInput { request, .. } = &outcome {
+            if request.skippable {
+                // A skippable window (a #476 fast-window prompt, a reaction
+                // window): the no-commits drive declines it.
+                InputResponse::Skip
+            } else {
+                match request.kind {
+                    InputKind::Confirm => InputResponse::Confirm,
+                    _ => InputResponse::PickMultiple {
+                        selected: Vec::new(),
+                    },
+                }
+            }
+        } else if matches!(outcome, EngineOutcome::Done) && !state.open_windows().is_empty() {
+            InputResponse::Skip
+        } else {
+            return ApplyResult {
+                state,
+                events,
+                outcome,
+            };
+        };
+```
+
+- [ ] **Step 2: Run the resolver + the previously-blast-radius tests**
+
+Run: `RUSTFLAGS="-D warnings" cargo test -p game-core`
+Expected: the no-commits-driver-mediated failures from Tasks 2–3 now PASS (the driver Skips the fast-window prompt). Any remaining failures are scripted-resolver tests that must add a `.skip()` / drive the prompt — fix each by driving the Skip or asserting the new prompt.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/game-core/src/test_support/resolver.rs
+git commit -m "test: no-commits driver Skips skippable fast-window prompts (#476)"
+```
+
+---
+
+### Task 5: Regression test — the real Gathering strand is fixed
+
+**Files:**
+- Create: `crates/scenarios/tests/issue_476_fast_window.rs` (a clean regression test; replaces the untracked debugging scratch `issue_476_repro.rs`, which is deleted/not committed)
+- Modify: none.
+
+**Interfaces:**
+- Consumes: the full fix (Tasks 1–4) through the real `cards` + `scenarios` registries.
+
+- [ ] **Step 1: Write the regression test**
+
+Create `crates/scenarios/tests/issue_476_fast_window.rs`:
+
+```rust
+//! #476 regression: a framework Fast window no longer strands. Real registries,
+//! Roland (01001), Rotting Remains (01163) on the encounter deck, a forced
+//! Cultist bag, and Magnifying Glass (01030, a Fast asset) in hand. After the
+//! Mythos draw + failed willpower test resolve, the InvestigatorTurnBegins Fast
+//! window finds a fast play eligible and surfaces a SKIPPABLE PickSingle (not a
+//! Done-idle strand). Skipping reaches the open turn; picking the option plays
+//! the asset.
+
+use game_core::action::RosterEntry;
+use game_core::engine::{apply, seat_and_open, EngineOutcome};
+use game_core::state::{CardCode, ChaosToken, GameState, InvestigatorId, Phase};
+use game_core::test_support::take_turn_action;
+use game_core::{Action, InputKind, InputResponse, OptionId, PlayerAction, TurnAction};
+use scenarios::{the_gathering, REGISTRY};
+
+#[ctor::ctor]
+fn install_registries() {
+    let _ = game_core::scenario_registry::install(REGISTRY);
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+}
+
+/// Drive to the post-Mythos-draw fast window: Roland holds Magnifying Glass,
+/// fails the Rotting Remains willpower test (Cultist −1), and the
+/// InvestigatorTurnBegins fast window prompts. Returns the state + outcome there.
+fn to_fast_window() -> (GameState, EngineOutcome) {
+    let roster = vec![RosterEntry {
+        investigator: CardCode("01001".into()),
+        deck: vec![],
+    }];
+    let mut state = seat_and_open(the_gathering::setup(), &roster).state;
+    state = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickMultiple { selected: vec![] },
+        }),
+    )
+    .state;
+    state.encounter_deck = vec![CardCode("01163".into())].into();
+    state.encounter_discard.clear();
+    state.chaos_bag.tokens = vec![ChaosToken::Cultist];
+    state
+        .investigators
+        .get_mut(&InvestigatorId(1))
+        .unwrap()
+        .hand
+        .push(CardCode("01030".into()));
+
+    let state = take_turn_action(state, &TurnAction::EndTurn).state;
+    let state = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Confirm,
+        }),
+    )
+    .state;
+    let r = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickMultiple { selected: vec![] },
+        }),
+    );
+    (r.state, r.outcome)
+}
+
+#[test]
+fn parked_fast_window_prompts_instead_of_stranding() {
+    let (state, outcome) = to_fast_window();
+    let EngineOutcome::AwaitingInput { request, .. } = &outcome else {
+        panic!("expected a skippable fast-window prompt, got {outcome:?} (strand regression)");
+    };
+    assert_eq!(request.kind, InputKind::PickSingle, "{request:?}");
+    assert!(request.skippable, "the fast window must be skippable (pass): {request:?}");
+    assert!(
+        !request.options.is_empty(),
+        "the fast window lists the eligible fast plays: {request:?}"
+    );
+    assert_eq!(state.phase, Phase::Investigation);
+    assert_eq!(state.round, 2);
+}
+
+#[test]
+fn skipping_the_fast_window_reaches_the_open_turn() {
+    let (state, _) = to_fast_window();
+    let r = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::Skip,
+        }),
+    );
+    let EngineOutcome::AwaitingInput { request, .. } = &r.outcome else {
+        panic!("Skip must reach the open turn, got {:?}", r.outcome);
+    };
+    assert_eq!(request.prompt, "Choose an action");
+}
+
+#[test]
+fn playing_the_fast_card_puts_magnifying_glass_in_play() {
+    let (state, _) = to_fast_window();
+    // Option 0 is the only eligible fast play (Magnifying Glass).
+    let r = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickSingle(OptionId(0)),
+        }),
+    );
+    assert!(
+        r.state.investigators[&InvestigatorId(1)]
+            .cards_in_play
+            .iter()
+            .any(|c| c.code == CardCode("01030".into())),
+        "Magnifying Glass entered play after the fast-window pick"
+    );
+}
+```
+
+- [ ] **Step 2: Run the regression test**
+
+Run: `cargo test -p scenarios --test issue_476_fast_window`
+Expected: PASS (all three).
+
+- [ ] **Step 3: Delete the debugging scratch file (if present)**
+
+```bash
+rm -f crates/scenarios/tests/issue_476_repro.rs
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/scenarios/tests/issue_476_fast_window.rs
+git rm --ignore-unmatch crates/scenarios/tests/issue_476_repro.rs
+git commit -m "test: regression for the #476 parked-fast-window strand"
+```
+
+---
+
+### Final: full CI gauntlet
+
+- [ ] **Run the complete gauntlet** (all seven jobs, from Global Constraints). Fix any `fmt`/`clippy`/`doc` findings. Pay attention to the `test` job for any remaining blast-radius failures (a test that drove past a now-prompting fast window) and resolve each by driving the `Skip` (or asserting the new prompt) — never by suppressing the prompt.
+- [ ] **No phase-doc update.** #476 is an unmilestoned `bug`/`engine`/`p1-next` issue not tracked in any `docs/phases/*` doc (consistent with its sibling bug/QoL fixes); do not invent a phase-doc entry.
+
+## Notes for the implementer
+
+- **Why no client change:** the engine now emits `AwaitingInput { PickSingle, skippable }` for a parked fast window; `AwaitingInputView`'s existing PickSingle arm renders the option buttons and the Skip control renders the pass. The strand was purely "client renders nothing for `Done`."
+- **Re-open loop is automatic:** `resume_window`'s `PickSingle` arm dispatches the play and returns; `apply` then runs the `drive` loop, which re-examines the still-top `FastWindow` via the Task 2 arm and re-emits the prompt (play another) or closes (no more plays). No explicit loop code.
+- **`permits_fast`:** never call `enumerate_fast_plays` without the `FastWindow` on top — both call sites (drive loop, resume) satisfy this; a future caller must too.
+- Design doc: `docs/superpowers/specs/2026-06-26-476-parked-fast-window-choice-design.md`.
+```

--- a/docs/superpowers/specs/2026-06-26-476-parked-fast-window-choice-design.md
+++ b/docs/superpowers/specs/2026-06-26-476-parked-fast-window-choice-design.md
@@ -1,0 +1,167 @@
+# #476 — Surface parked Fast windows as a skippable choice
+
+**Issue:** [#476](https://github.com/talelburg/eldritch/issues/476) — Stranded
+state after a Mythos skill-test treachery (Rotting Remains): board shows
+Investigation round 2 with no input controls and no rejection. Labels: `bug`,
+`engine`, `p1-next` (playability blocker).
+
+## Root cause (confirmed by reproduction)
+
+A framework **Fast player window** (`Continuation::FastWindow`, e.g.
+`Phase(InvestigatorTurnBegins)`) opens at the start of the Investigation turn.
+When the player holds a **fast-play-eligible card**, `open_fast_window`
+(`reaction_windows.rs`) finds an eligible play and **parks** the window —
+returning `EngineOutcome::Done` with the `FastWindow` still on the continuation
+stack, *not* `AwaitingInput`. This is the engine's intentional "Done-idle + open
+window = awaiting a fast-play-or-pass" protocol (the test resolver honors it; the
+`apply` drive loop idles such a window).
+
+The **web client renders only when the outcome is `AwaitingInput`** (`input.rs`);
+nothing inspects `state.open_windows()`. So a parked Fast window yields **no
+controls and no rejection** — the exact symptom. It is **independent of #478**
+(the acknowledge step) and of the skill-test/symbol-token effects (those resolve
+correctly).
+
+Reproduced in a pure-engine test (`crates/scenarios/tests/issue_476_repro.rs`):
+real registries, Roland (01001), Rotting Remains (01163) on the encounter deck, a
+forced Cultist bag, **and Magnifying Glass (01030, a Fast asset) in hand**. After
+the Mythos draw + failed willpower test resolve, the state is
+`phase=Investigation, round=2, outcome=Done, continuations=[InvestigationPhase,
+FastWindow{InvestigatorTurnBegins}]`, `open_windows=1`. With an *empty* hand the
+window auto-skips and the open turn appears normally — which is why earlier
+synthetic repros (empty deck) never stranded.
+
+Beyond the strand, this exposes a broader gap: the web client currently has **no
+way to play fast cards in any framework window** — when such a window auto-skips
+the player never notices; when it parks the player strands.
+
+## Goal
+
+When a framework Fast window has eligible fast plays, surface them to the player
+as a **skippable choice** (play a fast card / activate a 0-cost ability, or pass)
+instead of parking silently as `Done`. This fixes the strand and delivers
+fast-play-in-windows using the client's existing `PickSingle` + `Skip` rendering.
+
+## Decision (from brainstorming)
+
+Fix **engine-side**: a parked Fast window emits
+`AwaitingInput { PickSingle(<fast candidates>), skippable }` rather than `Done`.
+The candidate set includes **both** fast card plays and 0-cost activated
+abilities. After a fast play, the window **re-opens** (the player may play more)
+until they Skip. The web client needs **no change** — its existing skippable
+`PickSingle` rendering handles it.
+
+## Design
+
+### 1. Enumerate fast candidates
+
+Refactor the existing `any_fast_play_eligible(state) -> bool`
+(`dispatch/reaction_windows.rs`) into:
+
+```
+fn enumerate_fast_plays(state: &GameState) -> Vec<TurnAction>
+```
+
+It walks exactly what `any_fast_play_eligible` walks today, collecting the
+eligible plays as `TurnAction`s instead of short-circuiting to `true`:
+
+- **Fast cards in hand** — for each `inv` and `hand_index`,
+  `check_play_card(state, inv, hand_index)` is `Ok` *and* `result.is_fast` →
+  `TurnAction::PlayCard { investigator, hand_index }`.
+- **0-action activated abilities** — for each card in play with a
+  `Trigger::Activated { action_cost: 0 }` ability where
+  `check_activate_ability(state, inv, instance_id, ability_index)` is `Ok` →
+  `TurnAction::ActivateAbility { investigator, instance_id, ability_index }`.
+
+`permits_fast` gating is **already applied** by `check_play_card` (it reads
+`state.top_window().permits_fast(investigator)`), so this is enumerated *while
+the FastWindow is on the stack* and respects each window's actor scope
+(turn-begin permits the active investigator; mythos-after-draws permits anyone).
+
+`any_fast_play_eligible(state)` becomes `!enumerate_fast_plays(state).is_empty()`
+(retain the name where call sites want the bool, or inline).
+
+### 2. Emit a skippable choice instead of `Done`
+
+In `open_fast_window`, the parked branch (today: `EngineOutcome::Done` with the
+window left on the stack) becomes: build a `PickSingle` from
+`enumerate_fast_plays` (each `OptionId(i)` indexes the list; label via
+`TurnAction::label(state)`), mark it `.skippable()`, and return
+`AwaitingInput { request, resume_token: ResumeToken(0) }`. Mirrors the open-turn
+`turn_menu` builder, but skippable and filtered to fast plays.
+
+The auto-skip branch (no eligible plays) is **unchanged**: pop the window and run
+the continuation inline (still resolves to `Done`/next prompt). So windows with
+nothing to do behave exactly as before — no churn there.
+
+A `FastWindow` re-exposed on top by the `apply` drive loop must likewise emit
+this prompt rather than idling. The cleanest single source of truth is a helper
+`emit_fast_window(cx) -> EngineOutcome` that both `open_fast_window` (parked
+branch) and the resume path call; the drive-loop `FastWindow` idle arm routes a
+candidate-bearing window through it.
+
+### 3. Resume routing
+
+The top-frame `FastWindow` is already routed to `resume_window`
+(`dispatch/mod.rs`) on `ResolveInput`. Extend it:
+
+- `Skip` → existing behavior: `close_reaction_window` → run the window's
+  continuation → proceed (e.g. to the open-turn menu).
+- `PickSingle(OptionId(i))` → re-enumerate `enumerate_fast_plays`, dispatch the
+  i-th `TurnAction` via the existing `dispatch_turn_action`, then **re-open**:
+  re-enumerate; if any plays remain, `emit_fast_window` again (the player may
+  play another); else close the window and run its continuation.
+  - Bounds-check `i` against the re-enumerated list; out-of-range → `Rejected`
+    (mirrors the open-turn `OptionId` bounds arm).
+- Any other response → `Rejected` with a clear reason.
+
+Re-enumeration at resume (no stored option list) matches the open-turn pattern
+and stays correct if the playable set changes after a play.
+
+### 4. Client
+
+No change. The engine now emits `AwaitingInput { PickSingle, skippable }`, which
+`AwaitingInputView`'s existing PickSingle arm + Skip control render directly:
+option buttons for each fast play, a Skip button to pass.
+
+### 5. Blast radius
+
+Every framework Fast window (`InvestigationBegins`, `InvestigatorTurnBegins`,
+`MythosAfterDraws`, `UpkeepBegins`) now prompts when a fast play is available,
+instead of idling to `Done`. Affected:
+
+- **`drive_to_terminal_no_commits`** (`test_support/resolver.rs`) currently
+  treats "`Done` + open window" as "send `Skip`". It must instead answer a
+  **skippable** `AwaitingInput` (the fast-window prompt) with `Skip`. Rule: in
+  the no-commits driver, a `request.skippable` prompt → `Skip`.
+- A handful of integration tests that drive a sequence where a fast window parks
+  will shift from asserting `Done` to driving one more `Skip` (or asserting the
+  new prompt). Most test hands hold no fast card, so their windows still
+  auto-skip (`Done`) — the churn is expected to be small. Quantified during
+  planning by running the full suite.
+
+### 6. Testing
+
+- **Regression** (`crates/scenarios/tests/issue_476_repro.rs`, promoted from the
+  debugging scratch file): real registries + Roland + Rotting Remains + Cultist
+  bag + Magnifying Glass in hand. After commit-nothing, the outcome is
+  `AwaitingInput { PickSingle, skippable }` (not `Done`+open-window); the option
+  list includes the Magnifying Glass play; `Skip` reaches the open turn; picking
+  the option plays the asset (and the window re-opens / then Skip proceeds).
+- **Engine units** (`reaction_windows.rs` `#[cfg(test)]`): `enumerate_fast_plays`
+  returns the expected `TurnAction`s for a fast card + a 0-cost ability and
+  `[]` when none; a parked window emits the skippable PickSingle; the empty case
+  still returns `Done` via inline auto-skip; the re-open loop (play one →
+  prompt again → Skip → close); out-of-range OptionId rejects.
+- **Harness**: `drive_to_terminal_no_commits` Skips the fast-window prompt
+  (covered by an existing or new no-commits drive that parks a window).
+
+## Out of scope
+
+- Reaction (timing-point) windows already emit `AwaitingInput{skippable}` — only
+  framework `FastWindow`s change here.
+- Multiplayer fast-window arbitration (who acts first across investigators) —
+  solo scope: `enumerate_fast_plays` iterates all investigators but solo has one,
+  and `permits_fast` already gates per window.
+- Any change to which windows open or to fast-play *rules* — this only changes
+  how an already-open, already-parking window is *surfaced*.


### PR DESCRIPTION
## Summary

Fixes the playability blocker where the game stranded at "Investigation round 2 — no controls, no rejection." Root cause: a framework **Fast player window** (`Continuation::FastWindow`, e.g. `Phase(InvestigatorTurnBegins)`) parked as `EngineOutcome::Done` (idle, window left on the stack) whenever the player held a fast-playable card, and the web client only renders `AwaitingInput` — so a parked window showed nothing. Independent of #478 (the strand pre-dates it).

The fix is engine-side with **no client change**: when a framework Fast window is on top and has eligible fast plays, the engine now emits a **skippable `PickSingle`** of those plays (play a fast card / 0-cost ability, or Skip to pass) instead of `Done`-idle. The client's existing skippable `PickSingle` rendering handles it.

## What changed

- **`enumerate_fast_plays(state) -> Vec<TurnAction>`** — refactor of `any_fast_play_eligible` (now `!enumerate_fast_plays(..).is_empty()`); collects Fast card plays + 0-cost activated abilities. MUST run with the `FastWindow` on top so `check_play_card`'s `permits_fast` gate applies.
- **`drive_fast_window`** + a new `drive`-loop `FastWindow` arm — emits the skippable prompt, or `close_reaction_window` when none remain. The drive loop re-examines the still-top window after each play, giving the **re-open loop** (play multiple fast cards) for free.
- **`resume_window`** — `PickSingle(OptionId)` re-enumerates, bounds-checks (rejects out-of-range, state untouched), and dispatches the chosen fast play via the existing `dispatch_turn_action`; `Skip` keeps closing.
- **Test-support** — `drive_to_terminal_no_commits` now declines any skippable prompt with `Skip` (the semantically correct no-commits answer; was a type-mismatched `PickMultiple{empty}`).

## Blast radius

Every framework Fast window now prompts (skippable) when a fast play is available, instead of idling as `Done`. Updated `fast_play.rs` (realistic anchored windows) and `mythos_phase.rs` (assert the prompt) accordingly; no other tests changed.

## Test notes

- New regression `crates/scenarios/tests/issue_476_fast_window.rs`: real Gathering + Roland + Rotting Remains + Cultist + Magnifying Glass in hand → the post-Mythos window now surfaces a skippable `PickSingle` (not a `Done` strand); Skip reaches the open turn; picking plays the asset.
- Full CI gauntlet (fmt, clippy host+wasm, test, doc, wasm build/test) green locally. Pre-push review passed (one doc-attachment fix applied; no Critical/Important remaining).

Design + plan: `docs/superpowers/specs/2026-06-26-476-parked-fast-window-choice-design.md`, `docs/superpowers/plans/2026-06-26-476-parked-fast-window-choice.md`.

## Linked issues

Closes #476