### PR TITLE
engine: drawing a weakness from the player deck resolves its Revelation

### DIFF
--- a/crates/cards/tests/player_draw_revelation.rs
+++ b/crates/cards/tests/player_draw_revelation.rs
@@ -63,7 +63,10 @@ fn drawing_cover_up_reveals_it_into_the_threat_area() {
         .iter()
         .find(|c| c.code.as_str() == COVER_UP)
         .expect("Cover Up should be in the threat area after being drawn");
-    assert_eq!(placed.clues, 3, "Cover Up enters the threat area with 3 clues");
+    assert_eq!(
+        placed.clues, 3,
+        "Cover Up enters the threat area with 3 clues"
+    );
     assert!(
         result
             .events

--- a/crates/cards/tests/player_draw_revelation.rs
+++ b/crates/cards/tests/player_draw_revelation.rs
@@ -1,0 +1,95 @@
+//! #509: drawing a persistent treachery weakness (Cover Up 01007) from the
+//! player deck during play reveals it and resolves its Revelation — Cover Up
+//! enters the controller's threat area with 3 clues instead of staying in hand.
+
+use game_core::engine::EngineOutcome;
+use game_core::event::Event;
+use game_core::state::{CardCode, InvestigatorId, LocationId, Phase};
+use game_core::test_support::{
+    dispatch_turn_action_unchecked, test_investigator, test_location, GameStateBuilder,
+};
+use game_core::TurnAction;
+
+const COVER_UP: &str = "01007";
+const HOLY_ROSARY: &str = "01059"; // a non-weakness asset, for the negative case
+
+#[ctor::ctor(unsafe)]
+fn install_real_registry() {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+}
+
+/// Solo investigator at a revealed location, mid-Investigation, 3 actions, no
+/// enemies (so the Draw action's `AoO` loop is empty and resolves synchronously),
+/// with `deck_top` as the top card of an otherwise-filler deck.
+fn draw_state(deck_top: &str) -> (game_core::GameState, InvestigatorId) {
+    let id = InvestigatorId(1);
+    let loc = LocationId(101);
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(loc);
+    inv.actions_remaining = 3;
+    // Top of deck is drawn first (draw_cards drains from the front).
+    inv.deck = vec![
+        CardCode::new(deck_top),
+        CardCode::new(HOLY_ROSARY),
+        CardCode::new(HOLY_ROSARY),
+    ];
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(inv)
+        .with_active_investigator(id)
+        .with_location(test_location(101, "Study"))
+        .build();
+    (state, id)
+}
+
+#[test]
+fn drawing_cover_up_reveals_it_into_the_threat_area() {
+    let (state, id) = draw_state(COVER_UP);
+
+    let result = dispatch_turn_action_unchecked(state, &TurnAction::Draw { investigator: id });
+
+    assert!(
+        !matches!(result.outcome, EngineOutcome::Rejected { .. }),
+        "Draw must not be rejected; got {:?}",
+        result.outcome,
+    );
+    let inv = &result.state.investigators[&id];
+    assert!(
+        !inv.hand.iter().any(|c| c.as_str() == COVER_UP),
+        "Cover Up must not stay in hand — it is revealed on draw",
+    );
+    let placed = inv
+        .threat_area
+        .iter()
+        .find(|c| c.code.as_str() == COVER_UP)
+        .expect("Cover Up should be in the threat area after being drawn");
+    assert_eq!(placed.clues, 3, "Cover Up enters the threat area with 3 clues");
+    assert!(
+        result
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::CardRevealed { code, .. } if code.as_str() == COVER_UP)),
+        "a CardRevealed event must fire for the drawn weakness",
+    );
+}
+
+#[test]
+fn drawing_a_non_weakness_leaves_it_in_hand() {
+    let (state, id) = draw_state(HOLY_ROSARY);
+
+    let result = dispatch_turn_action_unchecked(state, &TurnAction::Draw { investigator: id });
+
+    let inv = &result.state.investigators[&id];
+    assert!(
+        inv.hand.iter().any(|c| c.as_str() == HOLY_ROSARY),
+        "a normal drawn card stays in hand",
+    );
+    assert!(inv.threat_area.is_empty(), "nothing enters the threat area");
+    assert!(
+        !result
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::CardRevealed { .. })),
+        "no reveal for a non-weakness draw",
+    );
+}

