### PR TITLE
server: randomize the per-game setup seed (closes #467)

### DIFF
--- a/crates/server/src/id.rs
+++ b/crates/server/src/id.rs
@@ -12,12 +12,33 @@ pub fn random_game_id() -> GameId {
     GameId::new(uuid::Uuid::new_v4().to_string())
 }
 
+/// Generate a fresh random RNG seed for a new game's setup shuffle (#467).
+///
+/// game-core is host-agnostic (no I/O, compiles to wasm), so entropy is the
+/// host's job; we reuse `uuid`'s getrandom-backed v4 generator (already a
+/// dependency for [`random_game_id`]) and take the high 64 bits of its 122
+/// random bits. The fixed 4-bit version nibble sits in that high word, so the
+/// seed carries ~60 uniformly-random bits — ample for per-game uniqueness
+/// (collision ≈ 2⁻⁶⁰). The seed need not be recorded separately: the server
+/// bakes it into the game's setup state, whose post-shuffle `RngState` is
+/// persisted as the frozen seed, so replay stays deterministic.
+#[must_use]
+pub fn random_seed() -> u64 {
+    uuid::Uuid::new_v4().as_u64_pair().0
+}
+
 #[cfg(test)]
 mod tests {
-    use super::random_game_id;
+    use super::{random_game_id, random_seed};
 
     #[test]
     fn random_ids_are_distinct() {
         assert_ne!(random_game_id(), random_game_id());
+    }
+
+    #[test]
+    fn random_seeds_are_distinct() {
+        // Two creations must not collide on the same setup shuffle (#467).
+        assert_ne!(random_seed(), random_seed());
     }
 }

--- a/crates/server/src/session.rs
+++ b/crates/server/src/session.rs
@@ -8,6 +8,7 @@
 //! replaying that log over the seed, reproducing state bit-for-bit.
 
 use game_core::action::RosterEntry;
+use game_core::rng::RngState;
 use game_core::scenario::ScenarioId;
 use game_core::state::GameState;
 use game_core::{Action, EngineOutcome, Event, PlayerAction};
@@ -73,6 +74,14 @@ impl GameSession {
             .ok_or_else(|| SessionError::UnknownScenario(scenario_id.clone()))?;
 
         let mut setup = (module.setup)();
+        // Seed the setup shuffle with fresh host entropy (#467). The scenario's
+        // setup() builds with a fixed builder seed (game-core is no-I/O, so it
+        // can't source randomness itself); without this override every game would
+        // share one shuffle/draw order. seat_and_open runs the shuffle below, and
+        // the resulting post-shuffle RngState is frozen into seed_state, so replay
+        // stays deterministic from the seed alone (the seed needs no separate
+        // recording).
+        setup.rng = RngState::new(crate::id::random_seed());
         // Human play surfaces skill-test results with a Confirm-to-dismiss step
         // (#478); the engine gates that pause on this flag (default off for tests
         // and non-interactive consumers). The flag persists through seating.

--- a/crates/server/tests/game_session.rs
+++ b/crates/server/tests/game_session.rs
@@ -288,6 +288,31 @@ async fn load_replays_log_to_reproduce_live_state() {
 }
 
 #[tokio::test]
+async fn create_randomizes_the_setup_seed_per_game() {
+    // #467: every game must get a fresh RNG seed so the setup shuffle/draw
+    // order differs across games. The mock scenario's setup() pins a fixed
+    // builder seed (42); create() must override it with host entropy, so two
+    // games created from the same module hold distinct frozen seeds.
+    install_registry();
+    let pool = memory_pool().await;
+    let one = GameSession::create(
+        pool.clone(),
+        "g1",
+        ScenarioId::new(TEST_SCENARIO_ID),
+        roster(),
+    )
+    .await
+    .expect("create g1");
+    let two = GameSession::create(pool, "g2", ScenarioId::new(TEST_SCENARIO_ID), roster())
+        .await
+        .expect("create g2");
+    assert_ne!(
+        one.state.rng.seed, two.state.rng.seed,
+        "each created game must get a distinct random setup seed"
+    );
+}
+
+#[tokio::test]
 async fn create_enables_interactive_acknowledge() {
     install_registry();
     let pool = memory_pool().await;


### PR DESCRIPTION
## Summary

Fixes #467 — every game was seeded with RNG seed **0**, so the setup shuffle and initial draw order were identical across all games. `GameStateBuilder` defaults to `RngState::new(0)`, and neither the scenario `setup()`, `seat_and_open`, nor the server injected entropy.

## Fix

game-core is host-agnostic (no I/O, compiles to wasm), so entropy is the host's job. `GameSession::create` now overrides `setup.rng` with a fresh seed from a new `random_seed()` helper **before** `seat_and_open` runs the deck shuffle:

```rust
setup.rng = RngState::new(crate::id::random_seed());
```

`random_seed()` (in `id.rs`) draws from `uuid::Uuid::new_v4()` — getrandom-backed, already a dependency for `random_game_id`.

### Why this is correct & complete

- **Timing:** `the_gathering::setup()` does not shuffle (the encounter deck is shuffled inside `seat_and_open`), so overriding rng after `setup()` lands before the only consumer.
- **Replay determinism preserved with no migration:** the post-shuffle `RngState` is frozen into `seed_state` exactly as today, and `load` replays from it without re-shuffling. The seed needs no separate recording — it's implicit in the frozen state.
- **Determinism boundary:** only the server's `create()` randomizes; `GameStateBuilder` test seeds are untouched.

## Tests

- `random_seed()` yields distinct values.
- Two `GameSession::create` calls from the same module hold distinct frozen `rng.seed` (the value that drives the shuffle). Seed→shuffle divergence itself is already pinned by `game-core`'s `rng.rs` tests (`different_seeds_diverge`).

## Verification

Full local CI gauntlet green: `fmt`, `clippy --all-targets --all-features -D warnings`, `RUSTFLAGS=-D warnings cargo test --all --all-features`, `RUSTDOCFLAGS=-D warnings cargo doc`, `wasm-build`, `wasm-clippy`. (wasm-test left to CI — no wasm code changed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)