### PR TITLE
engine: pay + gate card resource cost on play

### DIFF
--- a/crates/card-dsl/src/card_data.rs
+++ b/crates/card-dsl/src/card_data.rs
@@ -538,6 +538,25 @@ impl CardMetadata {
         )
     }
 
+    /// The printed resource cost to play this card from hand (Rules Reference
+    /// p.7, "Costs"). `Some(n)` is a fixed cost; `None` means either an X-cost
+    /// card or a card type that is never played for a cost (Skill, encounter
+    /// cards, …). Callers in the play path reach this only for Asset/Event (the
+    /// only playable types), where `None` therefore denotes an X-cost.
+    #[must_use]
+    pub fn play_cost(&self) -> Option<i8> {
+        match self.kind {
+            CardKind::Asset { cost, .. } | CardKind::Event { cost, .. } => cost,
+            CardKind::Investigator { .. }
+            | CardKind::Skill { .. }
+            | CardKind::Enemy { .. }
+            | CardKind::Treachery { .. }
+            | CardKind::Location { .. }
+            | CardKind::Act { .. }
+            | CardKind::Agenda { .. } => None,
+        }
+    }
+
     /// Surge keyword (Rules Reference p.19). Only Enemy/Treachery
     /// encounter cards carry it; everything else is `false`.
     #[must_use]
@@ -630,6 +649,68 @@ mod is_fast_tests {
         };
         assert!(event(true).play_only_during_turn());
         assert!(!event(false).play_only_during_turn());
+    }
+
+    #[test]
+    fn play_cost_reads_asset_and_event_cost_and_none_elsewhere() {
+        let asset = |cost| CardMetadata {
+            code: "01017".into(),
+            name: "Physical Training".into(),
+            traits: vec![],
+            text: None,
+            pack_code: "core".into(),
+            kind: CardKind::Asset {
+                class: Class::Guardian,
+                cost,
+                xp: None,
+                slots: vec![],
+                health: None,
+                sanity: None,
+                skill_icons: SkillIcons::default(),
+                is_fast: false,
+                deck_limit: 2,
+                uses: None,
+                play_only_during_turn: false,
+            },
+        };
+        // Fixed cost reads through; X-cost (`None`) reads through as `None`.
+        assert_eq!(asset(Some(2)).play_cost(), Some(2));
+        assert_eq!(asset(None).play_cost(), None);
+
+        let event = CardMetadata {
+            code: "01088".into(),
+            name: "Emergency Cache".into(),
+            traits: vec![],
+            text: None,
+            pack_code: "core".into(),
+            kind: CardKind::Event {
+                class: Class::Neutral,
+                cost: Some(0),
+                xp: None,
+                skill_icons: SkillIcons::default(),
+                is_fast: false,
+                deck_limit: 3,
+                play_only_during_turn: false,
+            },
+        };
+        assert_eq!(event.play_cost(), Some(0));
+
+        // A non-playable card type has no play cost.
+        let skill = CardMetadata {
+            code: "01089".into(),
+            name: "Guts".into(),
+            traits: vec![],
+            text: None,
+            pack_code: "core".into(),
+            kind: CardKind::Skill {
+                class: Class::Survivor,
+                xp: None,
+                skill_icons: SkillIcons::default(),
+                deck_limit: 2,
+                commit_limit: None,
+            },
+        };
+        assert_eq!(skill.play_cost(), None);
     }
 
     #[test]

--- a/crates/cards/tests/evidence.rs
+++ b/crates/cards/tests/evidence.rs
@@ -272,6 +272,69 @@ fn evidence_fast_event_discards_exactly_once() {
 }
 
 #[test]