--- a/crates/cards/tests/upkeep_draw_revelation.rs
+++ b/crates/cards/tests/upkeep_draw_revelation.rs
@@ -1,0 +1,107 @@
+//! #509 regression: drawing a persistent treachery weakness (Cover Up 01007)
+//! during **Upkeep step 4.4** must not panic the engine.
+//!
+//! `upkeep_resume` runs steps 4.2→4.6 synchronously, relying on the
+//! `UpkeepPhase` anchor staying on top of the continuation stack. The 4.4 draw
+//! resolving a drawn-weakness Revelation `push_effect`s onto the live stack,
+//! burying the anchor — so step 4.6's `set_upkeep_resume` used to find the
+//! pushed effect instead of the anchor and hit `unreachable!()`. The fix makes
+//! 4.4 cede to the drive loop (resume at `AfterDraw`) when it pushed.
+//!
+//! Drives a solo game via the public `EndTurn` apply path so the Investigation
+//! → Enemy → Upkeep cascade actually engages the drive loop (unlike the
+//! registry-free `upkeep_resume` unit tests, which call the helper directly and
+//! so never exercise the cede). Uses the real `cards::REGISTRY` because the
+//! synthetic Cover Up fixture has no `Trigger::Revelation` (it would push
+//! nothing and never trip the bug); only the real 01007 self-places into the
+//! threat area with 3 clues.
+
+use game_core::engine::EngineOutcome;
+use game_core::event::Event;
+use game_core::state::{CardCode, Continuation, InvestigatorId, LocationId, Phase};
+use game_core::test_support::{
+    take_turn_action, test_investigator, test_location, GameStateBuilder,
+};
+use game_core::TurnAction;
+
+const COVER_UP: &str = "01007";
+const HOLY_ROSARY: &str = "01059"; // a real non-weakness asset, deck filler
+
+#[ctor::ctor(unsafe)]
+fn install_real_registry() {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+}
+
+#[test]
+fn upkeep_draw_of_cover_up_does_not_panic_and_cedes_to_the_drive_loop() {
+    let id = InvestigatorId(1);
+    let loc = LocationId(101);
+
+    // Solo investigator mid-Investigation, no enemies (so the Enemy phase
+    // resolves quickly), with Cover Up on top of the deck so the Upkeep 4.4
+    // draw pulls it. Deck top is drawn first.
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(loc);
+    inv.actions_remaining = 3;
+    inv.deck = vec![
+        CardCode::new(COVER_UP),
+        CardCode::new(HOLY_ROSARY),
+        CardCode::new(HOLY_ROSARY),
+    ];
+
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(inv)
+        .with_active_investigator(id)
+        .with_turn_order([id])
+        .with_location(test_location(101, "Study"))
+        // Mid-Investigation invariant: EndTurn cascades through the phase anchor.
+        .with_phase_anchor(Continuation::InvestigationPhase {
+            resume: game_core::state::InvestigationResume::TurnBegins,
+        })
+        // Open-turn invariant: the InvestigatorTurn frame EndTurn pops.
+        .with_investigator_turn(id)
+        .build();
+
+    // The round-ending EndTurn cascades Investigation → Enemy → Upkeep. At
+    // step 4.4 the draw reveals Cover Up and pushes its Revelation. Before the
+    // fix this panics at `set_upkeep_resume`'s `unreachable!`; after, 4.4 cedes,
+    // the drive loop resolves the Revelation, and 4.5/4.6 run on re-exposure.
+    let result = take_turn_action(state, &TurnAction::EndTurn);
+
+    assert!(
+        !matches!(result.outcome, EngineOutcome::Rejected { .. }),
+        "EndTurn cascade must not be rejected; got {:?}",
+        result.outcome,
+    );
+
+    let inv = &result.state.investigators[&id];
+    assert!(
+        !inv.hand.iter().any(|c| c.as_str() == COVER_UP),
+        "Cover Up must not stay in hand — it is revealed on the Upkeep 4.4 draw",
+    );
+    let placed = inv
+        .threat_area
+        .iter()
+        .find(|c| c.code.as_str() == COVER_UP)
+        .expect("Cover Up should be in the threat area after the Upkeep draw resolves");
+    assert_eq!(
+        placed.clues, 3,
+        "Cover Up enters the threat area with 3 clues"
+    );
+    assert!(
+        result
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::CardRevealed { code, .. } if code.as_str() == COVER_UP)),
+        "a CardRevealed event must fire for the drawn weakness",
+    );
+
+    // Upkeep completed: the cascade advanced past 4.6 into the next round's
+    // Mythos (the single Upkeep → Mythos exit).
+    assert_eq!(
+        result.state.phase,
+        Phase::Mythos,
+        "the upkeep cascade must complete and advance to Mythos after the cede",
+    );
+}

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -4,7 +4,7 @@
 use crate::action::InputResponse;
 use crate::card_data::CardType;
 use crate::card_registry;
-use crate::dsl::Trigger;
+use crate::dsl::{Effect, Trigger};
 use crate::event::Event;
 use crate::state::{CardCode, InvestigatorId, Zone};
 
@@ -108,6 +108,82 @@ pub(super) fn replace_opening_hand_weaknesses(cx: &mut Cx, investigator: Investi
             .is_empty();
         if deck_empty {
             break;
+        }
+    }
+}
+
+/// Reveal-on-draw for a persistent treachery weakness drawn from the player
+/// deck during play (RR Weakness keyword: a drawn weakness resolves its
+/// Revelation immediately rather than staying a normal hand card). Scope:
+/// **persistent treachery weaknesses** (Cover Up 01007). Each matching card is
+/// removed from `investigator`'s hand, a [`Event::CardRevealed`] is emitted, and
+/// its `Trigger::Revelation` effects are pushed for the drive loop (Cover Up's
+/// `PutIntoThreatArea` then places it in the threat area).
+///
+/// Removal precedes the push deliberately: `PutIntoThreatArea` spawns a fresh
+/// instance by code, so a copy left in hand would duplicate the card.
+///
+/// Non-persistent treachery weaknesses and weakness enemies/assets are **left in
+/// hand untouched** — deferred to #514 (none reachable in the corpus draw path).
+/// No-op without an installed registry (registry-free engine unit tests).
+///
+/// MUST NOT be called from the setup opening-hand / mulligan path — those *set
+/// aside* weaknesses (#508), they do not resolve them.
+pub(in crate::engine) fn resolve_drawn_weaknesses(cx: &mut Cx, investigator: InvestigatorId) {
+    let Some(reg) = card_registry::current() else {
+        return;
+    };
+    // Collect indices of drawn persistent treachery weaknesses, in hand order.
+    let matches: Vec<(usize, CardCode)> = {
+        let Some(inv) = cx.state.investigators.get(&investigator) else {
+            return;
+        };
+        inv.hand
+            .iter()
+            .enumerate()
+            .filter(|(_, code)| {
+                (reg.metadata_for)(code).is_some_and(|m| {
+                    m.is_weakness() && m.card_type() == CardType::Treachery
+                }) && super::encounter::treachery_is_persistent(
+                    &(reg.abilities_for)(code).unwrap_or_default(),
+                )
+            })
+            .map(|(i, code)| (i, code.clone()))
+            .collect()
+    };
+    if matches.is_empty() {
+        return;
+    }
+    // Remove from hand high-index-to-low so earlier indices stay valid.
+    {
+        let inv = cx
+            .state
+            .investigators
+            .get_mut(&investigator)
+            .expect("resolve_drawn_weaknesses: investigator exists");
+        for &(i, _) in matches.iter().rev() {
+            inv.hand.remove(i);
+        }
+    }
+    // Reveal + push each Revelation, in original draw order.
+    for (_, code) in &matches {
+        cx.events.push(Event::CardRevealed {
+            investigator,
+            code: code.clone(),
+            card_type: CardType::Treachery,
+        });
+        let effects: Vec<Effect> = (reg.abilities_for)(code)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|a| a.trigger == Trigger::Revelation)
+            .map(|a| a.effect)
+            .collect();
+        if !effects.is_empty() {
+            push_effect(
+                cx,
+                &Effect::Seq(effects),
+                EvalContext::for_controller(investigator),
+            );
         }
     }
 }
