### PR TITLE
infra: enforce missing_errors_doc + missing_panics_doc, document the sites

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,13 @@ unsafe_code = "deny"
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
-# Allow some pedantic lints that fire too noisily for early-stage code:
+# Two pedantic lints we deliberately don't enforce — stylistic preferences, not
+# a maturity concession: `module_name_repetitions` would force churny renames
+# (e.g. `card::CardCode`), and `must_use_candidate` is noise (we hand-apply
+# `#[must_use]` where it earns its keep). The doc lints (`missing_errors_doc` /
+# `missing_panics_doc`) are enforced — see the `# Errors` / `# Panics` sections.
 module_name_repetitions = "allow"
 must_use_candidate = "allow"
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
 
 [profile.release]
 lto = "thin"

--- a/crates/game-core/src/engine/dispatch/act_agenda.rs
+++ b/crates/game-core/src/engine/dispatch/act_agenda.rs
@@ -293,6 +293,14 @@ pub fn round_end_advance_affordable(state: &GameState, contributor_location_code
 /// eligibility predicate (which calls [`round_end_advance_affordable`]), so the
 /// insufficient-clues branch here is a defensive backstop. Exposed for the
 /// `cards` registry's 01109 native handler.
+///
+/// # Panics
+///
+/// Panics if `contributor_location_code` is not a location in play. This is
+/// unreachable in practice: the affordability check above returns early unless
+/// the location is present, so reaching the `expect` would mean
+/// [`round_end_advance_affordable`] and [`location_id_by_code`](crate::engine::location_id_by_code)
+/// disagree about the same code.
 pub fn round_end_advance(cx: &mut Cx, contributor_location_code: &str) -> EngineOutcome {
     if !round_end_advance_affordable(cx.state, contributor_location_code) {
         return EngineOutcome::Rejected {

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -118,6 +118,13 @@ pub(in crate::engine) fn draw_cards(cx: &mut Cx, investigator: InvestigatorId, c
 /// crate root) so card-local natives can drive "discard at random from hand"
 /// without reaching into the crate-private RNG (agenda 01105's random-discard
 /// branch, Axis A #334).
+///
+/// # Panics
+///
+/// Panics if `investigator` vanishes from the state mid-call — the index draw
+/// re-`get`s the investigator already checked present above, so this is a
+/// state-corruption invariant, not a reachable input error (a missing
+/// investigator returns `None` at the top).
 pub fn discard_random_from_hand(cx: &mut Cx, investigator: InvestigatorId) -> Option<CardCode> {
     let inv = cx.state.investigators.get_mut(&investigator)?;
     if inv.hand.is_empty() {

--- a/crates/game-core/src/engine/dispatch/threat_area.rs
+++ b/crates/game-core/src/engine/dispatch/threat_area.rs
@@ -42,6 +42,12 @@ pub(super) fn new_in_play_instance(cx: &mut Cx, code: CardCode) -> CardInPlay {
 /// No-op (returns `None`) if the investigator isn't in state — callers
 /// in dispatch have already validated the investigator exists, but the
 /// helper stays total so a misuse can't panic.
+///
+/// # Panics
+///
+/// Does not panic in practice: the `get_mut` re-fetches the investigator just
+/// confirmed present, with no intervening mutation, so the `expect` is a
+/// state-corruption invariant guard.
 pub fn place_in_threat_area(
     cx: &mut Cx,
     investigator: InvestigatorId,
@@ -74,6 +80,12 @@ pub fn place_in_threat_area(
 /// **No limit enforcement** — "Limit 1 per location" is printed on
 /// specific cards (Obscuring Fog 01168), not a property of all
 /// attachments, so the limit lives in the card's Revelation, not here.
+///
+/// # Panics
+///
+/// Does not panic in practice: the `get_mut` re-fetches the location just
+/// confirmed present, with no intervening mutation, so the `expect` is a
+/// state-corruption invariant guard.
 pub fn attach_to_location(
     cx: &mut Cx,
     location: LocationId,

--- a/crates/game-core/src/state/builder.rs
+++ b/crates/game-core/src/state/builder.rs
@@ -281,7 +281,12 @@ impl GameStateBuilder {
     /// mid-phase (the real driver pushes the anchor at phase entry, beneath any
     /// framework windows). Tests that drive `end_turn` / open phase windows
     /// without going through the phase driver use this to satisfy the anchor
-    /// invariant. Panics if `c` is not a `*Phase` anchor variant.
+    /// invariant.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `c` is not a `*Phase` anchor variant (`MythosPhase` /
+    /// `InvestigationPhase` / `EnemyPhase` / `UpkeepPhase`).
     pub fn with_phase_anchor(mut self, c: Continuation) -> Self {
         assert!(
             matches!(

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -1865,7 +1865,11 @@ impl GameState {
     /// in-game investigator count, which isn't known at `setup()`; so the
     /// `Enemy` is minted from the corpus when a card effect brings it into
     /// play (see [`spawn_set_aside_enemy`](crate::engine::spawn_set_aside_enemy)).
-    /// Panics on non-Enemy metadata — a setup-time invariant.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `metadata` is not [`CardKind::Enemy`] — a setup-time invariant
+    /// (the scenario passes an enemy card).
     pub fn add_set_aside_enemy(&mut self, metadata: &CardMetadata) {
         assert!(
             matches!(metadata.kind, CardKind::Enemy { .. }),
@@ -1887,8 +1891,12 @@ impl GameState {
 
     /// Wire a **bidirectional** connection between two locations (each gains
     /// the other in its `connections`). Resolves both ids across the in-play
-    /// and set-aside zones. `expect`s each to exist — a build-time invariant
-    /// (callers connect freshly-minted ids).
+    /// and set-aside zones.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either `a` or `b` is not a location in the in-play or set-aside
+    /// zones — a build-time invariant (callers connect freshly-minted ids).
     pub fn connect(&mut self, a: LocationId, b: LocationId) {
         self.location_mut(a)
             .unwrap_or_else(|| panic!("connect: location {a:?} not found"))

--- a/crates/game-core/src/test_support/resolver.rs
+++ b/crates/game-core/src/test_support/resolver.rs
@@ -512,10 +512,14 @@ where
 
 /// Drive one open-turn action by enumerating the legal actions, finding the
 /// `OptionId` whose `TurnAction` equals `action`, and submitting it as
-/// `ResolveInput(PickSingle(..))`. Panics if `action` is not currently legal
-/// (a test-authoring bug). Returns the raw `ApplyResult` — assert on the
+/// `ResolveInput(PickSingle(..))`. Returns the raw `ApplyResult` — assert on the
 /// resulting **state/events**, not on `outcome == Done` (post-flip the outcome
 /// is the next open-turn menu's `AwaitingInput`).
+///
+/// # Panics
+///
+/// Panics if `action` is not currently legal (a test-authoring bug) — the
+/// rejection message lists the offered actions.
 pub fn take_turn_action(
     state: GameState,
     action: &crate::engine::enumerate::TurnAction,
@@ -630,6 +634,10 @@ impl TestSession {
     /// Fluent open-turn action: see [`take_turn_action`]. Threads the resulting
     /// state; drains any `AwaitingInput` the action itself opens via the session's
     /// resolver script, exactly like [`TestSession::apply`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `action` is not currently legal (a test-authoring bug).
     pub fn take(self, action: &crate::engine::enumerate::TurnAction) -> Self {
         let idx = crate::engine::enumerate::legal_actions(&self.state)
             .iter()
@@ -661,7 +669,11 @@ impl TestSession {
         self
     }
 
-    /// Execute. Panics if [`apply`](Self::apply) was not called.
+    /// Execute the recorded action through the resolver script.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`apply`](Self::apply) was not called to record an action first.
     pub fn run(self) -> ApplyResult {
         let action = self
             .action

--- a/crates/scenarios/src/the_gathering.rs
+++ b/crates/scenarios/src/the_gathering.rs
@@ -159,6 +159,12 @@ fn resolve_symbol(token: ChaosToken, cx: &SymbolCtx) -> SymbolOutcome {
 /// four set-aside locations (Hallway/Attic/Cellar/Parlor, pre-connected),
 /// the act/agenda decks, the Standard chaos bag, and `starting_location`.
 /// No investigators — they are seated via `seat_and_open` at scenario setup.
+///
+/// # Panics
+///
+/// Panics if any of The Gathering's location/act/agenda codes is missing from
+/// the card corpus — a build-time invariant (the scenario and the pinned
+/// snapshot ship together).
 pub fn setup() -> GameState {
     let mut state = GameStateBuilder::new()
         .with_chaos_bag(standard_chaos_bag())

--- a/crates/server/src/db.rs
+++ b/crates/server/src/db.rs
@@ -11,6 +11,11 @@ use sqlx::SqlitePool;
 /// `database_url` is a standard `SQLite` URL, e.g. `sqlite:eldritch.db` or
 /// `sqlite::memory:`. Migrations are applied separately via
 /// [`MIGRATOR`]; this only establishes the pool.
+///
+/// # Errors
+///
+/// Returns [`sqlx::Error`] if `database_url` is not a valid `SQLite` URL or the
+/// pool cannot open a connection (e.g. the file's directory is not writable).
 pub async fn connect_pool(database_url: &str) -> Result<SqlitePool, sqlx::Error> {
     let options = SqliteConnectOptions::from_str(database_url)?.create_if_missing(true);
     SqlitePoolOptions::new().connect_with(options).await

--- a/crates/server/src/session.rs
+++ b/crates/server/src/session.rs
@@ -59,10 +59,16 @@ impl GameSession {
     /// session at the mulligan prompt.
     ///
     /// Looks the scenario module up via the installed
-    /// [`scenario_registry`](game_core::scenario_registry); returns
-    /// [`SessionError::UnknownScenario`] if none is registered.
-    /// Returns [`SessionError::Seating`] if the engine rejects the roster
-    /// (empty roster, unknown investigator code, etc.).
+    /// [`scenario_registry`](game_core::scenario_registry).
+    ///
+    /// # Errors
+    ///
+    /// - [`SessionError::UnknownScenario`] if no module is registered for
+    ///   `scenario_id`.
+    /// - [`SessionError::Seating`] if the engine rejects the roster (empty
+    ///   roster, unknown investigator code, etc.).
+    /// - [`SessionError::Serde`] / [`SessionError::Db`] if persisting the seed
+    ///   state fails.
     pub async fn create(
         db: SqlitePool,
         game_id: impl Into<GameId>,
@@ -122,6 +128,12 @@ impl GameSession {
     /// A rejected action persists nothing and leaves the state
     /// unchanged (the engine guarantees this); the returned
     /// [`EngineOutcome`] carries the rejection reason.
+    ///
+    /// # Errors
+    ///
+    /// [`SessionError::Serde`] if the action fails to serialize, or
+    /// [`SessionError::Db`] if persisting the accepted action fails. An engine
+    /// *rejection* is not an error — it is returned in the `EngineOutcome`.
     pub async fn apply(
         &mut self,
         action: PlayerAction,
@@ -147,6 +159,11 @@ impl GameSession {
     /// `Done`), so a freshly-created game with an empty log — whose seed
     /// is already `AwaitingInput` (the setup mulligan) — loads correctly.
     /// Each replayed action overwrites `outcome` exactly as today.
+    ///
+    /// # Errors
+    ///
+    /// [`SessionError::Db`] if a query fails, or [`SessionError::Serde`] if the
+    /// persisted seed state or a logged action fails to deserialize.
     pub async fn load(db: SqlitePool, game_id: &GameId) -> Result<Option<Self>, SessionError> {
         let Some((_scenario_id, seed_state, seed_outcome)) = store::load_game(&db, game_id).await?
         else {

--- a/crates/web/src/store.rs
+++ b/crates/web/src/store.rs
@@ -90,8 +90,12 @@ pub fn provide_store() -> StoreSignal {
     signal
 }
 
-/// Read the store signal from context. Panics if not provided — a
-/// programmer error (every view lives under `provide_store`).
+/// Read the store signal from context.
+///
+/// # Panics
+///
+/// Panics if no store signal is in context — a programmer error (every view
+/// lives under [`provide_store`]).
 pub fn use_store() -> StoreSignal {
     use_context::<StoreSignal>().expect("store signal provided at App root")
 }

--- a/crates/web/src/url.rs
+++ b/crates/web/src/url.rs
@@ -13,6 +13,11 @@ pub fn ws_url(location_protocol: &str, host: &str, game_id: &str) -> String {
 }
 
 /// Read `window.location` and build this game's WebSocket URL.
+///
+/// # Panics
+///
+/// Panics if there is no browser `window` (e.g. called outside a DOM context) —
+/// always present in the wasm client this targets.
 #[cfg(target_arch = "wasm32")]
 pub fn current_ws_url(game_id: &str) -> String {
     let loc = web_sys::window().expect("a browser window").location();


### PR DESCRIPTION
## Summary

The `[workspace.lints.clippy]` allows carried a stale "fire too noisily for early-stage code" rationale. The project is well past early-stage, so this revisits them:

- **Re-enabled** `missing_errors_doc` and `missing_panics_doc` — genuine documentation discipline for a stable codebase. Added the `# Errors` / `# Panics` sections they require: **4 errors-doc** sites (all in `server/`) and **13 panics-doc** sites (game-core, scenarios, web — including one wasm-only fn `wasm-clippy` caught that host clippy can't see).
- **Kept allowed**, with the comment rewritten to state the real (non-time-based) reason: `module_name_repetitions` (would force churny `card::CardCode`-style renames) and `must_use_candidate` (noise; `#[must_use]` is hand-applied where it earns its keep).

Most of the new doc sections describe invariant guards (`expect`/`assert` that are unreachable given a checked precondition) — documenting them makes the intent explicit and locks the discipline in going forward.

## Verification

Full local gauntlet green, including `wasm-clippy` (which surfaced the wasm-only `current_ws_url` panic site that host clippy doesn't compile): `fmt`, `clippy --all-targets --all-features -D warnings`, `RUSTFLAGS=-D warnings cargo test --all --all-features`, `RUSTDOCFLAGS=-D warnings cargo doc`, `wasm-build`, `wasm-clippy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)