### PR TITLE
engine: reject AdvanceAct for non-clue-objective acts (closes #486)

### DIFF
--- a/crates/cards/tests/act_advancement.rs
+++ b/crates/cards/tests/act_advancement.rs
@@ -60,6 +60,45 @@ fn defeating_other_enemy_does_not_advance_act_3() {
     );
 }
 
+/// Act 01110 ("What Have You Done?") advances only via its Forced
+/// `EnemyDefeated` objective (the Ghoul Priest), so its corpus clue threshold is
+/// `null` -> 0. The deliberate clue-spend `AdvanceAct` action must be rejected
+/// for it — otherwise the player could "spend 0 clues to advance" and instantly
+/// latch the terminal Won resolution, bypassing the Ghoul Priest fight (#486).
+/// The legitimate defeat path stays covered by
+/// `defeating_ghoul_priest_advances_act_3_to_won` above.
+#[test]
+fn advance_act_action_rejected_for_act_3_objective() {
+    let inv = InvestigatorId(1);
+    let mut investigator = test_investigator(1);
+    investigator.clues = 5; // plenty — reject must be the objective, not affordability
+    let mut state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(investigator)
+        .with_active_investigator(inv)
+        .with_turn_order([inv])
+        .build();
+    // Act 3 is current and terminal-Won (mirrors the_gathering setup()).
+    state.act_deck = vec![Act {
+        code: CardCode("01110".into()),
+        clue_threshold: 0,
+        resolution: Some(Resolution::Won { id: "R1".into() }),
+    }];
+
+    let result =
+        dispatch_turn_action_unchecked(state, &TurnAction::AdvanceAct { investigator: inv });
+    assert!(
+        matches!(result.outcome, EngineOutcome::Rejected { .. }),
+        "AdvanceAct must be rejected for Act 3's non-clue objective"
+    );
+    assert!(
+        result.state.resolution.is_none(),
+        "rejected AdvanceAct must not latch the Won resolution (no instant win)"
+    );
+    assert_eq!(result.state.act_index, 0, "act did not advance");
+    assert_eq!(result.state.investigators[&inv].clues, 5, "no clues spent");
+}
+
 /// Act 01109 ("The Barrier") advances only at the end of the round (its
 /// `When`-`RoundEnded` group objective), so the `AdvanceAct` *action* is rejected.
 /// Registry-based detection (`act_advances_at_round_end`, #434) — needs the real

