### PR TITLE
engine: discard (not reject) an enemy whose spawn location isn't in play (#517)

### DIFF
--- a/crates/cards/tests/enemy_spawn_no_location.rs
+++ b/crates/cards/tests/enemy_spawn_no_location.rs
@@ -1,0 +1,74 @@
+//! Integration (#517): an encounter enemy whose designated spawn location is
+//! not in play is placed in the encounter discard pile — the draw must NOT
+//! reject. Driven through the real `cards` registry and the full `apply` →
+//! resolve → disposal pipeline. Own process so it can install the
+//! process-global registry against the real corpus.
+//!
+//! Rules Reference p.24: "If an enemy has no legal location to spawn at (for
+//! example, if its spawn instruction directs it to a specific location that is
+//! not in play …), it does not spawn, and is discarded instead." Flesh-Eater
+//! (01118) FAQ: "If an enemy should spawn at a location that is not currently
+//! in play (i.e. while you're at the Study), place that enemy card into the
+//! encounter discard pile without any further effects."
+
+use game_core::action::EngineRecord;
+use game_core::state::{CardCode, InvestigatorId, LocationId};
+use game_core::test_support::{
+    drive, test_investigator, test_location, GameStateBuilder, ScriptedResolver,
+};
+use game_core::{Action, EngineOutcome};
+
+/// Flesh-Eater (01118) — Core enemy, "Spawn - Attic" (location 01113).
+const FLESH_EATER: &str = "01118";
+/// The Study (01111) — The Gathering's starting location.
+const STUDY: &str = "01111";
+
+#[ctor::ctor(unsafe)]
+fn install_registry() {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+}
+
+/// Reveal the top encounter card for investigator 1.
+fn reveal_top(state: game_core::GameState) -> game_core::ApplyResult {
+    drive(
+        state,
+        Action::Engine(EngineRecord::EncounterCardRevealed {
+            investigator: InvestigatorId(1),
+        }),
+        ScriptedResolver::new(),
+    )
+}
+
+#[test]
+fn enemy_with_offboard_spawn_location_is_discarded_not_rejected() {
+    // Investigator at the Study; the Attic (Flesh-Eater's spawn location) is
+    // NOT in play. Flesh-Eater on top of the encounter deck.
+    let mut study = test_location(20, "Study");
+    study.code = CardCode::new(STUDY);
+    let mut state = GameStateBuilder::new()
+        .with_investigator_at(test_investigator(1), LocationId(20))
+        .with_location(study)
+        .with_turn_order([InvestigatorId(1)])
+        .build();
+    state.encounter_deck.push_back(CardCode::new(FLESH_EATER));
+
+    let result = reveal_top(state);
+
+    assert_eq!(
+        result.outcome,
+        EngineOutcome::Done,
+        "an off-board spawn location must not reject the draw: {:?}",
+        result.outcome,
+    );
+    assert!(
+        result.state.enemies.is_empty(),
+        "the enemy does not spawn (its location is not in play)",
+    );
+    assert!(
+        result
+            .state
+            .encounter_discard
+            .contains(&CardCode::new(FLESH_EATER)),
+        "the enemy card is placed in the encounter discard pile (RR p.24)",
+    );
+}

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -277,12 +277,17 @@ pub fn resolve_encounter_card(
 ///
 /// # Validate-first contract
 ///
-/// The one precondition that can reject — spawn-location resolution —
-/// is checked before any mutation, leaving `state`/`events` unchanged
-/// on rejection. Engagement resolution never rejects: it either
-/// resolves inline or suspends (`AwaitingInput`) with the enemy already
-/// minted into `state.enemies` and `Event::EnemySpawned` pushed (the
-/// pending choice carries the rest of the work to [`resume_spawn_engage`]).
+/// Spawn-location resolution is checked before any mutation. It has three
+/// outcomes: (1) a legal location → mint + engage (below); (2) a `Specific`
+/// location not in play → the enemy does **not** spawn and its card is placed
+/// in `encounter_discard`, returning `Done` (RR p.24 / Flesh-Eater 01118 FAQ,
+/// #517) — this is the only mutating non-spawn path; (3) the default spawn with
+/// no drawing-investigator location → `Rejected` with `state`/`events`
+/// unchanged (a state-corruption invariant, not the RR "no legal location"
+/// case). Engagement resolution never rejects: it either resolves inline or
+/// suspends (`AwaitingInput`) with the enemy already minted into `state.enemies`
+/// and `Event::EnemySpawned` pushed (the pending choice carries the rest of the
+/// work to [`resume_spawn_engage`]).
 fn spawn_enemy(
     cx: &mut Cx,
     investigator: InvestigatorId,
@@ -846,7 +851,10 @@ pub(super) fn advance_encounter_draw(cx: &mut Cx) -> EngineOutcome {
 /// - `Spawn` (enemy, RR p.24 step 4): re-derive the enemy metadata from the
 ///   registry and [`spawn_enemy`] at the drawer's location. The spawn may
 ///   suspend on an engagement tie ([`EngineOutcome::AwaitingInput`]) or reject;
-///   either is returned immediately (the loop does not continue).
+///   either is returned immediately (the loop does not continue). It may also
+///   return `Done` *without* minting an enemy — a `Specific` spawn location not
+///   in play discards the card to `encounter_discard` (RR p.24, #517) — in which
+///   case the loop continues past the (already-popped) frame as usual.
 ///
 /// After disposal the frame is gone and the loop re-dispatches whatever is
 /// beneath: a [`PlayerDraw`](Continuation::PlayerDraw) frame (Mythos chain →

--- a/crates/game-core/src/engine/dispatch/encounter.rs
+++ b/crates/game-core/src/engine/dispatch/encounter.rs
@@ -301,20 +301,28 @@ fn spawn_enemy(
     let location_id = match spawn {
         Some(Spawn {
             location: SpawnLocation::Specific(loc_code),
-        }) => match cx
-            .state
-            .locations
-            .iter()
-            .find(|(_, loc)| loc.code.as_str() == loc_code.as_str())
-        {
-            Some((id, _)) => *id,
-            None => {
-                return EngineOutcome::Rejected {
-                    reason: format!("spawn_enemy: spawn location not in play (code {loc_code:?})")
-                        .into(),
-                };
+        }) => {
+            if let Some((id, _)) = cx
+                .state
+                .locations
+                .iter()
+                .find(|(_, loc)| loc.code.as_str() == loc_code.as_str())
+            {
+                *id
+            } else {
+                // Rules Reference p.24: "If an enemy has no legal location to
+                // spawn at (for example, if its spawn instruction directs it to
+                // a specific location that is not in play …), it does not spawn,
+                // and is discarded instead." Flesh-Eater 01118 FAQ: "place that
+                // enemy card into the encounter discard pile without any further
+                // effects." So the draw resolves (`Done`) rather than rejecting:
+                // the enemy never enters play and its card goes to the encounter
+                // discard. Silent, matching the treachery `Discard` disposal
+                // arm. (#517.)
+                cx.state.encounter_discard.push(code);
+                return EngineOutcome::Done;
             }
-        },
+        }
         None => match cx
             .state
             .investigators
@@ -1593,7 +1601,12 @@ mod spawn_enemy_tests {
     }
 
     #[test]
-    fn spawn_at_specific_location_rejects_when_location_not_in_play() {
+    fn spawn_at_specific_location_discards_when_location_not_in_play() {
+        // Rules Reference p.24: "If an enemy has no legal location to spawn at
+        // (for example, if its spawn instruction directs it to a specific
+        // location that is not in play …), it does not spawn, and is discarded
+        // instead." Flesh-Eater FAQ: "place that enemy card into the encounter
+        // discard pile without any further effects." So the draw does NOT reject.
         let mut state = GameStateBuilder::new()
             .with_investigator(test_investigator(1))
             .build();
@@ -1610,16 +1623,13 @@ mod spawn_enemy_tests {
             CardCode("_synth_enemy".into()),
             &metadata,
         );
-        match outcome {
-            EngineOutcome::Rejected { reason } => {
-                assert!(
-                    reason.contains("spawn location not in play"),
-                    "unexpected reason: {reason:?}",
-                );
-            }
-            other => panic!("expected Rejected, got {other:?}"),
-        }
-        assert!(state.enemies.is_empty());
+        assert_eq!(outcome, EngineOutcome::Done, "discard is not a rejection");
+        assert!(state.enemies.is_empty(), "the enemy does not spawn");
+        assert_eq!(
+            state.encounter_discard,
+            vec![CardCode("_synth_enemy".into())],
+            "the enemy card is placed in the encounter discard pile",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #517: drawing an encounter enemy whose **designated (bold) `Spawn`
location is not in play** rejected the entire encounter draw. The canonical
case is The Gathering's **Flesh-Eater** ("Spawn - Attic") or **Icy Ghoul**
("Spawn - Cellar") drawn while the investigators are still in the Study, before
the Attic/Cellar have been explored into play.

`spawn_enemy` returned `EngineOutcome::Rejected` when a `SpawnLocation::Specific`
named a location absent from `state.locations`, and the disposal loop propagated
that rejection, aborting the draw.

## Rules basis

**Rules Reference p.24** (verbatim):
> "If an enemy has no legal location to spawn at (for example, if its spawn
> instruction directs it to a specific location that is not in play, or if no
> location in play satisfies its 'spawn' instruction), it does not spawn, and is
> discarded instead."

**Flesh-Eater 01118 ArkhamDB FAQ** (verbatim):
> "If an enemy should spawn at a location that is not currently in play (i.e.
> while you're at the Study), place that enemy card into the encounter discard
> pile without any further effects."

## Fix

The `Specific`-location-not-in-play branch of `spawn_enemy` now pushes the enemy
card to `encounter_discard` and returns `Done` (no enemy minted, no engagement,
no event — silent, matching the existing treachery `Discard` disposal arm),
rather than rejecting. The card lands in the encounter discard exactly once (the
disposal loop continues on `Done` and adds no second push).

The default-spawn branch (no instruction → drawing investigator's location) is
unchanged and still rejects on a missing location — that's a state-corruption
invariant, not the RR "no legal location" case.

## Testing

- Flipped engine unit test `spawn_at_specific_location_discards_when_location_not_in_play`
  (TDD red→green): `Done`, no enemy spawned, card in `encounter_discard`.
- New integration test `crates/cards/tests/enemy_spawn_no_location.rs`: real
  Flesh-Eater (01118) drawn through the full `apply` pipeline with the Attic not
  in play → draw resolves, card discarded.
- Full local gauntlet green: fmt, clippy (host `--all-targets --all-features`),
  test (`--all --all-features`), doc, wasm-build, wasm-clippy.

Closes #517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
