### PR TITLE
engine: surface single-option auto-binds as choices when interactive (#466)

### DIFF
--- a/crates/cards/src/impls/crypt_chill.rs
+++ b/crates/cards/src/impls/crypt_chill.rs
@@ -79,7 +79,7 @@ fn crypt_chill_fail(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
         return discard_asset_instance(cx, controller, instance);
     }
 
-    match resolve_choice_count(assets.len()) {
+    match resolve_choice_count(assets.len(), cx.state.interactive_acknowledge) {
         // Cannot discard an asset → take 2 damage instead (the printed
         // fallback; defeat handled by the kernel helper).
         ChoiceResolution::Empty => {

--- a/crates/cards/src/impls/crypt_chill.rs
+++ b/crates/cards/src/impls/crypt_chill.rs
@@ -195,4 +195,39 @@ mod tests {
             other => panic!("expected a one-option discard suspend, got {other:?}"),
         }
     }
+
+    #[test]
+    fn single_asset_auto_discards_when_flag_off() {
+        use game_core::state::{CardCode, CardInPlay};
+        use game_core::test_support::{test_investigator, GameStateBuilder};
+
+        // Flag off (default): the lone asset auto-discards silently, as today —
+        // the n=1 regression guard local to this card (#466).
+        let mut inv = test_investigator(1);
+        inv.cards_in_play.push(CardInPlay::enter_play(
+            CardCode::new("01020"),
+            CardInstanceId(1),
+        ));
+        let mut state = GameStateBuilder::new().with_investigator(inv).build();
+        let mut events: Vec<Event> = Vec::new();
+        let ctx = EvalContext::for_controller(InvestigatorId(1));
+        let out = {
+            let mut cx = Cx {
+                state: &mut state,
+                events: &mut events,
+            };
+            super::crypt_chill_fail(&mut cx, &ctx)
+        };
+        assert!(
+            matches!(out, EngineOutcome::Done),
+            "flag off: auto-discard, no suspend"
+        );
+        let inv = &state.investigators[&InvestigatorId(1)];
+        assert!(inv.cards_in_play.is_empty(), "the asset was discarded");
+        assert_eq!(
+            inv.discard,
+            vec![CardCode::new("01020")],
+            "asset moved to discard"
+        );
+    }
 }

--- a/crates/cards/src/impls/crypt_chill.rs
+++ b/crates/cards/src/impls/crypt_chill.rs
@@ -159,4 +159,40 @@ mod tests {
         assert!(native_effect_for(CRYPT_CHILL_FAIL).is_some());
         assert!(native_effect_for("nope").is_none());
     }
+
+    #[test]
+    fn single_asset_discard_surfaces_under_interactive_flag() {
+        use game_core::state::{CardCode, CardInPlay};
+        use game_core::test_support::{test_investigator, GameStateBuilder};
+
+        // Exactly one discardable asset (Machete 01020) in play. With
+        // interactive_acknowledge on, the fail branch must surface the discard as
+        // a one-option pick rather than auto-discarding silently (#466).
+        let mut inv = test_investigator(1);
+        inv.cards_in_play.push(CardInPlay::enter_play(
+            CardCode::new("01020"),
+            CardInstanceId(1),
+        ));
+        let mut state = GameStateBuilder::new().with_investigator(inv).build();
+        state.interactive_acknowledge = true;
+        let mut events: Vec<Event> = Vec::new();
+        let ctx = EvalContext::for_controller(InvestigatorId(1));
+        let out = {
+            let mut cx = Cx {
+                state: &mut state,
+                events: &mut events,
+            };
+            super::crypt_chill_fail(&mut cx, &ctx)
+        };
+        match out {
+            EngineOutcome::AwaitingInput { request, .. } => {
+                assert_eq!(
+                    request.options.len(),
+                    1,
+                    "lone asset surfaces as one option"
+                );
+            }
+            other => panic!("expected a one-option discard suspend, got {other:?}"),
+        }
+    }
 }

--- a/crates/cards/src/impls/dynamite_blast.rs
+++ b/crates/cards/src/impls/dynamite_blast.rs
@@ -90,7 +90,7 @@ fn dynamite_blast(cx: &mut Cx, ctx: &EvalContext) -> EngineOutcome {
         return blast_location(cx, controller, loc);
     }
 
-    match resolve_choice_count(locations.len()) {
+    match resolve_choice_count(locations.len(), cx.state.interactive_acknowledge) {
         // Controller is between locations — no legal target.
         ChoiceResolution::Empty => EngineOutcome::Rejected {
             reason: "01024 blast: controller has no location to target".into(),

--- a/crates/cards/src/impls/dynamite_blast.rs
+++ b/crates/cards/src/impls/dynamite_blast.rs
@@ -160,4 +160,40 @@ mod tests {
     fn registry_dispatches_to_this_modules_abilities() {
         assert_eq!(crate::abilities_for(CODE), Some(abilities()));
     }
+
+    #[test]
+    fn single_location_blast_surfaces_under_interactive_flag() {
+        use game_core::test_support::{test_investigator, test_location, GameStateBuilder};
+
+        // Sole candidate (controller's location, no connections). With
+        // interactive_acknowledge on, the blast target must surface as a
+        // one-option pick rather than auto-targeting silently (#466).
+        let loc = test_location(1, "Lonely Spot"); // no connections by default
+        let mut inv = test_investigator(1);
+        inv.current_location = Some(LocationId(1));
+        let mut state = GameStateBuilder::new()
+            .with_investigator(inv)
+            .with_location(loc)
+            .build();
+        state.interactive_acknowledge = true;
+        let mut events: Vec<game_core::Event> = Vec::new();
+        let ctx = EvalContext::for_controller(InvestigatorId(1));
+        let out = {
+            let mut cx = Cx {
+                state: &mut state,
+                events: &mut events,
+            };
+            super::dynamite_blast(&mut cx, &ctx)
+        };
+        match out {
+            EngineOutcome::AwaitingInput { request, .. } => {
+                assert_eq!(
+                    request.options.len(),
+                    1,
+                    "lone location surfaces as one option"
+                );
+            }
+            other => panic!("expected a one-option blast suspend, got {other:?}"),
+        }
+    }
 }

--- a/crates/cards/tests/forced_acknowledge.rs
+++ b/crates/cards/tests/forced_acknowledge.rs
@@ -1,0 +1,144 @@
+//! #466: a no-choice forced location ability (the Attic's 1 horror, the Cellar's
+//! 1 damage) surfaces a one-option acknowledge *before* the harm lands when
+//! `interactive_acknowledge` is on, and resolves synchronously when it is off.
+//!
+//! Own process → installs `cards::REGISTRY`. The forced effect is driven through
+//! the real `EnteredLocation` dispatch via `fire_forced_on_enter`; the
+//! interactive pause is then resumed through the public `apply(ResolveInput)`
+//! path (the same way a host resumes an `AwaitingInput`).
+
+use game_core::engine::EngineOutcome;
+use game_core::state::{CardCode, Continuation, GameState, InvestigatorId, LocationId};
+use game_core::test_support::{
+    fire_forced_on_enter, test_investigator, test_location, GameStateBuilder,
+};
+use game_core::{Action, InputResponse, OptionId, PlayerAction};
+
+const INV: InvestigatorId = InvestigatorId(1);
+const LOC: LocationId = LocationId(1);
+
+#[ctor::ctor]
+fn install() {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+}
+
+/// One investigator standing on a location whose card `code` carries a forced
+/// on-enter ability, with `interactive_acknowledge` set as given.
+fn state_on_location(code: &str, interactive: bool) -> GameState {
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(LOC);
+    // Back the investigator with a real corpus card so the harm path's defeat
+    // check (max_health/max_sanity, read from the registry) resolves — Roland
+    // Banks (01001), 9 health / 5 sanity, so 1 harm never defeats.
+    inv.investigator_card.code = CardCode::new("01001");
+    let mut loc = test_location(1, "Forced Location");
+    loc.code = CardCode::new(code);
+    let mut state = GameStateBuilder::new()
+        .with_investigator(inv)
+        .with_location(loc)
+        .with_turn_order([INV])
+        .build();
+    state.interactive_acknowledge = interactive;
+    state
+}
+
+fn resume_single_option(state: GameState) -> game_core::engine::ApplyResult {
+    game_core::apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickSingle(OptionId(0)),
+        }),
+    )
+}
+
+#[test]
+fn attic_forced_acknowledges_before_horror_when_interactive() {
+    let mut state = state_on_location("01113", true); // the Attic — 1 horror
+    let mut events = Vec::new();
+    let out = fire_forced_on_enter(&mut state, &mut events, INV, LOC);
+    match out {
+        EngineOutcome::AwaitingInput { request, .. } => {
+            assert_eq!(request.options.len(), 1, "forced ack is a one-option pick");
+        }
+        other => panic!("expected a one-option acknowledge, got {other:?}"),
+    }
+    assert_eq!(
+        state.investigators[&INV].horror(),
+        0,
+        "horror must not be applied before the player acknowledges"
+    );
+
+    let result = resume_single_option(state);
+    assert!(!matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert_eq!(
+        result.state.investigators[&INV].horror(),
+        1,
+        "horror applied after the acknowledge"
+    );
+    assert!(
+        !result
+            .state
+            .continuations
+            .iter()
+            .any(|c| matches!(c, Continuation::AcknowledgeForced { .. })),
+        "the acknowledge frame must be gone after resume"
+    );
+}
+
+#[test]
+fn attic_forced_resolves_synchronously_when_not_interactive() {
+    let mut state = state_on_location("01113", false);
+    let mut events = Vec::new();
+    let out = fire_forced_on_enter(&mut state, &mut events, INV, LOC);
+    assert!(
+        matches!(out, EngineOutcome::Done),
+        "flag off: no suspend, got {out:?}"
+    );
+    assert_eq!(
+        state.investigators[&INV].horror(),
+        1,
+        "flag off: horror applied synchronously (today's behavior)"
+    );
+}
+
+#[test]
+fn cellar_forced_acknowledges_before_damage_when_interactive() {
+    let mut state = state_on_location("01114", true); // the Cellar — 1 damage
+    let mut events = Vec::new();
+    let out = fire_forced_on_enter(&mut state, &mut events, INV, LOC);
+    match out {
+        EngineOutcome::AwaitingInput { request, .. } => {
+            assert_eq!(request.options.len(), 1, "forced ack is a one-option pick");
+        }
+        other => panic!("expected a one-option acknowledge, got {other:?}"),
+    }
+    assert_eq!(
+        state.investigators[&INV].damage(),
+        0,
+        "damage must not be applied before the player acknowledges"
+    );
+
+    let result = resume_single_option(state);
+    assert!(!matches!(result.outcome, EngineOutcome::Rejected { .. }));
+    assert_eq!(
+        result.state.investigators[&INV].damage(),
+        1,
+        "damage applied after the acknowledge"
+    );
+}
+
+#[test]
+fn cellar_forced_resolves_synchronously_when_not_interactive() {
+    let mut state = state_on_location("01114", false);
+    let mut events = Vec::new();
+    let out = fire_forced_on_enter(&mut state, &mut events, INV, LOC);
+    assert!(
+        matches!(out, EngineOutcome::Done),
+        "flag off: no suspend, got {out:?}"
+    );
+    assert_eq!(
+        state.investigators[&INV].damage(),
+        1,
+        "flag off: damage applied synchronously (today's behavior)"
+    );
+}

--- a/crates/game-core/src/engine/dispatch/choice.rs
+++ b/crates/game-core/src/engine/dispatch/choice.rs
@@ -22,10 +22,13 @@ pub enum ChoiceResolution {
     Suspend,
 }
 
-/// Map a legal-option count to the resolve convention.
-pub fn resolve_choice_count(n: usize) -> ChoiceResolution {
+/// Map a legal-option count to the resolve convention. When `interactive` is set
+/// (human play, `interactive_acknowledge`), a single option surfaces as a
+/// one-option pick (`Suspend`) instead of auto-binding silently (#466).
+pub fn resolve_choice_count(n: usize, interactive: bool) -> ChoiceResolution {
     match n {
         0 => ChoiceResolution::Empty,
+        1 if interactive => ChoiceResolution::Suspend,
         1 => ChoiceResolution::Auto(0),
         _ => ChoiceResolution::Suspend,
     }
@@ -113,17 +116,43 @@ mod tests {
 
     #[test]
     fn resolve_zero_options_is_reject() {
-        assert!(matches!(resolve_choice_count(0), ChoiceResolution::Empty));
+        assert!(matches!(
+            resolve_choice_count(0, false),
+            ChoiceResolution::Empty
+        ));
+        assert!(matches!(
+            resolve_choice_count(0, true),
+            ChoiceResolution::Empty
+        ));
     }
 
     #[test]
-    fn resolve_one_option_auto_binds_index_zero() {
-        assert!(matches!(resolve_choice_count(1), ChoiceResolution::Auto(0)));
+    fn resolve_one_option_auto_binds_when_not_interactive() {
+        assert!(matches!(
+            resolve_choice_count(1, false),
+            ChoiceResolution::Auto(0)
+        ));
     }
 
     #[test]
-    fn resolve_two_options_suspends() {
-        assert!(matches!(resolve_choice_count(2), ChoiceResolution::Suspend));
+    fn resolve_one_option_suspends_when_interactive() {
+        // #466: a lone option surfaces as a one-option pick in human play.
+        assert!(matches!(
+            resolve_choice_count(1, true),
+            ChoiceResolution::Suspend
+        ));
+    }
+
+    #[test]
+    fn resolve_two_options_suspends_regardless_of_flag() {
+        assert!(matches!(
+            resolve_choice_count(2, false),
+            ChoiceResolution::Suspend
+        ));
+        assert!(matches!(
+            resolve_choice_count(2, true),
+            ChoiceResolution::Suspend
+        ));
     }
 
     #[test]

--- a/crates/game-core/src/engine/dispatch/choice.rs
+++ b/crates/game-core/src/engine/dispatch/choice.rs
@@ -194,4 +194,60 @@ mod tests {
              not be dropped at suspend",
         );
     }
+
+    #[test]
+    fn single_branch_choose_one_surfaces_under_interactive_flag() {
+        use crate::state::InvestigatorId;
+        use crate::test_support::GameStateBuilder;
+
+        // One ChooseOne branch: today it auto-binds. With interactive_acknowledge
+        // on it must surface as a one-option pick (#466).
+        let effect = Effect::ChooseOne(vec![Effect::Seq(vec![])]);
+        let ctx = EvalContext::for_controller(InvestigatorId(1));
+
+        let mut state = GameStateBuilder::default().build();
+        state.interactive_acknowledge = true;
+        let mut events = Vec::new();
+        let out = {
+            let mut cx = Cx {
+                state: &mut state,
+                events: &mut events,
+            };
+            push_effect(&mut cx, &effect, ctx);
+            crate::engine::dispatch::drive(&mut cx, EngineOutcome::Done)
+        };
+        match out {
+            EngineOutcome::AwaitingInput { request, .. } => {
+                assert_eq!(
+                    request.options.len(),
+                    1,
+                    "lone branch surfaces as one option"
+                );
+            }
+            other => panic!("expected a one-option suspend, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn single_branch_choose_one_auto_binds_when_flag_off() {
+        use crate::state::InvestigatorId;
+        use crate::test_support::GameStateBuilder;
+
+        let effect = Effect::ChooseOne(vec![Effect::Seq(vec![])]);
+        let ctx = EvalContext::for_controller(InvestigatorId(1));
+        let mut state = GameStateBuilder::default().build(); // flag defaults false
+        let mut events = Vec::new();
+        let out = {
+            let mut cx = Cx {
+                state: &mut state,
+                events: &mut events,
+            };
+            push_effect(&mut cx, &effect, ctx);
+            crate::engine::dispatch::drive(&mut cx, EngineOutcome::Done)
+        };
+        assert!(
+            matches!(out, EngineOutcome::Done),
+            "flag off: auto-binds, no suspend"
+        );
+    }
 }

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -155,7 +155,26 @@ pub(crate) fn fire_forced_triggers(
         hits.len(),
     );
     match hits.first() {
-        Some(hit) => resolve_one(cx, hit),
+        Some(hit) => {
+            let out = resolve_one(cx, hit);
+            // #466: in interactive play, surface the lone forced effect as a
+            // one-option pick *before* it resolves. resolve_one already pushed the
+            // effect root frame and returned Done; push the ack *above* it so the
+            // `drive` loop hits the ack first (suspend), and on resume pops it —
+            // then resolves the effect. fire_forced_triggers still returns Done
+            // (push-frame contract), so emit callers stay correct. Scoped to this
+            // single-hit path: the 2+ ordered run resolves via the forced-window's
+            // own path (never `resolve_one`), so its ordering pick is the only
+            // confirmation (no per-effect ack).
+            if cx.state.interactive_acknowledge && matches!(out, EngineOutcome::Done) {
+                cx.state
+                    .continuations
+                    .push(crate::state::Continuation::AcknowledgeForced {
+                        source: hit.code.clone(),
+                    });
+            }
+            out
+        }
         None => EngineOutcome::Done,
     }
 }

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -596,4 +596,32 @@ mod tests {
             "the AcknowledgeForced frame must be popped on resume"
         );
     }
+
+    #[test]
+    fn acknowledge_forced_rejects_non_pick_response() {
+        use crate::action::InputResponse;
+        use crate::state::Continuation;
+        use crate::test_support::GameStateBuilder;
+
+        // Validate-first: a Confirm/Skip (not the single PickSingle) is rejected
+        // and leaves the frame in place.
+        let mut state = GameStateBuilder::default().build();
+        state.continuations.push(Continuation::AcknowledgeForced {
+            source: CardCode("01113".into()),
+        });
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+        let out = super::resume_acknowledge_forced(&mut cx, &InputResponse::Confirm);
+        assert!(matches!(out, EngineOutcome::Rejected { .. }));
+        assert!(
+            matches!(
+                cx.state.continuations.last(),
+                Some(Continuation::AcknowledgeForced { .. })
+            ),
+            "a rejected resume must leave the frame in place"
+        );
+    }
 }

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -476,3 +476,105 @@ fn resolve_one(cx: &mut Cx, hit: &ResolutionCandidate) -> EngineOutcome {
     push_effect(cx, &effect, ctx);
     EngineOutcome::Done
 }
+
+/// Display name for the card a forced ability is printed on, for the
+/// [`AcknowledgeForced`](crate::state::Continuation::AcknowledgeForced) prompt.
+/// Resolved via the registry; falls back to the raw code when no
+/// registry/metadata is available (tests).
+fn forced_source_name(code: &CardCode) -> String {
+    crate::card_registry::current()
+        .and_then(|r| (r.metadata_for)(code))
+        .map_or_else(|| code.0.clone(), |m| m.name.clone())
+}
+
+/// Drive a [`Continuation::AcknowledgeForced`](crate::state::Continuation::AcknowledgeForced)
+/// frame (#466): suspend with a one-option `PickSingle` naming the source. The
+/// pick precedes the forced effect's resolution ("confirm before the effect").
+/// Mirrors `advance_reverse::drive`'s `AwaitAck` suspend.
+pub(crate) fn drive_acknowledge_forced(cx: &mut Cx) -> EngineOutcome {
+    use crate::engine::{ChoiceOption, InputRequest, OptionId, ResumeToken};
+    let Some(crate::state::Continuation::AcknowledgeForced { source }) =
+        cx.state.continuations.last()
+    else {
+        return EngineOutcome::Rejected {
+            reason: "drive_acknowledge_forced: top frame is not AcknowledgeForced".into(),
+        };
+    };
+    let name = forced_source_name(source);
+    EngineOutcome::AwaitingInput {
+        request: InputRequest::pick_single(
+            format!("Forced — {name}"),
+            vec![ChoiceOption {
+                id: OptionId(0),
+                label: "Resolve".into(),
+            }],
+        ),
+        resume_token: ResumeToken(0),
+    }
+}
+
+/// Resume an [`AcknowledgeForced`](crate::state::Continuation::AcknowledgeForced)
+/// frame: validate the single option, pop the frame, and return `Done` so the
+/// `drive` loop resolves the forced effect beneath.
+pub(crate) fn resume_acknowledge_forced(
+    cx: &mut Cx,
+    response: &crate::action::InputResponse,
+) -> EngineOutcome {
+    use crate::engine::OptionId;
+    if !matches!(
+        response,
+        crate::action::InputResponse::PickSingle(OptionId(0))
+    ) {
+        return EngineOutcome::Rejected {
+            reason: "resume_acknowledge_forced: expected the single forced-resolution option"
+                .into(),
+        };
+    }
+    debug_assert!(matches!(
+        cx.state.continuations.last(),
+        Some(crate::state::Continuation::AcknowledgeForced { .. })
+    ));
+    cx.state.continuations.pop();
+    EngineOutcome::Done
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn acknowledge_forced_suspends_then_pops_on_pick() {
+        use crate::action::InputResponse;
+        use crate::engine::OptionId;
+        use crate::state::Continuation;
+        use crate::test_support::GameStateBuilder;
+
+        let mut state = GameStateBuilder::default().build();
+        state.continuations.push(Continuation::AcknowledgeForced {
+            source: CardCode("01113".into()),
+        });
+        let mut events = Vec::new();
+        let mut cx = Cx {
+            state: &mut state,
+            events: &mut events,
+        };
+
+        // Drive: one-option suspend.
+        let out = super::drive_acknowledge_forced(&mut cx);
+        match out {
+            EngineOutcome::AwaitingInput { request, .. } => {
+                assert_eq!(request.options.len(), 1, "forced ack is a one-option pick");
+            }
+            other => panic!("expected one-option suspend, got {other:?}"),
+        }
+
+        // Resume with the single option: frame pops, returns Done.
+        let out =
+            super::resume_acknowledge_forced(&mut cx, &InputResponse::PickSingle(OptionId(0)));
+        assert!(matches!(out, EngineOutcome::Done));
+        assert!(
+            cx.state.continuations.is_empty(),
+            "the AcknowledgeForced frame must be popped on resume"
+        );
+    }
+}

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -256,6 +256,11 @@ pub(crate) fn drive(cx: &mut Cx, outcome: EngineOutcome) -> EngineOutcome {
                 EngineOutcome::Done => {}
                 other => return other,
             },
+            // #466: a one-option forced-effect acknowledge always suspends; on
+            // resume it pops and the effect frame beneath resolves.
+            Some(Continuation::AcknowledgeForced { .. }) => {
+                return forced_triggers::drive_acknowledge_forced(cx)
+            }
             Some(Continuation::SkillTest(_)) => match skill_test::advance(cx) {
                 EngineOutcome::Done => {}
                 other => return other,
@@ -612,6 +617,11 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
         // The #482 advance acknowledge pause: a Confirm resumes the AdvanceReverse
         // frame past its AwaitAck step into firing the leaving card's reverse.
         Some(Continuation::AdvanceReverse { .. }) => advance_reverse::resume(cx, response),
+        // #466: the one-option forced-effect acknowledge — its PickSingle pops the
+        // frame so the `drive` loop resolves the effect beneath.
+        Some(Continuation::AcknowledgeForced { .. }) => {
+            forced_triggers::resume_acknowledge_forced(cx, response)
+        }
         // An order-pick suspension parks the `AttackLoop` frame as the top frame
         // (it *is* the prompt) — route its `PickSingle` to the order resume
         // (#143). Every other `AttackLoop` stage sits beneath a reaction window

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -541,7 +541,7 @@ fn step_choose_one(
             )));
         EngineOutcome::Done
     };
-    match resolve_choice_count(branches.len()) {
+    match resolve_choice_count(branches.len(), cx.state.interactive_acknowledge) {
         ChoiceResolution::Empty => EngineOutcome::Rejected {
             reason: "Effect::ChooseOne with no branches".into(),
         },
@@ -685,30 +685,31 @@ fn apply_search_deck(
         .collect();
 
     // 3. Choice convention — but 0 ⇒ find nothing (not reject).
-    let chosen_deck_index: Option<usize> = match resolve_choice_count(eligible.len()) {
-        ChoiceResolution::Empty => None,
-        ChoiceResolution::Auto(i) => Some(eligible[i].0),
-        ChoiceResolution::Suspend => {
-            if let Some(OptionId(i)) = eval_ctx.chosen_option() {
-                match eligible.get(i as usize) {
-                    Some((idx, _)) => Some(*idx),
-                    None => {
-                        return EngineOutcome::Rejected {
-                            reason: format!(
-                                "SearchDeck: pick {i} out of range (0..{})",
-                                eligible.len()
-                            )
-                            .into(),
+    let chosen_deck_index: Option<usize> =
+        match resolve_choice_count(eligible.len(), cx.state.interactive_acknowledge) {
+            ChoiceResolution::Empty => None,
+            ChoiceResolution::Auto(i) => Some(eligible[i].0),
+            ChoiceResolution::Suspend => {
+                if let Some(OptionId(i)) = eval_ctx.chosen_option() {
+                    match eligible.get(i as usize) {
+                        Some((idx, _)) => Some(*idx),
+                        None => {
+                            return EngineOutcome::Rejected {
+                                reason: format!(
+                                    "SearchDeck: pick {i} out of range (0..{})",
+                                    eligible.len()
+                                )
+                                .into(),
+                            }
                         }
                     }
+                } else {
+                    let labels = eligible.iter().map(|(_, c)| c.0.clone()).collect();
+                    suspend_leaf_in_place(cx, node, eval_ctx);
+                    return awaiting_choice("Search: choose a card to take", labels);
                 }
-            } else {
-                let labels = eligible.iter().map(|(_, c)| c.0.clone()).collect();
-                suspend_leaf_in_place(cx, node, eval_ctx);
-                return awaiting_choice("Search: choose a card to take", labels);
             }
-        }
-    };
+        };
 
     // 4. Take chosen → hand.
     if let Some(idx) = chosen_deck_index {
@@ -1599,11 +1600,12 @@ fn resolve_grounded_choice<Id: Copy>(
     prompt: &'static str,
     label: impl Fn(&Id) -> String,
     bind: impl Fn(Id) -> EvalContext,
+    interactive: bool,
 ) -> Result<EvalContext, EngineOutcome> {
     use crate::engine::dispatch::choice::{
         awaiting_choice, resolve_choice_count, ChoiceResolution,
     };
-    match resolve_choice_count(candidates.len()) {
+    match resolve_choice_count(candidates.len(), interactive) {
         ChoiceResolution::Empty => Err(EngineOutcome::Rejected {
             reason: empty_reason.into(),
         }),
@@ -1650,6 +1652,7 @@ fn ground_investigator_choice(
             ctx.set_chosen_option(None);
             ctx
         },
+        cx.state.interactive_acknowledge,
     )
 }
 
@@ -1674,6 +1677,7 @@ fn ground_location_choice(
             ctx.set_chosen_option(None);
             ctx
         },
+        cx.state.interactive_acknowledge,
     )
 }
 
@@ -1698,6 +1702,7 @@ fn ground_enemy_choice(
             ctx.set_chosen_option(None);
             ctx
         },
+        cx.state.interactive_acknowledge,
     )
 }
 
@@ -1737,6 +1742,7 @@ fn ground_fight_target_choice(
             ctx.set_chosen_option(None);
             ctx
         },
+        cx.state.interactive_acknowledge,
     )
 }
 

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -466,6 +466,14 @@ pub enum Continuation {
         /// Where in the sub-process we are.
         step: AdvanceStep,
     },
+    /// A no-choice forced ability is about to resolve and the game is in
+    /// interactive mode (`interactive_acknowledge`): surface it as a one-option
+    /// pick so the player "performs" it before it lands (#466). Pushed by
+    /// `fire_forced_triggers` (the single-hit path) *above* the forced effect's
+    /// root frame; the `drive` loop suspends here, and on resume pops, letting the
+    /// effect frame beneath resolve. `source` is the card the forced ability is
+    /// printed on (for the prompt's display name).
+    AcknowledgeForced { source: CardCode },
     /// A skill test is mid-resolution. Carries the in-flight test's data
     /// directly (the former `GameState::in_flight_skill_test` singleton, folded
     /// onto the frame — #348). Pushed at test start; popped when the test fully

--- a/docs/superpowers/plans/2026-06-27-surface-single-option-choices.md
+++ b/docs/superpowers/plans/2026-06-27-surface-single-option-choices.md
@@ -412,32 +412,44 @@ git commit -m "engine: AcknowledgeForced continuation frame (one-option forced-e
 
 ---
 
-### Task 4: Push `AcknowledgeForced` from `resolve_one` when interactive
+### Task 4: Push `AcknowledgeForced` from `fire_forced_triggers` (single-hit path) when interactive
 
 **Files:**
-- Modify: `crates/game-core/src/engine/dispatch/forced_triggers.rs:456-477` (`resolve_one`)
+- Modify: `crates/game-core/src/engine/dispatch/forced_triggers.rs:157-160` (`fire_forced_triggers`'s `match hits.first()` tail)
 - Test: `crates/game-core/src/engine/dispatch/forced_triggers.rs` (`#[cfg(test)] mod`)
 
 **Interfaces:**
-- Consumes: `Continuation::AcknowledgeForced` and the drive/resume from Task 3; `interactive_acknowledge`.
+- Consumes: `Continuation::AcknowledgeForced` and the drive/resume from Task 3; `interactive_acknowledge`; `resolve_one` (unchanged — stays a pure resolution primitive).
 
-- [ ] **Step 1: Modify `resolve_one` to push the ack frame above the effect when interactive**
+**Why here, not in `resolve_one`:** `resolve_one` is called *only* from `fire_forced_triggers` (the 0/1-hit path; the 2+ ordered run resolves candidates via `reaction_windows.rs:864/894`, never `resolve_one`). Placing the ack in `fire_forced_triggers` — whose docstring already states "at most one hit reaches here" — scopes it to the lone-forced case at the call site, so the 2+ ordered run never gets a per-effect ack (its ordering pick *is* the confirmation), and `resolve_one` stays ack-free if ever reused.
 
-In `crates/game-core/src/engine/dispatch/forced_triggers.rs`, change the tail of `resolve_one` (currently `push_effect(cx, &effect, ctx); EngineOutcome::Done`) to:
+- [ ] **Step 1: Modify `fire_forced_triggers` to push the ack frame above the effect when interactive**
+
+In `crates/game-core/src/engine/dispatch/forced_triggers.rs`, replace the closing `match` (`:157-160`):
 
 ```rust
-    push_effect(cx, &effect, ctx);
-    // #466: in interactive play, surface the forced effect as a one-option pick
-    // *before* it resolves. Pushed above the effect frame so the `drive` loop
-    // hits it first, suspends, and on resume pops it — then resolves the effect.
-    // resolve_one still returns Done (push-frame contract), so emit callers that
-    // do post-emit work stay correct.
-    if cx.state.interactive_acknowledge {
-        cx.state
-            .continuations
-            .push(crate::state::Continuation::AcknowledgeForced { source: hit.code.clone() });
+    match hits.first() {
+        Some(hit) => {
+            let out = resolve_one(cx, hit);
+            // #466: in interactive play, surface the lone forced effect as a
+            // one-option pick *before* it resolves. resolve_one already pushed the
+            // effect root frame and returned Done; push the ack *above* it so the
+            // `drive` loop hits the ack first (suspend), and on resume pops it —
+            // then resolves the effect. fire_forced_triggers still returns Done
+            // (push-frame contract), so emit callers stay correct. Scoped to the
+            // single-hit path: the 2+ ordered run never reaches here, so its
+            // ordering pick is the only confirmation (no per-effect ack).
+            if cx.state.interactive_acknowledge && matches!(out, EngineOutcome::Done) {
+                cx.state
+                    .continuations
+                    .push(crate::state::Continuation::AcknowledgeForced {
+                        source: hit.code.clone(),
+                    });
+            }
+            out
+        }
+        None => EngineOutcome::Done,
     }
-    EngineOutcome::Done
 ```
 
 - [ ] **Step 2: Write a test — a single forced hit pushes the ack frame under the flag**

--- a/docs/superpowers/plans/2026-06-27-surface-single-option-choices.md
+++ b/docs/superpowers/plans/2026-06-27-surface-single-option-choices.md
@@ -551,10 +551,33 @@ gh issue create --title "Descriptive player-facing text for forced/auto-resolved
 - [ ] **Step 2: Note the framework-harm case on #429**
 
 ```bash
-gh issue comment 429 --body "From #466: the draw-from-empty-deck horror penalty is pure-framework harm (no card forced ability), so #466's AcknowledgeForced (which hooks card forced abilities via resolve_one) does not reach it. When this interactive soak/harm work lands, it should likewise surface an acknowledge before the harm, for parity with #466."
+gh issue comment 429 --body "From #466: the draw-from-empty-deck horror penalty is pure-framework harm (no card forced ability), so #466's AcknowledgeForced (which hooks card forced abilities via fire_forced_triggers) does not reach it. When this interactive soak/harm work lands, it should likewise surface an acknowledge before the harm, for parity with #466."
 ```
 
-- [ ] **Step 3: No commit** (issue/comment only).
+- [ ] **Step 3: File the remaining-single-option-auto-binds follow-up (with the frame-model blocker note)**
+
+```bash
+gh issue create --title "Surface remaining single-option auto-binds (combat soak, attack-order, …) as choices when interactive" \
+  --label engine,ui,p2-later \
+  --body "Follow-up from #466. #466 surfaced single options two ways: (1) resolve_choice_count became flag-aware (ChooseOne, Effect::Fight target, asset/location discard, deck search), and (2) a dedicated Continuation::AcknowledgeForced frame surfaces no-choice forced effects (Attic/Cellar) before they resolve.
+
+Remaining single-option auto-binds live in **bespoke frame logic not routed through resolve_choice_count**, so they still resolve silently under interactive_acknowledge:
+- combat damage/horror **soak distribution** (combat.rs ~:874/:902) when only one soak target exists;
+- single-enemy **attack-order** (no AttackLoopStage::PickOrder is opened for one enemy);
+- any other frame-local n=1 shortcut.
+
+**Elegant end-state:** one uniform rule — a single legal option becomes a one-option PickSingle when interactive_acknowledge is on — applied everywhere, routing all single-option situations through the shared choice mechanism (return Suspend-with-1-option). That would retire the dedicated AcknowledgeForced frame and the per-frame n=1 shortcuts in favor of one mechanism.
+
+**Blocker:** that uniform mechanism depends on the **pure frame-driven model** — the dormant 'B end-state' of #393 ('every straight-line step is a frame'). The remaining sites either resolve synchronously through emit callers that assume a Done return (some use \`let _ = emit_event(...)\`) or carry bespoke n=1 auto-binds; converting them to frame-driven single-option suspends is the prerequisite. Until then, #466's dedicated frame + flag-aware resolve_choice_count is the pragmatic split."
+```
+
+- [ ] **Step 4: Cross-reference the blocker on the (closed) frame-model arc #393**
+
+```bash
+gh issue comment 393 --body "Note for the dormant 'B end-state' (every straight-line step a frame): #466 had to use a dedicated AcknowledgeForced frame for no-choice forced-effect surfacing because the elegant uniform 'single option ⇒ suspend with one option when interactive' mechanism is blocked on the frame-driven conversion — emit callers that assume a Done return (some \`let _ = emit_event(...)\`) can't yet absorb a single-forced suspend. Tracked as the #466 follow-up for the remaining single-option auto-binds."
+```
+
+- [ ] **Step 5: No commit** (issues/comments only).
 
 ---
 

--- a/docs/superpowers/plans/2026-06-27-surface-single-option-choices.md
+++ b/docs/superpowers/plans/2026-06-27-surface-single-option-choices.md
@@ -1,0 +1,553 @@
+# Surface single-option auto-binds as choices — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When `interactive_acknowledge` is on (human play), a single legal option surfaces as a one-option `PickSingle` *before* it resolves — instead of auto-binding silently — covering both effect-level choices and no-choice forced effects (the Attic/Cellar examples in #466).
+
+**Architecture:** Two flag-aware tweaks. (A) `resolve_choice_count` returns `Suspend` for n=1 when interactive, so every effect-level choice site (`ChooseOne`, `Effect::Fight` target, asset/location discard natives, deck search) surfaces its lone option. (B) A new `Continuation::AcknowledgeForced { source }` frame, pushed by `resolve_one` above a forced effect when interactive, surfaces a one-option pick before the forced effect resolves — mirroring the existing `AdvanceReverse`/`AwaitAck` pause and preserving the synchronous-return contract emit callers rely on.
+
+**Tech Stack:** Rust workspace (`game-core` kernel, `cards` content). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-06-27-surface-single-option-choices-design.md`
+
+## Global Constraints
+
+- **CI gauntlet (all warnings-as-errors), run before pushing:** `cargo fmt --check`; `cargo clippy --all-targets --all-features -- -D warnings`; `RUSTFLAGS="-D warnings" cargo test --all --all-features`; `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`; `cargo build -p web --target wasm32-unknown-unknown`; `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`.
+- **Flag-off determinism is sacros.** `interactive_acknowledge` defaults `false`. With it off, behavior must be byte-identical to today (single options auto-bind). The whole existing suite runs flag-off and must stay green.
+- **Crate layering.** `game-core` is the kernel: no I/O, compiles to wasm, never depends on `cards`. Card data is reached only through `card_registry::current()`.
+- **Validate-first / mutate-second.** Every handler checks all preconditions and returns `EngineOutcome::Rejected { reason }` with state+events unchanged before mutating.
+- **Never paraphrase card text from memory.** The only cards touched (Attic 01113, Cellar 01114) are already implemented; do not change their effects. If you must cite text, read `crates/cards/src/impls/attic.rs` / `cellar.rs` or ArkhamDB.
+- **No speculative DSL.** Add no new effect/DSL primitives; this is engine plumbing only.
+
+---
+
+### Task 1: Make `resolve_choice_count` flag-aware and thread the flag through all call sites
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/choice.rs:26-32` (signature + body), and its unit tests `:114-127`
+- Modify: `crates/game-core/src/engine/evaluator.rs:544` (`ChooseOne`), `:688` (deck search), `:1595-1606` (`resolve_grounded_choice` signature + match), `:1641,1665,1689,1728` (its 4 callers)
+- Modify: `crates/cards/src/impls/crypt_chill.rs:82`, `crates/cards/src/impls/dynamite_blast.rs:93`
+
+**Interfaces:**
+- Produces: `resolve_choice_count(n: usize, interactive: bool) -> ChoiceResolution` — `0 => Empty`, `2+ => Suspend`, `1 => Suspend` when `interactive` else `Auto(0)`. Callers pass `cx.state.interactive_acknowledge`.
+
+- [ ] **Step 1: Update the resolver's unit tests to the new signature (failing)**
+
+In `crates/game-core/src/engine/dispatch/choice.rs`, replace the three tests at `:114-127`:
+
+```rust
+    #[test]
+    fn resolve_zero_options_is_reject() {
+        assert!(matches!(resolve_choice_count(0, false), ChoiceResolution::Empty));
+        assert!(matches!(resolve_choice_count(0, true), ChoiceResolution::Empty));
+    }
+
+    #[test]
+    fn resolve_one_option_auto_binds_when_not_interactive() {
+        assert!(matches!(resolve_choice_count(1, false), ChoiceResolution::Auto(0)));
+    }
+
+    #[test]
+    fn resolve_one_option_suspends_when_interactive() {
+        // #466: a lone option surfaces as a one-option pick in human play.
+        assert!(matches!(resolve_choice_count(1, true), ChoiceResolution::Suspend));
+    }
+
+    #[test]
+    fn resolve_two_options_suspends_regardless_of_flag() {
+        assert!(matches!(resolve_choice_count(2, false), ChoiceResolution::Suspend));
+        assert!(matches!(resolve_choice_count(2, true), ChoiceResolution::Suspend));
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail to compile**
+
+Run: `cargo test -p game-core --lib dispatch::choice 2>&1 | tail -5`
+Expected: compile error — `resolve_choice_count` takes 1 argument, not 2.
+
+- [ ] **Step 3: Change `resolve_choice_count`'s signature and body**
+
+In `crates/game-core/src/engine/dispatch/choice.rs`, replace `:25-32`:
+
+```rust
+/// Map a legal-option count to the resolve convention. When `interactive` is set
+/// (human play, `interactive_acknowledge`), a single option surfaces as a
+/// one-option pick (`Suspend`) instead of auto-binding silently (#466).
+pub fn resolve_choice_count(n: usize, interactive: bool) -> ChoiceResolution {
+    match n {
+        0 => ChoiceResolution::Empty,
+        1 if interactive => ChoiceResolution::Suspend,
+        1 => ChoiceResolution::Auto(0),
+        _ => ChoiceResolution::Suspend,
+    }
+}
+```
+
+- [ ] **Step 4: Thread the flag through the three evaluator call sites**
+
+In `crates/game-core/src/engine/evaluator.rs`:
+
+At `:544` change `match resolve_choice_count(branches.len()) {` to:
+```rust
+    match resolve_choice_count(branches.len(), cx.state.interactive_acknowledge) {
+```
+
+At `:688` change `let chosen_deck_index: Option<usize> = match resolve_choice_count(eligible.len()) {` to:
+```rust
+    let chosen_deck_index: Option<usize> = match resolve_choice_count(
+        eligible.len(),
+        cx.state.interactive_acknowledge,
+    ) {
+```
+
+For `resolve_grounded_choice` at `:1595`, add an `interactive: bool` parameter (place it last, after `bind`) and use it at the match. Change the signature's closing to include it:
+```rust
+fn resolve_grounded_choice<Id: Copy>(
+    eval_ctx: EvalContext,
+    candidates: &[Id],
+    empty_reason: &'static str,
+    prompt: &'static str,
+    label: impl Fn(&Id) -> String,
+    bind: impl Fn(Id) -> EvalContext,
+    interactive: bool,
+) -> Result<EvalContext, EngineOutcome> {
+```
+and at `:1606` change `match resolve_choice_count(candidates.len()) {` to:
+```rust
+    match resolve_choice_count(candidates.len(), interactive) {
+```
+
+- [ ] **Step 5: Pass the flag from `resolve_grounded_choice`'s four callers**
+
+Each of `ground_investigator_choice` (`:1635`), `ground_location_choice` (`:1659`), `ground_enemy_choice` (`:1682`), and the co-located fight-target caller (`:1728`) takes `cx`. In each `resolve_grounded_choice(...)` call (at `:1641,1665,1689,1728`), add a final argument `cx.state.interactive_acknowledge,` (after the `bind` closure).
+
+- [ ] **Step 6: Thread the flag through the two card natives**
+
+In `crates/cards/src/impls/crypt_chill.rs:82` change `match resolve_choice_count(assets.len()) {` to:
+```rust
+    match resolve_choice_count(assets.len(), cx.state.interactive_acknowledge) {
+```
+
+In `crates/cards/src/impls/dynamite_blast.rs:93` change `match resolve_choice_count(locations.len()) {` to:
+```rust
+    match resolve_choice_count(locations.len(), cx.state.interactive_acknowledge) {
+```
+
+- [ ] **Step 7: Run the resolver unit tests + full suite**
+
+Run: `cargo test -p game-core --lib dispatch::choice 2>&1 | tail -5`
+Expected: PASS (4 tests).
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features 2>&1 | grep -E "test result: FAILED|error\[" ; echo done`
+Expected: no `FAILED`/`error[` lines (whole suite green — it runs flag-off, so behavior is unchanged).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/choice.rs crates/game-core/src/engine/evaluator.rs crates/cards/src/impls/crypt_chill.rs crates/cards/src/impls/dynamite_blast.rs
+git commit -m "engine: make resolve_choice_count flag-aware (single option surfaces when interactive) (#466)"
+```
+
+---
+
+### Task 2: Verify Mechanism A surfaces a single effect-choice option under the flag
+
+**Files:**
+- Test: `crates/game-core/src/engine/dispatch/choice.rs` (add to `#[cfg(test)] mod tests`)
+- Test: `crates/cards/src/impls/crypt_chill.rs` (add a card test in its `#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Consumes: flag-aware `resolve_choice_count` from Task 1; `Effect::ChooseOne`; `interactive_acknowledge` (a `pub` field on `GameState`).
+
+- [ ] **Step 1: Write a failing integration test — one-branch ChooseOne suspends under the flag**
+
+Add to `crates/game-core/src/engine/dispatch/choice.rs` tests (the existing test module already imports `Effect`, `push_effect`, `EvalContext`, `GameStateBuilder`, `Cx`, `drive`):
+
+```rust
+    #[test]
+    fn single_branch_choose_one_surfaces_under_interactive_flag() {
+        use crate::state::InvestigatorId;
+        use crate::test_support::GameStateBuilder;
+
+        // One ChooseOne branch: today it auto-binds. With interactive_acknowledge
+        // on it must surface as a one-option pick (#466).
+        let effect = Effect::ChooseOne(vec![Effect::Seq(vec![])]);
+        let ctx = EvalContext::for_controller(InvestigatorId(1));
+
+        let mut state = GameStateBuilder::default().build();
+        state.interactive_acknowledge = true;
+        let mut events = Vec::new();
+        let out = {
+            let mut cx = Cx { state: &mut state, events: &mut events };
+            push_effect(&mut cx, &effect, ctx);
+            crate::engine::dispatch::drive(&mut cx, EngineOutcome::Done)
+        };
+        match out {
+            EngineOutcome::AwaitingInput { request, .. } => {
+                assert_eq!(request.options.len(), 1, "lone branch surfaces as one option");
+            }
+            other => panic!("expected a one-option suspend, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn single_branch_choose_one_auto_binds_when_flag_off() {
+        use crate::state::InvestigatorId;
+        use crate::test_support::GameStateBuilder;
+
+        let effect = Effect::ChooseOne(vec![Effect::Seq(vec![])]);
+        let ctx = EvalContext::for_controller(InvestigatorId(1));
+        let mut state = GameStateBuilder::default().build(); // flag defaults false
+        let mut events = Vec::new();
+        let out = {
+            let mut cx = Cx { state: &mut state, events: &mut events };
+            push_effect(&mut cx, &effect, ctx);
+            crate::engine::dispatch::drive(&mut cx, EngineOutcome::Done)
+        };
+        assert!(matches!(out, EngineOutcome::Done), "flag off: auto-binds, no suspend");
+    }
+```
+
+- [ ] **Step 2: Run to verify the flag-off test passes and the flag-on test passes**
+
+Run: `cargo test -p game-core --lib single_branch_choose_one 2>&1 | tail -6`
+Expected: both PASS (Task 1 already provides the behavior — this test pins it). If the flag-on test fails with `Done`, Task 1's `ChooseOne` site was not threaded — fix `evaluator.rs:544`.
+
+- [ ] **Step 3: Write a Crypt Chill card test — one asset surfaces under the flag**
+
+Read `crates/cards/src/impls/crypt_chill.rs` first to mirror its existing test setup (controller + one in-play asset + the fail-path entry). Add to its `#[cfg(test)] mod tests`:
+
+```rust
+    #[test]
+    fn single_asset_discard_surfaces_under_interactive_flag() {
+        // With exactly one discardable asset and interactive_acknowledge on,
+        // the discard must surface as a one-option pick rather than auto-discard.
+        // (Mirror the existing fail-path test's setup; set
+        // state.interactive_acknowledge = true before invoking the fail handler,
+        // and assert the outcome is AwaitingInput with one option.)
+    }
+```
+Replace the comment body with the concrete setup copied from the nearest existing Crypt Chill fail-path test (same registry install, one asset in `cards_in_play`, call `crypt_chill_fail` via its test entry), adding `state.interactive_acknowledge = true;` and asserting:
+```rust
+        match out {
+            EngineOutcome::AwaitingInput { request, .. } => assert_eq!(request.options.len(), 1),
+            other => panic!("expected one-option discard, got {other:?}"),
+        }
+```
+
+- [ ] **Step 4: Run the Crypt Chill tests**
+
+Run: `cargo test -p cards crypt_chill 2>&1 | tail -8`
+Expected: PASS (existing + new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/choice.rs crates/cards/src/impls/crypt_chill.rs
+git commit -m "test: Mechanism A surfaces single effect-choice options under the flag (#466)"
+```
+
+---
+
+### Task 3: Add the `AcknowledgeForced` frame + drive/resume handlers
+
+**Files:**
+- Modify: `crates/game-core/src/state/game_state.rs` (add the `Continuation::AcknowledgeForced` variant near `AdvanceReverse`, `:459`)
+- Modify: `crates/game-core/src/engine/dispatch/forced_triggers.rs` (add `drive_acknowledge_forced`, `resume_acknowledge_forced`, and a `forced_source_name` helper)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs` (drive arm ~`:255`, resume arm ~`:614`)
+- Test: `crates/game-core/src/engine/dispatch/forced_triggers.rs` (`#[cfg(test)] mod`)
+
+**Interfaces:**
+- Produces: `Continuation::AcknowledgeForced { source: CardCode }`; `forced_triggers::drive_acknowledge_forced(cx) -> EngineOutcome` (suspends a one-option `PickSingle`); `forced_triggers::resume_acknowledge_forced(cx, &InputResponse) -> EngineOutcome` (validates `PickSingle(0)`, pops the frame, returns `Done`).
+
+- [ ] **Step 1: Add the continuation variant**
+
+In `crates/game-core/src/state/game_state.rs`, immediately after the `AdvanceReverse { ... }` variant (ends near `:468`), add:
+
+```rust
+    /// A no-choice forced ability is about to resolve and the game is in
+    /// interactive mode (`interactive_acknowledge`): surface it as a one-option
+    /// pick so the player "performs" it before it lands (#466). Pushed by
+    /// `resolve_one` above the forced effect's root frame; the `drive` loop
+    /// suspends here, and on resume pops, letting the effect frame beneath
+    /// resolve. `source` is the card the forced ability is printed on (for the
+    /// prompt's display name).
+    AcknowledgeForced { source: CardCode },
+```
+
+- [ ] **Step 2: Write a failing unit test for the frame's drive + resume**
+
+Add to `crates/game-core/src/engine/dispatch/forced_triggers.rs` `#[cfg(test)] mod` (create the module if absent; import `Continuation`, `CardCode`, `GameStateBuilder`, `Cx`, `EngineOutcome`, `InputResponse`, `OptionId`):
+
+```rust
+    #[test]
+    fn acknowledge_forced_suspends_then_pops_on_pick() {
+        use crate::action::InputResponse;
+        use crate::engine::OptionId;
+        use crate::state::{CardCode, Continuation};
+        use crate::test_support::GameStateBuilder;
+
+        let mut state = GameStateBuilder::default().build();
+        state
+            .continuations
+            .push(Continuation::AcknowledgeForced { source: CardCode("01113".into()) });
+        let mut events = Vec::new();
+        let mut cx = Cx { state: &mut state, events: &mut events };
+
+        // Drive: one-option suspend.
+        let out = super::drive_acknowledge_forced(&mut cx);
+        match out {
+            EngineOutcome::AwaitingInput { request, .. } => assert_eq!(request.options.len(), 1),
+            other => panic!("expected one-option suspend, got {other:?}"),
+        }
+
+        // Resume with the single option: frame pops, returns Done.
+        let out = super::resume_acknowledge_forced(&mut cx, &InputResponse::PickSingle(OptionId(0)));
+        assert!(matches!(out, EngineOutcome::Done));
+        assert!(
+            cx.state.continuations.is_empty(),
+            "the AcknowledgeForced frame must be popped on resume"
+        );
+    }
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cargo test -p game-core --lib acknowledge_forced_suspends 2>&1 | tail -6`
+Expected: compile error — `drive_acknowledge_forced` / `resume_acknowledge_forced` not found.
+
+- [ ] **Step 4: Implement the helpers in `forced_triggers.rs`**
+
+Add (top-level in `forced_triggers.rs`; the file already imports `Cx`, `EngineOutcome`, `card_registry`, `CardCode`):
+
+```rust
+/// Display name for the card a forced ability is printed on, for the
+/// `AcknowledgeForced` prompt. Resolved via the registry; falls back to the raw
+/// code when no registry/metadata is available (tests).
+fn forced_source_name(code: &CardCode) -> String {
+    crate::card_registry::current()
+        .and_then(|r| (r.metadata_for)(code))
+        .map_or_else(|| code.0.clone(), |m| m.name.clone())
+}
+
+/// Drive a [`Continuation::AcknowledgeForced`] frame (#466): suspend with a
+/// one-option `PickSingle` naming the source. The pick precedes the forced
+/// effect's resolution ("confirm before the effect"). Mirrors
+/// `advance_reverse::drive`'s `AwaitAck` suspend.
+pub(crate) fn drive_acknowledge_forced(cx: &mut Cx) -> EngineOutcome {
+    use crate::engine::{ChoiceOption, InputRequest, OptionId, ResumeToken};
+    let Some(crate::state::Continuation::AcknowledgeForced { source }) =
+        cx.state.continuations.last()
+    else {
+        return EngineOutcome::Rejected {
+            reason: "drive_acknowledge_forced: top frame is not AcknowledgeForced".into(),
+        };
+    };
+    let name = forced_source_name(source);
+    EngineOutcome::AwaitingInput {
+        request: InputRequest::pick_single(
+            format!("Forced — {name}"),
+            vec![ChoiceOption { id: OptionId(0), label: "Resolve".into() }],
+        ),
+        resume_token: ResumeToken(0),
+    }
+}
+
+/// Resume an [`AcknowledgeForced`] frame: validate the single option, pop the
+/// frame, and return `Done` so the `drive` loop resolves the effect beneath.
+pub(crate) fn resume_acknowledge_forced(
+    cx: &mut Cx,
+    response: &crate::action::InputResponse,
+) -> EngineOutcome {
+    use crate::engine::OptionId;
+    if !matches!(response, crate::action::InputResponse::PickSingle(OptionId(0))) {
+        return EngineOutcome::Rejected {
+            reason: "resume_acknowledge_forced: expected the single forced-resolution option".into(),
+        };
+    }
+    debug_assert!(matches!(
+        cx.state.continuations.last(),
+        Some(crate::state::Continuation::AcknowledgeForced { .. })
+    ));
+    cx.state.continuations.pop();
+    EngineOutcome::Done
+}
+```
+
+- [ ] **Step 5: Wire the drive arm in `mod.rs`**
+
+In `crates/game-core/src/engine/dispatch/mod.rs`, in the `drive` loop match (near the `AdvanceReverse` arm at `:255`), add:
+
+```rust
+            Some(Continuation::AcknowledgeForced { .. }) => {
+                return forced_triggers::drive_acknowledge_forced(cx)
+            }
+```
+(Match the surrounding arms' early-return shape — the `AwaitingInput` propagates out of the loop, exactly like other suspending arms.)
+
+- [ ] **Step 6: Wire the resume arm in `mod.rs`**
+
+In the resume dispatch match (near the `AdvanceReverse` resume arm at `:614`), add:
+
+```rust
+        Some(Continuation::AcknowledgeForced { .. }) => {
+            forced_triggers::resume_acknowledge_forced(cx, response)
+        }
+```
+
+- [ ] **Step 7: Run the unit test + full suite**
+
+Run: `cargo test -p game-core --lib acknowledge_forced_suspends 2>&1 | tail -6`
+Expected: PASS.
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features 2>&1 | grep -E "test result: FAILED|error\[" ; echo done`
+Expected: no failures (the frame is not pushed anywhere yet, so nothing else changes).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/game-core/src/state/game_state.rs crates/game-core/src/engine/dispatch/forced_triggers.rs crates/game-core/src/engine/dispatch/mod.rs
+git commit -m "engine: AcknowledgeForced continuation frame (one-option forced-effect pause) (#466)"
+```
+
+---
+
+### Task 4: Push `AcknowledgeForced` from `resolve_one` when interactive
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/forced_triggers.rs:456-477` (`resolve_one`)
+- Test: `crates/game-core/src/engine/dispatch/forced_triggers.rs` (`#[cfg(test)] mod`)
+
+**Interfaces:**
+- Consumes: `Continuation::AcknowledgeForced` and the drive/resume from Task 3; `interactive_acknowledge`.
+
+- [ ] **Step 1: Modify `resolve_one` to push the ack frame above the effect when interactive**
+
+In `crates/game-core/src/engine/dispatch/forced_triggers.rs`, change the tail of `resolve_one` (currently `push_effect(cx, &effect, ctx); EngineOutcome::Done`) to:
+
+```rust
+    push_effect(cx, &effect, ctx);
+    // #466: in interactive play, surface the forced effect as a one-option pick
+    // *before* it resolves. Pushed above the effect frame so the `drive` loop
+    // hits it first, suspends, and on resume pops it — then resolves the effect.
+    // resolve_one still returns Done (push-frame contract), so emit callers that
+    // do post-emit work stay correct.
+    if cx.state.interactive_acknowledge {
+        cx.state
+            .continuations
+            .push(crate::state::Continuation::AcknowledgeForced { source: hit.code.clone() });
+    }
+    EngineOutcome::Done
+```
+
+- [ ] **Step 2: Write a test — a single forced hit pushes the ack frame under the flag**
+
+Add to `forced_triggers.rs` tests. Use the existing `fire_forced_on_enemy_defeat` / a registered forced source if a helper exists; otherwise drive `fire_forced_triggers` directly with a registered single-forced point. The minimal, dependency-light assertion drives `emit_event` for entering a location with a forced ability and checks the suspend. Prefer reusing the cards-crate integration path (Task 5) for the real-card assertion and keep this unit test focused on the frame-push:
+
+```rust
+    #[test]
+    fn single_forced_pushes_acknowledge_when_interactive() {
+        // With interactive_acknowledge on, resolving one forced hit must leave an
+        // AcknowledgeForced frame on top (the one-option pause) above the effect.
+        // Build a state with the flag on, a registered forced source, drive the
+        // forced trigger, and assert the top frame is AcknowledgeForced.
+        // (If forced_triggers has no in-crate registry helper, assert this in the
+        // cards integration test in Task 5 instead and delete this unit test.)
+    }
+```
+If `game-core` cannot register a forced source without the `cards` registry (likely — `collect_forced_hits` returns empty with no registry), **delete this unit test** and rely on Task 5's real-card integration coverage; note that in the commit message. Do not fake a registry in a `game-core` lib test.
+
+- [ ] **Step 3: Run the full suite (flag-off regression)**
+
+Run: `RUSTFLAGS="-D warnings" cargo test --all --all-features 2>&1 | grep -E "test result: FAILED|error\[" ; echo done`
+Expected: no failures. The flag is off everywhere in the existing suite, so `resolve_one` pushes nothing extra and forced resolution is unchanged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/forced_triggers.rs
+git commit -m "engine: surface single forced effects as a one-option pause when interactive (#466)"
+```
+
+---
+
+### Task 5: Real-card integration test — Attic/Cellar acknowledge before harm
+
+**Files:**
+- Create: `crates/cards/tests/forced_acknowledge.rs`
+
+**Interfaces:**
+- Consumes: `Continuation::AcknowledgeForced`, the drive/resume from Tasks 3–4, the real `cards::REGISTRY`, the Attic (01113) and Cellar (01114) location forced abilities.
+
+- [ ] **Step 1: Write the failing integration test**
+
+First read `crates/cards/tests/act_advancement.rs` for the `#[ctor::ctor]` registry-install pattern and `crates/cards/src/impls/attic.rs` + `cellar.rs` to confirm the forced trigger (`EnteredLocation`, `After`) and the harm (1 horror / 1 damage). Then create `crates/cards/tests/forced_acknowledge.rs`:
+
+```rust
+//! #466: a no-choice forced location ability (the Attic's 1 horror, the Cellar's
+//! 1 damage) surfaces a one-option acknowledge *before* the harm lands when
+//! interactive_acknowledge is on, and resolves synchronously when it is off.
+
+use game_core::engine::EngineOutcome;
+use game_core::state::Continuation;
+
+#[ctor::ctor]
+fn install() {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+}
+
+// Helper: build a one-investigator state standing on the given location code,
+// with the flag set, then emit EnteredLocation and drive. Returns (outcome,
+// final state). Mirror the move/emit path used by the engine's location tests;
+// if a `test_support` helper to emit EnteredLocation exists, use it, otherwise
+// construct the location in play, place the investigator on it, and call the
+// engine's emit entry for EnteredLocation.
+```
+
+Implement two tests. For **flag on**: after emitting `EnteredLocation` for the Attic, drive once; assert the outcome is `AwaitingInput` with one option **and** the investigator's accumulated horror is still 0 (harm not yet applied); then resume with `PickSingle(OptionId(0))` and assert horror is now 1 and no `AcknowledgeForced` frame remains. For **flag off**: emit + drive resolves synchronously (no suspend) and horror is 1 immediately. Repeat the on/off pair for the Cellar (1 damage).
+
+Use the actual harm-accumulator fields from `attic.rs`/`cellar.rs`'s tests (read them — likely `Investigator` sanity/horror and health/damage counters) for the assertions.
+
+- [ ] **Step 2: Run to verify the flag-on test fails first if any wiring is missing**
+
+Run: `cargo test -p cards --test forced_acknowledge 2>&1 | tail -15`
+Expected: PASS once Tasks 3–4 are in. If the flag-on test sees harm applied with no suspend, `resolve_one`'s push (Task 4) is not reached on this path — verify the Attic's forced routes through `fire_forced_triggers` (single hit) and that `interactive_acknowledge` is set on the state.
+
+- [ ] **Step 3: Run the gauntlet**
+
+Run the full Global-Constraints gauntlet. Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cards/tests/forced_acknowledge.rs
+git commit -m "test: Attic/Cellar forced effects acknowledge before harm when interactive (#466)"
+```
+
+---
+
+### Task 6: File the deferred follow-ups (non-code)
+
+- [ ] **Step 1: File the descriptive-effect-text follow-up issue**
+
+```bash
+gh issue create --title "Descriptive player-facing text for forced/auto-resolved effects" \
+  --label engine,ui,p2-later \
+  --body "Follow-up from #466. The #466 acknowledge names the *source* (\"Forced — The Attic\") but not the effect (\"…takes 1 horror\"). Build player-facing prose from an effect tree / emitted events so prompts and a future event feed can describe what happened. Overlaps #469 (player-facing copy, not protocol strings)."
+```
+
+- [ ] **Step 2: Note the framework-harm case on #429**
+
+```bash
+gh issue comment 429 --body "From #466: the draw-from-empty-deck horror penalty is pure-framework harm (no card forced ability), so #466's AcknowledgeForced (which hooks card forced abilities via resolve_one) does not reach it. When this interactive soak/harm work lands, it should likewise surface an acknowledge before the harm, for parity with #466."
+```
+
+- [ ] **Step 3: No commit** (issue/comment only).
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Mechanism A → Tasks 1–2; Mechanism B (dedicated `AcknowledgeForced` frame) → Tasks 3–5; prompt copy (`"Forced — {name}"`, registry name, code fallback) → Task 3 Step 4; flag reuse → throughout; deferred follow-ups → Task 6. Web client needs no change (spec §Web client; `InputKind::PickSingle` already renders one button per option).
+- **Flag-off determinism:** every task's regression step runs the full suite flag-off; Task 1 changes only the n=1-interactive branch; Task 4 guards the push behind the flag.
+- **Type consistency:** `resolve_choice_count(n, interactive)` is used identically at all 7 call sites; `Continuation::AcknowledgeForced { source: CardCode }` matches `forced_source_name(&CardCode)` and `hit.code` (a `CardCode`); `resume_acknowledge_forced` expects `PickSingle(OptionId(0))`, the same option `drive_acknowledge_forced` emits.

--- a/docs/superpowers/specs/2026-06-27-surface-single-option-choices-design.md
+++ b/docs/superpowers/specs/2026-06-27-surface-single-option-choices-design.md
@@ -106,32 +106,36 @@ if candidates.len() >= 2 {
 }
 ```
 
-`open_forced_resolution` (`reaction_windows.rs:123`) builds a `ChoiceOption` per
-forced candidate ("forced — cannot skip; the lead orders them") and resolves them
-in the picked order. That is exactly a "which forced effect to resolve next"
-choice — and for a single candidate it is the acknowledge we want.
+**The synchronous-return constraint.** The 2+ path (`open_forced_resolution`,
+`reaction_windows.rs:123`) returns `AwaitingInput` *directly* from `emit_event`. Its
+callers must therefore be frame-resumable; the comment in `emit.rs` notes the
+others `debug_assert!(Done)`. The single-forced path is different on purpose:
+`fire_forced_triggers` → `resolve_one` *pushes* the effect root frame and returns
+**`Done`**, letting the global `drive` loop own any later suspend — so emit callers
+that do post-emit work (the move action, etc.) stay correct. Re-routing single
+forced through `open_forced_resolution` would make `emit_event` return
+`AwaitingInput` for the n=1 case and break every such caller. So Mechanism B must
+preserve the push-frame-then-`Done` shape.
 
-Change: route **n ≥ 1** through `open_forced_resolution` **when interactive**, and
-let that path present a single candidate as a one-option choice:
+**The change: a dedicated one-option frame, pushed by `resolve_one`.** When
+`interactive_acknowledge` is on, `resolve_one` pushes a new
+`Continuation::AcknowledgeForced { source }` frame **above** the forced effect's
+root frame, then returns `Done` exactly as today. The `drive` loop reaches the
+`AcknowledgeForced` frame first and suspends with a **one-option `PickSingle`**
+labelled from the source; on resume it pops the frame, and the `drive` loop then
+resolves the effect frame beneath. The pick precedes resolution → "confirm before
+the effect" holds. With the flag off, `resolve_one` pushes nothing extra and the
+effect resolves synchronously (today's behavior), so non-interactive consumers and
+tests are unaffected.
 
-```rust
-let candidates = collect_forced_hits(state, &point, After);
-let interactive = cx.state.interactive_acknowledge;
-match candidates.len() {
-    0 => fire_forced_triggers(cx, &point, After), // nothing forced (→ reaction)
-    1 if !interactive => fire_forced_triggers(cx, &point, After), // today's path
-    _ => open_forced_resolution(cx, event, candidates), // ≥2 always; 1 when interactive
-}
-```
-
-`open_forced_resolution` / its window-resume must present a single-candidate set as
-a one-option `PickSingle` rather than auto-firing (the analog of Mechanism A's n=1
-change). The pick precedes resolution → "confirm before the effect" holds. With the
-flag off, a single forced effect still fires synchronously (today's behavior), so
-non-interactive consumers and tests are unaffected.
-
-This covers the original #466 examples (Attic, Cellar) and any future no-choice
-forced ability uniformly, with no per-card work.
+This is the same idiom the engine already uses for a "pause, then continue"
+framework step — the `AdvanceReverse`/`AwaitAck` frame (#482) — and it is the
+single-candidate analog of Mechanism A's n=1 change (a lone option surfaces as a
+one-option `PickSingle`). Reusing the 2+ forced-ordering window for n=1 was
+considered and rejected: it would violate the emit synchronous-return contract and
+require adapting the 1900-line window machinery to a case it never sees, for no
+behavioral gain. It covers the original #466 examples (Attic, Cellar) and any
+future no-choice forced ability uniformly, with no per-card work.
 
 ### Prompt copy
 

--- a/docs/superpowers/specs/2026-06-27-surface-single-option-choices-design.md
+++ b/docs/superpowers/specs/2026-06-27-surface-single-option-choices-design.md
@@ -189,6 +189,16 @@ churn in this PR; noted as a follow-up.
   separate UI investment, not pursued here.
 - **2+ simultaneous-forced ordering UX** is unchanged (already surfaced).
 - **`interactive_acknowledge` rename** — deferred (see The flag).
+- **Remaining single-option auto-binds outside `resolve_choice_count`** — combat
+  soak distribution, single-enemy attack-order, and other bespoke frame-local n=1
+  shortcuts. The elegant end-state is one uniform "single option ⇒ one-option
+  suspend when interactive" rule (retiring the dedicated `AcknowledgeForced` frame
+  and the per-frame n=1 checks), but it depends on the **pure frame-driven model**
+  — the dormant "B end-state" of #393 — because the remaining sites resolve through
+  emit callers that assume a `Done` return (some `let _ = emit_event(...)`).
+  **Action: file a follow-up issue** and cross-reference #393. This is *why* #466
+  splits into the flag-aware `resolve_choice_count` + a dedicated forced frame
+  rather than one unified mechanism.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-06-27-surface-single-option-choices-design.md
+++ b/docs/superpowers/specs/2026-06-27-surface-single-option-choices-design.md
@@ -1,0 +1,200 @@
+# Surface single-option auto-binds as choices (#466)
+
+## Problem
+
+The engine auto-resolves things the player never sees or "performs":
+
+- **No-choice forced effects** — the Attic (01113) "Forced: take 1 horror", the
+  Cellar (01114) "Forced: take 1 damage". They apply silently; the only trace is
+  a changed counter the player may not notice.
+- **Auto-bound single-option choices** — when exactly one option is legal the
+  engine auto-binds it without asking (`resolve_choice_count`'s `1 ⇒ Auto`): the
+  sole attack target, the only asset to discard, etc. The player never "does" it.
+
+Tabletop Arkham makes the player physically perform all of these, so surfacing
+them is also more faithful.
+
+## Decisions from brainstorming
+
+- **UX shape: surface as a choice, not a separate acknowledge frame.** Rather than
+  bolt on a bespoke "acknowledge" continuation, we treat the *auto-bind itself* as
+  the root cause and make a single legal option surface as a **one-option
+  `PickSingle`** — gated behind the interactive flag. The pick happens **before**
+  the option resolves (the player "performs" it, then the effect lands).
+- **No double-confirm.** When 2+ options exist the player already picks (an
+  ordering / target choice) — that *is* the awareness. We only change the n=1 case.
+- **Reuse `interactive_acknowledge`.** It already means "human play — make things
+  visible" (it gates the skill-test result pause #478 and the act/agenda advance
+  pause #482). We broaden its meaning to also gate single-option surfacing; a
+  rename is deferred (noted below).
+- **Full unification in this PR.** Every single-option auto-bind surfaces under the
+  flag — attack target, asset discard, forced effect — not just forced harm. This
+  is the whole point: one mechanism, not a parallel acknowledge subsystem. The
+  previously-"deferred" single-option surfacing is no longer a follow-up; it *is*
+  the solution.
+
+## Goal
+
+With `interactive_acknowledge` on, a solo human in the browser sees and confirms
+every auto-resolved single-option step before it resolves: the Attic's forced
+horror, the sole attack target, the only asset to discard. With the flag off
+(tests, non-interactive consumers) behavior is **unchanged** — single options
+auto-bind exactly as today, so determinism and existing tests are preserved.
+
+## Design
+
+Two auto-bind mechanisms exist; both get the same flag-aware n=1 treatment.
+
+### Mechanism A — `resolve_choice_count` (effect-level choices)
+
+`crates/game-core/src/engine/dispatch/choice.rs` defines the shared resolver:
+
+```rust
+pub fn resolve_choice_count(n: usize) -> ChoiceResolution {
+    match n {
+        0 => ChoiceResolution::Empty,   // caller's printed fallback / reject
+        1 => ChoiceResolution::Auto(0), // bind the sole option silently
+        _ => ChoiceResolution::Suspend, // controller picks
+    }
+}
+```
+
+Make it flag-aware:
+
+```rust
+pub fn resolve_choice_count(n: usize, interactive: bool) -> ChoiceResolution {
+    match n {
+        0 => ChoiceResolution::Empty,
+        1 if interactive => ChoiceResolution::Suspend, // surface the sole option
+        1 => ChoiceResolution::Auto(0),                // flag off: today's behavior
+        _ => ChoiceResolution::Suspend,
+    }
+}
+```
+
+The five call sites pass `cx.state.interactive_acknowledge`:
+
+- `evaluator.rs:544` — `ChooseOne` branches
+- `evaluator.rs:688` — deck choice
+- `evaluator.rs:1606` — spatial/entity candidate choice (e.g. `Effect::Fight` target)
+- `crates/cards/src/impls/crypt_chill.rs:82` — asset to discard
+- `crates/cards/src/impls/dynamite_blast.rs:93` — location to blast
+
+Each call site already has a `Suspend` arm that builds one render label per
+candidate and suspends (`awaiting_choice` / `suspend_for_native_choice`). With one
+candidate that arm naturally produces a **one-option** `PickSingle`; resume indexes
+`OptionId(0)` to the sole candidate. So the call sites need no structural change
+beyond passing the flag — the existing `Suspend` path handles n=1 correctly because
+label-building maps over the candidate list (length 1 → one label). No new resume
+logic: `resume_effect_choice` already validates the pick by checked indexing.
+
+**`ChoiceResolution::Auto`** stays for the flag-off path; it is not removed.
+
+### Mechanism B — forced-trigger surfacing (no-choice forced effects)
+
+Attic/Cellar forced abilities are `forced_on_event(..., deal_horror/deal_damage)`
+— no `ChooseOne`, so they never reach `resolve_choice_count`. They resolve through
+the forced-trigger chokepoint in `emit.rs`:
+
+```rust
+// emit_event(): today
+let candidates = collect_forced_hits(state, &point, After);
+if candidates.len() >= 2 {
+    open_forced_resolution(cx, event, candidates) // lead orders them (a choice)
+} else {
+    fire_forced_triggers(cx, &point, After)       // 0 or 1: fire synchronously
+}
+```
+
+`open_forced_resolution` (`reaction_windows.rs:123`) builds a `ChoiceOption` per
+forced candidate ("forced — cannot skip; the lead orders them") and resolves them
+in the picked order. That is exactly a "which forced effect to resolve next"
+choice — and for a single candidate it is the acknowledge we want.
+
+Change: route **n ≥ 1** through `open_forced_resolution` **when interactive**, and
+let that path present a single candidate as a one-option choice:
+
+```rust
+let candidates = collect_forced_hits(state, &point, After);
+let interactive = cx.state.interactive_acknowledge;
+match candidates.len() {
+    0 => fire_forced_triggers(cx, &point, After), // nothing forced (→ reaction)
+    1 if !interactive => fire_forced_triggers(cx, &point, After), // today's path
+    _ => open_forced_resolution(cx, event, candidates), // ≥2 always; 1 when interactive
+}
+```
+
+`open_forced_resolution` / its window-resume must present a single-candidate set as
+a one-option `PickSingle` rather than auto-firing (the analog of Mechanism A's n=1
+change). The pick precedes resolution → "confirm before the effect" holds. With the
+flag off, a single forced effect still fires synchronously (today's behavior), so
+non-interactive consumers and tests are unaffected.
+
+This covers the original #466 examples (Attic, Cellar) and any future no-choice
+forced ability uniformly, with no per-card work.
+
+### Prompt copy
+
+- **Forced effects (Mechanism B):** `"Forced — {name}"`, where `{name}` is the
+  source card's display name resolved via `card_registry::current().metadata_for`
+  (fallback to the raw code when no registry is installed — i.e. tests). One option
+  labelled with the source.
+- **Effect choices (Mechanism A):** keep the labels each call site already builds
+  (asset name, enemy name, branch label). No copy change.
+- **Descriptive effect text** ("…takes 1 horror") is explicitly **out of scope** —
+  see follow-ups. The MVP names the source; the player reads the resulting counter
+  change.
+
+### Web client
+
+No new view. `AwaitingInputView` already renders `InputKind::PickSingle` as one
+button per option and `InputKind::Confirm` as a Confirm button. A one-option
+`PickSingle` renders as a single labelled button — the desired "perform it" control.
+Display names already resolve client-side (`crate::names`), so `"Forced — The
+Attic"` shows the location name.
+
+### The flag
+
+`interactive_acknowledge` (`game_state.rs:248`, default `false`; the server sets it
+`true` for human play in `GameSession::create`). Its meaning broadens from "pause
+to acknowledge results" to "human play — surface single-option steps". A rename to
+something like `interactive` / `surface_single_options` is **deferred** to avoid
+churn in this PR; noted as a follow-up.
+
+## Non-goals / deferred (with follow-ups)
+
+- **Descriptive effect/ability text.** Building player-facing prose from an effect
+  tree or emitted events ("Roland takes 1 horror") — a general capability that also
+  serves an event feed. **Action: file a new follow-up issue.** (Overlaps #469's
+  "player-facing copy, not protocol strings".)
+- **Pure-framework harm with no card ability.** The draw-from-empty-deck horror
+  penalty deals harm via a framework rule, not a forced *ability*, so Mechanism B
+  does not reach it. **Action: note on #429** that its interactive soak/harm should
+  also surface an acknowledge when that work lands.
+- **Event feed / passive log.** A running history pane in the web client — a
+  separate UI investment, not pursued here.
+- **2+ simultaneous-forced ordering UX** is unchanged (already surfaced).
+- **`interactive_acknowledge` rename** — deferred (see The flag).
+
+## Testing
+
+- **`resolve_choice_count` unit (choice.rs):** `1 with interactive ⇒ Suspend`;
+  `1 without ⇒ Auto(0)`; `0 ⇒ Empty`; `2+ ⇒ Suspend` regardless of the flag.
+- **Mechanism A integration:** a `ChooseOne`/`Effect::Fight` with a single legal
+  option suspends a one-option `PickSingle` when `interactive_acknowledge` is on,
+  and resolves on resume; with the flag off it auto-binds (today's behavior,
+  regression-guarded). Card test: Crypt Chill with one asset surfaces the discard
+  as a one-option pick under the flag.
+- **Mechanism B integration (cards crate, real registry):** entering the Attic
+  (01113) with the flag on suspends a one-option `PickSingle` whose label names the
+  source, and applies the 1 horror only **after** the pick; the Cellar (01114)
+  likewise for 1 damage. With the flag off both fire synchronously (no suspend),
+  guarding today's behavior.
+- **No-regression sweep:** the existing engine/server suites run with the flag off
+  by default, so they must pass unchanged.
+
+## Open questions
+
+None outstanding — the brainstorm settled the UX shape (surface as choice, before
+resolution), the flag (reuse `interactive_acknowledge`), and scope (full
+unification; descriptive text and framework-harm deferred to follow-ups).

--- a/docs/superpowers/specs/2026-06-27-surface-single-option-choices-design.md
+++ b/docs/superpowers/specs/2026-06-27-surface-single-option-choices-design.md
@@ -117,16 +117,26 @@ forced through `open_forced_resolution` would make `emit_event` return
 `AwaitingInput` for the n=1 case and break every such caller. So Mechanism B must
 preserve the push-frame-then-`Done` shape.
 
-**The change: a dedicated one-option frame, pushed by `resolve_one`.** When
-`interactive_acknowledge` is on, `resolve_one` pushes a new
-`Continuation::AcknowledgeForced { source }` frame **above** the forced effect's
-root frame, then returns `Done` exactly as today. The `drive` loop reaches the
-`AcknowledgeForced` frame first and suspends with a **one-option `PickSingle`**
-labelled from the source; on resume it pops the frame, and the `drive` loop then
-resolves the effect frame beneath. The pick precedes resolution → "confirm before
-the effect" holds. With the flag off, `resolve_one` pushes nothing extra and the
-effect resolves synchronously (today's behavior), so non-interactive consumers and
-tests are unaffected.
+**The change: a dedicated one-option frame, pushed on the single-hit path.** When
+`interactive_acknowledge` is on, `fire_forced_triggers` (the 0/1-hit path) pushes a
+new `Continuation::AcknowledgeForced { source }` frame **above** the forced
+effect's root frame after `resolve_one` pushes it, then returns `Done` exactly as
+today. The `drive` loop reaches the `AcknowledgeForced` frame first and suspends
+with a **one-option `PickSingle`** labelled from the source; on resume it pops the
+frame, and the `drive` loop then resolves the effect frame beneath. The pick
+precedes resolution → "confirm before the effect" holds. With the flag off,
+nothing extra is pushed and the effect resolves synchronously (today's behavior),
+so non-interactive consumers and tests are unaffected.
+
+**No double-confirm on 2+ forced.** The ack lives on the single-hit path only.
+`resolve_one` is called *exclusively* from `fire_forced_triggers`; the 2+
+simultaneous-forced run resolves its candidates through the forced-resolution
+window's own path (`reaction_windows.rs:864/894`), never `resolve_one`. So when the
+player orders 2+ forced effects, that ordering pick *is* the confirmation and no
+per-effect ack is added — exactly the desired behavior. Placing the push in
+`fire_forced_triggers` (docstring: "at most one hit reaches here") rather than
+`resolve_one` makes this scoping self-evident and keeps `resolve_one` a pure
+resolution primitive.
 
 This is the same idiom the engine already uses for a "pause, then continue"
 framework step — the `AdvanceReverse`/`AwaitAck` frame (#482) — and it is the


### PR DESCRIPTION
## Summary

Fixes #466. When `interactive_acknowledge` is on (human play), a single legal option now surfaces as a **one-option `PickSingle` before it resolves**, instead of auto-binding silently — so the player sees and "performs" forced effects (the Attic's 1 horror, the Cellar's 1 damage) and single-option choices (sole attack target, lone asset to discard). With the flag **off** (tests / non-interactive consumers), behavior is byte-identical to before.

## Two flag-aware mechanisms

- **A — `resolve_choice_count`** gained an `interactive` arg: `1 => Suspend` when interactive, else `Auto(0)` (`0 => Empty`, `2+ => Suspend` unchanged). The flag (`cx.state.interactive_acknowledge`) is threaded through all 5 effect-choice sites (ChooseOne, deck search, the grounded-choice helper backing `Effect::Fight`/investigator/location/enemy targets) and the Crypt Chill + Dynamite Blast natives. Each site's existing `Suspend` arm renders a one-option pick for n=1; resume indexes `OptionId(0)`.
- **B — `Continuation::AcknowledgeForced { source }`**, a new frame pushed by `fire_forced_triggers` (the single-forced-hit path) *above* the forced effect's root frame when interactive. The drive loop suspends a one-option `PickSingle` ("Forced — {name}", name via the registry, code fallback); on resume it pops, and the effect resolves. `fire_forced_triggers` still returns `Done`, preserving the synchronous-return contract emit callers rely on.

### Why a dedicated frame for B (not rerouting through `open_forced_resolution`)

The 2+ ordered-forced run returns `AwaitingInput` directly from `emit_event`; rerouting single-forced through it would break emit callers that assume `Done` (some `let _ = emit_event(...)`). The dedicated frame keeps `emit_event` returning `Done` — fully transparent. The ack lives on the single-hit path only, so **no double-confirm on 2+** (the ordering pick is the confirmation; the 2+ run resolves via the window's own path, never `resolve_one`).

## Deferred (follow-ups filed)

- **#491** — descriptive player-facing effect text ("…takes 1 horror"); this PR names only the source.
- **#492** — surface the remaining single-option auto-binds (combat soak, single-enemy attack-order) via a uniform "suspend-1-option" mechanism that would retire the dedicated frame; **blocked on the pure frame-driven model** (the dormant "B end-state" of #393, cross-referenced).
- Comment on **#429** — empty-deck framework harm should likewise acknowledge when that work lands.

## Tests

`resolve_choice_count` unit (flag on/off × n); single-branch ChooseOne surfaces/auto-binds (game-core); Crypt Chill + Dynamite Blast n=1 surface under flag and auto-bind off; the `AcknowledgeForced` frame drive/resume + non-`PickSingle` rejection; and a real-card integration test (`crates/cards/tests/forced_acknowledge.rs`) proving Attic/Cellar acknowledge **before** the harm lands when interactive and resolve synchronously when off.

## Verification

Full local gauntlet green: `fmt`, `clippy --all-targets --all-features -D warnings`, `RUSTFLAGS=-D warnings cargo test --all --all-features`, `RUSTDOCFLAGS=-D warnings cargo doc`, `wasm-build`, `wasm-clippy`. Pre-push review: ready to merge, no Critical/Important findings (the three recommended symmetric tests were added).

Design + plan: `docs/superpowers/specs/2026-06-27-surface-single-option-choices-design.md`, `docs/superpowers/plans/2026-06-27-surface-single-option-choices.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)