### PR TITLE
web: board layout — stack map above panel + sticky action bar

### DIFF
--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -27,9 +27,14 @@ pub fn App() -> impl IntoView {
                     {
                         #[cfg(target_arch = "wasm32")]
                         { view! {
-                            <crate::picker::PickerView/>
-                            <crate::skill_test_result::SkillTestResultView/>
-                            <crate::input::AwaitingInputView/>
+                            // Sticky action bar: pinned to the viewport bottom so the
+                            // controls stay reachable however far the (tall) board is
+                            // scrolled. Invisible when nothing is pending.
+                            <div class="action-bar">
+                                <crate::picker::PickerView/>
+                                <crate::skill_test_result::SkillTestResultView/>
+                                <crate::input::AwaitingInputView/>
+                            </div>
                         }.into_any() }
                         #[cfg(not(target_arch = "wasm32"))]
                         { ().into_any() }

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -28,6 +28,11 @@
    lets them overflow onto the panel. A column gives each full width — the map
    reserves its inline height, the panel flows below it. */
 .board-main { display: flex; flex-direction: column; gap: 1rem; align-items: flex-start; }
+/* Interactive controls pinned to the viewport bottom so they stay reachable
+   however far the (tall) board is scrolled. Transparent/zero-height when no
+   prompt is pending; the white background sits behind the controls so they
+   stay legible over scrolled board content. */
+.action-bar { position: sticky; bottom: 0; z-index: 10; background: #fff; padding: 0.25rem 0; }
 
 /* Event log panel (#505): fixed-width column left of the board, scrolls with
    the newest entry pinned to the bottom. Monospace so raw Debug lines align. */

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -23,7 +23,11 @@
 .enemy-token { color: #a3261b; }
 .threat ul { list-style: none; padding-left: 0; margin: 0; }
 .enemy-engaged { color: #a3261b; font-size: 0.85rem; }
-.board-main { display: flex; gap: 1rem; align-items: flex-start; }
+/* Map stacked above the investigators panel (not side-by-side): the map's
+   location nodes are absolutely positioned, so in a flex *row* a shrunk map
+   lets them overflow onto the panel. A column gives each full width — the map
+   reserves its inline height, the panel flows below it. */
+.board-main { display: flex; flex-direction: column; gap: 1rem; align-items: flex-start; }
 
 /* Event log panel (#505): fixed-width column left of the board, scrolls with
    the newest entry pinned to the bottom. Monospace so raw Debug lines align. */


### PR DESCRIPTION
## Summary

Two related board-layout usability fixes for the web client.

### 1. Stack the map above the Investigators panel (fixes overlap)

The map was overlapping the panel — location nodes rendering on top of the investigator's stats. **Root cause:** `.board-main` was a flex *row*; the map's location nodes are `position: absolute` and `.map` sizes only from an inline `width`, so a flex item whose children are all absolutely positioned has no intrinsic width and shrinks under the default `flex-shrink: 1` when the row is tight (the wide card rows pushed it over) — the fixed-position nodes then spilled onto the panel. **Fix:** `.board-main { flex-direction: column; }` — map above panel, each full width.

### 2. Sticky action bar (fixes scrolling to reach inputs)

Stacking made the board tall, pushing the input/picker controls below the fold. **Fix:** wrap them in a `.action-bar` with `position: sticky; bottom: 0` so they stay pinned to the viewport bottom and reachable however far the board is scrolled; invisible when no prompt is pending.

CSS + a small app-wiring change. No automated test: the headless component harness doesn't load `style.css`, so this layout behavior isn't exercisable there (consistent with prior CSS changes) — verified via `trunk build`.

Closes #525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)