### PR TITLE
web: spatial board map — positioned location nodes + connection lines (closes #497)

### DIFF
--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -119,6 +119,23 @@ fn investigators_panel(game: &GameState) -> impl IntoView {
                 .iter()
                 .map(|c| view! { <li class="card">{crate::names::card_name(&c.code)}</li> })
                 .collect();
+            let threat: Vec<_> = inv
+                .threat_area
+                .iter()
+                .map(|c| view! { <li class="card">{crate::names::card_name(&c.code)}</li> })
+                .collect();
+            let engaged: Vec<_> = game
+                .enemies
+                .values()
+                .filter(|e| e.engaged_with == Some(inv.id))
+                .map(|e| {
+                    view! {
+                        <li class="enemy-engaged">
+                            {e.name.clone()} " " {e.damage} "/" {e.max_health}
+                        </li>
+                    }
+                })
+                .collect();
             view! {
                 <article class="investigator">
                     <h3 class="inv-name">{inv.name.clone()}</h3>
@@ -131,6 +148,8 @@ fn investigators_panel(game: &GameState) -> impl IntoView {
                     <span class="inv-status">{format!("{:?}", inv.status)}</span>
                     <div class="hand"><h4>"Hand"</h4><ul>{hand}</ul></div>
                     <div class="in-play"><h4>"In play"</h4><ul>{in_play}</ul></div>
+                    <div class="threat"><h4>"Threat area"</h4><ul>{threat}</ul></div>
+                    <div class="engaged"><h4>"Engaged enemies"</h4><ul>{engaged}</ul></div>
                 </article>
             }
         })

--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -31,7 +31,7 @@ pub fn BoardView() -> impl IntoView {
             <div class="game">
                 {resolution_banner(&game)}
                 {phase_bar(&game)}
-                {locations_panel(&game)}
+                {crate::map::location_map(&game)}
                 {investigators_panel(&game)}
                 {enemies_panel(&game)}
             </div>
@@ -68,6 +68,7 @@ pub fn BoardView() -> impl IntoView {
 
 /// One row per location: name, shroud, clues, and a revealed flag.
 /// Iterates the `BTreeMap` in `LocationId` order (deterministic).
+#[allow(dead_code)]
 fn locations_panel(game: &GameState) -> impl IntoView {
     let rows: Vec<_> = game
         .locations

--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -31,8 +31,10 @@ pub fn BoardView() -> impl IntoView {
             <div class="game">
                 {resolution_banner(&game)}
                 {phase_bar(&game)}
-                {crate::map::location_map(&game)}
-                {investigators_panel(&game)}
+                <div class="board-main">
+                    {crate::map::location_map(&game)}
+                    {investigators_panel(&game)}
+                </div>
             </div>
         }
         .into_any(),

--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -2,7 +2,7 @@
 //! helper fns; `BoardView` is the only component. Cards and locations render as
 //! their names via `crate::names` (the client installs `cards::REGISTRY`).
 
-use game_core::state::{GameState, InvestigatorId};
+use game_core::state::GameState;
 use game_core::Resolution;
 use leptos::prelude::*;
 
@@ -33,7 +33,6 @@ pub fn BoardView() -> impl IntoView {
                 {phase_bar(&game)}
                 {crate::map::location_map(&game)}
                 {investigators_panel(&game)}
-                {enemies_panel(&game)}
             </div>
         }
         .into_any(),
@@ -62,37 +61,6 @@ pub fn BoardView() -> impl IntoView {
                 }
             }
             {board}
-        </section>
-    }
-}
-
-/// One row per location: name, shroud, clues, and a revealed flag.
-/// Iterates the `BTreeMap` in `LocationId` order (deterministic).
-#[allow(dead_code)]
-fn locations_panel(game: &GameState) -> impl IntoView {
-    let rows: Vec<_> = game
-        .locations
-        .values()
-        .map(|loc| {
-            let revealed = if loc.revealed {
-                "revealed"
-            } else {
-                "unrevealed"
-            };
-            view! {
-                <li class="location">
-                    <span class="loc-name">{loc.name.clone()}</span>
-                    <span class="loc-shroud">"shroud " {loc.shroud}</span>
-                    <span class="loc-clues">"clues " {loc.clues}</span>
-                    <span class="loc-revealed">{revealed}</span>
-                </li>
-            }
-        })
-        .collect();
-    view! {
-        <section class="locations">
-            <h2>"Locations"</h2>
-            <ul>{rows}</ul>
         </section>
     }
 }
@@ -157,41 +125,6 @@ fn investigators_panel(game: &GameState) -> impl IntoView {
         <section class="investigators">
             <h2>"Investigators"</h2>
             {panels}
-        </section>
-    }
-}
-
-/// One row per enemy: name, fight/evade, health (`damage/max_health`),
-/// location, and engagement.
-fn enemies_panel(game: &GameState) -> impl IntoView {
-    let rows: Vec<_> = game
-        .enemies
-        .values()
-        .map(|e| {
-            let engaged = match e.engaged_with {
-                Some(InvestigatorId(id)) => format!("engaged with {id}"),
-                None => "unengaged".to_string(),
-            };
-            let location = e.current_location.map_or_else(
-                || "—".to_string(),
-                |id| crate::names::location_name(game, id),
-            );
-            view! {
-                <li class="enemy">
-                    <span class="enemy-name">{e.name.clone()}</span>
-                    <span class="enemy-fight">"fight " {e.fight}</span>
-                    <span class="enemy-evade">"evade " {e.evade}</span>
-                    <span class="enemy-health">"health " {e.damage} "/" {e.max_health}</span>
-                    <span class="enemy-location">{location}</span>
-                    <span class="enemy-engaged">{engaged}</span>
-                </li>
-            }
-        })
-        .collect();
-    view! {
-        <section class="enemies">
-            <h2>"Enemies"</h2>
-            <ul>{rows}</ul>
         </section>
     }
 }

--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -148,8 +148,7 @@ fn investigators_panel(game: &GameState) -> impl IntoView {
                     <span class="inv-status">{format!("{:?}", inv.status)}</span>
                     <div class="hand"><h4>"Hand"</h4><ul>{hand}</ul></div>
                     <div class="in-play"><h4>"In play"</h4><ul>{in_play}</ul></div>
-                    <div class="threat"><h4>"Threat area"</h4><ul>{threat}</ul></div>
-                    <div class="engaged"><h4>"Engaged enemies"</h4><ul>{engaged}</ul></div>
+                    <div class="threat"><h4>"Threat area"</h4><ul>{threat}{engaged}</ul></div>
                 </article>
             }
         })

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod app;
 pub mod board;
+pub mod map;
 pub mod names;
 pub mod skill_test_result;
 pub mod store;

--- a/crates/web/src/map.rs
+++ b/crates/web/src/map.rs
@@ -74,10 +74,52 @@ const CELL_H: u16 = 150;
 const NODE_W: u16 = 170;
 const NODE_H: u16 = 120;
 
+/// Center pixel of a node at grid cell `(col, row)`.
+fn node_center((col, row): (u16, u16)) -> (u16, u16) {
+    (col * CELL_W + NODE_W / 2, row * CELL_H + NODE_H / 2)
+}
+
+/// One `<line>` per undirected pair of connected, in-play locations, between
+/// node centers. A peer not in `positions` (set-aside, not yet in play) is
+/// skipped. Dedups by ordered `LocationId` pair so each edge draws once.
+fn connection_lines(
+    game: &GameState,
+    positions: &BTreeMap<LocationId, (u16, u16)>,
+) -> Vec<impl IntoView> {
+    let mut seen: BTreeSet<(u32, u32)> = BTreeSet::new();
+    let mut lines = Vec::new();
+    for loc in game.locations.values() {
+        let Some(&a) = positions.get(&loc.id) else {
+            continue;
+        };
+        for peer in &loc.connections {
+            let Some(&b) = positions.get(peer) else {
+                continue; // peer not in play
+            };
+            let key = (loc.id.0.min(peer.0), loc.id.0.max(peer.0));
+            if !seen.insert(key) {
+                continue;
+            }
+            let (x1, y1) = node_center(a);
+            let (x2, y2) = node_center(b);
+            lines.push(view! {
+                <line class="map-line" x1=x1 y1=y1 x2=x2 y2=y2 />
+            });
+        }
+    }
+    lines
+}
+
+/// Pixel `(width, height)` spanning all placed nodes (one extra cell of slack).
+fn map_extent(positions: &BTreeMap<LocationId, (u16, u16)>) -> (u16, u16) {
+    let max_col = positions.values().map(|(c, _)| *c).max().unwrap_or(0);
+    let max_row = positions.values().map(|(_, r)| *r).max().unwrap_or(0);
+    ((max_col + 1) * CELL_W, (max_row + 1) * CELL_H)
+}
+
 /// The map panel: one absolutely-positioned container node per in-play location,
 /// holding the investigators and unengaged enemies in it. Connection lines are
-/// added by [`connection_lines`] (Task 4). Read-only — pure derivation of
-/// `game`.
+/// drawn by [`connection_lines`]. Read-only — pure derivation of `game`.
 pub fn location_map(game: &GameState) -> impl IntoView {
     let locs: Vec<_> = game
         .locations
@@ -130,7 +172,14 @@ pub fn location_map(game: &GameState) -> impl IntoView {
         })
         .collect();
 
-    view! { <section class="map">{nodes}</section> }
+    let lines = connection_lines(game, &positions);
+    let (w, h) = map_extent(&positions);
+    view! {
+        <section class="map" style=format!("width:{w}px;height:{h}px;")>
+            <svg class="map-lines" width=w height=h>{lines}</svg>
+            {nodes}
+        </section>
+    }
 }
 
 #[cfg(test)]

--- a/crates/web/src/map.rs
+++ b/crates/web/src/map.rs
@@ -171,11 +171,14 @@ pub fn location_map(game: &GameState) -> impl IntoView {
             } else {
                 "unrevealed"
             };