+fn playing_evidence_from_hand_pays_its_resource_cost() {
+    // Evidence! (01022) costs 1 resource. Playing it from its after-defeat
+    // window deducts the cost (RR p.22, Initiation Sequence) — a Fast play
+    // skips the *action* cost, not the *resource* cost. The fixture starts at
+    // the default 5 resources.
+    let (inv_id, enemy_id, _loc_id, state) = investigator_with_evidence_and_enemy(2);
+    assert_eq!(
+        state.investigators[&inv_id].resources, 5,
+        "fixture invariant: 5 starting resources",
+    );
+
+    let result = TestSession::new(state)
+        .take(&fight_action(inv_id, enemy_id))
+        .resolve_choices(|c| {
+            c.commit_cards(&[]).pick_single(OptionId(0));
+        })
+        .run();
+
+    assert_event!(
+        result.events,
+        Event::ResourcesPaid { investigator, amount } if *investigator == inv_id && *amount == 1
+    );
+    assert_eq!(
+        result.state.investigators[&inv_id].resources, 4,
+        "5 - cost 1 = 4 after playing Evidence!",
+    );
+}
+
+#[test]
+fn evidence_not_offered_when_resources_below_cost() {
+    // Evidence! costs 1; with 0 resources the cost can't be paid, so the
+    // after-defeat window must not offer it (RR p.22: the cost must be
+    // established as payable before initiation). Mirror of the #495 change-
+    // game-state suppression, but on affordability.
+    let (inv_id, enemy_id, _loc_id, mut state) = investigator_with_evidence_and_enemy(2);
+    state.investigators.get_mut(&inv_id).unwrap().resources = 0;
+
+    let after_fight = take_turn_action(state, &fight_action(inv_id, enemy_id));
+    let result = apply(
+        after_fight.state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickMultiple { selected: vec![] },
+        }),
+    );
+
+    let EngineOutcome::AwaitingInput { request, .. } = &result.outcome else {
+        panic!("expected AwaitingInput, got {:?}", result.outcome);
+    };
+    assert!(
+        !request.options.iter().any(|o| o.label.contains(EVIDENCE)),
+        "Evidence! must not be offered with insufficient resources; request = {request:?}",
+    );
+    assert!(
+        result.state.investigators[&inv_id]
+            .hand
+            .iter()
+            .any(|c| c.as_str() == EVIDENCE),
+        "Evidence! stays in hand (never played)",
+    );
+    assert_no_event!(result.events, Event::CluePlaced { .. });
+}
+
+#[test]
 fn window_offers_both_in_play_reaction_and_hand_evidence() {
     use game_core::state::{CardInPlay, CardInstanceId};
     let inv_id = InvestigatorId(1);

--- a/crates/cards/tests/play_card.rs
+++ b/crates/cards/tests/play_card.rs
@@ -458,3 +458,99 @@ fn play_card_after_defeat_is_rejected() {
     assert!(matches!(result.outcome, EngineOutcome::Rejected { .. }));
     assert!(result.events.is_empty());
 }
+
+// --- Resource-cost payment (#501) -----------------------------------------
+//
+// Playing a card is paying its cost (RR p.22, Initiation Sequence): a card
+// cannot be played unless its resource cost can be paid in full, and on a
+// successful play the cost is deducted before attacks of opportunity resolve.
+// Holy Rosary (01059) costs 2 resources (verified against the corpus).
+
+#[test]
+fn play_card_rejected_when_resources_below_cost() {
+    let (mut state, id, _loc) = play_state(vec![HOLY_ROSARY]); // cost 2
+    state.investigators.get_mut(&id).unwrap().resources = 1;
+
+    let result = dispatch_turn_action_unchecked(
+        state,
+        &TurnAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        },
+    );
+
+    assert!(
+        matches!(result.outcome, EngineOutcome::Rejected { .. }),
+        "playing a cost-2 card with 1 resource must be rejected",
+    );
+    let inv = &result.state.investigators[&id];
+    assert_eq!(inv.resources, 1, "resources unchanged on a rejected play");
+    assert_eq!(inv.hand.len(), 1, "card stays in hand on a rejected play");
+    assert!(inv.cards_in_play.is_empty(), "nothing enters play");
+    assert!(result.events.is_empty(), "no events on rejection");
+}
+
+#[test]
+fn play_card_deducts_resource_cost_and_emits_resources_paid() {
+    let (mut state, id, _loc) = play_state(vec![HOLY_ROSARY]); // cost 2
+    state.investigators.get_mut(&id).unwrap().resources = 5;
+
+    let result = dispatch_turn_action_unchecked(
+        state,
+        &TurnAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        },
+    );
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_eq!(
+        result.state.investigators[&id].resources, 3,
+        "5 - cost 2 = 3 after a successful play",
+    );
+    assert_event_count!(
+        result.events,
+        1,
+        Event::ResourcesPaid { investigator, amount }
+            if *investigator == id && *amount == 2
+    );
+}
+
+#[test]
+fn play_card_at_exactly_its_cost_succeeds() {
+    let (mut state, id, _loc) = play_state(vec![HOLY_ROSARY]); // cost 2
+    state.investigators.get_mut(&id).unwrap().resources = 2;
+
+    let result = dispatch_turn_action_unchecked(
+        state,
+        &TurnAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        },
+    );
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_eq!(
+        result.state.investigators[&id].resources, 0,
+        "paying the full cost empties the pool",
+    );
+}
+
+#[test]
+fn play_zero_cost_card_is_free_and_emits_no_resources_paid() {
+    // Emergency Cache (01088) costs 0: affordable even at 0 resources, and a
+    // 0-resource deduction emits no ResourcesPaid event.
+    let (mut state, id, _loc) = play_state(vec![EMERGENCY_CACHE]);
+    state.investigators.get_mut(&id).unwrap().resources = 0;
+
+    let result = dispatch_turn_action_unchecked(
+        state,
+        &TurnAction::PlayCard {
+            investigator: id,
+            hand_index: 0,
+        },
+    );
+
+    assert_eq!(result.outcome, EngineOutcome::Done);
+    assert_no_event!(result.events, Event::ResourcesPaid { .. });
+}

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -176,6 +176,39 @@ pub(crate) fn grant_resources(cx: &mut Cx, investigator: InvestigatorId, amount:
     });
 }
 
