### PR TITLE
web: event log panel left of the board

### DIFF
--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -23,7 +23,7 @@ gloo-timers = { version = "0.4", features = ["futures"] }
 futures = "0.3"
 wasm-bindgen-futures = "0.4"
 serde_json = "1"
-web-sys = { version = "0.3", features = ["Storage", "Location", "Window"] }
+web-sys = { version = "0.3", features = ["Storage", "Location", "Window", "Element", "HtmlElement", "HtmlDivElement"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -20,7 +20,10 @@ pub fn App() -> impl IntoView {
     view! {
         <main>
             <h1>"Eldritch"</h1>
-            <BoardView/>
+            <div class="layout">
+                <crate::event_log::EventLogView/>
+                <BoardView/>
+            </div>
             {
                 #[cfg(target_arch = "wasm32")]
                 { view! {

--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -22,18 +22,20 @@ pub fn App() -> impl IntoView {
             <h1>"Eldritch"</h1>
             <div class="layout">
                 <crate::event_log::EventLogView/>
-                <BoardView/>
+                <div class="main-column">
+                    <BoardView/>
+                    {
+                        #[cfg(target_arch = "wasm32")]
+                        { view! {
+                            <crate::picker::PickerView/>
+                            <crate::skill_test_result::SkillTestResultView/>
+                            <crate::input::AwaitingInputView/>
+                        }.into_any() }
+                        #[cfg(not(target_arch = "wasm32"))]
+                        { ().into_any() }
+                    }
+                </div>
             </div>
-            {
-                #[cfg(target_arch = "wasm32")]
-                { view! {
-                    <crate::picker::PickerView/>
-                    <crate::skill_test_result::SkillTestResultView/>
-                    <crate::input::AwaitingInputView/>
-                }.into_any() }
-                #[cfg(not(target_arch = "wasm32"))]
-                { ().into_any() }
-            }
         </main>
     }
 }

--- a/crates/web/src/event_log.rs
+++ b/crates/web/src/event_log.rs
@@ -28,6 +28,60 @@ pub(crate) fn response_label(request: &InputRequest, response: &InputResponse) -
     }
 }
 
+use leptos::prelude::*;
+
+use crate::store::use_store;
+
+/// Read-only event log, left of the board. Renders every accumulated `LogBatch`
+/// oldest-first (newest at the bottom); a header line per batch then one Debug
+/// line per event. On wasm, auto-scrolls to the bottom as the log grows.
+#[component]
+pub fn EventLogView() -> impl IntoView {
+    let store = use_store();
+    let scroll_ref = NodeRef::<leptos::html::Div>::new();
+
+    // Auto-scroll to the newest line whenever the batch count changes.
+    #[cfg(target_arch = "wasm32")]
+    {
+        Effect::new(move |_| {
+            let _ = store.with(|s| s.log.len());
+            if let Some(el) = scroll_ref.get() {
+                el.set_scroll_top(el.scroll_height());
+            }
+        });
+    }
+
+    let batches = move || {
+        store
+            .get()
+            .log
+            .into_iter()
+            .map(|batch| {
+                let events: Vec<_> = batch
+                    .events
+                    .iter()
+                    .map(|e| view! { <div class="log-event">{format!("{e:?}")}</div> })
+                    .collect();
+                view! {
+                    <div class="log-batch">
+                        <div class="log-action">{format!("▸ {}", batch.header)}</div>
+                        {events}
+                    </div>
+                }
+            })
+            .collect::<Vec<_>>()
+    };
+
+    view! {
+        <aside class="event-log">
+            <h2>"Event log"</h2>
+            <div class="log-scroll" node_ref=scroll_ref>
+                {batches}
+            </div>
+        </aside>
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/web/src/event_log.rs
+++ b/crates/web/src/event_log.rs
@@ -1,36 +1,8 @@
 //! Event-log panel (#505): a read-only, accumulating view of the game's events,
 //! left of the board, newest at the bottom, grouped per submitted action.
 
-use game_core::{InputRequest, InputResponse};
-
-/// The event-log header for a submitted response, given the prompt it answered.
-///
-/// - `PickSingle(id)` → that option's `label` (fallback `"Pick <n>"` if absent).
-/// - `Confirm`        → `"Confirm"`.
-/// - `Skip`           → `"Skip"`.
-/// - `PickMultiple`   → `"Commit <n> card(s)"`.
-#[allow(dead_code)]
-pub(crate) fn response_label(request: &InputRequest, response: &InputResponse) -> String {
-    match response {
-        InputResponse::PickSingle(id) => request
-            .options
-            .iter()
-            .find(|o| o.id == *id)
-            .map_or_else(|| format!("Pick {}", id.0), |o| o.label.clone()),
-        InputResponse::Confirm => "Confirm".to_string(),
-        InputResponse::Skip => "Skip".to_string(),
-        InputResponse::PickMultiple { selected } => {
-            format!("Commit {} card(s)", selected.len())
-        }
-        // `InputResponse` is `#[non_exhaustive]`; a future variant gets a generic
-        // header rather than failing to compile.
-        _ => "(action)".to_string(),
-    }
-}
-
-use leptos::prelude::*;
-
 use crate::store::use_store;
+use leptos::prelude::*;
 
 /// Read-only event log, left of the board. Renders every accumulated `LogBatch`
 /// oldest-first (newest at the bottom); a header line per batch then one Debug
@@ -79,53 +51,5 @@ pub fn EventLogView() -> impl IntoView {
                 {batches}
             </div>
         </aside>
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use game_core::engine::OptionId;
-    use game_core::ChoiceOption;
-
-    fn request_with_options(opts: Vec<(u32, &str)>) -> InputRequest {
-        let options = opts
-            .into_iter()
-            .map(|(i, l)| ChoiceOption {
-                id: OptionId(i),
-                label: l.to_string(),
-            })
-            .collect();
-        InputRequest::pick_single("choose", options)
-    }
-
-    #[test]
-    fn pick_single_uses_the_chosen_option_label() {
-        let req = request_with_options(vec![(0, "Move to Cellar"), (1, "Play 01059 from hand")]);
-        let label = response_label(&req, &InputResponse::PickSingle(OptionId(1)));
-        assert_eq!(label, "Play 01059 from hand");
-    }
-
-    #[test]
-    fn pick_single_unknown_id_falls_back() {
-        let req = request_with_options(vec![(0, "Move to Cellar")]);
-        let label = response_label(&req, &InputResponse::PickSingle(OptionId(7)));
-        assert_eq!(label, "Pick 7");
-    }
-
-    #[test]
-    fn confirm_skip_and_commit_have_fixed_labels() {
-        let req = request_with_options(vec![]);
-        assert_eq!(response_label(&req, &InputResponse::Confirm), "Confirm");
-        assert_eq!(response_label(&req, &InputResponse::Skip), "Skip");
-        assert_eq!(
-            response_label(
-                &req,
-                &InputResponse::PickMultiple {
-                    selected: vec![OptionId(0), OptionId(1)]
-                }
-            ),
-            "Commit 2 card(s)"
-        );
     }
 }

--- a/crates/web/src/event_log.rs
+++ b/crates/web/src/event_log.rs
@@ -12,14 +12,19 @@ pub fn EventLogView() -> impl IntoView {
     let store = use_store();
     let scroll_ref = NodeRef::<leptos::html::Div>::new();
 
-    // Auto-scroll to the newest line whenever the batch count changes.
+    // Keep the panel pinned to the newest line. Re-runs whenever a batch is
+    // appended; the scroll is deferred to the next animation frame so it reads
+    // `scroll_height` *after* the new rows are laid out (reading it inline races
+    // the reactive DOM update and lands short of the true bottom).
     #[cfg(target_arch = "wasm32")]
     {
         Effect::new(move |_| {
             let _ = store.with(|s| s.log.len());
-            if let Some(el) = scroll_ref.get() {
-                el.set_scroll_top(el.scroll_height());
-            }
+            request_animation_frame(move || {
+                if let Some(el) = scroll_ref.get() {
+                    el.set_scroll_top(el.scroll_height());
+                }
+            });
         });
     }
 

--- a/crates/web/src/event_log.rs
+++ b/crates/web/src/event_log.rs
@@ -1,0 +1,77 @@
+//! Event-log panel (#505): a read-only, accumulating view of the game's events,
+//! left of the board, newest at the bottom, grouped per submitted action.
+
+use game_core::{InputRequest, InputResponse};
+
+/// The event-log header for a submitted response, given the prompt it answered.
+///
+/// - `PickSingle(id)` → that option's `label` (fallback `"Pick <n>"` if absent).
+/// - `Confirm`        → `"Confirm"`.
+/// - `Skip`           → `"Skip"`.
+/// - `PickMultiple`   → `"Commit <n> card(s)"`.
+#[allow(dead_code)]
+pub(crate) fn response_label(request: &InputRequest, response: &InputResponse) -> String {
+    match response {
+        InputResponse::PickSingle(id) => request
+            .options
+            .iter()
+            .find(|o| o.id == *id)
+            .map_or_else(|| format!("Pick {}", id.0), |o| o.label.clone()),
+        InputResponse::Confirm => "Confirm".to_string(),
+        InputResponse::Skip => "Skip".to_string(),
+        InputResponse::PickMultiple { selected } => {
+            format!("Commit {} card(s)", selected.len())
+        }
+        // `InputResponse` is `#[non_exhaustive]`; a future variant gets a generic
+        // header rather than failing to compile.
+        _ => "(action)".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use game_core::engine::OptionId;
+    use game_core::ChoiceOption;
+
+    fn request_with_options(opts: Vec<(u32, &str)>) -> InputRequest {
+        let options = opts
+            .into_iter()
+            .map(|(i, l)| ChoiceOption {
+                id: OptionId(i),
+                label: l.to_string(),
+            })
+            .collect();
+        InputRequest::pick_single("choose", options)
+    }
+
+    #[test]
+    fn pick_single_uses_the_chosen_option_label() {
+        let req = request_with_options(vec![(0, "Move to Cellar"), (1, "Play 01059 from hand")]);
+        let label = response_label(&req, &InputResponse::PickSingle(OptionId(1)));
+        assert_eq!(label, "Play 01059 from hand");
+    }
+
+    #[test]
+    fn pick_single_unknown_id_falls_back() {
+        let req = request_with_options(vec![(0, "Move to Cellar")]);
+        let label = response_label(&req, &InputResponse::PickSingle(OptionId(7)));
+        assert_eq!(label, "Pick 7");
+    }
+
+    #[test]
+    fn confirm_skip_and_commit_have_fixed_labels() {
+        let req = request_with_options(vec![]);
+        assert_eq!(response_label(&req, &InputResponse::Confirm), "Confirm");
+        assert_eq!(response_label(&req, &InputResponse::Skip), "Skip");
+        assert_eq!(
+            response_label(
+                &req,
+                &InputResponse::PickMultiple {
+                    selected: vec![OptionId(0), OptionId(1)]
+                }
+            ),
+            "Commit 2 card(s)"
+        );
+    }
+}

--- a/crates/web/src/input.rs
+++ b/crates/web/src/input.rs
@@ -76,6 +76,7 @@ pub fn AwaitingInputView() -> impl IntoView {
                             class="skip"
                             on:click=move |_| {
                                 if let Some(tx) = tx.clone() {
+                                    store.update(|s| s.pending_label = Some("Skip".to_string()));
                                     let _ = tx.unbounded_send(ClientMessage::Submit {
                                         action: PlayerAction::ResolveInput {
                                             response: InputResponse::Skip,
@@ -102,11 +103,13 @@ pub fn AwaitingInputView() -> impl IntoView {
                         .map(|opt: ChoiceOption| {
                             let ChoiceOption { id, label } = opt;
                             let tx = tx.clone();
+                            let header = label.clone();
                             view! {
                                 <button
                                     class="option"
                                     on:click=move |_| {
                                         if let Some(tx) = tx.clone() {
+                                            store.update(|s| s.pending_label = Some(header.clone()));
                                             let _ = tx.unbounded_send(ClientMessage::Submit {
                                                 action: PlayerAction::ResolveInput {
                                                     response: InputResponse::PickSingle(id),
@@ -139,6 +142,7 @@ pub fn AwaitingInputView() -> impl IntoView {
                                 class="confirm"
                                 on:click=move |_| {
                                     if let Some(tx) = tx.clone() {
+                                        store.update(|s| s.pending_label = Some("Confirm".to_string()));
                                         let _ = tx.unbounded_send(ClientMessage::Submit {
                                             action: PlayerAction::ResolveInput {
                                                 response: InputResponse::Confirm,
@@ -186,6 +190,8 @@ pub fn AwaitingInputView() -> impl IntoView {
                         let selected_ids: Vec<OptionId> =
                             selected.get().into_iter().map(OptionId).collect();
                         if let Some(tx) = tx.clone() {
+                            let header = format!("Commit {} card(s)", selected_ids.len());
+                            store.update(|s| s.pending_label = Some(header));
                             let _ = tx.unbounded_send(ClientMessage::Submit {
                                 action: PlayerAction::ResolveInput {
                                     response: InputResponse::PickMultiple {

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod app;
 pub mod board;
+pub mod event_log;
 pub mod map;
 pub mod names;
 pub mod skill_test_result;

--- a/crates/web/src/store.rs
+++ b/crates/web/src/store.rs
@@ -20,6 +20,16 @@ pub enum ConnStatus {
     VersionMismatch,
 }
 
+/// One applied submit's worth of events, for the event-log view (#505).
+#[derive(Debug, Clone, PartialEq)]
+pub struct LogBatch {
+    /// Human label of the menu choice that produced this batch
+    /// (e.g. "Play 01059 from hand"); a generic fallback when unknown.
+    pub header: String,
+    /// The events emitted by that submit, in order.
+    pub events: Vec<game_core::Event>,
+}
+
 /// Everything the UI renders. `game`/`outcome`/`last_rejection` come
 /// from `reduce`; `status` is driven by the transport.
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -37,6 +47,13 @@ pub struct ClientState {
     /// `SkillTestSucceeded`/`Failed` margin to show total-vs-difficulty.
     /// Cleared by `Hello`.
     pub last_skill_test_difficulty: Option<i8>,
+    /// Full accumulated event history, grouped per applied submit, oldest
+    /// first. Cleared by `Hello`. The event-log panel (#505) renders this.
+    pub log: Vec<LogBatch>,
+    /// Header label for the *next* `Applied` batch, set by the input view at
+    /// submit time and taken when that batch arrives. Cleared on `Rejected`
+    /// (the submit produced no batch) and `Hello`.
+    pub pending_label: Option<String>,
 }
 
 /// Fold one server message into the client state. Data only — never
@@ -50,6 +67,8 @@ pub fn reduce(state: &mut ClientState, msg: ServerMessage) {
             state.last_rejection = None;
             state.last_events = Vec::new();
             state.last_skill_test_difficulty = None;
+            state.log = Vec::new();
+            state.pending_label = None;
         }
         ServerMessage::Applied {
             state: s,
@@ -72,10 +91,19 @@ pub fn reduce(state: &mut ClientState, msg: ServerMessage) {
             }) {
                 state.last_skill_test_difficulty = Some(difficulty);
             }
+            let header = state
+                .pending_label
+                .take()
+                .unwrap_or_else(|| "(action)".into());
+            state.log.push(LogBatch {
+                header,
+                events: events.clone(),
+            });
             state.last_events = events;
         }
         ServerMessage::Rejected { reason } => {
             state.last_rejection = Some(reason);
+            state.pending_label = None;
         }
     }
 }
@@ -215,5 +243,95 @@ mod tests {
         assert_eq!(s.last_rejection.as_deref(), Some("not your turn"));
         assert_eq!(s.game, before);
         assert_eq!(s.outcome, Some(EngineOutcome::Done));
+    }
+
+    #[test]
+    fn applied_pushes_a_log_batch_using_pending_label() {
+        let mut s = ClientState {
+            pending_label: Some("Move to Cellar".into()),
+            ..Default::default()
+        };
+        reduce(
+            &mut s,
+            ServerMessage::Applied {
+                state: Box::new(sample_state()),
+                events: vec![game_core::Event::ScenarioStarted],
+                outcome: EngineOutcome::Done,
+            },
+        );
+        assert_eq!(s.log.len(), 1);
+        assert_eq!(s.log[0].header, "Move to Cellar");
+        assert_eq!(s.log[0].events, vec![game_core::Event::ScenarioStarted]);
+        assert_eq!(s.pending_label, None, "pending_label is consumed");
+    }
+
+    #[test]
+    fn applied_without_pending_label_uses_generic_header() {
+        let mut s = ClientState::default();
+        reduce(
+            &mut s,
+            ServerMessage::Applied {
+                state: Box::new(sample_state()),
+                events: Vec::new(),
+                outcome: EngineOutcome::Done,
+            },
+        );
+        assert_eq!(s.log.len(), 1);
+        assert_eq!(s.log[0].header, "(action)");
+    }
+
+    #[test]
+    fn consecutive_applied_accumulate_in_order() {
+        let mut s = ClientState::default();
+        for label in ["first", "second"] {
+            s.pending_label = Some(label.to_string());
+            reduce(
+                &mut s,
+                ServerMessage::Applied {
+                    state: Box::new(sample_state()),
+                    events: Vec::new(),
+                    outcome: EngineOutcome::Done,
+                },
+            );
+        }
+        let headers: Vec<&str> = s.log.iter().map(|b| b.header.as_str()).collect();
+        assert_eq!(headers, vec!["first", "second"]);
+    }
+
+    #[test]
+    fn rejected_clears_pending_label_without_pushing_a_batch() {
+        let mut s = ClientState {
+            pending_label: Some("Move to Cellar".into()),
+            ..Default::default()
+        };
+        reduce(
+            &mut s,
+            ServerMessage::Rejected {
+                reason: "nope".into(),
+            },
+        );
+        assert!(s.log.is_empty(), "rejection pushes no batch");
+        assert_eq!(s.pending_label, None, "rejection clears the stale label");
+    }
+
+    #[test]
+    fn hello_clears_log_and_pending_label() {
+        let mut s = ClientState {
+            pending_label: Some("stale".into()),
+            ..Default::default()
+        };
+        s.log.push(LogBatch {
+            header: "old".into(),
+            events: Vec::new(),
+        });
+        reduce(
+            &mut s,
+            ServerMessage::Hello {
+                state: Box::new(sample_state()),
+                outcome: EngineOutcome::Done,
+            },
+        );
+        assert!(s.log.is_empty());
+        assert_eq!(s.pending_label, None);
     }
 }

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -25,3 +25,14 @@
 .threat ul { list-style: none; padding-left: 0; margin: 0; }
 .enemy-engaged { color: #a3261b; font-size: 0.85rem; }
 .board-main { display: flex; gap: 1rem; align-items: flex-start; }
+
+/* Event log panel (#505): fixed-width column left of the board, scrolls with
+   the newest entry pinned to the bottom. Monospace so raw Debug lines align. */
+.layout { display: flex; gap: 1rem; align-items: flex-start; }
+.event-log { flex: 0 0 auto; width: 22rem; }
+.event-log h2 { font-size: 1rem; margin: 0 0 0.25rem; }
+.log-scroll { max-height: 80vh; overflow-y: auto; font-family: ui-monospace, monospace; font-size: 0.8rem; border: 1px solid #ccc; border-radius: 4px; padding: 0.5rem; }
+.log-batch { border-top: 1px solid #eee; padding: 0.25rem 0; }
+.log-batch:first-child { border-top: none; }
+.log-action { font-weight: 600; color: #2a4d69; }
+.log-event { white-space: pre-wrap; word-break: break-word; color: #333; }

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -29,6 +29,10 @@
 /* Event log panel (#505): fixed-width column left of the board, scrolls with
    the newest entry pinned to the bottom. Monospace so raw Debug lines align. */
 .layout { display: flex; gap: 1rem; align-items: flex-start; }
+/* Right of the event log: the board with the input/picker panels stacked below
+   it (the full-width header stays above the whole row). min-width:0 lets the
+   column shrink within the flex row instead of overflowing. */
+.main-column { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 1rem; }
 .event-log { flex: 0 0 auto; width: 22rem; }
 .event-log h2 { font-size: 1rem; margin: 0 0 0.25rem; }
 .log-scroll { max-height: 80vh; overflow-y: auto; font-family: ui-monospace, monospace; font-size: 0.8rem; border: 1px solid #ccc; border-radius: 4px; padding: 0.5rem; }

--- a/crates/web/tests/awaiting_input.rs
+++ b/crates/web/tests/awaiting_input.rs
@@ -286,3 +286,42 @@ async fn pick_single_does_not_render_commit_button_or_hand_list() {
         "commit-hand list should not appear in PickSingle branch"
     );
 }
+
+#[wasm_bindgen_test]
+async fn picking_an_option_sets_the_pending_log_header() {
+    let store = RwSignal::new(ClientState::default());
+    let (tx, _rx) = mpsc::unbounded::<ClientMessage>();
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        provide_context::<OutboundTx>(tx.clone());
+        leptos::view! { <AwaitingInputView/> }
+    });
+    // A PickSingle prompt whose first option has a known label.
+    store.update(|s| {
+        reduce(
+            s,
+            ServerMessage::Hello {
+                state: Box::new(base_game()),
+                outcome: awaiting_pick_single_input("Choose an action"),
+            },
+        );
+    });
+    leptos::task::tick().await;
+
+    // Click the first rendered option button.
+    let section = last_section();
+    let buttons = section.query_selector_all(".option").expect("options");
+    buttons
+        .item(0)
+        .expect("an option button")
+        .dyn_into::<web_sys::HtmlElement>()
+        .expect("HtmlElement")
+        .click();
+    leptos::task::tick().await;
+
+    let header = store.with_untracked(|s| s.pending_label.clone());
+    assert!(
+        header.is_some(),
+        "clicking an option must set the event-log header"
+    );
+}

--- a/crates/web/tests/awaiting_input.rs
+++ b/crates/web/tests/awaiting_input.rs
@@ -320,8 +320,9 @@ async fn picking_an_option_sets_the_pending_log_header() {
     leptos::task::tick().await;
 
     let header = store.with_untracked(|s| s.pending_label.clone());
-    assert!(
-        header.is_some(),
-        "clicking an option must set the event-log header"
+    assert_eq!(
+        header.as_deref(),
+        Some("End turn"),
+        "clicking an option must set the event-log header to the chosen option's label"
     );
 }

--- a/crates/web/tests/event_log.rs
+++ b/crates/web/tests/event_log.rs
@@ -1,0 +1,43 @@
+//! Headless render test for `EventLogView` (#505): seed the store with a couple
+//! of `LogBatch`es and assert the panel renders each header and its events as
+//! Debug text, oldest-first. wasm32-only (browser DOM).
+#![cfg(target_arch = "wasm32")]
+
+use leptos::prelude::*;
+use wasm_bindgen::JsCast as _;
+use wasm_bindgen_test::*;
+use web::event_log::EventLogView;
+use web::store::{ClientState, LogBatch};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+async fn renders_batches_with_headers_and_event_debug() {
+    let store = RwSignal::new(ClientState::default());
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        leptos::view! { <EventLogView/> }
+    });
+    store.update(|s| {
+        s.log.push(LogBatch {
+            header: "Move to Cellar".into(),
+            events: vec![game_core::Event::ScenarioStarted],
+        });
+    });
+    leptos::task::tick().await;
+
+    let logs = leptos::prelude::document()
+        .query_selector_all(".event-log")
+        .expect("query");
+    let panel = logs
+        .item(logs.length() - 1)
+        .expect("an .event-log panel")
+        .dyn_into::<web_sys::Element>()
+        .expect("Element");
+    let text = panel.text_content().unwrap_or_default();
+    assert!(text.contains("Move to Cellar"), "header rendered: {text}");
+    assert!(
+        text.contains("ScenarioStarted"),
+        "event Debug rendered: {text}"
+    );
+}

--- a/crates/web/tests/event_log.rs
+++ b/crates/web/tests/event_log.rs
@@ -1,6 +1,6 @@
-//! Headless render test for `EventLogView` (#505): seed the store with a couple
-//! of `LogBatch`es and assert the panel renders each header and its events as
-//! Debug text, oldest-first. wasm32-only (browser DOM).
+//! Headless render test for `EventLogView` (#505): seed the store with one
+//! `LogBatch` and assert the panel renders the batch header and an event's
+//! `Debug` text. wasm32-only (browser DOM).
 #![cfg(target_arch = "wasm32")]
 
 use leptos::prelude::*;
@@ -29,6 +29,7 @@ async fn renders_batches_with_headers_and_event_debug() {
     let logs = leptos::prelude::document()
         .query_selector_all(".event-log")
         .expect("query");
+    assert!(logs.length() >= 1, "no .event-log element rendered");
     let panel = logs
         .item(logs.length() - 1)
         .expect("an .event-log panel")

--- a/docs/superpowers/plans/2026-06-28-event-log-panel.md
+++ b/docs/superpowers/plans/2026-06-28-event-log-panel.md
@@ -1,0 +1,666 @@
+# Event Log Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a read-only event-log panel left of the board that accumulates the full game's events, newest at the bottom, each batch headed by the menu-choice label the player submitted.
+
+**Architecture:** Client-only slice. The store accumulates a `Vec<LogBatch>` and holds a one-shot `pending_label`; the input view sets `pending_label` (from the chosen option's label) at submit time; the reducer consumes it into the next `Applied` batch. A new `EventLogView` renders the log; a wasm-only effect auto-scrolls to the bottom. No protocol or server change.
+
+**Tech Stack:** Rust, Leptos 0.8 (CSR), `web-sys`, `wasm-bindgen-test`. Spec: `docs/superpowers/specs/2026-06-28-event-log-panel-design.md` (issue #505).
+
+## Global Constraints
+
+- Match CI's strict flags before declaring done: `RUSTFLAGS="-D warnings" cargo test --all --all-features`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`, `cargo build -p web --target wasm32-unknown-unknown`, `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`, and `wasm-pack test --headless --firefox crates/web`.
+- `store.rs` and the new `event_log.rs` compile on **both** native and wasm; `input.rs` is wasm-only (`#[cfg(target_arch = "wasm32")] pub mod input;`). Keep all `web_sys`/DOM calls behind `#[cfg(target_arch = "wasm32")]`.
+- Raw `Debug` (`{:?}`) for event bodies. No card-name enrichment in event lines.
+- Commit after each task (one logical change per commit), scope `web:`.
+
+---
+
+### Task 1: Store accumulates the event log
+
+**Files:**
+- Modify: `crates/web/src/store.rs`
+
+**Interfaces:**
+- Produces: `pub struct LogBatch { pub header: String, pub events: Vec<game_core::Event> }`; new `ClientState` fields `pub log: Vec<LogBatch>` and `pub pending_label: Option<String>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `mod tests` block in `crates/web/src/store.rs`:
+
+```rust
+#[test]
+fn applied_pushes_a_log_batch_using_pending_label() {
+    let mut s = ClientState {
+        pending_label: Some("Move to Cellar".into()),
+        ..Default::default()
+    };
+    reduce(
+        &mut s,
+        ServerMessage::Applied {
+            state: Box::new(sample_state()),
+            events: vec![game_core::Event::ScenarioStarted],
+            outcome: EngineOutcome::Done,
+        },
+    );
+    assert_eq!(s.log.len(), 1);
+    assert_eq!(s.log[0].header, "Move to Cellar");
+    assert_eq!(s.log[0].events, vec![game_core::Event::ScenarioStarted]);
+    assert_eq!(s.pending_label, None, "pending_label is consumed");
+}
+
+#[test]
+fn applied_without_pending_label_uses_generic_header() {
+    let mut s = ClientState::default();
+    reduce(
+        &mut s,
+        ServerMessage::Applied {
+            state: Box::new(sample_state()),
+            events: Vec::new(),
+            outcome: EngineOutcome::Done,
+        },
+    );
+    assert_eq!(s.log.len(), 1);
+    assert_eq!(s.log[0].header, "(action)");
+}
+
+#[test]
+fn consecutive_applied_accumulate_in_order() {
+    let mut s = ClientState::default();
+    for label in ["first", "second"] {
+        s.pending_label = Some(label.to_string());
+        reduce(
+            &mut s,
+            ServerMessage::Applied {
+                state: Box::new(sample_state()),
+                events: Vec::new(),
+                outcome: EngineOutcome::Done,
+            },
+        );
+    }
+    let headers: Vec<&str> = s.log.iter().map(|b| b.header.as_str()).collect();
+    assert_eq!(headers, vec!["first", "second"]);
+}
+
+#[test]
+fn rejected_clears_pending_label_without_pushing_a_batch() {
+    let mut s = ClientState {
+        pending_label: Some("Move to Cellar".into()),
+        ..Default::default()
+    };
+    reduce(&mut s, ServerMessage::Rejected { reason: "nope".into() });
+    assert!(s.log.is_empty(), "rejection pushes no batch");
+    assert_eq!(s.pending_label, None, "rejection clears the stale label");
+}
+
+#[test]
+fn hello_clears_log_and_pending_label() {
+    let mut s = ClientState {
+        pending_label: Some("stale".into()),
+        ..Default::default()
+    };
+    s.log.push(LogBatch { header: "old".into(), events: Vec::new() });
+    reduce(
+        &mut s,
+        ServerMessage::Hello {
+            state: Box::new(sample_state()),
+            outcome: EngineOutcome::Done,
+        },
+    );
+    assert!(s.log.is_empty());
+    assert_eq!(s.pending_label, None);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p web --lib store:: 2>&1 | tail -20`
+Expected: FAIL to compile — `LogBatch` / `log` / `pending_label` do not exist.
+
+- [ ] **Step 3: Add the `LogBatch` type and fields**
+
+In `crates/web/src/store.rs`, after the `ConnStatus` enum, add:
+
+```rust
+/// One applied submit's worth of events, for the event-log view (#505).
+#[derive(Debug, Clone, PartialEq)]
+pub struct LogBatch {
+    /// Human label of the menu choice that produced this batch
+    /// (e.g. "Play 01059 from hand"); a generic fallback when unknown.
+    pub header: String,
+    /// The events emitted by that submit, in order.
+    pub events: Vec<game_core::Event>,
+}
+```
+
+Add two fields to `ClientState` (after `last_skill_test_difficulty`):
+
+```rust
+    /// Full accumulated event history, grouped per applied submit, oldest
+    /// first. Cleared by `Hello`. The event-log panel (#505) renders this.
+    pub log: Vec<LogBatch>,
+    /// Header label for the *next* `Applied` batch, set by the input view at
+    /// submit time and taken when that batch arrives. Cleared on `Rejected`
+    /// (the submit produced no batch) and `Hello`.
+    pub pending_label: Option<String>,
+```
+
+- [ ] **Step 4: Update the reducer**
+
+In `reduce`, the `Hello` arm — add after `state.last_skill_test_difficulty = None;`:
+
+```rust
+            state.log = Vec::new();
+            state.pending_label = None;
+```
+
+In the `Applied` arm — replace the final `state.last_events = events;` with:
+
+```rust
+            let header = state.pending_label.take().unwrap_or_else(|| "(action)".into());
+            state.log.push(LogBatch { header, events: events.clone() });
+            state.last_events = events;
+```
+
+In the `Rejected` arm — add after `state.last_rejection = Some(reason);`:
+
+```rust
+            state.pending_label = None;
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p web --lib store:: 2>&1 | tail -20`
+Expected: PASS (all store tests, including the pre-existing ones).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/web/src/store.rs
+git commit -m "web: accumulate event log + pending header in the client store (#505)"
+```
+
+---
+
+### Task 2: `response_label` helper + `event_log` module
+
+**Files:**
+- Create: `crates/web/src/event_log.rs`
+- Modify: `crates/web/src/lib.rs`
+
+**Interfaces:**
+- Consumes: `game_core::{InputRequest, InputResponse, OptionId}`, `game_core::engine::OptionId` (re-exported as `game_core::OptionId`).
+- Produces: `pub(crate) fn response_label(request: &game_core::InputRequest, response: &game_core::InputResponse) -> String`.
+
+- [ ] **Step 1: Create the module with a failing test**
+
+Create `crates/web/src/event_log.rs`:
+
+```rust
+//! Event-log panel (#505): a read-only, accumulating view of the game's events,
+//! left of the board, newest at the bottom, grouped per submitted action.
+
+use game_core::{InputRequest, InputResponse};
+
+/// The event-log header for a submitted response, given the prompt it answered.
+///
+/// - `PickSingle(id)` → that option's `label` (fallback `"Pick <n>"` if absent).
+/// - `Confirm`        → `"Confirm"`.
+/// - `Skip`           → `"Skip"`.
+/// - `PickMultiple`   → `"Commit <n> card(s)"`.
+pub(crate) fn response_label(request: &InputRequest, response: &InputResponse) -> String {
+    match response {
+        InputResponse::PickSingle(id) => request
+            .options
+            .iter()
+            .find(|o| o.id == *id)
+            .map(|o| o.label.clone())
+            .unwrap_or_else(|| format!("Pick {}", id.0)),
+        InputResponse::Confirm => "Confirm".to_string(),
+        InputResponse::Skip => "Skip".to_string(),
+        InputResponse::PickMultiple { selected } => {
+            format!("Commit {} card(s)", selected.len())
+        }
+        // `InputResponse` is `#[non_exhaustive]`; a future variant gets a generic
+        // header rather than failing to compile.
+        _ => "(action)".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use game_core::engine::OptionId;
+    use game_core::{ChoiceOption, InputKind};
+
+    fn request_with_options(opts: Vec<(u32, &str)>) -> InputRequest {
+        InputRequest {
+            prompt: "choose".into(),
+            options: opts
+                .into_iter()
+                .map(|(i, l)| ChoiceOption { id: OptionId(i), label: l.to_string() })
+                .collect(),
+            kind: InputKind::PickSingle,
+            skippable: false,
+        }
+    }
+
+    #[test]
+    fn pick_single_uses_the_chosen_option_label() {
+        let req = request_with_options(vec![(0, "Move to Cellar"), (1, "Play 01059 from hand")]);
+        let label = response_label(&req, &InputResponse::PickSingle(OptionId(1)));
+        assert_eq!(label, "Play 01059 from hand");
+    }
+
+    #[test]
+    fn pick_single_unknown_id_falls_back() {
+        let req = request_with_options(vec![(0, "Move to Cellar")]);
+        let label = response_label(&req, &InputResponse::PickSingle(OptionId(7)));
+        assert_eq!(label, "Pick 7");
+    }
+
+    #[test]
+    fn confirm_skip_and_commit_have_fixed_labels() {
+        let req = request_with_options(vec![]);
+        assert_eq!(response_label(&req, &InputResponse::Confirm), "Confirm");
+        assert_eq!(response_label(&req, &InputResponse::Skip), "Skip");
+        assert_eq!(
+            response_label(&req, &InputResponse::PickMultiple { selected: vec![OptionId(0), OptionId(1)] }),
+            "Commit 2 card(s)"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Declare the module**
+
+In `crates/web/src/lib.rs`, add to the both-targets block (after `pub mod board;`):
+
+```rust
+pub mod event_log;
+```
+
+- [ ] **Step 3: Run tests to verify they fail, then pass**
+
+Run: `cargo test -p web --lib event_log:: 2>&1 | tail -20`
+Expected: PASS (the module is written with its implementation; if `InputRequest`/`InputResponse`/`OptionId` import paths are wrong the compile error names the right path — fix the `use` and re-run). If `InputResponse` is NOT `#[non_exhaustive]`, clippy may flag the `_` arm as unreachable; in that case remove the `_ => ...` arm.
+
+Note: verify the field path for `OptionId`'s inner value — the tests use `OptionId(7)` and `id.0`. If `OptionId` is a named-field struct rather than a tuple, adjust `id.0` and the constructors to match (grep `pub struct OptionId` in `crates/game-core/src/engine/outcome.rs`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/web/src/event_log.rs crates/web/src/lib.rs
+git commit -m "web: response_label helper + event_log module (#505)"
+```
+
+---
+
+### Task 3: `EventLogView` component, layout, and styles
+
+**Files:**
+- Modify: `crates/web/src/event_log.rs` (add the component)
+- Modify: `crates/web/src/app.rs` (layout)
+- Modify: `crates/web/style.css` (styles)
+- Modify: `crates/web/Cargo.toml` (web-sys `Element` features for the scroll effect)
+- Create: `crates/web/tests/event_log.rs` (wasm render test)
+
+**Interfaces:**
+- Consumes: `crate::store::{use_store, LogBatch}`.
+- Produces: `#[component] pub fn EventLogView() -> impl IntoView`.
+
+- [ ] **Step 1: Write the failing wasm render test**
+
+Create `crates/web/tests/event_log.rs`:
+
+```rust
+//! Headless render test for `EventLogView` (#505): seed the store with a couple
+//! of `LogBatch`es and assert the panel renders each header and its events as
+//! Debug text, oldest-first. wasm32-only (browser DOM).
+#![cfg(target_arch = "wasm32")]
+
+use leptos::prelude::*;
+use wasm_bindgen::JsCast as _;
+use wasm_bindgen_test::*;
+use web::event_log::EventLogView;
+use web::store::{ClientState, LogBatch};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+async fn renders_batches_with_headers_and_event_debug() {
+    let store = RwSignal::new(ClientState::default());
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        leptos::view! { <EventLogView/> }
+    });
+    store.update(|s| {
+        s.log.push(LogBatch {
+            header: "Move to Cellar".into(),
+            events: vec![game_core::Event::ScenarioStarted],
+        });
+    });
+    leptos::task::tick().await;
+
+    let logs = leptos::prelude::document()
+        .query_selector_all(".event-log")
+        .expect("query");
+    let panel = logs
+        .item(logs.length() - 1)
+        .expect("an .event-log panel")
+        .dyn_into::<web_sys::Element>()
+        .expect("Element");
+    let text = panel.text_content().unwrap_or_default();
+    assert!(text.contains("Move to Cellar"), "header rendered: {text}");
+    assert!(text.contains("ScenarioStarted"), "event Debug rendered: {text}");
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `wasm-pack test --headless --firefox crates/web --test event_log 2>&1 | tail -20`
+Expected: FAIL to compile — `EventLogView` does not exist yet.
+
+- [ ] **Step 3: Add the `web-sys` Element features**
+
+In `crates/web/Cargo.toml`, change the `[target.'cfg(target_arch = "wasm32")'.dependencies]` `web-sys` line (line ~26) to:
+
+```toml
+web-sys = { version = "0.3", features = ["Storage", "Location", "Window", "Element", "HtmlElement", "HtmlDivElement"] }
+```
+
+- [ ] **Step 4: Implement `EventLogView`**
+
+Append to `crates/web/src/event_log.rs` (after `response_label`):
+
+```rust
+use leptos::prelude::*;
+
+use crate::store::use_store;
+
+/// Read-only event log, left of the board. Renders every accumulated `LogBatch`
+/// oldest-first (newest at the bottom); a header line per batch then one Debug
+/// line per event. On wasm, auto-scrolls to the bottom as the log grows.
+#[component]
+pub fn EventLogView() -> impl IntoView {
+    let store = use_store();
+    let scroll_ref = NodeRef::<leptos::html::Div>::new();
+
+    // Auto-scroll to the newest line whenever the batch count changes.
+    #[cfg(target_arch = "wasm32")]
+    {
+        Effect::new(move |_| {
+            let _ = store.with(|s| s.log.len());
+            if let Some(el) = scroll_ref.get() {
+                el.set_scroll_top(el.scroll_height());
+            }
+        });
+    }
+
+    let batches = move || {
+        store
+            .get()
+            .log
+            .into_iter()
+            .map(|batch| {
+                let events: Vec<_> = batch
+                    .events
+                    .iter()
+                    .map(|e| view! { <div class="log-event">{format!("{e:?}")}</div> })
+                    .collect();
+                view! {
+                    <div class="log-batch">
+                        <div class="log-action">{format!("▸ {}", batch.header)}</div>
+                        {events}
+                    </div>
+                }
+            })
+            .collect::<Vec<_>>()
+    };
+
+    view! {
+        <aside class="event-log">
+            <h2>"Event log"</h2>
+            <div class="log-scroll" node_ref=scroll_ref>
+                {batches}
+            </div>
+        </aside>
+    }
+}
+```
+
+- [ ] **Step 5: Wire the layout in `app.rs`**
+
+In `crates/web/src/app.rs`, replace the `<BoardView/>` line in the `view!` with a flex wrapper:
+
+```rust
+            <div class="layout">
+                <crate::event_log::EventLogView/>
+                <BoardView/>
+            </div>
+```
+
+(Leave the `#[cfg(target_arch = "wasm32")]` picker/skill-test/input block below unchanged.)
+
+- [ ] **Step 6: Add styles**
+
+Append to `crates/web/style.css`:
+
+```css
+/* Event log panel (#505): fixed-width column left of the board, scrolls with
+   the newest entry pinned to the bottom. Monospace so raw Debug lines align. */
+.layout { display: flex; gap: 1rem; align-items: flex-start; }
+.event-log { flex: 0 0 auto; width: 22rem; }
+.event-log h2 { font-size: 1rem; margin: 0 0 0.25rem; }
+.log-scroll { max-height: 80vh; overflow-y: auto; font-family: ui-monospace, monospace; font-size: 0.8rem; border: 1px solid #ccc; border-radius: 4px; padding: 0.5rem; }
+.log-batch { border-top: 1px solid #eee; padding: 0.25rem 0; }
+.log-batch:first-child { border-top: none; }
+.log-action { font-weight: 600; color: #2a4d69; }
+.log-event { white-space: pre-wrap; word-break: break-word; color: #333; }
+```
+
+- [ ] **Step 7: Run the wasm render test to verify it passes**
+
+Run: `wasm-pack test --headless --firefox crates/web --test event_log 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 8: Verify native + wasm builds**
+
+Run: `cargo build -p web 2>&1 | tail -5` (native — confirms `EventLogView` compiles off-wasm with the scroll effect gated out).
+Run: `cargo build -p web --target wasm32-unknown-unknown 2>&1 | tail -5`
+Expected: both succeed. If native fails on `NodeRef`/`leptos::html::Div`, that type is target-agnostic in leptos 0.8; re-read the error — most likely a missing `use leptos::prelude::*;` already covers it.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/web/src/event_log.rs crates/web/src/app.rs crates/web/style.css crates/web/Cargo.toml crates/web/tests/event_log.rs
+git commit -m "web: EventLogView panel left of the board, auto-scrolled (#505)"
+```
+
+---
+
+### Task 4: Input view captures the menu-choice label
+
+**Files:**
+- Modify: `crates/web/src/input.rs`
+- Modify: `crates/web/tests/awaiting_input.rs` (assert the submit sets `pending_label`)
+
+**Interfaces:**
+- Consumes: `crate::event_log::response_label`, `crate::store::use_store`.
+
+- [ ] **Step 1: Add a failing test that a PickSingle submit sets the header**
+
+Open `crates/web/tests/awaiting_input.rs`. Its `mount` helper returns the outbound `rx` but also has access to the store via context. Add a test that reads the store's `pending_label` after a click. First, adjust `mount` to also return the store (find `async fn mount(` and change it to return the store handle alongside `rx`), OR add a sibling test that constructs its own mount. Add this self-contained test at the end of the file:
+
+```rust
+#[wasm_bindgen_test]
+async fn picking_an_option_sets_the_pending_log_header() {
+    use game_core::test_support::fixtures::awaiting_pick_single_input;
+
+    let store = RwSignal::new(ClientState::default());
+    let (tx, _rx) = mpsc::unbounded::<ClientMessage>();
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        provide_context::<OutboundTx>(tx.clone());
+        leptos::view! { <AwaitingInputView/> }
+    });
+    // A PickSingle prompt whose first option has a known label.
+    store.update(|s| {
+        reduce(
+            s,
+            ServerMessage::Hello {
+                state: Box::new(base_game()),
+                outcome: awaiting_pick_single_input(),
+            },
+        );
+    });
+    leptos::task::tick().await;
+
+    // Click the first rendered option button.
+    let section = last_section();
+    let buttons = section.query_selector_all(".option").expect("options");
+    buttons
+        .item(0)
+        .expect("an option button")
+        .dyn_into::<web_sys::HtmlElement>()
+        .expect("HtmlElement")
+        .click();
+    leptos::task::tick().await;
+
+    let header = store.with_untracked(|s| s.pending_label.clone());
+    assert!(
+        header.is_some(),
+        "clicking an option must set the event-log header"
+    );
+}
+```
+
+Note: confirm `awaiting_pick_single_input()` (already imported elsewhere in this file) yields options with a `.option` button; the existing tests in this file click `.option` buttons, so the selector is correct. If `ClientState` is not already imported in this test file, add `use web::store::ClientState;`.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `wasm-pack test --headless --firefox crates/web --test awaiting_input 2>&1 | tail -20`
+Expected: FAIL — `pending_label` is `None` after the click (the input view doesn't set it yet).
+
+- [ ] **Step 3: Set `pending_label` at each submit site**
+
+In `crates/web/src/input.rs`, capture `store` for the closures and set the label before each send. The component already has `let store = use_store();` at the top (`RwSignal` is `Copy`, so it can be moved into closures freely).
+
+**Skip button** (`skip_button` closure) — before the `tx.unbounded_send(... Skip ...)`:
+
+```rust
+                                    store.update(|s| s.pending_label = Some("Skip".to_string()));
+                                    let _ = tx.unbounded_send(ClientMessage::Submit {
+                                        action: PlayerAction::ResolveInput {
+                                            response: InputResponse::Skip,
+                                        },
+                                    });
+```
+
+**PickSingle option button** — the chosen option's `label` is already destructured (`let ChoiceOption { id, label } = opt;`). Clone it for the closure and set it as the header before sending:
+
+```rust
+                            let header = label.clone();
+                            // ...inside on:click, before the send:
+                                        store.update(|s| s.pending_label = Some(header.clone()));
+                                        let _ = tx.unbounded_send(ClientMessage::Submit {
+                                            action: PlayerAction::ResolveInput {
+                                                response: InputResponse::PickSingle(id),
+                                            },
+                                        });
+```
+
+**Confirm button** — before the send:
+
+```rust
+                                    store.update(|s| s.pending_label = Some("Confirm".to_string()));
+                                    let _ = tx.unbounded_send(ClientMessage::Submit {
+                                        action: PlayerAction::ResolveInput {
+                                            response: InputResponse::Confirm,
+                                        },
+                                    });
+```
+
+**PickMultiple commit** (`on_commit`) — compute the label from the selection count before sending:
+
+```rust
+                        let header = format!("Commit {} card(s)", selected_ids.len());
+                        store.update(|s| s.pending_label = Some(header));
+                        let _ = tx.unbounded_send(ClientMessage::Submit {
+                            action: PlayerAction::ResolveInput {
+                                response: InputResponse::PickMultiple { selected: selected_ids },
+                            },
+                        });
+```
+
+These mirror `response_label`'s four arms (Skip/PickSingle-label/Confirm/`Commit N`); the PickSingle and PickMultiple sites use the value directly since it's already in scope, keeping the busy click closures free of the `request` borrow. (`response_label` remains the single tested source of truth for the same mapping and is what `store.rs`'s fallback documents.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `wasm-pack test --headless --firefox crates/web --test awaiting_input 2>&1 | tail -20`
+Expected: PASS (the new test and all pre-existing ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/web/src/input.rs crates/web/tests/awaiting_input.rs
+git commit -m "web: input view sets the event-log header on submit (#505)"
+```
+
+---
+
+### Task 5: Full gauntlet + manual check
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full CI gauntlet**
+
+```bash
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+wasm-pack test --headless --firefox crates/web
+```
+
+Expected: all green. Fix any clippy/fmt issues with follow-up edits and re-run.
+
+- [ ] **Step 2: Manual smoke (optional but recommended)**
+
+```bash
+cd crates/web && trunk build && cd ../.. && cargo run -p server
+# open http://localhost:8000, start a game, take a few actions:
+# the left panel shows "▸ <menu choice>" headers with the events under each,
+# newest at the bottom, auto-scrolled into view.
+```
+
+- [ ] **Step 3: Commit any gauntlet fixes**
+
+```bash
+git add -A && git commit -m "web: event-log gauntlet fixes (#505)"   # only if needed
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Raw Debug event lines → Task 3 (`format!("{e:?}")`). ✓
+- Full accumulated history, cleared on Hello → Task 1 (`log` push; Hello clears). ✓
+- Newest at bottom + auto-scroll → Task 3 (oldest-first render + wasm scroll effect). ✓
+- Header = menu-choice label → Task 4 (sets `pending_label`) + Task 1 (consumes it). ✓
+- Generic fallback when unknown / multiplayer → Task 1 (`"(action)"`). ✓
+- Rejected must not bleed a label → Task 1 (`Rejected` clears `pending_label`). ✓
+- `response_label` mapping (all four responses) → Task 2 (helper + tests). ✓
+- Layout left of board → Task 3 (app.rs `.layout` flex, log first). ✓
+- No protocol/server change → none present. ✓
+- Out-of-scope items (filtering, timestamps, enrichment, phase sub-segmentation, persistence) → not implemented. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. ✓
+
+**Type consistency:** `LogBatch { header: String, events: Vec<Event> }` defined in Task 1, consumed identically in Tasks 3 & the Task 3 test. `pending_label: Option<String>` set in Task 4, consumed in Task 1. `response_label(&InputRequest, &InputResponse) -> String` defined in Task 2; its mapping is mirrored inline in Task 4 (documented). ✓
+
+**Known verification points flagged for the implementer:** `OptionId` tuple-vs-named field (Task 2 Step 3 note); `InputResponse` `#[non_exhaustive]` wildcard (Task 2 Step 3 note); native compile of `NodeRef` (Task 3 Step 8).

--- a/docs/superpowers/specs/2026-06-28-event-log-panel-design.md
+++ b/docs/superpowers/specs/2026-06-28-event-log-panel-design.md
@@ -139,7 +139,8 @@ There is no shared helper: each site sets `pending_label` directly. `store` (an
 
 ### 4. Layout — `crates/web/src/app.rs` + `crates/web/style.css`
 
-Wrap the log and board in a flex row, log first (left):
+The full-width header sits above a flex row of `[event log | main column]`; the
+main column stacks the board with the input/picker/skill-test panels below it:
 
 ```rust
 view! {
@@ -147,20 +148,28 @@ view! {
         <h1>"Eldritch"</h1>
         <div class="layout">
             <crate::event_log::EventLogView/>
-            <BoardView/>
+            <div class="main-column">
+                <BoardView/>
+                // picker / skill-test / input overlays (wasm-only)
+            </div>
         </div>
-        // picker / skill-test / input overlays unchanged
     </main>
 }
 ```
 
-`EventLogView` renders on both targets (like `BoardView`), so it sits outside the
-existing `#[cfg(target_arch = "wasm32")]` overlay block. CSS:
+`EventLogView` and the main column both render on native (the overlays inside the
+column stay `#[cfg(target_arch = "wasm32")]`-gated). CSS:
 `.layout { display: flex; gap: 1rem; align-items: flex-start; }`,
 `.event-log { flex: 0 0 auto; width: 22rem; }`,
+`.main-column { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 1rem; }`,
 `.log-scroll { max-height: 80vh; overflow-y: auto; font-family: monospace;
 font-size: 0.8rem; }`, with light per-batch separation and a distinct
 `.log-action` weight. Exact values are cosmetic and may be tuned during build.
+
+The auto-scroll effect defers its `scrollTop = scrollHeight` to the next
+animation frame (`request_animation_frame`), so it measures the container height
+*after* the new rows are laid out — reading it inline races the reactive DOM
+update and lands short of the true bottom.
 
 ## Data flow
 

--- a/docs/superpowers/specs/2026-06-28-event-log-panel-design.md
+++ b/docs/superpowers/specs/2026-06-28-event-log-panel-design.md
@@ -7,9 +7,9 @@
 ## Goal
 
 Add a read-only event-log view to the **left of the board** that shows the full
-game's event history, newest at the bottom, grouped by the player action that
-produced each batch. A developer-facing debugging aid: "what happened, when, and
-was it a bug?"
+game's event history, newest at the bottom, grouped by the action that produced
+each batch. A developer-facing debugging aid: "what happened, when, and was it a
+bug?"
 
 ## Decisions (settled in brainstorm)
 
@@ -20,116 +20,102 @@ was it a bug?"
 - **History: full game, accumulated.** Every event since the game started,
   cleared on `Hello` (new game / reconnect). Newest batch at the **bottom**;
   the scroll container **auto-scrolls to the bottom** on update.
-- **Grouping: by player action.** Each `Applied` batch is one group with a
-  header phrased as the *trigger* — `▸ from {action:?}` — so it reads as
-  causation ("these events were caused by EndTurn"), not identity.
-- **Framework events** (Mythos/Upkeep/enemy-phase) are **not** special-cased.
-  They cascade synchronously from whatever action drove them (typically
-  `EndTurn`, then `ResolveInput` for each continuation pause), so they group
-  under that action. The engine already emits `PhaseStarted`/`PhaseEnded`/
-  `TurnEnded`/`AgendaAdvanced`/… as ordinary events, so framework boundaries are
-  legible inline. No phase sub-segmentation.
+- **Grouping: by action, headed with the menu-choice label.** Each `Applied`
+  batch is one group. The header is the **human label of the menu choice the
+  player submitted** (e.g. `▸ Play 01059 from hand`, `▸ Move to Cellar`), not the
+  raw wire action.
 
-### Why action grouping is sound
+### Why the header comes from the client, not the protocol
 
-There are **zero server-initiated applies**: `crates/server/src/ws.rs` calls
-`session.apply()` only in response to a client `Submit { action }` — no timers,
-no auto-advance. So every event the client ever receives is already inside an
-`Applied` batch caused by exactly one `PlayerAction`. Attributing each batch to
-its action is therefore exact, not a heuristic.
+Every player action over the wire is a single opaque variant —
+`PlayerAction::ResolveInput { response }`, where `response` is
+`Confirm | Skip | PickSingle(OptionId) | PickMultiple { selected }`. There is **no
+`Move`/`PlayCard` action on the wire**; those are engine-internal `TurnAction`s.
+So a protocol-carried action would render as
+`ResolveInput { response: PickSingle(OptionId(2)) }` — opaque (the `OptionId` only
+means something against the menu that was on screen).
+
+The genuinely useful label — the chosen menu option's text — is known **on the
+client** at submit time (`InputRequest::options: Vec<ChoiceOption { id, label }>`).
+So the client captures it when it submits and pairs it with the resulting batch.
+No protocol or server change is needed.
+
+This pairing is exact in solo play: there are **zero server-initiated applies**
+(`crates/server/src/ws.rs` calls `session.apply()` only in response to a client
+`Submit { action }` — no timers, no auto-advance), and the UI is turn-based (one
+submit in flight at a time), so the next `Applied` the client receives is the
+result of the submit it just made. (Multiplayer — another client's action
+arriving with no local pending label — is out of scope; it falls back to a
+generic header.)
+
+### Framework events
+
+Framework events (Mythos/Upkeep/enemy-phase) are **not** special-cased. They
+cascade synchronously from whatever submit drove them, pausing at each
+`AwaitingInput`. So ending a turn produces a batch headed by that submit's label
+(e.g. `▸ End turn`), then each continuation pause is its own batch headed by the
+choice that resumed it (e.g. `▸ Skip`). The engine already emits
+`PhaseStarted`/`PhaseEnded`/`TurnEnded`/`AgendaAdvanced`/… as ordinary events, so
+framework boundaries are legible inline. No phase sub-segmentation.
 
 ## Architecture / components
 
-A thin slice across protocol → server → client store → a new view, plus layout.
+A thin client-only slice: store accumulation + a label helper + a new view +
+layout. No protocol or server changes.
 
-### 1. Protocol — `crates/protocol/src/lib.rs`
+### 1. Client store — `crates/web/src/store.rs`
 
-Add `action: PlayerAction` to `ServerMessage::Applied`:
-
-```rust
-Applied {
-    state: Box<GameState>,
-    events: Vec<Event>,
-    outcome: EngineOutcome,
-    action: PlayerAction, // the submitted action that produced this batch
-},
-```
-
-`PlayerAction` already derives the needed `Serialize`/`Deserialize`/`Clone`/
-`Debug`/`PartialEq` (it travels in `ClientMessage`). This is a wire-format
-change; the client/server already negotiate a version and surface
-`ConnStatus::VersionMismatch`, so a mismatched pair fails loudly rather than
-mis-parsing. Update the existing `Applied` serde round-trip test to construct
-the new field.
-
-### 2. Server — `crates/server/src/ws.rs`
-
-The submitted `action` is already in scope at the broadcast site
-(`handle_client_message`). Clone it into the broadcast (one cheap clone per
-accepted action; `apply` takes the original by value):
+Add an accumulated log and a one-shot pending header:
 
 ```rust
-Ok(ClientMessage::Submit { action }) => {
-    let mut session = room.session.lock().await;
-    let action_for_log = action.clone();
-    match session.apply(action).await {
-        ...
-        Ok((events, outcome)) => {
-            let _ = room.tx.send(ServerMessage::Applied {
-                state: Box::new(session.state.clone()),
-                events,
-                outcome,
-                action: action_for_log,
-            });
-            None
-        }
-        ...
-    }
-}
-```
-
-### 3. Client store — `crates/web/src/store.rs`
-
-Add an accumulated log alongside the existing fields:
-
-```rust
-/// One applied action's worth of events, for the event-log view.
+/// One applied submit's worth of events, for the event-log view.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LogBatch {
-    pub action: PlayerAction,
+    /// Human label of the menu choice that produced this batch
+    /// (e.g. "Play 01059 from hand"); a generic fallback when unknown.
+    pub header: String,
     pub events: Vec<Event>,
 }
 
 pub struct ClientState {
     // ...existing fields...
-    /// Full accumulated event history, grouped per applied action, oldest
+    /// Full accumulated event history, grouped per applied submit, oldest
     /// first. Cleared by `Hello` (new game / reconnect), like `last_events`.
     pub log: Vec<LogBatch>,
+    /// The header label for the *next* `Applied` batch, set by the input view
+    /// at submit time and consumed (taken) when that batch arrives. Cleared on
+    /// `Rejected` (the submit produced no batch) and `Hello`.
+    pub pending_label: Option<String>,
 }
 ```
 
-Reducer changes:
-- `Applied { state, events, outcome, action }`: push
-  `LogBatch { action, events: events.clone() }`, then keep the existing
-  `last_events = events` (the skill-test panel still reads `last_events`) and
-  the existing difficulty capture. One events-vec clone per action — negligible.
-- `Hello`: `state.log = Vec::new()` (alongside the existing `last_events` /
-  difficulty clears).
+Reducer changes (`reduce`):
+- `Applied { events, .. }`: `let header = state.pending_label.take().unwrap_or_else(|| "(action)".into()); state.log.push(LogBatch { header, events: events.clone() });` then keep the existing `last_events = events` (the skill-test panel still reads it) and difficulty capture. One events-vec clone per submit — negligible.
+- `Rejected { .. }`: also `state.pending_label = None;` (the rejected submit yields no batch, so its label must not bleed onto the next one) — alongside the existing `last_rejection` set.
+- `Hello { .. }`: `state.log = Vec::new(); state.pending_label = None;` (alongside the existing clears).
 
-This reducer is the **primary testable unit**.
+This reducer is the **primary testable unit** (runs on the native test target —
+`store` is compiled on both targets).
 
-### 4. New view — `crates/web/src/event_log.rs`
+### 2. Label helper + view — `crates/web/src/event_log.rs` (new, both targets)
 
-`EventLogView` reads the store and renders the log oldest-first (newest at the
-bottom). Formatting lives in a **pure, DOM-free helper** so it is unit-testable:
+A pure, DOM-free helper maps a submit to its header so it is unit-testable on the
+native target:
 
 ```rust
-/// The lines for one batch: a `▸ from {action:?}` header followed by one
-/// `{event:?}` line per event. Pure; unit-tested without a DOM.
-fn batch_lines(batch: &LogBatch) -> BatchLines { /* header String + Vec<String> */ }
+/// The event-log header for a submitted response, given the prompt it answered.
+/// - `PickSingle(id)` → that option's `label` (fallback `"Pick <n>"` if absent).
+/// - `Confirm`        → `"Confirm"`.
+/// - `Skip`           → `"Skip"`.
+/// - `PickMultiple`   → `"Commit <n> card(s)"`.
+pub(crate) fn response_label(
+    request: &InputRequest,
+    response: &InputResponse,
+) -> String { /* ... */ }
 ```
 
-Markup (sketch):
+`EventLogView` reads the store and renders the log oldest-first (newest at the
+bottom):
 
 ```
 <aside class="event-log">
@@ -137,20 +123,38 @@ Markup (sketch):
   <div class="log-scroll" node_ref=scroll_ref>
     // for each batch, oldest first:
     <div class="log-batch">
-      <div class="log-action">{header}</div>      // "▸ from EndTurn"
+      <div class="log-action">"▸ " {batch.header}</div>
       <div class="log-event">{event_line}</div>   // one per event, "{:?}"
     </div>
   </div>
 </aside>
 ```
 
-**Auto-scroll:** a wasm-only effect keyed on the total event/batch count sets
-`scroll_ref.scrollTop = scrollHeight` so the newest line is visible. Gated
-`#[cfg(target_arch = "wasm32")]` (uses `web-sys`); the rest of the component is
-target-agnostic. The scroll effect is the one piece not unit-tested (it needs a
-real DOM); the pure formatter and the store reducer carry the coverage.
+`event_log` is declared `pub mod event_log;` (both targets) so `response_label`'s
+tests run under `cargo test`. The component body is target-agnostic except the
+**auto-scroll** effect — a `#[cfg(target_arch = "wasm32")]` effect keyed on the
+total batch/event count that sets `scroll_ref.scrollTop = scrollHeight` so the
+newest line is visible. The scroll effect (needs a real DOM) is the one piece not
+unit-tested; the pure `response_label` and the store reducer carry the coverage.
 
-### 5. Layout — `crates/web/src/app.rs` + `crates/web/style.css`
+### 3. Input view captures the header — `crates/web/src/input.rs`
+
+`AwaitingInputView` is the sole gameplay submit site (wasm-only). At each of its
+four submit sites (Skip / PickSingle option button / Confirm / PickMultiple
+commit), set the pending label in the store immediately before sending:
+
+```rust
+store.update(|s| s.pending_label = Some(crate::event_log::response_label(&request, &response)));
+let _ = tx.unbounded_send(ClientMessage::Submit { action: PlayerAction::ResolveInput { response } });
+```
+
+`store` (an `RwSignal`, `Copy`) is already read at the top of the component, so it
+can be captured into the click closures. For the `PickSingle` buttons the chosen
+option's `label` is already in scope, so the header can be set directly from it
+(identical to `response_label`'s `PickSingle` arm) to avoid cloning the request
+into every button closure; the other three sites call `response_label`.
+
+### 4. Layout — `crates/web/src/app.rs` + `crates/web/style.css`
 
 Wrap the log and board in a flex row, log first (left):
 
@@ -159,7 +163,7 @@ view! {
     <main>
         <h1>"Eldritch"</h1>
         <div class="layout">
-            <EventLogView/>
+            <crate::event_log::EventLogView/>
             <BoardView/>
         </div>
         // picker / skill-test / input overlays unchanged
@@ -167,7 +171,9 @@ view! {
 }
 ```
 
-CSS: `.layout { display: flex; gap: 1rem; align-items: flex-start; }`,
+`EventLogView` renders on both targets (like `BoardView`), so it sits outside the
+existing `#[cfg(target_arch = "wasm32")]` overlay block. CSS:
+`.layout { display: flex; gap: 1rem; align-items: flex-start; }`,
 `.event-log { flex: 0 0 auto; width: 22rem; }`,
 `.log-scroll { max-height: 80vh; overflow-y: auto; font-family: monospace;
 font-size: 0.8rem; }`, with light per-batch separation and a distinct
@@ -176,21 +182,24 @@ font-size: 0.8rem; }`, with light per-batch separation and a distinct
 ## Data flow
 
 ```
-player Submit{action}
-  → server apply → broadcast Applied{state, events, outcome, action}
-  → client transport → store.reduce → push LogBatch{action, events}
+prompt (AwaitingInput) shown by AwaitingInputView
+  → user picks option → set store.pending_label = response_label(request, response)
+  → Submit{ResolveInput{response}} → server apply → broadcast Applied{state, events, outcome}
+  → client transport → store.reduce(Applied): header = pending_label.take(); push LogBatch{header, events}
   → EventLogView re-renders (oldest→newest) → auto-scroll to bottom
 ```
 
 ## Testing
 
-- **Store reducer** (`store.rs`, native): `Applied` appends a `LogBatch` with the
-  action + events; consecutive `Applied`s accumulate in order; `Hello` clears
-  `log`; `last_events`/difficulty behavior unchanged.
-- **Pure formatter** (`event_log.rs`, native): `batch_lines` produces the
-  `▸ from {action:?}` header and one `{:?}` line per event, in order.
-- **Protocol** (`protocol`): updated `Applied` serde round-trip includes
-  `action`.
+- **Store reducer** (`store.rs`, native): `Applied` appends a `LogBatch` whose
+  `header` is the taken `pending_label` (and the generic fallback when it is
+  `None`); consecutive `Applied`s accumulate in order; `Rejected` clears
+  `pending_label` without pushing a batch; `Hello` clears `log` and
+  `pending_label`; `last_events`/difficulty behavior unchanged.
+- **Label helper** (`event_log.rs`, native): `response_label` returns the option
+  label for `PickSingle`, `"Confirm"`/`"Skip"` for those, and
+  `"Commit <n> card(s)"` for `PickMultiple`; `PickSingle` with an unknown id
+  falls back to `"Pick <n>"`.
 - **Gauntlet:** fmt/clippy/test/doc + wasm-build/wasm-clippy/wasm-test (the new
   component must compile to wasm; the scroll effect is wasm-only).
 
@@ -198,9 +207,12 @@ player Submit{action}
 
 - No filtering, search, or collapsing.
 - No per-event timestamps (insertion order is the signal).
-- No card-name / id enrichment (raw codes per the format decision).
+- No card-name / id enrichment in event bodies (raw codes per the format
+  decision); headers use the menu label the client already has.
 - No phase sub-segmentation within a batch (inline phase events suffice).
 - No persistence across reload (log is rebuilt from `Hello` onward).
+- No multiplayer header attribution (a non-local submit's batch gets the generic
+  fallback header).
 
 ## Open questions
 

--- a/docs/superpowers/specs/2026-06-28-event-log-panel-design.md
+++ b/docs/superpowers/specs/2026-06-28-event-log-panel-design.md
@@ -60,8 +60,8 @@ framework boundaries are legible inline. No phase sub-segmentation.
 
 ## Architecture / components
 
-A thin client-only slice: store accumulation + a label helper + a new view +
-layout. No protocol or server changes.
+A thin client-only slice: store accumulation + a new view + layout. No protocol
+or server changes.
 
 ### 1. Client store — `crates/web/src/store.rs`
 
@@ -97,22 +97,7 @@ Reducer changes (`reduce`):
 This reducer is the **primary testable unit** (runs on the native test target —
 `store` is compiled on both targets).
 
-### 2. Label helper + view — `crates/web/src/event_log.rs` (new, both targets)
-
-A pure, DOM-free helper maps a submit to its header so it is unit-testable on the
-native target:
-
-```rust
-/// The event-log header for a submitted response, given the prompt it answered.
-/// - `PickSingle(id)` → that option's `label` (fallback `"Pick <n>"` if absent).
-/// - `Confirm`        → `"Confirm"`.
-/// - `Skip`           → `"Skip"`.
-/// - `PickMultiple`   → `"Commit <n> card(s)"`.
-pub(crate) fn response_label(
-    request: &InputRequest,
-    response: &InputResponse,
-) -> String { /* ... */ }
-```
+### 2. View — `crates/web/src/event_log.rs` (new, both targets)
 
 `EventLogView` reads the store and renders the log oldest-first (newest at the
 bottom):
@@ -130,29 +115,27 @@ bottom):
 </aside>
 ```
 
-`event_log` is declared `pub mod event_log;` (both targets) so `response_label`'s
-tests run under `cargo test`. The component body is target-agnostic except the
-**auto-scroll** effect — a `#[cfg(target_arch = "wasm32")]` effect keyed on the
-total batch/event count that sets `scroll_ref.scrollTop = scrollHeight` so the
-newest line is visible. The scroll effect (needs a real DOM) is the one piece not
-unit-tested; the pure `response_label` and the store reducer carry the coverage.
+`event_log` is declared `pub mod event_log;` (both targets). The component body
+is target-agnostic except the **auto-scroll** effect — a
+`#[cfg(target_arch = "wasm32")]` effect keyed on the total batch/event count that
+sets `scroll_ref.scrollTop = scrollHeight` so the newest line is visible. The
+scroll effect (needs a real DOM) is the one piece not unit-tested; the store
+reducer carries the native coverage.
 
 ### 3. Input view captures the header — `crates/web/src/input.rs`
 
 `AwaitingInputView` is the sole gameplay submit site (wasm-only). At each of its
-four submit sites (Skip / PickSingle option button / Confirm / PickMultiple
-commit), set the pending label in the store immediately before sending:
+four submit sites the pending label is set inline immediately before sending:
 
-```rust
-store.update(|s| s.pending_label = Some(crate::event_log::response_label(&request, &response)));
-let _ = tx.unbounded_send(ClientMessage::Submit { action: PlayerAction::ResolveInput { response } });
-```
+- **Skip** → `pending_label = Some("Skip".to_string())`
+- **PickSingle** option button → `pending_label = Some(label.clone())` where
+  `label` is the chosen `ChoiceOption`'s label already in scope in the button
+  closure
+- **Confirm** → `pending_label = Some("Confirm".to_string())`
+- **PickMultiple** commit → `pending_label = Some(format!("Commit {} card(s)", n))`
 
-`store` (an `RwSignal`, `Copy`) is already read at the top of the component, so it
-can be captured into the click closures. For the `PickSingle` buttons the chosen
-option's `label` is already in scope, so the header can be set directly from it
-(identical to `response_label`'s `PickSingle` arm) to avoid cloning the request
-into every button closure; the other three sites call `response_label`.
+There is no shared helper: each site sets `pending_label` directly. `store` (an
+`RwSignal`, `Copy`) is captured into the click closures.
 
 ### 4. Layout — `crates/web/src/app.rs` + `crates/web/style.css`
 
@@ -183,7 +166,7 @@ font-size: 0.8rem; }`, with light per-batch separation and a distinct
 
 ```
 prompt (AwaitingInput) shown by AwaitingInputView
-  → user picks option → set store.pending_label = response_label(request, response)
+  → user picks option → set store.pending_label = <chosen label> (inline at submit site)
   → Submit{ResolveInput{response}} → server apply → broadcast Applied{state, events, outcome}
   → client transport → store.reduce(Applied): header = pending_label.take(); push LogBatch{header, events}
   → EventLogView re-renders (oldest→newest) → auto-scroll to bottom
@@ -196,10 +179,9 @@ prompt (AwaitingInput) shown by AwaitingInputView
   `None`); consecutive `Applied`s accumulate in order; `Rejected` clears
   `pending_label` without pushing a batch; `Hello` clears `log` and
   `pending_label`; `last_events`/difficulty behavior unchanged.
-- **Label helper** (`event_log.rs`, native): `response_label` returns the option
-  label for `PickSingle`, `"Confirm"`/`"Skip"` for those, and
-  `"Commit <n> card(s)"` for `PickMultiple`; `PickSingle` with an unknown id
-  falls back to `"Pick <n>"`.
+- **PickSingle live path** (`awaiting_input.rs` wasm test): clicking an option
+  button sets `pending_label` to the exact option label (e.g. `"End turn"` for
+  `OptionId(0)` in the standard fixture); tested end-to-end via DOM click.
 - **Gauntlet:** fmt/clippy/test/doc + wasm-build/wasm-clippy/wasm-test (the new
   component must compile to wasm; the scroll effect is wasm-only).
 

--- a/docs/superpowers/specs/2026-06-28-event-log-panel-design.md
+++ b/docs/superpowers/specs/2026-06-28-event-log-panel-design.md
@@ -1,0 +1,207 @@
+# Event log panel (left of the board) — design
+
+**Date:** 2026-06-28
+**Status:** approved (brainstorm) — pending implementation plan
+
+## Goal
+
+Add a read-only event-log view to the **left of the board** that shows the full
+game's event history, newest at the bottom, grouped by the player action that
+produced each batch. A developer-facing debugging aid: "what happened, when, and
+was it a bug?"
+
+## Decisions (settled in brainstorm)
+
+- **Entry format: raw `Debug` (`{:?}`).** Every event renders verbatim with all
+  fields, e.g. `EnemyEngaged { enemy: EnemyId(100), investigator: InvestigatorId(1) }`.
+  No human-readable mapping to maintain; faithful and complete. Codes/ids show
+  raw (no card-name enrichment).
+- **History: full game, accumulated.** Every event since the game started,
+  cleared on `Hello` (new game / reconnect). Newest batch at the **bottom**;
+  the scroll container **auto-scrolls to the bottom** on update.
+- **Grouping: by player action.** Each `Applied` batch is one group with a
+  header phrased as the *trigger* — `▸ from {action:?}` — so it reads as
+  causation ("these events were caused by EndTurn"), not identity.
+- **Framework events** (Mythos/Upkeep/enemy-phase) are **not** special-cased.
+  They cascade synchronously from whatever action drove them (typically
+  `EndTurn`, then `ResolveInput` for each continuation pause), so they group
+  under that action. The engine already emits `PhaseStarted`/`PhaseEnded`/
+  `TurnEnded`/`AgendaAdvanced`/… as ordinary events, so framework boundaries are
+  legible inline. No phase sub-segmentation.
+
+### Why action grouping is sound
+
+There are **zero server-initiated applies**: `crates/server/src/ws.rs` calls
+`session.apply()` only in response to a client `Submit { action }` — no timers,
+no auto-advance. So every event the client ever receives is already inside an
+`Applied` batch caused by exactly one `PlayerAction`. Attributing each batch to
+its action is therefore exact, not a heuristic.
+
+## Architecture / components
+
+A thin slice across protocol → server → client store → a new view, plus layout.
+
+### 1. Protocol — `crates/protocol/src/lib.rs`
+
+Add `action: PlayerAction` to `ServerMessage::Applied`:
+
+```rust
+Applied {
+    state: Box<GameState>,
+    events: Vec<Event>,
+    outcome: EngineOutcome,
+    action: PlayerAction, // the submitted action that produced this batch
+},
+```
+
+`PlayerAction` already derives the needed `Serialize`/`Deserialize`/`Clone`/
+`Debug`/`PartialEq` (it travels in `ClientMessage`). This is a wire-format
+change; the client/server already negotiate a version and surface
+`ConnStatus::VersionMismatch`, so a mismatched pair fails loudly rather than
+mis-parsing. Update the existing `Applied` serde round-trip test to construct
+the new field.
+
+### 2. Server — `crates/server/src/ws.rs`
+
+The submitted `action` is already in scope at the broadcast site
+(`handle_client_message`). Clone it into the broadcast (one cheap clone per
+accepted action; `apply` takes the original by value):
+
+```rust
+Ok(ClientMessage::Submit { action }) => {
+    let mut session = room.session.lock().await;
+    let action_for_log = action.clone();
+    match session.apply(action).await {
+        ...
+        Ok((events, outcome)) => {
+            let _ = room.tx.send(ServerMessage::Applied {
+                state: Box::new(session.state.clone()),
+                events,
+                outcome,
+                action: action_for_log,
+            });
+            None
+        }
+        ...
+    }
+}
+```
+
+### 3. Client store — `crates/web/src/store.rs`
+
+Add an accumulated log alongside the existing fields:
+
+```rust
+/// One applied action's worth of events, for the event-log view.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LogBatch {
+    pub action: PlayerAction,
+    pub events: Vec<Event>,
+}
+
+pub struct ClientState {
+    // ...existing fields...
+    /// Full accumulated event history, grouped per applied action, oldest
+    /// first. Cleared by `Hello` (new game / reconnect), like `last_events`.
+    pub log: Vec<LogBatch>,
+}
+```
+
+Reducer changes:
+- `Applied { state, events, outcome, action }`: push
+  `LogBatch { action, events: events.clone() }`, then keep the existing
+  `last_events = events` (the skill-test panel still reads `last_events`) and
+  the existing difficulty capture. One events-vec clone per action — negligible.
+- `Hello`: `state.log = Vec::new()` (alongside the existing `last_events` /
+  difficulty clears).
+
+This reducer is the **primary testable unit**.
+
+### 4. New view — `crates/web/src/event_log.rs`
+
+`EventLogView` reads the store and renders the log oldest-first (newest at the
+bottom). Formatting lives in a **pure, DOM-free helper** so it is unit-testable:
+
+```rust
+/// The lines for one batch: a `▸ from {action:?}` header followed by one
+/// `{event:?}` line per event. Pure; unit-tested without a DOM.
+fn batch_lines(batch: &LogBatch) -> BatchLines { /* header String + Vec<String> */ }
+```
+
+Markup (sketch):
+
+```
+<aside class="event-log">
+  <h2>"Event log"</h2>
+  <div class="log-scroll" node_ref=scroll_ref>
+    // for each batch, oldest first:
+    <div class="log-batch">
+      <div class="log-action">{header}</div>      // "▸ from EndTurn"
+      <div class="log-event">{event_line}</div>   // one per event, "{:?}"
+    </div>
+  </div>
+</aside>
+```
+
+**Auto-scroll:** a wasm-only effect keyed on the total event/batch count sets
+`scroll_ref.scrollTop = scrollHeight` so the newest line is visible. Gated
+`#[cfg(target_arch = "wasm32")]` (uses `web-sys`); the rest of the component is
+target-agnostic. The scroll effect is the one piece not unit-tested (it needs a
+real DOM); the pure formatter and the store reducer carry the coverage.
+
+### 5. Layout — `crates/web/src/app.rs` + `crates/web/style.css`
+
+Wrap the log and board in a flex row, log first (left):
+
+```rust
+view! {
+    <main>
+        <h1>"Eldritch"</h1>
+        <div class="layout">
+            <EventLogView/>
+            <BoardView/>
+        </div>
+        // picker / skill-test / input overlays unchanged
+    </main>
+}
+```
+
+CSS: `.layout { display: flex; gap: 1rem; align-items: flex-start; }`,
+`.event-log { flex: 0 0 auto; width: 22rem; }`,
+`.log-scroll { max-height: 80vh; overflow-y: auto; font-family: monospace;
+font-size: 0.8rem; }`, with light per-batch separation and a distinct
+`.log-action` weight. Exact values are cosmetic and may be tuned during build.
+
+## Data flow
+
+```
+player Submit{action}
+  → server apply → broadcast Applied{state, events, outcome, action}
+  → client transport → store.reduce → push LogBatch{action, events}
+  → EventLogView re-renders (oldest→newest) → auto-scroll to bottom
+```
+
+## Testing
+
+- **Store reducer** (`store.rs`, native): `Applied` appends a `LogBatch` with the
+  action + events; consecutive `Applied`s accumulate in order; `Hello` clears
+  `log`; `last_events`/difficulty behavior unchanged.
+- **Pure formatter** (`event_log.rs`, native): `batch_lines` produces the
+  `▸ from {action:?}` header and one `{:?}` line per event, in order.
+- **Protocol** (`protocol`): updated `Applied` serde round-trip includes
+  `action`.
+- **Gauntlet:** fmt/clippy/test/doc + wasm-build/wasm-clippy/wasm-test (the new
+  component must compile to wasm; the scroll effect is wasm-only).
+
+## Out of scope (YAGNI)
+
+- No filtering, search, or collapsing.
+- No per-event timestamps (insertion order is the signal).
+- No card-name / id enrichment (raw codes per the format decision).
+- No phase sub-segmentation within a batch (inline phase events suffice).
+- No persistence across reload (log is rebuilt from `Hello` onward).
+
+## Open questions
+
+None blocking. Cosmetic CSS values (width, max-height, separators) are tunable
+during implementation.

--- a/docs/superpowers/specs/2026-06-28-event-log-panel-design.md
+++ b/docs/superpowers/specs/2026-06-28-event-log-panel-design.md
@@ -1,6 +1,7 @@
 # Event log panel (left of the board) — design
 
 **Date:** 2026-06-28
+**Issue:** [#505](https://github.com/talelburg/eldritch/issues/505)
 **Status:** approved (brainstorm) — pending implementation plan
 
 ## Goal


### PR DESCRIPTION
## Summary

Adds a read-only **event log** panel to the left of the board (closes #505) — a developer-facing debugging aid that accumulates the full game's events, newest at the bottom, grouped by the action that produced each batch. Client-only; no protocol or server change.

Design + plan: `docs/superpowers/specs/2026-06-28-event-log-panel-design.md`, `docs/superpowers/plans/2026-06-28-event-log-panel.md`.

## What it does

- **Raw `Debug` event lines** — every event renders verbatim with all fields (e.g. `EnemyEngaged { enemy: EnemyId(100), investigator: InvestigatorId(1) }`), so nothing is hidden when hunting a bug.
- **Full accumulated history**, cleared on new game / reconnect; auto-scrolled to the bottom so the newest line is always visible.
- **Grouped by the menu choice you submitted** — each batch is headed `▸ <label>` (e.g. `▸ Play 01059 from hand`, `▸ Move to Cellar`).

## Why the header comes from the client

Every player action over the wire is a single opaque `PlayerAction::ResolveInput { response }` (Move/PlayCard are engine-internal `TurnAction`s, not wire actions), so a protocol-carried action would read `ResolveInput { PickSingle(OptionId(2)) }` — useless. The useful label (the chosen menu option's text) is known **client-side** at submit time, so the input view captures it into a one-shot `pending_label` that the reducer consumes into the next `Applied` batch. Exact in solo play (zero server-initiated applies; turn-based UI).

## Implementation (thin client slice)

- `store.rs` — `log: Vec<LogBatch { header, events }>` + one-shot `pending_label`; reducer pushes on `Applied`, clears on `Rejected`/`Hello`.
- `input.rs` — sets `pending_label` to the chosen option's label inline at each of the four submit sites (Skip / PickSingle / Confirm / PickMultiple).
- `event_log.rs` — `EventLogView` renders batches oldest-first; a wasm-only `request_animation_frame`-deferred effect pins the scroll to the bottom after layout.
- `app.rs` + `style.css` — full-width header on top; below it a `[event log | main column]` flex row, the main column stacking the board with the input/picker/skill-test panels beneath it.

## Test notes

Built TDD via subagent-driven execution with per-task + a final whole-branch review. New coverage: store-reducer unit tests (batch accumulation, lifecycle clears), and wasm render/interaction tests (`crates/web/tests/event_log.rs` renders a batch's header + Debug event lines; `awaiting_input.rs` asserts a click sets the exact `pending_label` label). Full gauntlet run locally — host test/clippy/fmt/doc + wasm build/clippy/test, all green.

A final-review finding (a vestigial `response_label` helper) was resolved by deleting it and asserting the live header path directly.

## Out of scope (YAGNI)

No filtering/search/collapsing, no timestamps, no card-name enrichment, no phase sub-segmentation, no persistence across reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)