### PR TITLE
web: act/agenda cards + turn tracker + collapsible event log

### DIFF
--- a/crates/web/src/act_agenda.rs
+++ b/crates/web/src/act_agenda.rs
@@ -1,0 +1,61 @@
+//! Act + Agenda cards atop the board (above the map). A pure render of
+//! `GameState` (mirrors `map::location_map`): the current act and agenda render
+//! as cards — name + ability text from the corpus by `code`, thresholds from the
+//! `Act`/`Agenda` structs. The act has no running clue counter (clues sit on
+//! locations/investigators), so it shows `clues to advance: N` rather than a
+//! fake `0/N`. Display-only.
+
+use game_core::state::{CardCode, GameState};
+use leptos::prelude::*;
+
+use crate::card::{parse_card_text, render_segments};
+
+/// Name (printed, or the raw code when no metadata) + rendered ability text for
+/// an act/agenda card code.
+fn name_and_text(code: &CardCode) -> (String, Option<Vec<AnyView>>) {
+    let meta = game_core::card_registry::current().and_then(|r| (r.metadata_for)(code));
+    let name = meta.map_or_else(|| code.to_string(), |m| m.name.clone());
+    let text = meta
+        .and_then(|m| m.text.as_deref())
+        .map(|t| render_segments(parse_card_text(t)));
+    (name, text)
+}
+
+/// The current act + agenda as cards. Each is omitted when its deck is empty
+/// (fixtures may carry neither).
+pub fn act_agenda_view(game: &GameState) -> impl IntoView {
+    let act = game.act_deck.get(game.act_index).map(|act| {
+        let (name, text) = name_and_text(&act.code);
+        let threshold = act.clue_threshold;
+        view! {
+            <article class="card card--act">
+                <div class="card-head">
+                    <span class="card-kind">"Act"</span>
+                    <span class="card-name">{name}</span>
+                </div>
+                <div class="card-text">{text}</div>
+                <div class="loc-stats">
+                    <span>{format!("clues to advance: {threshold}")}</span>
+                </div>
+            </article>
+        }
+    });
+    let agenda = game.agenda_deck.get(game.agenda_index).map(|ag| {
+        let (name, text) = name_and_text(&ag.code);
+        let doom = game.agenda_doom;
+        let threshold = ag.doom_threshold;
+        view! {
+            <article class="card card--agenda">
+                <div class="card-head">
+                    <span class="card-kind">"Agenda"</span>
+                    <span class="card-name">{name}</span>
+                </div>
+                <div class="card-text">{text}</div>
+                <div class="loc-stats">
+                    <span>{format!("doom {doom}/{threshold}")}</span>
+                </div>
+            </article>
+        }
+    });
+    view! { <section class="act-agenda">{act}{agenda}</section> }
+}

--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -19,7 +19,10 @@ pub fn App() -> impl IntoView {
 
     view! {
         <main>
-            <h1>"Eldritch"</h1>
+            <header class="app-header">
+                <h1>"Eldritch"</h1>
+                <crate::status_bar::StatusBarView/>
+            </header>
             <div class="layout">
                 <crate::event_log::EventLogView/>
                 <div class="main-column">

--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -40,6 +40,7 @@ pub fn App() -> impl IntoView {
                         { ().into_any() }
                     }
                 </div>
+                <crate::turn_tracker::TurnTrackerView/>
             </div>
         </main>
     }

--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -31,7 +31,6 @@ pub fn BoardView() -> impl IntoView {
             <div class="game">
                 {resolution_banner(&game)}
                 {crate::act_agenda::act_agenda_view(&game)}
-                {phase_bar(&game)}
                 <div class="board-main">
                     {crate::map::location_map(&game)}
                     {investigators_panel(&game)}
@@ -150,17 +149,4 @@ fn resolution_banner(game: &GameState) -> impl IntoView {
         };
         view! { <section class="resolution">{text}</section> }
     })
-}
-
-/// Phase + round header. Act/agenda now render as cards above the board via
-/// `act_agenda_view`; this bar keeps phase and round only.
-fn phase_bar(game: &GameState) -> impl IntoView {
-    let phase = format!("{:?}", game.phase);
-    let round = game.round;
-    view! {
-        <header class="phase-bar">
-            <span class="phase">{phase}</span>
-            <span class="round">"round " {round}</span>
-        </header>
-    }
 }

--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -30,6 +30,7 @@ pub fn BoardView() -> impl IntoView {
         Some(game) => view! {
             <div class="game">
                 {resolution_banner(&game)}
+                {crate::act_agenda::act_agenda_view(&game)}
                 {phase_bar(&game)}
                 <div class="board-main">
                     {crate::map::location_map(&game)}
@@ -151,26 +152,15 @@ fn resolution_banner(game: &GameState) -> impl IntoView {
     })
 }
 
-/// Phase + round, plus the current act's clue threshold and the current
-/// agenda's doom (`doom/threshold`). Act/agenda lines are omitted when
-/// their decks are empty (fixtures may omit them).
+/// Phase + round header. Act/agenda now render as cards above the board via
+/// `act_agenda_view`; this bar keeps phase and round only.
 fn phase_bar(game: &GameState) -> impl IntoView {
     let phase = format!("{:?}", game.phase);
     let round = game.round;
-    let act = game
-        .act_deck
-        .get(game.act_index)
-        .map(|a| format!("clues 0/{}", a.clue_threshold));
-    let agenda = game
-        .agenda_deck
-        .get(game.agenda_index)
-        .map(|a| format!("doom {}/{}", game.agenda_doom, a.doom_threshold));
     view! {
         <header class="phase-bar">
             <span class="phase">{phase}</span>
             <span class="round">"round " {round}</span>
-            {agenda.map(|t| view! { <span class="agenda">{t}</span> })}
-            {act.map(|t| view! { <span class="act">{t}</span> })}
         </header>
     }
 }

--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -113,16 +113,22 @@ fn investigators_panel(game: &GameState) -> impl IntoView {
             view! {
                 <article class="investigator">
                     <h3 class="inv-name">{inv.name.clone()}</h3>
-                    <span class="inv-location">{location}</span>
-                    <span class="inv-actions">"actions " {inv.actions_remaining}</span>
-                    <span class="inv-resources">"resources " {inv.resources}</span>
-                    <span class="inv-health">"health " {inv.damage()} "/" {inv.max_health()}</span>
-                    <span class="inv-sanity">"sanity " {inv.horror()} "/" {inv.max_sanity()}</span>
-                    <span class="inv-clues">"clues " {inv.clues}</span>
-                    <span class="inv-status">{format!("{:?}", inv.status)}</span>
-                    <div class="hand"><h4>"Hand"</h4><div class="card-row">{hand}</div></div>
-                    <div class="in-play"><h4>"In play"</h4><div class="card-row">{in_play}</div></div>
-                    <div class="threat"><h4>"Threat area"</h4><div class="card-row">{threat}{engaged}</div></div>
+                    <div class="inv-zones-top">
+                        <div class="in-play"><h4>"In play"</h4><div class="card-row">{in_play}</div></div>
+                        <div class="threat"><h4>"Threat area"</h4><div class="card-row">{threat}{engaged}</div></div>
+                    </div>
+                    <div class="inv-zones-bottom">
+                        <div class="inv-stats">
+                            <span class="inv-location">{location}</span>
+                            <span class="inv-actions">"actions " {inv.actions_remaining}</span>
+                            <span class="inv-resources">"resources " {inv.resources}</span>
+                            <span class="inv-health">"health " {inv.damage()} "/" {inv.max_health()}</span>
+                            <span class="inv-sanity">"sanity " {inv.horror()} "/" {inv.max_sanity()}</span>
+                            <span class="inv-clues">"clues " {inv.clues}</span>
+                            <span class="inv-status">{format!("{:?}", inv.status)}</span>
+                        </div>
+                        <div class="hand"><h4>"Hand"</h4><div class="card-row">{hand}</div></div>
+                    </div>
                 </article>
             }
         })

--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -136,7 +136,7 @@ fn investigators_panel(game: &GameState) -> impl IntoView {
 }
 
 /// Win/loss banner — rendered only once `GameState.resolution` latches.