+            let head = if loc.revealed {
+                format!("{} (shroud {} · clues {})", loc.name, loc.shroud, loc.clues)
+            } else {
+                loc.name.clone()
+            };
             view! {
                 <div class=node_class data-loc=loc.name.clone() style=style>
-                    <div class="loc-head">
-                        {loc.name.clone()} " (shroud " {loc.shroud} " · clues " {loc.clues} ")"
-                    </div>
+                    <div class="loc-head">{head}</div>
                     <span class="loc-revealed">{revealed_label}</span>
                     {invs}
                     {enemies}

--- a/crates/web/src/map.rs
+++ b/crates/web/src/map.rs
@@ -2,6 +2,10 @@
 //! connection lines. Read-only; a pure derivation of `GameState`. The map and
 //! its layout helpers live here; `board.rs` calls `location_map`.
 
+use std::collections::{BTreeMap, BTreeSet};
+
+use game_core::state::{CardCode, LocationId};
+
 /// Authored grid cell `(col, row)` for a known location code — the layout the
 /// client ships for scenarios it knows. The Gathering: the Study sits isolated
 /// to the left; the Hallway is the hub, with the Attic above, the Parlor below,
@@ -18,19 +22,89 @@ pub(crate) fn location_grid_pos(code: &str) -> Option<(u16, u16)> {
     }
 }
 
+/// Number of columns the fallback flows across before wrapping to a new row.
+/// Generous — the fallback is a degraded path for scenarios without an authored
+/// layout; authored cells stay well within this.
+const FALLBACK_COLS: u16 = 6;
+
+/// Resolve a `(col, row)` grid cell for every in-play location: its authored
+/// cell from [`location_grid_pos`], or — for codes without one — the next free
+/// cell in row-major order, skipping cells already taken (authored or
+/// previously assigned). Deterministic in `locations` order, so the layout is
+/// stable across renders.
+pub(crate) fn layout_positions(
+    locations: &[(LocationId, CardCode)],
+) -> BTreeMap<LocationId, (u16, u16)> {
+    // All authored cells are reserved up front so a fallback never lands on one.
+    let mut taken: BTreeSet<(u16, u16)> = locations
+        .iter()
+        .filter_map(|(_, code)| location_grid_pos(code.as_str()))
+        .collect();
+    let mut cursor: (u16, u16) = (0, 0);
+    let mut out = BTreeMap::new();
+    for (id, code) in locations {
+        let pos = location_grid_pos(code.as_str()).unwrap_or_else(|| {
+            while taken.contains(&cursor) {
+                cursor = advance_cell(cursor);
+            }
+            let p = cursor;
+            taken.insert(p);
+            cursor = advance_cell(cursor);
+            p
+        });
+        out.insert(*id, pos);
+    }
+    out
+}
+
+/// Row-major next cell, wrapping after [`FALLBACK_COLS`] columns.
+fn advance_cell((col, row): (u16, u16)) -> (u16, u16) {
+    if col + 1 >= FALLBACK_COLS {
+        (0, row + 1)
+    } else {
+        (col + 1, row)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::location_grid_pos;
+    use super::{location_grid_pos, layout_positions};
+    use game_core::state::{CardCode, LocationId};
 
     #[test]
     fn known_gathering_codes_have_authored_cells() {
         assert_eq!(location_grid_pos("01112"), Some((2, 1)));
         assert_eq!(location_grid_pos("01113"), Some((2, 0)));
         assert_eq!(location_grid_pos("01111"), Some((0, 1)));
+        assert_eq!(location_grid_pos("01114"), Some((3, 1))); // Cellar
+        assert_eq!(location_grid_pos("01115"), Some((2, 2))); // Parlor
     }
 
     #[test]
     fn unknown_code_has_no_authored_cell() {
         assert_eq!(location_grid_pos("99999"), None);
+    }
+
+    #[test]
+    fn authored_code_uses_its_cell_unknown_gets_a_free_one() {
+        let locs = vec![
+            (LocationId(1), CardCode::new("01112")), // authored (2, 1)
+            (LocationId(2), CardCode::new("99999")), // fallback
+        ];
+        let pos = layout_positions(&locs);
+        assert_eq!(pos[&LocationId(1)], (2, 1));
+        // The fallback location gets *some* cell, and it must not collide with
+        // the authored cell.
+        assert_ne!(pos[&LocationId(2)], (2, 1));
+    }
+
+    #[test]
+    fn two_unknown_codes_get_distinct_cells() {
+        let locs = vec![
+            (LocationId(1), CardCode::new("aaaaa")),
+            (LocationId(2), CardCode::new("bbbbb")),
+        ];
+        let pos = layout_positions(&locs);
+        assert_ne!(pos[&LocationId(1)], pos[&LocationId(2)]);
     }
 }

--- a/crates/web/src/map.rs
+++ b/crates/web/src/map.rs
@@ -4,7 +4,8 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use game_core::state::{CardCode, LocationId};
+use game_core::state::{CardCode, GameState, LocationId};
+use leptos::prelude::*;
 
 /// Authored grid cell `(col, row)` for a known location code — the layout the
 /// client ships for scenarios it knows. The Gathering: the Study sits isolated
@@ -66,9 +67,75 @@ fn advance_cell((col, row): (u16, u16)) -> (u16, u16) {
     }
 }
 
