### PR TITLE
web: render in-play assets as Card rectangles (display-only)

### DIFF
--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -88,7 +88,11 @@ fn investigators_panel(game: &GameState) -> impl IntoView {
             let in_play: Vec<_> = inv
                 .cards_in_play
                 .iter()
-                .map(|c| view! { <li class="card-line">{crate::names::card_name(&c.code)}</li> })
+                .cloned()
+                .map(|c| {
+                    let code = c.code.clone();
+                    view! { <crate::card::Card code=code in_play=c/> }
+                })
                 .collect();
             let threat: Vec<_> = inv
                 .threat_area
@@ -118,7 +122,7 @@ fn investigators_panel(game: &GameState) -> impl IntoView {
                     <span class="inv-clues">"clues " {inv.clues}</span>
                     <span class="inv-status">{format!("{:?}", inv.status)}</span>
                     <div class="hand"><h4>"Hand"</h4><div class="card-row">{hand}</div></div>
-                    <div class="in-play"><h4>"In play"</h4><ul>{in_play}</ul></div>
+                    <div class="in-play"><h4>"In play"</h4><div class="card-row">{in_play}</div></div>
                     <div class="threat"><h4>"Threat area"</h4><ul>{threat}{engaged}</ul></div>
                 </article>
             }

--- a/crates/web/src/card.rs
+++ b/crates/web/src/card.rs
@@ -309,11 +309,12 @@ pub fn live_state_chips(inst: &CardInPlay, kind: &CardKind) -> Vec<String> {
 /// a bare rectangle showing the raw code. Non-hand card kinds render as a
 /// generic rectangle (name/traits/text) — their detailed faces are later slices.
 /// Display-only: no click handlers.
-// Leptos components receive props by value (the macro builds a props struct); a
-// reference here would require lifetime annotations the macro can't express.
-#[allow(clippy::needless_pass_by_value)]
+// `code` and `in_play` are taken by value: Leptos `#[component]` generates a
+// props struct requiring owned fields, so a reference would need a lifetime the
+// macro can't express.
+#[allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
 #[component]
-pub fn Card(code: CardCode) -> impl IntoView {
+pub fn Card(code: CardCode, #[prop(optional)] in_play: Option<CardInPlay>) -> impl IntoView {
     let Some(meta) = game_core::card_registry::current().and_then(|r| (r.metadata_for)(&code))
     else {
         return view! {
@@ -338,6 +339,18 @@ pub fn Card(code: CardCode) -> impl IntoView {
         .weakness
         .then(|| view! { <span class="card-weakness">"Weakness"</span> });
 
+    let is_in_play = in_play.is_some();
+    let exhausted = in_play.as_ref().is_some_and(|c| c.exhausted);
+    let exhausted_badge =
+        exhausted.then(|| view! { <span class="card-exhausted">"Exhausted"</span> });
+    let live_views: Vec<_> = in_play
+        .as_ref()
+        .map(|inst| live_state_chips(inst, &meta.kind))
+        .unwrap_or_default()
+        .into_iter()
+        .map(|s| view! { <span class="chip chip--live">{s}</span> })
+        .collect();
+
     match card_face(&meta.kind) {
         Some(face) => {
             let CardFace {
@@ -347,7 +360,16 @@ pub fn Card(code: CardCode) -> impl IntoView {
                 skill_chips,
                 is_fast,
             } = face;
-            let cost_view = cost_corner.map(|c| view! { <span class="card-cost">{c}</span> });
+            let cost_view = if is_in_play {
+                None
+            } else {
+                cost_corner.map(|c| view! { <span class="card-cost">{c}</span> })
+            };
+            let root_class = if exhausted {
+                format!("card {class_css} card--exhausted")
+            } else {
+                format!("card {class_css}")
+            };
             let fast_view = is_fast.then(|| view! { <span class="card-fast">"Fast"</span> });
             let slot_views: Vec<_> = slot_chips
                 .into_iter()
@@ -366,11 +388,12 @@ pub fn Card(code: CardCode) -> impl IntoView {
                 })
                 .collect();
             view! {
-                <div class=format!("card {class_css}")>
+                <div class=root_class>
                     <div class="card-head">
                         {cost_view}
                         <span class="card-name">{name}</span>
                         {fast_view}
+                        {exhausted_badge}
                         {weakness_view}
                     </div>
                     <div class="card-traits">{traits}</div>
@@ -378,6 +401,7 @@ pub fn Card(code: CardCode) -> impl IntoView {
                     <div class="card-footer">
                         <span class="card-slots">{slot_views}</span>
                         <span class="card-skills">{skill_views}</span>
+                        <span class="card-live">{live_views}</span>
                     </div>
                 </div>
             }

--- a/crates/web/src/card.rs
+++ b/crates/web/src/card.rs
@@ -312,6 +312,9 @@ pub fn live_state_chips(inst: &CardInPlay, kind: &CardKind) -> Vec<String> {
 // `code` and `in_play` are taken by value: Leptos `#[component]` generates a
 // props struct requiring owned fields, so a reference would need a lifetime the
 // macro can't express.
+// `too_many_lines`: the component assembles many inline `view!` fragments
+// (head/traits/text/footer + the in-play overlays); splitting it would scatter
+// the markup without clarifying it.
 #[allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
 #[component]
 pub fn Card(code: CardCode, #[prop(optional)] in_play: Option<CardInPlay>) -> impl IntoView {
@@ -407,17 +410,22 @@ pub fn Card(code: CardCode, #[prop(optional)] in_play: Option<CardInPlay>) -> im
             }
             .into_any()
         }
-        None => view! {
-            <div class="card card--generic">
-                <div class="card-head">
-                    <span class="card-name">{name}</span>
-                    {weakness_view}
+        None => {
+            // In-play overlays (exhausted dim/badge, live chips) apply only to
+            // the Asset face above; only assets reach `cards_in_play` today, so a
+            // non-asset in-play card renders its plain face here.
+            view! {
+                <div class="card card--generic">
+                    <div class="card-head">
+                        <span class="card-name">{name}</span>
+                        {weakness_view}
+                    </div>
+                    <div class="card-traits">{traits}</div>
+                    <div class="card-text">{text_view}</div>
                 </div>
-                <div class="card-traits">{traits}</div>
-                <div class="card-text">{text_view}</div>
-            </div>
+            }
+            .into_any()
         }
-        .into_any(),
     }
 }
 

--- a/crates/web/src/card.rs
+++ b/crates/web/src/card.rs
@@ -4,7 +4,7 @@
 //! handlers) — interactivity is a later slice.
 
 use game_core::card_data::{CardKind, Class, SkillIcons, Slot};
-use game_core::state::CardCode;
+use game_core::state::{CardCode, CardInPlay, UseKind};
 use leptos::prelude::*;
 
 /// A parsed run of card text. `Symbol`/`Unknown` carry the bare token without
@@ -268,6 +268,38 @@ pub fn card_face(kind: &CardKind) -> Option<CardFace> {
         }),
         _ => None,
     }
+}
+
+/// Display label for a uses pool kind. `UseKind` is `#[non_exhaustive]`, so a
+/// future variant falls back to the generic `"uses"`.
+fn use_kind_label(kind: UseKind) -> &'static str {
+    match kind {
+        UseKind::Charges => "charges",
+        UseKind::Ammo => "ammo",
+        UseKind::Secrets => "secrets",
+        UseKind::Supplies => "supplies",
+        _ => "uses",
+    }
+}
+
+/// Live per-instance state of an in-play card as chip strings: uses pools first
+/// (`"2 ammo"`), then soak (`"dmg 1/2"` / `"hor 0/2"`) for an `Asset` that has
+/// that capacity. Empty for a plain asset with no uses and no soak capacity.
+#[must_use]
+pub fn live_state_chips(inst: &CardInPlay, kind: &CardKind) -> Vec<String> {
+    let mut chips = Vec::new();
+    for (use_kind, n) in &inst.uses {
+        chips.push(format!("{n} {}", use_kind_label(*use_kind)));
+    }
+    if let CardKind::Asset { health, sanity, .. } = kind {
+        if let Some(cap) = health {
+            chips.push(format!("dmg {}/{cap}", inst.accumulated_damage));
+        }
+        if let Some(cap) = sanity {
+            chips.push(format!("hor {}/{cap}", inst.accumulated_horror));
+        }
+    }
+    chips
 }
 
 /// One card rendered as a faithful mini-card rectangle, colour-coded by class.
@@ -552,5 +584,38 @@ mod tests {
             parse_card_text("a [b"),
             vec![TextSegment::Text("a [b".into())]
         );
+    }
+
+    use game_core::state::{CardInPlay as TestCardInPlay, CardInstanceId};
+
+    #[test]
+    fn live_state_chips_soak_uses_real_capacity() {
+        // Beat Cop 01018 is an ally asset with health 2 / sanity 2.
+        let meta = cards::by_code("01018").expect("Beat Cop in corpus");
+        let mut inst = TestCardInPlay::enter_play(CardCode::new("01018"), CardInstanceId(0));
+        inst.accumulated_damage = 1;
+        assert_eq!(
+            live_state_chips(&inst, &meta.kind),
+            vec!["dmg 1/2".to_string(), "hor 0/2".to_string()]
+        );
+    }
+
+    #[test]
+    fn live_state_chips_lists_uses_without_soak_for_plain_asset() {
+        // Machete 01020 is an asset with no soak capacity.
+        let meta = cards::by_code("01020").expect("Machete in corpus");
+        let mut inst = TestCardInPlay::enter_play(CardCode::new("01020"), CardInstanceId(0));
+        inst.uses.insert(game_core::state::UseKind::Ammo, 2);
+        assert_eq!(
+            live_state_chips(&inst, &meta.kind),
+            vec!["2 ammo".to_string()]
+        );
+    }
+
+    #[test]
+    fn live_state_chips_empty_for_plain_asset_no_uses() {
+        let meta = cards::by_code("01020").expect("Machete in corpus");
+        let inst = TestCardInPlay::enter_play(CardCode::new("01020"), CardInstanceId(0));
+        assert!(live_state_chips(&inst, &meta.kind).is_empty());
     }
 }

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -71,12 +71,14 @@
   padding: 0 0.4rem;
 }
 .card-name { font-weight: bold; }
-.card-fast, .card-weakness {
+.card-fast, .card-weakness, .card-exhausted {
   margin-left: auto;
   font-size: 0.7rem;
   text-transform: uppercase;
 }
 .card-weakness { color: #c0392b; }
+.card-exhausted { color: #b06f00; }
+.chip--live { background: #e3ecf5; }
 .card-traits { font-style: italic; color: #555; }
 .card-text { line-height: 1.3; color: #222; }
 .card-footer { display: flex; justify-content: space-between; gap: 0.3rem; flex-wrap: wrap; margin-top: auto; }
@@ -104,3 +106,6 @@
 .card--neutral  { border-color: #888; }
 .card--mythos   { border-color: #555; }
 .card--unknown, .card--generic { border-style: dashed; }
+/* Exhausted in-play asset: dimmed + dashed so it reads as unavailable.
+   Declared after the class palette so its border-color wins over the class hue. */
+.card--exhausted { opacity: 0.6; border-style: dashed; border-color: #aaa; }

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -3,7 +3,6 @@
 .status, .rejection { font-size: 0.85rem; color: #555; }
 .phase-bar { display: flex; gap: 1rem; font-weight: 600; padding: 0.5rem 0; border-bottom: 1px solid #ccc; }
 .game { display: flex; flex-direction: column; gap: 1rem; }
-.in-play ul { list-style: none; padding-left: 0; margin: 0; }
 .investigators { display: flex; flex-wrap: wrap; gap: 1rem; }
 .investigator { border: 1px solid #ccc; border-radius: 4px; padding: 0.5rem; display: flex; flex-direction: column; gap: 0.25rem; min-width: 16rem; }
 .investigator span { font-size: 0.9rem; }

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -145,6 +145,14 @@ async fn investigators_panel_renders_stats_and_hand() {
         html.contains("_synth_asset"),
         "in-play card missing: {html}"
     );
+    // In-play assets now render as Card rectangles in their own card-row.
+    let in_play_cards = leptos::prelude::document()
+        .query_selector_all(".in-play .card-row .card")
+        .expect("query_selector_all");
+    assert!(
+        in_play_cards.length() >= 1,
+        "in-play should render a Card: {html}"
+    );
     // Hand cards now render as Card rectangles (fallback to raw code without
     // metadata in the test registry).
     let cards = leptos::prelude::document()

--- a/crates/web/tests/card.rs
+++ b/crates/web/tests/card.rs
@@ -1,7 +1,7 @@
 //! Headless render tests for the `Card` component. wasm32-only (browser DOM).
 #![cfg(target_arch = "wasm32")]
 
-use game_core::state::CardCode;
+use game_core::state::{CardCode, CardInPlay, CardInstanceId};
 use leptos::prelude::*;
 use wasm_bindgen::JsCast as _;
 use wasm_bindgen_test::*;
@@ -73,4 +73,59 @@ async fn guardian_card_carries_class_modifier() {
 async fn unknown_code_falls_back_to_raw_code() {
     let html = mount_card("99999").await;
     assert!(html.contains("99999"), "raw code fallback missing: {html}");
+}
+
+/// Class list of the last mounted `.card` element.
+fn last_card_classes() -> String {
+    let cards = leptos::prelude::document()
+        .query_selector_all(".card")
+        .expect("query_selector_all");
+    cards
+        .item(cards.length() - 1)
+        .expect("at least one .card")
+        .dyn_into::<web_sys::Element>()
+        .expect("Element")
+        .class_name()
+}
+
+#[wasm_bindgen_test]
+async fn in_play_exhausted_asset_dims_badges_and_shows_soak() {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+    // Beat Cop 01018: ally asset, health 2 / sanity 2.
+    let mut inst = CardInPlay::enter_play(CardCode::new("01018"), CardInstanceId(0));
+    inst.exhausted = true;
+    inst.accumulated_damage = 1;
+    leptos::mount::mount_to_body(
+        move || view! { <Card code=CardCode::new("01018") in_play=inst.clone()/> },
+    );
+    leptos::task::tick().await;
+
+    assert!(
+        last_card_classes().contains("card--exhausted"),
+        "exhausted class missing"
+    );
+    let html = last_card_html();
+    assert!(
+        html.contains("Exhausted"),
+        "exhausted badge missing: {html}"
+    );
+    assert!(html.contains("dmg 1/2"), "soak chip missing: {html}");
+    assert!(
+        !html.contains("card-cost"),
+        "in-play card must not show a cost corner: {html}"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn in_play_ready_asset_is_not_dimmed() {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+    let inst = CardInPlay::enter_play(CardCode::new("01018"), CardInstanceId(0));
+    leptos::mount::mount_to_body(
+        move || view! { <Card code=CardCode::new("01018") in_play=inst.clone()/> },
+    );
+    leptos::task::tick().await;
+    assert!(
+        !last_card_classes().contains("card--exhausted"),
+        "ready card must not be dimmed"
+    );
 }

--- a/crates/web/tests/card.rs
+++ b/crates/web/tests/card.rs
@@ -128,4 +128,8 @@ async fn in_play_ready_asset_is_not_dimmed() {
         !last_card_classes().contains("card--exhausted"),
         "ready card must not be dimmed"
     );
+    assert!(
+        !last_card_html().contains("card-cost"),
+        "in-play card must not show a cost corner regardless of exhaustion"
+    );
 }

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -163,6 +163,14 @@ the now-stable set of input shapes:
   the chip→glyph seam built so it drops in without restructuring — revisit near a future
   merge. Spec/plan: `docs/superpowers/specs/2026-06-29-web-card-rendering-design.md`,
   `docs/superpowers/plans/2026-06-29-web-card-rendering-hand.md`.
+  - **Slice 2 — in-play assets (#521, PR #522).** `Card` gained an optional
+    `in_play: Option<CardInPlay>` prop (extend, don't fork): the printed face minus the
+    cost corner, plus live per-instance state — exhausted (`card--exhausted` dim + badge),
+    uses chips, and soak chips (`dmg`/`hor` vs the asset's health/sanity) built by a pure
+    `live_state_chips`. The board's in-play list is now a `.card-row` of `Card`s. Still
+    display-only; threat area, the spatial map (locations/enemies), and act/agenda remain
+    later slices. Spec/plan: `docs/superpowers/specs/2026-06-30-in-play-card-rendering-design.md`,
+    `docs/superpowers/plans/2026-06-30-in-play-card-rendering.md`.
 
 **Deferred past the gate:** #353 (uses-depletion — no Gathering card; gated on
 Forbidden Knowledge / Grotesque Statue), #294 (multi-soak-window drain —

--- a/docs/superpowers/plans/2026-06-30-in-play-card-rendering.md
+++ b/docs/superpowers/plans/2026-06-30-in-play-card-rendering.md
@@ -1,0 +1,494 @@
+# In-Play Card Rendering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render in-play assets as `Card` rectangles showing their printed face (minus the cost corner) plus live per-instance state — exhausted (dim + badge), uses chips, and soak chips — by extending the existing `Card` component with an optional `in_play` prop.
+
+**Architecture:** Add a pure `live_state_chips` helper (uses + soak strings from a `CardInPlay` instance against the asset's capacity), give `Card` an optional `in_play: Option<CardInPlay>` prop that drops the cost corner and adds the exhausted styling/badge + live chips when present, and swap the board's in-play `<ul>` text list for a `.card-row` of `Card`s. Hand cards (the `None` path) are unchanged.
+
+**Tech Stack:** Rust, Leptos (CSR), Trunk, `wasm-bindgen-test` (headless Firefox), the engine's `card_registry` + `cards::by_code` for metadata.
+
+## Global Constraints
+
+- **Warnings are errors in CI** across seven jobs (native + wasm). Before pushing, match: `RUSTFLAGS="-D warnings" cargo test --all --all-features`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo fmt --check`; `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`; `cargo build -p web --target wasm32-unknown-unknown`; `wasm-pack test --headless --firefox crates/web`; `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`.
+- **Clippy `pedantic` is on** (`module_name_repetitions` / `must_use_candidate` allowed); `doc_markdown` enforced — backtick-quote type names / `ArkhamDB` in doc comments.
+- **wasm-only test files** carry crate-level `#![cfg(target_arch = "wasm32")]`.
+- **Headless tests share one browser page** (DOM accumulates); scope presence/absence assertions to the last mounted subtree / a specific container.
+- **`UseKind` and `CardInPlay` are `#[non_exhaustive]`** — match `UseKind` with a `_ =>` arm; construct `CardInPlay` via `CardInPlay::enter_play(code, id)` then mutate public fields (never a struct literal).
+- **Card stats come only from the corpus / instance** — never hand-typed. Verified codes: Beat Cop `01018` (Asset, `health: 2`, `sanity: 2`), Machete `01020` (Asset, no soak capacity).
+- **Display-only:** no click handlers / no `OutboundTx`.
+
+## File structure
+
+- **Modify `crates/web/src/card.rs`** — add `live_state_chips` + `use_kind_label` (pure) with native tests; add the `in_play` prop + overlay rendering to the `Card` component.
+- **Modify `crates/web/style.css`** — `.card--exhausted` dim, the `.card-exhausted` badge, optional `.chip--live` tint; (Task 3) remove the dead `.in-play ul` rule.
+- **Modify `crates/web/tests/card.rs`** — headless tests for the in-play overlay.
+- **Modify `crates/web/src/board.rs`** — in-play list renders `<Card>`s.
+- **Modify `crates/web/tests/board.rs`** — assert the in-play section renders `.card-row .card`.
+
+Type/path notes (verified):
+- `use game_core::state::{CardCode, CardInPlay, CardInstanceId, UseKind};` — all re-exported from `game_core::state`.
+- `CardInPlay` public fields used: `exhausted: bool`, `uses: BTreeMap<UseKind, u8>`, `accumulated_damage: u8`, `accumulated_horror: u8`, `code: CardCode`.
+- Soak capacity: `CardKind::Asset { health: Option<u8>, sanity: Option<u8>, .. }`.
+- `cards::by_code(code: &str) -> Option<&'static CardMetadata>` — direct corpus lookup, no registry install needed (native-test friendly).
+- The `Card` component currently is `#[allow(clippy::needless_pass_by_value)] #[component] pub fn Card(code: CardCode) -> impl IntoView` at `card.rs:282`; its `Some(face)` arm builds `cost_view`/`fast_view`/`slot_views`/`skill_views` and the `<div class="card-head">` / `<div class="card-footer">`.
+
+---
+
+### Task 1: `live_state_chips` pure helper
+
+The uses + soak chip strings for an in-play instance. Pure, native-testable.
+
+**Files:**
+- Modify: `crates/web/src/card.rs`
+
+**Interfaces:**
+- Consumes: `CardKind` (already imported), `CardInPlay`, `UseKind` (new imports).
+- Produces:
+  - `pub fn live_state_chips(inst: &CardInPlay, kind: &CardKind) -> Vec<String>` — uses chips first (`"{n} {kind}"`), then soak chips (`"dmg {dmg}/{cap}"`, `"hor {hor}/{cap}"`) only for an `Asset` with that capacity. `[]` for a plain asset.
+  - private `use_kind_label(kind: UseKind) -> &'static str`.
+
+- [ ] **Step 1: Extend the imports**
+
+In `crates/web/src/card.rs`, change line 7 from:
+
+```rust
+use game_core::state::CardCode;
+```
+
+to:
+
+```rust
+use game_core::state::{CardCode, CardInPlay, UseKind};
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to the `#[cfg(test)] mod tests` block in `crates/web/src/card.rs`:
+
+```rust
+    use game_core::state::{CardInPlay as TestCardInPlay, CardInstanceId};
+
+    #[test]
+    fn live_state_chips_soak_uses_real_capacity() {
+        // Beat Cop 01018 is an ally asset with health 2 / sanity 2.
+        let meta = cards::by_code("01018").expect("Beat Cop in corpus");
+        let mut inst = TestCardInPlay::enter_play(CardCode::new("01018"), CardInstanceId(0));
+        inst.accumulated_damage = 1;
+        assert_eq!(
+            live_state_chips(&inst, &meta.kind),
+            vec!["dmg 1/2".to_string(), "hor 0/2".to_string()]
+        );
+    }
+
+    #[test]
+    fn live_state_chips_lists_uses_without_soak_for_plain_asset() {
+        // Machete 01020 is an asset with no soak capacity.
+        let meta = cards::by_code("01020").expect("Machete in corpus");
+        let mut inst = TestCardInPlay::enter_play(CardCode::new("01020"), CardInstanceId(0));
+        inst.uses.insert(game_core::state::UseKind::Ammo, 2);
+        assert_eq!(live_state_chips(&inst, &meta.kind), vec!["2 ammo".to_string()]);
+    }
+
+    #[test]
+    fn live_state_chips_empty_for_plain_asset_no_uses() {
+        let meta = cards::by_code("01020").expect("Machete in corpus");
+        let inst = TestCardInPlay::enter_play(CardCode::new("01020"), CardInstanceId(0));
+        assert!(live_state_chips(&inst, &meta.kind).is_empty());
+    }
+```
+
+> `CardInPlay` is imported at file scope (Step 1) but the test module re-imports it as `TestCardInPlay` plus `CardInstanceId` to keep the test self-contained; `cards::by_code` is the corpus crate, available in tests.
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `cargo test -p web card::tests::live_state`
+Expected: FAIL — `live_state_chips` not found.
+
+- [ ] **Step 4: Implement the helper**
+
+Add to `crates/web/src/card.rs` (above the `#[cfg(test)]` module; e.g. right after `card_face`):
+
+```rust
+/// Display label for a uses pool kind. `UseKind` is `#[non_exhaustive]`, so a
+/// future variant falls back to the generic `"uses"`.
+fn use_kind_label(kind: UseKind) -> &'static str {
+    match kind {
+        UseKind::Charges => "charges",
+        UseKind::Ammo => "ammo",
+        UseKind::Secrets => "secrets",
+        UseKind::Supplies => "supplies",
+        _ => "uses",
+    }
+}
+
+/// Live per-instance state of an in-play card as chip strings: uses pools first
+/// (`"2 ammo"`), then soak (`"dmg 1/2"` / `"hor 0/2"`) for an `Asset` that has
+/// that capacity. Empty for a plain asset with no uses and no soak capacity.
+#[must_use]
+pub fn live_state_chips(inst: &CardInPlay, kind: &CardKind) -> Vec<String> {
+    let mut chips = Vec::new();
+    for (use_kind, n) in &inst.uses {
+        chips.push(format!("{n} {}", use_kind_label(*use_kind)));
+    }
+    if let CardKind::Asset { health, sanity, .. } = kind {
+        if let Some(cap) = health {
+            chips.push(format!("dmg {}/{cap}", inst.accumulated_damage));
+        }
+        if let Some(cap) = sanity {
+            chips.push(format!("hor {}/{cap}", inst.accumulated_horror));
+        }
+    }
+    chips
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test -p web card::tests`
+Expected: PASS (the three new tests + all prior card tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/web/src/card.rs
+git commit -m "web: live_state_chips helper for in-play uses + soak
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01W8C6W8YhY8Lvo6aoKVDmcM"
+```
+
+---
+
+### Task 2: `in_play` prop + overlay rendering on `Card`
+
+Add the optional prop; when present, drop the cost corner, dim + badge an exhausted card, and append the live chips. Plus the CSS. Verified by a headless wasm test.
+
+**Files:**
+- Modify: `crates/web/src/card.rs` (the `Card` component, `card.rs:282`)
+- Modify: `crates/web/style.css`
+- Modify: `crates/web/tests/card.rs`
+
+**Interfaces:**
+- Consumes: `live_state_chips` (Task 1).
+- Produces: `Card` now accepts `#[prop(optional)] in_play: Option<CardInPlay>`. Renders `card--exhausted` on the root + an `Exhausted` badge when the instance is exhausted; omits `.card-cost`; appends `.chip chip--live` chips to the footer.
+
+- [ ] **Step 1: Write the failing headless tests**
+
+Add to `crates/web/tests/card.rs`. First extend its imports — change `use game_core::state::CardCode;` to:
+
+```rust
+use game_core::state::{CardCode, CardInPlay, CardInstanceId};
+```
+
+Then add these tests (alongside the existing ones):
+
+```rust
+/// Class list of the last mounted `.card` element.
+fn last_card_classes() -> String {
+    let cards = leptos::prelude::document()
+        .query_selector_all(".card")
+        .expect("query_selector_all");
+    cards
+        .item(cards.length() - 1)
+        .expect("at least one .card")
+        .dyn_into::<web_sys::Element>()
+        .expect("Element")
+        .class_name()
+}
+
+#[wasm_bindgen_test]
+async fn in_play_exhausted_asset_dims_badges_and_shows_soak() {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+    // Beat Cop 01018: ally asset, health 2 / sanity 2.
+    let mut inst = CardInPlay::enter_play(CardCode::new("01018"), CardInstanceId(0));
+    inst.exhausted = true;
+    inst.accumulated_damage = 1;
+    leptos::mount::mount_to_body(move || view! { <Card code=CardCode::new("01018") in_play=inst.clone()/> });
+    leptos::task::tick().await;
+
+    assert!(last_card_classes().contains("card--exhausted"), "exhausted class missing");
+    let html = last_card_html();
+    assert!(html.contains("Exhausted"), "exhausted badge missing: {html}");
+    assert!(html.contains("dmg 1/2"), "soak chip missing: {html}");
+    assert!(!html.contains("card-cost"), "in-play card must not show a cost corner: {html}");
+}
+
+#[wasm_bindgen_test]
+async fn in_play_ready_asset_is_not_dimmed() {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+    let inst = CardInPlay::enter_play(CardCode::new("01018"), CardInstanceId(0));
+    leptos::mount::mount_to_body(move || view! { <Card code=CardCode::new("01018") in_play=inst.clone()/> });
+    leptos::task::tick().await;
+    assert!(!last_card_classes().contains("card--exhausted"), "ready card must not be dimmed");
+}
+```
+
+> `last_card_html` already exists in this file (from the hand slice). `dyn_into` needs `wasm_bindgen::JsCast`, already imported as `use wasm_bindgen::JsCast as _;`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `wasm-pack test --headless --firefox crates/web -- card`
+Expected: FAIL — `Card` has no `in_play` prop (compile error).
+
+- [ ] **Step 3: Add the prop and compute the in-play locals**
+
+In `crates/web/src/card.rs`, update the component signature and add the in-play locals. Change the `#[allow]` comment + signature at `card.rs:282`:
+
+```rust
+// `code` and `in_play` are taken by value: Leptos `#[component]` generates a
+// props struct requiring owned fields, so a reference would need a lifetime the
+// macro can't express.
+#[allow(clippy::needless_pass_by_value)]
+#[component]
+pub fn Card(code: CardCode, #[prop(optional)] in_play: Option<CardInPlay>) -> impl IntoView {
+```
+
+Then, immediately after the `weakness_view` binding (currently ending at `card.rs:307`) and before `match card_face(&meta.kind) {`, insert:
+
+```rust
+    let is_in_play = in_play.is_some();
+    let exhausted = in_play.as_ref().is_some_and(|c| c.exhausted);
+    let exhausted_badge =
+        exhausted.then(|| view! { <span class="card-exhausted">"Exhausted"</span> });
+    let live_views: Vec<_> = in_play
+        .as_ref()
+        .map(|inst| live_state_chips(inst, &meta.kind))
+        .unwrap_or_default()
+        .into_iter()
+        .map(|s| view! { <span class="chip chip--live">{s}</span> })
+        .collect();
+```
+
+- [ ] **Step 4: Wire the locals into the `Some(face)` arm**
+
+In the `Some(face)` arm, replace the `cost_view` binding:
+
+```rust
+            let cost_view = cost_corner.map(|c| view! { <span class="card-cost">{c}</span> });
+```
+
+with (cost corner suppressed in play):
+
+```rust
+            let cost_view = if is_in_play {
+                None
+            } else {
+                cost_corner.map(|c| view! { <span class="card-cost">{c}</span> })
+            };
+            let root_class = if exhausted {
+                format!("card {class_css} card--exhausted")
+            } else {
+                format!("card {class_css}")
+            };
+```
+
+Then change the arm's opening `<div class=format!("card {class_css}")>` to `<div class=root_class>`, add `{exhausted_badge}` to the header after `{fast_view}`, and add the live chips to the footer. The arm's `view!` becomes:
+
+```rust
+            view! {
+                <div class=root_class>
+                    <div class="card-head">
+                        {cost_view}
+                        <span class="card-name">{name}</span>
+                        {fast_view}
+                        {exhausted_badge}
+                        {weakness_view}
+                    </div>
+                    <div class="card-traits">{traits}</div>
+                    <div class="card-text">{text_view}</div>
+                    <div class="card-footer">
+                        <span class="card-slots">{slot_views}</span>
+                        <span class="card-skills">{skill_views}</span>
+                        <span class="card-live">{live_views}</span>
+                    </div>
+                </div>
+            }
+            .into_any()
+```
+
+> The `None` (generic / non-Asset) arm is unchanged: in-play assets are always `CardKind::Asset`, so the overlay path lives only in the `Some(face)` arm. `exhausted_badge` / `live_views` are consumed only there; the compiler does not warn (they are used in one match arm).
+
+- [ ] **Step 5: Add the CSS**
+
+In `crates/web/style.css`: add `.card-exhausted` to the header-marker selector. Change:
+
+```css
+.card-fast, .card-weakness {
+```
+
+to:
+
+```css
+.card-fast, .card-weakness, .card-exhausted {
+```
+
+Then, after the `.card-weakness { color: #c0392b; }` line, add:
+
+```css
+.card-exhausted { color: #b06f00; }
+.chip--live { background: #e3ecf5; }
+```
+
+And after the class-palette block (after the `.card--unknown, .card--generic { ... }` line), add:
+
+```css
+/* Exhausted in-play asset: dimmed + dashed so it reads as unavailable.
+   Declared after the class palette so its border-color wins over the class hue. */
+.card--exhausted { opacity: 0.6; border-style: dashed; border-color: #aaa; }
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `wasm-pack test --headless --firefox crates/web -- card`
+Expected: PASS (the two new in-play tests + the existing card tests). Confirm native still builds: `cargo test -p web card::tests` (PASS).
+
+- [ ] **Step 7: Verify clippy (both targets) + build**
+
+Run: `cargo clippy -p web --all-targets --all-features -- -D warnings` and `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings` and `cargo fmt --check` and `cd crates/web && trunk build`.
+Expected: all clean / builds.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/web/src/card.rs crates/web/style.css crates/web/tests/card.rs
+git commit -m "web: in_play prop on Card — exhausted dim/badge, uses + soak chips
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01W8C6W8YhY8Lvo6aoKVDmcM"
+```
+
+---
+
+### Task 3: Render the in-play list as cards
+
+Swap the board's in-play `<ul>` text list for a `.card-row` of `Card`s carrying the instance; clean up the dead CSS rule.
+
+**Files:**
+- Modify: `crates/web/src/board.rs` (the in-play builder + container, `board.rs:88-91` and `:121`)
+- Modify: `crates/web/style.css`
+- Modify: `crates/web/tests/board.rs`
+
+**Interfaces:**
+- Consumes: the `in_play` prop on `Card` (Task 2).
+
+- [ ] **Step 1: Update the board test to expect in-play cards**
+
+In `crates/web/tests/board.rs`, in `investigators_panel_renders_stats_and_hand`, add after the existing in-play assertions (which check `"In play"` and `_synth_asset`):
+
+```rust
+    // In-play assets now render as Card rectangles in their own card-row.
+    let in_play_cards = leptos::prelude::document()
+        .query_selector_all(".in-play .card-row .card")
+        .expect("query_selector_all");
+    assert!(in_play_cards.length() >= 1, "in-play should render a Card: {html}");
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `wasm-pack test --headless --firefox crates/web -- board`
+Expected: FAIL — the in-play section still renders `<li>` text, no `.card-row .card` under `.in-play`.
+
+- [ ] **Step 3: Render in-play as a card row in `board.rs`**
+
+In `crates/web/src/board.rs`, replace the `in_play` builder (currently maps each card to `<li class="card-line">{card_name}</li>`):
+
+```rust
+            let in_play: Vec<_> = inv
+                .cards_in_play
+                .iter()
+                .map(|c| view! { <li class="card-line">{crate::names::card_name(&c.code)}</li> })
+                .collect();
+```
+
+with:
+
+```rust
+            let in_play: Vec<_> = inv
+                .cards_in_play
+                .iter()
+                .cloned()
+                .map(|c| {
+                    let code = c.code.clone();
+                    view! { <crate::card::Card code=code in_play=c/> }
+                })
+                .collect();
+```
+
+Then change the in-play container line from:
+
+```rust
+                    <div class="in-play"><h4>"In play"</h4><ul>{in_play}</ul></div>
+```
+
+to:
+
+```rust
+                    <div class="in-play"><h4>"In play"</h4><div class="card-row">{in_play}</div></div>
+```
+
+Leave the `threat` builder and its `<ul>` unchanged.
+
+- [ ] **Step 4: Remove the now-dead `.in-play ul` CSS rule**
+
+In `crates/web/style.css`, delete the line:
+
+```css
+.in-play ul { list-style: none; padding-left: 0; margin: 0; }
+```
+
+(The `.threat ul { ... }` rule is separate and stays.)
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `wasm-pack test --headless --firefox crates/web -- board`
+Expected: PASS (all board tests, including the new in-play `.card-row .card` check).
+
+- [ ] **Step 6: Verify build + clippy**
+
+Run: `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings` and `cargo fmt --check` and `cd crates/web && trunk build`.
+Expected: clean / builds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/web/src/board.rs crates/web/style.css crates/web/tests/board.rs
+git commit -m "web: render in-play assets as Card rectangles
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01W8C6W8YhY8Lvo6aoKVDmcM"
+```
+
+---
+
+### Task 4: Full CI gauntlet + phase doc + PR
+
+- [ ] **Step 1: Run every CI job locally**
+
+```bash
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+wasm-pack test --headless --firefox crates/web
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+
+Expected: all green. Fix any clippy/doc findings (wasm-clippy is the one that sees the new component code).
+
+- [ ] **Step 2: Update the phase-7 doc — only when the PR is ready**
+
+Per the repo convention, the `docs/phases/phase-7-the-gathering.md` update is the **final** commit. Extend the visual-card-rendering bullet (added by the hand slice in the browser-capstone section) to note that **in-play assets** now also render as `Card` rectangles (printed face minus cost corner, plus exhausted dim/badge and uses/soak chips), and that threat-area / locations / enemies / act-agenda remain later slices. Reference the new spec/plan. Keep it to load-bearing residue.
+
+- [ ] **Step 3: Open the PR**
+
+Branch is `web/in-play-cards`. File an issue first (issue-first convention), push, and open the PR with `gh pr create`; `Closes` the issue. Design-decisions paragraph: extend `Card` with an optional `in_play` prop (no parallel component); cost corner dropped in play; exhausted = dim + badge; uses/soak as footer chips reusing `.chip`.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** `Card` optional `in_play` prop (Task 2) ✓; cost corner dropped in play (Task 2 Step 4) ✓; exhausted dim + badge (Task 2) ✓; uses chips + soak chips with capacity (Task 1 `live_state_chips`) ✓; `live_state_chips` pure + native-tested (Task 1) ✓; board in-play → `.card-row` of `Card`s (Task 3) ✓; dead `.in-play ul` cleanup (Task 3 Step 4) ✓; hand path unchanged (`None` path untouched) ✓; threat/locations/enemies/act-agenda out of scope ✓; native + headless tests ✓.
+- **Type consistency:** `live_state_chips(&CardInPlay, &CardKind) -> Vec<String>` defined in Task 1, consumed in Task 2 Step 3. `in_play: Option<CardInPlay>` prop name matches between the signature (Task 2 Step 3) and the call site (`in_play=c`, Task 3 Step 3). `use_kind_label` covers all four `UseKind` variants + `_`. Test construction uses `enter_play` + field mutation (both `#[non_exhaustive]`).
+- **Out of scope (unchanged):** threat-area cards, the spatial map (locations/enemies), act/agenda, clickable cards, the icon font, attached cards.

--- a/docs/superpowers/specs/2026-06-30-in-play-card-rendering-design.md
+++ b/docs/superpowers/specs/2026-06-30-in-play-card-rendering-design.md
@@ -1,0 +1,129 @@
+# In-play card rendering — design
+
+**Date:** 2026-06-30
+**Status:** approved (brainstorm), pending implementation plan
+**Phase:** 7 (web iteration); second slice of the zone-by-zone card-rendering rework
+
+## Goal
+
+Render **in-play assets** as card rectangles that show the asset's printed face
+*plus* its live per-instance state — exhausted/ready, uses remaining, and
+soak (damage/horror accumulated on the card). Display-only.
+
+This is the second slice of the card-rendering rework. The first slice
+([#519 / PR #520](2026-06-29-web-card-rendering-design.md)) shipped the reusable
+`Card` component for **hand** cards. This slice extends that component with an
+optional in-play overlay and applies it to the in-play asset list. Threat area,
+locations, enemies, and act/agenda remain later slices.
+
+## Scope decisions
+
+- **Display-only.** No click handlers; actions still flow through the existing
+  controls/pickers (consistent with the hand slice).
+- **In-play assets only.** `Investigator.cards_in_play`. Threat area
+  (treacheries + engaged enemies), the spatial map (locations/enemies), and
+  act/agenda are out of scope — each is its own later slice.
+- **Extend, don't fork.** An in-play asset is the same Asset face the `Card`
+  component already renders, plus live state. So `Card` gains an optional
+  per-instance prop rather than spawning a parallel component.
+- **Cost corner dropped for in-play.** A card in play has already been paid for,
+  so the cost corner is omitted; the header space holds the exhausted badge.
+
+## Architecture
+
+### `Card` gains an optional in-play prop (`crates/web/src/card.rs`)
+
+- New prop: `#[prop(optional)] in_play: Option<CardInPlay>`.
+- **`None`** (hand path): unchanged from the first slice — cost corner, name,
+  traits, text, slots, skill icons, fast/weakness markers.
+- **`Some(inst)`** (in-play path): same printed face **minus the cost corner**,
+  **plus**:
+  - a `card--exhausted` class on the root (dimmed appearance) and an
+    `EXHAUSTED` badge in the header marker slot, when `inst.exhausted`;
+  - live-state footer chips (uses + soak), after the skill icons.
+
+`CardInPlay` is `Clone`; the in-play call passes `code=c.code.clone()
+in_play=c.clone()`. `code` stays required (the component is "a card identified by
+code, optionally with in-play state"); the hand call site is untouched.
+
+### New pure helper `live_state_chips` (`crates/web/src/card.rs`)
+
+```
+pub fn live_state_chips(inst: &CardInPlay, kind: &CardKind) -> Vec<String>
+```
+
+- **Uses:** one chip per `(UseKind, u8)` in `inst.uses`, formatted
+  `"{count} {kind}"` with `kind` lowercased — `"2 ammo"`, `"3 supplies"`,
+  `"1 charges"`, `"0 secrets"`. A `0` count still renders (depletion is visible).
+- **Soak:** from `inst.accumulated_damage` / `inst.accumulated_horror` against the
+  asset's capacity. Only when the asset (`CardKind::Asset { health, sanity, .. }`)
+  has that capacity: `health: Some(h)` → `"dmg {accumulated_damage}/{h}"`;
+  `sanity: Some(s)` → `"hor {accumulated_horror}/{s}"`. No chip when the
+  capacity is `None` (non-ally asset).
+- Order: uses chips, then soak chips. Returns `[]` for a plain asset with no
+  uses and no soak capacity (e.g. Machete in play).
+- Pure and native-testable, mirroring `slot_chips` / `skill_chips`. `UseKind`
+  ordering follows `inst.uses` iteration (a `BTreeMap`, so deterministic).
+
+### Board integration (`crates/web/src/board.rs`)
+
+In `investigators_panel`, the in-play `<ul>` of `<li class="card-line">` items
+becomes a `.card-row` of `<Card code=c.code.clone() in_play=c.clone()/>`. The
+threat-area builder/container is unchanged. The now-dead `.in-play ul` CSS rule
+is removed (mirrors the `.hand ul` cleanup from the first slice); `.threat ul`
+stays.
+
+### Styling (`crates/web/style.css`)
+
+- `.card--exhausted` — dimmed: reduced opacity and a muted border so an
+  exhausted card is visually distinct from a ready one. (Ready cards keep the
+  full class-coloured border.)
+- The exhausted badge reuses the `.card-fast` / `.card-weakness` header-marker
+  styling; uses/soak chips reuse the existing `.chip` style. No new chip palette.
+
+## Field rendering summary (in-play asset)
+
+| Element | Source | Rendering |
+|---|---|---|
+| Cost corner | — | omitted |
+| Name / traits / text / slots / skill icons | metadata | unchanged from hand face |
+| Exhausted | `CardInPlay.exhausted` | `card--exhausted` dim + `EXHAUSTED` badge |
+| Uses | `CardInPlay.uses` | chips: `"2 ammo"`, `"3 supplies"`, … |
+| Soak | `CardInPlay.accumulated_damage/horror` vs asset `health`/`sanity` | chips: `"dmg 1/2"`, `"hor 0/2"` (only when capacity present) |
+
+## Testing
+
+- **Pure native test** for `live_state_chips`:
+  - Beat Cop `01018` (`health: 2`, `sanity: 2`) with `accumulated_damage: 1` →
+    `["dmg 1/2", "hor 0/2"]`.
+  - An asset instance with `uses: {Ammo: 2}` → `["2 ammo"]`.
+  - A plain asset (no uses, no soak capacity) → `[]`.
+- **Headless wasm test** (`crates/web/tests/card.rs`):
+  - In-play Beat Cop `01018`, `exhausted: true`, `accumulated_damage: 1`: assert
+    the `card--exhausted` class, the `EXHAUSTED` badge text, the `dmg 1/2` chip,
+    and that **no `card-cost`** element renders.
+  - A non-exhausted in-play asset: assert no `card--exhausted` class.
+- **Board headless test** (`crates/web/tests/board.rs`): the in-play section
+  renders `.card-row .card` (scoped like the hand assertion), keeping the
+  existing `_synth_asset` presence check.
+
+All assertions read from the corpus/instance — no hand-typed stats. Card codes
+verified against the snapshot (`data/arkhamdb-snapshot`): Beat Cop `01018`,
+Machete `01020`.
+
+## What "done" looks like (this slice)
+
+- In-play assets render as `Card` rectangles with their printed face minus the
+  cost corner, plus uses/soak chips, and a dimmed + badged appearance when
+  exhausted.
+- Hand cards are unchanged (the `None` path).
+- Threat area, locations, enemies, act/agenda still render as before.
+- Native + headless tests pass; the full 7-job CI gauntlet is green.
+
+## Out of scope (later slices)
+
+- Threat-area cards (treacheries like Cover Up, engaged enemies).
+- Locations / enemies in the spatial map; act/agenda.
+- Clickable / interactive cards (activating an asset by clicking it).
+- The ArkhamDB icon font (still deferred; seam unchanged from the first slice).
+- Attached cards (no in-scope asset carries attachments).


### PR DESCRIPTION
## Summary

Second slice of the web card-rendering rework (after #519/#520 hand cards). In-play assets now render as `Card` rectangles: the printed face **minus the cost corner**, plus live per-instance state — **exhausted** (dimmed + `EXHAUSTED` badge), **uses** remaining, and **soak** (damage/horror against the asset's health/sanity capacity). Display-only. In-play assets only — threat area, the spatial map (locations/enemies), and act/agenda remain later slices.

## What's here

- **`crates/web/src/card.rs`**
  - `live_state_chips(inst: &CardInPlay, kind: &CardKind) -> Vec<String>` — pure helper building uses chips (`"2 ammo"`, `"3 supplies"`) then soak chips (`"dmg 1/2"`, `"hor 0/2"`, only for assets with capacity). Native-tested against real corpus data.
  - `Card` gains `#[prop(optional)] in_play: Option<CardInPlay>`: drops the cost corner, adds the `card--exhausted` dim + badge when exhausted, appends the live chips to the footer. The hand (`None`) path is unchanged.
- **`crates/web/src/board.rs`** — the in-play list becomes a `.card-row` of `Card`s carrying each instance; the dead `.in-play ul` CSS rule removed.
- **`crates/web/style.css`** — `.card--exhausted` (dim + dashed, declared after the class palette so its border wins), the exhausted badge, and a `.chip--live` tint.

## Design decisions

- **Extend, don't fork** — an in-play asset is the same Asset face plus state, so `Card` got an optional prop rather than a parallel component. Consistent with the slice-1 chip seam (`.chip` reused).
- **Cost corner dropped in play** (already paid); the header slot holds the exhausted badge.
- **`#[non_exhaustive]` handled** — `UseKind` match has a `_ =>` fallback; `CardInPlay` constructed in tests via `enter_play` + field mutation.
- **Stats only from the corpus/instance** — soak capacity from metadata, accumulated harm from the instance; tests self-validate against Beat Cop's real 2/2.

## Testing

- Native unit tests for `live_state_chips` (soak with real capacity, uses, empty).
- Headless `wasm-bindgen-test` for the in-play overlay: exhausted class + badge + soak chip + no cost corner; ready-not-dimmed + no cost corner; board in-play `.card-row .card`.
- Full 7-job CI gauntlet green locally.

Closes #521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)