### PR TITLE
engine: set aside + reshuffle opening-hand weaknesses at setup

### DIFF
--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -35,8 +35,11 @@ fn is_weakness_code(code: &CardCode) -> bool {
 ///
 /// - Caller guarantees `investigator` exists in `cx.state.investigators`.
 /// - The loop terminates: if the deck runs out mid-replacement, the call
-///   returns without panic — the hand may be shorter than the original
-///   draw count, but it holds no weakness.
+///   returns without panic. The hand then holds no weakness — UNLESS the deck
+///   exhausted on a replacement draw that was itself a weakness (RR's "replaced
+///   by drawing another card" has no card left to draw). That needs a deck of
+///   almost entirely weaknesses, which a legal deck never is; the guard exists
+///   only so a pathological deck can't spin the loop forever.
 /// - Registry-free (no registry installed): `is_weakness_code` always returns
 ///   `false`, so this function is a no-op, preserving the engine's
 ///   registry-free unit test behavior.

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -16,6 +16,99 @@ use super::Cx;
 /// each investigator draws 5 cards before mulligan.
 pub(super) const INITIAL_HAND_SIZE: u8 = 5;
 
+/// Whether `code` is a weakness per the installed registry. Returns `false`
+/// when no registry is installed or the card code has no metadata —
+/// the engine's registry-free unit tests behave as if no card is a weakness.
+fn is_weakness_code(code: &CardCode) -> bool {
+    crate::card_registry::current()
+        .and_then(|reg| (reg.metadata_for)(code))
+        .is_some_and(card_dsl::CardMetadata::is_weakness)
+}
+
+/// Replace weaknesses currently in `investigator`'s hand per Rules Reference
+/// setup step 8: move each to `setaside` (emitting
+/// [`Event::WeaknessSetAside`](crate::event::Event::WeaknessSetAside))
+/// and draw replacements, looping until the hand holds no weakness or the
+/// deck is exhausted.
+///
+/// # Contract
+///
+/// - Caller guarantees `investigator` exists in `cx.state.investigators`.
+/// - The loop terminates: if the deck runs out mid-replacement, the call
+///   returns without panic — the hand may be shorter than the original
+///   draw count, but it holds no weakness.
+/// - Registry-free (no registry installed): `is_weakness_code` always returns
+///   `false`, so this function is a no-op, preserving the engine's
+///   registry-free unit test behavior.
+pub(super) fn replace_opening_hand_weaknesses(cx: &mut Cx, investigator: InvestigatorId) {
+    loop {
+        // Scan the hand for weakness indices. Collect before mutating.
+        let weakness_indices: Vec<usize> = cx
+            .state
+            .investigators
+            .get(&investigator)
+            .expect("replace_opening_hand_weaknesses: investigator exists")
+            .hand
+            .iter()
+            .enumerate()
+            .filter(|(_, code)| is_weakness_code(code))
+            .map(|(i, _)| i)
+            .collect();
+
+        if weakness_indices.is_empty() {
+            break;
+        }
+
+        let n = weakness_indices.len();
+
+        // Remove weaknesses high-to-low so earlier indices remain valid.
+        // Codes are collected in reverse-removal order; reverse at the end
+        // to restore hand-order before emitting events.
+        let mut removed_codes: Vec<CardCode> = Vec::with_capacity(n);
+        {
+            let inv = cx
+                .state
+                .investigators
+                .get_mut(&investigator)
+                .expect("replace_opening_hand_weaknesses: investigator exists");
+            for &i in weakness_indices.iter().rev() {
+                let code = inv.hand.remove(i);
+                inv.setaside.push(code.clone());
+                removed_codes.push(code);
+            }
+        }
+        removed_codes.reverse(); // restore hand order (lowest index first)
+
+        for code in &removed_codes {
+            cx.events.push(Event::WeaknessSetAside {
+                investigator,
+                code: code.clone(),
+            });
+        }
+
+        // Draw replacements: draw_cards stops at deck end, so n_drawn ≤ n.
+        draw_cards(
+            cx,
+            investigator,
+            u8::try_from(n).expect("hand size fits u8 (≤ INITIAL_HAND_SIZE ≤ 8)"),
+        );
+
+        // Guard: if the deck is now empty we stop. Without this break the
+        // loop could spin forever when replacements are themselves weaknesses
+        // and the deck is exhausted.
+        let deck_empty = cx
+            .state
+            .investigators
+            .get(&investigator)
+            .expect("replace_opening_hand_weaknesses: investigator exists")
+            .deck
+            .is_empty();
+        if deck_empty {
+            break;
+        }
+    }
+}
+
 /// Handler for [`EngineRecord::DeckShuffled`].
 ///
 /// Permutes the named investigator's player deck via the deterministic
@@ -419,6 +512,9 @@ pub(super) fn resume_mulligan(cx: &mut Cx, response: &InputResponse) -> EngineOu
     if redrawn_count > 0 {
         shuffle_player_deck(cx, investigator);
         draw_cards(cx, investigator, redrawn_count);
+        // RR setup step 8 applies to the mulligan redraw too: any weakness
+        // drawn as a replacement is set aside and replaced again.
+        replace_opening_hand_weaknesses(cx, investigator);
     }
     cx.events.push(Event::MulliganPerformed {
         investigator,
@@ -431,6 +527,37 @@ pub(super) fn resume_mulligan(cx: &mut Cx, response: &InputResponse) -> EngineOu
     // Pop the current Mulligan frame (validated above; it is the top frame).
     cx.state.continuations.pop();
     if remaining.is_empty() {
+        // All mulligans complete. Flush every investigator's set-aside
+        // weaknesses back into their deck (RR setup step 8: "Upon completion
+        // of this step, shuffle each of these weakness cards back into its
+        // owner's deck."). Drain `setaside` into `deck` and reshuffle.
+        // Process in deterministic id order.
+        let mut ids_with_setaside: Vec<crate::state::InvestigatorId> = cx
+            .state
+            .investigators
+            .iter()
+            .filter(|(_, inv)| !inv.setaside.is_empty())
+            .map(|(id, _)| *id)
+            .collect();
+        ids_with_setaside.sort_unstable();
+        for id in ids_with_setaside {
+            let cards: Vec<crate::state::CardCode> = cx
+                .state
+                .investigators
+                .get_mut(&id)
+                .expect("id from investigators")
+                .setaside
+                .drain(..)
+                .collect();
+            cx.state
+                .investigators
+                .get_mut(&id)
+                .expect("id from investigators")
+                .deck
+                .extend(cards);
+            shuffle_player_deck(cx, id);
+        }
+
         // Setup complete — "the game begins" (Rules Reference p.27). Round 1
         // skips Mythos (p.24), so the first phase to begin is Investigation.
         // Begin it HERE (the kickoff moved off `apply_player_action`): setup has

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -99,6 +99,7 @@ pub(super) fn start_scenario(cx: &mut Cx, roster: &[RosterEntry]) -> EngineOutco
                 deck,
                 hand: Vec::new(),
                 discard: Vec::new(),
+                setaside: Vec::new(),
                 cards_in_play: Vec::new(),
                 threat_area: Vec::new(),
                 removed_from_game: Vec::new(),
@@ -126,11 +127,13 @@ pub(super) fn start_scenario(cx: &mut Cx, roster: &[RosterEntry]) -> EngineOutco
     cx.events.push(Event::ScenarioStarted);
 
     // For each investigator (sorted by id for determinism), shuffle
-    // their deck and deal an initial hand of up to 5.
+    // their deck, deal an initial hand of up to 5, then set aside any
+    // weaknesses per Rules Reference setup step 8.
     let inv_ids: Vec<InvestigatorId> = cx.state.investigators.keys().copied().collect();
     for inv_id in inv_ids {
         super::cards::shuffle_player_deck(cx, inv_id);
         super::cards::draw_cards(cx, inv_id, super::cards::INITIAL_HAND_SIZE);
+        super::cards::replace_opening_hand_weaknesses(cx, inv_id);
     }
 
     // Shuffle the shared encounter deck with the same scenario-start RNG

--- a/crates/game-core/src/event.rs
+++ b/crates/game-core/src/event.rs
@@ -341,6 +341,22 @@ pub enum Event {
         /// How many cards were redrawn.
         redrawn_count: u8,
     },
+    /// A weakness card was set aside from an investigator's opening hand
+    /// during scenario setup (Rules Reference step 8: "Each weakness card
+    /// drawn during this step is ignored, set aside (without resolving
+    /// it), and replaced by drawing another card from the deck.").
+    ///
+    /// Emitted by `replace_opening_hand_weaknesses` (in
+    /// `engine::dispatch::cards`) for each weakness pulled from the hand
+    /// before drawing a replacement. The weakness moves to
+    /// `investigator.setaside`; once the mulligan loop drains it is
+    /// shuffled back into the owner's deck.
+    WeaknessSetAside {
+        /// The investigator whose opening hand contained the weakness.
+        investigator: InvestigatorId,
+        /// The weakness card code that was set aside.
+        code: CardCode,
+    },
     /// Every investigator in `state.investigators` is now non-Active.
     /// Fires immediately after the [`InvestigatorDefeated`] that
     /// flipped the last active investigator. Scenario-resolution

--- a/crates/game-core/src/state/investigator.rs
+++ b/crates/game-core/src/state/investigator.rs
@@ -83,6 +83,21 @@ pub struct Investigator {
     ///
     /// [`cards_in_play`]: Self::cards_in_play
     pub threat_area: Vec<CardInPlay>,
+    /// Weaknesses set aside from the opening hand during scenario setup
+    /// (Rules Reference step 8: "Each weakness card drawn during this step
+    /// is ignored, set aside (without resolving it), and replaced by
+    /// drawing another card from the deck."). Transient: populated by
+    /// `replace_opening_hand_weaknesses` (in `engine::dispatch::cards`)
+    /// during the setup draw and mulligan redraw, then drained back into
+    /// `deck` (and shuffled) once the mulligan loop fully drains.
+    /// Empty for all investigators once the Investigation phase begins.
+    ///
+    /// `#[serde(default)]`: this field is always empty in wire-serialized
+    /// game-in-progress states (setup is complete before any client sees the
+    /// state), so older payloads without the field deserialize to the correct
+    /// empty-vector default rather than failing.
+    #[serde(default)]
+    pub setaside: Vec<CardCode>,
     /// Cards removed from the game (Rules Reference p.10, "Elimination,"
     /// step 1). When this investigator is eliminated, every card they
     /// control in play (`cards_in_play`) and every card they own in an

--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -55,6 +55,7 @@ pub fn test_investigator(id: u32) -> Investigator {
         deck: Vec::new(),
         hand: Vec::new(),
         discard: Vec::new(),
+        setaside: Vec::new(),
         cards_in_play: Vec::new(),
         threat_area: Vec::new(),
         removed_from_game: Vec::new(),

--- a/crates/scenarios/tests/opening_hand_weaknesses.rs
+++ b/crates/scenarios/tests/opening_hand_weaknesses.rs
@@ -1,0 +1,277 @@
+//! #508 acceptance: opening-hand weaknesses are set aside and reshuffled
+//! per Rules Reference setup step 8.
+//!
+//! "Each weakness card drawn during this step is ignored, set aside
+//! (without resolving it), and replaced by drawing another card from
+//! the deck. Upon completion of this step, shuffle each of these
+//! weakness cards back into its owner's deck." (RR p.27, Step 8)
+//!
+//! Lives in `crates/scenarios/tests/` (own process) so it can install
+//! [`TEST_REGISTRY`] without colliding with other test binaries.
+
+use game_core::action::RosterEntry;
+use game_core::engine::{apply, EngineOutcome};
+use game_core::event::Event;
+use game_core::seat_and_open;
+use game_core::state::{CardCode, InvestigatorId, Phase};
+use game_core::test_support::{test_investigator, GameStateBuilder, TEST_INV};
+use game_core::{Action, InputResponse, PlayerAction};
+use scenarios::test_fixtures::synth_cards::{SYNTH_COVER_UP_CODE, TEST_REGISTRY};
+use scenarios::test_fixtures::synthetic;
+
+#[ctor::ctor(unsafe)]
+fn install_test_registry() {
+    let _ = game_core::card_registry::install(TEST_REGISTRY);
+}
+
+const INV: InvestigatorId = InvestigatorId(1);
+
+// ---- helpers ---------------------------------------------------------------
+
+/// Apply a "keep my whole hand" mulligan response (empty `PickMultiple`).
+fn keep_hand(state: game_core::state::GameState) -> game_core::engine::ApplyResult {
+    apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickMultiple { selected: vec![] },
+        }),
+    )
+}
+
+// ---- Test 1: opening-hand weakness is set aside and replaced ---------------
+
+/// A 5-card deck where one card is the synthetic weakness. Because the deck
+/// has exactly 5 cards and `start_scenario` draws 5, all cards are in hand
+/// after the initial draw regardless of shuffle order — the weakness is
+/// guaranteed to be drawn.
+///
+/// After `replace_opening_hand_weaknesses`:
+/// - The weakness is in `setaside`, not in `hand`.
+/// - `WeaknessSetAside` fires.
+/// - Hand holds the 4 non-weakness cards.
+///
+/// After the mulligan keep + drain:
+/// - `setaside` is empty.
+/// - Weakness is back in `deck`.
+#[test]
+fn opening_hand_weakness_set_aside_and_returned_to_deck() {
+    let deck = vec![
+        CardCode::new(SYNTH_COVER_UP_CODE), // weakness
+        CardCode::new("01001"),
+        CardCode::new("01002"),
+        CardCode::new("01003"),
+        CardCode::new("01004"),
+    ];
+    let roster = vec![RosterEntry {
+        investigator: CardCode::new(TEST_INV),
+        deck,
+    }];
+
+    // seat_and_open → initial draw + weakness set-aside, then mulligan prompt.
+    let r1 = seat_and_open(synthetic::setup(), &roster);
+    assert!(
+        matches!(r1.outcome, EngineOutcome::AwaitingInput { .. }),
+        "seat_and_open opens the mulligan prompt, got {:?}",
+        r1.outcome,
+    );
+
+    // The opening-hand weakness-set-aside events fire during seat_and_open.
+    assert!(
+        r1.events.iter().any(|e| matches!(
+            e,
+            Event::WeaknessSetAside { investigator: INV, code }
+            if code.as_str() == SYNTH_COVER_UP_CODE
+        )),
+        "WeaknessSetAside must fire for Cover Up during initial draw; events = {:?}",
+        r1.events,
+    );
+
+    // Hand has no weakness after the initial replace.
+    let inv = &r1.state.investigators[&INV];
+    assert!(
+        !inv.hand.iter().any(|c| c.as_str() == SYNTH_COVER_UP_CODE),
+        "weakness must NOT be in hand after initial draw; hand = {:?}",
+        inv.hand,
+    );
+    // Weakness is in setaside, waiting for drain.
+    assert!(
+        inv.setaside
+            .iter()
+            .any(|c| c.as_str() == SYNTH_COVER_UP_CODE),
+        "weakness must be in setaside before mulligan drains; setaside = {:?}",
+        inv.setaside,
+    );
+
+    // Keep-hand mulligan: investigator keeps the remaining 4 non-weakness cards.
+    // At drain, setaside weaknesses are shuffled back into the deck.
+    let r2 = keep_hand(r1.state);
+    assert!(
+        !matches!(r2.outcome, EngineOutcome::Rejected { .. }),
+        "keep-hand mulligan must not reject; outcome = {:?}",
+        r2.outcome,
+    );
+
+    let inv2 = &r2.state.investigators[&INV];
+
+    // Hand has no weakness after drain.
+    assert!(
+        !inv2.hand.iter().any(|c| c.as_str() == SYNTH_COVER_UP_CODE),
+        "weakness must NOT be in hand after mulligan + drain; hand = {:?}",
+        inv2.hand,
+    );
+
+    // setaside is clear — weaknesses were moved back to deck.
+    assert!(
+        inv2.setaside.is_empty(),
+        "setaside must be empty after mulligan loop drains; setaside = {:?}",
+        inv2.setaside,
+    );
+
+    // Weakness is now in the deck (shuffled back per RR step 8).
+    assert!(
+        inv2.deck.iter().any(|c| c.as_str() == SYNTH_COVER_UP_CODE),
+        "weakness must be in deck after drain; deck = {:?}",
+        inv2.deck,
+    );
+}
+
+// ---- Test 2: mulligan redraw also avoids weaknesses -----------------------
+
+/// With seed 42, Fisher-Yates on a 2-element deck [weakness, non1] is a
+/// no-op (j = `next_index(2)` = 1, which swaps an element with itself).
+/// After the mulligan returns non1 to the deck and shuffles, the deck
+/// remains [weakness, non1], so the redraw draws the weakness first.
+///
+/// `replace_opening_hand_weaknesses` then sets the weakness aside again
+/// and draws non1 as the replacement, leaving a weakness-free hand.
+/// At drain the weakness is shuffled back into the deck.
+///
+/// Seed derivation: frozen contract `RngState::new(42)`, first `next_u64`
+/// = `0xae90_bfb5_395d_5ba1` (odd) → `% 2 = 1` → i=1, j=1, no swap.
+#[test]
+fn mulligan_redraw_weakness_is_set_aside() {
+    let mut inv = test_investigator(1);
+    // Hand: one non-weakness card to mulligan.
+    inv.hand = vec![CardCode::new("01001")];
+    // Deck: only the weakness — guarantees the mulligan redraw draws it.
+    inv.deck = vec![CardCode::new(SYNTH_COVER_UP_CODE)];
+
+    let state = GameStateBuilder::new()
+        .with_rng_seed(42)
+        .with_investigator(inv)
+        .with_phase(Phase::Investigation)
+        .with_turn_order([INV])
+        .with_mulligan_remaining([INV])
+        .build();
+
+    // Player mulligans index 0 ("01001"):
+    //   → "01001" pushed to deck → deck = [weakness, "01001"]
+    //   → Fisher-Yates(seed=42): j=1, no-op → deck = [weakness, "01001"]
+    //   → draw 1 → weakness drawn → hand = [weakness]
+    //   → replace_opening_hand_weaknesses: weakness → setaside, draw 1
+    //   → deck = ["01001"], draw "01001" → hand = ["01001"]
+    //   → deck empty, break.
+    // MulliganPerformed{redrawn_count:1}.
+    // Drain: setaside[weakness] → deck, shuffle.
+    let r = apply(
+        state,
+        Action::Player(PlayerAction::ResolveInput {
+            response: InputResponse::PickMultiple {
+                selected: vec![game_core::engine::OptionId(0)],
+            },
+        }),
+    );
+    assert!(
+        !matches!(r.outcome, EngineOutcome::Rejected { .. }),
+        "mulligan must not reject; outcome = {:?}",
+        r.outcome,
+    );
+
+    // WeaknessSetAside fired for the weakness drawn during the mulligan redraw.
+    assert!(
+        r.events.iter().any(|e| matches!(
+            e,
+            Event::WeaknessSetAside { investigator: INV, code }
+            if code.as_str() == SYNTH_COVER_UP_CODE
+        )),
+        "WeaknessSetAside must fire for weakness drawn during mulligan; events = {:?}",
+        r.events,
+    );
+
+    let inv = &r.state.investigators[&INV];
+
+    // Hand has no weakness.
+    assert!(
+        !inv.hand.iter().any(|c| c.as_str() == SYNTH_COVER_UP_CODE),
+        "weakness must NOT be in hand after mulligan; hand = {:?}",
+        inv.hand,
+    );
+
+    // setaside is clear (drained at mulligan loop completion).
+    assert!(
+        inv.setaside.is_empty(),
+        "setaside must be empty after mulligan drains; setaside = {:?}",
+        inv.setaside,
+    );
+
+    // Weakness is back in deck.
+    assert!(
+        inv.deck.iter().any(|c| c.as_str() == SYNTH_COVER_UP_CODE),
+        "weakness must be in deck after drain; deck = {:?}",
+        inv.deck,
+    );
+}
+
+// ---- Test 3: non-weakness deck unchanged ----------------------------------
+
+/// A deck with no weakness cards must produce no `WeaknessSetAside` events
+/// and leave the hand intact (5 non-weakness cards drawn).
+#[test]
+fn non_weakness_deck_produces_no_weakness_events() {
+    let deck: Vec<CardCode> = (1u32..=5)
+        .map(|i| CardCode::new(format!("010{i:02}")))
+        .collect();
+    let roster = vec![RosterEntry {
+        investigator: CardCode::new(TEST_INV),
+        deck,
+    }];
+
+    let r1 = seat_and_open(synthetic::setup(), &roster);
+    assert!(
+        matches!(r1.outcome, EngineOutcome::AwaitingInput { .. }),
+        "seat_and_open opens the mulligan prompt",
+    );
+
+    // No WeaknessSetAside events during initial draw.
+    assert!(
+        !r1.events
+            .iter()
+            .any(|e| matches!(e, Event::WeaknessSetAside { .. })),
+        "no WeaknessSetAside must fire for a weakness-free deck; events = {:?}",
+        r1.events,
+    );
+
+    // All 5 non-weakness cards are in hand.
+    let inv = &r1.state.investigators[&INV];
+    assert_eq!(
+        inv.hand.len(),
+        5,
+        "hand must hold all 5 non-weakness cards; hand = {:?}",
+        inv.hand,
+    );
+
+    // Keep mulligan — no WeaknessSetAside during drain either.
+    let r2 = keep_hand(r1.state);
+    assert!(
+        !r2.events
+            .iter()
+            .any(|e| matches!(e, Event::WeaknessSetAside { .. })),
+        "no WeaknessSetAside must fire during mulligan for a weakness-free deck",
+    );
+
+    let inv2 = &r2.state.investigators[&INV];
+    assert!(
+        inv2.setaside.is_empty(),
+        "setaside must stay empty for a weakness-free deck",
+    );
+}


### PR DESCRIPTION
## Summary

Part 2 of #494. Implements Rules Reference Setup step 8 for weaknesses in the opening hand: a weakness drawn while building the opening hand is **set aside (without resolving), replaced by another draw, and shuffled back into the owner's deck** once setup completes — including across the mulligan. It does **not** stay in hand and its Revelation does **not** fire at setup.

> RR step 8: "Each weakness card drawn during this step is ignored, set aside (without resolving it), and replaced by drawing another card from the deck. Upon completion of this step, shuffle each of these weakness cards back into its owner's deck."

This fixes the actual #494 bug (Cover Up sat in Roland's opening hand instead of being reshuffled). Its Revelation then firing on a later draw is Part 3 (#509).

## What changed

- `Investigator` gains a transient `setaside: Vec<CardCode>` zone (`#[serde(default)]`; always empty once setup completes).
- `Event::WeaknessSetAside { investigator, code }`.
- `replace_opening_hand_weaknesses` (cards.rs): after a draw, moves any weakness in hand to `setaside` (emitting the event) and draws replacements, looping until the hand has no weakness or the deck exhausts (guarded against infinite loop). No-op without a registry (preserves registry-free unit tests).
- `start_scenario`: runs it right after the **initial** opening draw — so a weakness is gone from the hand before the mulligan prompt.
- `resume_mulligan`: runs it after a mulligan **redraw**, and at the mulligan-loop drain (setup complete) reshuffles each investigator's `setaside` back into their deck in deterministic id order.

## Determinism

All draws/shuffles go through the existing RNG-seeded `draw_cards`/`shuffle_player_deck`; no new randomness or `EngineRecord` — replay stays deterministic.

## Test notes

3 integration tests in `crates/scenarios/tests/opening_hand_weaknesses.rs`: a weakness in the opening 5 is set aside (event fired) and ends back in the deck after setup; a mulligan redraw also avoids weaknesses; a no-weakness hand is unchanged. (No "chained weakness" test — Roland's deck has only one weakness, Cover Up, so a replacement-is-also-a-weakness path is unreachable with the real corpus.) Full gauntlet green locally.

## Linked issues

Part of #494. Closes #508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)