-/// Read-only display of state, matching the `phase_bar` pattern; keeps
+/// Read-only display of state, matching the pure-fn display pattern; keeps
 /// `board.rs` read-only (no new interactivity).
 fn resolution_banner(game: &GameState) -> impl IntoView {
     game.resolution.as_ref().map(|r| {

--- a/crates/web/src/board.rs
+++ b/crates/web/src/board.rs
@@ -6,7 +6,7 @@ use game_core::state::GameState;
 use game_core::Resolution;
 use leptos::prelude::*;
 
-use crate::store::{use_store, ConnStatus};
+use crate::store::use_store;
 
 /// Read-only board. Always renders a status line (connection status +
 /// last rejection); renders the panels when a game is present, else a
@@ -14,16 +14,6 @@ use crate::store::{use_store, ConnStatus};
 #[component]
 pub fn BoardView() -> impl IntoView {
     let store = use_store();
-
-    let status = move || match store.get().status {
-        ConnStatus::Connecting => "connecting",
-        ConnStatus::Connected => "connected",
-        ConnStatus::Reconnecting => "reconnecting",
-        ConnStatus::Failed => "failed",
-        ConnStatus::AwaitingRoster => "awaiting-roster",
-        ConnStatus::VersionMismatch => "version mismatch — restart the server and reload",
-    };
-    let rejection = move || store.get().last_rejection.unwrap_or_default();
 
     let board = move || match store.get().game {
         None => view! { <p class="no-game">"<no game>"</p> }.into_any(),
@@ -42,26 +32,6 @@ pub fn BoardView() -> impl IntoView {
 
     view! {
         <section class="board">
-            <p class="status">"status: " {status}</p>
-            <p class="rejection">"rejection: " {rejection}</p>
-            {
-                #[cfg(target_arch = "wasm32")]
-                {
-                    view! {
-                        <button
-                            class="new-game"
-                            on:click=move |_| crate::transport::start_new_game()
-                        >
-                            "New game"
-                        </button>
-                    }
-                    .into_any()
-                }
-                #[cfg(not(target_arch = "wasm32"))]
-                {
-                    ().into_any()
-                }
-            }
             {board}
         </section>
     }

--- a/crates/web/src/event_log.rs
+++ b/crates/web/src/event_log.rs
@@ -10,6 +10,7 @@ use leptos::prelude::*;
 #[component]
 pub fn EventLogView() -> impl IntoView {
     let store = use_store();
+    let collapsed = RwSignal::new(false);
     let scroll_ref = NodeRef::<leptos::html::Div>::new();
 
     // Keep the panel pinned to the newest line. Re-runs whenever a batch is
@@ -51,8 +52,20 @@ pub fn EventLogView() -> impl IntoView {
 
     view! {
         <aside class="event-log">
-            <h2>"Event log"</h2>
-            <div class="log-scroll" node_ref=scroll_ref>
+            <div class="event-log-head">
+                <h2>"Event log"</h2>
+                <button
+                    class="log-toggle"
+                    on:click=move |_| collapsed.update(|c| *c = !*c)
+                >
+                    {move || if collapsed.get() { "show" } else { "hide" }}
+                </button>
+            </div>
+            <div
+                class="log-scroll"
+                class:hidden=move || collapsed.get()
+                node_ref=scroll_ref
+            >
                 {batches}
             </div>
         </aside>

--- a/crates/web/src/event_log.rs
+++ b/crates/web/src/event_log.rs
@@ -51,14 +51,14 @@ pub fn EventLogView() -> impl IntoView {
     };
 
     view! {
-        <aside class="event-log">
+        <aside class="event-log" class:collapsed=move || collapsed.get()>
             <div class="event-log-head">
                 <h2>"Event log"</h2>
                 <button
                     class="log-toggle"
                     on:click=move |_| collapsed.update(|c| *c = !*c)
                 >
-                    {move || if collapsed.get() { "show" } else { "hide" }}
+                    {move || if collapsed.get() { "▸ log" } else { "◂ hide" }}
                 </button>
             </div>
             <div

--- a/crates/web/src/event_log.rs
+++ b/crates/web/src/event_log.rs
@@ -21,6 +21,7 @@ pub fn EventLogView() -> impl IntoView {
     {
         Effect::new(move |_| {
             let _ = store.with(|s| s.log.len());
+            let _ = collapsed.get();
             request_animation_frame(move || {
                 if let Some(el) = scroll_ref.get() {
                     el.set_scroll_top(el.scroll_height());

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -14,6 +14,7 @@ pub mod map;
 pub mod names;
 pub mod skill_test_result;
 pub mod store;
+pub mod turn_tracker;
 pub mod url;
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -13,6 +13,7 @@ pub mod event_log;
 pub mod map;
 pub mod names;
 pub mod skill_test_result;
+pub mod status_bar;
 pub mod store;
 pub mod turn_tracker;
 pub mod url;

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -4,6 +4,7 @@
 //! Components live here so integration tests in `tests/` — and later Phase-6
 //! components — can import them.
 
+pub mod act_agenda;
 pub mod app;
 pub mod board;
 pub mod card;

--- a/crates/web/src/status_bar.rs
+++ b/crates/web/src/status_bar.rs
@@ -1,0 +1,48 @@
+//! The app status bar: connection status, last rejection, and the New-game
+//! button — rendered inline with the page heading to keep the header compact.
+//! Reads the store; the New-game button is wasm-only (it drives the transport).
+
+use leptos::prelude::*;
+
+use crate::store::{use_store, ConnStatus};
+
+/// A horizontal status strip (status · rejection · New game) for the app header.
+#[component]
+pub fn StatusBarView() -> impl IntoView {
+    let store = use_store();
+
+    let status = move || match store.get().status {
+        ConnStatus::Connecting => "connecting",
+        ConnStatus::Connected => "connected",
+        ConnStatus::Reconnecting => "reconnecting",
+        ConnStatus::Failed => "failed",
+        ConnStatus::AwaitingRoster => "awaiting-roster",
+        ConnStatus::VersionMismatch => "version mismatch — restart the server and reload",
+    };
+    let rejection = move || store.get().last_rejection.unwrap_or_default();
+
+    view! {
+        <div class="status-bar">
+            <span class="status">"status: " {status}</span>
+            <span class="rejection">"rejection: " {rejection}</span>
+            {
+                #[cfg(target_arch = "wasm32")]
+                {
+                    view! {
+                        <button
+                            class="new-game"
+                            on:click=move |_| crate::transport::start_new_game()
+                        >
+                            "New game"
+                        </button>
+                    }
+                    .into_any()
+                }
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    ().into_any()
+                }
+            }
+        </div>
+    }
+}

--- a/crates/web/src/turn_tracker.rs
+++ b/crates/web/src/turn_tracker.rs
@@ -1,0 +1,129 @@
+//! Right-hand turn tracker: the round's four phases with their Rules-Reference
+//! sub-steps and structural player windows, highlighting the current phase.
+//!
+//! The `ROUND` outline is transcribed verbatim from the FFG Rules Reference,
+//! Appendix II "Timing and Gameplay" — the Phase Sequence timing chart and
+//! Framework Event Details (`data/rules-reference/ahc01_rules_reference_web.pdf`,
+//! pp. 23-25). Grey boxes are framework events; red boxes are player windows.
+//! The engine exposes only the coarse phase, so only the current *phase* is
+//! highlighted. Display-only.
+
+use game_core::state::Phase;
+use leptos::prelude::*;
+
+use crate::store::use_store;
+
+/// One entry in a phase's ordered outline.
+enum Step {
+    /// A framework event (mandatory, grey box).
+    Framework(&'static str),
+    /// A structural player window (red box).
+    Window,
+}
+
+struct PhaseOutline {
+    phase: Phase,
+    label: &'static str,
+    steps: &'static [Step],
+}
+
+use Step::{Framework, Window};
+
+const ROUND: &[PhaseOutline] = &[
+    PhaseOutline {
+        phase: Phase::Mythos,
+        label: "Mythos",
+        steps: &[
+            Framework("1.1 Round begins. Mythos phase begins."),
+            Framework("1.2 Place 1 doom on the current agenda."),
+            Framework("1.3 Check doom threshold."),
+            Framework("1.4 Each investigator draws 1 encounter card."),
+            Window,
+            Framework("1.5 Mythos phase ends."),
+        ],
+    },
+    PhaseOutline {
+        phase: Phase::Investigation,
+        label: "Investigation",
+        steps: &[
+            Framework("2.1 Investigation phase begins."),
+            Window,
+            Framework("2.2 Next investigator's turn begins."),
+            Window,
+            Framework("2.2.1 Active investigator may take an action, if able."),
+            Framework("2.2.2 Investigator's turn ends."),
+            Framework("2.3 Investigation phase ends."),
+        ],
+    },
+    PhaseOutline {
+        phase: Phase::Enemy,
+        label: "Enemy",
+        steps: &[
+            Framework("3.1 Enemy phase begins."),
+            Framework("3.2 Hunter enemies move."),
+            Window,
+            Framework("3.3 Next investigator resolves engaged enemy attacks."),
+            Window,
+            Framework("3.4 Enemy phase ends."),
+        ],
+    },
+    PhaseOutline {
+        phase: Phase::Upkeep,
+        label: "Upkeep",
+        steps: &[
+            Framework("4.1 Upkeep phase begins."),
+            Window,
+            Framework("4.2 Reset actions."),
+            Framework("4.3 Ready each exhausted card."),
+            Framework("4.4 Each investigator draws 1 card and gains 1 resource."),
+            Framework("4.5 Each investigator checks hand size."),
+            Framework("4.6 Upkeep phase ends. Round ends."),
+        ],
+    },
+];
+
+#[component]
+pub fn TurnTrackerView() -> impl IntoView {
+    let store = use_store();
+    move || {
+        let game = store.get().game;
+        let current = game.as_ref().map(|g| g.phase);
+        let round = game.as_ref().map(|g| g.round);
+        let phases: Vec<_> = ROUND
+            .iter()
+            .map(|p| {
+                let cls = if current == Some(p.phase) {
+                    "tracker-phase current"
+                } else {
+                    "tracker-phase"
+                };
+                let steps: Vec<_> = p
+                    .steps
+                    .iter()
+                    .map(|s| match s {
+                        Step::Framework(t) => {
+                            view! { <li class="tracker-step">{*t}</li> }.into_any()
+                        }
+                        Step::Window => {
+                            view! { <li class="tracker-window">"player window"</li> }.into_any()
+                        }
+                    })
+                    .collect();
+                view! {
+                    <div class=cls>
+                        <div class="tracker-phase-label">{p.label}</div>
+                        <ul>{steps}</ul>
+                    </div>
+                }
+            })
+            .collect();
+        view! {
+            <aside class="turn-tracker">
+                <h2>"Turn"</h2>
+                {round.map(|r| view! { <div class="tracker-round">{format!("Round {r}")}</div> })}
+                {phases}
+            </aside>
+        }
+        .into_any()
+    }
+}

--- a/crates/web/src/turn_tracker.rs
+++ b/crates/web/src/turn_tracker.rs
@@ -1,10 +1,11 @@
 //! Right-hand turn tracker: the round's four phases with their Rules-Reference
 //! sub-steps and structural player windows, highlighting the current phase.
 //!
-//! The `ROUND` outline is transcribed verbatim from the FFG Rules Reference,
-//! Appendix II "Timing and Gameplay" — the Phase Sequence timing chart and
-//! Framework Event Details (`data/rules-reference/ahc01_rules_reference_web.pdf`,
-//! pp. 23-25). Grey boxes are framework events; red boxes are player windows.
+//! The `ROUND` outline's step labels are transcribed from the RR Appendix II
+//! "Timing and Gameplay" — the Phase Sequence timing chart and Framework Event
+//! Details (`data/rules-reference/ahc01_rules_reference_web.pdf`, pp. 23-25),
+//! with loop/flow-control tails elided for the cheat-sheet.
+//! Grey boxes are framework events; red boxes are player windows.
 //! The engine exposes only the coarse phase, so only the current *phase* is
 //! highlighted. Display-only.
 

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -120,6 +120,10 @@
 .card--mythos   { border-color: #555; }
 .card--enemy    { border-color: #a3261b; }
 .card--unknown, .card--generic { border-style: dashed; }
+.act-agenda { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.5rem; }
+.card--act { border-color: #c8a020; }
+.card--agenda { border-color: #7a2f2f; }
+.card-kind { font-size: 0.7rem; text-transform: uppercase; opacity: 0.7; margin-right: 0.3rem; }
 /* Exhausted in-play asset: dimmed + dashed so it reads as unavailable.
    Declared after the class palette so its border-color wins over the class hue. */
 .card--exhausted { opacity: 0.6; border-style: dashed; border-color: #aaa; }

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -52,6 +52,16 @@
 .log-action { font-weight: 600; color: #2a4d69; }
 .log-event { white-space: pre-wrap; word-break: break-word; color: #333; }
 
+.turn-tracker { flex: 0 0 auto; width: 18rem; font-size: 0.8rem; }
+.turn-tracker h2 { font-size: 1rem; margin: 0 0 0.25rem; }
+.tracker-round { font-weight: 600; margin-bottom: 0.4rem; }
+.tracker-phase { border-left: 3px solid transparent; padding: 0.15rem 0 0.15rem 0.4rem; margin-bottom: 0.3rem; }
+.tracker-phase.current { border-left-color: #2f6fb3; background: #eef4fb; }
+.tracker-phase-label { font-weight: 600; }
+.tracker-phase ul { list-style: none; padding-left: 0.5rem; margin: 0.1rem 0; }
+.tracker-step { color: #444; }
+.tracker-window { color: #8a5a00; font-style: italic; }
+
 /* --- Cards (hand slice) ------------------------------------------------ */
 .card-row {
   display: flex;

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -6,8 +6,15 @@
 /* Full-width so the heading wraps onto its own line ABOVE the panels rather
    than sitting beside them as a flex sibling. */
 .investigators h2 { flex-basis: 100%; margin: 0 0 0.25rem; }
-.investigator { border: 1px solid #ccc; border-radius: 4px; padding: 0.5rem; display: flex; flex-direction: column; gap: 0.25rem; min-width: 16rem; }
+.investigator { border: 1px solid #ccc; border-radius: 4px; padding: 0.5rem; display: flex; flex-direction: column; gap: 0.5rem; min-width: 30rem; }
 .investigator span { font-size: 0.9rem; }
+/* Top row: in-play (left) and threat (right), each boxed for clear separation. */
+.inv-zones-top { display: flex; gap: 1rem; align-items: flex-start; }
+.inv-zones-top > div { flex: 1; border: 1px solid #e3e3e3; border-radius: 4px; padding: 0.4rem; min-width: 0; }
+/* Bottom row: the stat block (left) beside the hand (right). */
+.inv-zones-bottom { display: flex; gap: 1rem; align-items: flex-start; }
+.inv-stats { flex: 0 0 auto; min-width: 9rem; display: flex; flex-direction: column; gap: 0.2rem; }
+.inv-zones-bottom .hand { flex: 1; min-width: 0; }
 .card-line { font-family: ui-monospace, monospace; font-size: 0.85rem; }
 
 /* Spatial board map (#497). Nodes are absolutely positioned at computed

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -1,7 +1,6 @@
 /* P6.5 board — minimal functional layout. */
 .board { font-family: system-ui, sans-serif; margin: 1rem; }
 .status, .rejection { font-size: 0.85rem; color: #555; }
-.phase-bar { display: flex; gap: 1rem; font-weight: 600; padding: 0.5rem 0; border-bottom: 1px solid #ccc; }
 .game { display: flex; flex-direction: column; gap: 1rem; }
 .investigators { display: flex; flex-wrap: wrap; gap: 1rem; }
 /* Full-width so the heading wraps onto its own line ABOVE the panels rather

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -38,10 +38,10 @@
 .loc-head { font-weight: 600; margin-bottom: 0.15rem; }
 .inv-token { color: #157a3a; }
 .enemy-token { color: #a3261b; }
-/* Map stacked above the investigators panel (not side-by-side): the map's
-   location nodes are absolutely positioned, so in a flex *row* a shrunk map
-   lets them overflow onto the panel. A column gives each full width — the map
-   reserves its inline height, the panel flows below it. */
+/* Column direction stacks the map above the investigators panel: the map's
+   location nodes are absolutely positioned, so a flex *row* would let a shrunk
+   map overflow them onto the panel. The map reserves its inline height; the
+   panel flows below it. (Children are centered via align-items: center.) */
 .board-main { display: flex; flex-direction: column; gap: 1rem; align-items: center; }
 /* Interactive controls pinned to the viewport bottom so they stay reachable
    however far the (tall) board is scrolled. Transparent/zero-height when no

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -46,6 +46,9 @@
 .main-column { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 1rem; }
 .event-log { flex: 0 0 auto; width: 22rem; }
 .event-log h2 { font-size: 1rem; margin: 0 0 0.25rem; }
+.event-log-head { display: flex; align-items: baseline; justify-content: space-between; }
+.log-toggle { font-size: 0.75rem; }
+.hidden { display: none; }
 .log-scroll { max-height: 80vh; overflow-y: auto; font-family: ui-monospace, monospace; font-size: 0.8rem; border: 1px solid #ccc; border-radius: 4px; padding: 0.5rem; }
 .log-batch { border-top: 1px solid #eee; padding: 0.25rem 0; }
 .log-batch:first-child { border-top: none; }

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -5,7 +5,9 @@
 .app-header h1 { margin: 0; font-size: 1.4rem; }
 .status-bar { display: flex; align-items: baseline; flex-wrap: wrap; gap: 1rem; }
 .status, .rejection { font-size: 0.85rem; color: #555; }
-.game { display: flex; flex-direction: column; gap: 1rem; }
+/* Center the board content (act/agenda, map, investigators) horizontally in the
+   center column rather than hugging the left edge. */
+.game { display: flex; flex-direction: column; gap: 1rem; align-items: center; }
 .investigators { display: flex; flex-wrap: wrap; gap: 1rem; }
 /* Full-width so the heading wraps onto its own line ABOVE the panels rather
    than sitting beside them as a flex sibling. */
@@ -40,7 +42,7 @@
    location nodes are absolutely positioned, so in a flex *row* a shrunk map
    lets them overflow onto the panel. A column gives each full width — the map
    reserves its inline height, the panel flows below it. */
-.board-main { display: flex; flex-direction: column; gap: 1rem; align-items: flex-start; }
+.board-main { display: flex; flex-direction: column; gap: 1rem; align-items: center; }
 /* Interactive controls pinned to the viewport bottom so they stay reachable
    however far the (tall) board is scrolled. Transparent/zero-height when no
    prompt is pending; the white background sits behind the controls so they

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -44,6 +44,10 @@
    column shrink within the flex row instead of overflowing. */
 .main-column { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 1rem; }
 .event-log { flex: 0 0 auto; width: 22rem; }
+/* Collapsed: shrink to a thin strip (just the expand toggle) so the log frees
+   the left side when hidden, instead of leaving a 22rem empty column. */
+.event-log.collapsed { width: auto; }
+.event-log.collapsed h2 { display: none; }
 .event-log h2 { font-size: 1rem; margin: 0 0 0.25rem; }
 .event-log-head { display: flex; align-items: baseline; justify-content: space-between; }
 .log-toggle { font-size: 0.75rem; }

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -1,5 +1,9 @@
 /* P6.5 board — minimal functional layout. */
 .board { font-family: system-ui, sans-serif; margin: 1rem; }
+/* Compact header: the title and the status strip share one horizontal row. */
+.app-header { display: flex; align-items: baseline; flex-wrap: wrap; gap: 1rem; margin: 1rem; }
+.app-header h1 { margin: 0; font-size: 1.4rem; }
+.status-bar { display: flex; align-items: baseline; flex-wrap: wrap; gap: 1rem; }
 .status, .rejection { font-size: 0.85rem; color: #555; }
 .game { display: flex; flex-direction: column; gap: 1rem; }
 .investigators { display: flex; flex-wrap: wrap; gap: 1rem; }

--- a/crates/web/tests/act_agenda.rs
+++ b/crates/web/tests/act_agenda.rs
@@ -1,0 +1,60 @@
+//! Headless render test for the Act/Agenda cards. Own binary so it installs the
+//! real `cards::REGISTRY` (registry install is first-wins per process); mounts
+//! `act_agenda_view` directly (no investigator panel → no `TEST_INV` lookup).
+#![cfg(target_arch = "wasm32")]
+
+use game_core::state::{Act, Agenda, CardCode, GameStateBuilder};
+use leptos::prelude::document;
+use wasm_bindgen::JsCast as _;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn section_text() -> String {
+    let nodes = document()
+        .query_selector_all(".act-agenda")
+        .expect("query ok");
+    nodes
+        .item(nodes.length() - 1)
+        .and_then(|n| n.dyn_into::<web_sys::Element>().ok())
+        .and_then(|el| el.text_content())
+        .unwrap_or_default()
+}
+
+#[wasm_bindgen_test]
+async fn act_and_agenda_render_name_text_and_thresholds() {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+    // Act 01109 "The Barrier" (Objective text); Agenda 01107 "They're Getting
+    // Out!" (Forced text).
+    let mut state = GameStateBuilder::new().build();
+    state.act_deck = vec![Act {
+        code: CardCode::new("01109"),
+        clue_threshold: 2,
+        resolution: None,
+    }];
+    state.agenda_deck = vec![Agenda {
+        code: CardCode::new("01107"),
+        doom_threshold: 3,
+        resolution: None,
+    }];
+    state.agenda_doom = 1;
+
+    leptos::mount::mount_to_body(move || web::act_agenda::act_agenda_view(&state));
+    leptos::task::tick().await;
+
+    let text = section_text();
+    assert!(text.contains("The Barrier"), "act name missing: {text}");
+    assert!(
+        text.contains("clues to advance: 2"),
+        "act threshold missing: {text}"
+    );
+    assert!(
+        text.contains("Objective"),
+        "act ability text missing: {text}"
+    );
+    assert!(
+        text.contains("They're Getting Out!"),
+        "agenda name missing: {text}"
+    );
+    assert!(text.contains("doom 1/3"), "agenda doom missing: {text}");
+}

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -81,7 +81,7 @@ async fn phase_bar_renders_phase_round_act_agenda() {
         "agenda doom missing: {html}"
     );
     assert!(
-        html.contains("clues 0/2") || html.contains("0/2"),
+        html.contains("clues to advance: 2"),
         "act threshold missing: {html}"
     );
 }

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -154,6 +154,21 @@ async fn investigators_panel_renders_stats_and_hand() {
         cards.length() >= 1,
         "hand should render Card rectangles: {html}"
     );
+
+    // Layout: in-play + threat sit in the top zone row; the stat block + hand sit
+    // in the bottom row (stats left, hand right).
+    let doc = leptos::prelude::document();
+    for sel in [
+        ".investigator .inv-zones-top .in-play",
+        ".investigator .inv-zones-top .threat",
+        ".investigator .inv-zones-bottom .inv-stats",
+        ".investigator .inv-zones-bottom .hand",
+    ] {
+        assert!(
+            doc.query_selector(sel).expect("query ok").is_some(),
+            "expected layout element {sel}: {html}"
+        );
+    }
 }
 
 #[wasm_bindgen_test]

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -51,7 +51,7 @@ async fn render_state(state: game_core::state::GameState) -> String {
 }
 
 #[wasm_bindgen_test]
-async fn phase_bar_renders_phase_round_act_agenda() {
+async fn act_agenda_cards_render_name_and_thresholds() {
     let mut state = GameStateBuilder::new()
         .with_investigator(test_investigator(1))
         .with_phase(Phase::Investigation)
@@ -71,15 +71,7 @@ async fn phase_bar_renders_phase_round_act_agenda() {
 
     let html = render_state(state).await;
 
-    assert!(html.contains("Investigation"), "phase missing: {html}");
-    assert!(
-        html.contains("round 3") || html.contains("Round 3"),
-        "round missing: {html}"
-    );
-    assert!(
-        html.contains("doom 1/5") || html.contains("1/5"),
-        "agenda doom missing: {html}"
-    );
+    assert!(html.contains("doom 1/5"), "agenda doom missing: {html}");
     assert!(
         html.contains("clues to advance: 2"),
         "act threshold missing: {html}"

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -4,7 +4,7 @@
 #![cfg(target_arch = "wasm32")]
 
 use game_core::state::GameStateBuilder;
-use game_core::state::{Act, Agenda, CardCode, Phase};
+use game_core::state::{Act, Agenda, CardCode};
 use game_core::test_support::fixtures::{test_investigator, test_location};
 use game_core::EngineOutcome;
 use leptos::prelude::{provide_context, RwSignal, Update};
@@ -54,8 +54,6 @@ async fn render_state(state: game_core::state::GameState) -> String {
 async fn act_agenda_cards_render_name_and_thresholds() {
     let mut state = GameStateBuilder::new()
         .with_investigator(test_investigator(1))
-        .with_phase(Phase::Investigation)
-        .with_round(3)
         .build();
     state.act_deck = vec![Act {
         code: CardCode("_test_act".into()),

--- a/crates/web/tests/board.rs
+++ b/crates/web/tests/board.rs
@@ -258,38 +258,6 @@ async fn resolution_banner_renders_lost() {
 }
 
 #[wasm_bindgen_test]
-async fn version_mismatch_status_renders_actionable_message() {
-    use web::store::ConnStatus;
-    let store = RwSignal::new(ClientState::default());
-    leptos::mount::mount_to_body(move || {
-        provide_context(store);
-        leptos::view! { <BoardView/> }
-    });
-    store.update(|s| s.status = ConnStatus::VersionMismatch);
-    leptos::task::tick().await;
-
-    // Scope to the last mounted .status line (DOM accumulates across tests).
-    let lines = leptos::prelude::document()
-        .query_selector_all(".status")
-        .expect("query_selector_all");
-    let html = lines
-        .item(lines.length() - 1)
-        .expect("at least one .status line")
-        .dyn_ref::<web_sys::Element>()
-        .expect("Element")
-        .inner_html();
-
-    assert!(
-        html.contains("version mismatch"),
-        "status line must name the version mismatch: {html}"
-    );
-    assert!(
-        html.contains("restart the server"),
-        "status line must tell the user what to do: {html}"
-    );
-}
-
-#[wasm_bindgen_test]
 async fn map_and_investigators_are_inside_board_main() {
     let state = GameStateBuilder::new()
         .with_investigator(test_investigator(1))
@@ -381,29 +349,5 @@ async fn threat_area_treachery_renders_as_card() {
     assert!(
         card.is_some(),
         "threat-area treachery should render as a card: {html}"
-    );
-}
-
-#[wasm_bindgen_test]
-async fn board_renders_a_new_game_button() {
-    let store = RwSignal::new(ClientState::default());
-    leptos::mount::mount_to_body(move || {
-        provide_context(store);
-        leptos::view! { <BoardView/> }
-    });
-    leptos::task::tick().await;
-
-    // Scope to the last mounted .board (DOM accumulates across tests).
-    let boards = leptos::prelude::document()
-        .query_selector_all(".board")
-        .expect("query_selector_all");
-    let last = boards
-        .item(boards.length() - 1)
-        .expect("at least one .board section")
-        .dyn_into::<web_sys::Element>()
-        .expect("Element");
-    assert!(
-        last.query_selector(".new-game").expect("query").is_some(),
-        "BoardView must render a .new-game button"
     );
 }

--- a/crates/web/tests/event_log.rs
+++ b/crates/web/tests/event_log.rs
@@ -85,4 +85,10 @@ async fn log_collapses_and_expands() {
         "log body should be hidden after collapse: {}",
         scroll.class_name()
     );
+    // The panel itself collapses to a thin strip (frees the left side).
+    assert!(
+        panel.class_name().contains("collapsed"),
+        "panel should carry the collapsed class: {}",
+        panel.class_name()
+    );
 }

--- a/crates/web/tests/event_log.rs
+++ b/crates/web/tests/event_log.rs
@@ -53,9 +53,17 @@ async fn log_collapses_and_expands() {
     });
     leptos::task::tick().await;
 
-    let doc = leptos::prelude::document();
-    let scroll = doc
-        .query_selector(".event-log .log-scroll")
+    let logs = leptos::prelude::document()
+        .query_selector_all(".event-log")
+        .expect("query ok");
+    let panel = logs
+        .item(logs.length() - 1)
+        .expect("an .event-log panel")
+        .dyn_into::<web_sys::Element>()
+        .expect("Element");
+
+    let scroll = panel
+        .query_selector(".log-scroll")
         .expect("query ok")
         .expect(".log-scroll present");
     assert!(
@@ -64,8 +72,8 @@ async fn log_collapses_and_expands() {
         scroll.class_name()
     );
 
-    let toggle = doc
-        .query_selector(".event-log .log-toggle")
+    let toggle = panel
+        .query_selector(".log-toggle")
         .expect("query ok")
         .expect(".log-toggle present")
         .dyn_into::<web_sys::HtmlElement>()

--- a/crates/web/tests/event_log.rs
+++ b/crates/web/tests/event_log.rs
@@ -42,3 +42,39 @@ async fn renders_batches_with_headers_and_event_debug() {
         "event Debug rendered: {text}"
     );
 }
+
+#[wasm_bindgen_test]
+async fn log_collapses_and_expands() {
+    // Mount EventLogView (use the file's existing mount helper / store setup).
+    let store = leptos::prelude::RwSignal::new(web::store::ClientState::default());
+    leptos::mount::mount_to_body(move || {
+        leptos::prelude::provide_context(store);
+        leptos::view! { <web::event_log::EventLogView/> }
+    });
+    leptos::task::tick().await;
+
+    let doc = leptos::prelude::document();
+    let scroll = doc
+        .query_selector(".event-log .log-scroll")
+        .expect("query ok")
+        .expect(".log-scroll present");
+    assert!(
+        !scroll.class_name().contains("hidden"),
+        "log body should start visible: {}",
+        scroll.class_name()
+    );
+
+    let toggle = doc
+        .query_selector(".event-log .log-toggle")
+        .expect("query ok")
+        .expect(".log-toggle present")
+        .dyn_into::<web_sys::HtmlElement>()
+        .expect("HtmlElement");
+    toggle.click();
+    leptos::task::tick().await;
+    assert!(
+        scroll.class_name().contains("hidden"),
+        "log body should be hidden after collapse: {}",
+        scroll.class_name()
+    );
+}

--- a/crates/web/tests/status_bar.rs
+++ b/crates/web/tests/status_bar.rs
@@ -1,0 +1,69 @@
+//! Headless render tests for the app status bar (status / rejection / New game),
+//! which now lives in the page header (moved out of `BoardView`). wasm32-only.
+#![cfg(target_arch = "wasm32")]
+
+use leptos::prelude::{document, provide_context, RwSignal, Update};
+use wasm_bindgen::JsCast as _;
+use wasm_bindgen_test::*;
+use web::status_bar::StatusBarView;
+use web::store::{ClientState, ConnStatus};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+/// Mount `StatusBarView` against a fresh store; returns the store so a test can
+/// drive `status`/`last_rejection`.
+fn mount() -> RwSignal<ClientState> {
+    let store = RwSignal::new(ClientState::default());
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        leptos::view! { <StatusBarView/> }
+    });
+    store
+}
+
+#[wasm_bindgen_test]
+async fn version_mismatch_status_renders_actionable_message() {
+    let store = mount();
+    store.update(|s| s.status = ConnStatus::VersionMismatch);
+    leptos::task::tick().await;
+
+    // Scope to the last mounted .status line (DOM accumulates across tests).
+    let lines = document()
+        .query_selector_all(".status")
+        .expect("query_selector_all");
+    let html = lines
+        .item(lines.length() - 1)
+        .expect("at least one .status line")
+        .dyn_ref::<web_sys::Element>()
+        .expect("Element")
+        .inner_html();
+
+    assert!(
+        html.contains("version mismatch"),
+        "status line must name the version mismatch: {html}"
+    );
+    assert!(
+        html.contains("restart the server"),
+        "status line must tell the user what to do: {html}"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn status_bar_renders_a_new_game_button() {
+    let _store = mount();
+    leptos::task::tick().await;
+
+    // Scope to the last mounted .status-bar (DOM accumulates across tests).
+    let bars = document()
+        .query_selector_all(".status-bar")
+        .expect("query_selector_all");
+    let last = bars
+        .item(bars.length() - 1)
+        .expect("at least one .status-bar")
+        .dyn_into::<web_sys::Element>()
+        .expect("Element");
+    assert!(
+        last.query_selector(".new-game").expect("query").is_some(),
+        "status bar must render a .new-game button"
+    );
+}

--- a/crates/web/tests/store.rs
+++ b/crates/web/tests/store.rs
@@ -58,5 +58,11 @@ async fn hello_renders_state_present() {
     // with `update`. Yield so the DOM reflects the new signal value.
     leptos::task::tick().await;
 
-    assert!(body_html().contains("phase-bar"), "after: {}", body_html());
+    // `phase_bar` was retired (phase/round moved to the turn tracker); assert the
+    // game now renders its board — the investigators-panel heading.
+    assert!(
+        body_html().contains("Investigators"),
+        "after: {}",
+        body_html()
+    );
 }

--- a/crates/web/tests/turn_tracker.rs
+++ b/crates/web/tests/turn_tracker.rs
@@ -69,6 +69,10 @@ async fn current_phase_is_highlighted() {
     mount_at(Phase::Enemy, 1).await;
     let tracker = last_tracker();
     // Exactly one phase block carries `current`, and it is the Enemy block.
+    let currents = tracker
+        .query_selector_all(".tracker-phase.current")
+        .expect("query ok");
+    assert_eq!(currents.length(), 1, "exactly one phase should be current");
     let current = tracker
         .query_selector(".tracker-phase.current")
         .expect("query ok")

--- a/crates/web/tests/turn_tracker.rs
+++ b/crates/web/tests/turn_tracker.rs
@@ -14,7 +14,6 @@ use web::turn_tracker::TurnTrackerView;
 wasm_bindgen_test_configure!(run_in_browser);
 
 async fn mount_at(phase: Phase, round: u32) {
-    game_core::test_support::install_test_registry();
     let state = GameStateBuilder::new()
         .with_investigator(test_investigator(1))
         .with_phase(phase)

--- a/crates/web/tests/turn_tracker.rs
+++ b/crates/web/tests/turn_tracker.rs
@@ -1,0 +1,86 @@
+//! Headless render tests for the turn tracker. wasm32-only.
+#![cfg(target_arch = "wasm32")]
+
+use game_core::state::{GameStateBuilder, Phase};
+use game_core::test_support::fixtures::test_investigator;
+use game_core::EngineOutcome;
+use leptos::prelude::{document, provide_context, RwSignal, Update};
+use protocol::ServerMessage;
+use wasm_bindgen::JsCast as _;
+use wasm_bindgen_test::*;
+use web::store::{reduce, ClientState};
+use web::turn_tracker::TurnTrackerView;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+async fn mount_at(phase: Phase, round: u32) {
+    game_core::test_support::install_test_registry();
+    let state = GameStateBuilder::new()
+        .with_investigator(test_investigator(1))
+        .with_phase(phase)
+        .with_round(round)
+        .build();
+    let store = RwSignal::new(ClientState::default());
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        leptos::view! { <TurnTrackerView/> }
+    });
+    store.update(|s| {
+        reduce(
+            s,
+            ServerMessage::Hello {
+                state: Box::new(state),
+                outcome: EngineOutcome::Done,
+                events: Vec::new(),
+            },
+        );
+    });
+    leptos::task::tick().await;
+}
+
+fn last_tracker() -> web_sys::Element {
+    let nodes = document()
+        .query_selector_all(".turn-tracker")
+        .expect("query ok");
+    nodes
+        .item(nodes.length() - 1)
+        .and_then(|n| n.dyn_into::<web_sys::Element>().ok())
+        .expect("a .turn-tracker")
+}
+
+#[wasm_bindgen_test]
+async fn lists_all_phases_substeps_and_round() {
+    mount_at(Phase::Investigation, 2).await;
+    let t = last_tracker().text_content().unwrap_or_default();
+    assert!(t.contains("Round 2"), "round missing: {t}");
+    assert!(t.contains("Mythos"), "Mythos missing: {t}");
+    assert!(t.contains("Investigation"), "Investigation missing: {t}");
+    assert!(t.contains("Enemy"), "Enemy missing: {t}");
+    assert!(t.contains("Upkeep"), "Upkeep missing: {t}");
+    assert!(
+        t.contains("Place 1 doom on the current agenda."),
+        "a Mythos sub-step missing: {t}"
+    );
+    assert!(t.contains("player window"), "player windows missing: {t}");
+}
+
+#[wasm_bindgen_test]
+async fn current_phase_is_highlighted() {
+    mount_at(Phase::Enemy, 1).await;
+    let tracker = last_tracker();
+    // Exactly one phase block carries `current`, and it is the Enemy block.
+    let current = tracker
+        .query_selector(".tracker-phase.current")
+        .expect("query ok")
+        .expect("a current phase block")
+        .text_content()
+        .unwrap_or_default();
+    assert!(
+        current.contains("Enemy"),
+        "current phase should be Enemy: {current}"
+    );
+    assert!(
+        !current.contains("Mythos"),
+        "only the Enemy block is current: {current}"
+    );
+}

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -212,6 +212,20 @@ the now-stable set of input shapes:
     their own action buttons; retire the sticky `.action-bar`). Spec/plan:
     `docs/superpowers/specs/2026-06-30-treachery-card-rendering-design.md`,
     `docs/superpowers/plans/2026-06-30-treachery-card-rendering.md`.
+  - **Slice 6 — act/agenda cards + turn tracker + collapsible log (#532, PR #533).** A
+    three-column layout. **Act/Agenda render as cards** atop the board (`act_agenda.rs`, a
+    `location_map`-style pure fn in `BoardView` — act shows `clues to advance: N` since the
+    act has no running clue counter; agenda shows real `doom d/N`). A **right-hand
+    `TurnTrackerView`** outlines the round's four phases with their RR sub-steps + structural
+    player windows (the `ROUND` const is transcribed from RR Appendix II pp. 23-25 — step
+    labels, loop tails elided — and cited in the module doc; reviewer-verified against the
+    pinned PDF), highlighting the current phase. The **left event log is collapsible**. The
+    `phase_bar` is **retired** (phase/round → tracker, act/agenda → cards). This finishes
+    the display-only card/layout pass for every zone. **The remaining web work is the
+    interactivity pass** (cards/locations/enemies grow their own action buttons; retire the
+    sticky `.action-bar`). Spec/plan:
+    `docs/superpowers/specs/2026-06-30-act-agenda-and-sidebars-design.md`,
+    `docs/superpowers/plans/2026-06-30-act-agenda-and-sidebars.md`.
 
 **Deferred past the gate:** #353 (uses-depletion — no Gathering card; gated on
 Forbidden Knowledge / Grotesque Statue), #294 (multi-soak-window drain —

--- a/docs/superpowers/plans/2026-06-30-act-agenda-and-sidebars.md
+++ b/docs/superpowers/plans/2026-06-30-act-agenda-and-sidebars.md
@@ -1,0 +1,772 @@
+# Act/Agenda Cards + Turn Tracker + Collapsible Log Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Three-column layout: Act/Agenda cards atop the board, a right-hand turn tracker (RR phase/sub-step/player-window outline, current phase highlighted), and a collapsible left event log.
+
+**Architecture:** New `act_agenda.rs` (a `location_map`-style pub fn rendered in `BoardView`) and `turn_tracker.rs` (a store-reading component in the right column). `BoardView`'s `phase_bar` is dismantled (act/agenda → cards, phase/round → tracker). `EventLogView` gains a client `collapsed` signal. `app.rs` wires three columns.
+
+**Tech Stack:** Rust, Leptos (CSR), Trunk, `wasm-bindgen-test` (headless Firefox), `card_registry`/`cards::REGISTRY`, `game_core::test_support::fixtures`.
+
+## Global Constraints
+
+- **Warnings are errors in CI** across seven jobs (native + wasm). Before pushing: `RUSTFLAGS="-D warnings" cargo test --all --all-features`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo fmt --check`; `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`; `cargo build -p web --target wasm32-unknown-unknown`; `wasm-pack test --headless --firefox crates/web`; `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings`.
+- **Clippy `pedantic` is on** (`module_name_repetitions` / `must_use_candidate` allowed); `doc_markdown` enforced — backtick-quote type names / `ArkhamDB` in doc comments.
+- **wasm-only test files** carry crate-level `#![cfg(target_arch = "wasm32")]`; headless tests share one page (scope to last subtree). Registry install is **first-wins per process** — never mix `install_test_registry` and `cards::REGISTRY` in one test binary.
+- **Stats/text from the corpus / `GameState`** — never hand-typed. Act card shows `clues to advance: {clue_threshold}` (no fake progress); agenda shows `doom {agenda_doom}/{doom_threshold}`.
+- **Turn-tracker outline is authored from the Rules Reference** (verbatim, with the page citation in the module doc-comment) — the exact text is supplied in Task 2 below; do not paraphrase from memory.
+- **Display-only:** no engine wiring / no `OutboundTx`.
+
+## File structure
+
+- **Create `crates/web/src/act_agenda.rs`** — `pub fn act_agenda_view(game: &GameState) -> impl IntoView` (mirrors `map::location_map`). (Task 1)
+- **Create `crates/web/src/turn_tracker.rs`** — `#[component] pub fn TurnTrackerView()` + the static RR `ROUND` outline. (Task 2)
+- **Modify `crates/web/src/lib.rs`** — register both new modules.
+- **Modify `crates/web/src/board.rs`** — render `act_agenda_view` in `BoardView`; dismantle `phase_bar` (Task 1 removes act/agenda from it; Task 2 removes it entirely).
+- **Modify `crates/web/src/event_log.rs`** — collapsible. (Task 3)
+- **Modify `crates/web/src/app.rs`** — three-column layout (right tracker). (Task 2)
+- **Modify `crates/web/style.css`** — act/agenda accents (Task 1), 3-column + tracker (Task 2), collapsed log (Task 3).
+- **Create `crates/web/tests/act_agenda.rs`** (Task 1), **`crates/web/tests/turn_tracker.rs`** (Task 2); **modify `crates/web/tests/board.rs`** (Tasks 1–2), **`crates/web/tests/event_log.rs`** (Task 3).
+
+Type notes (verified): `GameState.act_deck: Vec<Act>` / `act_index: usize`; `agenda_deck: Vec<Agenda>` / `agenda_index` / `agenda_doom: u8`. `Act { code: CardCode, clue_threshold: u8, resolution: Option<..> }`; `Agenda { code, doom_threshold: u8, resolution }`. `Phase` (`game_core::state::Phase`) is `Copy + PartialEq`, variants `Mythos`/`Investigation`/`Enemy`/`Upkeep`. `crate::card::parse_card_text` (pub) + `render_segments` (pub(crate)). `map::location_map` is the pub-fn-rendered-in-BoardView precedent.
+
+---
+
+### Task 1: Act/Agenda cards atop the board
+
+**Files:**
+- Create: `crates/web/src/act_agenda.rs`
+- Modify: `crates/web/src/lib.rs`, `crates/web/src/board.rs`, `crates/web/style.css`
+- Create: `crates/web/tests/act_agenda.rs`
+- Modify: `crates/web/tests/board.rs`
+
+**Interfaces:**
+- Produces: `pub fn act_agenda_view(game: &GameState) -> impl IntoView` rendering `<section class="act-agenda">` with an act card (`card card--act`, `clues to advance: N`) and an agenda card (`card card--agenda`, `doom d/N`), each name/text from the corpus by `code`. Empty when the respective deck is empty.
+
+- [ ] **Step 1: Register the module**
+
+In `crates/web/src/lib.rs`, add (alphabetically, after `pub mod app;`):
+
+```rust
+pub mod act_agenda;
+```
+
+- [ ] **Step 2: Write the failing headless test**
+
+Create `crates/web/tests/act_agenda.rs`:
+
+```rust
+//! Headless render test for the Act/Agenda cards. Own binary so it installs the
+//! real `cards::REGISTRY` (registry install is first-wins per process); mounts
+//! `act_agenda_view` directly (no investigator panel → no TEST_INV lookup).
+#![cfg(target_arch = "wasm32")]
+
+use game_core::state::{Act, Agenda, CardCode, GameStateBuilder};
+use leptos::prelude::document;
+use wasm_bindgen::JsCast as _;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn section_text() -> String {
+    let nodes = document().query_selector_all(".act-agenda").expect("query ok");
+    nodes
+        .item(nodes.length() - 1)
+        .and_then(|n| n.dyn_into::<web_sys::Element>().ok())
+        .and_then(|el| el.text_content())
+        .unwrap_or_default()
+}
+
+#[wasm_bindgen_test]
+async fn act_and_agenda_render_name_text_and_thresholds() {
+    let _ = game_core::card_registry::install(cards::REGISTRY);
+    // Act 01109 "The Barrier" (Objective text); Agenda 01107 "They're Getting
+    // Out!" (Forced text).
+    let mut state = GameStateBuilder::new().build();
+    state.act_deck = vec![Act {
+        code: CardCode::new("01109"),
+        clue_threshold: 2,
+        resolution: None,
+    }];
+    state.agenda_deck = vec![Agenda {
+        code: CardCode::new("01107"),
+        doom_threshold: 3,
+        resolution: None,
+    }];
+    state.agenda_doom = 1;
+
+    leptos::mount::mount_to_body(move || web::act_agenda::act_agenda_view(&state));
+    leptos::task::tick().await;
+
+    let text = section_text();
+    assert!(text.contains("The Barrier"), "act name missing: {text}");
+    assert!(text.contains("clues to advance: 2"), "act threshold missing: {text}");
+    assert!(text.contains("Objective"), "act ability text missing: {text}");
+    assert!(text.contains("They're Getting Out!"), "agenda name missing: {text}");
+    assert!(text.contains("doom 1/3"), "agenda doom missing: {text}");
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `wasm-pack test --headless --firefox crates/web --test act_agenda`
+Expected: FAIL — `web::act_agenda::act_agenda_view` doesn't exist (compile error).
+
+- [ ] **Step 4: Implement `act_agenda_view`**
+
+Create `crates/web/src/act_agenda.rs`:
+
+```rust
+//! Act + Agenda cards atop the board (above the map). A pure render of
+//! `GameState` (mirrors `map::location_map`): the current act and agenda render
+//! as cards — name + ability text from the corpus by `code`, thresholds from the
+//! `Act`/`Agenda` structs. The act has no running clue counter (clues sit on
+//! locations/investigators), so it shows `clues to advance: N` rather than a
+//! fake `0/N`. Display-only.
+
+use game_core::state::{CardCode, GameState};
+use leptos::prelude::*;
+
+use crate::card::{parse_card_text, render_segments};
+
+/// Name (printed, or the raw code when no metadata) + rendered ability text for
+/// an act/agenda card code.
+fn name_and_text(code: &CardCode) -> (String, Option<Vec<AnyView>>) {
+    let meta = game_core::card_registry::current().and_then(|r| (r.metadata_for)(code));
+    let name = meta.map_or_else(|| code.to_string(), |m| m.name.clone());
+    let text = meta
+        .and_then(|m| m.text.as_deref())
+        .map(|t| render_segments(parse_card_text(t)));
+    (name, text)
+}
+
+/// The current act + agenda as cards. Each is omitted when its deck is empty
+/// (fixtures may carry neither).
+pub fn act_agenda_view(game: &GameState) -> impl IntoView {
+    let act = game.act_deck.get(game.act_index).map(|act| {
+        let (name, text) = name_and_text(&act.code);
+        let threshold = act.clue_threshold;
+        view! {
+            <article class="card card--act">
+                <div class="card-head">
+                    <span class="card-kind">"Act"</span>
+                    <span class="card-name">{name}</span>
+                </div>
+                <div class="card-text">{text}</div>
+                <div class="loc-stats">
+                    <span>{format!("clues to advance: {threshold}")}</span>
+                </div>
+            </article>
+        }
+    });
+    let agenda = game.agenda_deck.get(game.agenda_index).map(|ag| {
+        let (name, text) = name_and_text(&ag.code);
+        let doom = game.agenda_doom;
+        let threshold = ag.doom_threshold;
+        view! {
+            <article class="card card--agenda">
+                <div class="card-head">
+                    <span class="card-kind">"Agenda"</span>
+                    <span class="card-name">{name}</span>
+                </div>
+                <div class="card-text">{text}</div>
+                <div class="loc-stats">
+                    <span>{format!("doom {doom}/{threshold}")}</span>
+                </div>
+            </article>
+        }
+    });
+    view! { <section class="act-agenda">{act}{agenda}</section> }
+}
+```
+
+- [ ] **Step 5: Render it in `BoardView` + drop act/agenda from `phase_bar`**
+
+In `crates/web/src/board.rs`, in the `Some(game)` board view, insert the act/agenda section after the resolution banner:
+
+```rust
+            <div class="game">
+                {resolution_banner(&game)}
+                {crate::act_agenda::act_agenda_view(&game)}
+                {phase_bar(&game)}
+                <div class="board-main">
+                    {crate::map::location_map(&game)}
+                    {investigators_panel(&game)}
+                </div>
+            </div>
+```
+
+Then remove the act + agenda lines from `phase_bar` (keep phase + round for now — Task 2 removes the rest). The `phase_bar` fn becomes:
+
+```rust
+fn phase_bar(game: &GameState) -> impl IntoView {
+    let phase = format!("{:?}", game.phase);
+    let round = game.round;
+    view! {
+        <header class="phase-bar">
+            <span class="phase">{phase}</span>
+            <span class="round">"round " {round}</span>
+        </header>
+    }
+}
+```
+
+- [ ] **Step 6: Update the board test's act/agenda assertion**
+
+In `crates/web/tests/board.rs`, `phase_bar_renders_phase_round_act_agenda` currently asserts `"clues 0/2"`. Act/agenda now render via `act_agenda_view` (synthetic registry → `_test_act`/`_test_agenda` have no metadata, so names fall back to codes, thresholds come from the structs). Replace the act assertion:
+
+```rust
+    assert!(
+        html.contains("clues 0/2") || html.contains("0/2"),
+        "act threshold missing: {html}"
+    );
+```
+
+with:
+
+```rust
+    assert!(
+        html.contains("clues to advance: 2"),
+        "act threshold missing: {html}"
+    );
+```
+
+(The `doom 1/5` assertion stays — the agenda card renders it. The `Investigation` + `round 3` assertions stay — `phase_bar` still shows them.)
+
+- [ ] **Step 7: Add the CSS**
+
+In `crates/web/style.css`, after the card-palette block (near `.card--unknown, .card--generic`), add:
+
+```css
+.act-agenda { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.5rem; }
+.card--act { border-color: #c8a020; }
+.card--agenda { border-color: #7a2f2f; }
+.card-kind { font-size: 0.7rem; text-transform: uppercase; opacity: 0.7; margin-right: 0.3rem; }
+```
+
+(The act/agenda articles reuse `.card` from the existing rules; these add the accents + the kind label.)
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `wasm-pack test --headless --firefox crates/web --test act_agenda` (PASS), then `wasm-pack test --headless --firefox crates/web --test board` (PASS — updated assertion).
+
+- [ ] **Step 9: Verify clippy (both targets) + fmt + build**
+
+Run: `cargo clippy -p web --all-targets --all-features -- -D warnings` and `cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings` and `cargo fmt --check` and `cd crates/web && trunk build`.
+Expected: clean / builds.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/web/src/act_agenda.rs crates/web/src/lib.rs crates/web/src/board.rs crates/web/style.css crates/web/tests/act_agenda.rs crates/web/tests/board.rs
+git commit -m "web: render Act/Agenda as cards atop the board
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01W8C6W8YhY8Lvo6aoKVDmcM"
+```
+
+---
+
+### Task 2: Right-hand turn tracker + 3-column layout
+
+**Files:**
+- Create: `crates/web/src/turn_tracker.rs`
+- Modify: `crates/web/src/lib.rs`, `crates/web/src/app.rs`, `crates/web/src/board.rs`, `crates/web/style.css`
+- Create: `crates/web/tests/turn_tracker.rs`
+- Modify: `crates/web/tests/board.rs`
+
+**Interfaces:**
+- Produces: `#[component] pub fn TurnTrackerView()` rendering `<aside class="turn-tracker">` with `Round {n}` and the four phases; the phase matching `game.phase` carries a `current` class; player windows render as `<li class="tracker-window">`.
+
+- [ ] **Step 1: Register the module**
+
+In `crates/web/src/lib.rs`, add `pub mod turn_tracker;` (alphabetically — after `skill_test_result` is fine; keep the list sorted).
+
+- [ ] **Step 2: Write the failing headless test**
+
+Create `crates/web/tests/turn_tracker.rs`:
+
+```rust
+//! Headless render tests for the turn tracker. wasm32-only.
+#![cfg(target_arch = "wasm32")]
+
+use game_core::state::{GameStateBuilder, Phase};
+use game_core::test_support::fixtures::test_investigator;
+use game_core::EngineOutcome;
+use leptos::prelude::{document, provide_context, RwSignal, Update};
+use protocol::ServerMessage;
+use wasm_bindgen::JsCast as _;
+use wasm_bindgen_test::*;
+use web::store::{reduce, ClientState};
+use web::turn_tracker::TurnTrackerView;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+async fn mount_at(phase: Phase, round: u32) {
+    game_core::test_support::install_test_registry();
+    let state = GameStateBuilder::new()
+        .with_investigator(test_investigator(1))
+        .with_phase(phase)
+        .with_round(round)
+        .build();
+    let store = RwSignal::new(ClientState::default());
+    leptos::mount::mount_to_body(move || {
+        provide_context(store);
+        leptos::view! { <TurnTrackerView/> }
+    });
+    store.update(|s| {
+        reduce(
+            s,
+            ServerMessage::Hello {
+                state: Box::new(state),
+                outcome: EngineOutcome::Done,
+                events: Vec::new(),
+            },
+        );
+    });
+    leptos::task::tick().await;
+}
+
+fn last_tracker() -> web_sys::Element {
+    let nodes = document().query_selector_all(".turn-tracker").expect("query ok");
+    nodes
+        .item(nodes.length() - 1)
+        .and_then(|n| n.dyn_into::<web_sys::Element>().ok())
+        .expect("a .turn-tracker")
+}
+
+#[wasm_bindgen_test]
+async fn lists_all_phases_substeps_and_round() {
+    mount_at(Phase::Investigation, 2).await;
+    let t = last_tracker().text_content().unwrap_or_default();
+    assert!(t.contains("Round 2"), "round missing: {t}");
+    assert!(t.contains("Mythos"), "Mythos missing: {t}");
+    assert!(t.contains("Investigation"), "Investigation missing: {t}");
+    assert!(t.contains("Enemy"), "Enemy missing: {t}");
+    assert!(t.contains("Upkeep"), "Upkeep missing: {t}");
+    assert!(t.contains("Place 1 doom on the current agenda."), "a Mythos sub-step missing: {t}");
+    assert!(t.contains("player window"), "player windows missing: {t}");
+}
+
+#[wasm_bindgen_test]
+async fn current_phase_is_highlighted() {
+    mount_at(Phase::Enemy, 1).await;
+    let tracker = last_tracker();
+    // Exactly one phase block carries `current`, and it is the Enemy block.
+    let current = tracker
+        .query_selector(".tracker-phase.current")
+        .expect("query ok")
+        .expect("a current phase block")
+        .text_content()
+        .unwrap_or_default();
+    assert!(current.contains("Enemy"), "current phase should be Enemy: {current}");
+    assert!(!current.contains("Mythos"), "only the Enemy block is current: {current}");
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `wasm-pack test --headless --firefox crates/web --test turn_tracker`
+Expected: FAIL — `web::turn_tracker::TurnTrackerView` doesn't exist.
+
+- [ ] **Step 4: Implement `TurnTrackerView` with the RR outline**
+
+Create `crates/web/src/turn_tracker.rs`. The `ROUND` constant is transcribed **verbatim from the FFG Rules Reference, Appendix II "Timing and Gameplay"** — the Phase Sequence timing chart + Framework Event Details (`data/rules-reference/ahc01_rules_reference_web.pdf`, pp. 23–25): grey boxes are framework events (`Step::Framework`), red boxes are player windows (`Step::Window`).
+
+```rust
+//! Right-hand turn tracker: the round's four phases with their Rules-Reference
+//! sub-steps and structural player windows, highlighting the current phase.
+//!
+//! The `ROUND` outline is transcribed verbatim from the FFG Rules Reference,
+//! Appendix II "Timing and Gameplay" — the Phase Sequence timing chart and
+//! Framework Event Details (`data/rules-reference/ahc01_rules_reference_web.pdf`,
+//! pp. 23-25). Grey boxes are framework events; red boxes are player windows.
+//! The engine exposes only the coarse phase, so only the current *phase* is
+//! highlighted. Display-only.
+
+use game_core::state::Phase;
+use leptos::prelude::*;
+
+use crate::store::use_store;
+
+/// One entry in a phase's ordered outline.
+enum Step {
+    /// A framework event (mandatory, grey box).
+    Framework(&'static str),
+    /// A structural player window (red box).
+    Window,
+}
+
+struct PhaseOutline {
+    phase: Phase,
+    label: &'static str,
+    steps: &'static [Step],
+}
+
+use Step::{Framework, Window};
+
+const ROUND: &[PhaseOutline] = &[
+    PhaseOutline {
+        phase: Phase::Mythos,
+        label: "Mythos",
+        steps: &[
+            Framework("1.1 Round begins. Mythos phase begins."),
+            Framework("1.2 Place 1 doom on the current agenda."),
+            Framework("1.3 Check doom threshold."),
+            Framework("1.4 Each investigator draws 1 encounter card."),
+            Window,
+            Framework("1.5 Mythos phase ends."),
+        ],
+    },
+    PhaseOutline {
+        phase: Phase::Investigation,
+        label: "Investigation",
+        steps: &[
+            Framework("2.1 Investigation phase begins."),
+            Window,
+            Framework("2.2 Next investigator's turn begins."),
+            Window,
+            Framework("2.2.1 Active investigator may take an action, if able."),
+            Framework("2.2.2 Investigator's turn ends."),
+            Framework("2.3 Investigation phase ends."),
+        ],
+    },
+    PhaseOutline {
+        phase: Phase::Enemy,
+        label: "Enemy",
+        steps: &[
+            Framework("3.1 Enemy phase begins."),
+            Framework("3.2 Hunter enemies move."),
+            Window,
+            Framework("3.3 Next investigator resolves engaged enemy attacks."),
+            Window,
+            Framework("3.4 Enemy phase ends."),
+        ],
+    },
+    PhaseOutline {
+        phase: Phase::Upkeep,
+        label: "Upkeep",
+        steps: &[
+            Framework("4.1 Upkeep phase begins."),
+            Window,
+            Framework("4.2 Reset actions."),
+            Framework("4.3 Ready each exhausted card."),
+            Framework("4.4 Each investigator draws 1 card and gains 1 resource."),
+            Framework("4.5 Each investigator checks hand size."),
+            Framework("4.6 Upkeep phase ends. Round ends."),
+        ],
+    },
+];
+
+#[component]
+pub fn TurnTrackerView() -> impl IntoView {
+    let store = use_store();
+    move || {
+        let game = store.get().game;
+        let current = game.as_ref().map(|g| g.phase);
+        let round = game.as_ref().map(|g| g.round);
+        let phases: Vec<_> = ROUND
+            .iter()
+            .map(|p| {
+                let cls = if current == Some(p.phase) {
+                    "tracker-phase current"
+                } else {
+                    "tracker-phase"
+                };
+                let steps: Vec<_> = p
+                    .steps
+                    .iter()
+                    .map(|s| match s {
+                        Step::Framework(t) => view! { <li class="tracker-step">{*t}</li> }.into_any(),
+                        Step::Window => {
+                            view! { <li class="tracker-window">"player window"</li> }.into_any()
+                        }
+                    })
+                    .collect();
+                view! {
+                    <div class=cls>
+                        <div class="tracker-phase-label">{p.label}</div>
+                        <ul>{steps}</ul>
+                    </div>
+                }
+            })
+            .collect();
+        view! {
+            <aside class="turn-tracker">
+                <h2>"Turn"</h2>
+                {round.map(|r| view! { <div class="tracker-round">{format!("Round {r}")}</div> })}
+                {phases}
+            </aside>
+        }
+        .into_any()
+    }
+}
+```
+
+- [ ] **Step 5: Wire the right column in `app.rs` + remove `phase_bar`**
+
+In `crates/web/src/app.rs`, add the tracker as the third column of `.layout` (after `main-column`):
+
+```rust
+            <div class="layout">
+                <crate::event_log::EventLogView/>
+                <div class="main-column">
+                    <BoardView/>
+                    {
+                        #[cfg(target_arch = "wasm32")]
+                        { view! {
+                            <div class="action-bar">
+                                <crate::picker::PickerView/>
+                                <crate::skill_test_result::SkillTestResultView/>
+                                <crate::input::AwaitingInputView/>
+                            </div>
+                        }.into_any() }
+                        #[cfg(not(target_arch = "wasm32"))]
+                        { ().into_any() }
+                    }
+                </div>
+                <crate::turn_tracker::TurnTrackerView/>
+            </div>
+```
+
+In `crates/web/src/board.rs`, remove the `phase_bar` call from the board view and delete the `phase_bar` fn entirely (phase + round now live in the tracker):
+
+```rust
+            <div class="game">
+                {resolution_banner(&game)}
+                {crate::act_agenda::act_agenda_view(&game)}
+                <div class="board-main">
+                    {crate::map::location_map(&game)}
+                    {investigators_panel(&game)}
+                </div>
+            </div>
+```
+
+Delete the entire `fn phase_bar(...) { ... }` definition.
+
+- [ ] **Step 6: Update the board test (phase/round move to the tracker)**
+
+In `crates/web/tests/board.rs`, the `phase_bar_renders_phase_round_act_agenda` test now over-asserts: `BoardView` no longer renders the phase/round (they're in `TurnTrackerView`, which this test does not mount). Rename it and drop the phase/round assertions, keeping the act/agenda ones:
+
+```rust
+#[wasm_bindgen_test]
+async fn act_agenda_cards_render_name_and_thresholds() {
+    let mut state = GameStateBuilder::new()
+        .with_investigator(test_investigator(1))
+        .with_phase(Phase::Investigation)
+        .with_round(3)
+        .build();
+    state.act_deck = vec![Act {
+        code: CardCode("_test_act".into()),
+        clue_threshold: 2,
+        resolution: None,
+    }];
+    state.agenda_deck = vec![Agenda {
+        code: CardCode("_test_agenda".into()),
+        doom_threshold: 5,
+        resolution: None,
+    }];
+    state.agenda_doom = 1;
+
+    let html = render_state(state).await;
+
+    assert!(html.contains("doom 1/5"), "agenda doom missing: {html}");
+    assert!(
+        html.contains("clues to advance: 2"),
+        "act threshold missing: {html}"
+    );
+}
+```
+
+(The `Phase`/`with_round` setup stays valid — `with_phase`/`with_round` are still on the builder; the test just no longer asserts the phase/round text, which the tracker test now covers. If `Phase` is now unused elsewhere in the file, keep the `use ... Phase` import since this test still references `Phase::Investigation`.)
+
+- [ ] **Step 7: Add the 3-column + tracker CSS**
+
+In `crates/web/style.css`, add (the `.layout` flex already exists; these size the columns + style the tracker):
+
+```css
+.turn-tracker { flex: 0 0 auto; width: 18rem; font-size: 0.8rem; }
+.turn-tracker h2 { font-size: 1rem; margin: 0 0 0.25rem; }
+.tracker-round { font-weight: 600; margin-bottom: 0.4rem; }
+.tracker-phase { border-left: 3px solid transparent; padding: 0.15rem 0 0.15rem 0.4rem; margin-bottom: 0.3rem; }
+.tracker-phase.current { border-left-color: #2f6fb3; background: #eef4fb; }
+.tracker-phase-label { font-weight: 600; }
+.tracker-phase ul { list-style: none; padding-left: 0.5rem; margin: 0.1rem 0; }
+.tracker-step { color: #444; }
+.tracker-window { color: #8a5a00; font-style: italic; }
+```
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `wasm-pack test --headless --firefox crates/web --test turn_tracker` (PASS), then `--test board` (PASS), then `--test act_agenda` (PASS).
+
+- [ ] **Step 9: Verify clippy (both targets) + fmt + build**
+
+Run the two clippy targets, `cargo fmt --check`, and `cd crates/web && trunk build`. Expected: clean / builds.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/web/src/turn_tracker.rs crates/web/src/lib.rs crates/web/src/app.rs crates/web/src/board.rs crates/web/style.css crates/web/tests/turn_tracker.rs crates/web/tests/board.rs
+git commit -m "web: right-hand turn tracker (RR phase outline) + 3-column layout
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01W8C6W8YhY8Lvo6aoKVDmcM"
+```
+
+---
+
+### Task 3: Collapsible event log
+
+**Files:**
+- Modify: `crates/web/src/event_log.rs`, `crates/web/style.css`
+- Modify: `crates/web/tests/event_log.rs`
+
+**Interfaces:**
+- `EventLogView` renders a toggle button (`.log-toggle`); a client `collapsed` signal hides the `.log-scroll` body (`hidden` class) when set.
+
+- [ ] **Step 1: Write the failing headless test**
+
+Read `crates/web/tests/event_log.rs` for its mount helper, then add (adapt the mount to the file's existing harness — it mounts `EventLogView` with a store):
+
+```rust
+#[wasm_bindgen_test]
+async fn log_collapses_and_expands() {
+    // Mount EventLogView (use the file's existing mount helper / store setup).
+    let store = leptos::prelude::RwSignal::new(web::store::ClientState::default());
+    leptos::mount::mount_to_body(move || {
+        leptos::prelude::provide_context(store);
+        leptos::view! { <web::event_log::EventLogView/> }
+    });
+    leptos::task::tick().await;
+
+    let doc = leptos::prelude::document();
+    let scroll = doc
+        .query_selector(".event-log .log-scroll")
+        .expect("query ok")
+        .expect(".log-scroll present");
+    assert!(
+        !scroll.class_name().contains("hidden"),
+        "log body should start visible: {}",
+        scroll.class_name()
+    );
+
+    let toggle = doc
+        .query_selector(".event-log .log-toggle")
+        .expect("query ok")
+        .expect(".log-toggle present")
+        .dyn_into::<web_sys::HtmlElement>()
+        .expect("HtmlElement");
+    toggle.click();
+    leptos::task::tick().await;
+    assert!(
+        scroll.class_name().contains("hidden"),
+        "log body should be hidden after collapse: {}",
+        scroll.class_name()
+    );
+}
+```
+
+Ensure the test file's imports include `use wasm_bindgen::JsCast as _;` (for `dyn_into`) and `use wasm_bindgen_test::*;`; if the file lacks them, add them.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `wasm-pack test --headless --firefox crates/web --test event_log`
+Expected: FAIL — no `.log-toggle` exists.
+
+- [ ] **Step 3: Add the collapse toggle**
+
+In `crates/web/src/event_log.rs`, add a `collapsed` signal at the top of the component (after `let store = use_store();`):
+
+```rust
+    let collapsed = RwSignal::new(false);
+```
+
+Replace the returned `view!` with a header carrying the toggle and a `hidden`-gated body:
+
+```rust
+    view! {
+        <aside class="event-log">
+            <div class="event-log-head">
+                <h2>"Event log"</h2>
+                <button
+                    class="log-toggle"
+                    on:click=move |_| collapsed.update(|c| *c = !*c)
+                >
+                    {move || if collapsed.get() { "show" } else { "hide" }}
+                </button>
+            </div>
+            <div
+                class="log-scroll"
+                class:hidden=move || collapsed.get()
+                node_ref=scroll_ref
+            >
+                {batches}
+            </div>
+        </aside>
+    }
+```
+
+- [ ] **Step 4: Add the CSS**
+
+In `crates/web/style.css`, add:
+
+```css
+.event-log-head { display: flex; align-items: baseline; justify-content: space-between; }
+.log-toggle { font-size: 0.75rem; }
+.hidden { display: none; }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `wasm-pack test --headless --firefox crates/web --test event_log`
+Expected: PASS (collapse test + any existing event-log tests).
+
+- [ ] **Step 6: Verify clippy (both targets) + fmt + build**
+
+Run the two clippy targets, `cargo fmt --check`, and `cd crates/web && trunk build`. Expected: clean / builds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/web/src/event_log.rs crates/web/style.css crates/web/tests/event_log.rs
+git commit -m "web: make the event log collapsible
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01W8C6W8YhY8Lvo6aoKVDmcM"
+```
+
+---
+
+### Task 4: Full CI gauntlet + phase doc + PR
+
+- [ ] **Step 1: Run every CI job locally**
+
+```bash
+RUSTFLAGS="-D warnings" cargo test --all --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+cargo build -p web --target wasm32-unknown-unknown
+wasm-pack test --headless --firefox crates/web
+cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Update the phase-7 doc — only when the PR is ready**
+
+Extend the visual-card-rendering bullet in `docs/phases/phase-7-the-gathering.md` with this slice: Act/Agenda render as cards atop the board (act shows `clues to advance: N` — no running counter; agenda shows real `doom d/N`); a right-hand `TurnTrackerView` outlines the round (4 phases + RR sub-steps + structural player windows, transcribed verbatim from RR Appendix II pp. 23-25, current phase highlighted); the left event log is collapsible; the page is now three columns and the `phase_bar` is retired. Note the interactivity pass remains. Reference the new spec/plan.
+
+- [ ] **Step 3: Open the PR**
+
+Branch `web/act-agenda-sidebars`. File an issue first, push, open the PR; `Closes` it. Design-decisions paragraph: act/agenda via a `location_map`-style pure fn (own-binary metadata test); turn-tracker outline transcribed verbatim from RR Appendix II (cited); collapsible log via a client signal; `phase_bar` retired into the cards + tracker.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** act/agenda cards atop board, no fake clue progress (Task 1) ✓; turn tracker w/ RR sub-steps + player windows + current-phase highlight + round (Task 2) ✓; collapsible log (Task 3) ✓; 3-column layout (Task 2 app.rs + CSS) ✓; `phase_bar` retired (Task 2) ✓; own-binary act/agenda metadata test + tracker test + log click test + board-test evolution ✓.
+- **Type consistency:** `act_agenda_view(&GameState) -> impl IntoView` (pub fn) called in BoardView + mounted in its test; `TurnTrackerView` component mounted in app.rs + its test; `Phase` `Copy`+`PartialEq` used for `current == Some(p.phase)`; `Act`/`Agenda` field names (`code`/`clue_threshold`/`doom_threshold`) match `game_state.rs`; CSS classes (`act-agenda`, `card--act/agenda`, `turn-tracker`, `tracker-phase.current`, `tracker-window`, `log-toggle`, `hidden`) consistent between components, CSS, and tests.
+- **RR fidelity:** the `ROUND` outline is transcribed verbatim from RR Appendix II (pp. 23-25), cited in the module doc-comment — not from memory.
+- **Out of scope (unchanged):** interactivity/clickable cards, live sub-step highlighting, per-investigator turn tracking, the icon font.

--- a/docs/superpowers/specs/2026-06-30-act-agenda-and-sidebars-design.md
+++ b/docs/superpowers/specs/2026-06-30-act-agenda-and-sidebars-design.md
@@ -1,0 +1,130 @@
+# Act/Agenda cards + turn tracker + collapsible log — design
+
+**Date:** 2026-06-30
+**Status:** approved (brainstorm), pending implementation plan
+**Phase:** 7 (web iteration); sixth slice of the card-rendering / layout rework
+
+## Goal
+
+Three related layout changes:
+1. Render the current **Act and Agenda as cards** at the top of the board
+   (above the map), replacing the terse phase-bar act/agenda text.
+2. Move the **phase indicator into a right-hand turn tracker** that outlines the
+   round's phases, their Rules-Reference sub-steps, and the structural player
+   windows, highlighting the current phase.
+3. Make the left **event log collapsible**.
+
+Together these turn the page into a three-column layout. Display-only.
+
+## Scope decisions
+
+- **Display-only.** No click handlers / engine wiring.
+- **Three-column layout:** left = event log (collapsible), center = act/agenda
+  cards → board (map stacked above the investigators panel) → sticky action bar,
+  right = turn tracker.
+- **Turn tracker is a static RR-sourced cheat-sheet.** It lists the round's four
+  phases, each with its RR sub-steps and the structural player/reaction windows,
+  and highlights only the **current phase** (`game.phase`) — the engine exposes
+  the coarse phase, not sub-step position. The outline content is authored from
+  the Rules Reference and cited in the plan / component doc-comment — **never from
+  memory** (per the repo's rules-verification rule).
+- **Act has no running clue counter.** The current phase-bar's "clues 0/N"
+  hardcodes the 0; clues live on locations/investigators, not on the act. The act
+  card shows `clues to advance: {clue_threshold}` (no fake progress). The agenda
+  card shows real progress `doom {agenda_doom}/{doom_threshold}`.
+- **In scope:** the three layout pieces. The interactivity pass (clickable cards,
+  retiring the action bar) is a separate, later effort.
+
+## Architecture
+
+### New component `crates/web/src/act_agenda.rs` — `ActAgendaView`
+
+Reads the store. Renders the current Act (`act_deck[act_index]`) and Agenda
+(`agenda_deck[agenda_index]`, with `agenda_doom`) as two cards:
+
+- Name + ability text from the corpus by `code` (`metadata_for`), text via
+  `crate::card::parse_card_text` + `crate::card::render_segments`.
+- Act: a `clues to advance: {clue_threshold}` line. Agenda:
+  `doom {agenda_doom}/{doom_threshold}`.
+- Rendered only when the respective deck is non-empty (fixtures may omit them).
+- Reuses the card CSS vocabulary; act/agenda get distinct accents.
+
+Rendered at the top of `BoardView` (above the map), after the resolution banner.
+
+### New component `crates/web/src/turn_tracker.rs` — `TurnTrackerView`
+
+Reads the store (`game.phase`, `game.round`). Renders:
+
+- `Round {n}`.
+- A static outline: the four phases (Mythos, Investigation, Enemy, Upkeep), each
+  with its RR sub-steps and structural player windows, as a nested list. The
+  content is a module-level constant authored from the Rules Reference.
+- The phase whose label matches `game.phase` carries a `current` CSS class; the
+  others do not.
+
+Lives in the right column.
+
+### `EventLogView` collapse (`crates/web/src/event_log.rs`)
+
+A client-side `collapsed` `RwSignal` (default expanded) + a toggle button. When
+collapsed, the log body is hidden and a compact "show log" affordance remains.
+No engine involvement; the auto-scroll effect stays.
+
+### `BoardView` (`crates/web/src/board.rs`)
+
+The `phase_bar` is dismantled: act/agenda move to `ActAgendaView` (top), phase +
+round move to `TurnTrackerView` (right). `BoardView` renders the resolution
+banner, then `ActAgendaView`, then `board-main` (map + investigators). The
+`phase_bar` fn and its `.phase-bar` usage are removed.
+
+### `app.rs` + `style.css`
+
+`app.rs` wires the three columns: `<EventLogView/>` (left) · `main-column`
+(BoardView + action bar) · `<TurnTrackerView/>` (right). `style.css` adds the
+three-column layout, the tracker styling (+ `current`-phase highlight), the
+act/agenda accents, and the collapsed-log state.
+
+## Field / content summary
+
+| Piece | Source | Rendering |
+|---|---|---|
+| Act card | `act_deck[act_index]` + registry | name, text, `clues to advance: {clue_threshold}` |
+| Agenda card | `agenda_deck[agenda_index]` + `agenda_doom` + registry | name, text, `doom {agenda_doom}/{doom_threshold}` |
+| Turn tracker | static RR outline + `game.phase`/`game.round` | `Round n`; 4 phases w/ sub-steps + player windows; current phase highlighted |
+| Event log | client `collapsed` signal | toggle hides/shows the log body |
+
+## Testing
+
+- **`ActAgendaView`** — own-binary headless test (`crates/web/tests/act_agenda.rs`,
+  real `cards::REGISTRY`, mounts `ActAgendaView` directly; registry install is
+  first-wins per process, so it must be its own binary): a state with a real Act
+  and Agenda code renders both names, their ability text, `clues to advance: N`,
+  and `doom d/N`. Act/agenda codes verified against the snapshot at plan time.
+- **`TurnTrackerView`** — headless (synthetic registry fine): all four phase
+  labels and their sub-steps render; with `game.phase = Investigation`, the
+  Investigation entry carries the `current` class and the others do not.
+- **`EventLogView`** — headless click test: the log body is visible initially;
+  after clicking the toggle it is hidden (and a show affordance is present);
+  clicking again restores it.
+- **Smoke** — the three columns (`.event-log`, `.main-column`, the tracker) all
+  mount.
+
+Stats/text read from the corpus / `GameState` — never hand-typed. The turn-tracker
+outline is authored from the Rules Reference and cited in the plan.
+
+## What "done" looks like (this slice)
+
+- Act + Agenda render as cards at the top of the board; the terse phase-bar
+  act/agenda text is gone.
+- A right-hand turn tracker outlines the round (phases + RR sub-steps + player
+  windows), highlighting the current phase, with the round number.
+- The left event log can be collapsed/expanded.
+- Hand/in-play/enemy/location/treachery cards unchanged.
+- Native + headless tests pass; the full 7-job CI gauntlet is green.
+
+## Out of scope (later slices)
+
+- Clickable act/agenda or any interactivity (the interactivity pass).
+- Live sub-step highlighting in the tracker (engine exposes only the coarse phase).
+- Per-investigator turn / action-point tracking in the tracker.
+- The ArkhamDB icon font (still deferred).


### PR DESCRIPTION
## Summary

A three-column layout for the web client (sixth slice of the card-rendering/layout rework):

1. **Act/Agenda cards atop the board** — `act_agenda.rs` (a `location_map`-style pure fn): name + ability text from the corpus by `code` (act 1/agenda 1 have no front text, so they show name + threshold only — by data); act shows `clues to advance: N`, agenda shows real `doom {agenda_doom}/{doom_threshold}`.
2. **Right-hand turn tracker** — `TurnTrackerView`: round + the four phases with their RR sub-steps and structural player windows (transcribed from RR Appendix II pp. 23-25, cited; reviewer-verified vs the pinned PDF), current phase highlighted. (Per-sub-step highlight needs the engine to surface it — deferred to #534.)
3. **Collapsible left event log** — collapses to a thin `▸ log` strip that frees the left side; expands back to the full panel.
4. **Investigator panel regrouped** into two zone rows: in-play (left) + threat (right) on top, each boxed; stat block (left) + hand (right) below.

The `phase_bar` is retired (phase/round → tracker, act/agenda → cards). Display-only.

## Testing

- `tests/act_agenda.rs` (own binary, real registry): names, ability text, `clues to advance: N`, `doom d/N`.
- `tests/turn_tracker.rs`: all phases + sub-steps + windows; exactly one `current` phase; round.
- `tests/event_log.rs`: collapse toggle hides the body and shrinks the panel to a strip.
- `tests/board.rs`: investigator stats/cards + the two-row zone layout (in-play/threat top, stats/hand bottom).
- `tests/store.rs` smoke updated for the retired phase_bar.
- Full 7-job CI gauntlet green locally.

Closes #532.

🤖 Generated with [Claude Code](https://claude.com/claude-code)