### PR TITLE
server/web: surface scenario-setup events in the event log

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -39,6 +39,11 @@ pub enum ServerMessage {
         state: Box<GameState>,
         /// Outcome of the most recent apply.
         outcome: EngineOutcome,
+        /// Events emitted during scenario setup (`seat_and_open`), so
+        /// the client's event log can show the opening draws, shuffles,
+        /// and weakness set-aside. Empty for a session reloaded from the
+        /// DB — setup already ran.
+        events: Vec<Event>,
     },
     /// Broadcast to every connection of a game after an accepted action.
     Applied {
@@ -130,19 +135,30 @@ mod tests {
 
     #[test]
     fn hello_round_trips_through_json() {
+        use game_core::Event;
+
         let state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
+        let events = vec![Event::ScenarioStarted];
         let msg = ServerMessage::Hello {
             state: Box::new(state.clone()),
             outcome: EngineOutcome::Done,
+            events: events.clone(),
         };
 
         let json = serde_json::to_string(&msg).expect("serialize");
         let back: ServerMessage = serde_json::from_str(&json).expect("deserialize");
 
         match back {
-            ServerMessage::Hello { state: s, .. } => assert_eq!(*s, state),
+            ServerMessage::Hello {
+                state: s,
+                events: e,
+                ..
+            } => {
+                assert_eq!(*s, state);
+                assert_eq!(e, events, "events round-trip through JSON");
+            }
             other => panic!("expected Hello, got {other:?}"),
         }
     }

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -41,8 +41,9 @@ pub enum ServerMessage {
         outcome: EngineOutcome,
         /// Events emitted during scenario setup (`seat_and_open`), so
         /// the client's event log can show the opening draws, shuffles,
-        /// and weakness set-aside. Empty for a session reloaded from the
-        /// DB — setup already ran.
+        /// and weakness set-aside. Carried for both freshly-created and
+        /// reloaded games (the server persists them); empty only for games
+        /// created before this was added.
         events: Vec<Event>,
     },
     /// Broadcast to every connection of a game after an accepted action.

--- a/crates/server/migrations/0003_setup_events.sql
+++ b/crates/server/migrations/0003_setup_events.sql
@@ -1,0 +1,5 @@
+-- Persist the events emitted during scenario setup (seat_and_open), so a
+-- session reloaded from the DB can still surface them in the client's event
+-- log (#512). Existing rows predate the feature; default to an empty JSON
+-- array so they load as "no setup events" rather than failing NOT NULL.
+ALTER TABLE games ADD COLUMN setup_events TEXT NOT NULL DEFAULT '[]';

--- a/crates/server/src/session.rs
+++ b/crates/server/src/session.rs
@@ -109,6 +109,10 @@ impl GameSession {
         let state = result.state;
         let seed_state = serde_json::to_string(&state)?;
         let seed_outcome = serde_json::to_string(&outcome)?;
+        // Persist the setup events so a reloaded session can still surface them
+        // in the client's event log (#512) — the action log doesn't contain
+        // them (setup isn't an action; the seed state is already post-setup).
+        let seed_setup_events = serde_json::to_string(&setup_events)?;
         let game_id = game_id.into();
         store::insert_game(
             &db,
@@ -116,6 +120,7 @@ impl GameSession {
             &scenario_id,
             &seed_state,
             &seed_outcome,
+            &seed_setup_events,
             &unix_millis_string(),
         )
         .await?;
@@ -173,13 +178,18 @@ impl GameSession {
     /// [`SessionError::Db`] if a query fails, or [`SessionError::Serde`] if the
     /// persisted seed state or a logged action fails to deserialize.
     pub async fn load(db: SqlitePool, game_id: &GameId) -> Result<Option<Self>, SessionError> {
-        let Some((_scenario_id, seed_state, seed_outcome)) = store::load_game(&db, game_id).await?
+        let Some((_scenario_id, seed_state, seed_outcome, seed_setup_events)) =
+            store::load_game(&db, game_id).await?
         else {
             return Ok(None);
         };
 
         let mut state: GameState = serde_json::from_str(&seed_state)?;
         let mut outcome: EngineOutcome = serde_json::from_str(&seed_outcome)?;
+        // Setup events were captured at create time (#512); replaying the
+        // action log doesn't reproduce them (setup isn't an action), so they
+        // come straight from the persisted column.
+        let setup_events: Vec<Event> = serde_json::from_str(&seed_setup_events)?;
         let mut seq: i64 = 0;
         for action_json in store::load_actions(&db, game_id).await? {
             let action: Action = serde_json::from_str(&action_json)?;
@@ -193,7 +203,7 @@ impl GameSession {
             game_id: game_id.clone(),
             state,
             outcome,
-            setup_events: Vec::new(),
+            setup_events,
             seq,
             db,
         }))

--- a/crates/server/src/session.rs
+++ b/crates/server/src/session.rs
@@ -46,6 +46,12 @@ pub struct GameSession {
     /// with no actions yet — the seed outcome (the setup mulligan prompt,
     /// i.e. `AwaitingInput`).
     pub outcome: EngineOutcome,
+    /// Events emitted during `seat_and_open` at creation time, surfaced to
+    /// newly-connecting clients via `ServerMessage::Hello` so the event log
+    /// can show opening draws, shuffles, and the weakness set-aside.
+    /// Empty for a session reloaded from the DB — setup already ran and its
+    /// events are not recoverable from the persisted seed state.
+    pub setup_events: Vec<Event>,
     /// Next sequence number to assign to a persisted action — equal to
     /// the number of actions already in the log.
     seq: i64,
@@ -99,6 +105,7 @@ impl GameSession {
             }
             other => other,
         };
+        let setup_events = result.events;
         let state = result.state;
         let seed_state = serde_json::to_string(&state)?;
         let seed_outcome = serde_json::to_string(&outcome)?;
@@ -117,6 +124,7 @@ impl GameSession {
             game_id,
             state,
             outcome,
+            setup_events,
             seq: 0,
             db,
         })
@@ -185,6 +193,7 @@ impl GameSession {
             game_id: game_id.clone(),
             state,
             outcome,
+            setup_events: Vec::new(),
             seq,
             db,
         }))

--- a/crates/server/src/session.rs
+++ b/crates/server/src/session.rs
@@ -48,9 +48,11 @@ pub struct GameSession {
     pub outcome: EngineOutcome,
     /// Events emitted during `seat_and_open` at creation time, surfaced to
     /// newly-connecting clients via `ServerMessage::Hello` so the event log
-    /// can show opening draws, shuffles, and the weakness set-aside.
-    /// Empty for a session reloaded from the DB — setup already ran and its
-    /// events are not recoverable from the persisted seed state.
+    /// can show opening draws, shuffles, and the weakness set-aside. Persisted
+    /// in the `setup_events` column and restored by [`load`](Self::load), so a
+    /// session reloaded from the DB carries the same list (the action log can't
+    /// reproduce them — setup isn't an action). A row created before migration
+    /// 0003 loads as empty (the column defaults to `'[]'`).
     pub setup_events: Vec<Event>,
     /// Next sequence number to assign to a persisted action — equal to
     /// the number of actions already in the log.

--- a/crates/server/src/store.rs
+++ b/crates/server/src/store.rs
@@ -14,15 +14,17 @@ pub(crate) async fn insert_game(
     scenario_id: &ScenarioId,
     seed_state: &str,
     seed_outcome: &str,
+    setup_events: &str,
     created_at: &str,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
-        "INSERT INTO games (game_id, scenario_id, seed_state, seed_outcome, created_at) VALUES (?, ?, ?, ?, ?)",
+        "INSERT INTO games (game_id, scenario_id, seed_state, seed_outcome, setup_events, created_at) VALUES (?, ?, ?, ?, ?, ?)",
     )
     .bind(game_id.as_str())
     .bind(scenario_id.as_str())
     .bind(seed_state)
     .bind(seed_outcome)
+    .bind(setup_events)
     .bind(created_at)
     .execute(db)
     .await?;
@@ -45,15 +47,19 @@ pub(crate) async fn insert_action(
     Ok(())
 }
 
-/// Fetch a game's `(scenario_id, seed_state, seed_outcome)`, or `None`.
+/// Fetch a game's `(scenario_id, seed_state, seed_outcome, setup_events)`, or
+/// `None`. `setup_events` is the JSON array of events emitted during setup
+/// (`'[]'` for rows created before the column existed).
 pub(crate) async fn load_game(
     db: &SqlitePool,
     game_id: &GameId,
-) -> Result<Option<(String, String, String)>, sqlx::Error> {
-    sqlx::query_as("SELECT scenario_id, seed_state, seed_outcome FROM games WHERE game_id = ?")
-        .bind(game_id.as_str())
-        .fetch_optional(db)
-        .await
+) -> Result<Option<(String, String, String, String)>, sqlx::Error> {
+    sqlx::query_as(
+        "SELECT scenario_id, seed_state, seed_outcome, setup_events FROM games WHERE game_id = ?",
+    )
+    .bind(game_id.as_str())
+    .fetch_optional(db)
+    .await
 }
 
 /// Fetch a game's action JSON blobs in `seq` order.

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -82,6 +82,7 @@ async fn handle_socket(socket: WebSocket, state: AppState, game_id: GameId) {
         ServerMessage::Hello {
             state: Box::new(session.state.clone()),
             outcome: session.outcome.clone(),
+            events: session.setup_events.clone(),
         }
     };
     if send_msg(&mut sink, &hello).await.is_err() {

--- a/crates/server/tests/setup_events.rs
+++ b/crates/server/tests/setup_events.rs
@@ -1,0 +1,53 @@
+//! #512: the events emitted during scenario setup (`seat_and_open`) are
+//! persisted at create time and delivered in the reconnect baseline `Hello`,
+//! so the client's event log can show the opening draws / shuffles / weakness
+//! set-aside. This is the path the live client hits: `POST /games` creates and
+//! persists the session, then the websocket connection reloads it from the DB
+//! (the in-memory created session is not held), so the events must survive the
+//! round-trip through the persisted column — not just live in memory.
+
+mod common;
+
+use common::{
+    connect, install_registry, memory_pool, recv, roster, spawn_server, TEST_SCENARIO_ID,
+};
+use game_core::scenario::ScenarioId;
+use protocol::ServerMessage;
+use server::GameSession;
+
+#[tokio::test]
+async fn hello_carries_setup_events_after_reload_from_db() {
+    install_registry();
+    let pool = memory_pool().await;
+    // Create + persist a game (as `POST /games` does), then spin a server that
+    // serves it purely from the DB — proving the events come from the persisted
+    // column, not a retained in-memory session.
+    GameSession::create(
+        pool.clone(),
+        "g-setup-events",
+        ScenarioId::new(TEST_SCENARIO_ID),
+        roster(),
+    )
+    .await
+    .expect("seed game");
+    let addr = spawn_server(pool).await;
+
+    let mut c = connect(addr, "g-setup-events").await;
+    match recv(&mut c).await {
+        ServerMessage::Hello { events, .. } => {
+            assert!(
+                !events.is_empty(),
+                "the reconnect Hello must carry the persisted setup events; \
+                 got an empty list (setup events were dropped on reload)",
+            );
+            // ScenarioStarted is always emitted at setup, so it must be present.
+            assert!(
+                events
+                    .iter()
+                    .any(|e| matches!(e, game_core::Event::ScenarioStarted)),
+                "setup events should include ScenarioStarted; got {events:?}",
+            );
+        }
+        other => panic!("expected Hello, got {other:?}"),
+    }
+}

--- a/crates/server/tests/ws.rs
+++ b/crates/server/tests/ws.rs
@@ -32,7 +32,7 @@ async fn connect_receives_hello_with_current_state() {
     let mut ws = connect(addr, "g-hello").await;
 
     match recv(&mut ws).await {
-        ServerMessage::Hello { state, outcome } => {
+        ServerMessage::Hello { state, outcome, .. } => {
             // create seats the roster: round is 1, mulligan is pending.
             assert_eq!(state.round, 1);
             assert!(

--- a/crates/web/src/store.rs
+++ b/crates/web/src/store.rs
@@ -61,7 +61,11 @@ pub struct ClientState {
 /// `game`/`outcome` unchanged (the rejection was sender-only).
 pub fn reduce(state: &mut ClientState, msg: ServerMessage) {
     match msg {
-        ServerMessage::Hello { state: s, outcome } => {
+        ServerMessage::Hello {
+            state: s,
+            outcome,
+            events,
+        } => {
             state.game = Some(*s);
             state.outcome = Some(outcome);
             state.last_rejection = None;
@@ -69,6 +73,12 @@ pub fn reduce(state: &mut ClientState, msg: ServerMessage) {
             state.last_skill_test_difficulty = None;
             state.log = Vec::new();
             state.pending_label = None;
+            if !events.is_empty() {
+                state.log.push(LogBatch {
+                    header: "Setup".to_string(),
+                    events,
+                });
+            }
         }
         ServerMessage::Applied {
             state: s,
@@ -151,6 +161,7 @@ mod tests {
             ServerMessage::Hello {
                 state: Box::new(sample_state()),
                 outcome: EngineOutcome::Done,
+                events: Vec::new(),
             },
         );
         assert!(s.game.is_some());
@@ -214,6 +225,7 @@ mod tests {
             ServerMessage::Hello {
                 state: Box::new(sample_state()),
                 outcome: EngineOutcome::Done,
+                events: Vec::new(),
             },
         );
         assert!(
@@ -329,9 +341,61 @@ mod tests {
             ServerMessage::Hello {
                 state: Box::new(sample_state()),
                 outcome: EngineOutcome::Done,
+                events: Vec::new(),
             },
         );
         assert!(s.log.is_empty());
         assert_eq!(s.pending_label, None);
+    }
+
+    #[test]
+    fn hello_with_events_pushes_setup_batch() {
+        let mut s = ClientState::default();
+        reduce(
+            &mut s,
+            ServerMessage::Hello {
+                state: Box::new(sample_state()),
+                outcome: EngineOutcome::Done,
+                events: vec![game_core::Event::ScenarioStarted],
+            },
+        );
+        assert_eq!(s.log.len(), 1, "one Setup batch expected");
+        assert_eq!(s.log[0].header, "Setup");
+        assert_eq!(s.log[0].events, vec![game_core::Event::ScenarioStarted]);
+    }
+
+    #[test]
+    fn hello_with_empty_events_leaves_log_empty() {
+        let mut s = ClientState::default();
+        reduce(
+            &mut s,
+            ServerMessage::Hello {
+                state: Box::new(sample_state()),
+                outcome: EngineOutcome::Done,
+                events: Vec::new(),
+            },
+        );
+        assert!(s.log.is_empty(), "no setup batch when events is empty");
+    }
+
+    #[test]
+    fn hello_with_events_clears_prior_batches_first() {
+        let mut s = ClientState::default();
+        // Seed a prior action batch.
+        s.log.push(LogBatch {
+            header: "prior action".into(),
+            events: vec![game_core::Event::ScenarioStarted],
+        });
+        // Hello with setup events: prior batch gone, Setup batch present.
+        reduce(
+            &mut s,
+            ServerMessage::Hello {
+                state: Box::new(sample_state()),
+                outcome: EngineOutcome::Done,
+                events: vec![game_core::Event::ScenarioStarted],
+            },
+        );
+        assert_eq!(s.log.len(), 1, "only the Setup batch should remain");
+        assert_eq!(s.log[0].header, "Setup");
     }
 }

--- a/crates/web/tests/awaiting_input.rs
+++ b/crates/web/tests/awaiting_input.rs
@@ -53,6 +53,7 @@ async fn mount(
             ServerMessage::Hello {
                 state: Box::new(state),
                 outcome,
+                events: Vec::new(),
             },
         );
     });
@@ -303,6 +304,7 @@ async fn picking_an_option_sets_the_pending_log_header() {
             ServerMessage::Hello {
                 state: Box::new(base_game()),
                 outcome: awaiting_pick_single_input("Choose an action"),
+                events: Vec::new(),
             },
         );
     });

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -42,6 +42,7 @@ async fn render_state(state: game_core::state::GameState) -> String {
             ServerMessage::Hello {
                 state: Box::new(state),
                 outcome: EngineOutcome::Done,
+                events: Vec::new(),
             },
         );
     });

--- a/crates/web/tests/entity_names.rs
+++ b/crates/web/tests/entity_names.rs
@@ -45,6 +45,7 @@ async fn board_renders_card_and_location_names() {
             ServerMessage::Hello {
                 state: Box::new(state),
                 outcome: EngineOutcome::Done,
+                events: Vec::new(),
             },
         );
     });

--- a/crates/web/tests/input.rs
+++ b/crates/web/tests/input.rs
@@ -50,6 +50,7 @@ async fn mount(state: game_core::state::GameState) -> mpsc::UnboundedReceiver<Cl
             ServerMessage::Hello {
                 state: Box::new(state),
                 outcome: awaiting_commit_input("Commit cards for the skill test"),
+                events: Vec::new(),
             },
         );
     });

--- a/crates/web/tests/map.rs
+++ b/crates/web/tests/map.rs
@@ -30,6 +30,7 @@ async fn mount_state(state: game_core::state::GameState) {
             ServerMessage::Hello {
                 state: Box::new(state),
                 outcome: EngineOutcome::Done,
+                events: Vec::new(),
             },
         );
     });

--- a/crates/web/tests/store.rs
+++ b/crates/web/tests/store.rs
@@ -49,6 +49,7 @@ async fn hello_renders_state_present() {
             ServerMessage::Hello {
                 state: Box::new(game),
                 outcome: EngineOutcome::Done,
+                events: Vec::new(),
             },
         );
     });