+/// Pixel geometry for the grid. A node occupies `NODE_W`×`NODE_H`; cells are
+/// larger to leave gaps for the connection lines.
+const CELL_W: u16 = 200;
+const CELL_H: u16 = 150;
+const NODE_W: u16 = 170;
+const NODE_H: u16 = 120;
+
+/// The map panel: one absolutely-positioned container node per in-play location,
+/// holding the investigators and unengaged enemies in it. Connection lines are
+/// added by [`connection_lines`] (Task 4). Read-only — pure derivation of
+/// `game`.
+pub fn location_map(game: &GameState) -> impl IntoView {
+    let locs: Vec<_> = game
+        .locations
+        .values()
+        .map(|l| (l.id, l.code.clone()))
+        .collect();
+    let positions = layout_positions(&locs);
+
+    let nodes: Vec<_> = game
+        .locations
+        .values()
+        .map(|loc| {
+            let (col, row) = positions[&loc.id];
+            let (left, top) = (col * CELL_W, row * CELL_H);
+            let invs: Vec<_> = game
+                .investigators
+                .values()
+                .filter(|i| i.current_location == Some(loc.id))
+                .map(|i| {
+                    view! {
+                        <div class="inv-token">
+                            {i.name.clone()} " " {i.damage()} "/" {i.max_health()} " hp · "
+                            {i.horror()} "/" {i.max_sanity()} " san · clues " {i.clues}
+                        </div>
+                    }
+                })
+                .collect();
+            let enemies: Vec<_> = game
+                .enemies
+                .values()
+                .filter(|e| e.current_location == Some(loc.id) && e.engaged_with.is_none())
+                .map(|e| {
+                    view! {
+                        <div class="enemy-token">
+                            {e.name.clone()} " " {e.damage} "/" {e.max_health}
+                        </div>
+                    }
+                })
+                .collect();
+            let style = format!("left:{left}px;top:{top}px;width:{NODE_W}px;height:{NODE_H}px;");
+            view! {
+                <div class="map-location" data-loc=loc.name.clone() style=style>
+                    <div class="loc-head">
+                        {loc.name.clone()} " (shroud " {loc.shroud} " · clues " {loc.clues} ")"
+                    </div>
+                    {invs}
+                    {enemies}
+                </div>
+            }
+        })
+        .collect();
+
+    view! { <section class="map">{nodes}</section> }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{location_grid_pos, layout_positions};
+    use super::{layout_positions, location_grid_pos};
     use game_core::state::{CardCode, LocationId};
 
     #[test]

--- a/crates/web/src/map.rs
+++ b/crates/web/src/map.rs
@@ -119,7 +119,8 @@ fn map_extent(positions: &BTreeMap<LocationId, (u16, u16)>) -> (u16, u16) {
 
 /// The map panel: one absolutely-positioned container node per in-play location,
 /// holding the investigators and unengaged enemies in it. Connection lines are
-/// drawn by [`connection_lines`]. Read-only — pure derivation of `game`.
+/// drawn by a private helper; SVG lines sit behind the nodes. Read-only —
+/// pure derivation of `game`.
 pub fn location_map(game: &GameState) -> impl IntoView {
     let locs: Vec<_> = game
         .locations

--- a/crates/web/src/map.rs
+++ b/crates/web/src/map.rs
@@ -161,11 +161,22 @@ pub fn location_map(game: &GameState) -> impl IntoView {
                 })
                 .collect();
             let style = format!("left:{left}px;top:{top}px;width:{NODE_W}px;height:{NODE_H}px;");
+            let node_class = if loc.revealed {
+                "map-location"
+            } else {
+                "map-location unrevealed"
+            };
+            let revealed_label = if loc.revealed {
+                "revealed"
+            } else {
+                "unrevealed"
+            };
             view! {
-                <div class="map-location" data-loc=loc.name.clone() style=style>
+                <div class=node_class data-loc=loc.name.clone() style=style>
                     <div class="loc-head">
                         {loc.name.clone()} " (shroud " {loc.shroud} " · clues " {loc.clues} ")"
                     </div>
+                    <span class="loc-revealed">{revealed_label}</span>
                     {invs}
                     {enemies}
                 </div>

--- a/crates/web/src/map.rs
+++ b/crates/web/src/map.rs
@@ -1,0 +1,36 @@
+//! Spatial board map (#497): positioned location-container nodes with drawn
+//! connection lines. Read-only; a pure derivation of `GameState`. The map and
+//! its layout helpers live here; `board.rs` calls `location_map`.
+
+/// Authored grid cell `(col, row)` for a known location code — the layout the
+/// client ships for scenarios it knows. The Gathering: the Study sits isolated
+/// to the left; the Hallway is the hub, with the Attic above, the Parlor below,
+/// and the Cellar to its right. Codes without an authored cell return `None` and
+/// are placed by the fallback in [`layout_positions`].
+pub(crate) fn location_grid_pos(code: &str) -> Option<(u16, u16)> {
+    match code {
+        "01111" => Some((0, 1)), // Study (isolated)
+        "01112" => Some((2, 1)), // Hallway (hub)
+        "01113" => Some((2, 0)), // Attic
+        "01114" => Some((3, 1)), // Cellar
+        "01115" => Some((2, 2)), // Parlor
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::location_grid_pos;
+
+    #[test]
+    fn known_gathering_codes_have_authored_cells() {
+        assert_eq!(location_grid_pos("01112"), Some((2, 1)));
+        assert_eq!(location_grid_pos("01113"), Some((2, 0)));
+        assert_eq!(location_grid_pos("01111"), Some((0, 1)));
+    }
+
+    #[test]
+    fn unknown_code_has_no_authored_cell() {
+        assert_eq!(location_grid_pos("99999"), None);
+    }
+}

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -15,8 +15,10 @@
 .map-lines { position: absolute; top: 0; left: 0; z-index: 0; pointer-events: none; }
 .map-line { stroke: #999; stroke-width: 2; }
 .map-location { position: absolute; z-index: 1; box-sizing: border-box; border: 1px solid #333; border-radius: 4px; background: #fff; padding: 0.25rem; font-size: 0.8rem; overflow: hidden; }
+.map-location.unrevealed { opacity: 0.6; }
 .loc-head { font-weight: 600; margin-bottom: 0.15rem; }
 .inv-token { color: #157a3a; }
 .enemy-token { color: #a3261b; }
 .threat ul { list-style: none; padding-left: 0; margin: 0; }
 .enemy-engaged { color: #a3261b; font-size: 0.85rem; }
+.board-main { display: flex; gap: 1rem; align-items: flex-start; }

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -3,8 +3,7 @@
 .status, .rejection { font-size: 0.85rem; color: #555; }
 .phase-bar { display: flex; gap: 1rem; font-weight: 600; padding: 0.5rem 0; border-bottom: 1px solid #ccc; }
 .game { display: flex; flex-direction: column; gap: 1rem; }
-.locations ul, .enemies ul, .hand ul, .in-play ul { list-style: none; padding-left: 0; margin: 0; }
-.location, .enemy { display: flex; gap: 0.75rem; padding: 0.25rem 0; }
+.hand ul, .in-play ul { list-style: none; padding-left: 0; margin: 0; }
 .investigators { display: flex; flex-wrap: wrap; gap: 1rem; }
 .investigator { border: 1px solid #ccc; border-radius: 4px; padding: 0.5rem; display: flex; flex-direction: column; gap: 0.25rem; min-width: 16rem; }
 .investigator span { font-size: 0.9rem; }

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -9,3 +9,15 @@
 .investigator { border: 1px solid #ccc; border-radius: 4px; padding: 0.5rem; display: flex; flex-direction: column; gap: 0.25rem; min-width: 16rem; }
 .investigator span { font-size: 0.9rem; }
 .card { font-family: ui-monospace, monospace; font-size: 0.85rem; }
+
+/* Spatial board map (#497). Nodes are absolutely positioned at computed
+   left/top (set inline); the SVG line layer sits behind them. */
+.map { position: relative; margin: 1rem 0; }
+.map-lines { position: absolute; top: 0; left: 0; z-index: 0; pointer-events: none; }
+.map-line { stroke: #999; stroke-width: 2; }
+.map-location { position: absolute; z-index: 1; box-sizing: border-box; border: 1px solid #333; border-radius: 4px; background: #fff; padding: 0.25rem; font-size: 0.8rem; overflow: hidden; }
+.loc-head { font-weight: 600; margin-bottom: 0.15rem; }
+.inv-token { color: #157a3a; }
+.enemy-token { color: #a3261b; }
+.threat ul { list-style: none; padding-left: 0; margin: 0; }
+.enemy-engaged { color: #a3261b; font-size: 0.85rem; }

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -15,7 +15,10 @@
 .map-lines { position: absolute; top: 0; left: 0; z-index: 0; pointer-events: none; }
 .map-line { stroke: #999; stroke-width: 2; }
 .map-location { position: absolute; z-index: 1; box-sizing: border-box; border: 1px solid #333; border-radius: 4px; background: #fff; padding: 0.25rem; font-size: 0.8rem; overflow: hidden; }
-.map-location.unrevealed { opacity: 0.6; }
+/* Unrevealed locations read as dimmed/face-down WITHOUT element opacity —
+   opacity would let the connection lines behind the node bleed through. A muted
+   opaque background + greyed text + dashed border keep the node solid. */
+.map-location.unrevealed { background: #ececec; color: #888; border-style: dashed; }
 .loc-head { font-weight: 600; margin-bottom: 0.15rem; }
 .inv-token { color: #157a3a; }
 .enemy-token { color: #a3261b; }

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -86,7 +86,7 @@ async fn phase_bar_renders_phase_round_act_agenda() {
 }
 
 #[wasm_bindgen_test]
-async fn locations_panel_renders_name_shroud_clues_revealed() {
+async fn map_renders_location_name_shroud_clues() {
     let mut loc = test_location(7, "Rivertown");
     loc.shroud = 3;
     loc.clues = 2;
@@ -100,7 +100,6 @@ async fn locations_panel_renders_name_shroud_clues_revealed() {
     assert!(html.contains("Rivertown"), "location name missing: {html}");
     assert!(html.contains("shroud 3"), "shroud missing: {html}");
     assert!(html.contains("clues 2"), "location clues missing: {html}");
-    assert!(html.contains("revealed"), "revealed flag missing: {html}");
 }
 
 #[wasm_bindgen_test]

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -5,7 +5,7 @@
 
 use game_core::state::GameStateBuilder;
 use game_core::state::{Act, Agenda, CardCode, Phase};
-use game_core::test_support::fixtures::{test_enemy, test_investigator, test_location};
+use game_core::test_support::fixtures::{test_investigator, test_location};
 use game_core::EngineOutcome;
 use leptos::prelude::{provide_context, RwSignal, Update};
 use protocol::ServerMessage;
@@ -144,30 +144,6 @@ async fn investigators_panel_renders_stats_and_hand() {
     assert!(
         html.contains("_synth_asset"),
         "in-play card missing: {html}"
-    );
-}
-
-#[wasm_bindgen_test]
-async fn enemies_panel_renders_name_stats_engagement() {
-    use game_core::state::InvestigatorId;
-
-    let mut enemy = test_enemy(4, "Swarm of Rats");
-    enemy.damage = 1; // 1/2
-    enemy.engaged_with = Some(InvestigatorId(1));
-    let state = GameStateBuilder::new()
-        .with_investigator(test_investigator(1))
-        .with_enemy(enemy)
-        .build();
-
-    let html = render_state(state).await;
-
-    assert!(html.contains("Swarm of Rats"), "enemy name missing: {html}");
-    assert!(html.contains("fight 2"), "fight missing: {html}");
-    assert!(html.contains("evade 2"), "evade missing: {html}");
-    assert!(html.contains("1/2"), "enemy health missing: {html}");
-    assert!(
-        html.contains("engaged with 1"),
-        "engagement missing: {html}"
     );
 }
 

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -265,6 +265,41 @@ async fn version_mismatch_status_renders_actionable_message() {
 }
 
 #[wasm_bindgen_test]
+async fn map_and_investigators_are_inside_board_main() {
+    let state = GameStateBuilder::new()
+        .with_investigator(test_investigator(1))
+        .with_location(test_location(1, "Study"))
+        .build();
+    let _ = render_state(state).await;
+
+    // Scope to the last mounted .game so DOM accumulation from earlier tests
+    // does not pollute this assertion.
+    let document = leptos::prelude::document();
+    let games = document
+        .query_selector_all(".game")
+        .expect("query_selector_all");
+    let last_game = games
+        .item(games.length() - 1)
+        .and_then(|n| n.dyn_into::<web_sys::Element>().ok())
+        .expect("last .game is an Element");
+
+    assert!(
+        last_game
+            .query_selector(".board-main .map")
+            .expect("query ok")
+            .is_some(),
+        ".map must be a descendant of .board-main"
+    );
+    assert!(
+        last_game
+            .query_selector(".board-main .investigators")
+            .expect("query ok")
+            .is_some(),
+        ".investigators must be a descendant of .board-main"
+    );
+}
+
+#[wasm_bindgen_test]
 async fn board_renders_a_new_game_button() {
     let store = RwSignal::new(ClientState::default());
     leptos::mount::mount_to_body(move || {

--- a/crates/web/tests/map.rs
+++ b/crates/web/tests/map.rs
@@ -11,6 +11,7 @@ use wasm_bindgen::JsCast as _;
 use wasm_bindgen_test::*;
 use web::board::BoardView;
 use web::store::{reduce, ClientState};
+use web_sys::Element;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
@@ -57,6 +58,50 @@ fn node_text(loc_name: &str) -> String {
         .expect("query ok")
         .and_then(|el| el.text_content())
         .unwrap_or_default()
+}
+
+/// Count of `<line class="map-line">` elements in the LAST mounted `.map`
+/// section. Scoped to the last section so that DOM accumulation from earlier
+/// test mounts does not carry over stale lines into a fresh assertion.
+fn line_count() -> u32 {
+    let maps = document().query_selector_all(".map").expect("query ok");
+    let len = maps.length();
+    if len == 0 {
+        return 0;
+    }
+    let last_map = maps
+        .item(len - 1)
+        .and_then(|n| n.dyn_into::<Element>().ok())
+        .expect("last .map is an Element");
+    last_map
+        .query_selector_all("line.map-line")
+        .expect("query ok")
+        .length()
+}
+
+#[wasm_bindgen_test]
+async fn connected_locations_draw_a_line() {
+    let mut state = GameStateBuilder::new()
+        .with_location(test_location(10, "Hallway"))
+        .with_location(test_location(11, "Attic"))
+        .with_investigator(test_investigator(1))
+        .build();
+    state.connect(LocationId(10), LocationId(11));
+    mount_state(state).await;
+    assert!(
+        line_count() >= 1,
+        "a connected pair must draw at least one line"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn isolated_location_draws_no_line() {
+    let state = GameStateBuilder::new()
+        .with_location(test_location(10, "Study")) // no connections
+        .with_investigator(test_investigator(1))
+        .build();
+    mount_state(state).await;
+    assert_eq!(line_count(), 0, "an isolated location draws no lines");
 }
 
 #[wasm_bindgen_test]

--- a/crates/web/tests/map.rs
+++ b/crates/web/tests/map.rs
@@ -158,6 +158,42 @@ async fn engaged_enemy_renders_in_detail_panel_not_in_node() {
 }
 
 #[wasm_bindgen_test]
+async fn revealed_location_shows_revealed_not_unrevealed() {
+    let mut loc = test_location(20, "Study Revealed");
+    loc.revealed = true; // default, but explicit
+    let state = GameStateBuilder::new()
+        .with_location(loc)
+        .with_investigator(test_investigator(1))
+        .build();
+    mount_state(state).await;
+    let text = node_text("Study Revealed");
+    assert!(
+        text.contains("revealed"),
+        "revealed location must contain 'revealed'; text = {text:?}"
+    );
+    assert!(
+        !text.contains("unrevealed"),
+        "revealed location must NOT contain 'unrevealed'; text = {text:?}"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn unrevealed_location_shows_unrevealed() {
+    let mut loc = test_location(21, "Parlor Unrevealed");
+    loc.revealed = false;
+    let state = GameStateBuilder::new()
+        .with_location(loc)
+        .with_investigator(test_investigator(1))
+        .build();
+    mount_state(state).await;
+    let text = node_text("Parlor Unrevealed");
+    assert!(
+        text.contains("unrevealed"),
+        "unrevealed location must contain 'unrevealed'; text = {text:?}"
+    );
+}
+
+#[wasm_bindgen_test]
 async fn unengaged_enemy_renders_inside_its_location_node() {
     let mut enemy = test_enemy(100, "Mock Ghoul");
     enemy.current_location = Some(LocationId(10));

--- a/crates/web/tests/map.rs
+++ b/crates/web/tests/map.rs
@@ -194,6 +194,54 @@ async fn unrevealed_location_shows_unrevealed() {
 }
 
 #[wasm_bindgen_test]
+async fn unrevealed_location_hides_shroud_and_clues() {
+    let mut loc = test_location(30, "Cellar Unrevealed");
+    loc.revealed = false;
+    loc.shroud = 4;
+    loc.clues = 3;
+    let state = GameStateBuilder::new()
+        .with_location(loc)
+        .with_investigator(test_investigator(1))
+        .build();
+    mount_state(state).await;
+    let text = node_text("Cellar Unrevealed");
+    assert!(
+        text.contains("unrevealed"),
+        "unrevealed location must contain 'unrevealed'; text = {text:?}"
+    );
+    assert!(
+        !text.contains("shroud"),
+        "unrevealed location must NOT contain 'shroud'; text = {text:?}"
+    );
+    assert!(
+        !text.contains("clues"),
+        "unrevealed location must NOT contain 'clues'; text = {text:?}"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn revealed_location_shows_shroud_and_clues() {
+    let mut loc = test_location(31, "Attic Revealed");
+    loc.revealed = true;
+    loc.shroud = 2;
+    loc.clues = 5;
+    let state = GameStateBuilder::new()
+        .with_location(loc)
+        .with_investigator(test_investigator(1))
+        .build();
+    mount_state(state).await;
+    let text = node_text("Attic Revealed");
+    assert!(
+        text.contains("shroud"),
+        "revealed location must contain 'shroud'; text = {text:?}"
+    );
+    assert!(
+        text.contains("clues"),
+        "revealed location must contain 'clues'; text = {text:?}"
+    );
+}
+
+#[wasm_bindgen_test]
 async fn unengaged_enemy_renders_inside_its_location_node() {
     let mut enemy = test_enemy(100, "Mock Ghoul");
     enemy.current_location = Some(LocationId(10));

--- a/crates/web/tests/map.rs
+++ b/crates/web/tests/map.rs
@@ -2,7 +2,7 @@
 //! feed a constructed `GameState`, assert on the rendered DOM. wasm32-only.
 #![cfg(target_arch = "wasm32")]
 
-use game_core::state::{GameStateBuilder, LocationId};
+use game_core::state::{GameStateBuilder, InvestigatorId, LocationId};
 use game_core::test_support::fixtures::{test_enemy, test_investigator, test_location};
 use game_core::EngineOutcome;
 use leptos::prelude::{document, provide_context, RwSignal, Update};
@@ -88,9 +88,10 @@ async fn connected_locations_draw_a_line() {
         .build();
     state.connect(LocationId(10), LocationId(11));
     mount_state(state).await;
-    assert!(
-        line_count() >= 1,
-        "a connected pair must draw at least one line"
+    assert_eq!(
+        line_count(),
+        1,
+        "a connected pair must draw exactly one line"
     );
 }
 
@@ -117,6 +118,42 @@ async fn investigator_renders_inside_its_location_node() {
         node_text("Study").contains("Test Investigator 1"),
         "investigator token must render inside its location node; Study node = {:?}",
         node_text("Study"),
+    );
+}
+
+#[wasm_bindgen_test]
+async fn engaged_enemy_renders_in_detail_panel_not_in_node() {
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(LocationId(10));
+    let mut enemy = test_enemy(100, "Mock Ghoul");
+    enemy.current_location = Some(LocationId(10));
+    enemy.engaged_with = Some(InvestigatorId(1));
+    let state = GameStateBuilder::new()
+        .with_location(test_location(10, "Study"))
+        .with_investigator(inv)
+        .with_enemy(enemy)
+        .build();
+    mount_state(state).await;
+
+    // Not in the location node (engaged enemies leave the location box)…
+    assert!(
+        !node_text("Study").contains("Mock Ghoul"),
+        "engaged enemy must NOT render in the location node; node = {:?}",
+        node_text("Study"),
+    );
+    // …but present in the investigator detail panel (query last to avoid DOM accumulation).
+    let investigators = document()
+        .query_selector_all(".investigators")
+        .expect("query_selector_all ok");
+    let len = investigators.length();
+    let panel = investigators
+        .item(len.saturating_sub(1))
+        .and_then(|n| n.dyn_into::<web_sys::Element>().ok())
+        .and_then(|el| el.text_content())
+        .unwrap_or_default();
+    assert!(
+        panel.contains("Mock Ghoul"),
+        "engaged enemy must render in the detail panel; panel = {panel:?}",
     );
 }
 

--- a/crates/web/tests/map.rs
+++ b/crates/web/tests/map.rs
@@ -1,0 +1,94 @@
+//! Headless render tests for the spatial board map (#497). Mount `BoardView`,
+//! feed a constructed `GameState`, assert on the rendered DOM. wasm32-only.
+#![cfg(target_arch = "wasm32")]
+
+use game_core::state::{GameStateBuilder, LocationId};
+use game_core::test_support::fixtures::{test_enemy, test_investigator, test_location};
+use game_core::EngineOutcome;
+use leptos::prelude::{document, provide_context, RwSignal, Update};
+use protocol::ServerMessage;
+use wasm_bindgen::JsCast as _;
+use wasm_bindgen_test::*;
+use web::board::BoardView;
+use web::store::{reduce, ClientState};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+/// Mount `BoardView`, feed one `Hello` carrying `state`, tick, return nothing —
+/// assertions query the live DOM via `document()`.
+async fn mount_state(state: game_core::state::GameState) {
+    game_core::test_support::install_test_registry();
+    let store = RwSignal::new(ClientState::default());
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        leptos::view! { <BoardView/> }
+    });
+    store.update(|s| {
+        reduce(
+            s,
+            ServerMessage::Hello {
+                state: Box::new(state),
+                outcome: EngineOutcome::Done,
+            },
+        );
+    });
+    leptos::task::tick().await;
+}
+
+/// `textContent` of the map node whose `data-loc` equals `loc_name`, scoped to
+/// the LAST mounted `<section class="map">` so that DOM accumulation across tests
+/// does not make an earlier test's node shadow this one (same pattern as the
+/// `board.rs` wasm tests).
+fn node_text(loc_name: &str) -> String {
+    let maps = document()
+        .query_selector_all(".map")
+        .expect("query_selector_all ok");
+    let len = maps.length();
+    if len == 0 {
+        return String::new();
+    }
+    let last_map = maps
+        .item(len - 1)
+        .and_then(|n| n.dyn_into::<web_sys::Element>().ok())
+        .expect("last .map is an Element");
+    let sel = format!(".map-location[data-loc=\"{loc_name}\"]");
+    last_map
+        .query_selector(&sel)
+        .expect("query ok")
+        .and_then(|el| el.text_content())
+        .unwrap_or_default()
+}
+
+#[wasm_bindgen_test]
+async fn investigator_renders_inside_its_location_node() {
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(LocationId(10));
+    let state = GameStateBuilder::new()
+        .with_location(test_location(10, "Study"))
+        .with_investigator(inv)
+        .build();
+    mount_state(state).await;
+    assert!(
+        node_text("Study").contains("Test Investigator 1"),
+        "investigator token must render inside its location node; Study node = {:?}",
+        node_text("Study"),
+    );
+}
+
+#[wasm_bindgen_test]
+async fn unengaged_enemy_renders_inside_its_location_node() {
+    let mut enemy = test_enemy(100, "Mock Ghoul");
+    enemy.current_location = Some(LocationId(10));
+    enemy.engaged_with = None;
+    let state = GameStateBuilder::new()
+        .with_location(test_location(10, "Study"))
+        .with_investigator(test_investigator(1))
+        .with_enemy(enemy)
+        .build();
+    mount_state(state).await;
+    assert!(
+        node_text("Study").contains("Mock Ghoul"),
+        "unengaged enemy must render inside its location node; Study node = {:?}",
+        node_text("Study"),
+    );
+}

--- a/docs/superpowers/plans/2026-06-27-spatial-board-map.md
+++ b/docs/superpowers/plans/2026-06-27-spatial-board-map.md
@@ -1,0 +1,735 @@
+# Spatial board map (web) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the web board's flat locations/enemies text lists with a spatial map — positioned location-container nodes, drawn connection lines, investigators and unengaged enemies inside their location, engaged enemies + threat area in the per-investigator detail panel.
+
+**Architecture:** All changes in `crates/web/` (Leptos 0.8 CSR). A new `map.rs` holds pure layout helpers (host-testable) and a `location_map(&GameState)` panel fn (matching the existing `locations_panel`/`enemies_panel` fn pattern — *not* a store-reading component, a deliberate simplification over the spec's wording). `board.rs` calls it and drops the two old panels; the existing `investigators_panel` gains engaged enemies + threat area. The map is a pure derivation of `GameState` (no new client state). Tests: host unit tests for the layout helpers; wasm-bindgen-test render tests (mount `BoardView`, feed a `Hello`, assert on the DOM) for the rendered map.
+
+**Tech Stack:** Rust, Leptos 0.8 (CSR), `wasm-bindgen-test` (headless browser), plain `style.css`.
+
+**Spec:** `docs/superpowers/specs/2026-06-27-spatial-board-map-design.md`
+
+## Global Constraints
+
+- **CI gauntlet (warnings-as-errors), run before pushing:** `cargo fmt --check`; `cargo clippy --all-targets --all-features -- -D warnings`; `RUSTFLAGS="-D warnings" cargo test --all --all-features`; `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`; `cargo build -p web --target wasm32-unknown-unknown`; `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`; `wasm-pack test --headless --firefox crates/web`.
+- **Read-only board.** No interactivity — no click/hover handlers on nodes/tokens. Actions still flow through the `AwaitingInput` menu (`input.rs`), untouched.
+- **Pure derivation of `GameState`.** No new signals/`ClientState` fields. Names via `crate::names::{card_name, location_name}` (registry fallback to code).
+- **Layering / placement rules (from the spec):**
+  - Map node holds: investigators with `current_location == this`, and enemies with `current_location == this && engaged_with.is_none()`.
+  - Detail panel holds: the investigator's `threat_area` treacheries, and enemies with `engaged_with == Some(inv.id)`.
+  - Only locations in `game.locations` render (set-aside locations aren't there yet).
+- **Coordinates are client-side** (a code→cell table + fallback). No engine/`GameState` changes.
+- **Follow the existing plain-CSS approach** (classes in `style.css`; no inline styles except the computed node `left/top/width/height`, which must be dynamic).
+
+---
+
+### Task 1: Layout table `location_grid_pos`
+
+**Files:**
+- Create: `crates/web/src/map.rs`
+- Modify: `crates/web/src/lib.rs` (add `pub mod map;`)
+
+**Interfaces:**
+- Produces: `pub(crate) fn location_grid_pos(code: &str) -> Option<(u16, u16)>` — authored `(col, row)` grid cell for a known location code, else `None`.
+
+- [ ] **Step 1: Create `map.rs` with the table + a failing host test**
+
+Create `crates/web/src/map.rs`:
+
+```rust
+//! Spatial board map (#497): positioned location-container nodes with drawn
+//! connection lines. Read-only; a pure derivation of `GameState`. The map and
+//! its layout helpers live here; `board.rs` calls `location_map`.
+
+/// Authored grid cell `(col, row)` for a known location code — the layout the
+/// client ships for scenarios it knows. The Gathering: the Study sits isolated
+/// to the left; the Hallway is the hub, with the Attic above, the Parlor below,
+/// and the Cellar to its right. Codes without an authored cell return `None` and
+/// are placed by the fallback in [`layout_positions`].
+pub(crate) fn location_grid_pos(code: &str) -> Option<(u16, u16)> {
+    match code {
+        "01111" => Some((0, 1)), // Study (isolated)
+        "01112" => Some((2, 1)), // Hallway (hub)
+        "01113" => Some((2, 0)), // Attic
+        "01114" => Some((3, 1)), // Cellar
+        "01115" => Some((2, 2)), // Parlor
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::location_grid_pos;
+
+    #[test]
+    fn known_gathering_codes_have_authored_cells() {
+        assert_eq!(location_grid_pos("01112"), Some((2, 1)));
+        assert_eq!(location_grid_pos("01113"), Some((2, 0)));
+        assert_eq!(location_grid_pos("01111"), Some((0, 1)));
+    }
+
+    #[test]
+    fn unknown_code_has_no_authored_cell() {
+        assert_eq!(location_grid_pos("99999"), None);
+    }
+}
+```
+
+Add to `crates/web/src/lib.rs` after `pub mod board;`:
+
+```rust
+pub mod map;
+```
+
+- [ ] **Step 2: Run the host test to verify it passes**
+
+Run: `cargo test -p web --lib map::`
+Expected: PASS (2 tests). (These are plain host tests — `map.rs` is not wasm-gated.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/web/src/map.rs crates/web/src/lib.rs
+git commit -m "web: location-code → grid-cell layout table for the board map (#497)"
+```
+
+---
+
+### Task 2: `layout_positions` with deterministic fallback
+
+**Files:**
+- Modify: `crates/web/src/map.rs`
+
+**Interfaces:**
+- Consumes: `location_grid_pos` (Task 1).
+- Produces: `pub(crate) fn layout_positions(locations: &[(LocationId, CardCode)]) -> BTreeMap<LocationId, (u16, u16)>` — every in-play location's resolved cell (authored, or next free cell for unknown codes).
+
+- [ ] **Step 1: Add the failing host test**
+
+Add to `map.rs`'s `#[cfg(test)] mod tests`:
+
+```rust
+    use super::layout_positions;
+    use game_core::state::{CardCode, LocationId};
+
+    #[test]
+    fn authored_code_uses_its_cell_unknown_gets_a_free_one() {
+        let locs = vec![
+            (LocationId(1), CardCode::new("01112")), // authored (2, 1)
+            (LocationId(2), CardCode::new("99999")), // fallback
+        ];
+        let pos = layout_positions(&locs);
+        assert_eq!(pos[&LocationId(1)], (2, 1));
+        // The fallback location gets *some* cell, and it must not collide with
+        // the authored cell.
+        assert_ne!(pos[&LocationId(2)], (2, 1));
+    }
+
+    #[test]
+    fn two_unknown_codes_get_distinct_cells() {
+        let locs = vec![
+            (LocationId(1), CardCode::new("aaaaa")),
+            (LocationId(2), CardCode::new("bbbbb")),
+        ];
+        let pos = layout_positions(&locs);
+        assert_ne!(pos[&LocationId(1)], pos[&LocationId(2)]);
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p web --lib map::tests::authored_code_uses_its_cell_unknown_gets_a_free_one`
+Expected: compile error — `layout_positions` not found.
+
+- [ ] **Step 3: Implement `layout_positions`**
+
+Add to `map.rs` (top-level), and the imports it needs at the top of the file:
+
+```rust
+use std::collections::{BTreeMap, BTreeSet};
+
+use game_core::state::{CardCode, LocationId};
+```
+
+```rust
+/// Number of columns the fallback flows across before wrapping to a new row.
+/// Generous — the fallback is a degraded path for scenarios without an authored
+/// layout; authored cells stay well within this.
+const FALLBACK_COLS: u16 = 6;
+
+/// Resolve a `(col, row)` grid cell for every in-play location: its authored
+/// cell from [`location_grid_pos`], or — for codes without one — the next free
+/// cell in row-major order, skipping cells already taken (authored or
+/// previously assigned). Deterministic in `locations` order, so the layout is
+/// stable across renders.
+pub(crate) fn layout_positions(
+    locations: &[(LocationId, CardCode)],
+) -> BTreeMap<LocationId, (u16, u16)> {
+    // All authored cells are reserved up front so a fallback never lands on one.
+    let mut taken: BTreeSet<(u16, u16)> = locations
+        .iter()
+        .filter_map(|(_, code)| location_grid_pos(code.as_str()))
+        .collect();
+    let mut cursor: (u16, u16) = (0, 0);
+    let mut out = BTreeMap::new();
+    for (id, code) in locations {
+        let pos = location_grid_pos(code.as_str()).unwrap_or_else(|| {
+            while taken.contains(&cursor) {
+                cursor = advance_cell(cursor);
+            }
+            let p = cursor;
+            taken.insert(p);
+            cursor = advance_cell(cursor);
+            p
+        });
+        out.insert(*id, pos);
+    }
+    out
+}
+
+/// Row-major next cell, wrapping after [`FALLBACK_COLS`] columns.
+fn advance_cell((col, row): (u16, u16)) -> (u16, u16) {
+    if col + 1 >= FALLBACK_COLS {
+        (0, row + 1)
+    } else {
+        (col + 1, row)
+    }
+}
+```
+
+- [ ] **Step 4: Run the host tests**
+
+Run: `cargo test -p web --lib map::`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/web/src/map.rs
+git commit -m "web: resolve location grid positions with a deterministic fallback (#497)"
+```
+
+---
+
+### Task 3: `location_map` panel — nodes + tokens, wired into the board
+
+**Files:**
+- Modify: `crates/web/src/map.rs` (add `location_map` + node rendering)
+- Modify: `crates/web/src/board.rs` (call `crate::map::location_map(&game)` in the `Some(game)` arm)
+- Test: `crates/web/tests/map.rs` (create)
+
+**Interfaces:**
+- Consumes: `layout_positions` (Task 2).
+- Produces: `pub fn location_map(game: &GameState) -> impl IntoView` — a `<section class="map">` of absolutely-positioned `<div class="map-location" data-loc=NAME>` nodes; each node holds a `.loc-head` line plus `.inv-token` / `.enemy-token` children for the investigators and unengaged enemies in it. (Connection lines arrive in Task 4.)
+
+- [ ] **Step 1: Add `location_map` (nodes only) to `map.rs`**
+
+Add the Leptos imports at the top of `map.rs`:
+
+```rust
+use game_core::state::GameState;
+use leptos::prelude::*;
+```
+
+Add the geometry constants and the panel fn:
+
+```rust
+/// Pixel geometry for the grid. A node occupies `NODE_W`×`NODE_H`; cells are
+/// larger to leave gaps for the connection lines.
+const CELL_W: u16 = 200;
+const CELL_H: u16 = 150;
+const NODE_W: u16 = 170;
+const NODE_H: u16 = 120;
+
+/// The map panel: one absolutely-positioned container node per in-play location,
+/// holding the investigators and unengaged enemies in it. Connection lines are
+/// added by [`connection_lines`] (Task 4). Read-only — pure derivation of
+/// `game`.
+pub fn location_map(game: &GameState) -> impl IntoView {
+    let locs: Vec<_> = game
+        .locations
+        .values()
+        .map(|l| (l.id, l.code.clone()))
+        .collect();
+    let positions = layout_positions(&locs);
+
+    let nodes: Vec<_> = game
+        .locations
+        .values()
+        .map(|loc| {
+            let (col, row) = positions[&loc.id];
+            let (left, top) = (col * CELL_W, row * CELL_H);
+            let invs: Vec<_> = game
+                .investigators
+                .values()
+                .filter(|i| i.current_location == Some(loc.id))
+                .map(|i| {
+                    view! {
+                        <div class="inv-token">
+                            {i.name.clone()} " " {i.damage()} "/" {i.max_health()} " hp · "
+                            {i.horror()} "/" {i.max_sanity()} " san · clues " {i.clues}
+                        </div>
+                    }
+                })
+                .collect();
+            let enemies: Vec<_> = game
+                .enemies
+                .values()
+                .filter(|e| e.current_location == Some(loc.id) && e.engaged_with.is_none())
+                .map(|e| {
+                    view! {
+                        <div class="enemy-token">
+                            {e.name.clone()} " " {e.damage} "/" {e.max_health}
+                        </div>
+                    }
+                })
+                .collect();
+            let style = format!("left:{left}px;top:{top}px;width:{NODE_W}px;height:{NODE_H}px;");
+            view! {
+                <div class="map-location" data-loc=loc.name.clone() style=style>
+                    <div class="loc-head">
+                        {loc.name.clone()} " (shroud " {loc.shroud} " · clues " {loc.clues} ")"
+                    </div>
+                    {invs}
+                    {enemies}
+                </div>
+            }
+        })
+        .collect();
+
+    view! { <section class="map">{nodes}</section> }
+}
+```
+
+- [ ] **Step 2: Wire it into `BoardView`**
+
+In `crates/web/src/board.rs`, in the `Some(game)` arm of `board` (currently lines 30-39), insert the map call after `phase_bar`. Replace:
+
+```rust
+        Some(game) => view! {
+            <div class="game">
+                {resolution_banner(&game)}
+                {phase_bar(&game)}
+                {locations_panel(&game)}
+                {investigators_panel(&game)}
+                {enemies_panel(&game)}
+            </div>
+        }
+```
+
+with:
+
+```rust
+        Some(game) => view! {
+            <div class="game">
+                {resolution_banner(&game)}
+                {phase_bar(&game)}
+                {crate::map::location_map(&game)}
+                {investigators_panel(&game)}
+                {enemies_panel(&game)}
+            </div>
+        }
+```
+
+(`locations_panel` is now unused; Task 6 deletes it. To keep this task compiling under `-D warnings`, add `#[allow(dead_code)]` to `fn locations_panel` for now.) In `board.rs`, change `fn locations_panel` to:
+
+```rust
+#[allow(dead_code)]
+fn locations_panel(game: &GameState) -> impl IntoView {
+```
+
+- [ ] **Step 3: Create the wasm render test `crates/web/tests/map.rs`**
+
+```rust
+//! Headless render tests for the spatial board map (#497). Mount `BoardView`,
+//! feed a constructed `GameState`, assert on the rendered DOM. wasm32-only.
+#![cfg(target_arch = "wasm32")]
+
+use game_core::state::{GameStateBuilder, InvestigatorId, LocationId};
+use game_core::test_support::fixtures::{test_enemy, test_investigator, test_location};
+use game_core::EngineOutcome;
+use leptos::prelude::{document, provide_context, RwSignal, Update};
+use protocol::ServerMessage;
+use wasm_bindgen_test::*;
+use web::board::BoardView;
+use web::store::{reduce, ClientState};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+/// Mount `BoardView`, feed one `Hello` carrying `state`, tick, return nothing —
+/// assertions query the live DOM via `document()`.
+async fn mount_state(state: game_core::state::GameState) {
+    game_core::test_support::install_test_registry();
+    let store = RwSignal::new(ClientState::default());
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        leptos::view! { <BoardView/> }
+    });
+    store.update(|s| {
+        reduce(
+            s,
+            ServerMessage::Hello {
+                state: Box::new(state),
+                outcome: EngineOutcome::Done,
+            },
+        );
+    });
+    leptos::task::tick().await;
+}
+
+/// `textContent` of the map node whose `data-loc` equals `loc_name` (empty if no
+/// such node).
+fn node_text(loc_name: &str) -> String {
+    let sel = format!(".map-location[data-loc=\"{loc_name}\"]");
+    document()
+        .query_selector(&sel)
+        .expect("query ok")
+        .and_then(|el| el.text_content())
+        .unwrap_or_default()
+}
+
+#[wasm_bindgen_test]
+async fn investigator_renders_inside_its_location_node() {
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(LocationId(10));
+    let state = GameStateBuilder::new()
+        .with_location(test_location(10, "Study"))
+        .with_investigator(inv)
+        .build();
+    mount_state(state).await;
+    assert!(
+        node_text("Study").contains("Investigator 1"),
+        "investigator token must render inside its location node; Study node = {:?}",
+        node_text("Study"),
+    );
+}
+
+#[wasm_bindgen_test]
+async fn unengaged_enemy_renders_inside_its_location_node() {
+    let mut enemy = test_enemy(100, "Mock Ghoul");
+    enemy.current_location = Some(LocationId(10));
+    enemy.engaged_with = None;
+    let state = GameStateBuilder::new()
+        .with_location(test_location(10, "Study"))
+        .with_investigator(test_investigator(1))
+        .with_enemy(enemy)
+        .build();
+    mount_state(state).await;
+    assert!(
+        node_text("Study").contains("Mock Ghoul"),
+        "unengaged enemy must render inside its location node; Study node = {:?}",
+        node_text("Study"),
+    );
+}
+```
+
+(If `test_investigator(1).name` is not the string `"Investigator 1"`, read the fixture in `crates/game-core/src/test_support/fixtures.rs` and use its actual name in the assertion. Likewise confirm `test_location(id, name)` sets `name` to the passed string.)
+
+- [ ] **Step 4: Run the host build + wasm tests**
+
+Run: `cargo build -p web --target wasm32-unknown-unknown`
+Expected: compiles.
+
+Run: `wasm-pack test --headless --firefox crates/web -- --test map`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/web/src/map.rs crates/web/src/board.rs crates/web/tests/map.rs
+git commit -m "web: render location-container nodes with investigator/enemy tokens (#497)"
+```
+
+---
+
+### Task 4: Connection lines (SVG)
+
+**Files:**
+- Modify: `crates/web/src/map.rs` (add `connection_lines` + `map_extent`; render the SVG layer)
+- Test: `crates/web/tests/map.rs` (add cases)
+
+**Interfaces:**
+- Consumes: `layout_positions`, `CELL_W/CELL_H/NODE_W/NODE_H` (Task 3).
+- Produces: an `<svg class="map-lines">` layer inside the `.map` section with one `<line class="map-line">` per undirected pair of connected, in-play locations.
+
+- [ ] **Step 1: Add `connection_lines` + `map_extent` to `map.rs`**
+
+```rust
+/// Center pixel of a node at grid cell `(col, row)`.
+fn node_center((col, row): (u16, u16)) -> (u16, u16) {
+    (col * CELL_W + NODE_W / 2, row * CELL_H + NODE_H / 2)
+}
+
+/// One `<line>` per undirected pair of connected, in-play locations, between
+/// node centers. A peer not in `positions` (set-aside, not yet in play) is
+/// skipped. Dedups by ordered `LocationId` pair so each edge draws once.
+fn connection_lines(
+    game: &GameState,
+    positions: &BTreeMap<LocationId, (u16, u16)>,
+) -> Vec<impl IntoView> {
+    let mut seen: BTreeSet<(u32, u32)> = BTreeSet::new();
+    let mut lines = Vec::new();
+    for loc in game.locations.values() {
+        let Some(&a) = positions.get(&loc.id) else {
+            continue;
+        };
+        for peer in &loc.connections {
+            let Some(&b) = positions.get(peer) else {
+                continue; // peer not in play
+            };
+            let key = (loc.id.0.min(peer.0), loc.id.0.max(peer.0));
+            if !seen.insert(key) {
+                continue;
+            }
+            let (x1, y1) = node_center(a);
+            let (x2, y2) = node_center(b);
+            lines.push(view! {
+                <line class="map-line" x1=x1 y1=y1 x2=x2 y2=y2 />
+            });
+        }
+    }
+    lines
+}
+
+/// Pixel `(width, height)` spanning all placed nodes (one extra cell of slack).
+fn map_extent(positions: &BTreeMap<LocationId, (u16, u16)>) -> (u16, u16) {
+    let max_col = positions.values().map(|(c, _)| *c).max().unwrap_or(0);
+    let max_row = positions.values().map(|(_, r)| *r).max().unwrap_or(0);
+    ((max_col + 1) * CELL_W, (max_row + 1) * CELL_H)
+}
+```
+
+- [ ] **Step 2: Render the SVG layer in `location_map`**
+
+In `location_map`, replace the final `view! { <section class="map">{nodes}</section> }` with:
+
+```rust
+    let lines = connection_lines(game, &positions);
+    let (w, h) = map_extent(&positions);
+    view! {
+        <section class="map" style=format!("width:{w}px;height:{h}px;")>
+            <svg class="map-lines" width=w height=h>{lines}</svg>
+            {nodes}
+        </section>
+    }
+}
+```
+
+- [ ] **Step 3: Add wasm tests for the lines**
+
+Add to `crates/web/tests/map.rs`:
+
+```rust
+fn line_count() -> u32 {
+    document()
+        .query_selector_all("line.map-line")
+        .expect("query ok")
+        .length()
+}
+
+#[wasm_bindgen_test]
+async fn connected_locations_draw_a_line() {
+    let mut state = GameStateBuilder::new()
+        .with_location(test_location(10, "Hallway"))
+        .with_location(test_location(11, "Attic"))
+        .with_investigator(test_investigator(1))
+        .build();
+    state.connect(LocationId(10), LocationId(11));
+    mount_state(state).await;
+    assert!(line_count() >= 1, "a connected pair must draw at least one line");
+}
+
+#[wasm_bindgen_test]
+async fn isolated_location_draws_no_line() {
+    let state = GameStateBuilder::new()
+        .with_location(test_location(10, "Study")) // no connections
+        .with_investigator(test_investigator(1))
+        .build();
+    mount_state(state).await;
+    assert_eq!(line_count(), 0, "an isolated location draws no lines");
+}
+```
+
+(Confirm `GameState::connect(LocationId, LocationId)` is callable from the test — it's a `pub` method on `GameState` per `game_state.rs`. If the locations must exist first, `with_location` adds them before `connect`; both ids are present.)
+
+- [ ] **Step 4: Run wasm tests**
+
+Run: `wasm-pack test --headless --firefox crates/web -- --test map`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/web/src/map.rs crates/web/tests/map.rs
+git commit -m "web: draw connection lines between location nodes (#497)"
+```
+
+---
+
+### Task 5: Detail panel — threat area + engaged enemies
+
+**Files:**
+- Modify: `crates/web/src/board.rs` (`investigators_panel`)
+- Test: `crates/web/tests/map.rs` (add a case)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: each `.investigator` article also renders a `.threat` block (the investigator's `threat_area` treacheries by name) and an `.engaged` block (enemies with `engaged_with == Some(inv.id)`).
+
+- [ ] **Step 1: Extend `investigators_panel`**
+
+In `crates/web/src/board.rs`, inside the `.map(|inv| { ... })` closure of `investigators_panel`, after the `in_play` vec (currently ~line 116-120), add:
+
+```rust
+            let threat: Vec<_> = inv
+                .threat_area
+                .iter()
+                .map(|c| view! { <li class="card">{crate::names::card_name(&c.code)}</li> })
+                .collect();
+            let engaged: Vec<_> = game
+                .enemies
+                .values()
+                .filter(|e| e.engaged_with == Some(inv.id))
+                .map(|e| {
+                    view! {
+                        <li class="enemy-engaged">
+                            {e.name.clone()} " " {e.damage} "/" {e.max_health}
+                        </li>
+                    }
+                })
+                .collect();
+```
+
+Then, in that closure's `view! { <article class="investigator"> ... </article> }`, add two blocks after the `in-play` div (currently line 132):
+
+```rust
+                    <div class="threat"><h4>"Threat area"</h4><ul>{threat}</ul></div>
+                    <div class="engaged"><h4>"Engaged enemies"</h4><ul>{engaged}</ul></div>
+```
+
+- [ ] **Step 2: Add the wasm test (engaged enemy in panel, not node)**
+
+Add to `crates/web/tests/map.rs`:
+
+```rust
+#[wasm_bindgen_test]
+async fn engaged_enemy_renders_in_detail_panel_not_in_node() {
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(LocationId(10));
+    let mut enemy = test_enemy(100, "Mock Ghoul");
+    enemy.current_location = Some(LocationId(10));
+    enemy.engaged_with = Some(InvestigatorId(1));
+    let state = GameStateBuilder::new()
+        .with_location(test_location(10, "Study"))
+        .with_investigator(inv)
+        .with_enemy(enemy)
+        .build();
+    mount_state(state).await;
+
+    // Not in the location node (engaged enemies leave the location box)…
+    assert!(
+        !node_text("Study").contains("Mock Ghoul"),
+        "engaged enemy must NOT render in the location node; node = {:?}",
+        node_text("Study"),
+    );
+    // …but present in the investigator detail panel.
+    let panel = document()
+        .query_selector(".investigators")
+        .expect("query ok")
+        .and_then(|el| el.text_content())
+        .unwrap_or_default();
+    assert!(
+        panel.contains("Mock Ghoul"),
+        "engaged enemy must render in the detail panel; panel = {panel:?}",
+    );
+}
+```
+
+- [ ] **Step 3: Run wasm tests + the existing board tests (the panel changed)**
+
+Run: `wasm-pack test --headless --firefox crates/web -- --test map`
+Expected: PASS (5 tests).
+
+Run: `wasm-pack test --headless --firefox crates/web -- --test board`
+Expected: PASS (the existing board tests still pass — the panel only gained blocks).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/web/src/board.rs crates/web/tests/map.rs
+git commit -m "web: show threat area + engaged enemies in the investigator panel (#497)"
+```
+
+---
+
+### Task 6: Remove the old panels, add styles, full gauntlet
+
+**Files:**
+- Modify: `crates/web/src/board.rs` (delete `locations_panel` + `enemies_panel`; drop the now-unused `InvestigatorId` import if unused)
+- Modify: `crates/web/style.css`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: the board renders the map + detail panels only; CSS positions the nodes and styles the line layer.
+
+- [ ] **Step 1: Delete the dead panels**
+
+In `crates/web/src/board.rs`:
+- Delete `fn locations_panel(...)` (the `#[allow(dead_code)]` one) entirely.
+- Delete `fn enemies_panel(...)` entirely, and remove its call `{enemies_panel(&game)}` from the `Some(game)` arm (the `.game` div should now contain `resolution_banner`, `phase_bar`, `location_map`, `investigators_panel`).
+- `enemies_panel` was the only user of `InvestigatorId` in `board.rs`'s `use` (line 5). If `cargo build` then reports `InvestigatorId` unused, change the import `use game_core::state::{GameState, InvestigatorId};` to `use game_core::state::GameState;`.
+
+The `Some(game)` arm is now:
+
+```rust
+        Some(game) => view! {
+            <div class="game">
+                {resolution_banner(&game)}
+                {phase_bar(&game)}
+                {crate::map::location_map(&game)}
+                {investigators_panel(&game)}
+            </div>
+        }
+```
+
+- [ ] **Step 2: Add map styles to `style.css`**
+
+Append to `crates/web/style.css`:
+
+```css
+/* Spatial board map (#497). Nodes are absolutely positioned at computed
+   left/top (set inline); the SVG line layer sits behind them. */
+.map { position: relative; margin: 1rem 0; }
+.map-lines { position: absolute; top: 0; left: 0; z-index: 0; pointer-events: none; }
+.map-line { stroke: #999; stroke-width: 2; }
+.map-location { position: absolute; z-index: 1; box-sizing: border-box; border: 1px solid #333; border-radius: 4px; background: #fff; padding: 0.25rem; font-size: 0.8rem; overflow: hidden; }
+.loc-head { font-weight: 600; margin-bottom: 0.15rem; }
+.inv-token { color: #157a3a; }
+.enemy-token { color: #a3261b; }
+.engaged ul, .threat ul { list-style: none; padding-left: 0; margin: 0; }
+.enemy-engaged { color: #a3261b; font-size: 0.85rem; }
+```
+
+- [ ] **Step 3: Run the full gauntlet**
+
+Run each Global-Constraints command. Expected: all green, including:
+- `cargo test -p web --lib map::` (host layout tests)
+- `wasm-pack test --headless --firefox crates/web` (all web wasm tests: `board` + `map`)
+- `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/web/src/board.rs crates/web/style.css
+git commit -m "web: drop the old locations/enemies text panels; style the map (#497)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** positioned nodes + container contents → Task 3; connection lines → Task 4; token-in-node + detail-panel split → Tasks 3 & 5; engaged-in-panel / unengaged-in-node → Tasks 3 & 5; coordinate table + fallback → Tasks 1 & 2; read-only (no handlers) → throughout; only-in-play locations → Task 3 (iterates `game.locations`); subsumes #497 → Task 5 (threat area). Non-goals (interactivity, engine hints, background image) respected.
+- **Deviation from spec wording:** the map is a panel `fn location_map(&GameState)` (matching `locations_panel`/`enemies_panel`), not a standalone store-reading component — simpler, host-testable layout helpers, same render output. Noted in the header.
+- **Type consistency:** `location_grid_pos(&str) -> Option<(u16,u16)>`, `layout_positions(&[(LocationId, CardCode)]) -> BTreeMap<LocationId,(u16,u16)>`, `node_center((u16,u16)) -> (u16,u16)`, `location_map(&GameState) -> impl IntoView` are used consistently across tasks. `LocationId.0` is the numeric id used for line dedup. `e.engaged_with == Some(inv.id)` matches `Enemy.engaged_with: Option<InvestigatorId>` and `Investigator.id: InvestigatorId`.
+- **Verify-before-asserting:** Task 3 Step 3 flags confirming the `test_investigator`/`test_location` fixture name strings before locking the DOM assertions.

--- a/docs/superpowers/specs/2026-06-27-spatial-board-map-design.md
+++ b/docs/superpowers/specs/2026-06-27-spatial-board-map-design.md
@@ -1,0 +1,137 @@
+# Spatial board map (web) — design (#497, expanded)
+
+## Problem
+
+The web board (`crates/web/src/board.rs`) renders three flat text panels — a
+locations list, an investigators list, and an enemies list. Nothing shows
+*where* things are: a player can't see the location graph, which location they're
+in, where enemies lurk, or (the original #497 complaint) what's in their threat
+area. Found repeatedly in live playtest.
+
+## Goal
+
+A spatial board: a map of the in-play locations with their connections drawn as
+lines, each location a container holding the investigators and unengaged enemies
+that are *in* it, plus a per-investigator detail panel for the state that doesn't
+fit on the map (hand, assets, threat area, engaged enemies). Read-only — actions
+still flow through the existing `AwaitingInput` menu.
+
+This **subsumes #497** (threat-area display is part of the detail panel).
+
+## Decisions from brainstorming
+
+- **Positioned map with drawn connection lines** *and* **location-as-container** —
+  the nodes on the map are rich boxes, with SVG lines between connected boxes.
+- **Token-in-node + detail panel** — the location box shows a compact investigator
+  token; full investigator detail lives in a separate panel.
+- **Engaged enemies render with the investigator** (in the detail panel), not in
+  the location box; unengaged enemies render in the location box.
+- **Client-side coordinate table** keyed by location code, with a graceful
+  fallback for codes not in the table. Engine-provided layout hints are a bigger
+  cross-crate change, deferred.
+- **Read-only**; no click/hover interaction, no background image, no drag.
+
+## Architecture
+
+All changes are in `crates/web/` (Leptos 0.8 CSR). The full `GameState` is already
+available to views via the store (`use_store().get().game`), so the map is a pure
+derivation of state — no new client state.
+
+### Components
+
+- **`LocationMap`** (new component; new file `crates/web/src/map.rs`, exported from
+  `lib.rs`). Reads the game from the store and renders the positioned location
+  nodes + an SVG connection-line layer. Replaces today's `locations_panel` and
+  `enemies_panel` in `board.rs`.
+- **Location node** — a container box per in-play location showing:
+  - location name (`location.name`), `shroud`, `clues`;
+  - **investigator tokens** for each investigator whose `current_location` is this
+    location — compact: name + `health`/`max_health`, `sanity`/`max_sanity` (i.e.
+    `damage`/`horror` against capacity), and carried `clues`;
+  - **unengaged enemy tokens** for each enemy where `current_location == this` and
+    `engaged_with.is_none()` — name + `damage`/`max_health`.
+- **Investigator detail panel** — the existing `investigators_panel` in `board.rs`,
+  kept and extended. Per investigator: `resources`, `actions_remaining`,
+  `health`/`sanity` (damage/horror vs capacity), `clues`, `status`, hand
+  (`names::card_name`), in-play assets, threat-area treacheries (`threat_area`),
+  **and** the investigator's **engaged enemies** (`Enemy` entities where
+  `engaged_with == Some(this.id)`).
+
+### Layout & connection lines
+
+- A pure function `location_grid_pos(code: &str) -> Option<(u16, u16)>` returns a
+  `(col, row)` grid cell for known location codes. The Gathering's five locations:
+  Study isolated to one side; Hallway as the hub with Attic / Cellar / Parlor on
+  its three sides. Exact cells are an implementation detail of the table.
+- Nodes render at `(col, row)` on a fixed-cell grid (each cell a fixed size, so
+  centers are computable as `col * CELL_W + CELL_W/2`, etc.).
+- **Fallback:** in-play locations whose code is absent from the table are assigned
+  the next free grid cells deterministically (e.g. appended in `game.locations`
+  iteration order), so future scenarios render — unstyled-but-functional — until
+  their coordinates are added.
+- **Lines:** an SVG layer positioned behind the nodes draws one `<line>` per pair
+  of connected, in-play locations (`location.connections`, dedup undirected pairs),
+  endpoints at the two node centers. Set-aside locations aren't in `game.locations`
+  yet, so they neither render nor get lines until they enter play.
+
+### Data flow
+
+`LocationMap` reads `store.get().game`, then derives (all by iterating
+`GameState`):
+- investigators grouped by `current_location`;
+- enemies with `engaged_with.is_none()` grouped by `current_location` (unengaged →
+  location box);
+- enemies with `engaged_with == Some(id)` grouped by investigator (→ detail panel).
+
+No mutation, no new signals. Re-renders reactively when the store's `game` changes
+(same pattern as the current panels).
+
+### Styling
+
+Extend `crates/web/style.css`:
+- `.map` — `position: relative`, sized to the grid extent.
+- `.map-lines` — an absolutely-positioned SVG layer behind the nodes (`z-index`
+  below `.map-location`).
+- `.map-location` — absolutely positioned (or CSS-grid placed) fixed-size box;
+  reuse the existing border/padding idiom from `.investigator`.
+- token classes (`.inv-token`, `.enemy-token`) — compact rows inside a node.
+
+No Tailwind, no inline styles (matches the existing plain-CSS approach).
+
+## Testing
+
+wasm-bindgen-test (`crates/web/tests/`), using the existing `render_state` helper
+(mount component, inject state via `reduce(Hello{..})`, `tick().await`, assert on
+`inner_html()`). New cases:
+
+- **Location nodes render** — a state with two connected locations renders both
+  names in the map.
+- **Investigator placed in its location** — an investigator at location A renders
+  its token inside A's node (assert the token markup appears within the A box, e.g.
+  via a per-node container class + the name).
+- **Unengaged enemy in its location** — an enemy at A with `engaged_with == None`
+  renders in A's node.
+- **Engaged enemy in the detail panel, not the node** — an enemy `engaged_with`
+  the investigator renders in that investigator's detail panel and is **absent**
+  from the location node.
+- **Connection lines render** — assert ≥1 SVG `<line>` for a two-connected-location
+  state (and none for an isolated single location).
+- **Fallback for an off-table code** — a location whose code isn't in the table
+  still renders (no panic, name present).
+
+## Non-goals (explicit)
+
+- **Interactivity** — the board stays read-only; clicking a node/token does
+  nothing; all actions remain on the `AwaitingInput` menu. (A future "click the
+  map to act" step is out of scope.)
+- **Engine layout hints** — coordinates stay client-side; no `GameState`/scenario
+  changes. Promote to engine-provided hints only when a scenario needs authored
+  geometry the client can't reasonably table.
+- **Map background image, draggable nodes, zoom/pan.**
+- **Set-aside location preview** — only in-play locations render.
+
+## Open questions
+
+None outstanding — the brainstorm settled the layout (positioned containers +
+drawn lines), the node/detail split (token-in-node + detail panel), engaged-enemy
+placement (detail panel), and the coordinate source (client-side table + fallback).


### PR DESCRIPTION
## Summary

Replaces the web board's three flat text panels (locations / investigators / enemies lists) with a **spatial map**: in-play locations as positioned container nodes with drawn SVG connection lines, investigators and unengaged enemies rendered *inside* their location node, and a per-investigator detail panel where engaged enemies sit in the single **Threat area** list alongside threat-area treacheries. Read-only — actions still flow through the `AwaitingInput` menu. Subsumes #497.

## How it works

- **`crates/web/src/map.rs`** (new): pure, host-tested layout helpers — `location_grid_pos` (a client-side location-code → grid-cell table for The Gathering) and `layout_positions` (resolves every in-play location to a cell, with a deterministic collision-free fallback for codes without an authored cell) — plus the `location_map(&GameState)` panel fn that renders the nodes and an SVG layer drawing one line per undirected connected pair (set-aside peers skipped).
- **`board.rs`**: composes `resolution_banner` + `phase_bar` + `location_map` + `investigators_panel`; the old `locations_panel`/`enemies_panel` are deleted. The detail panel gained the Threat-area list (treacheries + engaged enemies).
- **`style.css`**: positioned `.map-location` nodes over a behind-the-nodes `.map-lines` SVG; dead panel CSS removed.

Coordinates are client-side (no engine change); locations not in the table flow into free cells, so future scenarios render functionally until their cells are authored. Only in-play locations render — set-aside locations appear as they enter play.

## Tests

Host unit tests for the layout helpers (authored cells, fallback non-collision, two-unknowns-distinct). wasm-bindgen-test render tests (headless Firefox): investigator/unengaged-enemy placed in their node; connection line drawn for a connected pair and none for an isolated location (exactly one per undirected pair); engaged enemy renders in the detail panel and **not** in the node.

## Process

Built via subagent-driven development (6 tasks, per-task spec+quality review, final whole-branch review). Final review was "ready with fixes" — the one Important (a bogus `contains("revealed")` assertion that passed only via the test runner's injected name) is fixed.

## Verification

Full local gauntlet green: `fmt`, `clippy --all-targets --all-features -D warnings`, `RUSTFLAGS=-D warnings test --all`, `RUSTDOCFLAGS=-D warnings doc`, `wasm-build`, `wasm-clippy`, `wasm-pack test --headless --firefox`.

Design + plan: `docs/superpowers/specs/2026-06-27-spatial-board-map-design.md`, `docs/superpowers/plans/2026-06-27-spatial-board-map.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)