+/// Pay `code`'s printed resource cost for `investigator` (RR p.22, Initiation
+/// Sequence): saturating-subtract the cost from the wallet and emit
+/// [`Event::ResourcesPaid`]. A 0-cost card is a no-op (no event), mirroring
+/// [`grant_resources`]'s zero-amount behavior. The cost is read from the
+/// registry by `code`; absent metadata (registry-free unit tests) or a 0 cost
+/// pays nothing.
+///
+/// The caller has already validated affordability
+/// (`check_play_resource_cost_payable`), so the `saturating_sub` never silently
+/// underflows a real shortfall — it's belt-and-suspenders.
+///
+/// Caller guarantees `investigator` exists in `state.investigators`.
+pub(super) fn pay_play_cost(cx: &mut Cx, investigator: InvestigatorId, code: &CardCode) {
+    let cost = card_registry::current()
+        .and_then(|reg| (reg.metadata_for)(code))
+        .and_then(crate::card_data::CardMetadata::play_cost)
+        .and_then(|c| u8::try_from(c).ok())
+        .unwrap_or(0);
+    if cost == 0 {
+        return;
+    }
+    let inv = cx
+        .state
+        .investigators
+        .get_mut(&investigator)
+        .expect("pay_play_cost: caller guarantees investigator exists");
+    inv.resources = inv.resources.saturating_sub(cost);
+    cx.events.push(Event::ResourcesPaid {
+        investigator,
+        amount: cost,
+    });
+}
+
 /// Reshuffle the discard pile back into the deck for the named
 /// investigator. Used by [`draw`] when the deck runs empty. Drains
 /// `discard` into `deck`, then calls [`shuffle_player_deck`] (which