### PR DESCRIPTION
## Summary

Follow-up to #505 (event log) and the verification path for #508. The event log never showed anything that happened during scenario setup — the opening draws, deck shuffles, starting-location reveal, and (now) the opening-hand weakness set-aside. This surfaces them as a `▸ Setup` batch at the top of the log.

## Why nothing showed before

Setup events are produced by `seat_and_open` at game creation, but they were dropped twice over: `GameSession::create` kept only `state`/`outcome` (discarding `result.events`), and `ServerMessage::Hello` had no `events` field while the client's log reducer *cleared* the log on `Hello`. And the live path always reloads from the DB (`create_game` doesn't retain the in-memory session), so even capturing them in memory wasn't enough.

## What changed

- **protocol**: `ServerMessage::Hello` gains `events: Vec<Event>`.
- **server**: `GameSession` carries `setup_events`; `create` captures `seat_and_open`'s events; they're **persisted** in a new `setup_events` column (migration `0003`, `DEFAULT '[]'` so pre-existing rows load empty) and **restored by `load`** — so a reloaded/reconnected session delivers them too. `ws.rs` includes them in the `Hello` baseline.
- **web store**: the `Hello` reducer clears the log, then pushes a single `Setup` `LogBatch` when events are present.

## Verified

Live: a freshly created game now opens with a `▸ Setup` batch (ScenarioStarted, opening CardsDrawn, DeckShuffled, LocationRevealed), and when Cover Up lands in the opening 5 the batch shows `WeaknessSetAside { code: "01007" }` — confirming #508 visually. A server integration test drives create → persist → reload → Hello and asserts the events (incl. ScenarioStarted) arrive over the reload path; store reducer unit tests pin the Setup-batch behavior. Full gauntlet green.

Caveat: games created before migration 0003 have no persisted setup events (column defaults to `'[]'`), so they load with an empty setup batch — only new games show it.

## Linked issues

Closes #512. (Makes #508's opening-hand set-aside observable.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)