### PR TITLE
engine: OptionTarget anchor on ChoiceOption + open-turn menu anchors (interactivity S0)

### DIFF
--- a/crates/game-core/src/engine/dispatch/choice.rs
+++ b/crates/game-core/src/engine/dispatch/choice.rs
@@ -43,9 +43,11 @@ pub(crate) fn awaiting_choice(prompt: impl Into<String>, labels: Vec<String>) ->
     let options: Vec<ChoiceOption> = labels
         .into_iter()
         .enumerate()
-        .map(|(i, label)| ChoiceOption {
-            id: OptionId(u32::try_from(i).expect("offered option count fits in u32")),
-            label,
+        .map(|(i, label)| {
+            ChoiceOption::global(
+                OptionId(u32::try_from(i).expect("offered option count fits in u32")),
+                label,
+            )
         })
         .collect();
     EngineOutcome::AwaitingInput {

--- a/crates/game-core/src/engine/dispatch/forced_triggers.rs
+++ b/crates/game-core/src/engine/dispatch/forced_triggers.rs
@@ -537,10 +537,7 @@ pub(crate) fn drive_acknowledge_forced(cx: &mut Cx) -> EngineOutcome {
     EngineOutcome::AwaitingInput {
         request: InputRequest::pick_single(
             format!("Forced — {name}"),
-            vec![ChoiceOption {
-                id: OptionId(0),
-                label: "Resolve".into(),
-            }],
+            vec![ChoiceOption::global(OptionId(0), "Resolve")],
         ),
         resume_token: ResumeToken(0),
     }

--- a/crates/game-core/src/engine/dispatch/hunters.rs
+++ b/crates/game-core/src/engine/dispatch/hunters.rs
@@ -387,9 +387,11 @@ pub(super) fn candidate_options<T: std::fmt::Debug>(candidates: &[T]) -> Vec<Cho
     candidates
         .iter()
         .enumerate()
-        .map(|(i, c)| ChoiceOption {
-            id: OptionId(u32::try_from(i).expect("candidate count fits u32")),
-            label: format!("{c:?}"),
+        .map(|(i, c)| {
+            ChoiceOption::global(
+                OptionId(u32::try_from(i).expect("candidate count fits u32")),
+                format!("{c:?}"),
+            )
         })
         .collect()
 }

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -111,9 +111,10 @@ fn turn_menu(state: &crate::state::GameState) -> crate::engine::InputRequest {
         .iter()
         .enumerate()
         .map(|(i, a)| {
-            crate::engine::ChoiceOption::global(
+            crate::engine::ChoiceOption::new(
                 crate::engine::OptionId(u32::try_from(i).unwrap_or(u32::MAX)),
                 a.label(state),
+                a.target(state),
             )
         })
         .collect();
@@ -715,4 +716,58 @@ pub(crate) fn resolve_input(cx: &mut Cx, response: &InputResponse) -> EngineOutc
     // Mythos chain (#423). `apply_player_action` runs `drive(cx, outcome)` after
     // this returns.
     outcome
+}
+
+#[cfg(test)]
+mod turn_menu_tests {
+    use super::turn_menu;
+    use crate::engine::enumerate::legal_actions;
+    use crate::engine::OptionTarget;
+    use crate::state::{Continuation, InvestigationResume, InvestigatorId, Phase};
+    use crate::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
+
+    #[test]
+    fn turn_menu_carries_action_targets() {
+        // An open-turn state with a co-located, engaged enemy so the menu holds
+        // at least one Enemy-anchored option (Fight/Evade), proving turn_menu
+        // propagates each action's target — not just Global.
+        let mut state = GameStateBuilder::default()
+            .with_investigator(test_investigator(1))
+            .with_phase(Phase::Investigation)
+            .with_active_investigator(InvestigatorId(1))
+            .with_turn_order([InvestigatorId(1)])
+            .with_chaos_bag(crate::state::ChaosBag::new([crate::state::ChaosToken::Numeric(0)]))
+            .with_phase_anchor(Continuation::InvestigationPhase {
+                resume: InvestigationResume::TurnBegins,
+            })
+            .with_investigator_turn(InvestigatorId(1))
+            .build();
+        let loc = test_location(10, "Study");
+        let loc_id = loc.id;
+        state.locations.insert(loc_id, loc);
+        state.locations.get_mut(&loc_id).unwrap().revealed = true;
+        {
+            let inv = state.investigators.get_mut(&InvestigatorId(1)).unwrap();
+            inv.current_location = Some(loc_id);
+            inv.actions_remaining = 3;
+        }
+        let mut e = test_enemy(7, "Ghoul");
+        e.engaged_with = Some(InvestigatorId(1));
+        e.current_location = Some(loc_id);
+        state.enemies.insert(e.id, e);
+
+        let actions = legal_actions(&state);
+        let menu = turn_menu(&state);
+        assert_eq!(menu.options.len(), actions.len());
+        for (i, action) in actions.iter().enumerate() {
+            assert_eq!(menu.options[i].target, action.target(&state));
+        }
+        assert!(
+            menu.options
+                .iter()
+                .any(|o| matches!(o.target, OptionTarget::Enemy(_))),
+            "expected at least one Enemy-anchored option, got {:?}",
+            menu.options.iter().map(|o| o.target).collect::<Vec<_>>()
+        );
+    }
 }

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -110,9 +110,11 @@ fn turn_menu(state: &crate::state::GameState) -> crate::engine::InputRequest {
     let options = crate::engine::enumerate::legal_actions(state)
         .iter()
         .enumerate()
-        .map(|(i, a)| crate::engine::ChoiceOption {
-            id: crate::engine::OptionId(u32::try_from(i).unwrap_or(u32::MAX)),
-            label: a.label(state),
+        .map(|(i, a)| {
+            crate::engine::ChoiceOption::global(
+                crate::engine::OptionId(u32::try_from(i).unwrap_or(u32::MAX)),
+                a.label(state),
+            )
         })
         .collect();
     crate::engine::InputRequest::pick_single("Choose an action", options)

--- a/crates/game-core/src/engine/dispatch/mod.rs
+++ b/crates/game-core/src/engine/dispatch/mod.rs
@@ -736,7 +736,9 @@ mod turn_menu_tests {
             .with_phase(Phase::Investigation)
             .with_active_investigator(InvestigatorId(1))
             .with_turn_order([InvestigatorId(1)])
-            .with_chaos_bag(crate::state::ChaosBag::new([crate::state::ChaosToken::Numeric(0)]))
+            .with_chaos_bag(crate::state::ChaosBag::new([
+                crate::state::ChaosToken::Numeric(0),
+            ]))
             .with_phase_anchor(Continuation::InvestigationPhase {
                 resume: InvestigationResume::TurnBegins,
             })

--- a/crates/game-core/src/engine/dispatch/reaction_windows.rs
+++ b/crates/game-core/src/engine/dispatch/reaction_windows.rs
@@ -606,10 +606,10 @@ fn build_resolution_options(candidates: &[ResolutionCandidate]) -> Vec<ChoiceOpt
                     format!("Resolve reaction: {}", cand.code)
                 }
             };
-            ChoiceOption {
-                id: OptionId(u32::try_from(i).expect("option count fits in u32")),
+            ChoiceOption::global(
+                OptionId(u32::try_from(i).expect("option count fits in u32")),
                 label,
-            }
+            )
         })
         .collect()
 }
@@ -1804,9 +1804,11 @@ pub(super) fn drive_fast_window(cx: &mut Cx) -> EngineOutcome {
     let options = plays
         .iter()
         .enumerate()
-        .map(|(i, a)| ChoiceOption {
-            id: OptionId(u32::try_from(i).unwrap_or(u32::MAX)),
-            label: a.label(cx.state),
+        .map(|(i, a)| {
+            ChoiceOption::global(
+                OptionId(u32::try_from(i).unwrap_or(u32::MAX)),
+                a.label(cx.state),
+            )
         })
         .collect::<Vec<_>>();
     EngineOutcome::AwaitingInput {

--- a/crates/game-core/src/engine/dispatch/skill_test.rs
+++ b/crates/game-core/src/engine/dispatch/skill_test.rs
@@ -131,14 +131,8 @@ pub(in crate::engine) fn start_skill_test(
                      (PickSingle(0) = use {use_skill:?}, PickSingle(1) = keep {skill:?})",
                 ),
                 vec![
-                    ChoiceOption {
-                        id: OptionId(0),
-                        label: format!("Use {use_skill:?}"),
-                    },
-                    ChoiceOption {
-                        id: OptionId(1),
-                        label: format!("Keep {skill:?}"),
-                    },
+                    ChoiceOption::global(OptionId(0), format!("Use {use_skill:?}")),
+                    ChoiceOption::global(OptionId(1), format!("Keep {skill:?}")),
                 ],
             ),
             resume_token: ResumeToken(0),

--- a/crates/game-core/src/engine/enumerate.rs
+++ b/crates/game-core/src/engine/enumerate.rs
@@ -915,7 +915,11 @@ mod tests {
             OptionTarget::Global
         );
         assert_eq!(
-            TurnAction::Move { investigator: inv, destination: LocationId(11) }.target(&state),
+            TurnAction::Move {
+                investigator: inv,
+                destination: LocationId(11)
+            }
+            .target(&state),
             OptionTarget::Location(LocationId(11))
         );
         assert_eq!(
@@ -923,20 +927,39 @@ mod tests {
             OptionTarget::Location(loc_id)
         );
         assert_eq!(
-            TurnAction::Fight { investigator: inv, enemy: EnemyId(7) }.target(&state),
+            TurnAction::Fight {
+                investigator: inv,
+                enemy: EnemyId(7)
+            }
+            .target(&state),
             OptionTarget::Enemy(EnemyId(7))
         );
         assert_eq!(
-            TurnAction::Evade { investigator: inv, enemy: EnemyId(7) }.target(&state),
+            TurnAction::Evade {
+                investigator: inv,
+                enemy: EnemyId(7)
+            }
+            .target(&state),
             OptionTarget::Enemy(EnemyId(7))
         );
         assert_eq!(
-            TurnAction::Engage { investigator: inv, enemy: EnemyId(7) }.target(&state),
+            TurnAction::Engage {
+                investigator: inv,
+                enemy: EnemyId(7)
+            }
+            .target(&state),
             OptionTarget::Enemy(EnemyId(7))
         );
         assert_eq!(
-            TurnAction::PlayCard { investigator: inv, hand_index: 2 }.target(&state),
-            OptionTarget::HandCard { investigator: inv, hand_index: 2 }
+            TurnAction::PlayCard {
+                investigator: inv,
+                hand_index: 2
+            }
+            .target(&state),
+            OptionTarget::HandCard {
+                investigator: inv,
+                hand_index: 2
+            }
         );
         assert_eq!(
             TurnAction::ActivateAbility {

--- a/crates/game-core/src/engine/enumerate.rs
+++ b/crates/game-core/src/engine/enumerate.rs
@@ -126,6 +126,40 @@ impl TurnAction {
             TurnAction::AdvanceAct { .. } => "Advance act".into(),
         }
     }
+
+    /// The board surface this action anchors to, for host rendering (#535).
+    /// Mirrors [`label`](Self::label): it takes `state` because some actions'
+    /// anchors are implicit — Investigate acts at the investigator's current
+    /// location, which is not a field on the variant.
+    #[must_use]
+    pub fn target(&self, state: &GameState) -> crate::engine::OptionTarget {
+        use crate::engine::OptionTarget;
+        match self {
+            TurnAction::EndTurn | TurnAction::Resource { .. } | TurnAction::Draw { .. } => {
+                OptionTarget::Global
+            }
+            TurnAction::Move { destination, .. } => OptionTarget::Location(*destination),
+            TurnAction::Investigate { investigator } => state
+                .investigators
+                .get(investigator)
+                .and_then(|inv| inv.current_location)
+                .map_or(OptionTarget::Global, OptionTarget::Location),
+            TurnAction::Fight { enemy, .. }
+            | TurnAction::Evade { enemy, .. }
+            | TurnAction::Engage { enemy, .. } => OptionTarget::Enemy(*enemy),
+            TurnAction::PlayCard {
+                investigator,
+                hand_index,
+            } => OptionTarget::HandCard {
+                investigator: *investigator,
+                hand_index: *hand_index,
+            },
+            TurnAction::ActivateAbility { instance_id, .. } => {
+                OptionTarget::CardInstance(*instance_id)
+            }
+            TurnAction::AdvanceAct { .. } => OptionTarget::Act,
+        }
+    }
 }
 
 /// The legal [`TurnAction`]s the active investigator may take at the open
@@ -850,6 +884,72 @@ mod tests {
             !matches!(result.outcome, crate::EngineOutcome::Rejected { .. }),
             "open-turn OptionId dispatch rejected: {:?}",
             result.outcome
+        );
+    }
+
+    #[test]
+    fn target_maps_each_variant() {
+        use crate::engine::OptionTarget;
+        use crate::state::{CardInstanceId, EnemyId, LocationId};
+
+        // A state where investigator 1 stands on a location, so Investigate's
+        // implicit anchor resolves to that location.
+        let mut state = open_turn_state();
+        let loc = crate::test_support::test_location(10, "Study");
+        let loc_id = loc.id;
+        state.locations.insert(loc_id, loc);
+        state
+            .investigators
+            .get_mut(&InvestigatorId(1))
+            .unwrap()
+            .current_location = Some(loc_id);
+        let inv = InvestigatorId(1);
+
+        assert_eq!(TurnAction::EndTurn.target(&state), OptionTarget::Global);
+        assert_eq!(
+            TurnAction::Resource { investigator: inv }.target(&state),
+            OptionTarget::Global
+        );
+        assert_eq!(
+            TurnAction::Draw { investigator: inv }.target(&state),
+            OptionTarget::Global
+        );
+        assert_eq!(
+            TurnAction::Move { investigator: inv, destination: LocationId(11) }.target(&state),
+            OptionTarget::Location(LocationId(11))
+        );
+        assert_eq!(
+            TurnAction::Investigate { investigator: inv }.target(&state),
+            OptionTarget::Location(loc_id)
+        );
+        assert_eq!(
+            TurnAction::Fight { investigator: inv, enemy: EnemyId(7) }.target(&state),
+            OptionTarget::Enemy(EnemyId(7))
+        );
+        assert_eq!(
+            TurnAction::Evade { investigator: inv, enemy: EnemyId(7) }.target(&state),
+            OptionTarget::Enemy(EnemyId(7))
+        );
+        assert_eq!(
+            TurnAction::Engage { investigator: inv, enemy: EnemyId(7) }.target(&state),
+            OptionTarget::Enemy(EnemyId(7))
+        );
+        assert_eq!(
+            TurnAction::PlayCard { investigator: inv, hand_index: 2 }.target(&state),
+            OptionTarget::HandCard { investigator: inv, hand_index: 2 }
+        );
+        assert_eq!(
+            TurnAction::ActivateAbility {
+                investigator: inv,
+                instance_id: CardInstanceId(5),
+                ability_index: 0,
+            }
+            .target(&state),
+            OptionTarget::CardInstance(CardInstanceId(5))
+        );
+        assert_eq!(
+            TurnAction::AdvanceAct { investigator: inv }.target(&state),
+            OptionTarget::Act
         );
     }
 }

--- a/crates/game-core/src/engine/mod.rs
+++ b/crates/game-core/src/engine/mod.rs
@@ -33,7 +33,9 @@ pub use dispatch::reveal::reveal_location;
 pub use dispatch::threat_area::{attach_to_location, place_in_threat_area};
 pub use enumerate::{legal_actions, TurnAction};
 pub use evaluator::{effective_shroud, location_id_by_code, EvalContext};
-pub use outcome::{ChoiceOption, EngineOutcome, InputKind, InputRequest, OptionId, ResumeToken};
+pub use outcome::{
+    ChoiceOption, EngineOutcome, InputKind, InputRequest, OptionId, OptionTarget, ResumeToken,
+};
 pub use pathfinding::{shortest_first_steps, shortest_first_steps_with};
 
 // Crate-internal re-exports for `test_support::fire_forced_on_enter`.

--- a/crates/game-core/src/engine/outcome.rs
+++ b/crates/game-core/src/engine/outcome.rs
@@ -224,10 +224,8 @@ mod tests {
 
     #[test]
     fn pick_single_sets_kind_and_not_skippable() {
-        let req = InputRequest::pick_single(
-            "Choose one",
-            vec![ChoiceOption::global(OptionId(0), "A")],
-        );
+        let req =
+            InputRequest::pick_single("Choose one", vec![ChoiceOption::global(OptionId(0), "A")]);
         assert_eq!(req.kind, InputKind::PickSingle);
         assert!(!req.skippable);
         assert_eq!(req.options.len(), 1);

--- a/crates/game-core/src/engine/outcome.rs
+++ b/crates/game-core/src/engine/outcome.rs
@@ -4,6 +4,8 @@ use std::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
 
+use crate::state::{CardInstanceId, EnemyId, InvestigatorId, LocationId};
+
 /// The terminal status of an [`apply`](super::apply) call.
 ///
 /// After the engine finishes applying an action, it is in one of three
@@ -50,14 +52,62 @@ pub enum EngineOutcome {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct OptionId(pub u32);
 
+/// The board surface an offered [`ChoiceOption`] acts on, letting a host render
+/// the option on the entity it targets rather than in a flat list. `Global`
+/// means no board anchor (e.g. End turn, a Confirm). Anchors are derived from
+/// the engine's own action / candidate targets, so a host never re-computes
+/// legality (#535, #206).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum OptionTarget {
+    /// No board anchor — a global / contextual control.
+    Global,
+    /// A location on the map.
+    Location(LocationId),
+    /// An enemy.
+    Enemy(EnemyId),
+    /// A card in an investigator's hand, by zero-based hand index.
+    HandCard {
+        /// The hand's owner.
+        investigator: InvestigatorId,
+        /// Zero-based position in that investigator's hand.
+        hand_index: u8,
+    },
+    /// An in-play / threat-area / investigator card instance.
+    CardInstance(CardInstanceId),
+    /// The current act.
+    Act,
+}
+
 /// One selectable option in a structured choice prompt.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ChoiceOption {
     /// The id the host echoes back via
     /// [`InputResponse::PickSingle`](crate::action::InputResponse::PickSingle).
     pub id: OptionId,
-    /// Human-readable label for the host to render.
+    /// Human-readable label for the host to render (full and unambiguous,
+    /// e.g. `"Fight Ghoul"`; a host may shorten it for display).
     pub label: String,
+    /// The board surface this option acts on (`Global` if none).
+    pub target: OptionTarget,
+}
+
+impl ChoiceOption {
+    /// An option anchored to `target`.
+    #[must_use]
+    pub fn new(id: OptionId, label: impl Into<String>, target: OptionTarget) -> Self {
+        Self {
+            id,
+            label: label.into(),
+            target,
+        }
+    }
+
+    /// An option with no board anchor ([`OptionTarget::Global`]).
+    #[must_use]
+    pub fn global(id: OptionId, label: impl Into<String>) -> Self {
+        Self::new(id, label, OptionTarget::Global)
+    }
 }
 
 /// Which [`InputResponse`](crate::action::InputResponse) variant the host must
@@ -176,10 +226,7 @@ mod tests {
     fn pick_single_sets_kind_and_not_skippable() {
         let req = InputRequest::pick_single(
             "Choose one",
-            vec![ChoiceOption {
-                id: OptionId(0),
-                label: "A".into(),
-            }],
+            vec![ChoiceOption::global(OptionId(0), "A")],
         );
         assert_eq!(req.kind, InputKind::PickSingle);
         assert!(!req.skippable);
@@ -216,14 +263,8 @@ mod tests {
         let req = InputRequest::pick_single(
             "Choose one",
             vec![
-                ChoiceOption {
-                    id: OptionId(0),
-                    label: "Take 2 horror".into(),
-                },
-                ChoiceOption {
-                    id: OptionId(1),
-                    label: "Each discards 1".into(),
-                },
+                ChoiceOption::global(OptionId(0), "Take 2 horror"),
+                ChoiceOption::global(OptionId(1), "Each discards 1"),
             ],
         )
         .skippable();
@@ -232,5 +273,35 @@ mod tests {
         assert_eq!(back, req);
         assert_eq!(back.kind, InputKind::PickSingle);
         assert!(back.skippable);
+    }
+
+    #[test]
+    fn global_constructor_sets_global_target() {
+        let opt = ChoiceOption::global(OptionId(3), "End turn");
+        assert_eq!(opt.id, OptionId(3));
+        assert_eq!(opt.label, "End turn");
+        assert_eq!(opt.target, OptionTarget::Global);
+    }
+
+    #[test]
+    fn awaiting_input_round_trips_option_target() {
+        use crate::state::EnemyId;
+        let outcome = EngineOutcome::AwaitingInput {
+            request: InputRequest::pick_single(
+                "Choose an action",
+                vec![
+                    ChoiceOption::global(OptionId(0), "End turn"),
+                    ChoiceOption::new(OptionId(1), "Fight Ghoul", OptionTarget::Enemy(EnemyId(7))),
+                ],
+            ),
+            resume_token: ResumeToken(0),
+        };
+        let json = serde_json::to_string(&outcome).expect("serialize");
+        let back: EngineOutcome = serde_json::from_str(&json).expect("deserialize");
+        let EngineOutcome::AwaitingInput { request, .. } = back else {
+            panic!("expected AwaitingInput, got {back:?}");
+        };
+        assert_eq!(request.options[0].target, OptionTarget::Global);
+        assert_eq!(request.options[1].target, OptionTarget::Enemy(EnemyId(7)));
     }
 }

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -49,7 +49,8 @@ pub use engine::{
     resolve_encounter_card, reveal_location, round_end_advance, round_end_advance_affordable,
     seat_and_open, shortest_first_steps, shortest_first_steps_with, spawn_set_aside_enemy,
     suspend_for_native_choice, take_damage, ApplyResult, ChoiceOption, ChoiceResolution, Cx,
-    EngineOutcome, EvalContext, InputKind, InputRequest, OptionId, ResumeToken, TurnAction,
+    EngineOutcome, EvalContext, InputKind, InputRequest, OptionId, OptionTarget, ResumeToken,
+    TurnAction,
 };
 pub use event::{Event, FailureReason, TraumaKind};
 pub use rng::RngState;

--- a/crates/game-core/src/test_support/fixtures.rs
+++ b/crates/game-core/src/test_support/fixtures.rs
@@ -148,14 +148,8 @@ pub fn awaiting_pick_single_input(prompt: impl Into<String>) -> EngineOutcome {
         request: InputRequest::pick_single(
             prompt,
             vec![
-                ChoiceOption {
-                    id: OptionId(0),
-                    label: "End turn".into(),
-                },
-                ChoiceOption {
-                    id: OptionId(1),
-                    label: "Investigate".into(),
-                },
+                ChoiceOption::global(OptionId(0), "End turn"),
+                ChoiceOption::global(OptionId(1), "Investigate"),
             ],
         ),
         resume_token: ResumeToken(0),
@@ -182,10 +176,7 @@ pub fn awaiting_skippable_pick_single_input(prompt: impl Into<String>) -> Engine
     EngineOutcome::AwaitingInput {
         request: InputRequest::pick_single(
             prompt,
-            vec![ChoiceOption {
-                id: OptionId(0),
-                label: "Resolve".into(),
-            }],
+            vec![ChoiceOption::global(OptionId(0), "Resolve")],
         )
         .skippable(),
         resume_token: ResumeToken(0),

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -185,6 +185,40 @@ mod tests {
     }
 
     #[test]
+    fn applied_round_trips_awaiting_input_option_target() {
+        use game_core::OptionTarget;
+
+        let state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .build();
+        // The fixture's options are Global-anchored; this proves the new
+        // ChoiceOption.target field survives the ServerMessage envelope
+        // (game-core covers a non-Global value directly). See the interactivity
+        // S0 plan.
+        let outcome =
+            game_core::test_support::fixtures::awaiting_pick_single_input("Choose an action");
+        let msg = ServerMessage::Applied {
+            state: Box::new(state),
+            events: Vec::new(),
+            outcome,
+        };
+
+        let json = serde_json::to_string(&msg).expect("serialize");
+        let back: ServerMessage = serde_json::from_str(&json).expect("deserialize");
+
+        let ServerMessage::Applied { outcome, .. } = back else {
+            panic!("expected Applied, got {back:?}");
+        };
+        let game_core::EngineOutcome::AwaitingInput { request, .. } = outcome else {
+            panic!("expected AwaitingInput outcome");
+        };
+        assert!(
+            request.options.iter().all(|o| o.target == OptionTarget::Global),
+            "option targets survive the envelope"
+        );
+    }
+
+    #[test]
     fn create_game_request_round_trips_with_a_roster() {
         use game_core::action::RosterEntry;
         use game_core::state::CardCode;

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -213,7 +213,10 @@ mod tests {
             panic!("expected AwaitingInput outcome");
         };
         assert!(
-            request.options.iter().all(|o| o.target == OptionTarget::Global),
+            request
+                .options
+                .iter()
+                .all(|o| o.target == OptionTarget::Global),
             "option targets survive the envelope"
         );
     }

--- a/crates/web/src/input.rs
+++ b/crates/web/src/input.rs
@@ -101,7 +101,7 @@ pub fn AwaitingInputView() -> impl IntoView {
                         .iter()
                         .cloned()
                         .map(|opt: ChoiceOption| {
-                            let ChoiceOption { id, label } = opt;
+                            let ChoiceOption { id, label, .. } = opt;
                             let tx = tx.clone();
                             let header = label.clone();
                             view! {

--- a/docs/phases/phase-7-the-gathering.md
+++ b/docs/phases/phase-7-the-gathering.md
@@ -221,11 +221,28 @@ the now-stable set of input shapes:
     labels, loop tails elided — and cited in the module doc; reviewer-verified against the
     pinned PDF), highlighting the current phase. The **left event log is collapsible**. The
     `phase_bar` is **retired** (phase/round → tracker, act/agenda → cards). This finishes
-    the display-only card/layout pass for every zone. **The remaining web work is the
-    interactivity pass** (cards/locations/enemies grow their own action buttons; retire the
-    sticky `.action-bar`). Spec/plan:
+    the display-only card/layout pass for every zone. The remaining web work is the
+    **interactivity pass** (next bullet). Spec/plan:
     `docs/superpowers/specs/2026-06-30-act-agenda-and-sidebars-design.md`,
     `docs/superpowers/plans/2026-06-30-act-agenda-and-sidebars.md`.
+  - **Interactivity pass (#206 umbrella; slices S0–S6 = #535–#541).** Retires the flat
+    `.action-bar`: actionable board entities glow and open a **context menu** of their legal
+    actions; multi-select (mulligan/commit/discard) is click-to-select on the hand; windows /
+    soak / effect choices resolve on their source cards; a slim prompt banner carries prompt
+    text + Confirm/Pass. Engine-authoritative — each option the board offers *is* an option the
+    engine enumerated as legal, so the board can never surface an action the server rejects (no
+    client-side legality re-computation; the drift #206 warned of is structurally impossible).
+    Design (whole-model umbrella): `docs/superpowers/specs/2026-07-01-board-interactivity-pass-design.md`.
+    - **S0 — `OptionTarget` anchor on `ChoiceOption` (#535, PR #542).** Each wire `ChoiceOption`
+      gains a structured `OptionTarget` (`Global` / `Location` / `Enemy` / `HandCard` /
+      `CardInstance` / `Act`); `turn_menu` derives real anchors from a new `TurnAction::target`,
+      every other option-builder emits `Global` for now. `label` stays the full engine-authored
+      string. Required wire field (#453 precedent). Engine + protocol only — no web behavior
+      change (the bar still reads `label`). Plan:
+      `docs/superpowers/plans/2026-07-01-interactivity-s0-optiontarget.md`.
+    - **S1–S6** (#536–#541) queued: web plumbing + location menus (S1), enemies (S2), hand +
+      multi-select (S3), in-play/threat + window triggers (S4), act/soak/effect-choices (S5),
+      global-action homes + bar retirement (S6).
 
 **Deferred past the gate:** #353 (uses-depletion — no Gathering card; gated on
 Forbidden Knowledge / Grotesque Statue), #294 (multi-soak-window drain —

--- a/docs/superpowers/plans/2026-07-01-interactivity-s0-optiontarget.md
+++ b/docs/superpowers/plans/2026-07-01-interactivity-s0-optiontarget.md
@@ -1,0 +1,604 @@
+# Interactivity S0 — `OptionTarget` anchor on `ChoiceOption` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enrich each wire `ChoiceOption` with a structured `OptionTarget` anchor and have the open-turn action menu carry real anchors, so a host can later render options on the board entity they act on.
+
+**Architecture:** Add an `OptionTarget` enum + a `target` field to `ChoiceOption` (with `new`/`global` constructors to keep call sites terse). Every existing option-builder emits `OptionTarget::Global` (unchanged behavior); only `turn_menu` derives real anchors, via a new `TurnAction::target(&state)` mirroring `TurnAction::label`. No web behavior change — the flat action bar still reads `label`.
+
+**Tech Stack:** Rust workspace (`game-core`, `protocol`, `web`); serde for the wire; leptos in `web` (untouched here beyond one destructure fix).
+
+## Global Constraints
+
+- Issue: **#535** (interactivity S0). Umbrella: **#206**. Design spec: `docs/superpowers/specs/2026-07-01-board-interactivity-pass-design.md` (Section 1).
+- The new `ChoiceOption.target` field is **required** on the wire (no `#[serde(default)]`) — a stale payload errors rather than silently degrading (the #453 precedent).
+- `label` stays the **full, unambiguous** engine-authored string — do **not** shorten it engine-side.
+- Match CI's strict flags before pushing (all seven jobs, warnings-as-errors) — see the Verification section. Commit scope prefix: `engine:`.
+- Branch: `engine/interactivity-optiontarget` (one branch per issue). Commit only; do not merge. The design spec + this plan are committed on this branch too (the "doc in the same PR" pattern).
+
+---
+
+### Task 1: `OptionTarget` type, `ChoiceOption.target` field + constructors, migrate all sites to `Global`
+
+**Files:**
+- Modify: `crates/game-core/src/engine/outcome.rs` (add enum, field, constructors, imports; update two in-module test literals; add field round-trip tests)
+- Modify: `crates/game-core/src/engine/mod.rs:36` (re-export `OptionTarget`)
+- Modify: `crates/game-core/src/lib.rs:51` (root re-export `OptionTarget`)
+- Modify: `crates/game-core/src/engine/dispatch/hunters.rs:386-396` (`candidate_options`)
+- Modify: `crates/game-core/src/engine/dispatch/choice.rs:43-50` (`awaiting_choice`)
+- Modify: `crates/game-core/src/engine/dispatch/reaction_windows.rs:598-618` and `:1804-1811`
+- Modify: `crates/game-core/src/engine/dispatch/forced_triggers.rs:538-543`
+- Modify: `crates/game-core/src/engine/dispatch/skill_test.rs:133-141`
+- Modify: `crates/game-core/src/test_support/fixtures.rs:148-159` and `:183-189`
+- Modify: `crates/web/src/input.rs:104` (destructure fix — compile break in the wasm build)
+
+**Interfaces:**
+- Produces:
+  - `game_core::OptionTarget` (re-exported at crate root and `game_core::engine::OptionTarget`): `#[non_exhaustive]` enum — `Global`, `Location(LocationId)`, `Enemy(EnemyId)`, `HandCard { investigator: InvestigatorId, hand_index: u8 }`, `CardInstance(CardInstanceId)`, `Act`. Derives `Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize`.
+  - `ChoiceOption { id: OptionId, label: String, target: OptionTarget }`.
+  - `ChoiceOption::new(id: OptionId, label: impl Into<String>, target: OptionTarget) -> ChoiceOption`.
+  - `ChoiceOption::global(id: OptionId, label: impl Into<String>) -> ChoiceOption` (target = `Global`).
+
+- [ ] **Step 1: Write the failing tests** (append inside the existing `mod tests` in `crates/game-core/src/engine/outcome.rs`, before its closing `}`)
+
+```rust
+    #[test]
+    fn global_constructor_sets_global_target() {
+        let opt = ChoiceOption::global(OptionId(3), "End turn");
+        assert_eq!(opt.id, OptionId(3));
+        assert_eq!(opt.label, "End turn");
+        assert_eq!(opt.target, OptionTarget::Global);
+    }
+
+    #[test]
+    fn awaiting_input_round_trips_option_target() {
+        use crate::state::EnemyId;
+        let outcome = EngineOutcome::AwaitingInput {
+            request: InputRequest::pick_single(
+                "Choose an action",
+                vec![
+                    ChoiceOption::global(OptionId(0), "End turn"),
+                    ChoiceOption::new(OptionId(1), "Fight Ghoul", OptionTarget::Enemy(EnemyId(7))),
+                ],
+            ),
+            resume_token: ResumeToken(0),
+        };
+        let json = serde_json::to_string(&outcome).expect("serialize");
+        let back: EngineOutcome = serde_json::from_str(&json).expect("deserialize");
+        let EngineOutcome::AwaitingInput { request, .. } = back else {
+            panic!("expected AwaitingInput, got {back:?}");
+        };
+        assert_eq!(request.options[0].target, OptionTarget::Global);
+        assert_eq!(request.options[1].target, OptionTarget::Enemy(EnemyId(7)));
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p game-core --lib engine::outcome 2>&1 | tail -20`
+Expected: compile error — `OptionTarget` not found / `ChoiceOption` has no `global`/`target`.
+
+- [ ] **Step 3: Add imports + the `OptionTarget` enum + the field + constructors** in `crates/game-core/src/engine/outcome.rs`
+
+Add to the imports near the top (after `use serde::{Deserialize, Serialize};`):
+
+```rust
+use crate::state::{CardInstanceId, EnemyId, InvestigatorId, LocationId};
+```
+
+Add the enum immediately above `pub struct ChoiceOption`:
+
+```rust
+/// The board surface an offered [`ChoiceOption`] acts on, letting a host render
+/// the option on the entity it targets rather than in a flat list. `Global`
+/// means no board anchor (e.g. End turn, a Confirm). Anchors are derived from
+/// the engine's own action / candidate targets, so a host never re-computes
+/// legality (#535, #206).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum OptionTarget {
+    /// No board anchor — a global / contextual control.
+    Global,
+    /// A location on the map.
+    Location(LocationId),
+    /// An enemy.
+    Enemy(EnemyId),
+    /// A card in an investigator's hand, by zero-based hand index.
+    HandCard {
+        /// The hand's owner.
+        investigator: InvestigatorId,
+        /// Zero-based position in that investigator's hand.
+        hand_index: u8,
+    },
+    /// An in-play / threat-area / investigator card instance.
+    CardInstance(CardInstanceId),
+    /// The current act.
+    Act,
+}
+```
+
+Change the struct to add `target` and give it doc:
+
+```rust
+/// One selectable option in a structured choice prompt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChoiceOption {
+    /// The id the host echoes back via
+    /// [`InputResponse::PickSingle`](crate::action::InputResponse::PickSingle).
+    pub id: OptionId,
+    /// Human-readable label for the host to render (full and unambiguous,
+    /// e.g. `"Fight Ghoul"`; a host may shorten it for display).
+    pub label: String,
+    /// The board surface this option acts on (`Global` if none).
+    pub target: OptionTarget,
+}
+
+impl ChoiceOption {
+    /// An option anchored to `target`.
+    #[must_use]
+    pub fn new(id: OptionId, label: impl Into<String>, target: OptionTarget) -> Self {
+        Self {
+            id,
+            label: label.into(),
+            target,
+        }
+    }
+
+    /// An option with no board anchor ([`OptionTarget::Global`]).
+    #[must_use]
+    pub fn global(id: OptionId, label: impl Into<String>) -> Self {
+        Self::new(id, label, OptionTarget::Global)
+    }
+}
+```
+
+Update the two existing in-module test literals so the module compiles:
+- In `pick_single_sets_kind_and_not_skippable`, replace `vec![ChoiceOption { id: OptionId(0), label: "A".into() }]` with `vec![ChoiceOption::global(OptionId(0), "A")]`.
+- In `input_request_round_trips_with_kind_and_skippable`, replace the two `ChoiceOption { id: OptionId(0), label: "Take 2 horror".into() }` / `ChoiceOption { id: OptionId(1), label: "Each discards 1".into() }` literals with `ChoiceOption::global(OptionId(0), "Take 2 horror")` and `ChoiceOption::global(OptionId(1), "Each discards 1")`.
+
+- [ ] **Step 4: Re-export `OptionTarget`**
+
+In `crates/game-core/src/engine/mod.rs:36`, add `OptionTarget` to the `pub use outcome::{...}` list:
+
+```rust
+pub use outcome::{
+    ChoiceOption, EngineOutcome, InputKind, InputRequest, OptionId, OptionTarget, ResumeToken,
+};
+```
+
+In `crates/game-core/src/lib.rs:51`, add `OptionTarget` next to `ChoiceOption` in the root re-export (keep the surrounding names as-is):
+
+```rust
+    suspend_for_native_choice, take_damage, ApplyResult, ChoiceOption, ChoiceResolution, Cx,
+    OptionTarget,
+```
+(Place `OptionTarget` in the existing `pub use engine::{…}` grouping — adjust the exact line to keep alphabetical-ish order consistent with the file; the requirement is that `game_core::OptionTarget` resolves.)
+
+- [ ] **Step 5: Run the two new tests to verify they pass**
+
+Run: `cargo test -p game-core --lib engine::outcome 2>&1 | tail -20`
+Expected: PASS (`global_constructor_sets_global_target`, `awaiting_input_round_trips_option_target`, and the pre-existing outcome tests).
+
+- [ ] **Step 6: Migrate every other `ChoiceOption` construction site to `::global`**
+
+`crates/game-core/src/engine/dispatch/hunters.rs` — in `candidate_options`, replace the `.map(...)` body:
+
+```rust
+        .map(|(i, c)| {
+            ChoiceOption::global(
+                OptionId(u32::try_from(i).expect("candidate count fits u32")),
+                format!("{c:?}"),
+            )
+        })
+```
+
+`crates/game-core/src/engine/dispatch/choice.rs` — in `awaiting_choice`:
+
+```rust
+        .map(|(i, label)| {
+            ChoiceOption::global(
+                OptionId(u32::try_from(i).expect("offered option count fits in u32")),
+                label,
+            )
+        })
+```
+
+`crates/game-core/src/engine/dispatch/reaction_windows.rs` — in `build_resolution_options`, replace the trailing `ChoiceOption { id: …, label }` with:
+
+```rust
+            ChoiceOption::global(
+                OptionId(u32::try_from(i).expect("option count fits in u32")),
+                label,
+            )
+```
+
+and in the Fast-window builder near line 1807, replace the `.map(...)` body:
+
+```rust
+        .map(|(i, a)| {
+            ChoiceOption::global(
+                OptionId(u32::try_from(i).unwrap_or(u32::MAX)),
+                a.label(cx.state),
+            )
+        })
+```
+
+`crates/game-core/src/engine/dispatch/forced_triggers.rs` — replace the `vec![ChoiceOption { id: OptionId(0), label: "Resolve".into() }]` with:
+
+```rust
+            vec![ChoiceOption::global(OptionId(0), "Resolve")],
+```
+
+`crates/game-core/src/engine/dispatch/skill_test.rs` — replace the two literals:
+
+```rust
+                vec![
+                    ChoiceOption::global(OptionId(0), format!("Use {use_skill:?}")),
+                    ChoiceOption::global(OptionId(1), format!("Keep {skill:?}")),
+                ],
+```
+
+`crates/game-core/src/test_support/fixtures.rs` — in `awaiting_pick_single_input`:
+
+```rust
+            vec![
+                ChoiceOption::global(OptionId(0), "End turn"),
+                ChoiceOption::global(OptionId(1), "Investigate"),
+            ],
+```
+
+and in `awaiting_skippable_pick_single_input`:
+
+```rust
+            vec![ChoiceOption::global(OptionId(0), "Resolve")],
+```
+
+`crates/web/src/input.rs:104` — the destructure gains `..` (S0 does not consume `target` in web yet):
+
+```rust
+                            let ChoiceOption { id, label, .. } = opt;
+```
+
+- [ ] **Step 7: Run the full game-core + protocol suites to verify the migration compiles and passes**
+
+Run: `cargo test -p game-core -p protocol 2>&1 | tail -20`
+Expected: PASS, no compile errors.
+
+- [ ] **Step 8: Verify the wasm build compiles (the `web/input.rs` destructure fix)**
+
+Run: `cargo build -p web --target wasm32-unknown-unknown 2>&1 | tail -20`
+Expected: builds clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/game-core/src/engine/outcome.rs crates/game-core/src/engine/mod.rs \
+        crates/game-core/src/lib.rs crates/game-core/src/engine/dispatch/hunters.rs \
+        crates/game-core/src/engine/dispatch/choice.rs \
+        crates/game-core/src/engine/dispatch/reaction_windows.rs \
+        crates/game-core/src/engine/dispatch/forced_triggers.rs \
+        crates/game-core/src/engine/dispatch/skill_test.rs \
+        crates/game-core/src/test_support/fixtures.rs crates/web/src/input.rs
+git commit -m "engine: add OptionTarget anchor to ChoiceOption (Global everywhere)"
+```
+
+---
+
+### Task 2: `TurnAction::target` + wire real anchors into the open-turn menu
+
+**Files:**
+- Modify: `crates/game-core/src/engine/enumerate.rs` (add `TurnAction::target`; add a mapping test)
+- Modify: `crates/game-core/src/engine/dispatch/mod.rs:109-119` (`turn_menu` uses `target`; make `turn_menu` `pub(crate)`; add a propagation test)
+
+**Interfaces:**
+- Consumes: `game_core::OptionTarget`, `ChoiceOption::new` (Task 1).
+- Produces: `TurnAction::target(&self, state: &GameState) -> OptionTarget`. `turn_menu` becomes `pub(crate)`.
+
+- [ ] **Step 1: Write the failing mapping test** (append inside the existing `mod tests` in `crates/game-core/src/engine/enumerate.rs`)
+
+```rust
+    #[test]
+    fn target_maps_each_variant() {
+        use crate::engine::OptionTarget;
+        use crate::state::{CardInstanceId, EnemyId, LocationId};
+
+        // A state where investigator 1 stands on a location, so Investigate's
+        // implicit anchor resolves to that location.
+        let mut state = open_turn_state();
+        let loc = crate::test_support::test_location(10, "Study");
+        let loc_id = loc.id;
+        state.locations.insert(loc_id, loc);
+        state
+            .investigators
+            .get_mut(&InvestigatorId(1))
+            .unwrap()
+            .current_location = Some(loc_id);
+        let inv = InvestigatorId(1);
+
+        assert_eq!(TurnAction::EndTurn.target(&state), OptionTarget::Global);
+        assert_eq!(
+            TurnAction::Resource { investigator: inv }.target(&state),
+            OptionTarget::Global
+        );
+        assert_eq!(
+            TurnAction::Draw { investigator: inv }.target(&state),
+            OptionTarget::Global
+        );
+        assert_eq!(
+            TurnAction::Move { investigator: inv, destination: LocationId(11) }.target(&state),
+            OptionTarget::Location(LocationId(11))
+        );
+        assert_eq!(
+            TurnAction::Investigate { investigator: inv }.target(&state),
+            OptionTarget::Location(loc_id)
+        );
+        assert_eq!(
+            TurnAction::Fight { investigator: inv, enemy: EnemyId(7) }.target(&state),
+            OptionTarget::Enemy(EnemyId(7))
+        );
+        assert_eq!(
+            TurnAction::Evade { investigator: inv, enemy: EnemyId(7) }.target(&state),
+            OptionTarget::Enemy(EnemyId(7))
+        );
+        assert_eq!(
+            TurnAction::Engage { investigator: inv, enemy: EnemyId(7) }.target(&state),
+            OptionTarget::Enemy(EnemyId(7))
+        );
+        assert_eq!(
+            TurnAction::PlayCard { investigator: inv, hand_index: 2 }.target(&state),
+            OptionTarget::HandCard { investigator: inv, hand_index: 2 }
+        );
+        assert_eq!(
+            TurnAction::ActivateAbility {
+                investigator: inv,
+                instance_id: CardInstanceId(5),
+                ability_index: 0,
+            }
+            .target(&state),
+            OptionTarget::CardInstance(CardInstanceId(5))
+        );
+        assert_eq!(
+            TurnAction::AdvanceAct { investigator: inv }.target(&state),
+            OptionTarget::Act
+        );
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p game-core --lib engine::enumerate::tests::target_maps_each_variant 2>&1 | tail -15`
+Expected: compile error — no method `target` on `TurnAction`.
+
+- [ ] **Step 3: Implement `TurnAction::target`** (add to `impl TurnAction` in `crates/game-core/src/engine/enumerate.rs`, right after the `label` method)
+
+```rust
+    /// The board surface this action anchors to, for host rendering (#535).
+    /// Mirrors [`label`](Self::label): it takes `state` because some actions'
+    /// anchors are implicit — Investigate acts at the investigator's current
+    /// location, which is not a field on the variant.
+    #[must_use]
+    pub fn target(&self, state: &GameState) -> crate::engine::OptionTarget {
+        use crate::engine::OptionTarget;
+        match self {
+            TurnAction::EndTurn
+            | TurnAction::Resource { .. }
+            | TurnAction::Draw { .. } => OptionTarget::Global,
+            TurnAction::Move { destination, .. } => OptionTarget::Location(*destination),
+            TurnAction::Investigate { investigator } => state
+                .investigators
+                .get(investigator)
+                .and_then(|inv| inv.current_location)
+                .map_or(OptionTarget::Global, OptionTarget::Location),
+            TurnAction::Fight { enemy, .. }
+            | TurnAction::Evade { enemy, .. }
+            | TurnAction::Engage { enemy, .. } => OptionTarget::Enemy(*enemy),
+            TurnAction::PlayCard {
+                investigator,
+                hand_index,
+            } => OptionTarget::HandCard {
+                investigator: *investigator,
+                hand_index: *hand_index,
+            },
+            TurnAction::ActivateAbility { instance_id, .. } => {
+                OptionTarget::CardInstance(*instance_id)
+            }
+            TurnAction::AdvanceAct { .. } => OptionTarget::Act,
+        }
+    }
+```
+
+- [ ] **Step 4: Run the mapping test to verify it passes**
+
+Run: `cargo test -p game-core --lib engine::enumerate::tests::target_maps_each_variant 2>&1 | tail -15`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing propagation test** (append inside `mod tests` in `crates/game-core/src/engine/dispatch/mod.rs`; if the file has no `#[cfg(test)] mod tests`, add one at the end)
+
+```rust
+#[cfg(test)]
+mod turn_menu_tests {
+    use super::turn_menu;
+    use crate::engine::enumerate::legal_actions;
+    use crate::engine::OptionTarget;
+    use crate::state::{Continuation, InvestigationResume, InvestigatorId, Phase};
+    use crate::test_support::{test_enemy, test_investigator, test_location, GameStateBuilder};
+
+    #[test]
+    fn turn_menu_carries_action_targets() {
+        // An open-turn state with a co-located, engaged enemy so the menu holds
+        // at least one Enemy-anchored option (Fight/Evade), proving turn_menu
+        // propagates each action's target — not just Global.
+        let mut state = GameStateBuilder::default()
+            .with_investigator(test_investigator(1))
+            .with_phase(Phase::Investigation)
+            .with_active_investigator(InvestigatorId(1))
+            .with_turn_order([InvestigatorId(1)])
+            .with_chaos_bag(crate::state::ChaosBag::new([crate::state::ChaosToken::Numeric(0)]))
+            .with_phase_anchor(Continuation::InvestigationPhase {
+                resume: InvestigationResume::TurnBegins,
+            })
+            .with_investigator_turn(InvestigatorId(1))
+            .build();
+        let loc = test_location(10, "Study");
+        let loc_id = loc.id;
+        state.locations.insert(loc_id, loc);
+        state.locations.get_mut(&loc_id).unwrap().revealed = true;
+        {
+            let inv = state.investigators.get_mut(&InvestigatorId(1)).unwrap();
+            inv.current_location = Some(loc_id);
+            inv.actions_remaining = 3;
+        }
+        let mut e = test_enemy(7, "Ghoul");
+        e.engaged_with = Some(InvestigatorId(1));
+        e.current_location = Some(loc_id);
+        state.enemies.insert(e.id, e);
+
+        let actions = legal_actions(&state);
+        let menu = turn_menu(&state);
+        assert_eq!(menu.options.len(), actions.len());
+        for (i, action) in actions.iter().enumerate() {
+            assert_eq!(menu.options[i].target, action.target(&state));
+        }
+        assert!(
+            menu.options.iter().any(|o| matches!(o.target, OptionTarget::Enemy(_))),
+            "expected at least one Enemy-anchored option, got {:?}",
+            menu.options.iter().map(|o| o.target).collect::<Vec<_>>()
+        );
+    }
+}
+```
+
+- [ ] **Step 6: Run it to verify it fails**
+
+Run: `cargo test -p game-core --lib turn_menu_tests 2>&1 | tail -15`
+Expected: compile error — `turn_menu` is private (not importable via `super::turn_menu`).
+
+- [ ] **Step 7: Make `turn_menu` `pub(crate)` and wire in `target`** in `crates/game-core/src/engine/dispatch/mod.rs`
+
+Change the signature `fn turn_menu(` → `pub(crate) fn turn_menu(`, and replace the `.map(...)` body:
+
+```rust
+    let options = crate::engine::enumerate::legal_actions(state)
+        .iter()
+        .enumerate()
+        .map(|(i, a)| {
+            crate::engine::ChoiceOption::new(
+                crate::engine::OptionId(u32::try_from(i).unwrap_or(u32::MAX)),
+                a.label(state),
+                a.target(state),
+            )
+        })
+        .collect();
+```
+
+- [ ] **Step 8: Run the propagation test to verify it passes**
+
+Run: `cargo test -p game-core --lib turn_menu_tests 2>&1 | tail -15`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/game-core/src/engine/enumerate.rs crates/game-core/src/engine/dispatch/mod.rs
+git commit -m "engine: open-turn menu options carry their board-entity anchors"
+```
+
+---
+
+### Task 3: protocol envelope round-trip for the new field
+
+**Files:**
+- Modify: `crates/protocol/src/lib.rs` (add one test in the existing `mod tests`)
+
+**Interfaces:**
+- Consumes: `game_core::OptionTarget` (Task 1), `game_core::test_support::fixtures::awaiting_pick_single_input`.
+
+- [ ] **Step 1: Write the failing test** (append inside `mod tests` in `crates/protocol/src/lib.rs`)
+
+```rust
+    #[test]
+    fn applied_round_trips_awaiting_input_option_target() {
+        use game_core::OptionTarget;
+
+        let state = GameStateBuilder::new()
+            .with_investigator(test_investigator(1))
+            .build();
+        // The fixture's options are Global-anchored; this proves the new field
+        // survives the ServerMessage envelope (game-core covers a non-Global
+        // value directly). See the interactivity S0 plan.
+        let outcome =
+            game_core::test_support::fixtures::awaiting_pick_single_input("Choose an action");
+        let msg = ServerMessage::Applied {
+            state: Box::new(state),
+            events: Vec::new(),
+            outcome,
+        };
+
+        let json = serde_json::to_string(&msg).expect("serialize");
+        let back: ServerMessage = serde_json::from_str(&json).expect("deserialize");
+
+        let ServerMessage::Applied { outcome, .. } = back else {
+            panic!("expected Applied, got {back:?}");
+        };
+        let game_core::EngineOutcome::AwaitingInput { request, .. } = outcome else {
+            panic!("expected AwaitingInput outcome");
+        };
+        assert!(
+            request.options.iter().all(|o| o.target == OptionTarget::Global),
+            "option targets survive the envelope"
+        );
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p protocol applied_round_trips_awaiting_input_option_target 2>&1 | tail -15`
+Expected: compile error — `game_core::OptionTarget` unresolved *until* Task 1's re-export is in place; if Task 1 landed, the test compiles and PASSES immediately (it's a characterization test). If it passes on first run, that is acceptable — the value is regression protection for the envelope.
+
+- [ ] **Step 3: (If it failed to compile for another reason) fix imports**
+
+Ensure the test refers to `game_core::OptionTarget` and `game_core::EngineOutcome` by full path (as written). No production code changes are expected in this task.
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `cargo test -p protocol applied_round_trips_awaiting_input_option_target 2>&1 | tail -15`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/protocol/src/lib.rs
+git commit -m "protocol: regression-test OptionTarget survives the ServerMessage envelope"
+```
+
+---
+
+## Verification (full CI gauntlet, before pushing)
+
+Run all seven jobs with the strict flags (from `CLAUDE.md`). All must be green:
+
+```sh
+RUSTFLAGS="-D warnings"     cargo test --all --all-features
+                            cargo clippy --all-targets --all-features -- -D warnings
+                            cargo fmt --check
+RUSTDOCFLAGS="-D warnings"  cargo doc --workspace --no-deps --all-features
+                            cargo build -p web --target wasm32-unknown-unknown
+                            wasm-pack test --headless --firefox crates/web
+                            cargo clippy -p web --all-targets --target wasm32-unknown-unknown --all-features -- -D warnings
+```
+
+Watch for: an unused-import warning if a migrated module no longer needs `OptionId` in scope for a literal (it still does — `::global` takes an `OptionId`); the `web` clippy job is the one that exercises `input.rs`'s destructure fix.
+
+## PR flow (after the gauntlet is green)
+
+1. Also stage the design spec + this plan on the branch:
+   `git add docs/superpowers/specs/2026-07-01-board-interactivity-pass-design.md docs/superpowers/plans/2026-07-01-interactivity-s0-optiontarget.md` and commit (`docs: interactivity pass design + S0 plan`).
+2. Push `engine/interactivity-optiontarget`; open the PR with `gh pr create` using the repo template. Body: the Section-1 summary + `Closes #535.`
+3. Watch CI: `gh pr checks <PR#> --watch`.
+4. **Do not update the phase-7 doc yet** and **do not merge** — stop for review/approval (per the repo workflow).
+
+## Self-review notes
+
+- **Spec coverage (Section 1):** `OptionTarget` enum ✅ (Task 1); `ChoiceOption.target` required field ✅ (Task 1); `turn_menu` derives anchors from `TurnAction` ✅ (Task 2); other builders emit `Global` ✅ (Task 1); label stays full ✅ (constructors preserve the passed label verbatim); protocol recompile + wire test ✅ (Task 3); required-field / #453 precedent ✅ (no `serde(default)`).
+- **Testing (spec):** per-`TurnAction`→`OptionTarget` assertion ✅ (Task 2 Step 1); serde round-trip ✅ (Task 1 Step 1 in game-core + Task 3 envelope). The spec also mentions extending `every_enumerated_action_is_accepted_by_its_handler` with an anchor assertion — `turn_menu_carries_action_targets` (Task 2) covers the same ground more directly (menu option `target` == `action.target`), so that extension is intentionally omitted as redundant.
+- **Type consistency:** `OptionTarget::HandCard { investigator, hand_index }`, `CardInstance(CardInstanceId)`, `Enemy(EnemyId)`, `Location(LocationId)`, `Act`, `Global` used identically in the enum, `TurnAction::target`, and every test. `ChoiceOption::new`/`::global` signatures match all call sites (all pass `OptionId` + a `String`/`&str`).

--- a/docs/superpowers/specs/2026-07-01-board-interactivity-pass-design.md
+++ b/docs/superpowers/specs/2026-07-01-board-interactivity-pass-design.md
@@ -1,0 +1,212 @@
+# Board interactivity pass — design
+
+**Date:** 2026-07-01
+**Status:** approved (brainstorm), pending implementation plan
+**Phase:** 7 (web iteration); the interactivity pass that follows the display-only card-rendering rework
+**Umbrella issue:** #206 (`[ui] Intuitive legality affordances`)
+
+This is an **umbrella** design covering the whole interactivity model. It is
+sliced into independently-shippable PRs (S0–S6 below); each slice gets its own
+finer implementation plan (and, where useful, its own spec) at plan time,
+referencing this document.
+
+## Goal
+
+The display-only rework (#519–#533) rendered every board zone as a card. Player
+input, however, still flows through a **flat sticky action bar** — the open-turn
+action menu and every framework prompt render as a list of buttons detached from
+the board. This pass **retires the bar** and moves interaction onto the board:
+actionable entities glow and open a context menu of their legal actions; the
+board becomes the input surface.
+
+## The central constraint (why this touches the engine)
+
+The engine already advertises the legal action set every open turn:
+`enumerate::legal_actions` builds a rich `TurnAction` enum, each variant carrying
+its target (`LocationId` / `EnemyId` / `hand_index` / `CardInstanceId`). But at
+the wire boundary (`dispatch::mod::turn_menu`) that gets flattened to
+`ChoiceOption { id, label: String }` — the target is **thrown away**, leaving only
+a display string. So the client cannot map an option back to the board entity it
+acts on. That is the one thing blocking board-attached interaction.
+
+The fix is to **stop discarding the target**: enrich each wire `ChoiceOption` with
+a structured anchor. Every downstream decision (which cards glow, what a card's
+menu contains) derives from that anchor. This is the "richer per-option metadata
+beyond `label`" that #205 explicitly deferred, and it is the engine-authoritative
+answer to #206 (the board can never offer an action the server would reject,
+because every button *is* an option the engine enumerated as legal — no
+client-side legality re-computation, no drift).
+
+### Approaches weighed
+
+- **A — engine enriches `ChoiceOption` with a structured anchor (chosen).** Single
+  source of truth; the engine already holds the target. Cost: a struct field +
+  every option-builder supplies an anchor.
+- **B — client re-derives targets from labels** (`"Fight Ghoul"` → enemy).
+  String-coupled, blind to engine-internal targets (windows, effect choices),
+  violates the no-approximation discipline. Rejected.
+- **C — client re-computes `legal_actions`.** Duplicates engine legality → the
+  exact drift risk #206 warns against. Rejected.
+
+## The interaction model
+
+- **Actionable entity → glow.** Any card/location/enemy whose anchor has ≥1 live
+  option gets an "actionable" highlight. This alone satisfies #206's "communicate
+  what's legal intuitively" — the player sees what they can act on before clicking.
+- **Click → context menu.** Clicking an actionable entity opens a small popover
+  listing that anchor's options (as `label`s). Uniform: **even a single option
+  opens the menu** (player agency — always see and confirm what you commit to). No
+  auto-execute branch.
+- **Multi-select → click the cards to select.** Mulligan / skill-test commit /
+  hand-size discard are a distinct "selection mode": click the actual hand cards to
+  toggle a selected ring (no per-card buttons, no menu). Selecting **zero** is a
+  legal, meaningful choice, so finalization needs an explicit control — the
+  **Confirm (and Pass, when `skippable`) lives in the prompt banner**, not a
+  bespoke widget bolted to the hand.
+- **Prompt banner.** One slim, ephemeral surface (only while a prompt is live)
+  carrying `request.prompt` text for prompts that mean something (windows, choices,
+  soak) plus any Confirm/Pass. The open-turn menu's `"Choose an action"` is
+  suppressed (noise). Not a control cluster — it absorbs only the finalize/decline
+  controls that have no board home.
+- **No persistent floating bar.** The `.action-bar` is deleted (S6). Controls are
+  either on entities (menus), on the hand (selection), or in the transient banner.
+
+The client never distinguishes "open turn" from "reaction window" — it routes
+every option by anchor and renders banners/finalize controls off
+`kind` / `skippable` / a `Global` anchor. Open-turn actions, windows, effect
+choices, and soak all share one code path.
+
+## Section 1 — engine + protocol foundation
+
+```rust
+// beside ChoiceOption (game_core::engine::outcome)
+#[non_exhaustive]
+pub enum OptionTarget {
+    Global,                                                    // no board anchor
+    Location(LocationId),
+    Enemy(EnemyId),
+    HandCard { investigator: InvestigatorId, hand_index: u8 },
+    CardInstance(CardInstanceId),                              // in-play / threat / investigator / soak card
+    Act,
+}
+
+pub struct ChoiceOption {
+    pub id: OptionId,
+    pub label: String,        // unchanged: full, unambiguous, engine-authored ("Fight Ghoul")
+    pub target: OptionTarget, // NEW
+}
+```
+
+- `turn_menu` derives `target` from each `TurnAction`: Move/Investigate →
+  `Location`; Fight/Evade/Engage → `Enemy`; PlayCard → `HandCard`; ActivateAbility
+  → `CardInstance`; AdvanceAct → `Act`; EndTurn/Resource/Draw → `Global`.
+- `label` stays the **full** string (do **not** shorten it engine-side). The client
+  shortens for display if it wants; keeping the full label leaves the transitional
+  flat bar unambiguous while slices land, and decouples label text from render
+  context.
+- Every *other* option-builder (reaction windows, `choice.rs`, soak
+  `DamageAssignment`, attack-order) supplies `OptionTarget::Global` in S0; later
+  slices replace `Global` with real anchors as each prompt dissolves.
+- `ChoiceOption` rides `EngineOutcome` through `protocol` untouched — recompile
+  only. The new field is **required** on the wire, following the #453 precedent (a
+  stale payload errors rather than silently degrading).
+
+## Section 2 — web routing model
+
+- **Index.** A pure fn `route_options(&InputRequest) -> OptionIndex` groups
+  `request.options` by `target` into an `anchor → Vec<ChoiceOption>` map.
+  Native-testable, no DOM.
+- **Context provision.** Provide two things via leptos context (as `OutboundTx`
+  already is), avoiding prop-drilling through `board → map → node` and
+  `board → panel → card`:
+  - the `OptionIndex` (a derived signal off the store's `outcome`), and
+  - a `submit(InputResponse)` closure wrapping the existing
+    `tx.unbounded_send(ClientMessage::Submit{…})` + `pending_label` bookkeeping.
+- **Shared `ContextMenu` component.** Reads the active-anchor signal + the index +
+  submit; renders one popover of the anchor's options; a menu item submits
+  `ResolveInput(PickSingle(id))` and closes. Dismiss on outside-click / Escape.
+  Positioning anchors to the clicked node (absolutely-positioned map node vs.
+  flex-row hand card) is the one piece needing care.
+- **Per-entity seam.** Each display component (`Card`, `EnemyCard`, `location_map`
+  node, act card) gains: (a) glow when its anchor has ≥1 option, (b) a click
+  handler setting the active anchor (opening the menu). Components stay pure over
+  `(entity, options-for-this-anchor)` — still native-testable. Option-rendering is
+  centralized in `ContextMenu`, not smeared across components.
+
+## Section 3 — framework prompts finding homes
+
+Every prompt dissolves via the same `anchor → surface` mechanism; three
+*ephemeral* control types survive (only while a prompt is live):
+
+| Prompt | Anchor / home | Control shape |
+|---|---|---|
+| Open-turn menu | entity cards | glow + context menu |
+| Mulligan / skill-test commit / hand-size discard (`PickMultiple`, hand-indexed) | the hand cards — click to toggle a selected ring | banner Confirm (+ Pass if skippable) + prompt text |
+| Encounter draw (`Confirm`) | a new minimal **encounter-deck** element (renders `encounter_deck` count) | a Draw button on the deck |
+| Reaction / Fast window (`PickSingle` + Skip) | the source card (`CardInstance`) → "Trigger …" menu item | window-global Pass in the banner |
+| Interactive soak (`PickSingle`) | the soak cards (`CardInstance`) → click to assign | banner shows remaining damage/horror |
+| Effect `ChooseOne` (`PickSingle`) | the chosen enemies / locations (`Enemy`/`Location`) | banner with the choice prompt |
+
+**Genuinely-global open-turn actions** (End turn, Gain resource, Draw) have no
+board entity: End turn → a distinct always-present control on the active
+investigator's panel; Gain resource → a small affordance by the resource counter;
+Draw → a button on a minimal **player-deck** element. This is the most
+design-per-action for the least mechanical gain, so it lands last (S6).
+
+## Slicing (S0–S6)
+
+Mirrors the display-only cadence — each slice its own issue / plan / PR. The
+engine advertises anchors from S0 while the flat bar keeps reading `label`, so
+every web slice lands independently with the bar as a working fallback until S6
+retires it. **No slice leaves the client unusable.**
+
+- **S0 — engine + protocol foundation.** `OptionTarget` on `ChoiceOption`;
+  `turn_menu` derives anchors; other builders emit `Global`. No web behavior
+  change. `engine`.
+- **S1 — web plumbing + locations.** `route_options`, context provision,
+  `ContextMenu`, prompt banner, glow seam — proven on locations (Move/Investigate).
+  Flat bar coexists. `ui`.
+- **S2 — enemies** (Fight/Evade/Engage menu). `ui`.
+- **S3 — hand** (Play menu) + mulligan/commit/hand-size-discard as click-to-select
+  on hand cards + banner Confirm. `ui`.
+- **S4 — in-play / threat** (Activate + reaction/Fast-window "Trigger" menu;
+  window Pass in banner). `ui`.
+- **S5 — act + soak + effect choices** (Advance Act; click-to-assign soak;
+  `ChooseOne` anchoring). Touches adjacent #492 (single-option auto-binds surfaced
+  as choices). `ui`, `engine`.
+- **S6 — globals + bar retirement (the closer).** Homes for End turn / Gain
+  resource / Draw (investigator-panel controls + player-deck element);
+  encounter-deck element for the draw Confirm; **delete `.action-bar`**, folding
+  picker + skill-test-result into their own surfaces. `ui`.
+
+## Testing
+
+- **Engine** — anchor derivation covered in `enumerate`/`turn_menu` tests; extend
+  `every_enumerated_action_is_accepted_by_its_handler` to also assert each
+  `TurnAction` → expected `OptionTarget`. Pure, native.
+- **Protocol** — a serde round-trip test for the new field.
+- **Web pure fns** — `route_options` (anchor grouping) and menu-item derivation are
+  native-testable `#[cfg(test)]`, no DOM.
+- **Web rendering** — wasm-pack headless: glow appears iff the anchor has options;
+  click opens the menu; a menu item submits the correct `ResolveInput`.
+  Registry-dependent rendering goes in its own test binary (the `location_card.rs`
+  first-wins-registry precedent).
+
+## What "done" looks like (whole pass, at S6)
+
+- No `.action-bar`. Actionable board entities glow; clicking one opens a context
+  menu of its legal actions; selecting an item performs it.
+- Multi-select prompts are click-to-select on the hand with a banner Confirm.
+- Windows / soak / effect choices resolve on their source cards; the banner carries
+  prompt text + Pass/Confirm only.
+- End turn / Gain resource / Draw / encounter-draw have board homes.
+- The board can never surface an action the server rejects.
+- Full 7-job CI gauntlet green at every slice.
+
+## Out of scope
+
+- Any change to engine legality *rules* — this pass only surfaces the already-
+  enumerated legal set.
+- Multiplayer input routing (whose-turn, delegated tests) — Phase 8.
+- Animation / drag-and-drop / richer per-option metadata beyond the anchor.
+- The ArkhamDB icon font (still deferred).


### PR DESCRIPTION
## Summary

First slice of the board interactivity pass (#206): enrich each wire `ChoiceOption` with a structured `OptionTarget` anchor, and have the open-turn action menu carry real anchors, so a future web slice can render each option on the board entity it acts on rather than in a flat action bar. Engine + protocol only — **no web behavior change** (the flat bar still reads `label`).

## What changed

- **`OptionTarget`** (`game_core::engine::outcome`, re-exported at crate root): `#[non_exhaustive]` enum — `Global`, `Location`, `Enemy`, `HandCard { investigator, hand_index }`, `CardInstance`, `Act`.
- **`ChoiceOption` gains `target`**, plus `ChoiceOption::new` / `::global` constructors. `label` is unchanged — still the full, unambiguous string (`"Fight Ghoul"`); a host may shorten it. The new field is **required** on the wire (the #453 precedent: a stale payload errors rather than silently degrading).
- **`turn_menu` derives real anchors** from a new `TurnAction::target(&state)` (mirrors `TurnAction::label` — takes `state` to resolve Investigate's implicit current-location anchor). Every *other* option-builder (reaction windows, effect choices, soak, attack-order, forced/skill-test prompts) emits `OptionTarget::Global` for now; later slices replace those as each prompt dissolves onto the board.
- `ChoiceOption` rides `EngineOutcome` through `protocol` untouched (recompile only); `web/src/input.rs` gains a `..` in its destructure (S0 doesn't consume `target` yet).

Design spec (`docs/superpowers/specs/2026-07-01-board-interactivity-pass-design.md`) + the S0 plan are included on the branch.

## Design decisions

- **Engine-authoritative anchors, not client re-derivation.** The engine already enumerates the legal action set with targets inside `TurnAction`; we stop discarding them at the wire boundary. A host renders only options the engine offered, so the board can never surface an action the server rejects (the drift #206 warns against is structurally impossible). Client-side label-parsing and legality re-computation were both rejected.
- **`label` stays full** rather than being shortened engine-side — keeps the transitional flat bar unambiguous while slices land, and decouples label text from render context.

## Test notes

- `game-core`: `target_maps_each_variant` (every `TurnAction` → expected `OptionTarget`); `turn_menu_carries_action_targets` (each menu option's `target` equals the corresponding action's, and ≥1 is `Enemy`-anchored); `awaiting_input_round_trips_option_target` + `global_constructor_sets_global_target`.
- `protocol`: `applied_round_trips_awaiting_input_option_target` (the field survives the `ServerMessage` envelope).
- Full 7-job CI gauntlet run locally green (fmt, host test/clippy, doc, wasm build, wasm clippy, wasm-pack headless).

## Linked issues

Closes #535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