@@ -572,6 +605,11 @@ pub(super) fn play_card(
     if !is_fast {
         super::actions::spend_one_action(cx, investigator);
     }
+    // Pay the resource cost (RR p.22): both Fast and non-Fast plays pay it —
+    // Fast only skips the *action* cost. Affordability was validated in
+    // `check_play_card`; the deduction happens before the card is announced and
+    // before any attack of opportunity resolves (#501).
+    pay_play_cost(cx, investigator, &code);
     // The card is announced (`CardPlayed`): an event commences play via the
     // shared `begin_event_play` (leaves hand, stashed for discard-on-completion);
     // an asset emits `CardPlayed` now and enters play after its `OnPlay` effect

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -471,6 +471,12 @@ fn scan_hand_fast_events(
                 if !ability_eligible(state, ability, CandidateSource::Hand, id) {
                     continue;
                 }
+                // RR p.22 affordability: don't offer a Fast event whose resource
+                // cost can't be paid (Evidence! 01022 costs 1; not offered at 0
+                // resources). The play path (play_fast_event) pays it (#501).
+                if check_play_resource_cost_payable(state, id, code).is_err() {
+                    continue;
+                }
                 let ability_index = u8::try_from(idx)
                     .expect("abilities vec exceeds u8::MAX — card-impl bug, abilities are tiny");
                 plays.push(ResolutionCandidate {
@@ -848,10 +854,13 @@ fn fire_pending_trigger(cx: &mut Cx, i: u32) -> EngineOutcome {
 /// Appendix I step 4) and the window beneath resumes its candidate scan (Slice D
 /// #423).
 ///
-/// Charges no resource cost, matching [`super::cards::play_card`] (Slice 1
-/// does not model play-cost resources). The caller has already removed the
-/// candidate from the run, so a suspending effect's resume drives the
-/// remaining siblings, not this play again.
+/// Pays the event's resource cost (RR p.22) via [`super::cards::pay_play_cost`]
+/// before announcing the play, matching [`super::cards::play_card`] — a Fast
+/// play skips the *action* cost, not the *resource* cost (#501). Affordability
+/// was established at scan time ([`scan_hand_fast_events`] filters unaffordable
+/// Fast events out of the window). The caller has already removed the candidate
+/// from the run, so a suspending effect's resume drives the remaining siblings,
+/// not this play again.
 fn play_fast_event(cx: &mut Cx, candidate: &ResolutionCandidate) -> EngineOutcome {
     let controller = candidate.controller;
     // Find the event in the controller's hand by code (first match — copies
@@ -867,6 +876,10 @@ fn play_fast_event(cx: &mut Cx, candidate: &ResolutionCandidate) -> EngineOutcom
                  {controller:?}'s hand between scan and play"
             )
         });
+    // Pay the resource cost before announcing the play (RR p.22): Fast plays
+    // skip the action cost, not the resource cost. Affordability was filtered at
+    // scan time (#501).
+    super::cards::pay_play_cost(cx, controller, &candidate.code);
     super::cards::begin_event_play(cx, controller, hand_idx);
 
     // Look up the matched OnEvent ability's effect from the registry.
@@ -1432,6 +1445,10 @@ pub(crate) fn check_play_card(
     // Playing a card is an action (RR p.5), so a non-fast play needs an action
     // point (validate-first; `play_card` spends it). Fast plays are not actions.
     check_play_action_available(state, investigator, is_fast, &code)?;
+    // Playing a card is paying its cost (RR p.22, Initiation Sequence): the
+    // resource cost must be established as payable before initiation. Both Fast
+    // and non-Fast plays pay it — Fast only skips the *action* cost (#501).
+    check_play_resource_cost_payable(state, investigator, &code)?;
     Ok(super::PlayCheckResult {
         destination,
         abilities,
@@ -1464,6 +1481,57 @@ fn check_play_action_available(
         .into());
     }
     Ok(())
+}
+
+/// Playing a card is paying its resource cost in full (RR p.22, Initiation
+/// Sequence — the cost must be established as payable before initiation, and is
+/// then paid before attacks of opportunity resolve). Returns the reject reason
+/// when `investigator` cannot pay `code`'s printed cost. A 0-cost card is always
+/// affordable.
+///
+/// Cards with no fixed printed cost (`play_cost()` is `None` — an X-cost card,
+/// or a permanent) are **not yet modeled** — rejected loudly rather than
+/// silently played for free. No implemented card hits this: such cards are
+/// unplayable stubs refused earlier by `resolve_play_target`, and permanents
+/// enter play at setup rather than via `PlayCard`. The branch is currently
+/// unreachable in the corpus; it guards a future implemented X-cost card
+/// (deferral split from #501).
+///
+/// Short-circuits to `Ok` when the registry isn't installed — the metadata-free
+/// validation paths the engine's own unit tests exercise; the real play path
+/// always has a registry installed by the time it reaches here.
+fn check_play_resource_cost_payable(
+    state: &GameState,
+    investigator: InvestigatorId,
+    code: &CardCode,
+) -> Result<(), Cow<'static, str>> {
+    let Some(meta) = card_registry::current().and_then(|reg| (reg.metadata_for)(code)) else {
+        return Ok(());
+    };
+    let resources = state
+        .investigators
+        .get(&investigator)
+        .map_or(0, |inv| inv.resources);
+    match meta.play_cost() {
+        // Printed costs are non-negative; `try_from` clamps a (nonexistent)
+        // negative cost to 0 = free, never a panic.
+        Some(cost) => {
+            let cost = u8::try_from(cost).unwrap_or(0);
+            if resources < cost {
+                return Err(format!(
+                    "PlayCard: playing {code} costs {cost} resource(s); \
+                     {investigator:?} has {resources}"
+                )
+                .into());
+            }
+            Ok(())
+        }
+        None => Err(format!(
+            "PlayCard: {code} has no fixed printed cost (X-cost or permanent), \
+             which is not yet modeled — deferred from #501."
+        )
+        .into()),
+    }
 }
 
 /// True if `effect` initiates a Fight at its top level.

--- a/crates/game-core/src/event.rs
+++ b/crates/game-core/src/event.rs
@@ -130,8 +130,8 @@ pub enum Event {
         /// Amount gained.
         amount: u8,
     },
-    /// An investigator paid / lost resources (e.g. as a `Cost::Resources`
-    /// payment for an activated ability).
+    /// An investigator paid / lost resources (a `Cost::Resources` payment for an
+    /// activated ability, or a card's printed play cost on `PlayCard`).
     ResourcesPaid {
         /// Who paid resources.
         investigator: InvestigatorId,


### PR DESCRIPTION
## Summary

Playing a card from hand was free — the play path never read the printed `cost` from `CardMetadata`, so any asset/event could be played regardless of (or in excess of) the resource pool. This adds the affordability gate and the cost deduction, per the Rules Reference Initiation Sequence.

## Rules basis (RR p.22, Initiation Sequence — verified from the vendored PDF)

> **Determine the cost** ... to play the card ... If it is established that the cost (taking modifiers into account) can be paid, proceed...
> 2. Pay the cost(s). If this step is reached and the cost(s) cannot be paid, abort this process without paying any costs.
>    ...Upon completion of this step, attacks of opportunity, if applicable, resolve.

So: (1) affordability is a precondition, and (2) the cost is paid **before** AoO resolve. A Fast play skips the *action* cost, not the *resource* cost.

## What changed

- **`CardMetadata::play_cost()`** (`card-dsl`) — exposes the Asset/Event printed cost (`None` for X-cost / non-playable types).
- **Affordability gate** — `check_play_resource_cost_payable` in `check_play_card` (validate-first / mutate-second). Because `legal_actions` and the fast-play enumerations already route through `check_play_card`, unaffordable cards also drop out of offered actions (and the web UI) with no separate change.
- **Fast-reaction path** — `scan_hand_fast_events` filters unaffordable Fast events out of reaction windows (mirrors the #495 change-game-state suppression); `play_fast_event` now pays the cost.
- **Deduction** — `pay_play_cost` deducts the cost and emits `ResourcesPaid`, called from `play_card` (after the action spend, before announce + AoO) and `play_fast_event`. A 0-cost play emits no event.

## Design decisions / deferrals

- **X-cost & permanents (`cost: None`) are rejected loudly, not played for free.** No implemented card reaches this branch: such cards are either unimplemented stubs (refused earlier by `resolve_play_target`) or permanents (enter play at setup, never via `PlayCard`). Modeling a true X-cost play (which needs an `AwaitingInput` to pick X, composing with cost modifiers) is **deferred from #501** — I was not able to file a separate tracking issue automatically; flagging here in case you want one before this is needed.
- Cost is paid before the on-play effect resolves (RR-correct). This extends the pre-existing CLAUDE.md caveat — an on-play effect that rejects mid-resolution leaves partial state — to also strand the paid resources. Not a regression (no in-scope effect rejects mid-resolution); same deferred-hardening surface.

## Test notes

New tests (all green; full CI gauntlet run locally — test/clippy/fmt/doc/wasm-build/wasm-test/wasm-clippy):

- `card-dsl`: `play_cost()` reads Asset/Event/X-cost/non-playable.
- `cards/tests/play_card.rs`: rejected below cost (state + events unchanged), deducts cost + emits `ResourcesPaid`, exact-cost boundary, 0-cost free with no event.
- `cards/tests/evidence.rs`: Fast event (Evidence! 01022, cost 1) pays its cost on play; not offered at 0 resources.

Card costs verified against the corpus: Holy Rosary 01059 = 2, Emergency Cache 01088 = 0, Evidence! 01022 = 1.

## Linked issues

Closes #501