--- a/crates/cards/tests/advance_act_interactive_reverse.rs
+++ b/crates/cards/tests/advance_act_interactive_reverse.rs
@@ -49,18 +49,22 @@ fn install() {
 #[test]
 fn interactive_act_reverse_resolves_cleanly() {
     let inv = InvestigatorId(1);
+    let mut investigator = test_investigator(1);
+    investigator.clues = 1; // funds the AdvanceAct clue-spend (threshold 1 below)
     let mut state = GameStateBuilder::new()
         .with_phase(game_core::state::Phase::Investigation)
         .with_active_investigator(inv)
         .with_turn_order([inv])
-        .with_investigator(test_investigator(1))
+        .with_investigator(investigator)
         .build();
-    // Two acts: the leaving one (_iact, threshold 0 so AdvanceAct is affordable)
-    // carries the interactive reverse; a successor so the advance is non-terminal.
+    // Two acts: the leaving one (_iact) carries the interactive reverse; a
+    // successor so the advance is non-terminal. _iact has a positive clue
+    // threshold (the AdvanceAct action requires one — #486) and the
+    // investigator is funded for it above.
     state.act_deck = vec![
         Act {
             code: CardCode(IACT.into()),
-            clue_threshold: 0,
+            clue_threshold: 1,
             resolution: None,
         },
         Act {

--- a/crates/game-core/src/engine/dispatch/act_agenda.rs
+++ b/crates/game-core/src/engine/dispatch/act_agenda.rs
@@ -151,6 +151,23 @@ pub(crate) fn check_advance_act(
         );
     }
     let threshold = state.act_deck[state.act_index].clue_threshold;
+    // The AdvanceAct action is the deliberate clue-spend advance, which is only
+    // meaningful for an act that advances by spending clues (threshold >= 1). A
+    // zero threshold (corpus `null`) marks a non-clue objective — e.g. The
+    // Gathering's Act 3 (01110), which advances via its Forced EnemyDefeated on
+    // the Ghoul Priest. Offering the action there would let the player "spend 0
+    // clues to advance", bypassing the objective (#486 — an instant win on a
+    // terminal-Won act). Unlike `act_advances_at_round_end` (registry-based, so
+    // it silently fails open with no registry installed), this is a self-contained
+    // invariant. Act 01109's round-end objective carries a positive threshold and
+    // stays excluded by `act_advances_at_round_end` above.
+    if threshold == 0 {
+        return Err(
+            "this act advances on a non-clue objective, not via the AdvanceAct \
+                    action"
+                .into(),
+        );
+    }
     let total_clues: u32 = clue_contributors(state, investigator)
         .into_iter()
         .filter_map(|id| state.investigators.get(&id))
@@ -589,6 +606,60 @@ mod advance_act_tests {
                 .iter()
                 .any(|a| matches!(a, TurnAction::AdvanceAct { .. })),
             "AdvanceAct must not be legal when clues < threshold"
+        );
+    }
+
+    #[test]
+    fn advance_act_action_rejected_for_zero_clue_threshold_objective() {
+        use crate::state::{Act, CardCode};
+        // A non-clue-objective act (clue_threshold 0 — e.g. The Gathering's
+        // Act 3 01110, which advances when the Ghoul Priest is defeated). The
+        // deliberate clue-spend AdvanceAct action is nonsensical here ("spend 0
+        // clues to advance" / "spend 0 clues to instantly win"), so it must be
+        // neither offered nor accepted — even with no registry installed (this
+        // is a pure game-core unit test, so none is).
+        let inv = InvestigatorId(1);
+        let mut investigator = test_investigator(1);
+        investigator.clues = 5; // plenty — reject must be the objective, not affordability
+        let mut state = GameStateBuilder::new()
+            .with_phase(Phase::Investigation)
+            .with_investigator(investigator)
+            .with_active_investigator(inv)
+            .with_turn_order([inv])
+            .with_phase_anchor(crate::state::Continuation::InvestigationPhase {
+                resume: crate::state::InvestigationResume::TurnBegins,
+            })
+            .with_investigator_turn(inv)
+            .build();
+        state.act_deck = vec![Act {
+            code: CardCode("01110".into()),
+            clue_threshold: 0,
+            resolution: Some(crate::scenario::Resolution::Won { id: "R1".into() }),
+        }];
+
+        assert!(
+            !legal_actions(&state)
+                .iter()
+                .any(|a| matches!(a, TurnAction::AdvanceAct { .. })),
+            "AdvanceAct must not be offered for a zero-threshold objective act"
+        );
+        // Bypass the legality menu (the assert above already proves it's not
+        // offered) to confirm the handler itself rejects, leaving state unchanged.
+        let result = crate::test_support::dispatch_turn_action_unchecked(
+            state,
+            &TurnAction::AdvanceAct { investigator: inv },
+        );
+        assert!(
+            matches!(result.outcome, EngineOutcome::Rejected { .. }),
+            "AdvanceAct must be rejected for a zero-threshold objective act"
+        );
+        assert!(
+            result.state.resolution.is_none(),
+            "rejected AdvanceAct must not latch the act's Won resolution"
+        );
+        assert_eq!(
+            result.state.investigators[&inv].clues, 5,
+            "rejected AdvanceAct must not spend clues"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #486 — an exploitable instant win in The Gathering. The open-turn menu offered **"Advance act"** while the **Ghoul Priest** (Act 3's objective enemy) was still alive; clicking it spent 0 clues and latched Act 3's terminal **Won** resolution, bypassing the scenario objective.

## Root cause

The `AdvanceAct` action is the deliberate clue-spend advance. Act 3 (01110) advances via its Forced `EnemyDefeated` objective (the Ghoul Priest) and so carries a `null` (→ 0) clue threshold in the corpus. With no zero-threshold guard, `check_advance_act` trivially satisfied `total_clues (>= 0) >= 0`, so `push_act_actions` offered the action and `advance_act_action` accepted it.

## Fix

Reject `AdvanceAct` when `clue_threshold == 0` (issue's "option 1"). The check sits on the shared validate-first path (`check_advance_act`), so **both** the enumerator (`legal_actions` stops offering it) and the handler (rejects with state+events unchanged) honor it from one edit.

### Why option 1 over the objective-trigger generalization (option 2)

- It's a self-contained game-core invariant. Unlike the registry-based `act_advances_at_round_end` — which fails *open* when no registry is installed — this guard catches even registry-free.
- It's additive: Act 01109's round-end objective carries a positive threshold and stays excluded by `act_advances_at_round_end`, so the two checks don't overlap.
- Matches the project's "minimal correct fix, no speculative generalization" convention. A corpus sweep confirmed no act advances via the action with threshold 0 (no false positives) and the only positive-threshold non-action act (01109) is already excluded (no false negatives).

## Tests

- **game-core unit test** (registry-free) — the zero-threshold invariant: `AdvanceAct` not enumerated and rejected, resolution not latched, no clues spent.
- **Integration test** against the real 01110 — no instant win, no clues spent, cursor unmoved. The legitimate defeat path stays covered by `defeating_ghoul_priest_advances_act_3_to_won`.
- Updated `advance_act_interactive_reverse.rs`, which had used threshold 0 only as an affordability shortcut, to a real positive threshold + a funded investigator (no coverage loss).

## Verification

Full local CI gauntlet green: `fmt`, `clippy --all-targets --all-features -D warnings`, `RUSTFLAGS=-D warnings cargo test --all --all-features` (110 binaries), `RUSTDOCFLAGS=-D warnings cargo doc`, `wasm-build`, `wasm-clippy`. (wasm-test left to CI — no wasm code changed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)