@@ -358,6 +434,10 @@ pub(super) fn draw_one_with_deckout(cx: &mut Cx, investigator: InvestigatorId) {
     } else {
         draw_cards(cx, investigator, 1);
     }
+    // RR Weakness keyword: a weakness drawn during play reveals + resolves its
+    // Revelation (#509). Setup's opening-hand draw uses `draw_cards` directly,
+    // so it is unaffected (it sets aside instead, #508).
+    resolve_drawn_weaknesses(cx, investigator);
 }
 
 /// Handler for `TurnAction::Draw`.

--- a/crates/game-core/src/engine/dispatch/cards.rs
+++ b/crates/game-core/src/engine/dispatch/cards.rs
@@ -142,11 +142,11 @@ pub(in crate::engine) fn resolve_drawn_weaknesses(cx: &mut Cx, investigator: Inv
             .iter()
             .enumerate()
             .filter(|(_, code)| {
-                (reg.metadata_for)(code).is_some_and(|m| {
-                    m.is_weakness() && m.card_type() == CardType::Treachery
-                }) && super::encounter::treachery_is_persistent(
-                    &(reg.abilities_for)(code).unwrap_or_default(),
-                )
+                (reg.metadata_for)(code)
+                    .is_some_and(|m| m.is_weakness() && m.card_type() == CardType::Treachery)
+                    && super::encounter::treachery_is_persistent(
+                        &(reg.abilities_for)(code).unwrap_or_default(),
+                    )
             })
             .map(|(i, code)| (i, code.clone()))
             .collect()

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -99,7 +99,7 @@ pub(super) fn encounter_card_revealed(cx: &mut Cx, investigator: InvestigatorId)
 /// treacheries). Revisit with an explicit persistence marker only if a
 /// treachery must persist with no ongoing ability, or auto-discard
 /// despite carrying one.
-fn treachery_is_persistent(abilities: &[crate::dsl::Ability]) -> bool {
+pub(crate) fn treachery_is_persistent(abilities: &[crate::dsl::Ability]) -> bool {
     abilities.iter().any(|a| a.trigger != Trigger::Revelation)
 }
 

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -819,6 +819,11 @@ pub(super) fn anchor_on_child_pop(cx: &mut Cx) -> EngineOutcome {
             );
             upkeep_resume(cx)
         }
+        // A step-4.4 drawn-weakness Revelation (#509) drained, re-exposing this
+        // anchor: run 4.5 (hand size) + 4.6 (phase end + transition).
+        Some(Continuation::UpkeepPhase {
+            resume: UpkeepResume::AfterDraw,
+        }) => upkeep_after_draw(cx),
         Some(Continuation::UpkeepPhase {
             resume: UpkeepResume::AfterRoundEnd,
         }) => {
@@ -955,16 +960,35 @@ fn upkeep_phase(cx: &mut Cx) -> EngineOutcome {
     super::reaction_windows::open_fast_window(cx, FastWindowKind::Phase(PhaseStep::UpkeepBegins))
 }
 
-/// The post-4.1 window continuation. Steps 4.2–4.4 run inline as named
-/// call sites; step 4.5 ([`check_hand_size`]) may suspend with
-/// [`EngineOutcome::AwaitingInput`] when an investigator is over the hand
-/// cap — in which case `upkeep_resume` short-circuits and 4.6 runs only
-/// once the discard resolves. Otherwise it hands to [`upkeep_phase_end`]
-/// for 4.6 + transition.
+/// The post-4.1 window continuation. Steps 4.2–4.4 run inline as named call
+/// sites. The 4.4 draw may resolve a drawn-weakness Revelation (#509), which
+/// `push_effect`s onto the stack above this anchor; when that happens
+/// `upkeep_resume` cedes (resume `AfterDraw`) so the drive loop drains the
+/// Revelation, then re-runs 4.5/4.6 via [`upkeep_after_draw`] on re-exposure.
+/// Otherwise 4.5/4.6 run inline: step 4.5 ([`check_hand_size`]) may suspend
+/// with [`EngineOutcome::AwaitingInput`] when an investigator is over the hand
+/// cap — in which case 4.6 runs only once the discard resolves — else it hands
+/// to [`upkeep_phase_end`] for 4.6 + transition.
 pub(super) fn upkeep_resume(cx: &mut Cx) -> EngineOutcome {
     reset_actions(cx); // 4.2
     ready_exhausted_cards(cx); // 4.3
-    upkeep_draw_and_resource(cx); // 4.4
+    let depth = cx.state.continuations.len();
+    upkeep_draw_and_resource(cx); // 4.4 — may push a drawn-weakness Revelation (#509)
+    if cx.state.continuations.len() > depth {
+        // 4.4 pushed a drawn-weakness Revelation above the (now-buried) UpkeepPhase
+        // anchor. Cede: the drive loop resolves the Revelation, then re-exposes the
+        // anchor at AfterDraw (anchor_on_child_pop → upkeep_after_draw) for 4.5/4.6.
+        set_upkeep_resume(cx, crate::state::UpkeepResume::AfterDraw);
+        return EngineOutcome::Done;
+    }
+    upkeep_after_draw(cx) // 4.5 + 4.6 inline — common case, nothing pushed
+}
+
+/// Steps 4.5 (hand size; may suspend) + 4.6 (phase end + round-end transition).
+/// Run inline by `upkeep_resume` when 4.4 pushed nothing, or via
+/// `anchor_on_child_pop`'s `AfterDraw` arm once a 4.4 drawn-weakness Revelation
+/// has drained.
+fn upkeep_after_draw(cx: &mut Cx) -> EngineOutcome {
     if let outcome @ EngineOutcome::AwaitingInput { .. } = check_hand_size(cx) {
         return outcome; // 4.5 parked for discard; 4.6 runs on resume
     }
@@ -1004,15 +1028,22 @@ pub(crate) fn upkeep_phase_end(cx: &mut Cx) -> EngineOutcome {
     super::emit::emit_event(cx, &super::emit::TimingEvent::RoundEnded)
 }
 
-/// Set the top [`UpkeepPhase`](crate::state::Continuation::UpkeepPhase) anchor's
-/// resume cursor. The anchor is the top frame when `upkeep_phase_end` runs (the
-/// round-end coordinator is pushed *after* this call).
+/// Set the [`UpkeepPhase`](crate::state::Continuation::UpkeepPhase) anchor's
+/// resume cursor. Reverse-searches the stack (mirroring [`set_enemy_anchor`])
+/// so it is robust whether the anchor is on top (`upkeep_phase_end`'s call, made
+/// before the round-end coordinator is pushed) or buried beneath a drawn-weakness
+/// Revelation pushed by the step-4.4 draw (#509, `upkeep_resume`'s cede).
 fn set_upkeep_resume(cx: &mut Cx, resume: crate::state::UpkeepResume) {
-    match cx.state.continuations.last_mut() {
-        Some(crate::state::Continuation::UpkeepPhase { resume: slot }) => *slot = resume,
-        other => {
-            unreachable!("set_upkeep_resume: expected UpkeepPhase anchor on top, got {other:?}")
-        }
+    if let Some(c) = cx
+        .state
+        .continuations
+        .iter_mut()
+        .rev()
+        .find(|c| matches!(c, crate::state::Continuation::UpkeepPhase { .. }))
+    {
+        *c = crate::state::Continuation::UpkeepPhase { resume };
+    } else {
+        unreachable!("set_upkeep_resume: no UpkeepPhase anchor on the stack");
     }
 }
 
@@ -2249,6 +2280,12 @@ mod upkeep_phase_tests {
             .build();
         state.turn_order = vec![id];
         state.active_investigator = None;
+        // Give the investigator a card so the step-4.4 draw pulls it normally
+        // rather than decking out: since #509 routed 4.4 through
+        // `draw_one_with_deckout`, an empty deck applies the deckout horror
+        // penalty, whose capacity read requires a CardRegistry this registry-free
+        // unit test cannot install.
+        state.investigators.get_mut(&id).unwrap().deck = vec![CardCode("01000".into())];
 
         let mut events = Vec::new();
         step_phase(&mut Cx {

--- a/crates/game-core/src/engine/dispatch/phases.rs
+++ b/crates/game-core/src/engine/dispatch/phases.rs
@@ -972,6 +972,10 @@ fn upkeep_phase(cx: &mut Cx) -> EngineOutcome {
 pub(super) fn upkeep_resume(cx: &mut Cx) -> EngineOutcome {
     reset_actions(cx); // 4.2
     ready_exhausted_cards(cx); // 4.3
+                               // Sentinel for "4.4 pushed a continuation". Captured after 4.2/4.3 because
+                               // those are pure state mutations that never push — so a growth here is
+                               // attributable to the 4.4 draw (a drawn-weakness Revelation; or any future
+                               // pusher, which the cede below handles uniformly).
     let depth = cx.state.continuations.len();
     upkeep_draw_and_resource(cx); // 4.4 — may push a drawn-weakness Revelation (#509)
     if cx.state.continuations.len() > depth {

--- a/crates/game-core/src/engine/evaluator.rs
+++ b/crates/game-core/src/engine/evaluator.rs
@@ -626,6 +626,7 @@ fn draw_cards_effect(
         };
     }
     crate::engine::dispatch::cards::draw_cards(cx, target_id, count);
+    crate::engine::dispatch::cards::resolve_drawn_weaknesses(cx, target_id);
     EngineOutcome::Done
 }
 

--- a/crates/game-core/src/state/game_state.rs
+++ b/crates/game-core/src/state/game_state.rs
@@ -1003,6 +1003,10 @@ pub enum UpkeepResume {
     Entry,
     /// Post-4.1 window closed; run `upkeep_resume` (steps 4.2–4.6).
     Begins,
+    /// Steps 4.2–4.4 ran and the 4.4 draw pushed a drawn-weakness Revelation
+    /// (#509) that ceded to the drive loop. On re-exposure of the anchor, run
+    /// 4.5 (hand size) + 4.6 (phase end).
+    AfterDraw,
     /// The round-end `EmitEvent` coordinator (the `when` act advance + the `at`
     /// doom) popped; run `upkeep_round_end_teardown` (expire until-end-of-round
     /// effects, Upkeep → Mythos). Set by `upkeep_phase_end` before it cedes to

--- a/docs/superpowers/plans/2026-06-29-player-draw-revelation.md
+++ b/docs/superpowers/plans/2026-06-29-player-draw-revelation.md
@@ -1,0 +1,324 @@
+# Player-Draw Weakness Revelation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a persistent treachery weakness (Cover Up 01007) is drawn from the player deck during play, reveal it and resolve its Revelation (Cover Up → controller's threat area with 3 clues) instead of leaving it in hand.
+
+**Architecture:** A `resolve_drawn_weaknesses` helper removes a drawn persistent-treachery weakness from hand and pushes its Revelation onto the drive loop (mirroring the encounter path's `push_effect` of revelation effects). It's hooked into the two in-play draw entry points (`draw_one_with_deckout`, `draw_cards_effect`) — never the low-level `draw_cards` that setup/mulligan use (those set weaknesses aside per #508).
+
+**Tech Stack:** Rust, the game-core engine (continuation/drive-loop model), `cards`/`card-dsl` corpus. Spec: `docs/superpowers/specs/2026-06-29-player-draw-revelation-design.md` (issue #509; deferrals tracked in #514).
+
+## Global Constraints
+
+- **Scope:** persistent treachery weaknesses only (Cover Up). Non-persistent treachery, weakness enemies, and weakness assets are **deferred to #514** — leave them in hand untouched (no regression).
+- **Never resolve weaknesses on the setup/mulligan path.** The hook goes in `draw_one_with_deckout` and `draw_cards_effect` only — NOT `draw_cards` or `replace_opening_hand_weaknesses`. The #508 opening-hand tests (`crates/scenarios/tests/opening_hand_weaknesses.rs`) must still pass (setup *sets aside*, does not resolve).
+- **Remove the drawn weakness from hand BEFORE pushing its Revelation** — `Effect::PutIntoThreatArea` spawns a fresh instance by code (`evaluator.rs:479`), so a copy left in hand would duplicate Cover Up.
+- **No new randomness / `EngineRecord`.** Reuse `push_effect` + the drive loop; replay stays deterministic.
+- Match CI: `RUSTFLAGS="-D warnings" cargo test --all --all-features`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`, `cargo build -p web --target wasm32-unknown-unknown`, `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`. (No web change; the wasm-test browser job isn't required, but wasm build/clippy must pass.)
+- Commit scope: `engine:`.
+
+---
+
+### Task 1: `resolve_drawn_weaknesses` helper + draw-path hooks
+
+**Files:**
+- Modify: `crates/game-core/src/engine/dispatch/encounter.rs` (make `treachery_is_persistent` reusable)
+- Modify: `crates/game-core/src/engine/dispatch/cards.rs` (helper + `draw_one_with_deckout` hook)
+- Modify: `crates/game-core/src/engine/evaluator.rs` (`draw_cards_effect` hook)
+- Test: `crates/cards/tests/player_draw_revelation.rs` (new)
+
+**Interfaces:**
+- Consumes: `card_registry::current()` → `metadata_for` / `abilities_for`; `CardMetadata::is_weakness()`, `CardMetadata::card_type()`; `encounter::treachery_is_persistent(&[Ability]) -> bool`; `evaluator::push_effect(cx, &Effect, EvalContext)`; `EvalContext::for_controller(InvestigatorId)`; `Event::CardRevealed { investigator, code, card_type }`.
+- Produces: `cards::resolve_drawn_weaknesses(cx: &mut Cx, investigator: InvestigatorId)`.
+
+- [ ] **Step 1: Make `treachery_is_persistent` reusable**
+
+In `crates/game-core/src/engine/dispatch/encounter.rs`, change the helper's visibility from private to `pub(crate)` (signature otherwise unchanged):
+
+```rust
+pub(crate) fn treachery_is_persistent(abilities: &[crate::dsl::Ability]) -> bool {
+    abilities.iter().any(|a| a.trigger != Trigger::Revelation)
+}
+```
+
+- [ ] **Step 2: Write the failing integration test**
+
+Create `crates/cards/tests/player_draw_revelation.rs`. It seats a solo investigator with Cover Up (01007) on top of the deck, takes the basic Draw action, and asserts Cover Up was revealed into the threat area (not left in hand). Mirror the registry-install + builder patterns in `crates/cards/tests/play_card.rs` and `crates/scenarios/tests/opening_hand_weaknesses.rs`.
+
+```rust
+//! #509: drawing a persistent treachery weakness (Cover Up 01007) from the
+//! player deck during play reveals it and resolves its Revelation — Cover Up
+//! enters the controller's threat area with 3 clues instead of staying in hand.
+
+use game_core::engine::EngineOutcome;
+use game_core::event::Event;
+use game_core::state::{CardCode, InvestigatorId, LocationId, Phase};
+use game_core::test_support::{
+    dispatch_turn_action_unchecked, test_investigator, test_location, GameStateBuilder,
+};
+use game_core::TurnAction;
+
+const COVER_UP: &str = "01007";
+const HOLY_ROSARY: &str = "01059"; // a non-weakness asset, for the negative case
+
+#[ctor::ctor(unsafe)]
+fn install_real_registry() {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+}
+
+/// Solo investigator at a revealed location, mid-Investigation, 3 actions, no
+/// enemies (so the Draw action's AoO loop is empty and resolves synchronously),
+/// with `deck_top` as the top card of an otherwise-filler deck.
+fn draw_state(deck_top: &str) -> (game_core::GameState, InvestigatorId) {
+    let id = InvestigatorId(1);
+    let loc = LocationId(101);
+    let mut inv = test_investigator(1);
+    inv.current_location = Some(loc);
+    inv.actions_remaining = 3;
+    // Top of deck is drawn first (draw_cards drains from the front).
+    inv.deck = vec![
+        CardCode::new(deck_top),
+        CardCode::new(HOLY_ROSARY),
+        CardCode::new(HOLY_ROSARY),
+    ];
+    let state = GameStateBuilder::new()
+        .with_phase(Phase::Investigation)
+        .with_investigator(inv)
+        .with_active_investigator(id)
+        .with_location(test_location(101, "Study"))
+        .build();
+    (state, id)
+}
+
+#[test]
+fn drawing_cover_up_reveals_it_into_the_threat_area() {
+    let (state, id) = draw_state(COVER_UP);
+
+    let result = dispatch_turn_action_unchecked(state, &TurnAction::Draw { investigator: id });
+
+    assert!(
+        !matches!(result.outcome, EngineOutcome::Rejected { .. }),
+        "Draw must not be rejected; got {:?}",
+        result.outcome,
+    );
+    let inv = &result.state.investigators[&id];
+    assert!(
+        !inv.hand.iter().any(|c| c.as_str() == COVER_UP),
+        "Cover Up must not stay in hand — it is revealed on draw",
+    );
+    let placed = inv
+        .threat_area
+        .iter()
+        .find(|c| c.code.as_str() == COVER_UP)
+        .expect("Cover Up should be in the threat area after being drawn");
+    assert_eq!(placed.clues, 3, "Cover Up enters the threat area with 3 clues");
+    assert!(
+        result
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::CardRevealed { code, .. } if code.as_str() == COVER_UP)),
+        "a CardRevealed event must fire for the drawn weakness",
+    );
+}
+
+#[test]
+fn drawing_a_non_weakness_leaves_it_in_hand() {
+    let (state, id) = draw_state(HOLY_ROSARY);
+
+    let result = dispatch_turn_action_unchecked(state, &TurnAction::Draw { investigator: id });
+
+    let inv = &result.state.investigators[&id];
+    assert!(
+        inv.hand.iter().any(|c| c.as_str() == HOLY_ROSARY),
+        "a normal drawn card stays in hand",
+    );
+    assert!(inv.threat_area.is_empty(), "nothing enters the threat area");
+    assert!(
+        !result
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::CardRevealed { .. })),
+        "no reveal for a non-weakness draw",
+    );
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cargo test -p cards --test player_draw_revelation 2>&1 | tail -25`
+Expected: `drawing_cover_up_reveals_it_into_the_threat_area` FAILS — Cover Up is still in hand / not in the threat area (the helper doesn't exist yet). `drawing_a_non_weakness_leaves_it_in_hand` should already pass.
+
+(If the test fails to *compile* because `test_investigator`/`test_location`/`dispatch_turn_action_unchecked`/`GameStateBuilder`/`TurnAction` import paths differ, fix the `use` lines by matching `crates/cards/tests/play_card.rs` — do not change the assertions.)
+
+- [ ] **Step 4: Implement `resolve_drawn_weaknesses`**
+
+In `crates/game-core/src/engine/dispatch/cards.rs`, add the helper (place it near `replace_opening_hand_weaknesses`; reuse the existing imports — `CardCode`, `InvestigatorId`, `CardType`, `card_registry`, `Event`; add `use crate::dsl::{Effect, Trigger};` and the evaluator imports if not present):
+
+```rust
+/// Reveal-on-draw for a persistent treachery weakness drawn from the player
+/// deck during play (RR Weakness keyword: a drawn weakness resolves its
+/// Revelation immediately rather than staying a normal hand card). Scope:
+/// **persistent treachery weaknesses** (Cover Up 01007). Each matching card is
+/// removed from `investigator`'s hand, a [`Event::CardRevealed`] is emitted, and
+/// its `Trigger::Revelation` effects are pushed for the drive loop (Cover Up's
+/// `PutIntoThreatArea` then places it in the threat area).
+///
+/// Removal precedes the push deliberately: `PutIntoThreatArea` spawns a fresh
+/// instance by code, so a copy left in hand would duplicate the card.
+///
+/// Non-persistent treachery weaknesses and weakness enemies/assets are **left in
+/// hand untouched** — deferred to #514 (none reachable in the corpus draw path).
+/// No-op without an installed registry (registry-free engine unit tests).
+///
+/// MUST NOT be called from the setup opening-hand / mulligan path — those *set
+/// aside* weaknesses (#508), they do not resolve them.
+pub(super) fn resolve_drawn_weaknesses(cx: &mut Cx, investigator: InvestigatorId) {
+    let Some(reg) = card_registry::current() else {
+        return;
+    };
+    // Collect indices of drawn persistent treachery weaknesses, in hand order.
+    let matches: Vec<(usize, CardCode)> = {
+        let Some(inv) = cx.state.investigators.get(&investigator) else {
+            return;
+        };
+        inv.hand
+            .iter()
+            .enumerate()
+            .filter(|(_, code)| {
+                (reg.metadata_for)(code).is_some_and(|m| {
+                    m.is_weakness() && m.card_type() == CardType::Treachery
+                }) && super::encounter::treachery_is_persistent(
+                    &(reg.abilities_for)(code).unwrap_or_default(),
+                )
+            })
+            .map(|(i, code)| (i, code.clone()))
+            .collect()
+    };
+    if matches.is_empty() {
+        return;
+    }
+    // Remove from hand high-index-to-low so earlier indices stay valid.
+    {
+        let inv = cx
+            .state
+            .investigators
+            .get_mut(&investigator)
+            .expect("resolve_drawn_weaknesses: investigator exists");
+        for &(i, _) in matches.iter().rev() {
+            inv.hand.remove(i);
+        }
+    }
+    // Reveal + push each Revelation, in original draw order.
+    for (_, code) in &matches {
+        cx.events.push(Event::CardRevealed {
+            investigator,
+            code: code.clone(),
+            card_type: CardType::Treachery,
+        });
+        let effects: Vec<Effect> = (reg.abilities_for)(code)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|a| a.trigger == Trigger::Revelation)
+            .map(|a| a.effect)
+            .collect();
+        if !effects.is_empty() {
+            super::super::evaluator::push_effect(
+                cx,
+                &Effect::Seq(effects),
+                super::super::evaluator::EvalContext::for_controller(investigator),
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Hook the in-play draw entry points**
+
+In `crates/game-core/src/engine/dispatch/cards.rs`, at the end of `draw_one_with_deckout` (after both the `if deck_empty { … }` and `else { draw_cards(…) }` branches — i.e. as the last statement of the function body), add:
+
+```rust
+    // RR Weakness keyword: a weakness drawn during play reveals + resolves its
+    // Revelation (#509). Setup's opening-hand draw uses `draw_cards` directly,
+    // so it is unaffected (it sets aside instead, #508).
+    resolve_drawn_weaknesses(cx, investigator);
+```
+
+In `crates/game-core/src/engine/evaluator.rs`, in `draw_cards_effect`, replace the final `draw_cards` + `Done` tail:
+
+```rust
+    crate::engine::dispatch::cards::draw_cards(cx, target_id, count);
+    EngineOutcome::Done
+```
+
+with:
+
+```rust
+    crate::engine::dispatch::cards::draw_cards(cx, target_id, count);
+    crate::engine::dispatch::cards::resolve_drawn_weaknesses(cx, target_id);
+    EngineOutcome::Done
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cargo test -p cards --test player_draw_revelation 2>&1 | tail -15`
+Expected: both tests PASS.
+
+- [ ] **Step 7: Confirm no #508 regression**
+
+Run: `cargo test -p scenarios --test opening_hand_weaknesses 2>&1 | tail -8`
+Expected: all pass (setup still *sets aside* — the new hook is not on the setup draw path).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/game-core/src/engine/dispatch/encounter.rs \
+        crates/game-core/src/engine/dispatch/cards.rs \
+        crates/game-core/src/engine/evaluator.rs \
+        crates/cards/tests/player_draw_revelation.rs
+git commit -m "engine: drawing a weakness from the player deck resolves its Revelation (closes #509)"
+```
+
+---
+
+### Task 2: Full gauntlet
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full CI gauntlet**
+
+```bash
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+
+Expected: all green. Fix any clippy/fmt/doc issues with follow-up edits and re-run. In particular, watch for an unused-import warning if `cards.rs` already imported `Effect`/`Trigger` (dedupe) and confirm `treachery_is_persistent`'s new `pub(crate)` raises no dead-code/visibility lint.
+
+- [ ] **Step 2: Commit any gauntlet fixes** (only if needed)
+
+```bash
+git add -A && git commit -m "engine: player-draw revelation gauntlet fixes (#509)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Reveal persistent treachery weakness on draw → Task 1 (`resolve_drawn_weaknesses`). ✓
+- Remove-from-hand before push (no duplication) → Task 1 Step 4 (removal loop precedes the reveal/push loop). ✓
+- `push_effect` of Revelation effects via the drive loop → Task 1 Step 4. ✓
+- Reuse `treachery_is_persistent` (made `pub(crate)`) → Task 1 Step 1. ✓
+- Hook `draw_one_with_deckout` (Draw + Upkeep) and `draw_cards_effect` (DSL), never `draw_cards` → Task 1 Step 5. ✓
+- Deferred non-persistent/enemy/asset left in hand (#514) → Task 1 Step 4 (filter only matches persistent treachery weaknesses). ✓
+- Tests: Cover-Up-on-draw → threat area + 3 clues + CardRevealed; non-weakness untouched; #508 regression → Task 1 Steps 2/7. ✓
+- Determinism (no new RNG/EngineRecord) → only `push_effect` used. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. ✓
+
+**Type consistency:** `resolve_drawn_weaknesses(&mut Cx, InvestigatorId)` defined in Step 4, called identically in Step 5 and the evaluator hook. `treachery_is_persistent(&[Ability]) -> bool` reused from encounter.rs. `Event::CardRevealed { investigator, code, card_type }` matches the event def. ✓
+
+**Verification notes for the implementer:** the `super::super::evaluator::` path from `cards.rs` may differ — use whatever path resolves (`crate::engine::evaluator::push_effect` / `EvalContext` is the absolute form); the test's `use` paths may need matching to `play_card.rs`. These are mechanical, compiler-guided fixes, not design changes.

--- a/docs/superpowers/specs/2026-06-29-player-draw-revelation-design.md
+++ b/docs/superpowers/specs/2026-06-29-player-draw-revelation-design.md
@@ -1,0 +1,132 @@
+# Player-draw weakness Revelation — design
+
+**Date:** 2026-06-29
+**Issue:** [#509](https://github.com/talelburg/eldritch/issues/509) (Part 3 of [#494](https://github.com/talelburg/eldritch/issues/494))
+**Deferred follow-up:** [#514](https://github.com/talelburg/eldritch/issues/514)
+**Status:** approved (brainstorm) — pending implementation plan
+
+## Goal
+
+When a weakness is drawn from the **player deck during play**, resolve its
+Revelation immediately (RR Weakness keyword) instead of leaving it as a normal
+hand card. For Cover Up (01007) this puts it into the controller's threat area
+with 3 clues — the behavior that makes the #494 arc complete (after #508
+reshuffles it out of the opening hand, drawing it later sets it up).
+
+## Scope (settled in brainstorm)
+
+**In scope:** drawn **persistent treachery weaknesses** (Cover Up is the only
+one in the corpus). Minimal, YAGNI — no other weakness type is reachable in a
+player-draw path today.
+
+**Deferred to #514** (left in hand on draw — no regression, none reachable in
+the corpus): non-persistent treachery weaknesses (need a post-Revelation
+discard frame), weakness enemies (spawn on draw), weakness assets (enter play).
+
+## Load-bearing facts (from investigation)
+
+- **No synchronous effect-apply.** Effects resolve via `push_effect` + the
+  `drive` loop. The encounter path (`resolve_encounter_card`,
+  `crates/game-core/src/engine/dispatch/encounter.rs`) is the reference: it
+  emits `Event::CardRevealed`, collects the `Trigger::Revelation` effects, and
+  `push_effect`s them as one `Effect::Seq` with
+  `EvalContext::for_controller(investigator)`; the loop steps them (handling
+  suspension for free).
+- **`Effect::PutIntoThreatArea` spawns a fresh instance _by code_**
+  (`evaluator.rs:479` → `place_in_threat_area`). It does **not** move the drawn
+  card. So the drawn copy must be removed from hand *before* the Revelation is
+  pushed, or Cover Up duplicates (one in hand + one in the threat area).
+- **`treachery_is_persistent(&[Ability])`** already exists in `encounter.rs`
+  (private). It returns `true` when a treachery has a non-Revelation ability
+  (Cover Up has reaction + forced). It is the existing "stays in play vs.
+  auto-discard" signal and is reused here (made `pub(crate)`).
+- **Setup vs. play distinction.** The setup opening-hand draw (#508) *sets
+  weaknesses aside* (RR step 8), it does NOT resolve them. So the reveal hook
+  must live on the in-play draw entries, never on the shared low-level
+  `draw_cards` (which setup and mulligan call directly).
+
+## Architecture / components
+
+### 1. `resolve_drawn_weaknesses(cx, investigator)` — `crates/game-core/src/engine/dispatch/cards.rs`
+
+The new helper. After a play-time draw lands cards in hand:
+
+1. If no registry is installed, no-op (registry-free engine unit tests
+   unchanged).
+2. Scan the hand for codes that are **weakness** (`CardMetadata::is_weakness()`)
+   **and** treachery (`card_type() == CardType::Treachery`) **and** persistent
+   (`treachery_is_persistent(&abilities_for(code))`). Collect `(index, code)`.
+3. Remove those from hand high-index-to-low (indices stay valid), preserving
+   draw order for event emission.
+4. For each removed weakness, in draw order: emit
+   `Event::CardRevealed { investigator, code, card_type: Treachery }`; collect
+   its `Trigger::Revelation` effects; if non-empty,
+   `push_effect(cx, &Effect::Seq(effects), EvalContext::for_controller(investigator))`.
+5. Weaknesses that don't match (non-persistent / non-treachery) are **left in
+   hand untouched** — the #514 deferral.
+
+Removal (step 3) is synchronous; the pushed Revelation (step 4) resolves later
+on the drive loop — which is exactly why removal must precede the push.
+
+`treachery_is_persistent` becomes `pub(crate)` and is reused (not duplicated).
+
+### 2. Hook points
+
+- **`draw_one_with_deckout`** (`cards.rs`): call `resolve_drawn_weaknesses`
+  after the draw. This single site covers both the basic **Draw action**
+  (`draw_primary_effect`) and the **Upkeep 4.4** draw
+  (`upkeep_draw_and_resource`), which both route through it.
+- **`draw_cards_effect`** (`evaluator.rs`): call
+  `cards::resolve_drawn_weaknesses(cx, target_id)` after `draw_cards(...)`,
+  before returning `Done` — covers DSL / card draw effects.
+- **Never** `draw_cards` itself, nor `replace_opening_hand_weaknesses` — setup
+  and mulligan keep *setting aside* (#508).
+
+### Why no disposition frame
+
+The general drawn-weakness machinery (a player-weakness continuation frame
+mirroring `EncounterCard`, handling persistent vs. discard disposition) was
+considered and declined as YAGNI: the only in-scope card (Cover Up) is
+persistent and self-places via its own Revelation, so no post-Revelation
+disposal step is needed. The non-persistent path (which *would* need such a
+frame) is deferred to #514.
+
+## Data flow
+
+```
+play-time draw (Draw action / Upkeep / DSL draw effect)
+  → draw lands card(s) in hand
+  → resolve_drawn_weaknesses: persistent treachery weakness?
+      → remove from hand → CardRevealed → push_effect(Seq(revelation))
+  → drive loop resolves the Revelation (Cover Up: PutIntoThreatArea(3))
+  → Cover Up in the controller's threat area with 3 clues; not in hand
+```
+
+## Testing
+
+- **Cover Up drawn via the Draw action** (integration, with `cards::REGISTRY`):
+  deck with 01007 on top; after the Draw action resolves, Cover Up is NOT in
+  hand, IS in the controller's threat area with 3 clues, and a
+  `CardRevealed { code: "01007" }` event fired.
+- **DSL / Upkeep draw of Cover Up** reaches the same end state (cover whichever
+  of the upkeep / `DrawCards`-effect paths is cleanly drivable in a focused
+  test; both route through the two hook points).
+- **Non-weakness draw** is untouched: stays in hand, no `CardRevealed`, nothing
+  in the threat area.
+- **Regression:** the #508 opening-hand tests
+  (`crates/scenarios/tests/opening_hand_weaknesses.rs`) still pass — setup
+  *sets aside*, does NOT resolve.
+- **Gauntlet:** host test/clippy/fmt/doc + wasm build/clippy (no web change, but
+  the workspace must stay green).
+
+## Out of scope (YAGNI / deferred)
+
+- Non-persistent treachery weaknesses, weakness enemies, weakness assets on
+  draw → #514.
+- A suspending player-weakness Revelation: handled for free by the drive loop if
+  one ever exists, but none does; no special work.
+- No change to setup / mulligan (#508) or encounter-deck resolution.
+
+## Open questions
+
+None blocking.


### PR DESCRIPTION
## Summary

Part 3 (final) of #494. When a **persistent treachery weakness** (Cover Up 01007) is drawn from the player deck *during play*, it is revealed and its Revelation resolves — Cover Up enters the controller's threat area with 3 clues — instead of sitting in hand. With #507 (weakness marker), #508 (opening-hand set-aside), and #512 (setup events in the log), this completes the Cover Up arc: reshuffled out of the opening hand at setup, then set up when later drawn.

Design/plan: `docs/superpowers/specs/2026-06-29-player-draw-revelation-design.md`, `docs/superpowers/plans/2026-06-29-player-draw-revelation.md`. Deferred cases tracked in #514.

## What changed

- **`resolve_drawn_weaknesses`** (`cards.rs`): for a drawn persistent treachery weakness, remove it from hand (load-bearing — `PutIntoThreatArea` spawns by code, so a copy left in hand would duplicate), emit `CardRevealed`, and `push_effect` its Revelation onto the drive loop. Reuses `treachery_is_persistent` (now `pub(crate)`).
- **Hooks**: `draw_one_with_deckout` (Draw action + Upkeep) and `draw_cards_effect` (DSL) — never the setup/mulligan `draw_cards` (#508 sets aside there).
- **Upkeep 4.4 cede**: `upkeep_resume` runs 4.2→4.6 synchronously with the `UpkeepPhase` anchor on top, so a mid-chunk `push_effect` corrupted the stack and panicked. Fixed by ceding: if the 4.4 draw pushed a Revelation, set the anchor to a new `UpkeepResume::AfterDraw` (via a reverse-search setter) and return `Done`; the drive loop resolves the Revelation, then `anchor_on_child_pop` runs 4.5/4.6. (Caught by the whole-branch review; this is why it's worth the structured flow.)

## Scope / deferrals

Persistent treachery weaknesses only (Cover Up). Non-persistent treachery, weakness enemies/assets, and the `SearchDeck`-to-hand path are deferred to **#514** (left in hand — no panic, no regression; none reachable in the corpus draw path).

## Test notes

- `cards/tests/player_draw_revelation.rs`: Cover Up drawn via the Draw action → threat area + 3 clues + `CardRevealed`, not in hand; a non-weakness draw is untouched.
- `cards/tests/upkeep_draw_revelation.rs`: drives a solo EndTurn cascade into Upkeep 4.4 with Cover Up on top of the deck — no panic, Cover Up in the threat area, cascade reaches Mythos (the exact regression the fix addresses).
- Also de-flaked a pre-existing registry-dependent unit test (empty-deck upkeep `take_horror` capacity read) with a one-card deck.
- #508 opening-hand tests still pass (setup sets aside, does not resolve). Full host + wasm gauntlet green.

Built via the superpowers flow (brainstorm → spec → plan → subagent execution) with per-task, final whole-branch, and post-fix reviews.

## Linked issues

Closes #509. Final part of #494.

🤖 Generated with [Claude Code](https://claude.com/claude-code)